### PR TITLE
fix: unblock portal drive setup for shared members

### DIFF
--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -1397,6 +1397,45 @@ export function PortalProvider({ children }: { children: ReactNode }) {
       updatedAt: now,
     };
     await setDoc(doc(db, getOrgDocumentPath(orgId, 'projects', projectId)), withTenantScope(orgId, project), { merge: true });
+    const nextPortalProjectIds = normalizeProjectIds([
+      ...(Array.isArray(portalUser?.projectIds) ? portalUser.projectIds : []),
+      portalUser?.projectId,
+      projectId,
+    ]);
+    const nextPortalProjectId = resolvePrimaryProjectId(nextPortalProjectIds, projectId) || projectId;
+    const nextPortalProjectNames = {
+      ...(portalUser?.projectNames || {}),
+      [projectId]: payload.name,
+    };
+    await setDoc(doc(db, getOrgDocumentPath(orgId, 'members', authUser.uid)), {
+      uid: authUser.uid,
+      name: authUser.name || portalUser?.name || '사용자',
+      email: authUser.email || portalUser?.email || '',
+      role: (authUser.role || portalUser?.role || 'pm').toLowerCase(),
+      tenantId: orgId,
+      status: 'ACTIVE',
+      ...buildPortalProfilePatch({
+        projectId: nextPortalProjectId,
+        projectIds: nextPortalProjectIds,
+        projectNames: nextPortalProjectNames,
+        updatedAt: now,
+        updatedByUid: authUser.uid,
+        updatedByName: authUser.name || portalUser?.name || '사용자',
+      }),
+      updatedAt: now,
+      createdAt: authUser.registeredAt || now,
+      lastLoginAt: now,
+    }, { merge: true });
+    setPortalUser((previous) => normalizePortalUser({
+      id: authUser.uid,
+      name: authUser.name || previous?.name || portalUser?.name || '사용자',
+      email: authUser.email || previous?.email || portalUser?.email || '',
+      role: authUser.role || previous?.role || portalUser?.role || 'pm',
+      projectId: nextPortalProjectId,
+      projectIds: nextPortalProjectIds,
+      projectNames: nextPortalProjectNames,
+      registeredAt: previous?.registeredAt || authUser.registeredAt || now,
+    }));
     await setDoc(doc(db, getOrgDocumentPath(orgId, 'projectRequests', id)), {
       ...request,
       status: 'APPROVED',

--- a/src/app/platform/request-context.test.ts
+++ b/src/app/platform/request-context.test.ts
@@ -64,8 +64,8 @@ describe('request-context helpers', () => {
     });
 
     expect(headers.get('authorization')).toBe('Bearer token-123');
-    expect(headers.get('x-actor-id')).toBeNull();
-    expect(headers.get('x-actor-email')).toBeNull();
-    expect(headers.get('x-actor-role')).toBeNull();
+    expect(headers.get('x-actor-id')).toBe('u001');
+    expect(headers.get('x-actor-email')).toBe('viewer@mysc.co.kr');
+    expect(headers.get('x-actor-role')).toBe('viewer');
   });
 });

--- a/src/app/platform/request-context.ts
+++ b/src/app/platform/request-context.ts
@@ -56,16 +56,16 @@ export function buildStandardHeaders(input: BuildStandardHeadersInput): Headers 
   }
 
   headers.set('x-tenant-id', tenantId);
-  if (!hasIdToken) {
+  if (!headers.get('x-actor-id')) {
     headers.set('x-actor-id', actorId);
+  }
 
-    if (input.actor.email && !headers.get('x-actor-email')) {
-      headers.set('x-actor-email', input.actor.email.trim().toLowerCase());
-    }
+  if (input.actor.email && !headers.get('x-actor-email')) {
+    headers.set('x-actor-email', input.actor.email.trim().toLowerCase());
+  }
 
-    if (input.actor.role && !headers.get('x-actor-role')) {
-      headers.set('x-actor-role', input.actor.role);
-    }
+  if (input.actor.role && !headers.get('x-actor-role')) {
+    headers.set('x-actor-role', input.actor.role);
   }
 
   if (hasIdToken && !headers.get('authorization')) {


### PR DESCRIPTION
## Summary
- send actor role/email headers alongside Firebase ID tokens so the BFF can resolve member permissions consistently
- auto-assign newly created projects to the requesting member's portal profile
- keep newly created projects immediately readable by the same member in portal subcollections

## Verification
- npm run build
- npx vitest run src/app/platform/request-context.test.ts