### PR TITLE
fix: reuse linked evidence folders in weekly rows

### DIFF
--- a/src/app/components/cashflow/SettlementLedgerPage.tsx
+++ b/src/app/components/cashflow/SettlementLedgerPage.tsx
@@ -1996,6 +1996,7 @@ function ImportEditor({
     if (!uploadTargetTxId || !onUploadEvidenceDriveById || uploadDrafts.length === 0) return;
     setUploadingEvidence(true);
     try {
+      const uploadedNames = uploadDrafts.map((draft) => draft.reviewedFileName.trim() || draft.suggestedFileName);
       await onUploadEvidenceDriveById(
         uploadTargetTxId,
         uploadDrafts.map((draft) => ({
@@ -2005,7 +2006,12 @@ function ImportEditor({
           reviewedFileName: draft.reviewedFileName.trim() || draft.suggestedFileName,
         })),
       );
-      toast.success(`${uploadDrafts.length}건 업로드 완료`);
+      const firstFileName = uploadedNames[0] || '증빙 파일';
+      toast.success(
+        uploadDrafts.length === 1
+          ? `업로드 완료: ${firstFileName}`
+          : `업로드 완료: ${firstFileName} 외 ${uploadDrafts.length - 1}건`,
+      );
       setUploadDialogOpen(false);
       clearUploadDrafts();
     } catch (error) {

--- a/src/app/components/portal/PortalWeeklyExpensePage.tsx
+++ b/src/app/components/portal/PortalWeeklyExpensePage.tsx
@@ -481,6 +481,24 @@ export function PortalWeeklyExpensePage() {
   };
 
   const provisionEvidenceDrive = async (tx: Transaction) => {
+    if (tx.evidenceDriveFolderId) {
+      const folderName = tx.evidenceDriveFolderName || '기존 증빙 폴더';
+      toast.success(`이미 연결된 증빙 폴더를 사용합니다: ${folderName}`);
+      return {
+        transactionId: tx.id,
+        projectId: tx.projectId,
+        projectFolderId: myProject?.evidenceDriveRootFolderId || '',
+        projectFolderName: myProject?.evidenceDriveRootFolderName || '',
+        folderId: tx.evidenceDriveFolderId,
+        folderName,
+        webViewLink: tx.evidenceDriveLink || null,
+        sharedDriveId: tx.evidenceDriveSharedDriveId || myProject?.evidenceDriveSharedDriveId || null,
+        syncStatus: 'LINKED' as const,
+        version: tx.version || 1,
+        updatedAt: tx.updatedAt || new Date().toISOString(),
+      };
+    }
+
     try {
       const result = await provisionTransactionEvidenceDriveViaBff({
         tenantId: orgId,
@@ -622,7 +640,6 @@ export function PortalWeeklyExpensePage() {
       } else if (lastResult) {
         applySyncedEvidenceState(tx.id, lastResult);
       }
-      toast.success(`증빙 업로드 완료: ${uploads.length}건`);
     } catch (error) {
       handleEvidenceDriveError(error, '증빙 업로드');
       throw error;


### PR DESCRIPTION
## Summary\n- stop re-provisioning evidence folders for rows that already have a linked folder\n- show a clear success message with uploaded file names after evidence uploads\n- keep the upload success toast in the dialog so users get direct confirmation\n\n## Testing\n- npx vitest run src/app/platform/google-drive-browser-upload.test.ts src/app/lib/platform-bff-client.test.ts\n- npm run build