### PR TITLE
Phase 1 UX: confirm dialogs + cashflow unsaved-change guard

### DIFF
--- a/src/app/components/cashflow/cashflow-unsaved.test.ts
+++ b/src/app/components/cashflow/cashflow-unsaved.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { hasUnsavedChanges } from './cashflow-unsaved';
+
+describe('hasUnsavedChanges', () => {
+  it('returns false when there are no states', () => {
+    expect(hasUnsavedChanges({})).toBe(false);
+  });
+
+  it('returns false when all states are saved/unknown', () => {
+    expect(hasUnsavedChanges({ a: 'saved', b: undefined, c: 'noop' })).toBe(false);
+  });
+
+  it('returns true when any state is dirty', () => {
+    expect(hasUnsavedChanges({ a: 'saved', b: 'dirty' })).toBe(true);
+  });
+
+  it('returns true when any state is saving', () => {
+    expect(hasUnsavedChanges({ a: 'saving' })).toBe(true);
+  });
+
+  it('returns true when any state is error', () => {
+    expect(hasUnsavedChanges({ a: 'error' })).toBe(true);
+  });
+});
+

--- a/src/app/components/cashflow/cashflow-unsaved.ts
+++ b/src/app/components/cashflow/cashflow-unsaved.ts
@@ -1,0 +1,4 @@
+export function hasUnsavedChanges(states: Record<string, string | undefined>): boolean {
+  return Object.values(states).some((state) => state === 'dirty' || state === 'saving' || state === 'error');
+}
+


### PR DESCRIPTION
## 요약 (비개발자용)
- 캐시플로 입력 중 저장되지 않은 값이 있을 때, 다른 페이지로 이동하거나 탭을 닫으면 경고가 뜹니다.
- 사업비 세트 제출, 지출 항목 삭제, 인력변경 요청 제출 시 실수 방지를 위해 확인 팝업이 뜹니다.
- 포털 대시보드의 재무 KPI가 (가능한 경우) Firestore 실데이터를 기반으로 계산됩니다.

## 변경 내용 (개발자용)
- CashflowProjectSheet: `beforeunload` + `useBlocker`로 unsaved guard 추가.
- PortalExpenses: 세트 제출/항목 삭제 AlertDialog 추가.
- PortalChangeRequests: 제출 AlertDialog 추가.
- PortalDashboard: ledgers/transactions를 프로젝트 스코프 Firestore `onSnapshot(where(projectId == ...))`로 구독, 실패/미연결 시 mock fallback 유지.

## 테스트
- `npm test` (vitest)
- `npm run build`

## 수동 QA 시나리오
- 캐시플로: 값 입력 후 저장 전에 사이드바로 다른 페이지 이동 -> 경고 다이얼로그 표시 / 계속 편집 유지 / 나가기 이동
- 캐시플로: 값 입력 후 브라우저 탭 닫기 -> 브라우저 기본 경고 표시
- 사업비: DRAFT 세트에서 제출 클릭 -> 확인 다이얼로그 -> 취소 시 유지 / 제출 시 SUBMITTED
- 사업비: 항목 삭제 클릭 -> 확인 다이얼로그 -> 취소 시 유지 / 삭제 시 항목 제거
- 인력변경: DRAFT 요청에서 제출 -> 확인 다이얼로그 -> 제출 시 SUBMITTED
- 포털 대시보드: Firestore 연결 시 재무 KPI가 실데이터 기반으로 표시되는지 확인

## 체크리스트
- [x] 테스트 통과
- [x] 빌드 통과
- [x] 사용자 실수 방지(제출/삭제) UI 적용
- [x] 데이터 유실 방지(캐시플로 이동/닫기) 가드 적용
