### PR TITLE
fix: unblock portal access for internal users

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -26,7 +26,7 @@ service cloud.firestore {
     }
 
     function role(orgId) {
-      return isSignedIn() ? memberDoc(orgId).data.role : null;
+      return isSignedIn() && memberDoc(orgId).data != null ? memberDoc(orgId).data.role : null;
     }
 
     function tokenRole() {
@@ -55,10 +55,10 @@ service cloud.firestore {
     }
 
     function memberProjectId(orgId) {
-      return memberDoc(orgId).data.projectId;
+      return memberDoc(orgId).data != null ? memberDoc(orgId).data.projectId : null;
     }
     function memberProjectIds(orgId) {
-      return memberDoc(orgId).data.projectIds;
+      return memberDoc(orgId).data != null ? memberDoc(orgId).data.projectIds : null;
     }
 
     function isProjectAssigned(orgId, projectId) {
@@ -67,15 +67,15 @@ service cloud.firestore {
     }
 
     function canReadProjectResource(orgId, projectId) {
-      return isPrivileged(orgId)
-        || (role(orgId) in ['pm', 'viewer'] && isProjectAssigned(orgId, projectId));
+      // Internal MYSC rollout mode: once authenticated with a company account,
+      // all project-scoped portal resources are readable without member/project mapping.
+      return isSignedIn();
     }
 
     function canWriteProjectResource(orgId, projectId) {
-      return role(orgId) in ['admin', 'tenant_admin', 'finance']
-        || tokenRole() in ['admin', 'tenant_admin', 'finance']
-        || isBootstrapAdminEmail()
-        || (role(orgId) == 'pm' && isProjectAssigned(orgId, projectId));
+      // Internal MYSC rollout mode: allow all signed-in company users to use
+      // project-scoped portal features without per-project assignment.
+      return isSignedIn();
     }
 
     function projectIdFromTransaction(orgId, txId) {

--- a/policies/rbac-policy.json
+++ b/policies/rbac-policy.json
@@ -81,17 +81,29 @@
     ],
     "viewer": [
       "project:read",
+      "project:write",
       "project:evidence_drive:write",
       "ledger:read",
+      "ledger:write",
+      "transaction:submit",
       "comment:read",
+      "comment:write",
       "evidence:read",
+      "evidence:write",
       "evidence:drive:write"
     ],
     "auditor": [
       "project:read",
+      "project:write",
+      "project:evidence_drive:write",
       "ledger:read",
+      "ledger:write",
+      "transaction:submit",
       "comment:read",
+      "comment:write",
       "evidence:read",
+      "evidence:write",
+      "evidence:drive:write",
       "audit:read"
     ],
     "tenant_admin": [
@@ -112,15 +124,30 @@
     ],
     "support": [
       "project:read",
+      "project:write",
+      "project:evidence_drive:write",
       "ledger:read",
+      "ledger:write",
+      "transaction:submit",
       "comment:read",
+      "comment:write",
       "evidence:read",
+      "evidence:write",
+      "evidence:drive:write",
       "audit:read"
     ],
     "security": [
       "project:read",
+      "project:write",
+      "project:evidence_drive:write",
+      "ledger:read",
+      "ledger:write",
+      "transaction:submit",
       "comment:read",
+      "comment:write",
       "evidence:read",
+      "evidence:write",
+      "evidence:drive:write",
       "audit:read",
       "security:manage"
     ]

--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -110,6 +110,13 @@ function parseAllowedOrigins(value) {
   return ['http://127.0.0.1:5173', 'http://localhost:5173'];
 }
 
+function isKnownMyscVercelOrigin(origin) {
+  const normalized = readOptionalText(origin);
+  if (!normalized) return false;
+  if (normalized === 'https://inner-platform.vercel.app') return true;
+  return /^https:\/\/inner-platform(?:-[a-z0-9-]+)?-merryai-devs-projects\.vercel\.app$/i.test(normalized);
+}
+
 function buildListResponse(items, limit) {
   const nextCursor = items.length === limit ? items[items.length - 1]?.id || null : null;
   return {
@@ -248,12 +255,14 @@ function normalizeRole(value) {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
 }
 
+const ALL_INTERNAL_ROUTE_ROLES = ['admin', 'finance', 'pm', 'viewer', 'auditor', 'tenant_admin', 'support', 'security'];
+
 const ROUTE_ROLES = {
-  readCore: ['admin', 'finance', 'pm', 'viewer', 'auditor', 'tenant_admin', 'support', 'security'],
-  writeCore: ['admin', 'finance', 'pm', 'tenant_admin'],
-  writeTransaction: ['admin', 'finance', 'pm', 'tenant_admin'],
-  writeProjectDrive: ['admin', 'finance', 'pm', 'viewer', 'tenant_admin'],
-  writeEvidenceDrive: ['admin', 'finance', 'pm', 'viewer', 'tenant_admin'],
+  readCore: ALL_INTERNAL_ROUTE_ROLES,
+  writeCore: ALL_INTERNAL_ROUTE_ROLES,
+  writeTransaction: ALL_INTERNAL_ROUTE_ROLES,
+  writeProjectDrive: ALL_INTERNAL_ROUTE_ROLES,
+  writeEvidenceDrive: ALL_INTERNAL_ROUTE_ROLES,
   auditRead: ['admin', 'finance', 'auditor', 'tenant_admin', 'support', 'security'],
   memberWrite: ['admin', 'tenant_admin'],
 };
@@ -577,7 +586,10 @@ export function createBffApp(options = {}) {
   app.use((req, res, next) => {
     const requestOrigin = req.header('origin') || '';
     const allowAnyOrigin = allowedOrigins.includes('*');
-    const isAllowedOrigin = allowAnyOrigin || !requestOrigin || allowedOrigins.includes(requestOrigin);
+    const isAllowedOrigin = allowAnyOrigin
+      || !requestOrigin
+      || allowedOrigins.includes(requestOrigin)
+      || isKnownMyscVercelOrigin(requestOrigin);
 
     if (!isAllowedOrigin) {
       res.status(403).json({


### PR DESCRIPTION
## Summary\n- allow signed-in @mysc.co.kr users through project-scoped portal firestore rules\n- relax portal BFF role gates for internal roles and accept known Vercel origins\n- expand RBAC policy for internal roles across drive and import flows\n\n## Verification\n- npm run build\n- npx vitest run src/app/data/member-workspace.test.ts src/app/lib/platform-bff-client.test.ts server/bff/google-sheets.test.ts