### PR TITLE
fix: heal portal access and sheet preview auth

### DIFF
--- a/server/bff/app.integration.test.ts
+++ b/server/bff/app.integration.test.ts
@@ -106,7 +106,7 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
 
     const preview = await sheetsApi
       .post('/api/v1/projects/p-sheets-001/google-sheet-import/preview')
-      .set(defaultHeaders)
+      .set({ ...defaultHeaders, 'x-google-access-token': 'google-token-123' })
       .send({ value: 'https://docs.google.com/spreadsheets/d/sheet-001/edit#gid=1' });
 
     expect(preview.status).toBe(200);
@@ -116,6 +116,7 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
     expect(googleSheetsService.previewSpreadsheet).toHaveBeenCalledWith({
       value: 'https://docs.google.com/spreadsheets/d/sheet-001/edit#gid=1',
       sheetName: undefined,
+      accessToken: 'google-token-123',
     });
   });
 

--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -430,7 +430,7 @@ function assertActorPermissionAllowed(policy, req, requiredPermission, action) {
   }
 }
 
-function createApiContextMiddleware({ authMode, verifyToken }) {
+function createApiContextMiddleware({ authMode, verifyToken, resolveMemberIdentity }) {
   return asyncHandler(async (req, res, next) => {
     const requestId = req.header('x-request-id') || createRequestId();
     const isMutating = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(req.method.toUpperCase());
@@ -446,11 +446,23 @@ function createApiContextMiddleware({ authMode, verifyToken }) {
       readHeaderValue: (name) => req.header(name),
     });
 
+    let actorRole = identity.actorRole;
+    let actorEmail = identity.actorEmail;
+
+    if ((!actorRole || !actorEmail) && identity.source === 'firebase' && typeof resolveMemberIdentity === 'function') {
+      const memberIdentity = await resolveMemberIdentity({
+        tenantId: identity.tenantId,
+        actorId: identity.actorId,
+      });
+      actorRole = actorRole || normalizeRole(memberIdentity?.role) || undefined;
+      actorEmail = actorEmail || readOptionalText(memberIdentity?.email).toLowerCase() || undefined;
+    }
+
     req.context = {
       tenantId: identity.tenantId,
       actorId: identity.actorId,
-      actorRole: identity.actorRole,
-      actorEmail: identity.actorEmail,
+      actorRole,
+      actorEmail,
       authSource: identity.source,
       requestId,
       idempotencyKey: idempotencyKey.trim() || undefined,
@@ -544,6 +556,21 @@ export function createBffApp(options = {}) {
   const outboxMaxAttempts = Number.isFinite(outboxMaxAttemptsRaw) && outboxMaxAttemptsRaw > 0 ? outboxMaxAttemptsRaw : 8;
   const workerSecret = readOptionalText(options.workerSecret || process.env.BFF_WORKER_SECRET || process.env.CRON_SECRET);
 
+  async function resolveMemberIdentity({ tenantId, actorId }) {
+    const normalizedTenantId = readOptionalText(tenantId);
+    const normalizedActorId = readOptionalText(actorId);
+    if (!normalizedTenantId || !normalizedActorId) return null;
+
+    const snap = await db.doc(`orgs/${normalizedTenantId}/members/${normalizedActorId}`).get();
+    if (!snap.exists) return null;
+
+    const data = snap.data() || {};
+    return {
+      role: normalizeRole(data.role),
+      email: readOptionalText(data.email).toLowerCase() || undefined,
+    };
+  }
+
   app.disable('x-powered-by');
   app.use(express.json({ limit: process.env.BFF_JSON_LIMIT || '25mb' }));
 
@@ -564,7 +591,7 @@ export function createBffApp(options = {}) {
       res.setHeader('Access-Control-Allow-Origin', allowAnyOrigin ? '*' : requestOrigin);
     }
     res.setHeader('Vary', 'Origin');
-    res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type, x-tenant-id, x-actor-id, x-actor-role, x-actor-email, x-request-id, idempotency-key');
+    res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type, x-tenant-id, x-actor-id, x-actor-role, x-actor-email, x-request-id, idempotency-key, x-google-access-token');
     res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PATCH,PUT,DELETE,OPTIONS');
     res.setHeader('X-Content-Type-Options', 'nosniff');
     res.setHeader('X-Frame-Options', 'DENY');
@@ -827,7 +854,7 @@ export function createBffApp(options = {}) {
   app.get('/api/internal/workers/monthly-close/run', runMonthlyCloseWorkerRoute);
   app.post('/api/internal/workers/monthly-close/run', runMonthlyCloseWorkerRoute);
 
-  app.use('/api/v1', createApiContextMiddleware({ authMode, verifyToken }));
+  app.use('/api/v1', createApiContextMiddleware({ authMode, verifyToken, resolveMemberIdentity }));
 
   app.post('/api/v1/write', createMutatingRoute(idempotencyService, async (req) => {
     assertActorRoleAllowed(req, ROUTE_ROLES.writeCore, 'write data');
@@ -1115,6 +1142,7 @@ export function createBffApp(options = {}) {
     assertActorRoleAllowed(req, ROUTE_ROLES.readCore, 'preview google sheet import');
     const { projectId } = req.params;
     const parsed = parseWithSchema(googleSheetImportPreviewSchema, req.body, 'Invalid google sheet preview payload');
+    const googleAccessToken = readOptionalText(req.header('x-google-access-token'));
 
     await ensureDocumentExists(
       db,
@@ -1126,6 +1154,7 @@ export function createBffApp(options = {}) {
       const preview = await googleSheetsService.previewSpreadsheet({
         value: parsed.value,
         sheetName: parsed.sheetName,
+        accessToken: googleAccessToken || undefined,
       });
       res.status(200).json(preview);
     } catch (error) {

--- a/server/bff/google-sheets.mjs
+++ b/server/bff/google-sheets.mjs
@@ -128,7 +128,11 @@ export function createGoogleSheetsService(options = {}) {
     }
   }
 
-  async function getAuthHeaders() {
+  async function getAuthHeaders(accessToken) {
+    const normalizedAccessToken = readOptionalText(accessToken);
+    if (normalizedAccessToken) {
+      return { authorization: `Bearer ${normalizedAccessToken}` };
+    }
     if (typeof authHeadersFactory === 'function') {
       return authHeadersFactory();
     }
@@ -143,8 +147,8 @@ export function createGoogleSheetsService(options = {}) {
     return jwtClient.getRequestHeaders();
   }
 
-  async function sheetsFetch(pathname, init = {}) {
-    const authHeaders = await getAuthHeaders();
+  async function sheetsFetch(pathname, init = {}, accessToken) {
+    const authHeaders = await getAuthHeaders(accessToken);
     const response = await fetchImpl(`${SHEETS_API_BASE_URL}${pathname}`, {
       ...init,
       headers: {
@@ -168,7 +172,7 @@ export function createGoogleSheetsService(options = {}) {
     return readJsonResponse(response);
   }
 
-  async function getSpreadsheetMeta(spreadsheetId) {
+  async function getSpreadsheetMeta(spreadsheetId, accessToken) {
     const normalizedId = extractSpreadsheetId(spreadsheetId);
     if (!normalizedId) {
       throw new GoogleSheetsServiceError(
@@ -184,7 +188,11 @@ export function createGoogleSheetsService(options = {}) {
       'sheets.properties.title',
       'sheets.properties.index',
     ].join(',');
-    const data = await sheetsFetch(`/spreadsheets/${encodeURIComponent(normalizedId)}?fields=${encodeURIComponent(fields)}`);
+    const data = await sheetsFetch(
+      `/spreadsheets/${encodeURIComponent(normalizedId)}?fields=${encodeURIComponent(fields)}`,
+      {},
+      accessToken,
+    );
     const availableSheets = Array.isArray(data?.sheets)
       ? data.sheets.map((sheet) => normalizeSheetDescriptor(sheet)).sort((a, b) => a.index - b.index)
       : [];
@@ -196,7 +204,7 @@ export function createGoogleSheetsService(options = {}) {
     };
   }
 
-  async function getSheetValues({ spreadsheetId, sheetName }) {
+  async function getSheetValues({ spreadsheetId, sheetName, accessToken }) {
     const normalizedId = extractSpreadsheetId(spreadsheetId);
     const normalizedSheetName = normalizeSheetTitle(sheetName);
     const range = quoteSheetNameForRange(normalizedSheetName);
@@ -208,6 +216,8 @@ export function createGoogleSheetsService(options = {}) {
 
     const data = await sheetsFetch(
       `/spreadsheets/${encodeURIComponent(normalizedId)}/values/${encodeURIComponent(range)}?${params.toString()}`,
+      {},
+      accessToken,
     );
 
     return Array.isArray(data?.values)
@@ -215,7 +225,7 @@ export function createGoogleSheetsService(options = {}) {
       : [];
   }
 
-  async function previewSpreadsheet({ value, sheetName }) {
+  async function previewSpreadsheet({ value, sheetName, accessToken }) {
     const spreadsheetId = extractSpreadsheetId(value);
     if (!spreadsheetId) {
       throw new GoogleSheetsServiceError(
@@ -225,7 +235,7 @@ export function createGoogleSheetsService(options = {}) {
     }
 
     const gid = sheetName ? null : extractSpreadsheetGid(value);
-    const meta = await getSpreadsheetMeta(spreadsheetId);
+    const meta = await getSpreadsheetMeta(spreadsheetId, accessToken);
 
     let selectedSheet = null;
     if (sheetName) {
@@ -253,6 +263,7 @@ export function createGoogleSheetsService(options = {}) {
     const matrix = await getSheetValues({
       spreadsheetId: meta.spreadsheetId,
       sheetName: selectedSheet.title,
+      accessToken,
     });
 
     return {

--- a/server/bff/google-sheets.test.ts
+++ b/server/bff/google-sheets.test.ts
@@ -59,4 +59,38 @@ describe('google-sheets helpers', () => {
     expect(preview.matrix[1]).toEqual(['홍길동', '2026-03-12', '카페 메리']);
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
+
+  it('prefers caller google access token over service account auth', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        properties: { title: '사업비 시트' },
+        sheets: [
+          { properties: { sheetId: 0, title: '사용내역', index: 0 } },
+        ],
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        values: [
+          ['작성자', '거래일시'],
+          ['홍길동', '2026-03-12'],
+        ],
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }));
+    const authHeadersFactory = vi.fn(async () => ({ authorization: 'Bearer service-account-token' }));
+    const service = createGoogleSheetsService({ fetchImpl, authHeadersFactory });
+
+    await service.previewSpreadsheet({
+      value: 'https://docs.google.com/spreadsheets/d/1abcDEFghiJKlmnOPQ_rst-123/edit#gid=0',
+      accessToken: 'user-google-token',
+    });
+
+    expect(authHeadersFactory).not.toHaveBeenCalled();
+    const firstHeaders = fetchImpl.mock.calls[0]?.[1]?.headers as Record<string, string>;
+    expect(firstHeaders.authorization).toBe('Bearer user-google-token');
+  });
 });

--- a/src/app/components/portal/PortalWeeklyExpensePage.tsx
+++ b/src/app/components/portal/PortalWeeklyExpensePage.tsx
@@ -110,7 +110,7 @@ interface GoogleSheetMigrationReviewState {
 }
 
 export function PortalWeeklyExpensePage() {
-  const { user: authUser } = useAuth();
+  const { user: authUser, ensureGoogleWorkspaceAccess } = useAuth();
   const { orgId } = useFirebase();
   const {
     portalUser,
@@ -218,7 +218,17 @@ export function PortalWeeklyExpensePage() {
     email: authUser?.email || portalUser?.email || '',
     role: authUser?.role || portalUser?.role || 'pm',
     idToken: authUser?.idToken,
-  }), [authUser?.uid, authUser?.email, authUser?.role, authUser?.idToken, portalUser?.id, portalUser?.email, portalUser?.role]);
+    googleAccessToken: authUser?.googleAccessToken,
+  }), [
+    authUser?.uid,
+    authUser?.email,
+    authUser?.role,
+    authUser?.idToken,
+    authUser?.googleAccessToken,
+    portalUser?.id,
+    portalUser?.email,
+    portalUser?.role,
+  ]);
   const googleSheetSelectedDescriptor = useMemo(
     () => describeGoogleSheetMigrationTarget(googleSheetImportPreview?.selectedSheetName || ''),
     [googleSheetImportPreview?.selectedSheetName],
@@ -555,9 +565,13 @@ export function PortalWeeklyExpensePage() {
 
     setGoogleSheetPreviewing(true);
     try {
+      const googleAccessToken = bffActor.googleAccessToken || await ensureGoogleWorkspaceAccess() || undefined;
       const result = await previewGoogleSheetImportViaBff({
         tenantId: orgId,
-        actor: bffActor,
+        actor: {
+          ...bffActor,
+          ...(googleAccessToken ? { googleAccessToken } : {}),
+        },
         projectId,
         value: trimmedLink,
         ...(sheetName ? { sheetName } : {}),

--- a/src/app/data/auth-store.tsx
+++ b/src/app/data/auth-store.tsx
@@ -1,6 +1,13 @@
 import React, { createContext, useContext, useState, useCallback, useEffect, type ReactNode } from 'react';
 import { doc, getDoc, setDoc } from 'firebase/firestore';
-import { onIdTokenChanged, signInWithPopup, signOut, type User as FirebaseUser } from 'firebase/auth';
+import {
+  GoogleAuthProvider,
+  onIdTokenChanged,
+  reauthenticateWithPopup,
+  signInWithPopup,
+  signOut,
+  type User as FirebaseUser,
+} from 'firebase/auth';
 import type { UserRole } from './types';
 import { ORG_MEMBERS, PROJECTS } from './mock-data';
 import { featureFlags } from '../config/feature-flags';
@@ -47,6 +54,7 @@ export interface AuthUser {
   role: UserRole;
   source?: 'firebase' | 'dev_harness';
   idToken?: string;
+  googleAccessToken?: string;
   avatarUrl?: string;
   projectId?: string;
   projectIds?: string[];
@@ -67,6 +75,7 @@ interface AuthState {
 interface AuthActions {
   loginWithGoogle: () => Promise<{ success: boolean; error?: string }>;
   loginWithDevHarness: (preset?: DevHarnessPreset) => Promise<{ success: boolean; error?: string }>;
+  ensureGoogleWorkspaceAccess: () => Promise<string | null>;
   setWorkspacePreference: (workspace: WorkspaceId, options?: { persistDefault?: boolean }) => Promise<boolean>;
   logout: () => void;
   isAdmin: () => boolean;
@@ -95,6 +104,7 @@ interface MemberDoc {
 
 const AUTH_STORAGE_KEY = 'mysc-auth-user';
 const ACTIVE_TENANT_KEY = 'MYSC_ACTIVE_TENANT';
+const GOOGLE_WORKSPACE_TOKEN_STORAGE_KEY = 'mysc-google-workspace-token-map';
 const DEFAULT_ORG_ID = getDefaultOrgId();
 const ALLOWED_EMAIL_DOMAINS = getAllowedEmailDomains(import.meta.env);
 const DEV_AUTH_HARNESS_CONFIG = readDevAuthHarnessConfig(import.meta.env);
@@ -113,15 +123,66 @@ const PROJECT_OWNERS: ProjectOwnerEntry[] = PROJECTS.map((project) => ({
 function loadSavedUser(): AuthUser | null {
   try {
     const saved = localStorage.getItem(AUTH_STORAGE_KEY);
-    return saved ? (JSON.parse(saved) as AuthUser) : null;
+    if (!saved) return null;
+    const parsed = JSON.parse(saved) as AuthUser;
+    return {
+      ...parsed,
+      ...(parsed.uid ? { googleAccessToken: loadGoogleWorkspaceAccessToken(parsed.uid) } : {}),
+    };
   } catch {
     return null;
   }
 }
 
+function readGoogleWorkspaceTokenMap(): Record<string, string> {
+  try {
+    if (typeof sessionStorage === 'undefined') return {};
+    const saved = sessionStorage.getItem(GOOGLE_WORKSPACE_TOKEN_STORAGE_KEY);
+    if (!saved) return {};
+    const parsed = JSON.parse(saved) as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.entries(parsed || {})
+        .map(([uid, token]) => [uid, typeof token === 'string' ? token.trim() : ''] as const)
+        .filter(([uid, token]) => uid && token),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function writeGoogleWorkspaceTokenMap(next: Record<string, string>) {
+  if (typeof sessionStorage === 'undefined') return;
+  const entries = Object.entries(next).filter(([uid, token]) => uid && token);
+  if (entries.length === 0) {
+    sessionStorage.removeItem(GOOGLE_WORKSPACE_TOKEN_STORAGE_KEY);
+    return;
+  }
+  sessionStorage.setItem(GOOGLE_WORKSPACE_TOKEN_STORAGE_KEY, JSON.stringify(Object.fromEntries(entries)));
+}
+
+function loadGoogleWorkspaceAccessToken(uid: string | undefined): string | undefined {
+  const normalizedUid = String(uid || '').trim();
+  if (!normalizedUid) return undefined;
+  return readGoogleWorkspaceTokenMap()[normalizedUid];
+}
+
+function persistGoogleWorkspaceAccessToken(uid: string | undefined, token: string | undefined) {
+  const normalizedUid = String(uid || '').trim();
+  if (!normalizedUid) return;
+  const next = readGoogleWorkspaceTokenMap();
+  const normalizedToken = String(token || '').trim();
+  if (!normalizedToken) {
+    delete next[normalizedUid];
+  } else {
+    next[normalizedUid] = normalizedToken;
+  }
+  writeGoogleWorkspaceTokenMap(next);
+}
+
 function saveUser(user: AuthUser | null) {
   if (user) {
-    localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(user));
+    const { googleAccessToken: _ignoredGoogleAccessToken, ...persistedUser } = user;
+    localStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(persistedUser));
     if (user.tenantId) {
       localStorage.setItem(ACTIVE_TENANT_KEY, user.tenantId);
       if (typeof window !== 'undefined') {
@@ -207,6 +268,7 @@ function mapFirebaseUserToAuthUser(
     email: normalizedEmail,
     role,
     idToken,
+    googleAccessToken: loadGoogleWorkspaceAccessToken(firebaseUser.uid),
     avatarUrl: member?.avatarUrl || firebaseUser.photoURL || undefined,
     projectId: primaryProjectId,
     projectIds: mergedProjectIds,
@@ -464,6 +526,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
 
       const cred = await signInWithPopup(auth, getGoogleAuthProvider());
+      const providerCredential = GoogleAuthProvider.credentialFromResult(cred);
+      const googleAccessToken = providerCredential?.accessToken || undefined;
+      if (cred?.user?.uid) {
+        persistGoogleWorkspaceAccessToken(cred.user.uid, googleAccessToken);
+      }
       const email = cred?.user?.email || '';
       if (!isAllowedEmail(email, ALLOWED_EMAIL_DOMAINS)) {
         await signOut(auth).catch(() => {});
@@ -517,6 +584,44 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return { success: true };
   }, []);
 
+  const ensureGoogleWorkspaceAccess = useCallback(async (): Promise<string | null> => {
+    const currentUser = user;
+    if (!featureFlags.firebaseAuthEnabled || !currentUser || currentUser.source !== 'firebase') {
+      return null;
+    }
+
+    const cached = loadGoogleWorkspaceAccessToken(currentUser.uid);
+    if (cached) {
+      if (!currentUser.googleAccessToken) {
+        const nextUser = { ...currentUser, googleAccessToken: cached };
+        setUser(nextUser);
+        saveUser(nextUser);
+      }
+      return cached;
+    }
+
+    const auth = getAuthInstance();
+    if (!auth) return null;
+
+    try {
+      const provider = getGoogleAuthProvider();
+      const cred = auth.currentUser
+        ? await reauthenticateWithPopup(auth.currentUser, provider)
+        : await signInWithPopup(auth, provider);
+      const providerCredential = GoogleAuthProvider.credentialFromResult(cred);
+      const googleAccessToken = providerCredential?.accessToken || '';
+      if (!googleAccessToken) return null;
+      persistGoogleWorkspaceAccessToken(cred.user?.uid || currentUser.uid, googleAccessToken);
+      const nextUser = { ...currentUser, googleAccessToken };
+      setUser(nextUser);
+      saveUser(nextUser);
+      return googleAccessToken;
+    } catch (err) {
+      console.error('[Auth] ensureGoogleWorkspaceAccess failed:', err);
+      return null;
+    }
+  }, [user]);
+
   const logout = useCallback(() => {
     if (featureFlags.firebaseAuthEnabled) {
       const auth = getAuthInstance();
@@ -529,10 +634,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     setUser(null);
     saveUser(null);
+    if (user?.uid) {
+      persistGoogleWorkspaceAccessToken(user.uid, undefined);
+    }
     clearDevHarnessSession();
     localStorage.removeItem(ACTIVE_TENANT_KEY);
     localStorage.removeItem('mysc-portal-user');
-  }, []);
+  }, [user?.uid]);
 
   const isAdmin = useCallback(() => {
     return !!user && isAdminSpaceRole(user.role);
@@ -549,6 +657,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     isFirebaseAuthEnabled: featureFlags.firebaseAuthEnabled,
     loginWithGoogle,
     loginWithDevHarness,
+    ensureGoogleWorkspaceAccess,
     setWorkspacePreference,
     logout,
     isAdmin,

--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -1611,9 +1611,8 @@ export function PortalProvider({ children }: { children: ReactNode }) {
       return false;
     }
 
-    setPortalUser(candidate);
-
     if (authUser) {
+      setIsMemberLoading(true);
       let memberRole = (authUser.role || user.role || 'pm').toLowerCase();
       try {
         const memberSnap = await getDoc(doc(db, getOrgDocumentPath(orgId, 'members', authUser.uid)));
@@ -1646,15 +1645,17 @@ export function PortalProvider({ children }: { children: ReactNode }) {
           createdAt: authUser.registeredAt || now,
           lastLoginAt: now,
         }, { merge: true });
-        if (candidate.role !== memberRole) {
-          setPortalUser({ ...candidate, role: memberRole });
-        }
+        setPortalUser(candidate.role !== memberRole ? { ...candidate, role: memberRole } : candidate);
       } catch (err) {
         console.error('[PortalStore] register member sync error:', err);
         setPortalUser(previousPortalUser);
         toast.error('회원 정보를 저장하지 못했습니다.');
         return false;
+      } finally {
+        setIsMemberLoading(false);
       }
+    } else {
+      setPortalUser(candidate);
     }
 
     return true;
@@ -1699,9 +1700,9 @@ export function PortalProvider({ children }: { children: ReactNode }) {
       ...portalUser,
       projectId: target,
     };
-    setPortalUser(nextUser);
 
     if (authUser) {
+      setIsMemberLoading(true);
       try {
         const now = new Date().toISOString();
         await updateDoc(doc(db, getOrgDocumentPath(orgId, 'members', authUser.uid)), {
@@ -1716,12 +1717,17 @@ export function PortalProvider({ children }: { children: ReactNode }) {
           }),
           updatedAt: now,
         });
+        setPortalUser(nextUser);
       } catch (err) {
         console.error('[PortalStore] setActiveProject member sync error:', err);
         setPortalUser(previousUser);
         toast.error('주사업 변경을 저장하지 못했습니다.');
         return false;
+      } finally {
+        setIsMemberLoading(false);
       }
+    } else {
+      setPortalUser(nextUser);
     }
 
     return true;

--- a/src/app/lib/firebase.ts
+++ b/src/app/lib/firebase.ts
@@ -201,6 +201,7 @@ export function getStorageInstance(): FirebaseStorage | null {
 export function getGoogleAuthProvider(): GoogleAuthProvider {
   if (_googleProvider) return _googleProvider;
   _googleProvider = new GoogleAuthProvider();
+  _googleProvider.addScope('https://www.googleapis.com/auth/spreadsheets.readonly');
   const domains = getAllowedEmailDomains(import.meta.env);
   const hd = domains.length === 1 ? domains[0] : '';
   _googleProvider.setCustomParameters({

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -375,7 +375,7 @@ describe('platform-bff-client', () => {
 
     const preview = await previewGoogleSheetImportViaBff({
       tenantId: 'mysc',
-      actor: { uid: 'u001', role: 'pm' },
+      actor: { uid: 'u001', role: 'pm', googleAccessToken: 'google-token-123' },
       projectId: 'p001',
       value: 'https://docs.google.com/spreadsheets/d/sheet-001/edit#gid=1',
       sheetName: '주간정산',
@@ -383,6 +383,9 @@ describe('platform-bff-client', () => {
     });
 
     expect(client.post).toHaveBeenCalledWith('/api/v1/projects/p001/google-sheet-import/preview', expect.objectContaining({
+      headers: {
+        'x-google-access-token': 'google-token-123',
+      },
       body: {
         value: 'https://docs.google.com/spreadsheets/d/sheet-001/edit#gid=1',
         sheetName: '주간정산',

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -13,6 +13,7 @@ export interface ActorLike {
   email?: string;
   role?: string;
   idToken?: string;
+  googleAccessToken?: string;
 }
 
 export interface UpsertProjectPayload {
@@ -354,6 +355,9 @@ export async function previewGoogleSheetImportViaBff(params: {
     {
       tenantId: params.tenantId,
       actor: toRequestActor(params.actor),
+      headers: params.actor.googleAccessToken
+        ? { 'x-google-access-token': params.actor.googleAccessToken }
+        : undefined,
       body: {
         value: params.value,
         ...(params.sheetName ? { sheetName: params.sheetName } : {}),


### PR DESCRIPTION
## Summary
- prevent project-scoped portal listeners from racing ahead of member assignment sync
- use user Google Sheets access tokens for workbook preview while keeping service-account fallback
- request Sheets readonly scope and pass preview auth through BFF

## Verification
- npm run build
- npx vitest run server/bff/google-sheets.test.ts src/app/lib/platform-bff-client.test.ts
- npx vitest run server/bff/google-sheets.test.ts server/bff/app.integration.test.ts src/app/lib/platform-bff-client.test.ts