### PR TITLE
feat: tighten weekly expense happy path

### DIFF
--- a/src/app/components/cashflow/SettlementLedgerPage.tsx
+++ b/src/app/components/cashflow/SettlementLedgerPage.tsx
@@ -27,6 +27,12 @@ import { buildSettlementActualSyncPayload } from '../../platform/settlement-shee
 import { computeSettlementGridWindowRange } from '../../platform/settlement-grid-windowing';
 import { updateImportRowAt } from '../../platform/settlement-grid-state';
 import {
+  clearAllEditableCells,
+  clearSelectionCells,
+  DEFAULT_PROTECTED_SETTLEMENT_HEADERS,
+  deleteSelectedRows,
+} from '../../platform/settlement-grid-actions';
+import {
   deriveSettlementRows,
   isSettlementCascadeColumn,
 } from '../../platform/settlement-row-derivation';
@@ -729,7 +735,7 @@ export function SettlementLedgerPage({
     if (!autoSaveSheet || !importDirty || !importRows || !onSaveSheetRows || sheetSaving) return;
     const timer = window.setTimeout(() => {
       void handleImportSave({ silent: true, syncCashflow: false });
-    }, 10_000);
+    }, 20_000);
     return () => window.clearTimeout(timer);
   }, [autoSaveSheet, importDirty, importRows, onSaveSheetRows, sheetSaving, handleImportSave]);
 
@@ -737,7 +743,7 @@ export function SettlementLedgerPage({
     if (!autoSaveSheet || importDirty || !importRows || sheetSaving || cashflowSyncing || cashflowSyncState !== 'pending') return;
     const timer = window.setTimeout(() => {
       void syncImportRowsToCashflow(importRows, { silent: true });
-    }, 45_000);
+    }, 60_000);
     return () => window.clearTimeout(timer);
   }, [autoSaveSheet, cashflowSyncState, cashflowSyncing, importDirty, importRows, sheetSaving, syncImportRowsToCashflow]);
 
