### PR TITLE
fix(auth): allow only @mysc.co.kr + guide unauthorized-domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,19 @@ Enable Google login provider:
 npm run firebase:open:google-auth
 ```
 
+Authorized domains (to fix `auth/unauthorized-domain`):
+
+- Firebase Console > Authentication > Settings > Authorized domains
+- Add:
+  - `localhost` (local dev)
+  - your Vercel production domain (for example: `inner-platform.vercel.app`)
+  - any Preview domain you want to use for login (Preview URLs change per deploy)
+
+Email domain allowlist (company-only login):
+
+- Default: `@mysc.co.kr` only
+- Optional env: `VITE_ALLOWED_EMAIL_DOMAINS=mysc.co.kr` (comma-separated supported)
+
 Reference doc:
 
 - `guidelines/Firestore-Automation-System-Guide.md`

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -2,7 +2,9 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     function isSignedIn() {
-      return request.auth != null;
+      return request.auth != null
+        && request.auth.token.email != null
+        && request.auth.token.email.matches('.*@mysc\\.co\\.kr$');
     }
 
     function hasValidTenant(data, orgId) {

--- a/server/bff/auth.allowed-domain.test.ts
+++ b/server/bff/auth.allowed-domain.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveRequestIdentity } from './auth.mjs';
+
+function createHeaders(headers: Record<string, string>) {
+  const normalized: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) normalized[k.toLowerCase()] = v;
+  return (name: string) => normalized[name.toLowerCase()] || '';
+}
+
+describe('bff auth email allowlist', () => {
+  const original = process.env.BFF_ALLOWED_EMAIL_DOMAINS;
+
+  beforeEach(() => {
+    process.env.BFF_ALLOWED_EMAIL_DOMAINS = 'mysc.co.kr';
+  });
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.BFF_ALLOWED_EMAIL_DOMAINS;
+    else process.env.BFF_ALLOWED_EMAIL_DOMAINS = original;
+  });
+
+  it('accepts allowed email domain', async () => {
+    const identity = await resolveRequestIdentity({
+      authMode: 'firebase_required',
+      readHeaderValue: createHeaders({
+        authorization: 'Bearer test-token',
+        'x-tenant-id': 'mysc',
+      }),
+      verifyToken: async () => ({
+        uid: 'u1',
+        tenantId: 'mysc',
+        role: 'pm',
+        email: 'user@mysc.co.kr',
+      }),
+    });
+
+    expect(identity.source).toBe('firebase');
+    expect(identity.actorEmail).toBe('user@mysc.co.kr');
+  });
+
+  it('rejects disallowed email domain', async () => {
+    await expect(resolveRequestIdentity({
+      authMode: 'firebase_required',
+      readHeaderValue: createHeaders({
+        authorization: 'Bearer test-token',
+        'x-tenant-id': 'mysc',
+      }),
+      verifyToken: async () => ({
+        uid: 'u1',
+        tenantId: 'mysc',
+        role: 'pm',
+        email: 'user@gmail.com',
+      }),
+    })).rejects.toMatchObject({ statusCode: 403, code: 'email_domain_not_allowed' });
+  });
+
+  it('rejects missing email in token', async () => {
+    await expect(resolveRequestIdentity({
+      authMode: 'firebase_required',
+      readHeaderValue: createHeaders({
+        authorization: 'Bearer test-token',
+        'x-tenant-id': 'mysc',
+      }),
+      verifyToken: async () => ({
+        uid: 'u1',
+        tenantId: 'mysc',
+        role: 'pm',
+      }),
+    })).rejects.toMatchObject({ statusCode: 403, code: 'missing_email' });
+  });
+});
+

--- a/src/app/lib/firebase.ts
+++ b/src/app/lib/firebase.ts
@@ -9,6 +9,7 @@ import { connectAuthEmulator, getAuth, GoogleAuthProvider, type Auth } from 'fir
 import { connectStorageEmulator, getStorage, type FirebaseStorage } from 'firebase/storage';
 import { featureFlags, parseFeatureFlag } from '../config/feature-flags';
 import { buildTenantScopedPath, resolveTenantId } from '../platform/tenant';
+import { getAllowedEmailDomains } from '../platform/email-allowlist';
 
 const STORAGE_KEY = 'MYSC_FIREBASE_CONFIG';
 
@@ -184,7 +185,12 @@ export function getStorageInstance(): FirebaseStorage | null {
 export function getGoogleAuthProvider(): GoogleAuthProvider {
   if (_googleProvider) return _googleProvider;
   _googleProvider = new GoogleAuthProvider();
-  _googleProvider.setCustomParameters({ prompt: 'select_account' });
+  const domains = getAllowedEmailDomains(import.meta.env);
+  const hd = domains.length === 1 ? domains[0] : '';
+  _googleProvider.setCustomParameters({
+    prompt: 'select_account',
+    ...(hd ? { hd } : {}),
+  });
   return _googleProvider;
 }
 

--- a/src/app/platform/email-allowlist.test.ts
+++ b/src/app/platform/email-allowlist.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { formatAllowedDomains, isAllowedEmail, parseAllowedEmailDomains } from './email-allowlist';
+
+describe('email allowlist', () => {
+  it('parses domains from csv', () => {
+    expect(parseAllowedEmailDomains('mysc.co.kr, example.com')).toEqual(['mysc.co.kr', 'example.com']);
+  });
+
+  it('normalizes leading @ and casing', () => {
+    expect(parseAllowedEmailDomains('@MYSC.CO.KR')).toEqual(['mysc.co.kr']);
+  });
+
+  it('falls back when empty', () => {
+    expect(parseAllowedEmailDomains('', ['a.com'])).toEqual(['a.com']);
+  });
+
+  it('checks allowed emails', () => {
+    expect(isAllowedEmail('user@mysc.co.kr', ['mysc.co.kr'])).toBe(true);
+    expect(isAllowedEmail('user@other.com', ['mysc.co.kr'])).toBe(false);
+    expect(isAllowedEmail('not-an-email', ['mysc.co.kr'])).toBe(false);
+  });
+
+  it('formats domains', () => {
+    expect(formatAllowedDomains(['mysc.co.kr', '@example.com'])).toBe('@mysc.co.kr, @example.com');
+  });
+});
+

--- a/src/app/platform/email-allowlist.ts
+++ b/src/app/platform/email-allowlist.ts
@@ -1,0 +1,37 @@
+const DEFAULT_ALLOWED_DOMAINS = ['mysc.co.kr'];
+
+function normalizeDomain(value: unknown): string {
+  const raw = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  const withoutAt = raw.startsWith('@') ? raw.slice(1) : raw;
+  return withoutAt.replace(/\s+/g, '');
+}
+
+function normalizeEmail(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+export function parseAllowedEmailDomains(raw: unknown, fallback: string[] = DEFAULT_ALLOWED_DOMAINS): string[] {
+  const text = typeof raw === 'string' ? raw.trim() : '';
+  if (!text) return [...fallback];
+  return text
+    .split(',')
+    .map((part) => normalizeDomain(part))
+    .filter(Boolean);
+}
+
+export function getAllowedEmailDomains(env: Record<string, unknown> = import.meta.env): string[] {
+  return parseAllowedEmailDomains(env.VITE_ALLOWED_EMAIL_DOMAINS, DEFAULT_ALLOWED_DOMAINS);
+}
+
+export function isAllowedEmail(email: unknown, allowedDomains: string[] = DEFAULT_ALLOWED_DOMAINS): boolean {
+  const normalized = normalizeEmail(email);
+  if (!normalized || !normalized.includes('@')) return false;
+  const domain = normalized.split('@').pop() || '';
+  return allowedDomains.some((allowed) => domain === normalizeDomain(allowed));
+}
+
+export function formatAllowedDomains(allowedDomains: string[]): string {
+  const list = allowedDomains.map((d) => `@${normalizeDomain(d)}`).filter(Boolean);
+  return list.length ? list.join(', ') : '(none)';
+}
+


### PR DESCRIPTION
## 목적
- Google 로그인에서 `Firebase: Error (auth/unauthorized-domain)`가 발생할 때 원인/해결책을 **사용자에게 명확히 안내**.
- 로그인은 **회사 계정(@mysc.co.kr)만 허용**되도록 프론트/백엔드/BFF/Firestore Rules 레벨에서 차단.

## 변경 사항
- 프론트엔드
  - Google 로그인 성공 직후 이메일 도메인 검사 후, `@mysc.co.kr`이 아니면 즉시 `signOut` + 에러 표시
  - `auth/unauthorized-domain` 에러 코드일 때, Firebase Console에서 `Authorized domains`에 현재 도메인을 추가하라고 안내 메시지 제공
  - GoogleAuthProvider에 `hd=mysc.co.kr` 힌트 파라미터 추가 (계정 선택 UX 개선)
- BFF
  - Firebase ID token의 `email` 도메인이 허용 목록이 아니면 403 (`email_domain_not_allowed`)
  - 기본 허용 도메인: `mysc.co.kr` (옵션 env: `BFF_ALLOWED_EMAIL_DOMAINS`)
- Firestore Rules
  - `isSignedIn()`을 `request.auth.token.email`이 `@mysc.co.kr`로 끝나는 경우로 강화

## 테스트
- `npm test`
- `npm run build`

## 운영 체크리스트 (중요)
- Firebase Console에서 로그인 도메인 승인 필요
  - Authentication > Settings > Authorized domains
  - 아래 도메인을 추가하세요:
    - `localhost` (로컬)
    - `inner-platform.vercel.app` (prod)
    - Preview URL을 로그인에 쓸 경우 해당 Preview 도메인도 추가 (Preview는 배포마다 바뀜)
- Firestore rules 배포
  - `npm run firebase:deploy:firestore`
