### PR TITLE
fix: preserve portal member project access state

### DIFF
--- a/src/app/data/auth-store.tsx
+++ b/src/app/data/auth-store.tsx
@@ -31,6 +31,7 @@ import { normalizeProjectIds, resolvePrimaryProjectId } from './project-assignme
 import {
   buildWorkspacePreferencePatch,
   readMemberWorkspace,
+  resolveMemberProjectAccessState,
   type WorkspaceId,
 } from './member-workspace';
 import { extractAuthContextFromClaims } from '../platform/rbac';
@@ -296,12 +297,17 @@ async function upsertMemberFromFirebase(
   const now = new Date().toISOString();
   const normalizedEmail = normalizeEmail(firebaseUser.email || existing?.email || '');
   const bootstrapAdmin = isBootstrapAdminEmail(normalizedEmail);
+  const access = resolveMemberProjectAccessState(existing);
   const mergedProjectIds = normalizeProjectIds([
+    ...access.normalizedProjectIds,
     ...(Array.isArray(existing?.projectIds) ? existing?.projectIds : []),
     existing?.projectId,
     resolveProjectIdForManager(firebaseUser.uid, PROJECT_OWNERS),
   ]);
-  const primaryProjectId = resolvePrimaryProjectId(mergedProjectIds, existing?.projectId) || '';
+  const primaryProjectId = resolvePrimaryProjectId(
+    mergedProjectIds,
+    access.normalizedProjectId || existing?.projectId,
+  ) || '';
 
   const merged = omitUndefinedFields<MemberDoc>({
     uid: firebaseUser.uid,
@@ -322,7 +328,7 @@ async function upsertMemberFromFirebase(
     createdAt: existing?.createdAt || now,
     updatedAt: now,
     lastLoginAt: now,
-    projectNames: existing?.projectNames,
+    projectNames: access.projectNames || existing?.projectNames,
     portalProfile: existing?.portalProfile,
     defaultWorkspace: existing?.defaultWorkspace,
     lastWorkspace: existing?.lastWorkspace,

--- a/src/app/data/member-workspace.test.ts
+++ b/src/app/data/member-workspace.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { readMemberWorkspace, resolveMemberProjectAccessState } from './member-workspace';
+
+describe('member workspace project access', () => {
+  it('preserves portal profile assignments when root project fields are stale', () => {
+    const candidate = {
+      projectId: 'legacy-project',
+      projectIds: [],
+      portalProfile: {
+        projectId: 'p1772624885396',
+        projectIds: ['p1772624885396', 'p-other'],
+        projectNames: {
+          p1772624885396: '사업 A',
+        },
+      },
+    };
+
+    const access = resolveMemberProjectAccessState(candidate);
+
+    expect(access.normalizedProjectId).toBe('p1772624885396');
+    expect(access.normalizedProjectIds).toEqual(['legacy-project', 'p1772624885396', 'p-other']);
+    expect(access.needsRootSync).toBe(true);
+  });
+
+  it('flags object-shaped root project ids for normalization', () => {
+    const candidate = {
+      projectId: 'p-primary',
+      projectIds: [{ id: 'p-primary', name: '사업 A' }, { id: 'p-secondary', name: '사업 B' }],
+      portalProfile: {
+        projectId: 'p-primary',
+        projectIds: ['p-primary', 'p-secondary'],
+      },
+    };
+
+    const access = resolveMemberProjectAccessState(candidate);
+    const workspace = readMemberWorkspace(candidate);
+
+    expect(access.hasObjectRootProjectIds).toBe(true);
+    expect(access.needsRootSync).toBe(true);
+    expect(workspace.portalProfile?.projectIds).toEqual(['p-primary', 'p-secondary']);
+  });
+});

--- a/src/app/data/member-workspace.ts
+++ b/src/app/data/member-workspace.ts
@@ -17,6 +17,18 @@ export interface MemberWorkspaceState {
   portalProfile: MemberPortalProfile | null;
 }
 
+export interface MemberProjectAccessState {
+  rootProjectId?: string;
+  rootProjectIds: string[];
+  portalProjectId?: string;
+  portalProjectIds: string[];
+  normalizedProjectId?: string;
+  normalizedProjectIds: string[];
+  projectNames?: Record<string, string>;
+  hasObjectRootProjectIds: boolean;
+  needsRootSync: boolean;
+}
+
 interface BuildPortalProfilePatchInput {
   projectId?: string;
   projectIds?: string[];
@@ -39,11 +51,21 @@ function readString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+function readLooseProjectId(value: unknown): string {
+  if (typeof value === 'string') return value.trim();
+  if (isRecord(value)) return readString(value.id);
+  return '';
+}
+
 function readStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value
     .map((entry) => readString(entry))
     .filter(Boolean);
+}
+
+function hasObjectArrayEntries(value: unknown): boolean {
+  return Array.isArray(value) && value.some((entry) => typeof entry === 'object' && entry !== null);
 }
 
 function readProjectNames(value: unknown): Record<string, string> | undefined {
@@ -63,35 +85,79 @@ function mergeProjectNames(
   return Object.keys(merged).length > 0 ? merged : undefined;
 }
 
+function sameProjectIds(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((value, index) => value === b[index]);
+}
+
+export function resolveMemberProjectAccessState(candidate: unknown): MemberProjectAccessState {
+  if (!isRecord(candidate)) {
+    return {
+      rootProjectIds: [],
+      portalProjectIds: [],
+      normalizedProjectIds: [],
+      hasObjectRootProjectIds: false,
+      needsRootSync: false,
+    };
+  }
+
+  const rawPortalProfile = isRecord(candidate.portalProfile) ? candidate.portalProfile : null;
+  const rootProjectIds = normalizeProjectIds([
+    ...readStringArray(candidate.projectIds),
+    readLooseProjectId(candidate.projectId),
+  ]);
+  const portalProjectIds = normalizeProjectIds([
+    ...readStringArray(rawPortalProfile?.projectIds),
+    readLooseProjectId(rawPortalProfile?.projectId),
+  ]);
+  const normalizedProjectIds = normalizeProjectIds([
+    ...rootProjectIds,
+    ...portalProjectIds,
+  ]);
+  const rootProjectId = resolvePrimaryProjectId(rootProjectIds, readLooseProjectId(candidate.projectId));
+  const portalProjectId = resolvePrimaryProjectId(portalProjectIds, readLooseProjectId(rawPortalProfile?.projectId));
+  const normalizedProjectId = resolvePrimaryProjectId(
+    normalizedProjectIds,
+    portalProjectId || rootProjectId,
+  );
+  const projectNames = mergeProjectNames(
+    readProjectNames(candidate.projectNames),
+    readProjectNames(rawPortalProfile?.projectNames),
+  );
+  const hasObjectRootProjectIds = hasObjectArrayEntries(candidate.projectIds);
+
+  return {
+    rootProjectId: rootProjectId || undefined,
+    rootProjectIds,
+    portalProjectId: portalProjectId || undefined,
+    portalProjectIds,
+    normalizedProjectId: normalizedProjectId || undefined,
+    normalizedProjectIds,
+    ...(projectNames ? { projectNames } : {}),
+    hasObjectRootProjectIds,
+    needsRootSync:
+      hasObjectRootProjectIds
+      || (rootProjectId || '') !== (normalizedProjectId || '')
+      || !sameProjectIds(rootProjectIds, normalizedProjectIds),
+  };
+}
+
 export function readMemberWorkspace(candidate: unknown): MemberWorkspaceState {
   if (!isRecord(candidate)) {
     return { portalProfile: null };
   }
 
   const rawPortalProfile = isRecord(candidate.portalProfile) ? candidate.portalProfile : null;
-  const projectNames = mergeProjectNames(
-    readProjectNames(candidate.projectNames),
-    readProjectNames(rawPortalProfile?.projectNames),
-  );
-  const projectIds = normalizeProjectIds([
-    ...readStringArray(candidate.projectIds),
-    readString(candidate.projectId),
-    ...readStringArray(rawPortalProfile?.projectIds),
-    readString(rawPortalProfile?.projectId),
-  ]);
-  const projectId = resolvePrimaryProjectId(
-    projectIds,
-    readString(rawPortalProfile?.projectId) || readString(candidate.projectId),
-  );
+  const access = resolveMemberProjectAccessState(candidate);
 
   return {
     defaultWorkspace: normalizeWorkspaceId(candidate.defaultWorkspace),
     lastWorkspace: normalizeWorkspaceId(candidate.lastWorkspace),
-    portalProfile: projectIds.length > 0 || projectId
+    portalProfile: access.normalizedProjectIds.length > 0 || access.normalizedProjectId
       ? {
-        projectId: projectId || undefined,
-        projectIds,
-        ...(projectNames ? { projectNames } : {}),
+        projectId: access.normalizedProjectId || undefined,
+        projectIds: access.normalizedProjectIds,
+        ...(access.projectNames ? { projectNames: access.projectNames } : {}),
         ...(readString(rawPortalProfile?.updatedAt) ? { updatedAt: readString(rawPortalProfile?.updatedAt) } : {}),
         ...(readString(rawPortalProfile?.updatedByUid) ? { updatedByUid: readString(rawPortalProfile?.updatedByUid) } : {}),
         ...(readString(rawPortalProfile?.updatedByName) ? { updatedByName: readString(rawPortalProfile?.updatedByName) } : {}),

--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -49,7 +49,7 @@ import { useAuth } from './auth-store';
 import { useFirebase } from '../lib/firebase-context';
 import { getOrgCollectionPath, getOrgDocumentPath } from '../lib/firebase';
 import { duplicateExpenseSetAsDraft, withExpenseItems } from './portal-store.helpers';
-import { buildPortalProfilePatch, readMemberWorkspace } from './member-workspace';
+import { buildPortalProfilePatch, readMemberWorkspace, resolveMemberProjectAccessState } from './member-workspace';
 import { toast } from 'sonner';
 import { includesProject, normalizeProjectIds, resolvePrimaryProjectId } from './project-assignment';
 import { canEnterPortalWorkspace } from '../platform/navigation';
@@ -307,6 +307,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
           projectId?: string | { id?: string; name?: string };
         };
         const workspace = readMemberWorkspace(member);
+        const access = resolveMemberProjectAccessState(member);
         const nameMap: Record<string, string> = {};
         const rawIds = Array.isArray(member.projectIds) ? member.projectIds : [];
         const coercedIds = rawIds
@@ -346,9 +347,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
         }
         // Normalize member projectIds to string array for security rules (one-time fix)
         try {
-          const rawProjectIds = Array.isArray(member.projectIds) ? member.projectIds : [];
-          const hasObjectIds = rawProjectIds.some((entry) => typeof entry === 'object');
-          if (hasObjectIds || member.projectId !== normalized.projectId) {
+          if (access.needsRootSync) {
             await updateDoc(doc(db, getOrgDocumentPath(orgId, 'members', authUser.uid)), {
               projectId: normalized.projectId,
               projectIds: normalized.projectIds,


### PR DESCRIPTION
## Summary
- preserve project access assignments from portalProfile when syncing Firebase member docs
- repair root projectId/projectIds whenever stored member access drifts from portal assignments
- add regression tests for member project access normalization

## Verification
- npm run build
- npx vitest run src/app/data/member-workspace.test.ts src/app/lib/platform-bff-client.test.ts server/bff/google-sheets.test.ts