@@ -1760,6 +1766,7 @@ function ImportEditor({
   const [activeUploadDraftId, setActiveUploadDraftId] = useState('');
   const [uploadDialogOpen, setUploadDialogOpen] = useState(false);
   const [uploadingEvidence, setUploadingEvidence] = useState(false);
+  const [clearAllConfirmOpen, setClearAllConfirmOpen] = useState(false);
   const selectionBounds = useMemo(() => {
     if (!selection) return null;
     return {
@@ -1776,6 +1783,15 @@ function ImportEditor({
   const sourceTransactionMap = useMemo(
     () => new Map(sourceTransactions.map((transaction) => [transaction.id, transaction])),
     [sourceTransactions],
+  );
+  const protectedClearColumnIndexes = useMemo(
+    () => SETTLEMENT_COLUMNS.reduce<number[]>((indexes, column, index) => {
+      if (DEFAULT_PROTECTED_SETTLEMENT_HEADERS.includes(column.csvHeader as (typeof DEFAULT_PROTECTED_SETTLEMENT_HEADERS)[number])) {
+        indexes.push(index);
+      }
+      return indexes;
+    }, []),
+    [],
   );
   const shouldVirtualizeRows = inline && rows.length >= IMPORT_EDITOR_WINDOW_THRESHOLD;
   const visibleRowWindow = useMemo(() => {
@@ -2037,6 +2053,17 @@ function ImportEditor({
     return anchor.colIdx;
   }, [getSelectionAnchor, noIdx]);
   const selectedRowIdx = getSelectionAnchor()?.rowIdx ?? -1;
+  const getActiveSelectionBounds = useCallback(() => {
+    if (selectionBounds) return selectionBounds;
+    const anchor = getSelectionAnchor();
+    if (!anchor) return null;
+    return {
+      r1: anchor.rowIdx,
+      r2: anchor.rowIdx,
+      c1: anchor.colIdx,
+      c2: anchor.colIdx,
+    };
+  }, [getSelectionAnchor, selectionBounds]);
 
   const commitRows = useCallback((nextRows: ImportRow[], focusTarget?: { rowIdx: number; colIdx: number } | null) => {
     if (focusTarget) pendingFocusCell.current = focusTarget;
@@ -2103,6 +2130,75 @@ function ImportEditor({
   const cloneRows = useCallback((input: ImportRow[]) => {
     return input.map((row) => ({ ...row, cells: [...row.cells] }));
   }, []);
+
+  const pushUndoSnapshot = useCallback(() => {
+    undoStack.current.push(cloneRows(rows));
+  }, [cloneRows, rows]);
+
+  const clearSelectedCells = useCallback((options?: { silent?: boolean }) => {
+    const bounds = getActiveSelectionBounds();
+    if (!bounds) return false;
+    const nextRows = clearSelectionCells(rows, bounds, {
+      protectedColumnIndexes: protectedClearColumnIndexes,
+    });
+    if (nextRows === rows) {
+      if (!options?.silent) {
+        toast.message('비울 수 있는 셀이 선택되지 않았습니다.');
+      }
+      return false;
+    }
+    pushUndoSnapshot();
+    commitRows(nextRows, {
+      rowIdx: bounds.r1,
+      colIdx: bounds.c1 === noIdx ? getPreferredEditableCol() : bounds.c1,
+    });
+    return true;
+  }, [
+    commitRows,
+    getActiveSelectionBounds,
+    getPreferredEditableCol,
+    noIdx,
+    protectedClearColumnIndexes,
+    pushUndoSnapshot,
+    rows,
+  ]);
+
+  const removeSelectedRows = useCallback(() => {
+    const bounds = getActiveSelectionBounds();
+    if (!bounds) return false;
+    const nextRows = deleteSelectedRows(rows, bounds);
+    if (nextRows === rows) return false;
+    pushUndoSnapshot();
+    setSelection(null);
+    const nextFocusRow = Math.min(bounds.r1, Math.max(0, nextRows.length - 1));
+    commitRows(
+      nextRows,
+      nextRows.length > 0
+        ? { rowIdx: nextFocusRow, colIdx: getPreferredEditableCol() }
+        : null,
+    );
+    return true;
+  }, [commitRows, getActiveSelectionBounds, getPreferredEditableCol, pushUndoSnapshot, rows]);
+
+  const clearAllRows = useCallback(() => {
+    const nextRows = clearAllEditableCells(rows, {
+      protectedColumnIndexes: protectedClearColumnIndexes,
+    });
+    if (nextRows === rows) {
+      toast.message('비울 수 있는 내용이 없습니다.');
+      return false;
+    }
+    pushUndoSnapshot();
+    setSelection(null);
+    commitRows(
+      nextRows,
+      nextRows.length > 0
+        ? { rowIdx: 0, colIdx: getPreferredEditableCol() }
+        : null,
+    );
+    toast.success('현재 탭의 입력값을 비웠습니다.');
+    return true;
+  }, [commitRows, getPreferredEditableCol, protectedClearColumnIndexes, pushUndoSnapshot, rows]);
 
   const applyPaste = useCallback(
     (startRow: number, startCol: number, text: string) => {
@@ -2327,6 +2423,54 @@ function ImportEditor({
     handleCopy(e);
     if (e.defaultPrevented) return;
 
+    const target = e.target as HTMLElement | null;
+    const isTextEditingTarget = Boolean(
+      target
+      && (
+        target instanceof HTMLInputElement
+        || target instanceof HTMLTextAreaElement
+        || target.isContentEditable
+      ),
+    );
+    const hasMultiCellSelection = Boolean(
+      selectionBounds
+      && (selectionBounds.r1 !== selectionBounds.r2 || selectionBounds.c1 !== selectionBounds.c2),
+    );
+    const inputHasPartialSelection = Boolean(
+      target instanceof HTMLInputElement
+      && typeof target.selectionStart === 'number'
+      && typeof target.selectionEnd === 'number'
+      && target.selectionStart !== target.selectionEnd,
+    );
+
+    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'a') {
+      if (isTextEditingTarget) return;
+      if (rows.length === 0) return;
+      e.preventDefault();
+      const firstEditableCol = noIdx === 0 ? 1 : 0;
+      setSelection({
+        start: { r: 0, c: firstEditableCol },
+        end: { r: rows.length - 1, c: Math.max(firstEditableCol, SETTLEMENT_COLUMNS.length - 1) },
+      });
+      tableWrapRef.current?.focus();
+      return;
+    }
+
+    if (e.key === 'Escape') {
+      if (!selectionRef.current) return;
+      e.preventDefault();
+      setSelection(null);
+      return;
+    }
+
+    if ((e.key === 'Delete' || e.key === 'Backspace') && !e.altKey && !e.ctrlKey && !e.metaKey) {
+      if (isTextEditingTarget && !hasMultiCellSelection && inputHasPartialSelection) return;
+      if (!getActiveSelectionBounds()) return;
+      e.preventDefault();
+      void clearSelectedCells();
+      return;
+    }
+
     const anchor = selection
       ? {
         r: Math.min(selection.start.r, selection.end.r),
@@ -2360,7 +2504,17 @@ function ImportEditor({
     if (e.key === 'ArrowRight') {
       focusCellAt(anchor.r, anchor.c + 1);
     }
-  }, [handleUndo, handleCopy, selection, focusCellAt]);
+  }, [
+    clearSelectedCells,
+    focusCellAt,
+    getActiveSelectionBounds,
+    handleCopy,
+    handleUndo,
+    noIdx,
+    rows.length,
+    selection,
+    selectionBounds,
+  ]);
 
   useEffect(() => {
     const onPaste = (e: ClipboardEvent) => {
@@ -2487,11 +2641,14 @@ function ImportEditor({
 
   const removeRow = useCallback(
     (rowIdx: number) => {
-      const nextRows = rows.filter((_, i) => i !== rowIdx);
+      const nextRows = deleteSelectedRows(rows, { r1: rowIdx, r2: rowIdx, c1: 0, c2: SETTLEMENT_COLUMNS.length - 1 });
+      if (nextRows === rows) return;
+      pushUndoSnapshot();
+      setSelection(null);
       const nextFocusRow = Math.min(Math.max(0, rowIdx - 1), Math.max(0, nextRows.length - 1));
       commitRows(nextRows, nextRows.length > 0 ? { rowIdx: nextFocusRow, colIdx: getPreferredEditableCol() } : null);
     },
-    [rows, commitRows, getPreferredEditableCol],
+    [rows, pushUndoSnapshot, commitRows, getPreferredEditableCol],
   );
 
   const applyEvidenceMapping = useCallback((rowIdx?: number) => {
@@ -2623,13 +2780,33 @@ function ImportEditor({
             size="sm"
             className="h-7 text-[11px] gap-1 cursor-pointer shadow-sm hover:bg-muted/40"
             onClick={() => {
-              if (selectedRowIdx < 0) return;
-              removeRow(selectedRowIdx);
+              void clearSelectedCells();
+            }}
+            disabled={!getActiveSelectionBounds()}
+          >
+            <X className="h-3.5 w-3.5" />
+            선택 셀 비우기
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-[11px] gap-1 cursor-pointer shadow-sm hover:bg-muted/40"
+            onClick={() => {
+              void removeSelectedRows();
             }}
             disabled={selectedRowIdx < 0 || rows.length === 0}
           >
             <X className="h-3.5 w-3.5" />
             선택 행 삭제
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-7 text-[11px] cursor-pointer shadow-sm hover:bg-muted/40"
+            onClick={() => setClearAllConfirmOpen(true)}
+            disabled={rows.length === 0}
+          >
+            현재 탭 전체 비우기
           </Button>
           <Button
             variant="outline"
@@ -2651,6 +2828,27 @@ function ImportEditor({
           </Button>
         </div>
       </div>
+      <AlertDialog open={clearAllConfirmOpen} onOpenChange={setClearAllConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>현재 탭 입력값을 모두 비울까요?</AlertDialogTitle>
+            <AlertDialogDescription>
+              행 구조는 유지하고 일반 입력값만 비웁니다. 증빙/드라이브 관련 보호 컬럼은 유지됩니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>취소</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                void clearAllRows();
+                setClearAllConfirmOpen(false);
+              }}
+            >
+              전체 비우기
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       {/* Scrollable table */}
       <div

--- a/src/app/components/portal/PortalLayout.tsx
+++ b/src/app/components/portal/PortalLayout.tsx
@@ -181,7 +181,7 @@ function PortalContent() {
       isRegistered,
       pathname: location.pathname,
     })) {
-      navigate('/portal/onboarding', { replace: true });
+      navigate('/portal/project-settings', { replace: true });
     }
   }, [authLoading, portalLoading, isAuthenticated, authUser?.role, isRegistered, location.pathname, navigate]);
 
@@ -202,7 +202,9 @@ function PortalContent() {
   }
 
   const standaloneOnboarding = (
-    (location.pathname.includes('/portal/onboarding') || location.pathname.includes('/portal/register-project')) &&
+    (location.pathname.includes('/portal/onboarding')
+      || location.pathname.includes('/portal/project-settings')
+      || location.pathname.includes('/portal/register-project')) &&
     !isRegistered &&
     canEnterPortalWorkspace(authUser?.role)
   );
@@ -220,7 +222,7 @@ function PortalContent() {
             아직 배정된 사업이 없습니다. 관리자에게 사업 배정을 요청하거나, 온보딩에서 사업을 선택해 주세요.
           </p>
           <div className="mt-4 flex items-center justify-center gap-2">
-            <Button variant="outline" onClick={() => navigate('/portal/onboarding')}>
+            <Button variant="outline" onClick={() => navigate('/portal/project-settings')}>
               사업 배정 수정
             </Button>
             <Button variant="ghost" onClick={() => { portalLogout(); authLogout(); navigate('/login'); }}>
@@ -242,7 +244,7 @@ function PortalContent() {
             배정된 사업 정보가 존재하지 않거나 접근 권한이 없습니다. 관리자에게 문의해 주세요.
           </p>
           <div className="mt-4 flex items-center justify-center gap-2">
-            <Button variant="outline" onClick={() => navigate('/portal/onboarding')}>
+            <Button variant="outline" onClick={() => navigate('/portal/project-settings')}>
               사업 배정 수정
             </Button>
             <Button variant="ghost" onClick={() => { portalLogout(); authLogout(); navigate('/login'); }}>

--- a/src/app/components/portal/PortalProjectSettings.tsx
+++ b/src/app/components/portal/PortalProjectSettings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
-import { FolderKanban, AlertCircle, CheckCircle2, ExternalLink, Loader2 } from 'lucide-react';
+import { FolderKanban, AlertCircle, ArrowRight, CheckCircle2, ExternalLink, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { Card, CardContent } from '../ui/card';
 import { Button } from '../ui/button';
@@ -12,6 +12,7 @@ import { useAuth } from '../../data/auth-store';
 import { canEnterPortalWorkspace } from '../../platform/navigation';
 import { useFirebase } from '../../lib/firebase-context';
 import { PlatformApiError } from '../../platform/api-client';
+import { resolvePortalHappyPath } from '../../platform/portal-happy-path';
 import {
   linkProjectEvidenceDriveRootViaBff,
   provisionProjectEvidenceDriveRootViaBff,
@@ -60,13 +61,6 @@ export function PortalProjectSettings() {
   }, [authLoading, isAuthenticated, isAdminSpaceUser, navigate]);
 
   useEffect(() => {
-    if (authLoading || isLoading) return;
-    if (!isRegistered) {
-      navigate('/portal/onboarding', { replace: true });
-    }
-  }, [authLoading, isLoading, isRegistered, navigate]);
-
-  useEffect(() => {
     const merged = normalizeProjectIds([
       ...(Array.isArray(portalUser?.projectIds) ? portalUser.projectIds : []),
       portalUser?.projectId,
@@ -92,6 +86,12 @@ export function PortalProjectSettings() {
     role: authUser?.role || portalUser?.role || 'pm',
     idToken: authUser?.idToken,
   }), [authUser?.uid, authUser?.email, authUser?.role, authUser?.idToken, portalUser?.id, portalUser?.email, portalUser?.role]);
+
+  const happyPath = useMemo(() => resolvePortalHappyPath({
+    authUser,
+    portalUser,
+    project: primaryProject,
+  }), [authUser, portalUser, primaryProject]);
 
   useEffect(() => {
     setDriveRootInputs((prev) => {
@@ -255,9 +255,11 @@ export function PortalProjectSettings() {
           <div className="w-14 h-14 rounded-2xl flex items-center justify-center mx-auto mb-3 shadow-lg shadow-teal-500/20 bg-teal-600">
             <FolderKanban className="w-7 h-7 text-white" />
           </div>
-          <h1 className="text-[22px]" style={{ fontWeight: 800, letterSpacing: '-0.02em' }}>사업 배정 수정</h1>
+          <h1 className="text-[22px]" style={{ fontWeight: 800, letterSpacing: '-0.02em' }}>
+            {isRegistered ? '사업 배정 수정' : '포털 시작하기'}
+          </h1>
           <p className="text-[12px] text-muted-foreground">
-            내 사업 목록과 주사업을 수정할 수 있습니다.
+            로그인 후 바로 사업 선택과 증빙 기본 경로까지 한 번에 준비할 수 있습니다.
           </p>
         </div>
 
@@ -269,6 +271,76 @@ export function PortalProjectSettings() {
                 <span>{error}</span>
               </div>
             )}
+
+            <div className="rounded-xl border border-slate-200/80 bg-slate-50/80 px-4 py-4 space-y-3">
+              <div className="flex items-start justify-between gap-3 flex-wrap">
+                <div>
+                  <p className="text-[12px] text-slate-900" style={{ fontWeight: 800 }}>Evidence Workflow MVP 준비 상태</p>
+                  <p className="text-[11px] text-muted-foreground mt-1">
+                    로그인부터 사업 선택, 기본 증빙 폴더 연결까지 한 경로로 맞췄습니다.
+                  </p>
+                </div>
+                <Badge className={`text-[10px] ${
+                  happyPath.status === 'ready'
+                    ? 'bg-emerald-100 text-emerald-700'
+                    : happyPath.status === 'blocked'
+                      ? 'bg-rose-100 text-rose-700'
+                      : 'bg-amber-100 text-amber-800'
+                }`}>
+                  {happyPath.status === 'ready' ? '준비 완료' : happyPath.status === 'blocked' ? '권한 확인 필요' : '설정 필요'}
+                </Badge>
+              </div>
+
+              <div className="grid gap-2 md:grid-cols-2">
+                {happyPath.steps.map((step) => (
+                  <div
+                    key={step.key}
+                    className={`rounded-lg border px-3 py-3 text-[11px] ${
+                      step.status === 'complete'
+                        ? 'border-emerald-200 bg-emerald-50/70'
+                        : step.status === 'required'
+                          ? 'border-amber-200 bg-amber-50/70'
+                          : 'border-slate-200 bg-white'
+                    }`}
+                  >
+                    <div className="flex items-center gap-2">
+                      <CheckCircle2 className={`h-3.5 w-3.5 ${
+                        step.status === 'complete' ? 'text-emerald-600' : 'text-slate-400'
+                      }`} />
+                      <span className="font-semibold text-slate-900">{step.label}</span>
+                    </div>
+                    <p className="mt-1 text-slate-700/80">{step.detail}</p>
+                  </div>
+                ))}
+              </div>
+
+              <div className="flex items-center justify-between gap-3 flex-wrap rounded-lg border border-dashed border-slate-200 bg-white px-3 py-3">
+                <div>
+                  <p className="text-[12px] font-semibold text-slate-900">
+                    {happyPath.canUseEvidenceWorkflow
+                      ? `${happyPath.selectedProjectName || '주사업'}에서 바로 증빙 Workflow를 사용할 수 있습니다.`
+                      : happyPath.canOpenWeeklyExpenses
+                        ? '사업 선택은 끝났습니다. 기본 증빙 폴더만 연결하면 업로드/동기화를 바로 사용할 수 있습니다.'
+                        : '먼저 내 사업과 주사업을 저장하면 다음 단계로 넘어갈 수 있습니다.'}
+                  </p>
+                  <p className="mt-1 text-[11px] text-muted-foreground">
+                    주간 시트에서는 행 저장 후 `생성 → 업로드 → 동기화` 순서로 바로 이어집니다.
+                  </p>
+                </div>
+                <div className="flex items-center gap-2">
+                  {happyPath.canOpenWeeklyExpenses && (
+                    <Button
+                      variant="outline"
+                      className="h-9 text-[11px]"
+                      onClick={() => navigate('/portal/weekly-expenses')}
+                    >
+                      주간 시트로 이동
+                      <ArrowRight className="ml-1 h-3.5 w-3.5" />
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </div>
 
             {allProjects.length === 0 && (
               <div className="p-4 rounded-lg border border-dashed border-border text-center text-[12px] text-muted-foreground">

--- a/src/app/components/portal/PortalWeeklyExpensePage.tsx
+++ b/src/app/components/portal/PortalWeeklyExpensePage.tsx
@@ -36,6 +36,7 @@ import {
 import { splitLooseNameList } from '../../platform/name-list';
 import { type ImportRow } from '../../platform/settlement-csv';
 import { readDevAuthHarnessConfig } from '../../platform/dev-harness';
+import { resolvePortalHappyPath } from '../../platform/portal-happy-path';
 const GoogleSheetMigrationWizard = lazy(
   () => import('./GoogleSheetMigrationWizard').then((module) => ({ default: module.GoogleSheetMigrationWizard })),
 );
@@ -101,6 +102,12 @@ export function PortalWeeklyExpensePage() {
     const ledger = ledgers.find((l) => l.projectId === projectId);
     return ledger?.id || `l-${projectId}`;
   }, [projectId, ledgers]);
+  const happyPath = useMemo(() => resolvePortalHappyPath({
+    authUser,
+    portalUser,
+    project: myProject,
+    ledgers,
+  }), [authUser, portalUser, myProject, ledgers]);
 
   const effectiveBudgetCodeBook = useMemo(() => {
     const orderedCodes: string[] = [];
@@ -535,6 +542,54 @@ export function PortalWeeklyExpensePage() {
           >
             탭 삭제
           </Button>
+        </div>
+      </div>
+      <div className={`rounded-xl border px-4 py-3 text-[12px] ${
+        happyPath.canUseEvidenceWorkflow
+          ? 'border-emerald-200/80 bg-emerald-50/70 text-emerald-950'
+          : 'border-sky-200/80 bg-sky-50/70 text-sky-950'
+      }`}>
+        <div className="flex items-start justify-between gap-3 flex-wrap">
+          <div className="space-y-1">
+            <p className="font-semibold">현재 happy path 상태</p>
+            <p className={happyPath.canUseEvidenceWorkflow ? 'text-emerald-900/80' : 'text-sky-900/80'}>
+              {happyPath.canUseEvidenceWorkflow
+                ? `${happyPath.selectedProjectName || projectName}에서 행 저장 후 생성/업로드/동기화를 바로 사용할 수 있습니다.`
+                : '주간 입력은 가능하지만, 증빙 Workflow를 바로 쓰려면 기본 폴더 준비가 먼저 필요합니다.'}
+            </p>
+            <p className="text-[11px] text-muted-foreground">
+              {happyPath.steps
+                .filter((step) => step.status !== 'complete')
+                .map((step) => step.label)
+                .join(' · ') || '필수 준비가 모두 완료되었습니다.'}
+            </p>
+          </div>
+          <div className="flex items-center gap-2 flex-wrap">
+            {!happyPath.canUseEvidenceWorkflow && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-8 text-[11px]"
+                onClick={() => void provisionProjectDriveRoot()}
+                disabled={projectDriveProvisioning || !happyPath.canOpenWeeklyExpenses}
+              >
+                {projectDriveProvisioning ? (
+                  <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <FolderPlus className="mr-1 h-3.5 w-3.5" />
+                )}
+                기본 폴더 준비
+              </Button>
+            )}
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-8 text-[11px]"
+              onClick={() => window.location.assign('/portal/project-settings')}
+            >
+              설정 열기
+            </Button>
+          </div>
         </div>
       </div>
       <div className="rounded-xl border border-amber-200/70 bg-amber-50/70 px-4 py-3 text-[12px] text-amber-900">

--- a/src/app/platform/portal-happy-path.test.ts
+++ b/src/app/platform/portal-happy-path.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { resolvePortalHappyPath } from './portal-happy-path';
+
+describe('resolvePortalHappyPath', () => {
+  it('reports setup requirements when project assignment is missing', () => {
+    const state = resolvePortalHappyPath({
+      authUser: { role: 'pm', email: 'user@mysc.co.kr' },
+      portalUser: { role: 'pm', projectIds: [] },
+      project: null,
+      ledgers: [],
+    });
+
+    expect(state.status).toBe('setup_required');
+    expect(state.canOpenWeeklyExpenses).toBe(false);
+    expect(state.canUseEvidenceWorkflow).toBe(false);
+    expect(state.missingKeys).toEqual(['assignment', 'project']);
+  });
+
+  it('marks weekly expenses ready but evidence setup pending when drive root is missing', () => {
+    const state = resolvePortalHappyPath({
+      authUser: { role: 'pm', email: 'user@mysc.co.kr' },
+      portalUser: { role: 'pm', projectId: 'p1', projectIds: ['p1'] },
+      project: { id: 'p1', name: '테스트 사업' },
+      ledgers: [],
+    });
+
+    expect(state.status).toBe('setup_required');
+    expect(state.canOpenWeeklyExpenses).toBe(true);
+    expect(state.canUseEvidenceWorkflow).toBe(false);
+    expect(state.missingKeys).toEqual(['drive_root', 'evidence']);
+  });
+
+  it('closes the happy path once drive root is configured', () => {
+    const state = resolvePortalHappyPath({
+      authUser: { role: 'viewer', email: 'user@mysc.co.kr' },
+      portalUser: { role: 'viewer', projectId: 'p1', projectIds: ['p1'] },
+      project: {
+        id: 'p1',
+        name: '테스트 사업',
+        evidenceDriveRootFolderId: 'folder-1',
+        evidenceDriveRootFolderName: '테스트 사업_p1',
+      },
+      ledgers: [{ projectId: 'p1' }],
+    });
+
+    expect(state.status).toBe('ready');
+    expect(state.canOpenWeeklyExpenses).toBe(true);
+    expect(state.canUseEvidenceWorkflow).toBe(true);
+    expect(state.missingKeys).toEqual([]);
+    expect(state.steps.find((step) => step.key === 'evidence')?.status).toBe('complete');
+  });
+});

--- a/src/app/platform/portal-happy-path.ts
+++ b/src/app/platform/portal-happy-path.ts
@@ -1,0 +1,133 @@
+import { normalizeProjectIds } from '../data/project-assignment';
+import type { Ledger, Project, UserRole } from '../data/types';
+
+type PortalLikeUser = {
+  role?: string;
+  projectId?: string;
+  projectIds?: string[];
+};
+
+type AuthLikeUser = {
+  role?: UserRole | string;
+  email?: string;
+};
+
+export type PortalHappyPathStepStatus = 'complete' | 'required' | 'optional';
+
+export interface PortalHappyPathStep {
+  key: 'auth' | 'assignment' | 'project' | 'drive_root' | 'ledger' | 'evidence';
+  label: string;
+  status: PortalHappyPathStepStatus;
+  detail: string;
+}
+
+export interface PortalHappyPathState {
+  status: 'blocked' | 'setup_required' | 'ready';
+  canOpenWeeklyExpenses: boolean;
+  canUseEvidenceWorkflow: boolean;
+  selectedProjectId: string;
+  selectedProjectName: string;
+  missingKeys: PortalHappyPathStep['key'][];
+  steps: PortalHappyPathStep[];
+}
+
+interface ResolvePortalHappyPathInput {
+  authUser?: AuthLikeUser | null;
+  portalUser?: PortalLikeUser | null;
+  project?: Pick<Project, 'id' | 'name' | 'evidenceDriveRootFolderId' | 'evidenceDriveRootFolderName'> | null;
+  ledgers?: Array<Pick<Ledger, 'projectId'>>;
+}
+
+export function resolvePortalHappyPath(input: ResolvePortalHappyPathInput): PortalHappyPathState {
+  const authRole = String(input.authUser?.role || '').trim().toLowerCase();
+  const isPortalCapable = ['pm', 'viewer', 'admin', 'tenant_admin'].includes(authRole);
+  const assignedProjectIds = normalizeProjectIds([
+    ...(Array.isArray(input.portalUser?.projectIds) ? input.portalUser?.projectIds : []),
+    input.portalUser?.projectId,
+  ]);
+  const selectedProjectId = String(input.project?.id || input.portalUser?.projectId || assignedProjectIds[0] || '').trim();
+  const selectedProjectName = String(input.project?.name || '').trim();
+  const hasDriveRoot = Boolean(input.project?.evidenceDriveRootFolderId);
+  const hasLedger = Boolean(
+    selectedProjectId
+      && Array.isArray(input.ledgers)
+      && input.ledgers.some((ledger) => String(ledger.projectId || '').trim() === selectedProjectId),
+  );
+
+  const steps: PortalHappyPathStep[] = [
+    {
+      key: 'auth',
+      label: '회사 계정 로그인',
+      status: isPortalCapable ? 'complete' : 'required',
+      detail: isPortalCapable
+        ? '포털 접근 권한이 확인되었습니다.'
+        : '포털에 들어갈 수 있는 권한이 아직 확인되지 않았습니다.',
+    },
+    {
+      key: 'assignment',
+      label: '내 사업 선택',
+      status: assignedProjectIds.length > 0 ? 'complete' : 'required',
+      detail: assignedProjectIds.length > 0
+        ? `${assignedProjectIds.length}개 사업이 연결되어 있습니다.`
+        : '최소 1개 사업을 선택해야 포털 입력을 시작할 수 있습니다.',
+    },
+    {
+      key: 'project',
+      label: '주사업 확정',
+      status: selectedProjectId ? 'complete' : 'required',
+      detail: selectedProjectId
+        ? `${selectedProjectName || selectedProjectId} 기준으로 포털이 열립니다.`
+        : '현재 기준이 되는 주사업이 아직 없습니다.',
+    },
+    {
+      key: 'drive_root',
+      label: '사업 기본 폴더 준비',
+      status: !selectedProjectId ? 'optional' : hasDriveRoot ? 'complete' : 'required',
+      detail: !selectedProjectId
+        ? '주사업이 정해지면 Shared Drive 기본 폴더를 연결할 수 있습니다.'
+        : hasDriveRoot
+          ? `${input.project?.evidenceDriveRootFolderName || '기본 폴더'}가 연결되어 있습니다.`
+          : '증빙 폴더 자동 생성을 위해 사업 기본 폴더를 먼저 준비해야 합니다.',
+    },
+    {
+      key: 'ledger',
+      label: '기본 원장 준비',
+      status: !selectedProjectId ? 'optional' : hasLedger ? 'complete' : 'optional',
+      detail: !selectedProjectId
+        ? '주사업이 정해지면 원장 준비 상태를 확인할 수 있습니다.'
+        : hasLedger
+          ? '기본 원장이 이미 준비되어 있습니다.'
+          : '원장은 첫 거래 저장 시 자동 생성됩니다.',
+    },
+    {
+      key: 'evidence',
+      label: '증빙 Workflow 사용',
+      status: selectedProjectId && hasDriveRoot ? 'complete' : selectedProjectId ? 'required' : 'optional',
+      detail: selectedProjectId && hasDriveRoot
+        ? '주간 시트에서 행 저장 후 생성/업로드/동기화를 바로 사용할 수 있습니다.'
+        : selectedProjectId
+          ? '기본 폴더가 연결되면 행별 증빙 폴더와 업로드를 바로 사용할 수 있습니다.'
+          : '사업 선택과 기본 폴더 준비 후 증빙 Workflow를 사용할 수 있습니다.',
+    },
+  ];
+
+  const missingKeys = steps
+    .filter((step) => step.status === 'required')
+    .map((step) => step.key);
+  const canOpenWeeklyExpenses = isPortalCapable && Boolean(selectedProjectId);
+  const canUseEvidenceWorkflow = canOpenWeeklyExpenses && hasDriveRoot;
+
+  return {
+    status: !isPortalCapable
+      ? 'blocked'
+      : missingKeys.length > 0
+        ? 'setup_required'
+        : 'ready',
+    canOpenWeeklyExpenses,
+    canUseEvidenceWorkflow,
+    selectedProjectId,
+    selectedProjectName,
+    missingKeys,
+    steps,
+  };
+}

--- a/src/app/platform/settlement-grid-actions.test.ts
+++ b/src/app/platform/settlement-grid-actions.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import type { ImportRow } from './settlement-csv';
+import {
+  clearAllEditableCells,
+  clearSelectionCells,
+  deleteSelectedRows,
+} from './settlement-grid-actions';
+
+function createRow(label: string, cells: string[]): ImportRow {
+  return {
+    tempId: `row-${label}`,
+    cells,
+  };
+}
+
+describe('settlement-grid-actions', () => {
+  it('clears only editable cells inside the selected bounds', () => {
+    const rows = [
+      createRow('a', ['1', '작성자', 'A', 'Drive', '완료']),
+      createRow('b', ['2', '작성자2', 'B', 'Drive2', '완료2']),
+    ];
+
+    const next = clearSelectionCells(rows, { r1: 0, r2: 1, c1: 0, c2: 4 }, {
+      protectedColumnIndexes: [0, 3],
+    });
+
+    expect(next).not.toBe(rows);
+    expect(next[0]?.cells).toEqual(['1', '', '', 'Drive', '']);
+    expect(next[1]?.cells).toEqual(['2', '', '', 'Drive2', '']);
+  });
+
+  it('preserves references when nothing can be cleared', () => {
+    const first = createRow('a', ['1', '', '', 'Drive']);
+    const rows = [first];
+
+    const next = clearSelectionCells(rows, { r1: 0, r2: 0, c1: 0, c2: 3 }, {
+      protectedColumnIndexes: [0, 3],
+    });
+
+    expect(next).toBe(rows);
+    expect(next[0]).toBe(first);
+  });
+
+  it('deletes all rows inside the selected row range', () => {
+    const rows = [
+      createRow('a', ['1']),
+      createRow('b', ['2']),
+      createRow('c', ['3']),
+      createRow('d', ['4']),
+    ];
+
+    const next = deleteSelectedRows(rows, { r1: 1, r2: 2, c1: 1, c2: 3 });
+
+    expect(next.map((row) => row.cells[0])).toEqual(['1', '4']);
+  });
+
+  it('clears all editable cells while preserving protected columns', () => {
+    const rows = [
+      createRow('a', ['1', '작성자', '10,000', 'Drive']),
+      createRow('b', ['2', '작성자2', '', 'Drive2']),
+    ];
+
+    const next = clearAllEditableCells(rows, {
+      protectedColumnIndexes: [0, 3],
+    });
+
+    expect(next[0]?.cells).toEqual(['1', '', '', 'Drive']);
+    expect(next[1]?.cells).toEqual(['2', '', '', 'Drive2']);
+  });
+});

--- a/src/app/platform/settlement-grid-actions.ts
+++ b/src/app/platform/settlement-grid-actions.ts
@@ -1,0 +1,96 @@
+import type { ImportRow } from './settlement-csv';
+
+export interface SettlementSelectionBounds {
+  r1: number;
+  r2: number;
+  c1: number;
+  c2: number;
+}
+
+export const DEFAULT_PROTECTED_SETTLEMENT_HEADERS = [
+  'No.',
+  '필수증빙자료 리스트',
+  '실제 구비 완료된 증빙자료 리스트',
+  '준비필요자료',
+  '증빙자료 드라이브',
+  '준비 필요자료',
+] as const;
+
+function normalizeBounds(
+  rows: ImportRow[],
+  bounds: SettlementSelectionBounds | null,
+): SettlementSelectionBounds | null {
+  if (!bounds || rows.length === 0) return null;
+  const r1 = Math.max(0, Math.min(rows.length - 1, bounds.r1));
+  const r2 = Math.max(0, Math.min(rows.length - 1, bounds.r2));
+  if (r1 > r2) return null;
+  return {
+    r1,
+    r2,
+    c1: Math.max(0, Math.min(bounds.c1, bounds.c2)),
+    c2: Math.max(0, Math.max(bounds.c1, bounds.c2)),
+  };
+}
+
+export function clearSelectionCells(
+  rows: ImportRow[],
+  bounds: SettlementSelectionBounds | null,
+  options?: {
+    protectedColumnIndexes?: number[];
+  },
+): ImportRow[] {
+  const normalized = normalizeBounds(rows, bounds);
+  if (!normalized) return rows;
+  const protectedColumns = new Set(options?.protectedColumnIndexes || []);
+  let changed = false;
+  const next = rows.map((row, rowIdx) => {
+    if (rowIdx < normalized.r1 || rowIdx > normalized.r2) return row;
+    let rowChanged = false;
+    const cells = [...row.cells];
+    for (let colIdx = normalized.c1; colIdx <= normalized.c2; colIdx += 1) {
+      if (protectedColumns.has(colIdx)) continue;
+      if (colIdx >= cells.length) continue;
+      if (cells[colIdx] === '') continue;
+      cells[colIdx] = '';
+      rowChanged = true;
+    }
+    if (!rowChanged) return row;
+    changed = true;
+    return { ...row, cells };
+  });
+  return changed ? next : rows;
+}
+
+export function deleteSelectedRows(
+  rows: ImportRow[],
+  bounds: SettlementSelectionBounds | null,
+): ImportRow[] {
+  const normalized = normalizeBounds(rows, bounds);
+  if (!normalized) return rows;
+  return rows.filter((_, rowIdx) => rowIdx < normalized.r1 || rowIdx > normalized.r2);
+}
+
+export function clearAllEditableCells(
+  rows: ImportRow[],
+  options?: {
+    protectedColumnIndexes?: number[];
+  },
+): ImportRow[] {
+  if (rows.length === 0) return rows;
+  const protectedColumns = new Set(options?.protectedColumnIndexes || []);
+  let changed = false;
+  const next = rows.map((row) => {
+    let rowChanged = false;
+    const cells = [...row.cells];
+    for (let colIdx = 0; colIdx < cells.length; colIdx += 1) {
+      if (protectedColumns.has(colIdx)) continue;
+      if (cells[colIdx] === '') continue;
+      cells[colIdx] = '';
+      rowChanged = true;
+    }
+    if (!rowChanged) return row;
+    changed = true;
+    return { ...row, cells };
+  });
+  return changed ? next : rows;
+}


### PR DESCRIPTION
## Summary
- route portal onboarding through project settings as the happy-path setup hub
- show evidence workflow readiness in project settings and weekly expenses
- add spreadsheet-style clear actions for the weekly expense sheet
- extend weekly sheet autosave intervals to reduce write churn

## Verification
- npx vitest run src/app/platform/portal-happy-path.test.ts src/app/platform/settlement-grid-actions.test.ts
- npm run build