### PR TITLE
fix: allow stable vercel auth hosts

### DIFF
--- a/src/app/platform/preview-auth.test.ts
+++ b/src/app/platform/preview-auth.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildPreviewAuthBlockedMessage,
   isLocalAuthHost,
+  isStableVercelAliasHost,
   isStableVercelPreviewHost,
   readPreviewAuthGuardConfig,
   shouldBlockFirebasePopupAuth,
@@ -27,6 +28,9 @@ describe('preview-auth', () => {
     expect(isLocalAuthHost('127.0.0.1')).toBe(true);
     expect(isStableVercelPreviewHost('inner-platform-git-ft-izzie-merryai-devs-projects.vercel.app')).toBe(true);
     expect(isStableVercelPreviewHost('inner-platform-bbig48qgr-merryai-devs-projects.vercel.app')).toBe(false);
+    expect(isStableVercelAliasHost('inner-platform.vercel.app')).toBe(true);
+    expect(isStableVercelAliasHost('inner-platform-merryai-devs-projects.vercel.app')).toBe(true);
+    expect(isStableVercelAliasHost('inner-platform-bbig48qgr-merryai-devs-projects.vercel.app')).toBe(false);
   });
 
   it('blocks random vercel preview hosts and allows configured or stable hosts', () => {
@@ -36,7 +40,9 @@ describe('preview-auth', () => {
     };
 
     expect(shouldBlockFirebasePopupAuth('inner-platform-bbig48qgr-merryai-devs-projects.vercel.app', env)).toBe(true);
+    expect(shouldBlockFirebasePopupAuth('inner-platform-e6ksf2q01-merryai-devs-projects.vercel.app', env)).toBe(true);
     expect(shouldBlockFirebasePopupAuth('inner-platform.vercel.app', env)).toBe(false);
+    expect(shouldBlockFirebasePopupAuth('inner-platform-merryai-devs-projects.vercel.app', env)).toBe(false);
     expect(shouldBlockFirebasePopupAuth('inner-platform-git-ft-izzie-merryai-devs-projects.vercel.app', env)).toBe(false);
     expect(shouldBlockFirebasePopupAuth('localhost', env)).toBe(false);
   });

--- a/src/app/platform/preview-auth.ts
+++ b/src/app/platform/preview-auth.ts
@@ -56,6 +56,16 @@ export function isStableVercelPreviewHost(hostname: unknown): boolean {
   return normalized.endsWith('.vercel.app') && normalized.includes('-git-');
 }
 
+export function isStableVercelAliasHost(hostname: unknown): boolean {
+  const normalized = normalizeHost(hostname);
+  if (!normalized.endsWith('.vercel.app')) return false;
+  const label = normalized.slice(0, -'.vercel.app'.length);
+  if (!label) return false;
+  if (label.includes('-git-')) return true;
+  if (!label.includes('-')) return true;
+  return !/-[a-z0-9]*\d[a-z0-9]*-/.test(label);
+}
+
 export function shouldBlockFirebasePopupAuth(
   hostname: unknown,
   env: Record<string, unknown> = import.meta.env,
@@ -67,6 +77,7 @@ export function shouldBlockFirebasePopupAuth(
   const config = readPreviewAuthGuardConfig(env);
   if (config.allowedHosts.includes(normalized)) return false;
   if (isStableVercelPreviewHost(normalized)) return false;
+  if (isStableVercelAliasHost(normalized)) return false;
   return true;
 }
 


### PR DESCRIPTION
## Summary
- allow stable Vercel aliases like inner-platform.vercel.app and project aliases
- keep blocking random deployment URLs for Firebase popup auth
- cover the alias/random-host split with preview-auth tests

## Verification
- npx vitest run src/app/platform/preview-auth.test.ts
- npm run build