### PR TITLE
CPO Phase 1/2: 역할 기반 라우팅·메뉴 정리

### DIFF
--- a/src/app/components/auth/LoginPage.tsx
+++ b/src/app/components/auth/LoginPage.tsx
@@ -12,6 +12,8 @@ import { Label } from '../ui/label';
 import { Separator } from '../ui/separator';
 import { Badge } from '../ui/badge';
 import { useAuth } from '../../data/auth-store';
+import { featureFlags } from '../../config/feature-flags';
+import { resolveHomePath } from '../../platform/navigation';
 
 // ═══════════════════════════════════════════════════════════════
 // LoginPage — 통합 로그인 페이지
@@ -38,7 +40,7 @@ export function LoginPage() {
   // 이미 인증된 사용자는 역할에 맞는 페이지로 리다이렉트
   useEffect(() => {
     if (isAuthenticated && user) {
-      const target = (user.role === 'admin' || user.role === 'finance' || user.role === 'auditor') ? '/' : '/portal';
+      const target = resolveHomePath(user.role);
       navigate(target, { replace: true });
     }
   }, [isAuthenticated, user, navigate]);
@@ -70,11 +72,7 @@ export function LoginPage() {
 
   const handleDemoLogin = (role: 'admin' | 'pm' | 'finance' | 'auditor') => {
     loginAsDemo(role);
-    if (role === 'admin' || role === 'finance' || role === 'auditor') {
-      navigate('/', { replace: true });
-    } else {
-      navigate('/portal', { replace: true });
-    }
+    navigate(resolveHomePath(role), { replace: true });
   };
 
   return (
@@ -216,7 +214,7 @@ export function LoginPage() {
             <Separator className="my-5" />
 
             {/* Demo Access */}
-            {!isFirebaseAuthEnabled && (
+            {!isFirebaseAuthEnabled && featureFlags.demoLoginEnabled && (
               <div>
               <button
                 onClick={() => setShowDemoPanel(!showDemoPanel)}
@@ -261,7 +259,7 @@ export function LoginPage() {
                   <div className="p-2.5 rounded-lg bg-amber-50/60 dark:bg-amber-950/10 border border-amber-200/40 dark:border-amber-800/30">
                     <p className="text-[10px] text-amber-700 dark:text-amber-400">
                       <AlertCircle className="w-3 h-3 inline mr-0.5" />
-                      데모 계정은 모든 기존 사용자 이메일 + 비밀번호 <code className="bg-amber-200/40 dark:bg-amber-800/30 px-1 py-0.5 rounded text-[9px]">mysc1234</code>로 로그인할 수 있습니다.
+                      데모 로그인은 개발/데모 환경에서만 사용하세요. (프로덕션에서는 비활성화 권장)
                     </p>
                   </div>
                 </div>

--- a/src/app/components/dashboard/WelcomeBanner.tsx
+++ b/src/app/components/dashboard/WelcomeBanner.tsx
@@ -1,10 +1,12 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import {
   X, FolderKanban, BarChart3, Shield, Keyboard,
   ArrowRight, Sparkles,
 } from 'lucide-react';
 import { useAppStore } from '../../data/store';
+import { useAuth } from '../../data/auth-store';
+import { canShowAdminNavItem } from '../../platform/admin-nav';
 
 const QUICK_ACTIONS = [
   {
@@ -40,6 +42,7 @@ const QUICK_ACTIONS = [
 export function WelcomeBanner() {
   const navigate = useNavigate();
   const { currentUser } = useAppStore();
+  const { user } = useAuth();
   const [dismissed, setDismissed] = useState(() => {
     if (typeof window !== 'undefined') {
       return localStorage.getItem('mysc-welcome-dismissed') === 'true';
@@ -47,6 +50,14 @@ export function WelcomeBanner() {
     return false;
   });
   const [exiting, setExiting] = useState(false);
+
+  const visibleActions = useMemo(() => {
+    return QUICK_ACTIONS.filter((action) => {
+      if ('action' in action) return true;
+      if (!('path' in action) || !action.path) return true;
+      return canShowAdminNavItem(user?.role, action.path);
+    });
+  }, [user?.role]);
 
   const handleDismiss = () => {
     setExiting(true);
@@ -97,7 +108,7 @@ export function WelcomeBanner() {
         </p>
 
         <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
-          {QUICK_ACTIONS.map((action) => (
+          {visibleActions.map((action) => (
             <button
               key={action.label}
               onClick={() => {

--- a/src/app/components/layout/CommandPalette.tsx
+++ b/src/app/components/layout/CommandPalette.tsx
@@ -7,6 +7,8 @@ import {
 } from 'lucide-react';
 import { Dialog, DialogContent } from '../ui/dialog';
 import { useAppStore } from '../../data/store';
+import { useAuth } from '../../data/auth-store';
+import { canShowAdminNavItem } from '../../platform/admin-nav';
 
 interface CommandItem {
   id: string;
@@ -24,6 +26,7 @@ export function CommandPalette() {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const navigate = useNavigate();
   const { projects, transactions } = useAppStore();
+  const { user } = useAuth();
 
   // ⌘K / Ctrl+K
   useEffect(() => {
@@ -48,16 +51,18 @@ export function CommandPalette() {
 
   const items: CommandItem[] = useMemo(() => {
     const nav: CommandItem[] = [
-      { id: 'nav-dash', icon: LayoutDashboard, label: '대시보드', category: '탐색', action: () => go('/'), keywords: ['dashboard', '홈'] },
-      { id: 'nav-proj', icon: FolderKanban, label: '프로젝트 목록', category: '탐색', action: () => go('/projects'), keywords: ['project', '사업'] },
-      { id: 'nav-new', icon: Plus, label: '새 사업 등록', category: '빠른 작업', action: () => go('/projects/new'), keywords: ['new', '생성', '등록'] },
-      { id: 'nav-cash', icon: BarChart3, label: '캐시플로 분석', category: '탐색', action: () => go('/cashflow'), keywords: ['cashflow', '현금흐름'] },
-      { id: 'nav-evi', icon: FileCheck, label: '증빙/정산 관리', category: '탐색', action: () => go('/evidence'), keywords: ['evidence', '증빙'] },
-      { id: 'nav-part', icon: Shield, label: '참여율 관리 (100-1)', category: '탐색', action: () => go('/participation'), keywords: ['participation', '참여율'] },
-      { id: 'nav-koica', icon: ClipboardList, label: 'KOICA 인력배치', category: '탐색', action: () => go('/koica-personnel'), keywords: ['koica', '인력'] },
-      { id: 'nav-audit', icon: BookOpen, label: '감사 로그', category: '탐색', action: () => go('/audit'), keywords: ['audit', '감사'] },
-      { id: 'nav-set', icon: Settings, label: '설정', category: '탐색', action: () => go('/settings'), keywords: ['settings', '설정'] },
-    ];
+      { id: 'nav-dash', icon: LayoutDashboard, label: '대시보드', path: '/', category: '탐색', action: () => go('/'), keywords: ['dashboard', '홈'] },
+      { id: 'nav-proj', icon: FolderKanban, label: '프로젝트 목록', path: '/projects', category: '탐색', action: () => go('/projects'), keywords: ['project', '사업'] },
+      { id: 'nav-new', icon: Plus, label: '새 사업 등록', path: '/projects/new', category: '빠른 작업', action: () => go('/projects/new'), keywords: ['new', '생성', '등록'] },
+      { id: 'nav-cash', icon: BarChart3, label: '캐시플로 분석', path: '/cashflow', category: '탐색', action: () => go('/cashflow'), keywords: ['cashflow', '현금흐름'] },
+      { id: 'nav-evi', icon: FileCheck, label: '증빙/정산 관리', path: '/evidence', category: '탐색', action: () => go('/evidence'), keywords: ['evidence', '증빙'] },
+      { id: 'nav-part', icon: Shield, label: '참여율 관리 (100-1)', path: '/participation', category: '탐색', action: () => go('/participation'), keywords: ['participation', '참여율'] },
+      { id: 'nav-koica', icon: ClipboardList, label: 'KOICA 인력배치', path: '/koica-personnel', category: '탐색', action: () => go('/koica-personnel'), keywords: ['koica', '인력'] },
+      { id: 'nav-audit', icon: BookOpen, label: '감사 로그', path: '/audit', category: '탐색', action: () => go('/audit'), keywords: ['audit', '감사'] },
+      { id: 'nav-set', icon: Settings, label: '설정', path: '/settings', category: '탐색', action: () => go('/settings'), keywords: ['settings', '설정'] },
+    ]
+      .filter((item) => canShowAdminNavItem(user?.role, (item as any).path))
+      .map(({ path: _path, ...rest }) => rest);
 
     const projItems: CommandItem[] = projects.slice(0, 20).map(p => ({
       id: `proj-${p.id}`,
@@ -84,7 +89,7 @@ export function CommandPalette() {
     }));
 
     return [...nav, ...txItems, ...projItems];
-  }, [projects, transactions, go]);
+  }, [projects, transactions, go, user?.role]);
 
   const filtered = useMemo(() => {
     if (!query.trim()) return items;

--- a/src/app/components/layout/KeyboardShortcuts.tsx
+++ b/src/app/components/layout/KeyboardShortcuts.tsx
@@ -1,40 +1,14 @@
-import { useState, useEffect } from 'react';
-import { Keyboard, X } from 'lucide-react';
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '../ui/sheet';
+import { useMemo, useState, useEffect } from 'react';
+import { Keyboard } from 'lucide-react';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '../ui/sheet';
 import { Separator } from '../ui/separator';
-import { Button } from '../ui/button';
-
-const SHORTCUT_GROUPS = [
-  {
-    label: '글로벌',
-    shortcuts: [
-      { keys: ['⌘', 'K'], desc: '커맨드 팔레트 열기' },
-      { keys: ['⌘', '/'], desc: '키보드 단축키 도움말' },
-      { keys: ['Esc'], desc: '팝업/패널 닫기' },
-    ],
-  },
-  {
-    label: '네비게이션',
-    shortcuts: [
-      { keys: ['G', 'D'], desc: '대시보드로 이동' },
-      { keys: ['G', 'P'], desc: '프로젝트 목록으로 이동' },
-      { keys: ['G', 'C'], desc: '캐시플로로 이동' },
-      { keys: ['G', 'E'], desc: '증빙/정산으로 이동' },
-      { keys: ['G', 'A'], desc: '감사로그로 이동' },
-      { keys: ['G', 'S'], desc: '설정으로 이동' },
-    ],
-  },
-  {
-    label: '작업',
-    shortcuts: [
-      { keys: ['N'], desc: '새 사업 등록' },
-      { keys: ['⌘', 'Enter'], desc: '폼 제출 / 확인' },
-    ],
-  },
-];
+import { useAuth } from '../../data/auth-store';
+import { getShortcutGroupsForRole } from '../../platform/shortcut-policy';
 
 export function KeyboardShortcuts() {
   const [open, setOpen] = useState(false);
+  const { user } = useAuth();
+  const shortcutGroups = useMemo(() => getShortcutGroupsForRole(user?.role), [user?.role]);
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -64,7 +38,7 @@ export function KeyboardShortcuts() {
         </SheetHeader>
 
         <div className="px-5 pb-5 space-y-5 overflow-y-auto max-h-[calc(100vh-100px)]">
-          {SHORTCUT_GROUPS.map((group, gi) => (
+          {shortcutGroups.map((group, gi) => (
             <div key={group.label}>
               {gi > 0 && <Separator className="mb-4" />}
               <p

--- a/src/app/components/layout/QuickActionFab.tsx
+++ b/src/app/components/layout/QuickActionFab.tsx
@@ -4,6 +4,8 @@ import {
   Plus, X, FolderKanban, BarChart3, FileCheck,
   Shield, Zap,
 } from 'lucide-react';
+import { useAuth } from '../../data/auth-store';
+import { canShowAdminNavItem } from '../../platform/admin-nav';
 
 const ACTIONS = [
   { icon: FolderKanban, label: '새 사업 등록', path: '/projects/new', color: '#4f46e5' },
@@ -17,6 +19,10 @@ export function QuickActionFab() {
   const navigate = useNavigate();
   const location = useLocation();
   const fabRef = useRef<HTMLDivElement>(null);
+  const { user } = useAuth();
+
+  const visibleActions = ACTIONS.filter((action) => canShowAdminNavItem(user?.role, action.path));
+  if (visibleActions.length === 0) return null;
 
   // Close on route change
   useEffect(() => {
@@ -52,7 +58,7 @@ export function QuickActionFab() {
           transition: 'opacity 200ms ease-out, transform 200ms ease-out',
         }}
       >
-        {ACTIONS.map((action, i) => (
+        {visibleActions.map((action, i) => (
           <button
             key={action.path}
             onClick={() => {

--- a/src/app/components/portal/PortalLayout.tsx
+++ b/src/app/components/portal/PortalLayout.tsx
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react';
 import { Outlet, NavLink, useLocation, useNavigate } from 'react-router';
 import {
   LayoutDashboard, Wallet, Calculator, Users,
-  ArrowRightLeft, LogOut, Zap, ChevronRight,
-  FolderKanban, Bell, HelpCircle, Menu, X,
+  ArrowRightLeft, LogOut,
+  FolderKanban, Menu, X,
   Plus,
 } from 'lucide-react';
 import { PortalProvider, usePortalStore } from '../../data/portal-store';
@@ -14,6 +14,7 @@ import { Badge } from '../ui/badge';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip';
 import { DarkModeToggle } from '../layout/DarkModeToggle';
 import { PageTransition } from '../layout/PageTransition';
+import { resolveHomePath } from '../../platform/navigation';
 
 // ═══════════════════════════════════════════════════════════════
 // PortalLayout — 사용자(PM) 전용 레이아웃
@@ -47,7 +48,7 @@ function PortalContent() {
   useEffect(() => {
     const role = authUser?.role;
     if (!isAuthenticated || !role) return;
-    if (role === 'admin' || role === 'finance' || role === 'auditor') {
+    if (resolveHomePath(role) === '/') {
       navigate('/', { replace: true });
     }
   }, [isAuthenticated, authUser, navigate]);
@@ -175,17 +176,6 @@ function PortalContent() {
               })}
             </div>
 
-            {/* 관리자 페이지 링크 */}
-            <div className="mt-4 mx-2 pt-3 border-t border-slate-800">
-              <NavLink
-                to="/"
-                className="flex items-center gap-2 px-2.5 py-[6px] rounded-md text-[11px] text-slate-600 hover:text-slate-400 hover:bg-white/[0.04] transition-colors"
-              >
-                <Zap className="w-3.5 h-3.5" />
-                관리자 페이지로 이동
-                <ChevronRight className="w-3 h-3 ml-auto" />
-              </NavLink>
-            </div>
           </nav>
 
           {/* Footer */}

--- a/src/app/components/projects/ProjectListPage.tsx
+++ b/src/app/components/projects/ProjectListPage.tsx
@@ -22,6 +22,8 @@ import {
   type ProjectStatus, type ProjectType, type Project,
 } from '../../data/types';
 import { PageHeader } from '../layout/PageHeader';
+import { useAuth } from '../../data/auth-store';
+import { canShowAdminNavItem } from '../../platform/admin-nav';
 
 const statusColor: Record<string, string> = {
   CONTRACT_PENDING: 'bg-amber-100 text-amber-800',
@@ -44,6 +46,7 @@ type SortDir = 'asc' | 'desc';
 
 export function ProjectListPage() {
   const { projects, ledgers, transactions } = useAppStore();
+  const { user } = useAuth();
   const navigate = useNavigate();
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('ALL');
@@ -62,6 +65,7 @@ export function ProjectListPage() {
   const prospectProjects = useMemo(() => projects.filter(p => p.phase === 'PROSPECT'), [projects]);
 
   const baseProjects = activeTab === 'confirmed' ? confirmedProjects : prospectProjects;
+  const canCreateProject = canShowAdminNavItem(user?.role, '/projects/new');
 
   const filtered = useMemo(() => {
     let result = baseProjects.filter(p => {
@@ -284,7 +288,7 @@ export function ProjectListPage() {
                     {search || statusFilter !== 'ALL' || typeFilter !== 'ALL' || deptFilter !== 'ALL'
                       ? '검색 조건에 맞는 사업이 없습니다'
                       : activeTab === 'prospect'
-                        ? '예정 사업이 없습니다. 새 사업을 등록해보세요.'
+                        ? (canCreateProject ? '예정 사업이 없습니다. 새 사업을 등록해보세요.' : '예정 사업이 없습니다.')
                         : '확정 사업이 없습니다.'}
                   </TableCell>
                 </TableRow>
@@ -305,26 +309,28 @@ export function ProjectListPage() {
         title="사업 통합 관리"
         description={`전체 ${projects.length}개 사업 · 확정 ${confirmedProjects.length} / 예정 ${prospectProjects.length}`}
         actions={
-          <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => navigate('/projects/new?phase=PROSPECT')}
-              className="gap-1.5 h-8 text-[11px]"
-            >
-              <Sparkles className="w-3.5 h-3.5" />
-              예정 등록
-            </Button>
-            <Button
-              size="sm"
-              onClick={() => navigate('/projects/new?phase=CONFIRMED')}
-              className="gap-1.5 h-8 text-[11px]"
-              style={{ background: 'linear-gradient(135deg, #4f46e5, #6366f1)' }}
-            >
-              <Plus className="w-3.5 h-3.5" />
-              확정 등록
-            </Button>
-          </div>
+          canCreateProject ? (
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => navigate('/projects/new?phase=PROSPECT')}
+                className="gap-1.5 h-8 text-[11px]"
+              >
+                <Sparkles className="w-3.5 h-3.5" />
+                예정 등록
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => navigate('/projects/new?phase=CONFIRMED')}
+                className="gap-1.5 h-8 text-[11px]"
+                style={{ background: 'linear-gradient(135deg, #4f46e5, #6366f1)' }}
+              >
+                <Plus className="w-3.5 h-3.5" />
+                확정 등록
+              </Button>
+            </div>
+          ) : undefined
         }
       />
 

--- a/src/app/components/users/UserManagementPage.tsx
+++ b/src/app/components/users/UserManagementPage.tsx
@@ -55,26 +55,35 @@ interface ManagedUser {
 
 const ROLE_LABELS: Record<UserRole, string> = {
   admin: '관리자',
+  tenant_admin: '테넌트 관리자',
   finance: '재무팀',
   pm: 'PM (사업담당)',
   viewer: '뷰어',
   auditor: '감사',
+  support: '지원',
+  security: '보안',
 };
 
 const ROLE_COLORS: Record<UserRole, string> = {
   admin: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/50 dark:text-indigo-300',
+  tenant_admin: 'bg-violet-100 text-violet-700 dark:bg-violet-900/50 dark:text-violet-300',
   finance: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-300',
   pm: 'bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300',
   viewer: 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400',
   auditor: 'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-300',
+  support: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-400',
+  security: 'bg-rose-100 text-rose-700 dark:bg-rose-900/50 dark:text-rose-300',
 };
 
 const ROLE_ICONS: Record<UserRole, typeof Shield> = {
   admin: ShieldCheck,
+  tenant_admin: ShieldCheck,
   finance: Activity,
   pm: FolderKanban,
   viewer: Eye,
   auditor: ShieldAlert,
+  support: UserCog,
+  security: Key,
 };
 
 const STATUS_LABELS: Record<string, string> = {

--- a/src/app/config/feature-flags.test.ts
+++ b/src/app/config/feature-flags.test.ts
@@ -37,6 +37,7 @@ describe('readFeatureFlags', () => {
       firebaseUseEmulators: true,
       tenantIsolationStrict: false,
       platformApiEnabled: true,
+      demoLoginEnabled: false,
     });
   });
 
@@ -45,5 +46,6 @@ describe('readFeatureFlags', () => {
     expect(flags.firebaseUseEmulators).toBe(false);
     expect(flags.tenantIsolationStrict).toBe(true);
     expect(flags.platformApiEnabled).toBe(false);
+    expect(flags.demoLoginEnabled).toBe(false);
   });
 });

--- a/src/app/config/feature-flags.ts
+++ b/src/app/config/feature-flags.ts
@@ -5,6 +5,7 @@ export interface FeatureFlags {
   firebaseUseEmulators: boolean;
   tenantIsolationStrict: boolean;
   platformApiEnabled: boolean;
+  demoLoginEnabled: boolean;
 }
 
 const TRUE_SET = new Set(['1', 'true', 'yes', 'on', 'enabled']);
@@ -26,6 +27,7 @@ export function readFeatureFlags(env: Record<string, unknown> = import.meta.env)
     firebaseUseEmulators: parseFeatureFlag(env.VITE_FIREBASE_USE_EMULATORS, false),
     tenantIsolationStrict: parseFeatureFlag(env.VITE_TENANT_ISOLATION_STRICT, true),
     platformApiEnabled: parseFeatureFlag(env.VITE_PLATFORM_API_ENABLED, false),
+    demoLoginEnabled: parseFeatureFlag(env.VITE_DEMO_LOGIN_ENABLED, Boolean(env.DEV)),
   };
 }
 

--- a/src/app/data/auth-store.tsx
+++ b/src/app/data/auth-store.tsx
@@ -118,12 +118,18 @@ function saveUser(user: AuthUser | null) {
 }
 
 function toUserRole(role: string | undefined): UserRole | undefined {
-  if (role === 'admin' || role === 'finance' || role === 'pm' || role === 'viewer' || role === 'auditor') {
+  if (
+    role === 'admin' ||
+    role === 'tenant_admin' ||
+    role === 'finance' ||
+    role === 'pm' ||
+    role === 'viewer' ||
+    role === 'auditor' ||
+    role === 'support' ||
+    role === 'security'
+  ) {
     return role;
   }
-  if (role === 'tenant_admin') return 'admin';
-  if (role === 'support') return 'viewer';
-  if (role === 'security') return 'auditor';
   return undefined;
 }
 

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -5,7 +5,7 @@
 
 // ── Enums ──
 
-export type UserRole = 'admin' | 'finance' | 'pm' | 'viewer' | 'auditor';
+export type UserRole = 'admin' | 'tenant_admin' | 'finance' | 'pm' | 'viewer' | 'auditor' | 'support' | 'security';
 
 export type ProjectStatus = 'CONTRACT_PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'COMPLETED_PENDING_PAYMENT';
 export type ProjectType = 'DEV_COOPERATION' | 'CONSULTING' | 'SPACE_BIZ' | 'IMPACT_INVEST' | 'OTHER';

--- a/src/app/platform/admin-nav.test.ts
+++ b/src/app/platform/admin-nav.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { canAccessAdminPath, canShowAdminNavItem } from './admin-nav';
+
+describe('admin nav policy', () => {
+  it('allows full access for admin roles', () => {
+    expect(canShowAdminNavItem('admin', '/projects/new')).toBe(true);
+    expect(canShowAdminNavItem('tenant_admin', '/users')).toBe(true);
+  });
+
+  it('filters finance to core + finance + approvals + audit', () => {
+    expect(canShowAdminNavItem('finance', '/cashflow')).toBe(true);
+    expect(canShowAdminNavItem('finance', '/approvals')).toBe(true);
+    expect(canShowAdminNavItem('finance', '/users')).toBe(false);
+    expect(canShowAdminNavItem('finance', '/projects/new')).toBe(false);
+    expect(canShowAdminNavItem('finance', '/koica-personnel')).toBe(false);
+  });
+
+  it('filters auditor to read-only surfaces (no approvals/settings/users)', () => {
+    expect(canShowAdminNavItem('auditor', '/audit')).toBe(true);
+    expect(canShowAdminNavItem('auditor', '/approvals')).toBe(false);
+    expect(canShowAdminNavItem('auditor', '/settings')).toBe(false);
+    expect(canShowAdminNavItem('auditor', '/users')).toBe(false);
+    expect(canShowAdminNavItem('auditor', '/projects/new')).toBe(false);
+  });
+
+  it('denies unknown roles by default', () => {
+    expect(canShowAdminNavItem('unknown_role', '/')).toBe(false);
+    expect(canShowAdminNavItem(undefined, '/')).toBe(false);
+  });
+
+  it('guards direct URL access for dynamic admin routes', () => {
+    expect(canAccessAdminPath('finance', '/projects/p-123')).toBe(true);
+    expect(canAccessAdminPath('finance', '/projects/p-123/edit')).toBe(false);
+    expect(canAccessAdminPath('finance', '/users')).toBe(false);
+    expect(canAccessAdminPath('finance', '/settings')).toBe(false);
+    expect(canAccessAdminPath('admin', '/users')).toBe(true);
+  });
+
+  it('does not block unknown paths (lets NotFoundPage render)', () => {
+    expect(canAccessAdminPath('finance', '/totally-unknown')).toBe(true);
+  });
+});

--- a/src/app/platform/admin-nav.ts
+++ b/src/app/platform/admin-nav.ts
@@ -1,0 +1,102 @@
+function normalizeRole(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+const FULL_ACCESS_ROLES = new Set(['admin', 'tenant_admin']);
+
+const FINANCE_ALLOWED = new Set([
+  '/',
+  '/projects',
+  '/cashflow',
+  '/evidence',
+  '/budget-summary',
+  '/expense-management',
+  '/approvals',
+  '/audit',
+  '/portal',
+]);
+
+const AUDITOR_ALLOWED = new Set([
+  '/',
+  '/projects',
+  '/cashflow',
+  '/evidence',
+  '/budget-summary',
+  '/expense-management',
+  '/audit',
+  '/portal',
+]);
+
+const SUPPORT_ALLOWED = new Set([
+  '/',
+  '/projects',
+  '/evidence',
+  '/audit',
+  '/portal',
+]);
+
+const SECURITY_ALLOWED = new Set([
+  '/',
+  '/projects',
+  '/audit',
+]);
+
+/**
+ * UI-level navigation policy for the admin space (AppLayout).
+ * This is intentionally opinionated to keep role experiences clean:
+ * - finance/auditor shouldn't see HR menus or "new project" CTA
+ * - operational settings are admin-scoped
+ */
+export function canShowAdminNavItem(role: unknown, to: string): boolean {
+  const normalized = normalizeRole(role);
+  if (!normalized) return false;
+
+  if (FULL_ACCESS_ROLES.has(normalized)) return true;
+  if (normalized === 'finance') return FINANCE_ALLOWED.has(to);
+  if (normalized === 'auditor') return AUDITOR_ALLOWED.has(to);
+  if (normalized === 'support') return SUPPORT_ALLOWED.has(to);
+  if (normalized === 'security') return SECURITY_ALLOWED.has(to);
+
+  // Unknown roles should not be encouraged to navigate into admin-only areas.
+  return false;
+}
+
+function canonicalizeAdminPath(pathname: string): string | undefined {
+  if (pathname === '/') return '/';
+
+  if (pathname.startsWith('/projects/new')) return '/projects/new';
+  if (pathname.startsWith('/projects/') && pathname.endsWith('/edit')) return '/projects/new';
+  if (pathname === '/projects' || pathname.startsWith('/projects/')) return '/projects';
+
+  const prefixes = [
+    '/cashflow',
+    '/evidence',
+    '/budget-summary',
+    '/expense-management',
+    '/approvals',
+    '/users',
+    '/audit',
+    '/settings',
+    '/participation',
+    '/koica-personnel',
+    '/personnel-changes',
+    '/hr-announcements',
+  ];
+  for (const p of prefixes) {
+    if (pathname === p || pathname.startsWith(p + '/')) return p;
+  }
+
+  return undefined;
+}
+
+/**
+ * Route-level guard for the admin space.
+ *
+ * For unknown paths we return true so the router can display NotFoundPage
+ * instead of forcing a redirect.
+ */
+export function canAccessAdminPath(role: unknown, pathname: string): boolean {
+  const canonical = canonicalizeAdminPath(pathname);
+  if (!canonical) return true;
+  return canShowAdminNavItem(role, canonical);
+}

--- a/src/app/platform/navigation.test.ts
+++ b/src/app/platform/navigation.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { isPortalRole, resolveHomePath } from './navigation';
+
+describe('navigation helpers', () => {
+  it('classifies portal roles', () => {
+    expect(isPortalRole('pm')).toBe(true);
+    expect(isPortalRole('viewer')).toBe(true);
+    expect(isPortalRole('admin')).toBe(false);
+  });
+
+  it('normalizes role strings', () => {
+    expect(resolveHomePath(' PM ')).toBe('/portal');
+    expect(resolveHomePath('ADMIN')).toBe('/');
+  });
+
+  it('defaults unknown roles to portal space (least privilege)', () => {
+    expect(resolveHomePath('unknown_role')).toBe('/portal');
+    expect(resolveHomePath('')).toBe('/portal');
+    expect(resolveHomePath(null)).toBe('/portal');
+  });
+});

--- a/src/app/platform/navigation.ts
+++ b/src/app/platform/navigation.ts
@@ -1,0 +1,28 @@
+export type HomePath = '/' | '/portal';
+
+function normalizeRole(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+const ADMIN_SPACE_ROLES = new Set([
+  'admin',
+  'finance',
+  'auditor',
+  'tenant_admin',
+  'support',
+  'security',
+]);
+
+export function isPortalRole(role: unknown): boolean {
+  const normalized = normalizeRole(role);
+  return normalized === 'pm' || normalized === 'viewer';
+}
+
+export function resolveHomePath(role: unknown): HomePath {
+  const normalized = normalizeRole(role);
+  if (!normalized) return '/portal';
+  if (isPortalRole(normalized)) return '/portal';
+  if (ADMIN_SPACE_ROLES.has(normalized)) return '/';
+  // Least privilege: unknown roles land in the portal space.
+  return '/portal';
+}

--- a/src/app/platform/shortcut-policy.test.ts
+++ b/src/app/platform/shortcut-policy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { getShortcutGroupsForRole } from './shortcut-policy';
+
+function flattenDescriptions(groups: { shortcuts: { desc: string }[] }[]) {
+  return groups.flatMap((g) => g.shortcuts.map((s) => s.desc));
+}
+
+describe('shortcut policy', () => {
+  it('shows admin-only shortcuts for admin roles', () => {
+    const descs = flattenDescriptions(getShortcutGroupsForRole('admin'));
+    expect(descs).toContain('설정으로 이동');
+    expect(descs).toContain('새 사업 등록');
+  });
+
+  it('filters out settings/new-project for finance', () => {
+    const descs = flattenDescriptions(getShortcutGroupsForRole('finance'));
+    expect(descs).toContain('프로젝트 목록으로 이동');
+    expect(descs).toContain('감사로그로 이동');
+    expect(descs).not.toContain('설정으로 이동');
+    expect(descs).not.toContain('새 사업 등록');
+  });
+
+  it('filters shortcuts for security role', () => {
+    const descs = flattenDescriptions(getShortcutGroupsForRole('security'));
+    expect(descs).toContain('감사로그로 이동');
+    expect(descs).not.toContain('캐시플로로 이동');
+    expect(descs).not.toContain('증빙/정산으로 이동');
+    expect(descs).not.toContain('새 사업 등록');
+    expect(descs).not.toContain('설정으로 이동');
+  });
+});

--- a/src/app/platform/shortcut-policy.ts
+++ b/src/app/platform/shortcut-policy.ts
@@ -1,0 +1,55 @@
+import { canShowAdminNavItem } from './admin-nav';
+
+export interface Shortcut {
+  keys: string[];
+  desc: string;
+  /**
+   * Optional target path used to filter the shortcut by role navigation policy.
+   * If omitted, the shortcut is considered global.
+   */
+  to?: string;
+}
+
+export interface ShortcutGroup {
+  label: string;
+  shortcuts: Shortcut[];
+}
+
+const BASE_GROUPS: ShortcutGroup[] = [
+  {
+    label: '글로벌',
+    shortcuts: [
+      { keys: ['⌘', 'K'], desc: '커맨드 팔레트 열기' },
+      { keys: ['⌘', '/'], desc: '키보드 단축키 도움말' },
+      { keys: ['Esc'], desc: '팝업/패널 닫기' },
+    ],
+  },
+  {
+    label: '네비게이션',
+    shortcuts: [
+      { keys: ['G', 'D'], desc: '대시보드로 이동', to: '/' },
+      { keys: ['G', 'P'], desc: '프로젝트 목록으로 이동', to: '/projects' },
+      { keys: ['G', 'C'], desc: '캐시플로로 이동', to: '/cashflow' },
+      { keys: ['G', 'E'], desc: '증빙/정산으로 이동', to: '/evidence' },
+      { keys: ['G', 'A'], desc: '감사로그로 이동', to: '/audit' },
+      { keys: ['G', 'S'], desc: '설정으로 이동', to: '/settings' },
+    ],
+  },
+  {
+    label: '작업',
+    shortcuts: [
+      { keys: ['N'], desc: '새 사업 등록', to: '/projects/new' },
+      { keys: ['⌘', 'Enter'], desc: '폼 제출 / 확인' },
+    ],
+  },
+];
+
+export function getShortcutGroupsForRole(role: unknown): ShortcutGroup[] {
+  return BASE_GROUPS
+    .map((group) => ({
+      ...group,
+      shortcuts: group.shortcuts.filter((s) => (s.to ? canShowAdminNavItem(role, s.to) : true)),
+    }))
+    .filter((group) => group.shortcuts.length > 0);
+}
+


### PR DESCRIPTION
## PR 요약

- 문제: 역할 분기(/ vs /portal), 메뉴/CTA/단축키가 여러 곳에 하드코딩되어 있어 새 역할 추가 시 버그가 나고(finance/auditor 등) 필요 없는 기능이 노출되며, 포털에도 접근 불가 링크가 노출됨.
- 해결: 역할 기반 홈 라우팅을 단일 함수로 통합하고, admin-space UI를 역할별로 필터링/가드하여 “보이는 것 = 가능한 것”에 가깝게 정리.
- 기대 효과: 역할별 UI 혼란 감소, 운영 설정/쓰기 플로우 오노출 방지, 새 역할 추가 시 수정 포인트 축소.

## 변경 범위

- [x] 프론트엔드(UI/페이지)
- [ ] BFF/API
- [ ] Firebase/Firestore 설정
- [ ] 운영 스크립트(scripts)
- [ ] 워커/스케줄링(outbox/work_queue)
- [ ] 문서(README/guidelines)
- [ ] 기타

## 비개발자용 설명

- 이제 재무팀/감사 역할로 로그인하면 “업무와 무관한 메뉴(인력/HR, 사용자관리, 설정 등)”가 숨겨집니다.
- PM/Viewer 포털에서는 더 이상 “관리자 페이지로 이동” 같은 접근 불가 링크가 보이지 않습니다.
- 접근 권한이 없는 URL로 직접 들어가도 자동으로 안전한 화면으로 이동합니다.

## Firestore 자동화 실행 증거 (해당 시 필수)

해당 없음(UI/라우팅/권한 노출 정리 PR)

## 테스트/검증

- [x] `npm test` 통과
- [x] `npm run build` 통과
- [x] 기능 수동 검증 완료
- [x] 문서와 실제 동작 일치 확인

검증 결과 요약:
- 역할별( admin / tenant_admin / finance / auditor / pm / viewer / security )로 로그인 후 사이드바/커맨드팔레트/QuickAction/단축키 도움말 노출이 정책대로 필터링됨.
- `/settings`, `/users`, `/projects/new`, `/approvals` 등 직접 URL 접근 시도 시 권한 없으면 홈으로 리다이렉트됨.

## 수동 작업 필요 항목 (운영/관리자)

- [ ] Firebase Console에서 Google Provider 활성화 확인
- [ ] IAM/보안 승인 확인
- [ ] Vercel 환경변수 반영 후 redeploy
- [ ] Vercel Cron 또는 외부 워커 런타임 구성(outbox/work_queue)
- [ ] 기타: (선택) 데모 로그인 UI는 `VITE_DEMO_LOGIN_ENABLED` 플래그로 제어됩니다. 프로덕션에서는 비활성 권장.

## 위험도 및 롤백 계획

- 영향 범위: 역할별 UI 노출/라우팅
- 예상 리스크: (1) 실제 운영에서 사용하는 역할 문자열이 정책과 불일치하면 예상치 못한 리다이렉트가 발생할 수 있음. (2) security/support 역할의 노출 정책은 현재 UI 기준으로 최소화되어 있어 추후 RBAC 확정 시 조정 필요.
- 롤백 방법: 이 PR revert 후 재배포

## 체크리스트

- [x] 민감정보(.env, key, token) 커밋 없음
- [x] `.gitignore` 확인 완료
- [ ] PR 본문에 운영 증거 포함 (해당 없음)
- [ ] 필요한 후속 작업(담당자/기한) 명시

