### PR TITLE
fix: guard null date sorting on dashboard

### DIFF
--- a/src/app/components/dashboard/DashboardPage.tsx
+++ b/src/app/components/dashboard/DashboardPage.tsx
@@ -38,7 +38,13 @@ import {
   UpdateReminderBadge,
   validateProject,
 } from './DashboardGuide';
-import { buildDashboardCashflowRollups, toFiniteNumber } from './dashboard-rollups';
+import {
+  buildDashboardCashflowRollups,
+  compareSafeLocaleAsc,
+  compareSafeLocaleDesc,
+  toFiniteNumber,
+  toSafeString,
+} from './dashboard-rollups';
 import { getSeoulTodayIso } from '../../platform/business-days';
 import { findWeekForDate, getMonthMondayWeeks } from '../../platform/cashflow-weeks';
 import { useCashflowWeeks } from '../../data/cashflow-weeks-store';
@@ -276,12 +282,13 @@ export function DashboardPage() {
   const cashflowTrend = useMemo(() => {
     const months: Record<string, { month: string; in: number; out: number }> = {};
     transactions.filter(t => t.state === 'APPROVED').forEach(t => {
-      const m = t.dateTime.slice(0, 7);
+      const m = toSafeString(t.dateTime).slice(0, 7);
+      if (!m) return;
       if (!months[m]) months[m] = { month: m, in: 0, out: 0 };
       if (t.direction === 'IN') months[m].in += toFiniteNumber(t.amounts?.bankAmount);
       else months[m].out += toFiniteNumber(t.amounts?.bankAmount);
     });
-    return Object.values(months).sort((a, b) => a.month.localeCompare(b.month)).slice(-6);
+    return Object.values(months).sort((a, b) => compareSafeLocaleAsc(a.month, b.month)).slice(-6);
   }, [transactions]);
 
   const cashflowRollup = useMemo(() => {
@@ -294,7 +301,7 @@ export function DashboardPage() {
   }, [projects, transactions, cashflowWeeks, yearMonth]);
 
   const recentTx = useMemo(() => {
-    return [...transactions].sort((a, b) => b.dateTime.localeCompare(a.dateTime)).slice(0, 6);
+    return [...transactions].sort((a, b) => compareSafeLocaleDesc(a.dateTime, b.dateTime)).slice(0, 6);
   }, [transactions]);
 
   return (

--- a/src/app/components/dashboard/SystemHealthPanel.tsx
+++ b/src/app/components/dashboard/SystemHealthPanel.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Progress } from '../ui/progress';
 import { useAppStore } from '../../data/store';
 import { computeMemberSummaries } from '../../data/participation-data';
+import { compareSafeLocaleDesc, toSafeString } from './dashboard-rollups';
 
 interface HealthMetric {
   id: string;
@@ -212,7 +213,7 @@ export function ActivityFeed() {
       }
     });
 
-    return items.sort((a, b) => b.timestamp.localeCompare(a.timestamp)).slice(0, 12);
+    return items.sort((a, b) => compareSafeLocaleDesc(a.timestamp, b.timestamp)).slice(0, 12);
   }, [transactions, projects]);
 
   return (
@@ -240,7 +241,7 @@ export function ActivityFeed() {
                   <div className="flex items-center justify-between gap-2">
                     <span className="text-[11px]" style={{ fontWeight: 600 }}>{a.title}</span>
                     <span className="text-[9px] text-muted-foreground whitespace-nowrap" style={{ fontVariantNumeric: 'tabular-nums' }}>
-                      {a.timestamp.slice(5, 16)}
+                      {toSafeString(a.timestamp).slice(5, 16)}
                     </span>
                   </div>
                   <p className="text-[10px] text-muted-foreground mt-0.5 line-clamp-1">{a.detail}</p>

--- a/src/app/components/dashboard/dashboard-rollups.test.ts
+++ b/src/app/components/dashboard/dashboard-rollups.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { validateProject } from './DashboardGuide';
-import { buildDashboardCashflowRollups } from './dashboard-rollups';
+import {
+  buildDashboardCashflowRollups,
+  compareSafeLocaleDesc,
+  toSafeString,
+} from './dashboard-rollups';
 import type { CashflowWeekSheet, Project, Transaction } from '../../data/types';
 
 function makeProject(overrides: Partial<Project> = {}): Project {
@@ -168,5 +172,11 @@ describe('dashboard rollups', () => {
     const directCostOut = lineRows.find((row) => row.lineId === 'DIRECT_COST_OUT');
     expect(directCostOut?.currentMonthProjectionAmount).toBe(300000);
     expect(directCostOut?.currentMonthActualAmount).toBe(370000);
+  });
+
+  it('compares nullable date-like strings without throwing', () => {
+    expect(() => compareSafeLocaleDesc(null, '2026-03-12')).not.toThrow();
+    expect(compareSafeLocaleDesc(null, '2026-03-12')).toBeGreaterThan(0);
+    expect(toSafeString(null)).toBe('');
   });
 });

--- a/src/app/components/dashboard/dashboard-rollups.ts
+++ b/src/app/components/dashboard/dashboard-rollups.ts
@@ -7,6 +7,18 @@ export function toFiniteNumber(value: unknown): number {
   return Number.isFinite(num) ? num : 0;
 }
 
+export function toSafeString(value: unknown): string {
+  return typeof value === 'string' ? value : String(value ?? '');
+}
+
+export function compareSafeLocaleAsc(a: unknown, b: unknown): number {
+  return toSafeString(a).localeCompare(toSafeString(b));
+}
+
+export function compareSafeLocaleDesc(a: unknown, b: unknown): number {
+  return toSafeString(b).localeCompare(toSafeString(a));
+}
+
 function toTimestamp(value?: string): number {
   if (!value) return 0;
   const time = Date.parse(value);


### PR DESCRIPTION
## Summary\n- guard dashboard date sorting against null values in recent transactions and activity feed\n- centralize null-safe locale comparison helpers for dashboard rollups\n- add regression test for nullable date comparisons\n\n## Testing\n- npx vitest run src/app/components/dashboard/dashboard-rollups.test.ts\n- npm run build