### PR TITLE
feat: upload evidence files directly to drive

### DIFF
--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -39,6 +39,7 @@ import {
 import {
   commentCreateSchema,
   evidenceCreateSchema,
+  evidenceDriveOverrideSchema,
   evidenceDriveUploadSchema,
   genericWriteSchema,
   googleSheetImportPreviewSchema,
@@ -1661,20 +1662,33 @@ export function createBffApp(options = {}) {
     let ledger = ledgerSnap.exists ? (ledgerSnap.data() || {}) : null;
 
     if (!ledger) {
-      const ensuredLedger = await upsertVersionedDoc({
-        db,
-        path: ledgerPath,
-        payload: {
-          id: parsed.ledgerId.trim(),
-          projectId: parsed.projectId.trim(),
-          name: resolveAutoLedgerName(project),
-        },
-        tenantId,
-        actorId,
-        now: timestamp,
-        expectedVersion: 0,
-      });
-      ledger = ensuredLedger.data;
+      try {
+        const ensuredLedger = await upsertVersionedDoc({
+          db,
+          path: ledgerPath,
+          payload: {
+            id: parsed.ledgerId.trim(),
+            projectId: parsed.projectId.trim(),
+            name: resolveAutoLedgerName(project),
+          },
+          tenantId,
+          actorId,
+          now: timestamp,
+          expectedVersion: 0,
+        });
+        ledger = ensuredLedger.data;
+      } catch (error) {
+        const statusCode = Number.isFinite(error?.statusCode) ? Number(error.statusCode) : 0;
+        const errorCode = readOptionalText(error?.code);
+        if (statusCode !== 409 && errorCode !== 'version_conflict' && errorCode !== 'version_required') {
+          throw error;
+        }
+        const retryLedgerSnap = await ledgerRef.get();
+        if (!retryLedgerSnap.exists) {
+          throw error;
+        }
+        ledger = retryLedgerSnap.data() || {};
+      }
     }
 
     if (ledger.projectId !== parsed.projectId) {
@@ -2261,6 +2275,99 @@ export function createBffApp(options = {}) {
         evidenceMissing: txResult.data.evidenceMissing || [],
         evidenceStatus: txResult.data.evidenceStatus,
         lastSyncedAt: timestamp,
+        version: txResult.version,
+        updatedAt: txResult.data.updatedAt,
+      },
+    };
+  }));
+
+  app.post('/api/v1/transactions/:txId/evidence-drive/overrides', createMutatingRoute(idempotencyService, async (req) => {
+    assertActorRoleAllowed(req, ROUTE_ROLES.writeEvidenceDrive, 'override evidence drive metadata');
+    assertActorPermissionAllowed(rbacPolicy, req, 'evidence:drive:write', 'override evidence drive metadata');
+    const { tenantId, actorId } = req.context;
+    const { txId } = req.params;
+    const timestamp = now();
+    const parsed = parseWithSchema(evidenceDriveOverrideSchema, req.body, 'Invalid evidence drive override payload');
+
+    const transaction = await ensureDocumentExists(
+      db,
+      `orgs/${tenantId}/transactions/${txId}`,
+      `Transaction not found: ${txId}`,
+    );
+
+    const snapshot = await db
+      .collection(`orgs/${tenantId}/evidences`)
+      .where('transactionId', '==', txId)
+      .get();
+
+    const overrideByFileId = new Map(
+      parsed.items.map((item) => [item.driveFileId.trim(), item.category.trim()]),
+    );
+    const evidenceDocs = snapshot.docs.map((doc) => ({
+      id: doc.id,
+      ...(doc.data() || {}),
+    }));
+
+    const docsToUpdate = evidenceDocs.filter((item) => overrideByFileId.has(readOptionalText(item.driveFileId)));
+    if (docsToUpdate.length > 0) {
+      for (const docs of chunkArray(docsToUpdate, 400)) {
+        const batch = db.batch();
+        docs.forEach((item) => {
+          const category = overrideByFileId.get(readOptionalText(item.driveFileId));
+          if (!category) return;
+          batch.set(
+            db.doc(`orgs/${tenantId}/evidences/${item.id}`),
+            {
+              category,
+              updatedAt: timestamp,
+            },
+            { merge: true },
+          );
+          item.category = category;
+          item.updatedAt = timestamp;
+        });
+        await batch.commit();
+      }
+    }
+
+    const syncPatch = resolveEvidenceSyncPatch({
+      transaction,
+      evidences: evidenceDocs,
+      folder: {
+        id: transaction.evidenceDriveFolderId,
+        name: transaction.evidenceDriveFolderName,
+        webViewLink: transaction.evidenceDriveLink,
+        driveId: transaction.evidenceDriveSharedDriveId,
+      },
+    });
+
+    const txResult = await mergeSystemManagedDoc({
+      db,
+      path: `orgs/${tenantId}/transactions/${txId}`,
+      patch: syncPatch,
+      tenantId,
+      actorId,
+      now: timestamp,
+      notFoundMessage: `Transaction not found: ${txId}`,
+    });
+
+    return {
+      status: 200,
+      body: {
+        transactionId: txId,
+        projectId: transaction.projectId,
+        folderId: transaction.evidenceDriveFolderId || null,
+        folderName: transaction.evidenceDriveFolderName || null,
+        webViewLink: transaction.evidenceDriveLink || null,
+        sharedDriveId: transaction.evidenceDriveSharedDriveId || null,
+        evidenceCount: evidenceDocs.length,
+        evidenceCompletedDesc: txResult.data.evidenceCompletedDesc || null,
+        evidenceAutoListedDesc: txResult.data.evidenceAutoListedDesc || null,
+        evidencePendingDesc: txResult.data.evidencePendingDesc || null,
+        supportPendingDocs: txResult.data.supportPendingDocs || null,
+        evidenceMissing: txResult.data.evidenceMissing || [],
+        evidenceStatus: txResult.data.evidenceStatus,
+        lastSyncedAt: transaction.evidenceDriveLastSyncedAt || timestamp,
         version: txResult.version,
         updatedAt: txResult.data.updatedAt,
       },

--- a/server/bff/schemas.mjs
+++ b/server/bff/schemas.mjs
@@ -74,6 +74,15 @@ export const evidenceDriveUploadSchema = z.object({
   category: NON_EMPTY_STRING.optional(),
 }).strict();
 
+export const evidenceDriveOverrideSchema = z.object({
+  items: z.array(
+    z.object({
+      driveFileId: NON_EMPTY_STRING,
+      category: NON_EMPTY_STRING,
+    }).strict(),
+  ).min(1),
+}).strict();
+
 export const memberRoleUpdateSchema = z.object({
   role: z.enum(['admin', 'finance', 'pm', 'viewer', 'auditor', 'tenant_admin', 'support', 'security']),
   reason: z.string().trim().min(1).max(500).optional(),

--- a/src/app/components/portal/PortalWeeklyExpensePage.tsx
+++ b/src/app/components/portal/PortalWeeklyExpensePage.tsx
@@ -23,6 +23,7 @@ import { toast } from 'sonner';
 import { useFirebase } from '../../lib/firebase-context';
 import {
   type GoogleSheetImportPreviewResult,
+  overrideTransactionEvidenceDriveCategoriesViaBff,
   type ProvisionTransactionEvidenceDriveResult,
   type SyncTransactionEvidenceDriveResult,
   type UploadTransactionEvidenceDriveResult,
@@ -34,6 +35,10 @@ import {
   uploadTransactionEvidenceDriveViaBff,
 } from '../../lib/platform-bff-client';
 import { PlatformApiError } from '../../platform/api-client';
+import {
+  GoogleDriveBrowserUploadError,
+  uploadFileToGoogleDriveFolder,
+} from '../../platform/google-drive-browser-upload';
 import { splitLooseNameList } from '../../platform/name-list';
 import {
   GOOGLE_SHEET_PROTECTED_HEADERS,
@@ -341,6 +346,10 @@ export function PortalWeeklyExpensePage() {
 
   const handleEvidenceDriveError = (error: unknown, actionLabel: string) => {
     console.error(`[PortalWeeklyExpensePage] ${actionLabel} failed:`, error);
+    if (error instanceof GoogleDriveBrowserUploadError) {
+      toast.error(error.message || `${actionLabel}에 실패했습니다.`);
+      return;
+    }
     if (error instanceof PlatformApiError) {
       const message = typeof error.body === 'object' && error.body && 'message' in (error.body as Record<string, unknown>)
         ? String((error.body as Record<string, unknown>).message || '')
@@ -480,6 +489,7 @@ export function PortalWeeklyExpensePage() {
       });
       applyProvisionedDriveState(tx.id, result);
       toast.success(`증빙 폴더 연결 완료: ${result.folderName}`);
+      return result;
     } catch (error) {
       handleEvidenceDriveError(error, '증빙 폴더 생성');
       throw error;
@@ -520,8 +530,58 @@ export function PortalWeeklyExpensePage() {
 
   const uploadEvidenceDrive = async (tx: Transaction, uploads: EvidenceUploadSelection[]) => {
     try {
-      let lastResult: UploadTransactionEvidenceDriveResult | null = null;
+      const googleAccessToken = bffActor.googleAccessToken || await ensureGoogleWorkspaceAccess() || undefined;
+      let workingTx = transactions.find((candidate) => candidate.id === tx.id) || tx;
+      let folderId = workingTx.evidenceDriveFolderId || '';
+      let sharedDriveId = workingTx.evidenceDriveSharedDriveId || '';
+
+      if (!folderId) {
+        const provisioned = await provisionEvidenceDrive(workingTx);
+        folderId = provisioned.folderId;
+        sharedDriveId = provisioned.sharedDriveId || sharedDriveId;
+        workingTx = {
+          ...workingTx,
+          evidenceDriveFolderId: provisioned.folderId,
+          evidenceDriveFolderName: provisioned.folderName,
+          evidenceDriveLink: provisioned.webViewLink || workingTx.evidenceDriveLink,
+          evidenceDriveSharedDriveId: provisioned.sharedDriveId || workingTx.evidenceDriveSharedDriveId,
+        };
+      }
+
+      if (!folderId) {
+        throw new Error('증빙 Drive 폴더를 찾지 못했습니다.');
+      }
+
+      const categoryOverrides: Array<{ driveFileId: string; category: string }> = [];
+      let usedBrowserUpload = false;
+      let lastResult: UploadTransactionEvidenceDriveResult | SyncTransactionEvidenceDriveResult | null = null;
+
       for (const upload of uploads) {
+        if (googleAccessToken) {
+          const uploadedFile = await uploadFileToGoogleDriveFolder({
+            accessToken: googleAccessToken,
+            folderId,
+            file: upload.file,
+            fileName: upload.reviewedFileName,
+            mimeType: upload.file.type || 'application/octet-stream',
+            appProperties: {
+              managedBy: 'mysc-platform',
+              tenantId: orgId,
+              projectId,
+              transactionId: tx.id,
+              evidenceSource: 'platform-upload',
+              originalFileName: upload.file.name,
+              sharedDriveId,
+            },
+          });
+          categoryOverrides.push({
+            driveFileId: uploadedFile.id,
+            category: upload.category,
+          });
+          usedBrowserUpload = true;
+          continue;
+        }
+
         const contentBase64 = await readFileAsBase64(upload.file);
         lastResult = await uploadTransactionEvidenceDriveViaBff({
           tenantId: orgId,
@@ -537,7 +597,29 @@ export function PortalWeeklyExpensePage() {
           },
         });
       }
-      if (lastResult) {
+
+      if (usedBrowserUpload) {
+        lastResult = await syncTransactionEvidenceDriveViaBff({
+          tenantId: orgId,
+          actor: {
+            ...bffActor,
+            ...(googleAccessToken ? { googleAccessToken } : {}),
+          },
+          transactionId: tx.id,
+        });
+        applySyncedEvidenceState(tx.id, lastResult);
+
+        if (categoryOverrides.length > 0) {
+          const overrideResult = await overrideTransactionEvidenceDriveCategoriesViaBff({
+            tenantId: orgId,
+            actor: bffActor,
+            transactionId: tx.id,
+            overrides: { items: categoryOverrides },
+          });
+          applySyncedEvidenceState(tx.id, overrideResult);
+          lastResult = overrideResult;
+        }
+      } else if (lastResult) {
         applySyncedEvidenceState(tx.id, lastResult);
       }
       toast.success(`증빙 업로드 완료: ${uploads.length}건`);

--- a/src/app/lib/firebase.ts
+++ b/src/app/lib/firebase.ts
@@ -202,6 +202,7 @@ export function getGoogleAuthProvider(): GoogleAuthProvider {
   if (_googleProvider) return _googleProvider;
   _googleProvider = new GoogleAuthProvider();
   _googleProvider.addScope('https://www.googleapis.com/auth/spreadsheets.readonly');
+  _googleProvider.addScope('https://www.googleapis.com/auth/drive');
   const domains = getAllowedEmailDomains(import.meta.env);
   const hd = domains.length === 1 ? domains[0] : '';
   _googleProvider.setCustomParameters({

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -4,6 +4,7 @@ import {
   addEvidenceViaBff,
   changeTransactionStateViaBff,
   linkProjectEvidenceDriveRootViaBff,
+  overrideTransactionEvidenceDriveCategoriesViaBff,
   previewGoogleSheetImportViaBff,
   provisionProjectEvidenceDriveRootViaBff,
   provisionTransactionEvidenceDriveViaBff,
@@ -350,6 +351,52 @@ describe('platform-bff-client', () => {
     }));
     expect(result.driveFileId).toBe('drv-file-001');
     expect(result.evidenceCompletedDesc).toBe('ZOOM invoice');
+  });
+
+  it('posts evidence drive category overrides', async () => {
+    const client = {
+      post: vi.fn(),
+      get: vi.fn(),
+      request: vi.fn(async () => ({
+        data: {
+          transactionId: 'tx001',
+          projectId: 'p001',
+          folderId: 'fld-tx',
+          folderName: '20260311_회의비_다과비_tx001',
+          webViewLink: 'https://drive.google.com/drive/folders/fld-tx',
+          sharedDriveId: 'drive-001',
+          evidenceCount: 1,
+          evidenceCompletedDesc: '세금계산서',
+          evidenceAutoListedDesc: '세금계산서',
+          evidencePendingDesc: null,
+          supportPendingDocs: null,
+          evidenceMissing: [],
+          evidenceStatus: 'COMPLETE',
+          lastSyncedAt: '2026-03-11T11:10:00.000Z',
+          version: 6,
+          updatedAt: '2026-03-11T11:10:00.000Z',
+        },
+      })),
+    };
+
+    const result = await overrideTransactionEvidenceDriveCategoriesViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'u001', role: 'pm' },
+      transactionId: 'tx001',
+      overrides: {
+        items: [{ driveFileId: 'drv-file-001', category: '세금계산서' }],
+      },
+      client,
+    });
+
+    expect(client.request).toHaveBeenCalledWith('/api/v1/transactions/tx001/evidence-drive/overrides', expect.objectContaining({
+      method: 'POST',
+      tenantId: 'mysc',
+      body: {
+        items: [{ driveFileId: 'drv-file-001', category: '세금계산서' }],
+      },
+    }));
+    expect(result.evidenceCompletedDesc).toBe('세금계산서');
   });
 
   it('calls google sheet import preview endpoint', async () => {

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -135,6 +135,13 @@ export interface UploadTransactionEvidenceDriveResult extends SyncTransactionEvi
   parserConfidence: number;
 }
 
+export interface OverrideTransactionEvidenceDriveCategoriesPayload {
+  items: Array<{
+    driveFileId: string;
+    category: string;
+  }>;
+}
+
 export interface PlatformApiClientLike {
   get<T>(path: string, options: {
     tenantId: string;
@@ -444,6 +451,28 @@ export async function uploadTransactionEvidenceDriveViaBff(params: {
       body: params.upload,
       retries: 0,
       timeoutMs: 30000,
+    },
+  );
+  return response.data;
+}
+
+export async function overrideTransactionEvidenceDriveCategoriesViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  transactionId: string;
+  overrides: OverrideTransactionEvidenceDriveCategoriesPayload;
+  client?: PlatformApiClientLike;
+}): Promise<SyncTransactionEvidenceDriveResult> {
+  const apiClient = resolveClient(params.client);
+  const response = await apiClient.request<SyncTransactionEvidenceDriveResult>(
+    `/api/v1/transactions/${params.transactionId}/evidence-drive/overrides`,
+    {
+      method: 'POST',
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      body: params.overrides,
+      retries: 0,
+      timeoutMs: 15000,
     },
   );
   return response.data;

--- a/src/app/platform/google-drive-browser-upload.test.ts
+++ b/src/app/platform/google-drive-browser-upload.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  GoogleDriveBrowserUploadError,
+  uploadFileToGoogleDriveFolder,
+} from './google-drive-browser-upload';
+
+describe('google-drive-browser-upload', () => {
+  it('uploads a file to Google Drive with multipart metadata', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      id: 'drv-file-001',
+      name: '20260312_회의비_다과비_영수증.pdf',
+      mimeType: 'application/pdf',
+      size: '1024',
+      webViewLink: 'https://drive.google.com/file/d/drv-file-001/view',
+      parents: ['folder-001'],
+      driveId: 'drive-001',
+      appProperties: {
+        transactionId: 'tx001',
+      },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const file = new File(['fake-pdf'], 'raw.pdf', { type: 'application/pdf' });
+    const result = await uploadFileToGoogleDriveFolder({
+      accessToken: 'google-token-123',
+      folderId: 'folder-001',
+      file,
+      fileName: '20260312_회의비_다과비_영수증.pdf',
+      appProperties: {
+        transactionId: 'tx001',
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] || [];
+    expect(String(url)).toContain('uploadType=multipart');
+    expect(init?.method).toBe('POST');
+    expect(init?.headers?.authorization).toBe('Bearer google-token-123');
+    expect(result.id).toBe('drv-file-001');
+    expect(result.driveId).toBe('drive-001');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('throws a structured error when Google Drive rejects the upload', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      error: {
+        code: 403,
+        message: 'insufficient permissions',
+      },
+    }), {
+      status: 403,
+      headers: { 'content-type': 'application/json' },
+    }));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const file = new File(['fake-pdf'], 'raw.pdf', { type: 'application/pdf' });
+    await expect(uploadFileToGoogleDriveFolder({
+      accessToken: 'google-token-123',
+      folderId: 'folder-001',
+      file,
+      fileName: '20260312_회의비_다과비_영수증.pdf',
+    })).rejects.toBeInstanceOf(GoogleDriveBrowserUploadError);
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/app/platform/google-drive-browser-upload.ts
+++ b/src/app/platform/google-drive-browser-upload.ts
@@ -1,0 +1,122 @@
+export interface GoogleDriveBrowserUploadFile {
+  id: string;
+  name: string;
+  mimeType: string | null;
+  size: string | null;
+  webViewLink: string | null;
+  webContentLink: string | null;
+  modifiedTime: string | null;
+  createdTime: string | null;
+  parents: string[];
+  driveId: string | null;
+  appProperties: Record<string, string>;
+}
+
+export class GoogleDriveBrowserUploadError extends Error {
+  status: number;
+  details?: unknown;
+
+  constructor(message: string, status: number, details?: unknown) {
+    super(message);
+    this.name = 'GoogleDriveBrowserUploadError';
+    this.status = status;
+    this.details = details;
+  }
+}
+
+function readOptionalText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+async function readJsonSafe(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function normalizeDriveFile(value: any): GoogleDriveBrowserUploadFile {
+  const appProperties = value?.appProperties && typeof value.appProperties === 'object'
+    ? Object.fromEntries(
+      Object.entries(value.appProperties)
+        .map(([key, raw]) => [String(key), readOptionalText(raw)])
+        .filter(([, raw]) => raw),
+    )
+    : {};
+
+  return {
+    id: readOptionalText(value?.id),
+    name: readOptionalText(value?.name),
+    mimeType: readOptionalText(value?.mimeType) || null,
+    size: readOptionalText(value?.size) || null,
+    webViewLink: readOptionalText(value?.webViewLink) || null,
+    webContentLink: readOptionalText(value?.webContentLink) || null,
+    modifiedTime: readOptionalText(value?.modifiedTime) || null,
+    createdTime: readOptionalText(value?.createdTime) || null,
+    parents: Array.isArray(value?.parents) ? value.parents.map((entry: unknown) => readOptionalText(entry)).filter(Boolean) : [],
+    driveId: readOptionalText(value?.driveId) || null,
+    appProperties,
+  };
+}
+
+export async function uploadFileToGoogleDriveFolder(params: {
+  accessToken: string;
+  folderId: string;
+  file: File;
+  fileName: string;
+  mimeType?: string;
+  appProperties?: Record<string, string>;
+}): Promise<GoogleDriveBrowserUploadFile> {
+  const accessToken = readOptionalText(params.accessToken);
+  const folderId = readOptionalText(params.folderId);
+  const fileName = readOptionalText(params.fileName);
+  const mimeType = readOptionalText(params.mimeType) || params.file.type || 'application/octet-stream';
+
+  if (!accessToken) {
+    throw new GoogleDriveBrowserUploadError('Google Drive access token is required.', 401);
+  }
+  if (!folderId) {
+    throw new GoogleDriveBrowserUploadError('Google Drive folder is required.', 400);
+  }
+  if (!fileName) {
+    throw new GoogleDriveBrowserUploadError('업로드 파일명이 비어 있습니다.', 400);
+  }
+
+  const boundary = `driveupload_${Date.now().toString(36)}`;
+  const metadata = {
+    name: fileName,
+    parents: [folderId],
+    appProperties: params.appProperties || {},
+  };
+  const body = new Blob([
+    `--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${JSON.stringify(metadata)}\r\n`,
+    `--${boundary}\r\nContent-Type: ${mimeType}\r\n\r\n`,
+    params.file,
+    `\r\n--${boundary}--`,
+  ], { type: `multipart/related; boundary=${boundary}` });
+
+  const response = await fetch(
+    'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&supportsAllDrives=true&fields=id,name,mimeType,size,webViewLink,webContentLink,modifiedTime,createdTime,parents,driveId,appProperties',
+    {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${accessToken}`,
+        'content-type': `multipart/related; boundary=${boundary}`,
+      },
+      body,
+    },
+  );
+
+  const data = await readJsonSafe(response);
+  if (!response.ok) {
+    const message = typeof data === 'object' && data && 'error' in data
+      ? `Google Drive 업로드 실패 (${response.status})`
+      : `Google Drive 업로드 실패 (${response.status})`;
+    throw new GoogleDriveBrowserUploadError(message, response.status, data);
+  }
+
+  return normalizeDriveFile(data);
+}


### PR DESCRIPTION
## Summary\n- upload evidence files directly from the browser to Google Drive to avoid Vercel request body limits\n- sync uploaded files back into platform evidence state and persist category overrides after sync\n- tolerate concurrent auto-ledger creation so upload-time transaction saves stop failing with 409s\n\n## Testing\n- npx vitest run src/app/lib/platform-bff-client.test.ts src/app/platform/google-drive-browser-upload.test.ts\n- npm run build\n- node --check server/bff/app.mjs\n- node --check server/bff/schemas.mjs