### PR TITLE
fix(cashflow): harden weekly sheet writes

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1,13 +1,26 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { CheckCircle2, ClipboardCheck, ClipboardList, CircleDollarSign, ChevronLeft, ChevronRight } from 'lucide-react';
+import { toast } from 'sonner';
 import { Button } from '../ui/button';
 import { Card, CardContent } from '../ui/card';
 import { Input } from '../ui/input';
 import { Badge } from '../ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../ui/alert-dialog';
 import { PageHeader } from '../layout/PageHeader';
 import { useCashflowWeeks } from '../../data/cashflow-weeks-store';
 import { CASHFLOW_SHEET_LINE_LABELS, type CashflowSheetLineId, type CashflowWeekSheet } from '../../data/types';
+import { getSeoulTodayIso } from '../../platform/business-days';
+import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES } from '../../platform/cashflow-sheet';
 import { getMonthMondayWeeks } from '../../platform/cashflow-weeks';
 import { useAuth } from '../../data/auth-store';
 
@@ -18,38 +31,9 @@ function fmt(n: number): string {
 function parseAmount(raw: string): number {
   const cleaned = String(raw || '').trim().replaceAll(',', '');
   if (!cleaned) return 0;
-  const n = Number(cleaned);
+const n = Number(cleaned);
   if (!Number.isFinite(n)) return 0;
   return Math.trunc(n);
-}
-
-const IN_LINES: CashflowSheetLineId[] = [
-  'MYSC_PREPAY_IN',
-  'SALES_IN',
-  'SALES_VAT_IN',
-  'TEAM_SUPPORT_IN',
-  'BANK_INTEREST_IN',
-];
-
-const OUT_LINES: CashflowSheetLineId[] = [
-  'DIRECT_COST_OUT',
-  'INPUT_VAT_OUT',
-  'MYSC_LABOR_OUT',
-  'MYSC_PROFIT_OUT',
-  'SALES_VAT_OUT',
-  'TEAM_SUPPORT_OUT',
-  'BANK_INTEREST_OUT',
-];
-
-const ALL_LINES: CashflowSheetLineId[] = [...IN_LINES, ...OUT_LINES];
-
-function sumLines(map: Partial<Record<CashflowSheetLineId, number>> | undefined, lineIds: CashflowSheetLineId[]): number {
-  const src = map || {};
-  return lineIds.reduce((acc, id) => acc + (Number(src[id]) || 0), 0);
-}
-
-function resolveWeekDoc(weeks: CashflowWeekSheet[], projectId: string, yearMonth: string, weekNo: number): CashflowWeekSheet | undefined {
-  return weeks.find((w) => w.projectId === projectId && w.yearMonth === yearMonth && w.weekNo === weekNo);
 }
 
 export function CashflowProjectSheet({ projectId, projectName }: { projectId: string; projectName: string }) {
@@ -58,6 +42,8 @@ export function CashflowProjectSheet({ projectId, projectName }: { projectId: st
   const isPm = role === 'pm';
   const canClose = role === 'admin' || role === 'finance' || role === 'tenant_admin';
   const canEdit = isPm || canClose;
+  const todayIso = getSeoulTodayIso();
+  const todayYearMonth = todayIso.slice(0, 7);
 
   const {
     yearMonth,
@@ -65,82 +51,470 @@ export function CashflowProjectSheet({ projectId, projectName }: { projectId: st
     isLoading,
     goPrevMonth,
     goNextMonth,
-    upsertLineAmount,
+    upsertWeekAmounts,
     submitWeekAsPm,
     closeWeekAsAdmin,
   } = useCashflowWeeks();
 
   const monthWeeks = useMemo(() => getMonthMondayWeeks(yearMonth), [yearMonth]);
   const projectWeeks = useMemo(() => weeks.filter((w) => w.projectId === projectId && w.yearMonth === yearMonth), [projectId, weeks, yearMonth]);
+  const byWeekNo = useMemo(() => {
+    const map = new Map<number, CashflowWeekSheet>();
+    for (const w of projectWeeks) map.set(w.weekNo, w);
+    return map;
+  }, [projectWeeks]);
 
   const [mode, setMode] = useState<'projection' | 'actual'>('projection');
   const [drafts, setDrafts] = useState<Record<string, string>>({});
+  const draftsRef = useRef(drafts);
+  useEffect(() => {
+    draftsRef.current = drafts;
+  }, [drafts]);
+
+  type WeekSaveState = 'dirty' | 'saving' | 'error' | 'saved';
+  const [weekSaveState, setWeekSaveState] = useState<Record<string, WeekSaveState>>({});
+  const autosaveTimersRef = useRef<Record<string, ReturnType<typeof setTimeout> | undefined>>({});
+
+  const [submitConfirm, setSubmitConfirm] = useState<{ weekNo: number; yearMonth: string } | null>(null);
+  const [submitBusy, setSubmitBusy] = useState(false);
 
   useEffect(() => {
     // Clear drafts when switching month to avoid writing into wrong docs.
     setDrafts({});
+    setWeekSaveState({});
+    setSubmitConfirm(null);
+    for (const t of Object.values(autosaveTimersRef.current)) {
+      if (t) clearTimeout(t);
+    }
+    autosaveTimersRef.current = {};
   }, [yearMonth, projectId]);
 
   const weekMeta = useMemo(() => {
     const map: Record<number, { pmSubmitted: boolean; adminClosed: boolean }> = {};
     for (const def of monthWeeks) {
-      const doc = resolveWeekDoc(projectWeeks, projectId, yearMonth, def.weekNo);
+      const doc = byWeekNo.get(def.weekNo);
       map[def.weekNo] = {
         pmSubmitted: Boolean(doc?.pmSubmitted),
         adminClosed: Boolean(doc?.adminClosed),
       };
     }
     return map;
-  }, [monthWeeks, projectId, projectWeeks, yearMonth]);
+  }, [byWeekNo, monthWeeks]);
 
-  const rowTotals = useMemo(() => {
-    const totals: Record<CashflowSheetLineId, number> = Object.fromEntries(ALL_LINES.map((id) => [id, 0])) as any;
-    for (const def of monthWeeks) {
-      const doc = resolveWeekDoc(projectWeeks, projectId, yearMonth, def.weekNo);
-      const src = (mode === 'projection' ? doc?.projection : doc?.actual) || {};
-      for (const lineId of ALL_LINES) {
-        totals[lineId] += Number(src[lineId]) || 0;
-      }
-    }
-    return totals;
-  }, [monthWeeks, mode, projectId, projectWeeks, yearMonth]);
+  function resolveWeekKey(params: { yearMonth: string; mode: 'projection' | 'actual'; weekNo: number }): string {
+    return `${params.yearMonth}:${params.mode}:${params.weekNo}`;
+  }
 
-  const weekTotals = useMemo(() => {
-    return monthWeeks.map((def) => {
-      const doc = resolveWeekDoc(projectWeeks, projectId, yearMonth, def.weekNo);
-      const src = (mode === 'projection' ? doc?.projection : doc?.actual) || {};
-      const totalIn = sumLines(src, IN_LINES);
-      const totalOut = sumLines(src, OUT_LINES);
-      return {
-        weekNo: def.weekNo,
-        totalIn,
-        totalOut,
-        net: totalIn - totalOut,
-      };
-    });
-  }, [monthWeeks, mode, projectId, projectWeeks, yearMonth]);
-
-  const monthTotals = useMemo(() => {
-    const totalIn = weekTotals.reduce((acc, w) => acc + w.totalIn, 0);
-    const totalOut = weekTotals.reduce((acc, w) => acc + w.totalOut, 0);
-    return { totalIn, totalOut, net: totalIn - totalOut };
-  }, [weekTotals]);
-
-  async function commitCell(input: {
+  function resolveCellKey(params: {
+    yearMonth: string;
+    mode: 'projection' | 'actual';
     weekNo: number;
     lineId: CashflowSheetLineId;
-    value: string;
-  }) {
+  }): string {
+    return `${resolveWeekKey(params)}:${params.lineId}`;
+  }
+
+  function getPersistedCell(params: {
+    doc: CashflowWeekSheet | undefined;
+    mode: 'projection' | 'actual';
+    lineId: CashflowSheetLineId;
+  }): { amount: number; hasValue: boolean } {
+    const src = params.mode === 'projection' ? params.doc?.projection : params.doc?.actual;
+    const hasValue = !!src && Object.prototype.hasOwnProperty.call(src, params.lineId);
+    const amount = Number(src?.[params.lineId] ?? 0);
+    return { amount, hasValue };
+  }
+
+  function getEffectiveAmount(params: {
+    yearMonth: string;
+    mode: 'projection' | 'actual';
+    weekNo: number;
+    lineId: CashflowSheetLineId;
+  }): number {
+    const doc = byWeekNo.get(params.weekNo);
+    const persisted = getPersistedCell({ doc, mode: params.mode, lineId: params.lineId });
+    const key = resolveCellKey(params);
+    const raw = Object.prototype.hasOwnProperty.call(draftsRef.current, key) ? draftsRef.current[key] : undefined;
+    return raw !== undefined ? parseAmount(raw) : persisted.amount;
+  }
+
+  const derivedByMode = useMemo(() => {
+    function compute(mode: 'projection' | 'actual') {
+      const rowTotals: Record<CashflowSheetLineId, number> = Object.fromEntries(CASHFLOW_ALL_LINES.map((id) => [id, 0])) as any;
+      const weekTotals = monthWeeks.map((def) => {
+        const totalIn = CASHFLOW_IN_LINES.reduce((acc, id) => acc + getEffectiveAmount({ yearMonth, mode, weekNo: def.weekNo, lineId: id }), 0);
+        const totalOut = CASHFLOW_OUT_LINES.reduce((acc, id) => acc + getEffectiveAmount({ yearMonth, mode, weekNo: def.weekNo, lineId: id }), 0);
+        return { weekNo: def.weekNo, totalIn, totalOut, net: totalIn - totalOut };
+      });
+
+      for (const lineId of CASHFLOW_ALL_LINES) {
+        for (const def of monthWeeks) {
+          rowTotals[lineId] += getEffectiveAmount({ yearMonth, mode, weekNo: def.weekNo, lineId });
+        }
+      }
+
+      const totalIn = weekTotals.reduce((acc, w) => acc + w.totalIn, 0);
+      const totalOut = weekTotals.reduce((acc, w) => acc + w.totalOut, 0);
+      return {
+        rowTotals,
+        weekTotals,
+        monthTotals: { totalIn, totalOut, net: totalIn - totalOut },
+      };
+    }
+
+    return {
+      projection: compute('projection'),
+      actual: compute('actual'),
+    };
+  }, [getEffectiveAmount, monthWeeks, yearMonth]);
+
+  const flushWeek = useCallback(async (input: {
+    weekNo: number;
+    mode: 'projection' | 'actual';
+    silent?: boolean;
+  }): Promise<void> => {
     if (!canEdit) return;
-    const amount = parseAmount(input.value);
-    await upsertLineAmount({
-      projectId,
-      yearMonth,
-      weekNo: input.weekNo,
-      mode,
-      lineId: input.lineId,
-      amount,
-    });
+    const wkKey = resolveWeekKey({ yearMonth, mode: input.mode, weekNo: input.weekNo });
+    const doc = byWeekNo.get(input.weekNo);
+
+    const rawByLine: Partial<Record<CashflowSheetLineId, string>> = {};
+    const amounts: Partial<Record<CashflowSheetLineId, number>> = {};
+    for (const lineId of CASHFLOW_ALL_LINES) {
+      const cellKey = resolveCellKey({ yearMonth, mode: input.mode, weekNo: input.weekNo, lineId });
+      const hasDraft = Object.prototype.hasOwnProperty.call(draftsRef.current, cellKey);
+      if (!hasDraft) continue;
+
+      const raw = draftsRef.current[cellKey];
+      rawByLine[lineId] = raw;
+
+      const nextAmount = parseAmount(raw);
+      const persisted = getPersistedCell({ doc, mode: input.mode, lineId });
+      if (nextAmount !== persisted.amount || !persisted.hasValue) {
+        amounts[lineId] = nextAmount;
+      }
+    }
+
+    // Even if nothing changed (user typed and reverted), clear redundant drafts.
+    const hasAnyDrafts = Object.keys(rawByLine).length > 0;
+    if (!hasAnyDrafts) return;
+
+    if (Object.keys(amounts).length === 0) {
+      setWeekSaveState((prev) => ({ ...prev, [wkKey]: 'saved' }));
+      setDrafts((prev) => {
+        const next = { ...prev };
+        for (const lineId of Object.keys(rawByLine) as CashflowSheetLineId[]) {
+          const key = resolveCellKey({ yearMonth, mode: input.mode, weekNo: input.weekNo, lineId });
+          if (next[key] === rawByLine[lineId]) delete next[key];
+        }
+        return next;
+      });
+      return;
+    }
+
+    setWeekSaveState((prev) => ({ ...prev, [wkKey]: 'saving' }));
+    try {
+      await upsertWeekAmounts({
+        projectId,
+        yearMonth,
+        weekNo: input.weekNo,
+        mode: input.mode,
+        amounts,
+      });
+
+      setWeekSaveState((prev) => ({ ...prev, [wkKey]: 'saved' }));
+      setDrafts((prev) => {
+        const next = { ...prev };
+        for (const lineId of Object.keys(rawByLine) as CashflowSheetLineId[]) {
+          const key = resolveCellKey({ yearMonth, mode: input.mode, weekNo: input.weekNo, lineId });
+          if (next[key] === rawByLine[lineId]) delete next[key];
+        }
+        return next;
+      });
+    } catch (error) {
+      setWeekSaveState((prev) => ({ ...prev, [wkKey]: 'error' }));
+      if (!input.silent) {
+        toast.error('저장에 실패했습니다. 네트워크/권한을 확인하고 다시 시도해 주세요.');
+      }
+      throw error;
+    }
+  }, [byWeekNo, canEdit, projectId, resolveCellKey, resolveWeekKey, upsertWeekAmounts, yearMonth]);
+
+  const scheduleAutosave = useCallback((input: { weekNo: number; mode: 'projection' | 'actual' }) => {
+    const wkKey = resolveWeekKey({ yearMonth, mode: input.mode, weekNo: input.weekNo });
+    const existing = autosaveTimersRef.current[wkKey];
+    if (existing) clearTimeout(existing);
+
+    setWeekSaveState((prev) => ({ ...prev, [wkKey]: 'dirty' }));
+    autosaveTimersRef.current[wkKey] = setTimeout(() => {
+      void flushWeek({ weekNo: input.weekNo, mode: input.mode, silent: true }).catch(() => {});
+    }, 1200);
+  }, [flushWeek, resolveWeekKey, yearMonth]);
+
+  const flushAllDirtyBeforeMonthChange = useCallback(async () => {
+    const entries = Object.entries(weekSaveState).filter(([, state]) => state === 'dirty' || state === 'error');
+    for (const [key] of entries) {
+      const parts = key.split(':');
+      // `${yearMonth}:${mode}:${weekNo}`
+      if (parts.length < 3) continue;
+      const keyYearMonth = parts[0];
+      const keyMode = parts[1] as 'projection' | 'actual';
+      const keyWeekNo = Number(parts[2]);
+      if (keyYearMonth !== yearMonth) continue;
+      if (!Number.isFinite(keyWeekNo)) continue;
+      await flushWeek({ weekNo: keyWeekNo, mode: keyMode, silent: false });
+    }
+  }, [flushWeek, weekSaveState, yearMonth]);
+
+  const goPrevMonthSafe = useCallback(() => {
+    void flushAllDirtyBeforeMonthChange()
+      .then(() => goPrevMonth())
+      .catch(() => {});
+  }, [flushAllDirtyBeforeMonthChange, goPrevMonth]);
+
+  const goNextMonthSafe = useCallback(() => {
+    void flushAllDirtyBeforeMonthChange()
+      .then(() => goNextMonth())
+      .catch(() => {});
+  }, [flushAllDirtyBeforeMonthChange, goNextMonth]);
+
+  const handleSubmitWeek = useCallback(async (input: { weekNo: number; yearMonth: string }) => {
+    setSubmitBusy(true);
+    try {
+      await flushWeek({ weekNo: input.weekNo, mode: 'actual', silent: false });
+      await submitWeekAsPm({ projectId, yearMonth: input.yearMonth, weekNo: input.weekNo });
+      toast.success('작성완료 처리했습니다.');
+    } catch (e) {
+      toast.error('작성완료 처리에 실패했습니다.');
+    } finally {
+      setSubmitBusy(false);
+      setSubmitConfirm(null);
+    }
+  }, [flushWeek, projectId, submitWeekAsPm]);
+
+  const handleCloseWeek = useCallback(async (weekNo: number) => {
+    try {
+      await flushWeek({ weekNo, mode: 'actual', silent: false });
+      await closeWeekAsAdmin({ projectId, yearMonth, weekNo });
+      toast.success('결산완료 처리했습니다.');
+    } catch (e) {
+      toast.error('결산완료 처리에 실패했습니다.');
+    }
+  }, [closeWeekAsAdmin, flushWeek, projectId, yearMonth]);
+
+  function countEmptyCellsForWeek(input: { weekNo: number; mode: 'projection' | 'actual' }): number {
+    const doc = byWeekNo.get(input.weekNo);
+    let empty = 0;
+    for (const lineId of CASHFLOW_ALL_LINES) {
+      const persisted = getPersistedCell({ doc, mode: input.mode, lineId });
+      const key = resolveCellKey({ yearMonth, mode: input.mode, weekNo: input.weekNo, lineId });
+      const raw = Object.prototype.hasOwnProperty.call(draftsRef.current, key) ? draftsRef.current[key] : undefined;
+      const filled = persisted.hasValue || (typeof raw === 'string' && raw.trim() !== '');
+      if (!filled) empty += 1;
+    }
+    return empty;
+  }
+
+  function renderSheetTable(tableMode: 'projection' | 'actual') {
+    const derived = tableMode === 'projection' ? derivedByMode.projection : derivedByMode.actual;
+    return (
+      <Card className="overflow-hidden">
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <table className="min-w-[860px] w-full text-[11px]">
+              <thead>
+                <tr className="bg-muted/30">
+                  <th className="px-4 py-2 text-left" style={{ fontWeight: 700, minWidth: 180 }}>항목</th>
+                  {monthWeeks.map((w) => {
+                    const wkKey = resolveWeekKey({ yearMonth, mode: tableMode, weekNo: w.weekNo });
+                    const saveState = weekSaveState[wkKey];
+                    const doc = byWeekNo.get(w.weekNo);
+                    const isThisWeek = todayYearMonth === yearMonth && todayIso >= w.weekStart && todayIso <= w.weekEnd;
+                    const colClass = isThisWeek ? 'bg-teal-50/40 dark:bg-teal-950/10' : '';
+
+                    return (
+                      <th key={w.weekNo} className={`px-3 py-2 text-right ${colClass}`} style={{ fontWeight: 700, minWidth: 150 }}>
+                        <div className="flex items-center justify-end gap-2">
+                          <span>{w.label}</span>
+                          {weekMeta[w.weekNo]?.adminClosed ? (
+                            <Badge className="h-4 px-1 text-[9px] bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border-0">결산</Badge>
+                          ) : weekMeta[w.weekNo]?.pmSubmitted ? (
+                            <Badge className="h-4 px-1 text-[9px] bg-amber-500/15 text-amber-700 dark:text-amber-300 border-0">작성</Badge>
+                          ) : (
+                            <Badge className="h-4 px-1 text-[9px] bg-slate-500/10 text-slate-600 dark:text-slate-300 border-0">미작성</Badge>
+                          )}
+                          {saveState === 'dirty' && (
+                            <Badge className="h-4 px-1 text-[9px] bg-sky-500/15 text-sky-700 dark:text-sky-300 border-0">미저장</Badge>
+                          )}
+                          {saveState === 'saving' && (
+                            <Badge className="h-4 px-1 text-[9px] bg-slate-500/10 text-slate-600 dark:text-slate-300 border-0">저장중</Badge>
+                          )}
+                          {saveState === 'error' && (
+                            <Badge className="h-4 px-1 text-[9px] bg-rose-500/15 text-rose-700 dark:text-rose-300 border-0">오류</Badge>
+                          )}
+                        </div>
+                        <div className="text-[9px] text-muted-foreground mt-0.5">{w.weekStart} ~ {w.weekEnd}</div>
+                        <div className="mt-2 flex items-center justify-end gap-1.5">
+                          {canEdit && !weekMeta[w.weekNo]?.adminClosed && (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="h-7 text-[10px] gap-1"
+                              onClick={() => void flushWeek({ weekNo: w.weekNo, mode: tableMode, silent: false }).catch(() => {})}
+                            >
+                              저장
+                            </Button>
+                          )}
+                          {tableMode === 'actual' && !weekMeta[w.weekNo]?.pmSubmitted && isPm && (
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="h-7 text-[10px] gap-1"
+                              onClick={() => setSubmitConfirm({ weekNo: w.weekNo, yearMonth })}
+                            >
+                              <CheckCircle2 className="w-3 h-3" /> 작성완료
+                            </Button>
+                          )}
+                          {tableMode === 'actual' && !weekMeta[w.weekNo]?.adminClosed && canClose && (
+                            <Button
+                              size="sm"
+                              className="h-7 text-[10px] gap-1"
+                              onClick={() => void handleCloseWeek(w.weekNo)}
+                              style={{ background: 'linear-gradient(135deg, #059669, #0d9488)' }}
+                            >
+                              <CheckCircle2 className="w-3 h-3" /> 결산완료
+                            </Button>
+                          )}
+                        </div>
+                        {doc?.adminClosed && (
+                          <div className="mt-1 text-[9px] text-muted-foreground">결산완료 이후 입력이 잠깁니다.</div>
+                        )}
+                      </th>
+                    );
+                  })}
+                  <th className="px-3 py-2 text-right" style={{ fontWeight: 700, minWidth: 120 }}>월 합계</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="bg-emerald-50/40 dark:bg-emerald-950/10">
+                  <td className="px-4 py-2" colSpan={monthWeeks.length + 2} style={{ fontWeight: 700 }}>
+                    입금 ({tableMode === 'projection' ? 'Projection' : 'Actual'})
+                  </td>
+                </tr>
+                {CASHFLOW_IN_LINES.map((lineId) => (
+                  <tr key={lineId} className="border-t border-border/30">
+                    <td className="px-4 py-2" style={{ fontWeight: 500 }}>{CASHFLOW_SHEET_LINE_LABELS[lineId]}</td>
+                    {monthWeeks.map((w) => {
+                      const doc = byWeekNo.get(w.weekNo);
+                      const persisted = getPersistedCell({ doc, mode: tableMode, lineId });
+                      const key = resolveCellKey({ yearMonth, mode: tableMode, weekNo: w.weekNo, lineId });
+                      const raw = Object.prototype.hasOwnProperty.call(drafts, key) ? drafts[key] : undefined;
+                      const value = raw !== undefined ? raw : (persisted.hasValue ? String(persisted.amount) : '');
+                      const isThisWeek = todayYearMonth === yearMonth && todayIso >= w.weekStart && todayIso <= w.weekEnd;
+                      const colClass = isThisWeek ? 'bg-teal-50/30 dark:bg-teal-950/10' : '';
+
+                      return (
+                        <td key={w.weekNo} className={`px-3 py-1.5 text-right ${colClass}`}>
+                          <Input
+                            value={value}
+                            inputMode="numeric"
+                            className="h-8 text-[11px] text-right"
+                            placeholder="0"
+                            disabled={!canEdit || weekMeta[w.weekNo]?.adminClosed}
+                            onChange={(e) => {
+                              setDrafts((prev) => ({ ...prev, [key]: e.target.value }));
+                              scheduleAutosave({ weekNo: w.weekNo, mode: tableMode });
+                            }}
+                          />
+                        </td>
+                      );
+                    })}
+                    <td className="px-3 py-2 text-right" style={{ fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>
+                      {fmt(derived.rowTotals[lineId] || 0)}
+                    </td>
+                  </tr>
+                ))}
+
+                <tr className="border-t border-border/50 bg-rose-50/30 dark:bg-rose-950/10">
+                  <td className="px-4 py-2" colSpan={monthWeeks.length + 2} style={{ fontWeight: 700 }}>
+                    출금 ({tableMode === 'projection' ? 'Projection' : 'Actual'})
+                  </td>
+                </tr>
+                {CASHFLOW_OUT_LINES.map((lineId) => (
+                  <tr key={lineId} className="border-t border-border/30">
+                    <td className="px-4 py-2" style={{ fontWeight: 500 }}>{CASHFLOW_SHEET_LINE_LABELS[lineId]}</td>
+                    {monthWeeks.map((w) => {
+                      const doc = byWeekNo.get(w.weekNo);
+                      const persisted = getPersistedCell({ doc, mode: tableMode, lineId });
+                      const key = resolveCellKey({ yearMonth, mode: tableMode, weekNo: w.weekNo, lineId });
+                      const raw = Object.prototype.hasOwnProperty.call(drafts, key) ? drafts[key] : undefined;
+                      const value = raw !== undefined ? raw : (persisted.hasValue ? String(persisted.amount) : '');
+                      const isThisWeek = todayYearMonth === yearMonth && todayIso >= w.weekStart && todayIso <= w.weekEnd;
+                      const colClass = isThisWeek ? 'bg-teal-50/30 dark:bg-teal-950/10' : '';
+
+                      return (
+                        <td key={w.weekNo} className={`px-3 py-1.5 text-right ${colClass}`}>
+                          <Input
+                            value={value}
+                            inputMode="numeric"
+                            className="h-8 text-[11px] text-right"
+                            placeholder="0"
+                            disabled={!canEdit || weekMeta[w.weekNo]?.adminClosed}
+                            onChange={(e) => {
+                              setDrafts((prev) => ({ ...prev, [key]: e.target.value }));
+                              scheduleAutosave({ weekNo: w.weekNo, mode: tableMode });
+                            }}
+                          />
+                        </td>
+                      );
+                    })}
+                    <td className="px-3 py-2 text-right" style={{ fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>
+                      {fmt(derived.rowTotals[lineId] || 0)}
+                    </td>
+                  </tr>
+                ))}
+
+                <tr className="border-t border-border/50 bg-muted/40">
+                  <td className="px-4 py-2" style={{ fontWeight: 800 }}>입금 합계</td>
+                  {derived.weekTotals.map((w) => (
+                    <td key={w.weekNo} className="px-3 py-2 text-right" style={{ fontWeight: 800, color: '#059669' }}>
+                      {fmt(w.totalIn)}
+                    </td>
+                  ))}
+                  <td className="px-3 py-2 text-right" style={{ fontWeight: 900, color: '#059669' }}>
+                    {fmt(derived.monthTotals.totalIn)}
+                  </td>
+                </tr>
+                <tr className="border-t border-border/30 bg-muted/40">
+                  <td className="px-4 py-2" style={{ fontWeight: 800 }}>출금 합계</td>
+                  {derived.weekTotals.map((w) => (
+                    <td key={w.weekNo} className="px-3 py-2 text-right" style={{ fontWeight: 800, color: '#e11d48' }}>
+                      {fmt(w.totalOut)}
+                    </td>
+                  ))}
+                  <td className="px-3 py-2 text-right" style={{ fontWeight: 900, color: '#e11d48' }}>
+                    {fmt(derived.monthTotals.totalOut)}
+                  </td>
+                </tr>
+                <tr className="border-t border-border/30 bg-muted/40">
+                  <td className="px-4 py-2" style={{ fontWeight: 900 }}>NET</td>
+                  {derived.weekTotals.map((w) => (
+                    <td key={w.weekNo} className="px-3 py-2 text-right" style={{ fontWeight: 900, color: w.net >= 0 ? '#059669' : '#e11d48' }}>
+                      {fmt(w.net)}
+                    </td>
+                  ))}
+                  <td className="px-3 py-2 text-right" style={{ fontWeight: 900, color: derived.monthTotals.net >= 0 ? '#059669' : '#e11d48' }}>
+                    {fmt(derived.monthTotals.net)}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          {isLoading && (
+            <div className="px-4 py-3 text-[11px] text-muted-foreground">불러오는 중…</div>
+          )}
+        </CardContent>
+      </Card>
+    );
   }
 
   return (
@@ -152,10 +526,10 @@ export function CashflowProjectSheet({ projectId, projectName }: { projectId: st
         description={`${projectName} · ${yearMonth}`}
         actions={(
           <div className="flex items-center gap-2">
-            <Button variant="outline" size="sm" className="h-8 text-[12px] gap-1.5" onClick={goPrevMonth}>
+            <Button variant="outline" size="sm" className="h-8 text-[12px] gap-1.5" onClick={goPrevMonthSafe}>
               <ChevronLeft className="w-3.5 h-3.5" /> 이전 달
             </Button>
-            <Button variant="outline" size="sm" className="h-8 text-[12px] gap-1.5" onClick={goNextMonth}>
+            <Button variant="outline" size="sm" className="h-8 text-[12px] gap-1.5" onClick={goNextMonthSafe}>
               다음 달 <ChevronRight className="w-3.5 h-3.5" />
             </Button>
           </div>
@@ -175,326 +549,64 @@ export function CashflowProjectSheet({ projectId, projectName }: { projectId: st
         </TabsList>
 
         <TabsContent value="projection">
-          <Card className="overflow-hidden">
-            <CardContent className="p-0">
-              <div className="overflow-x-auto">
-                <table className="min-w-[860px] w-full text-[11px]">
-                  <thead>
-                    <tr className="bg-muted/30">
-                      <th className="px-4 py-2 text-left" style={{ fontWeight: 700, minWidth: 180 }}>항목</th>
-                      {monthWeeks.map((w) => (
-                        <th key={w.weekNo} className="px-3 py-2 text-right" style={{ fontWeight: 700, minWidth: 150 }}>
-                          <div className="flex items-center justify-end gap-2">
-                            <span>{w.label}</span>
-                            {weekMeta[w.weekNo]?.adminClosed ? (
-                              <Badge className="h-4 px-1 text-[9px] bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border-0">결산</Badge>
-                            ) : weekMeta[w.weekNo]?.pmSubmitted ? (
-                              <Badge className="h-4 px-1 text-[9px] bg-amber-500/15 text-amber-700 dark:text-amber-300 border-0">작성</Badge>
-                            ) : (
-                              <Badge className="h-4 px-1 text-[9px] bg-slate-500/10 text-slate-600 dark:text-slate-300 border-0">미작성</Badge>
-                            )}
-                          </div>
-                          <div className="text-[9px] text-muted-foreground mt-0.5">{w.weekStart} ~ {w.weekEnd}</div>
-                        </th>
-                      ))}
-                      <th className="px-3 py-2 text-right" style={{ fontWeight: 700, minWidth: 120 }}>월 합계</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {/* IN group */}
-                    <tr className="bg-emerald-50/40 dark:bg-emerald-950/10">
-                      <td className="px-4 py-2" colSpan={monthWeeks.length + 2} style={{ fontWeight: 700 }}>입금 (Projection)</td>
-                    </tr>
-                    {IN_LINES.map((lineId) => (
-                      <tr key={lineId} className="border-t border-border/30">
-                        <td className="px-4 py-2" style={{ fontWeight: 500 }}>{CASHFLOW_SHEET_LINE_LABELS[lineId]}</td>
-                        {monthWeeks.map((w) => {
-                          const doc = resolveWeekDoc(projectWeeks, projectId, yearMonth, w.weekNo);
-                          const current = (doc?.projection?.[lineId] ?? 0) as number;
-                          const key = `${mode}:${w.weekNo}:${lineId}`;
-                          const value = Object.prototype.hasOwnProperty.call(drafts, key) ? drafts[key] : (current ? String(current) : '');
-                          return (
-                            <td key={w.weekNo} className="px-3 py-1.5 text-right">
-                              <Input
-                                value={value}
-                                inputMode="numeric"
-                                className="h-8 text-[11px] text-right"
-                                placeholder="0"
-                                disabled={!canEdit || weekMeta[w.weekNo]?.adminClosed}
-                                onChange={(e) => setDrafts((prev) => ({ ...prev, [key]: e.target.value }))}
-                                onBlur={() => {
-                                  const nextValue = drafts[key] ?? value;
-                                  setDrafts((prev) => {
-                                    const clone = { ...prev };
-                                    delete clone[key];
-                                    return clone;
-                                  });
-                                  void commitCell({ weekNo: w.weekNo, lineId, value: nextValue });
-                                }}
-                              />
-                            </td>
-                          );
-                        })}
-                        <td className="px-3 py-2 text-right" style={{ fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>
-                          {fmt(rowTotals[lineId] || 0)}
-                        </td>
-                      </tr>
-                    ))}
-
-                    {/* OUT group */}
-                    <tr className="border-t border-border/50 bg-rose-50/30 dark:bg-rose-950/10">
-                      <td className="px-4 py-2" colSpan={monthWeeks.length + 2} style={{ fontWeight: 700 }}>출금 (Projection)</td>
-                    </tr>
-                    {OUT_LINES.map((lineId) => (
-                      <tr key={lineId} className="border-t border-border/30">
-                        <td className="px-4 py-2" style={{ fontWeight: 500 }}>{CASHFLOW_SHEET_LINE_LABELS[lineId]}</td>
-                        {monthWeeks.map((w) => {
-                          const doc = resolveWeekDoc(projectWeeks, projectId, yearMonth, w.weekNo);
-                          const current = (doc?.projection?.[lineId] ?? 0) as number;
-                          const key = `${mode}:${w.weekNo}:${lineId}`;
-                          const value = Object.prototype.hasOwnProperty.call(drafts, key) ? drafts[key] : (current ? String(current) : '');
-                          return (
-                            <td key={w.weekNo} className="px-3 py-1.5 text-right">
-                              <Input
-                                value={value}
-                                inputMode="numeric"
-                                className="h-8 text-[11px] text-right"
-                                placeholder="0"
-                                disabled={!canEdit || weekMeta[w.weekNo]?.adminClosed}
-                                onChange={(e) => setDrafts((prev) => ({ ...prev, [key]: e.target.value }))}
-                                onBlur={() => {
-                                  const nextValue = drafts[key] ?? value;
-                                  setDrafts((prev) => {
-                                    const clone = { ...prev };
-                                    delete clone[key];
-                                    return clone;
-                                  });
-                                  void commitCell({ weekNo: w.weekNo, lineId, value: nextValue });
-                                }}
-                              />
-                            </td>
-                          );
-                        })}
-                        <td className="px-3 py-2 text-right" style={{ fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>
-                          {fmt(rowTotals[lineId] || 0)}
-                        </td>
-                      </tr>
-                    ))}
-
-                    {/* Totals */}
-                    <tr className="border-t border-border/50 bg-muted/40">
-                      <td className="px-4 py-2" style={{ fontWeight: 800 }}>입금 합계</td>
-                      {weekTotals.map((w) => (
-                        <td key={w.weekNo} className="px-3 py-2 text-right" style={{ fontWeight: 800, color: '#059669' }}>
-                          {fmt(w.totalIn)}
-                        </td>
-                      ))}
-                      <td className="px-3 py-2 text-right" style={{ fontWeight: 900, color: '#059669' }}>
-                        {fmt(monthTotals.totalIn)}
-                      </td>
-                    </tr>
-                    <tr className="border-t border-border/30 bg-muted/40">
-                      <td className="px-4 py-2" style={{ fontWeight: 800 }}>출금 합계</td>
-                      {weekTotals.map((w) => (
-                        <td key={w.weekNo} className="px-3 py-2 text-right" style={{ fontWeight: 800, color: '#e11d48' }}>
-                          {fmt(w.totalOut)}
-                        </td>
-                      ))}
-                      <td className="px-3 py-2 text-right" style={{ fontWeight: 900, color: '#e11d48' }}>
-                        {fmt(monthTotals.totalOut)}
-                      </td>
-                    </tr>
-                    <tr className="border-t border-border/30 bg-muted/40">
-                      <td className="px-4 py-2" style={{ fontWeight: 900 }}>NET</td>
-                      {weekTotals.map((w) => (
-                        <td key={w.weekNo} className="px-3 py-2 text-right" style={{ fontWeight: 900, color: w.net >= 0 ? '#059669' : '#e11d48' }}>
-                          {fmt(w.net)}
-                        </td>
-                      ))}
-                      <td className="px-3 py-2 text-right" style={{ fontWeight: 900, color: monthTotals.net >= 0 ? '#059669' : '#e11d48' }}>
-                        {fmt(monthTotals.net)}
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-              {isLoading && (
-                <div className="px-4 py-3 text-[11px] text-muted-foreground">불러오는 중…</div>
-              )}
-            </CardContent>
-          </Card>
+          {renderSheetTable('projection')}
         </TabsContent>
 
         <TabsContent value="actual">
-          <Card className="overflow-hidden">
-            <CardContent className="p-0">
-              <div className="overflow-x-auto">
-                <table className="min-w-[860px] w-full text-[11px]">
-                  <thead>
-                    <tr className="bg-muted/30">
-                      <th className="px-4 py-2 text-left" style={{ fontWeight: 700, minWidth: 180 }}>항목</th>
-                      {monthWeeks.map((w) => (
-                        <th key={w.weekNo} className="px-3 py-2 text-right" style={{ fontWeight: 700, minWidth: 150 }}>
-                          <div className="flex items-center justify-end gap-2">
-                            <span>{w.label}</span>
-                            {weekMeta[w.weekNo]?.adminClosed ? (
-                              <Badge className="h-4 px-1 text-[9px] bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 border-0">결산</Badge>
-                            ) : weekMeta[w.weekNo]?.pmSubmitted ? (
-                              <Badge className="h-4 px-1 text-[9px] bg-amber-500/15 text-amber-700 dark:text-amber-300 border-0">작성</Badge>
-                            ) : (
-                              <Badge className="h-4 px-1 text-[9px] bg-slate-500/10 text-slate-600 dark:text-slate-300 border-0">미작성</Badge>
-                            )}
-                          </div>
-                          <div className="text-[9px] text-muted-foreground mt-0.5">{w.weekStart} ~ {w.weekEnd}</div>
-                          <div className="mt-2 flex items-center justify-end gap-1.5">
-                            {!weekMeta[w.weekNo]?.pmSubmitted && isPm && (
-                              <Button
-                                size="sm"
-                                variant="outline"
-                                className="h-7 text-[10px] gap-1"
-                                onClick={() => void submitWeekAsPm({ projectId, yearMonth, weekNo: w.weekNo })}
-                              >
-                                <CheckCircle2 className="w-3 h-3" /> 작성완료
-                              </Button>
-                            )}
-                            {!weekMeta[w.weekNo]?.adminClosed && canClose && (
-                              <Button
-                                size="sm"
-                                className="h-7 text-[10px] gap-1"
-                                onClick={() => void closeWeekAsAdmin({ projectId, yearMonth, weekNo: w.weekNo })}
-                                style={{ background: 'linear-gradient(135deg, #059669, #0d9488)' }}
-                              >
-                                <CheckCircle2 className="w-3 h-3" /> 결산완료
-                              </Button>
-                            )}
-                          </div>
-                        </th>
-                      ))}
-                      <th className="px-3 py-2 text-right" style={{ fontWeight: 700, minWidth: 120 }}>월 합계</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr className="bg-emerald-50/40 dark:bg-emerald-950/10">
-                      <td className="px-4 py-2" colSpan={monthWeeks.length + 2} style={{ fontWeight: 700 }}>입금 (Actual)</td>
-                    </tr>
-                    {IN_LINES.map((lineId) => (
-                      <tr key={lineId} className="border-t border-border/30">
-                        <td className="px-4 py-2" style={{ fontWeight: 500 }}>{CASHFLOW_SHEET_LINE_LABELS[lineId]}</td>
-                        {monthWeeks.map((w) => {
-                          const doc = resolveWeekDoc(projectWeeks, projectId, yearMonth, w.weekNo);
-                          const current = (doc?.actual?.[lineId] ?? 0) as number;
-                          const key = `${mode}:${w.weekNo}:${lineId}`;
-                          const value = Object.prototype.hasOwnProperty.call(drafts, key) ? drafts[key] : (current ? String(current) : '');
-                          return (
-                            <td key={w.weekNo} className="px-3 py-1.5 text-right">
-                              <Input
-                                value={value}
-                                inputMode="numeric"
-                                className="h-8 text-[11px] text-right"
-                                placeholder="0"
-                                disabled={!canEdit || weekMeta[w.weekNo]?.adminClosed}
-                                onChange={(e) => setDrafts((prev) => ({ ...prev, [key]: e.target.value }))}
-                                onBlur={() => {
-                                  const nextValue = drafts[key] ?? value;
-                                  setDrafts((prev) => {
-                                    const clone = { ...prev };
-                                    delete clone[key];
-                                    return clone;
-                                  });
-                                  void commitCell({ weekNo: w.weekNo, lineId, value: nextValue });
-                                }}
-                              />
-                            </td>
-                          );
-                        })}
-                        <td className="px-3 py-2 text-right" style={{ fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>
-                          {fmt(rowTotals[lineId] || 0)}
-                        </td>
-                      </tr>
-                    ))}
-
-                    <tr className="border-t border-border/50 bg-rose-50/30 dark:bg-rose-950/10">
-                      <td className="px-4 py-2" colSpan={monthWeeks.length + 2} style={{ fontWeight: 700 }}>출금 (Actual)</td>
-                    </tr>
-                    {OUT_LINES.map((lineId) => (
-                      <tr key={lineId} className="border-t border-border/30">
-                        <td className="px-4 py-2" style={{ fontWeight: 500 }}>{CASHFLOW_SHEET_LINE_LABELS[lineId]}</td>
-                        {monthWeeks.map((w) => {
-                          const doc = resolveWeekDoc(projectWeeks, projectId, yearMonth, w.weekNo);
-                          const current = (doc?.actual?.[lineId] ?? 0) as number;
-                          const key = `${mode}:${w.weekNo}:${lineId}`;
-                          const value = Object.prototype.hasOwnProperty.call(drafts, key) ? drafts[key] : (current ? String(current) : '');
-                          return (
-                            <td key={w.weekNo} className="px-3 py-1.5 text-right">
-                              <Input
-                                value={value}
-                                inputMode="numeric"
-                                className="h-8 text-[11px] text-right"
-                                placeholder="0"
-                                disabled={!canEdit || weekMeta[w.weekNo]?.adminClosed}
-                                onChange={(e) => setDrafts((prev) => ({ ...prev, [key]: e.target.value }))}
-                                onBlur={() => {
-                                  const nextValue = drafts[key] ?? value;
-                                  setDrafts((prev) => {
-                                    const clone = { ...prev };
-                                    delete clone[key];
-                                    return clone;
-                                  });
-                                  void commitCell({ weekNo: w.weekNo, lineId, value: nextValue });
-                                }}
-                              />
-                            </td>
-                          );
-                        })}
-                        <td className="px-3 py-2 text-right" style={{ fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>
-                          {fmt(rowTotals[lineId] || 0)}
-                        </td>
-                      </tr>
-                    ))}
-
-                    <tr className="border-t border-border/50 bg-muted/40">
-                      <td className="px-4 py-2" style={{ fontWeight: 800 }}>입금 합계</td>
-                      {weekTotals.map((w) => (
-                        <td key={w.weekNo} className="px-3 py-2 text-right" style={{ fontWeight: 800, color: '#059669' }}>
-                          {fmt(w.totalIn)}
-                        </td>
-                      ))}
-                      <td className="px-3 py-2 text-right" style={{ fontWeight: 900, color: '#059669' }}>
-                        {fmt(monthTotals.totalIn)}
-                      </td>
-                    </tr>
-                    <tr className="border-t border-border/30 bg-muted/40">
-                      <td className="px-4 py-2" style={{ fontWeight: 800 }}>출금 합계</td>
-                      {weekTotals.map((w) => (
-                        <td key={w.weekNo} className="px-3 py-2 text-right" style={{ fontWeight: 800, color: '#e11d48' }}>
-                          {fmt(w.totalOut)}
-                        </td>
-                      ))}
-                      <td className="px-3 py-2 text-right" style={{ fontWeight: 900, color: '#e11d48' }}>
-                        {fmt(monthTotals.totalOut)}
-                      </td>
-                    </tr>
-                    <tr className="border-t border-border/30 bg-muted/40">
-                      <td className="px-4 py-2" style={{ fontWeight: 900 }}>NET</td>
-                      {weekTotals.map((w) => (
-                        <td key={w.weekNo} className="px-3 py-2 text-right" style={{ fontWeight: 900, color: w.net >= 0 ? '#059669' : '#e11d48' }}>
-                          {fmt(w.net)}
-                        </td>
-                      ))}
-                      <td className="px-3 py-2 text-right" style={{ fontWeight: 900, color: monthTotals.net >= 0 ? '#059669' : '#e11d48' }}>
-                        {fmt(monthTotals.net)}
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-              {isLoading && (
-                <div className="px-4 py-3 text-[11px] text-muted-foreground">불러오는 중…</div>
-              )}
-            </CardContent>
-          </Card>
+          {renderSheetTable('actual')}
         </TabsContent>
       </Tabs>
+
+      <AlertDialog
+        open={!!submitConfirm}
+        onOpenChange={(open) => {
+          if (!open) setSubmitConfirm(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>이번 주차를 작성완료 처리할까요?</AlertDialogTitle>
+            <AlertDialogDescription>
+              작성완료 후에는 관리자 결산 전까지 수정은 가능하지만, 승인/결산 흐름이 시작됩니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          {submitConfirm && (
+            <div className="text-sm space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">주차</span>
+                <span style={{ fontWeight: 700 }}>
+                  {monthWeeks.find((x) => x.weekNo === submitConfirm.weekNo)?.label || `w${submitConfirm.weekNo}`}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">기간</span>
+                <span style={{ fontVariantNumeric: 'tabular-nums' }}>
+                  {monthWeeks.find((x) => x.weekNo === submitConfirm.weekNo)?.weekStart} ~ {monthWeeks.find((x) => x.weekNo === submitConfirm.weekNo)?.weekEnd}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">비어있는 항목</span>
+                <span style={{ fontWeight: 700 }}>
+                  {countEmptyCellsForWeek({ weekNo: submitConfirm.weekNo, mode: 'actual' })} / {CASHFLOW_ALL_LINES.length}
+                </span>
+              </div>
+            </div>
+          )}
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={submitBusy}>취소</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={!submitConfirm || submitBusy}
+              onClick={(e) => {
+                e.preventDefault();
+                if (!submitConfirm) return;
+                void handleSubmitWeek(submitConfirm);
+              }}
+            >
+              {submitBusy ? '처리 중…' : '작성완료'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/app/data/cashflow-weeks.helpers.test.ts
+++ b/src/app/data/cashflow-weeks.helpers.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { resolveFirestoreErrorCode, shouldCreateDocOnUpdateError } from './cashflow-weeks.helpers';
+
+describe('cashflow weeks helpers', () => {
+  it('resolves firestore error codes', () => {
+    expect(resolveFirestoreErrorCode({ code: 'not-found' })).toBe('not-found');
+    expect(resolveFirestoreErrorCode({ code: 123 })).toBe('');
+    expect(resolveFirestoreErrorCode(null)).toBe('');
+  });
+
+  it('creates docs only when update failed due to missing document', () => {
+    expect(shouldCreateDocOnUpdateError({ code: 'not-found' })).toBe(true);
+    expect(shouldCreateDocOnUpdateError({ code: 'permission-denied' })).toBe(false);
+    expect(shouldCreateDocOnUpdateError({})).toBe(false);
+  });
+});
+

--- a/src/app/data/cashflow-weeks.helpers.ts
+++ b/src/app/data/cashflow-weeks.helpers.ts
@@ -1,0 +1,10 @@
+export function resolveFirestoreErrorCode(error: unknown): string {
+  if (!error || typeof error !== 'object') return '';
+  const maybe = error as { code?: unknown };
+  return typeof maybe.code === 'string' ? maybe.code : '';
+}
+
+export function shouldCreateDocOnUpdateError(error: unknown): boolean {
+  return resolveFirestoreErrorCode(error) === 'not-found';
+}
+

--- a/src/app/platform/cashflow-sheet.test.ts
+++ b/src/app/platform/cashflow-sheet.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { chooseCashflowSheetForNet, computeCashflowTotals } from './cashflow-sheet';
+
+describe('cashflow sheet', () => {
+  it('computes totals for empty sheets', () => {
+    expect(computeCashflowTotals(undefined)).toEqual({ totalIn: 0, totalOut: 0, net: 0 });
+    expect(computeCashflowTotals({})).toEqual({ totalIn: 0, totalOut: 0, net: 0 });
+  });
+
+  it('computes totals for partial sheets', () => {
+    const { totalIn, totalOut, net } = computeCashflowTotals({
+      MYSC_PREPAY_IN: 5_000_000,
+      TEAM_SUPPORT_IN: 1_000_000,
+      DIRECT_COST_OUT: 1_000_000,
+      MYSC_LABOR_OUT: 500_000,
+    });
+    expect(totalIn).toBe(6_000_000);
+    expect(totalOut).toBe(1_500_000);
+    expect(net).toBe(4_500_000);
+  });
+
+  it('chooses actual when any keys exist, otherwise projection', () => {
+    expect(chooseCashflowSheetForNet({ actual: undefined, projection: { SALES_IN: 100 } })).toEqual({
+      source: 'projection',
+      sheet: { SALES_IN: 100 },
+    });
+
+    expect(chooseCashflowSheetForNet({ actual: {}, projection: { SALES_IN: 100 } })).toEqual({
+      source: 'projection',
+      sheet: { SALES_IN: 100 },
+    });
+
+    expect(chooseCashflowSheetForNet({ actual: { SALES_IN: 0 }, projection: { SALES_IN: 100 } })).toEqual({
+      source: 'actual',
+      sheet: { SALES_IN: 0 },
+    });
+  });
+});
+

--- a/src/app/platform/cashflow-sheet.ts
+++ b/src/app/platform/cashflow-sheet.ts
@@ -1,0 +1,50 @@
+import type { CashflowSheetLineId } from '../data/types';
+
+export const CASHFLOW_IN_LINES: CashflowSheetLineId[] = [
+  'MYSC_PREPAY_IN',
+  'SALES_IN',
+  'SALES_VAT_IN',
+  'TEAM_SUPPORT_IN',
+  'BANK_INTEREST_IN',
+];
+
+export const CASHFLOW_OUT_LINES: CashflowSheetLineId[] = [
+  'DIRECT_COST_OUT',
+  'INPUT_VAT_OUT',
+  'MYSC_LABOR_OUT',
+  'MYSC_PROFIT_OUT',
+  'SALES_VAT_OUT',
+  'TEAM_SUPPORT_OUT',
+  'BANK_INTEREST_OUT',
+];
+
+export const CASHFLOW_ALL_LINES: CashflowSheetLineId[] = [...CASHFLOW_IN_LINES, ...CASHFLOW_OUT_LINES];
+
+export interface CashflowTotals {
+  totalIn: number;
+  totalOut: number;
+  net: number;
+}
+
+export function computeCashflowTotals(
+  sheet: Partial<Record<CashflowSheetLineId, number>> | undefined,
+): CashflowTotals {
+  const src = sheet || {};
+
+  const totalIn = CASHFLOW_IN_LINES.reduce((acc, id) => acc + (Number(src[id]) || 0), 0);
+  const totalOut = CASHFLOW_OUT_LINES.reduce((acc, id) => acc + (Number(src[id]) || 0), 0);
+  return { totalIn, totalOut, net: totalIn - totalOut };
+}
+
+export function hasAnyCashflowKeys(sheet: Partial<Record<CashflowSheetLineId, number>> | undefined): boolean {
+  return !!sheet && Object.keys(sheet).length > 0;
+}
+
+export function chooseCashflowSheetForNet(input: {
+  actual: Partial<Record<CashflowSheetLineId, number>> | undefined;
+  projection: Partial<Record<CashflowSheetLineId, number>> | undefined;
+}): { source: 'actual' | 'projection'; sheet: Partial<Record<CashflowSheetLineId, number>> } {
+  if (hasAnyCashflowKeys(input.actual)) return { source: 'actual', sheet: input.actual || {} };
+  return { source: 'projection', sheet: input.projection || {} };
+}
+


### PR DESCRIPTION
## PR 요약

- 문제: 주간 캐시플로 시트가 셀 단위(onBlur)로 Firestore write를 발생시켜 비용/성능 리스크가 있었고, update 실패 시 silent setDoc fallback으로 데이터 유실 가능성이 있었습니다.
- 해결: 주차 단위(1.2s debounce)로 변경 사항을 배치 저장하고, Firestore update 실패 시 not-found일 때만 문서 생성하도록 안전하게 처리했습니다.
- 기대 효과: write 폭발 방지, 데이터 유실 방지, PM/관리자 입력 UX 개선(이번 주 하이라이트/작성완료 확인), 전사 현황에서 미래 주차 NET(예상) 가시화.

## 변경 범위

- [x] 프론트엔드(UI/페이지)
- [ ] BFF/API
- [ ] Firebase/Firestore 설정
- [ ] 운영 스크립트(scripts)
- [ ] 워커/스케줄링(outbox/work_queue)
- [ ] 문서(README/guidelines)
- [ ] 기타

## 비개발자용 설명

- 캐시플로 시트는 이제 "칸을 나갈 때마다" 저장하지 않고, 같은 주차에서 입력한 내용을 모아서 자동 저장합니다(짧게 기다리면 저장).
- 각 주차 상단에 "미저장/저장중/오류" 표시가 생겨서, 저장 상태를 바로 확인할 수 있습니다.
- PM이 "작성완료"를 누르기 전에 확인창이 떠서 실수로 제출하는 것을 줄입니다.
- 전사 현황 화면의 NET은 실적(Actual)이 없으면 계획(Projection)으로 "예상" NET을 보여줍니다.

## Firestore 자동화 실행 증거 (해당 시 필수)

해당 없음(규칙/인덱스 변경 없음).

## 테스트/검증

- [x] `npm test` 통과
- [x] `npm run build` 통과
- [x] 기능 수동 검증 완료
- [x] 문서와 실제 동작 일치 확인

검증 결과 요약:
- 단위 테스트: 통과
- BFF 통합 테스트(에뮬레이터): `npm run bff:test:integration` 통과
- 수동 확인:
  - `/cashflow/projects/:projectId`에서 입력 시 주차 단위로 저장(미저장→저장중→저장됨)
  - 이번 주 컬럼 하이라이트 확인
  - Actual 탭에서 작성완료 클릭 시 확인 다이얼로그 노출
  - `/cashflow/weekly`에서 NET이 (예상)으로 표시되는 경우 확인

## 수동 작업 필요 항목 (운영/관리자)

- [ ] Firebase Console에서 Google Provider 활성화 확인
- [ ] IAM/보안 승인 확인
- [ ] Vercel 환경변수 반영 후 redeploy
- [ ] Vercel Cron 또는 외부 워커 런타임 구성(outbox/work_queue)
- [ ] 기타: 없음

## 위험도 및 롤백 계획

- 영향 범위: 캐시플로(주간) 입력/전사 현황 화면
- 예상 리스크:
  - debounce 저장 특성상 입력 직후 바로 새로고침/탭 종료 시 마지막 입력이 저장되지 않을 수 있음(월 이동 시에는 dirty week를 flush 후 이동).
- 롤백 방법:
  - 이 PR revert 또는 `fix/cashflow-sheet-robustness` 브랜치 이전 커밋으로 롤백

## 체크리스트

- [x] 민감정보(.env, key, token) 커밋 없음
- [x] `.gitignore` 확인 완료
- [ ] PR 본문에 운영 증거 포함 (해당 없음)
- [x] 필요한 후속 작업(담당자/기한) 명시
