### PR TITLE
fix: harden RBAC policy (permissions + lockout guard)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,15 @@ Authentication mode:
 State transitions also require:
 - `expectedVersion` in request body
 
+State transition RBAC (permission-based):
+- `SUBMITTED`: `transaction:submit`
+- `APPROVED`: `transaction:approve`
+- `REJECTED`: `transaction:reject`
+
+Comment/Evidence RBAC (permission-based):
+- comments: `comment:read` / `comment:write`
+- evidences: `evidence:read` / `evidence:write`
+
 Role change endpoint requires:
 - `x-actor-role` allowed by policy (`policies/rbac-policy.json`)
 

--- a/policies/rbac-policy.json
+++ b/policies/rbac-policy.json
@@ -1,5 +1,6 @@
 {
   "version": 1,
+  "defaultRole": "viewer",
   "roles": [
     "admin",
     "finance",
@@ -15,12 +16,103 @@
     "project:write",
     "ledger:read",
     "ledger:write",
+    "transaction:submit",
     "transaction:approve",
+    "transaction:reject",
+    "comment:read",
+    "comment:write",
+    "evidence:read",
+    "evidence:write",
     "audit:read",
     "user:manage",
     "tenant:manage",
     "security:manage"
   ],
+  "rolePermissions": {
+    "admin": [
+      "project:read",
+      "project:write",
+      "ledger:read",
+      "ledger:write",
+      "transaction:submit",
+      "transaction:approve",
+      "transaction:reject",
+      "comment:read",
+      "comment:write",
+      "evidence:read",
+      "evidence:write",
+      "audit:read",
+      "user:manage",
+      "tenant:manage",
+      "security:manage"
+    ],
+    "finance": [
+      "project:read",
+      "project:write",
+      "ledger:read",
+      "ledger:write",
+      "transaction:submit",
+      "transaction:approve",
+      "transaction:reject",
+      "comment:read",
+      "comment:write",
+      "evidence:read",
+      "evidence:write",
+      "audit:read"
+    ],
+    "pm": [
+      "project:read",
+      "project:write",
+      "ledger:read",
+      "ledger:write",
+      "transaction:submit",
+      "comment:read",
+      "comment:write",
+      "evidence:read",
+      "evidence:write"
+    ],
+    "viewer": [
+      "project:read",
+      "ledger:read",
+      "comment:read",
+      "evidence:read"
+    ],
+    "auditor": [
+      "project:read",
+      "ledger:read",
+      "comment:read",
+      "evidence:read",
+      "audit:read"
+    ],
+    "tenant_admin": [
+      "project:read",
+      "project:write",
+      "ledger:read",
+      "ledger:write",
+      "transaction:submit",
+      "comment:read",
+      "comment:write",
+      "evidence:read",
+      "evidence:write",
+      "audit:read",
+      "user:manage",
+      "tenant:manage"
+    ],
+    "support": [
+      "project:read",
+      "ledger:read",
+      "comment:read",
+      "evidence:read",
+      "audit:read"
+    ],
+    "security": [
+      "project:read",
+      "comment:read",
+      "evidence:read",
+      "audit:read",
+      "security:manage"
+    ]
+  },
   "roleChangeRules": {
     "admin": ["admin", "finance", "pm", "viewer", "auditor", "tenant_admin", "support", "security"],
     "tenant_admin": ["finance", "pm", "viewer", "auditor"],

--- a/src/app/data/auth-helpers.test.ts
+++ b/src/app/data/auth-helpers.test.ts
@@ -15,9 +15,9 @@ describe('auth-helpers', () => {
     expect(normalizeEmail(' Test@Email.COM ')).toBe('test@email.com');
   });
 
-  it('falls back to pm role when no directory match exists', () => {
+  it('falls back to viewer role when no directory match exists', () => {
     const role = resolveRoleFromDirectory('unknown@mysc.co.kr', []);
-    expect(role).toBe('pm');
+    expect(role).toBe('viewer');
   });
 
   it('resolves manager project ownership', () => {

--- a/src/app/data/auth-helpers.ts
+++ b/src/app/data/auth-helpers.ts
@@ -18,7 +18,8 @@ export function normalizeEmail(email: string): string {
 export function resolveRoleFromDirectory(email: string, directory: RoleDirectoryEntry[]): UserRole {
   const normalized = normalizeEmail(email);
   const found = directory.find((entry) => normalizeEmail(entry.email) === normalized);
-  return found?.role ?? 'pm';
+  // Least privilege: unknown users should not get write access by default.
+  return found?.role ?? 'viewer';
 }
 
 export function resolveProjectIdForManager(uid: string, projects: ProjectOwnerEntry[]): string | undefined {

--- a/src/app/platform/rbac.test.ts
+++ b/src/app/platform/rbac.test.ts
@@ -29,6 +29,22 @@ describe('rbac helpers', () => {
     expect(hasPermission('pm', 'audit:read', ['audit:read'])).toBe(true);
   });
 
+  it('defaults unknown roles to viewer (least privilege)', () => {
+    const context = extractAuthContextFromClaims({
+      role: 'UNKNOWN_ROLE',
+      permissions: ['project:write'],
+    });
+
+    expect(context.role).toBe('viewer');
+    // Extra permissions still get normalized, but the default role stays least-privileged.
+    expect(context.permissions).toEqual(['project:write']);
+  });
+
+  it('grants finance approvals and tenant_admin tenant management based on policy', () => {
+    expect(hasPermission('finance', 'transaction:approve')).toBe(true);
+    expect(hasPermission('tenant_admin', 'tenant:manage')).toBe(true);
+  });
+
   it('classifies privileged roles', () => {
     expect(isPrivilegedPlatformRole('admin')).toBe(true);
     expect(isPrivilegedPlatformRole('tenant_admin')).toBe(true);

--- a/src/app/platform/rbac.ts
+++ b/src/app/platform/rbac.ts
@@ -1,5 +1,6 @@
 import type { UserRole } from '../data/types';
 import { normalizeTenantId } from './tenant';
+import rbacPolicyJson from '../../../policies/rbac-policy.json';
 
 export type PlatformRole = UserRole | 'tenant_admin' | 'support' | 'security';
 
@@ -8,32 +9,81 @@ export type PlatformPermission =
   | 'project:write'
   | 'ledger:read'
   | 'ledger:write'
+  | 'transaction:submit'
   | 'transaction:approve'
+  | 'transaction:reject'
+  | 'comment:read'
+  | 'comment:write'
+  | 'evidence:read'
+  | 'evidence:write'
   | 'audit:read'
   | 'user:manage'
   | 'tenant:manage'
   | 'security:manage';
 
-const PERMISSIONS_BY_ROLE: Record<PlatformRole, PlatformPermission[]> = {
-  admin: [
-    'project:read',
-    'project:write',
-    'ledger:read',
-    'ledger:write',
-    'transaction:approve',
-    'audit:read',
-    'user:manage',
-    'tenant:manage',
-    'security:manage',
-  ],
-  finance: ['project:read', 'project:write', 'ledger:read', 'ledger:write', 'audit:read'],
-  pm: ['project:read', 'project:write', 'ledger:read', 'ledger:write'],
-  viewer: ['project:read', 'ledger:read'],
-  auditor: ['project:read', 'ledger:read', 'audit:read'],
-  tenant_admin: ['project:read', 'project:write', 'ledger:read', 'ledger:write', 'user:manage', 'audit:read'],
-  support: ['project:read', 'ledger:read', 'audit:read'],
-  security: ['project:read', 'audit:read', 'security:manage'],
+type RbacPolicy = {
+  defaultRole?: unknown;
+  rolePermissions?: unknown;
 };
+
+const PLATFORM_ROLES: PlatformRole[] = ['admin', 'finance', 'pm', 'viewer', 'auditor', 'tenant_admin', 'support', 'security'];
+
+const KNOWN_PERMISSIONS = new Set<PlatformPermission>([
+  'project:read',
+  'project:write',
+  'ledger:read',
+  'ledger:write',
+  'transaction:submit',
+  'transaction:approve',
+  'transaction:reject',
+  'comment:read',
+  'comment:write',
+  'evidence:read',
+  'evidence:write',
+  'audit:read',
+  'user:manage',
+  'tenant:manage',
+  'security:manage',
+]);
+
+function normalizePlatformRole(value: unknown): PlatformRole | null {
+  const normalized = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  if (!normalized) return null;
+  return PLATFORM_ROLES.includes(normalized as PlatformRole) ? (normalized as PlatformRole) : null;
+}
+
+function normalizePolicyPermissions(value: unknown): PlatformPermission[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((entry): entry is string => typeof entry === 'string')
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry): entry is PlatformPermission => KNOWN_PERMISSIONS.has(entry as PlatformPermission));
+}
+
+const RBAC_POLICY = rbacPolicyJson as unknown as RbacPolicy;
+const DEFAULT_ROLE: PlatformRole = normalizePlatformRole(RBAC_POLICY.defaultRole) ?? 'viewer';
+
+const PERMISSIONS_BY_ROLE: Record<PlatformRole, PlatformPermission[]> = (() => {
+  const mapping: Record<PlatformRole, PlatformPermission[]> = {
+    admin: [],
+    finance: [],
+    pm: [],
+    viewer: [],
+    auditor: [],
+    tenant_admin: [],
+    support: [],
+    security: [],
+  };
+
+  const raw = RBAC_POLICY.rolePermissions && typeof RBAC_POLICY.rolePermissions === 'object'
+    ? (RBAC_POLICY.rolePermissions as Record<string, unknown>)
+    : {};
+
+  for (const role of PLATFORM_ROLES) {
+    mapping[role] = normalizePolicyPermissions(raw[role]);
+  }
+  return mapping;
+})();
 
 export interface FirebaseAuthClaims {
   role?: unknown;
@@ -50,30 +100,11 @@ export interface ResolvedAuthContext {
 }
 
 function normalizeRole(role: unknown): PlatformRole {
-  const normalized = typeof role === 'string' ? role.trim().toLowerCase() : '';
-  if (normalized in PERMISSIONS_BY_ROLE) {
-    return normalized as PlatformRole;
-  }
-  return 'pm';
+  return normalizePlatformRole(role) ?? DEFAULT_ROLE;
 }
 
 function normalizePermissions(value: unknown): PlatformPermission[] {
-  if (!Array.isArray(value)) return [];
-  const known = new Set<PlatformPermission>([
-    'project:read',
-    'project:write',
-    'ledger:read',
-    'ledger:write',
-    'transaction:approve',
-    'audit:read',
-    'user:manage',
-    'tenant:manage',
-    'security:manage',
-  ]);
-  return value
-    .filter((entry): entry is string => typeof entry === 'string')
-    .map((entry) => entry.trim().toLowerCase())
-    .filter((entry): entry is PlatformPermission => known.has(entry as PlatformPermission));
+  return normalizePolicyPermissions(value);
 }
 
 export function extractAuthContextFromClaims(claims?: FirebaseAuthClaims): ResolvedAuthContext {


### PR DESCRIPTION
## PR 요약

- 문제: `policies/rbac-policy.json`가 권한 "목록"만 제공하고 실제 역할-권한 매핑은 코드에 하드코딩되어 정책이 source of truth가 아니었습니다. 또한 unknown role 기본값이 `pm`이라 과도한 권한이 부여될 수 있었고, 마지막 admin 강등(lockout)도 방지되지 않았습니다.
- 해결: RBAC 정책 파일에 역할-권한 매핑(`rolePermissions`)을 추가하고, API/프론트가 해당 정책을 기준으로 권한을 판정하도록 변경했습니다. 거래 상태 전환을 제출/승인/반려로 세분화해 권한을 분리했고, 마지막 admin 강등을 차단했습니다.
- 기대 효과: 정책-as-code 일원화, 최소권한 기본값, 업무 흐름(제출/승인/반려) 권한 정합성, 운영 사고(lockout) 예방.

> NOTE: 이 PR은 **stacked PR** 입니다.
> - Base PR: `feat/platform-foundation-base -> main`
> - This PR: `feat/platform-foundation-firebase-hardening -> feat/platform-foundation-base` (RBAC hardening only)

## 변경 범위

- [x] 프론트엔드(RBAC 유틸)
- [x] BFF/API (권한 체크)
- [x] 정책 파일(policies)
- [x] 스크립트(policy verify)
- [x] 문서(README)

## 비개발자용 설명

"누가 무엇을 할 수 있는지"를 이제 파일 한 곳(`policies/rbac-policy.json`)에서 관리합니다.

- 모르는/잘못된 역할 값이 들어오면 기본적으로 읽기 전용(`viewer`)로 처리합니다.
- 거래(입출금) 워크플로우는 `제출`/`승인`/`반려`를 역할에 따라 분리합니다.
- 관리자가 실수로 마지막 admin을 없애서 시스템이 잠기는 상황을 방지합니다.

## 핵심 변경사항

### 1) 정책 파일이 권한의 단일 원천

- `policies/rbac-policy.json`
  - `defaultRole: "viewer"` 추가
  - `rolePermissions`(role -> permissions) 매핑 추가
  - 권한 추가:
    - 거래: `transaction:submit`, `transaction:approve`, `transaction:reject`
    - 코멘트: `comment:read`, `comment:write`
    - 증빙: `evidence:read`, `evidence:write`

### 2) 프론트: 하드코딩 제거 + 최소권한 기본값

- `src/app/platform/rbac.ts`
  - 정책의 `rolePermissions`를 읽어 권한 판정
  - unknown role은 `defaultRole`(현재 viewer)
- `src/app/data/auth-helpers.ts`
  - 디렉토리 미매칭 fallback: `pm` -> `viewer`

### 3) BFF: 상태별 권한 강제 + 마지막 admin 강등 방지

- `PATCH /api/v1/transactions/:txId/state`
  - `SUBMITTED` -> `transaction:submit`
  - `APPROVED` -> `transaction:approve`
  - `REJECTED` -> `transaction:reject`
- `POST/GET /api/v1/transactions/:txId/comments`
  - `comment:read` / `comment:write`
- `POST/GET /api/v1/transactions/:txId/evidences`
  - `evidence:read` / `evidence:write`
- `PATCH /api/v1/members/:memberId/role`
  - 마지막 admin 강등을 409 `last_admin_lockout` 으로 차단

### 4) 정책 검증 강화

- `scripts/verify_rbac_policy.mjs`
  - `defaultRole`/`rolePermissions` 유효성(roles/permissions 존재, unknown 값, 중복, 누락)을 검증

## 테스트/검증

```bash
npm run policy:verify
npm test
npm run bff:test:integration
```

통합 테스트에 포함된 시나리오:
- pm은 `SUBMITTED` 가능, `APPROVED`는 403
- finance는 `APPROVED` 가능
- 마지막 admin 강등은 409 차단

## 수동 작업 필요 항목 (운영/관리자)

- 없음(정책 변경은 repo 반영으로 관리)

## 위험도 및 롤백 계획

- 영향 범위: 거래 상태 전환/코멘트/증빙 API 권한
- 예상 리스크: 정책 파일에 누락/오타가 있으면 일부 기능이 403이 될 수 있음
- 롤백 방법:
  - `policies/rbac-policy.json`을 이전 버전으로 되돌리거나 PR revert
