### PR TITLE
fix: avoid redundant ledger saves on upload

### DIFF
--- a/src/app/components/cashflow/SettlementLedgerPage.tsx
+++ b/src/app/components/cashflow/SettlementLedgerPage.tsx
@@ -1977,6 +1977,10 @@ function ImportEditor({
 
   const openEvidenceUploadPicker = useCallback((txId: string) => {
     setUploadTargetTxId(txId);
+    setUploadDialogOpen(true);
+  }, []);
+
+  const triggerEvidenceFilePicker = useCallback(() => {
     if (evidenceFileInputRef.current) {
       evidenceFileInputRef.current.value = '';
       evidenceFileInputRef.current.click();
@@ -2898,10 +2902,17 @@ function ImportEditor({
       >
         <DialogContent className="h-[92vh] w-[96vw] max-w-[96vw] gap-0 overflow-hidden p-0 sm:max-w-[96vw]">
           <DialogHeader className="border-b px-6 py-4">
-            <DialogTitle>증빙 업로드 검토</DialogTitle>
-            <DialogDescription>
-              좌측에서 파일을 확인하고, 우측에서 자동 분류 결과를 수정한 뒤 업로드하세요.
-            </DialogDescription>
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <DialogTitle>증빙 업로드 검토</DialogTitle>
+                <DialogDescription>
+                  좌측에서 파일을 확인하고, 우측에서 자동 분류 결과를 수정한 뒤 업로드하세요.
+                </DialogDescription>
+              </div>
+              <Button type="button" variant="outline" size="sm" onClick={triggerEvidenceFilePicker} disabled={uploadingEvidence}>
+                파일 선택
+              </Button>
+            </div>
           </DialogHeader>
           <div className="flex-1 overflow-hidden px-6 py-4">
             <div className="grid h-full gap-4 lg:grid-cols-[minmax(0,1.4fr)_380px]">
@@ -2944,8 +2955,11 @@ function ImportEditor({
                   </div>
                 </div>
               ) : (
-                <div className="flex h-full min-h-[420px] items-center justify-center text-[12px] text-muted-foreground">
-                  업로드할 파일을 선택하세요.
+                <div className="flex h-full min-h-[420px] flex-col items-center justify-center gap-3 text-[12px] text-muted-foreground">
+                  <p>업로드할 파일을 선택하세요.</p>
+                  <Button type="button" variant="outline" size="sm" onClick={triggerEvidenceFilePicker} disabled={uploadingEvidence}>
+                    파일 선택
+                  </Button>
                 </div>
               )}
             </div>

--- a/src/app/components/portal/PortalWeeklyExpensePage.tsx
+++ b/src/app/components/portal/PortalWeeklyExpensePage.tsx
@@ -30,7 +30,6 @@ import {
   provisionProjectEvidenceDriveRootViaBff,
   provisionTransactionEvidenceDriveViaBff,
   syncTransactionEvidenceDriveViaBff,
-  upsertLedgerViaBff,
   upsertTransactionViaBff,
   uploadTransactionEvidenceDriveViaBff,
 } from '../../lib/platform-bff-client';
@@ -72,12 +71,6 @@ function normalizeBudgetLabel(value: string): string {
     .replace(/^\s*\d+(?:[.\-]\d+)?\s*/, '')
     .replace(/^[.\-]+\s*/, '')
     .trim();
-}
-
-function resolveAutoLedgerName(accountType?: string): string {
-  if (accountType === 'DEDICATED') return '전용통장 원장';
-  if (accountType === 'OPERATING') return '운영통장 원장';
-  return '기본 원장';
 }
 
 type GoogleSheetWizardStep = 'source' | 'sheet' | 'review' | 'apply';
@@ -435,20 +428,6 @@ export function PortalWeeklyExpensePage() {
     };
 
     try {
-      const existingLedger = ledgers.find((candidate) => candidate.id === defaultLedgerId);
-      await upsertLedgerViaBff({
-        tenantId: orgId,
-        actor: bffActor,
-        ledger: {
-          id: defaultLedgerId,
-          projectId,
-          name: existingLedger?.name || resolveAutoLedgerName(myProject?.accountType),
-          ...(Number.isFinite(existingLedger?.version)
-            ? { expectedVersion: existingLedger?.version }
-            : {}),
-        },
-      });
-
       const requestPayload = {
         ...nextTx,
         ...(Number.isFinite(existingTx?.version)
@@ -487,7 +466,7 @@ export function PortalWeeklyExpensePage() {
       }
       return txId;
     } catch (error) {
-      handleEvidenceDriveError(error, '거래/원장 저장');
+      handleEvidenceDriveError(error, '거래 저장');
       return null;
     }
   };


### PR DESCRIPTION
## Summary\n- remove the extra ledger upsert before transaction persistence in weekly evidence upload flows\n- open the evidence upload dialog first and let users trigger the file picker directly\n- reduce 409 conflicts and the perceived lag caused by repeated failing save requests\n\n## Testing\n- npm run build\n- npx vitest run src/app/lib/platform-bff-client.test.ts