### PR TITLE
fix: recover from stale lazy chunks

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,38 @@
 
-  import { createRoot } from "react-dom/client";
-  import App from "./app/App.tsx";
-  import "./styles/index.css";
+import { createRoot } from 'react-dom/client';
+import App from './app/App.tsx';
+import './styles/index.css';
 
-  createRoot(document.getElementById("root")!).render(<App />);
+const VITE_PRELOAD_RECOVERY_KEY = '__mysc_vite_preload_recovery__';
+
+function installVitePreloadRecovery(): void {
+  if (typeof window === 'undefined') return;
+
+  window.addEventListener('vite:preloadError', (event) => {
+    const customEvent = event as CustomEvent<{ message?: string } | undefined>;
+    const currentPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    const lastRecoveredPath = window.sessionStorage.getItem(VITE_PRELOAD_RECOVERY_KEY);
+
+    if (lastRecoveredPath === currentPath) {
+      window.sessionStorage.removeItem(VITE_PRELOAD_RECOVERY_KEY);
+      return;
+    }
+
+    customEvent.preventDefault();
+    window.sessionStorage.setItem(VITE_PRELOAD_RECOVERY_KEY, currentPath);
+    window.location.reload();
+  });
+
+  window.addEventListener('pageshow', () => {
+    const currentPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+    const lastRecoveredPath = window.sessionStorage.getItem(VITE_PRELOAD_RECOVERY_KEY);
+    if (lastRecoveredPath === currentPath) {
+      window.sessionStorage.removeItem(VITE_PRELOAD_RECOVERY_KEY);
+    }
+  });
+}
+
+installVitePreloadRecovery();
+
+createRoot(document.getElementById('root')!).render(<App />);
   


### PR DESCRIPTION
## Summary
- add a global Vite preload recovery guard in main.tsx
- reload once when a stale lazy chunk is requested after deployment swap
- prevent users from getting stuck on old hashed assets like GoogleSheetMigrationWizard

## Verification
- npm run build