### PR TITLE
fix: auto-provision ledgers for portal evidence uploads

### DIFF
--- a/server/bff/app.integration.test.ts
+++ b/server/bff/app.integration.test.ts
@@ -324,6 +324,35 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
     expect(seenIds.size).toBe(3);
   });
 
+  it('auto-provisions a default ledger when a transaction is created before ledger setup', async () => {
+    await api
+      .post('/api/v1/projects')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-auto-ledger-project-001' })
+      .send({
+        id: 'p-auto-ledger-001',
+        name: 'Auto Ledger Project',
+        accountType: 'DEDICATED',
+      });
+
+    const tx = await api
+      .post('/api/v1/transactions')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-auto-ledger-tx-001' })
+      .send({
+        id: 'tx-auto-ledger-001',
+        projectId: 'p-auto-ledger-001',
+        ledgerId: 'l-p-auto-ledger-001',
+        counterparty: 'Vendor Auto',
+      });
+
+    expect(tx.status).toBe(201);
+    expect(tx.body.state).toBe('DRAFT');
+
+    const ledgerSnap = await db.doc(`orgs/${tenantId}/ledgers/l-p-auto-ledger-001`).get();
+    expect(ledgerSnap.exists).toBe(true);
+    expect(ledgerSnap.data()?.projectId).toBe('p-auto-ledger-001');
+    expect(ledgerSnap.data()?.name).toBe('전용통장 원장');
+  });
+
   it('enforces deterministic state transitions and version checks', async () => {
     await api
       .post('/api/v1/projects')

--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -298,6 +298,13 @@ function stripUndefinedDeep(value) {
   return value;
 }
 
+function resolveAutoLedgerName(project) {
+  const accountType = readOptionalText(project?.accountType);
+  if (accountType === 'DEDICATED') return '전용통장 원장';
+  if (accountType === 'OPERATING') return '운영통장 원장';
+  return '기본 원장';
+}
+
 async function upsertVersionedDoc({
   db,
   path,
@@ -1648,8 +1655,28 @@ export function createBffApp(options = {}) {
     const projectPath = `orgs/${tenantId}/projects/${parsed.projectId}`;
     const ledgerPath = `orgs/${tenantId}/ledgers/${parsed.ledgerId}`;
 
-    await ensureDocumentExists(db, projectPath, `Project not found: ${parsed.projectId}`);
-    const ledger = await ensureDocumentExists(db, ledgerPath, `Ledger not found: ${parsed.ledgerId}`);
+    const project = await ensureDocumentExists(db, projectPath, `Project not found: ${parsed.projectId}`);
+    const ledgerRef = db.doc(ledgerPath);
+    const ledgerSnap = await ledgerRef.get();
+    let ledger = ledgerSnap.exists ? (ledgerSnap.data() || {}) : null;
+
+    if (!ledger) {
+      const ensuredLedger = await upsertVersionedDoc({
+        db,
+        path: ledgerPath,
+        payload: {
+          id: parsed.ledgerId.trim(),
+          projectId: parsed.projectId.trim(),
+          name: resolveAutoLedgerName(project),
+        },
+        tenantId,
+        actorId,
+        now: timestamp,
+        expectedVersion: 0,
+      });
+      ledger = ensuredLedger.data;
+    }
+
     if (ledger.projectId !== parsed.projectId) {
       throw createHttpError(400, `Ledger ${parsed.ledgerId} does not belong to project ${parsed.projectId}`);
     }

--- a/src/app/components/portal/PortalWeeklyExpensePage.tsx
+++ b/src/app/components/portal/PortalWeeklyExpensePage.tsx
@@ -30,6 +30,7 @@ import {
   provisionProjectEvidenceDriveRootViaBff,
   provisionTransactionEvidenceDriveViaBff,
   syncTransactionEvidenceDriveViaBff,
+  upsertLedgerViaBff,
   upsertTransactionViaBff,
   uploadTransactionEvidenceDriveViaBff,
 } from '../../lib/platform-bff-client';
@@ -71,6 +72,12 @@ function normalizeBudgetLabel(value: string): string {
     .replace(/^\s*\d+(?:[.\-]\d+)?\s*/, '')
     .replace(/^[.\-]+\s*/, '')
     .trim();
+}
+
+function resolveAutoLedgerName(accountType?: string): string {
+  if (accountType === 'DEDICATED') return '전용통장 원장';
+  if (accountType === 'OPERATING') return '운영통장 원장';
+  return '기본 원장';
 }
 
 type GoogleSheetWizardStep = 'source' | 'sheet' | 'review' | 'apply';
@@ -428,6 +435,20 @@ export function PortalWeeklyExpensePage() {
     };
 
     try {
+      const existingLedger = ledgers.find((candidate) => candidate.id === defaultLedgerId);
+      await upsertLedgerViaBff({
+        tenantId: orgId,
+        actor: bffActor,
+        ledger: {
+          id: defaultLedgerId,
+          projectId,
+          name: existingLedger?.name || resolveAutoLedgerName(myProject?.accountType),
+          ...(Number.isFinite(existingLedger?.version)
+            ? { expectedVersion: existingLedger?.version }
+            : {}),
+        },
+      });
+
       const requestPayload = {
         ...nextTx,
         ...(Number.isFinite(existingTx?.version)
@@ -466,7 +487,7 @@ export function PortalWeeklyExpensePage() {
       }
       return txId;
     } catch (error) {
-      handleEvidenceDriveError(error, '거래 저장');
+      handleEvidenceDriveError(error, '거래/원장 저장');
       return null;
     }
   };


### PR DESCRIPTION
## Summary\n- auto-create a default ledger before portal evidence upload transaction sync\n- backstop transaction upsert on the BFF by auto-provisioning a ledger when missing\n- cover the new server behavior with an integration regression test\n\n## Verification\n- npm run build\n- npx vitest run server/bff/app.integration.test.ts src/app/lib/platform-bff-client.test.ts