### PR TITLE
fix: reset cleared weekly sheets and replace imported budgets

### DIFF
--- a/src/app/components/cashflow/SettlementLedgerPage.tsx
+++ b/src/app/components/cashflow/SettlementLedgerPage.tsx
@@ -27,7 +27,6 @@ import { buildSettlementActualSyncPayload } from '../../platform/settlement-shee
 import { computeSettlementGridWindowRange } from '../../platform/settlement-grid-windowing';
 import { updateImportRowAt } from '../../platform/settlement-grid-state';
 import {
-  clearAllEditableCells,
   clearSelectionCells,
   DEFAULT_PROTECTED_SETTLEMENT_HEADERS,
   deleteSelectedRows,
@@ -39,6 +38,7 @@ import {
 import {
   buildSettlementDerivationContext,
   resolveEvidenceRequiredDesc,
+  isSettlementRowMeaningful,
 } from '../../platform/settlement-sheet-prepare';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
@@ -1613,20 +1613,24 @@ function ImportEditor({
   }) => Promise<string | null>;
   sourceTransactions?: Transaction[];
 }) {
-  const errorCount = rows.filter((r) => r.error).length;
-  const validCount = rows.length - errorCount;
+  const meaningfulRows = useMemo(
+    () => rows.filter((row) => isSettlementRowMeaningful(row)),
+    [rows],
+  );
+  const errorCount = meaningfulRows.filter((r) => r.error).length;
+  const validCount = meaningfulRows.length - errorCount;
   const noIdx = useMemo(
     () => SETTLEMENT_COLUMNS.findIndex((c) => c.csvHeader === 'No.'),
     [],
   );
   const missingCount = useMemo(() => {
-    return rows.filter((row) => {
+    return meaningfulRows.filter((row) => {
       const cells = row.cells || [];
       const hasAnyValue = cells.some((cell, idx) => idx !== noIdx && String(cell || '').trim() !== '');
       if (!hasAnyValue) return false;
       return cells.some((cell, idx) => idx !== noIdx && String(cell || '').trim() === '');
     }).length;
-  }, [rows, noIdx]);
+  }, [meaningfulRows, noIdx]);
   const budgetCodeIdx = useMemo(
     () => SETTLEMENT_COLUMNS.findIndex((c) => c.csvHeader === '비목'),
     [],
@@ -2147,24 +2151,16 @@ function ImportEditor({
   }, [commitRows, getActiveSelectionBounds, getPreferredEditableCol, pushUndoSnapshot, rows]);
 
   const clearAllRows = useCallback(() => {
-    const nextRows = clearAllEditableCells(rows, {
-      protectedColumnIndexes: protectedClearColumnIndexes,
-    });
-    if (nextRows === rows) {
-      toast.message('비울 수 있는 내용이 없습니다.');
+    if (rows.length === 0) {
+      toast.message('초기화할 행이 없습니다.');
       return false;
     }
     pushUndoSnapshot();
     setSelection(null);
-    commitRows(
-      nextRows,
-      nextRows.length > 0
-        ? { rowIdx: 0, colIdx: getPreferredEditableCol() }
-        : null,
-    );
-    toast.success('현재 탭의 입력값을 비웠습니다.');
+    commitRows([], null);
+    toast.success('현재 탭을 초기화했습니다.');
     return true;
-  }, [commitRows, getPreferredEditableCol, protectedClearColumnIndexes, pushUndoSnapshot, rows]);
+  }, [commitRows, pushUndoSnapshot, rows]);
 
   const applyPaste = useCallback(
     (startRow: number, startCol: number, text: string) => {
@@ -2797,9 +2793,9 @@ function ImportEditor({
       <AlertDialog open={clearAllConfirmOpen} onOpenChange={setClearAllConfirmOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>현재 탭 입력값을 모두 비울까요?</AlertDialogTitle>
+            <AlertDialogTitle>현재 탭을 완전히 초기화할까요?</AlertDialogTitle>
             <AlertDialogDescription>
-              행 구조는 유지하고 일반 입력값만 비웁니다. 증빙/드라이브 관련 보호 컬럼은 유지됩니다.
+              현재 탭의 모든 행을 제거하고 빈 상태로 저장합니다. 되돌리기를 누르기 전까지는 기존 데이터가 복구되지 않습니다.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -2810,7 +2806,7 @@ function ImportEditor({
                 setClearAllConfirmOpen(false);
               }}
             >
-              전체 비우기
+              탭 초기화
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/app/components/portal/GoogleSheetMigrationWizard.tsx
+++ b/src/app/components/portal/GoogleSheetMigrationWizard.tsx
@@ -212,13 +212,13 @@ export function GoogleSheetMigrationWizard({
         return {
           descriptor,
           applySupported: parsed.rows.length > 0,
-          applyButtonLabel: '예산/비목 세목 반영',
-          applyHint: '같은 비목/세목은 갱신하고, 없는 항목은 추가합니다. 기존 예산 외 다른 화면 값은 건드리지 않습니다.',
+          applyButtonLabel: '예산/비목 세목 교체 반영',
+          applyHint: '가져온 예산총괄시트를 기준으로 현재 예산/비목·세목 구성을 교체합니다. 기존에만 있던 항목은 제거됩니다.',
           summaryStats: [
             { label: '가져온 행', value: `${parsed.rows.length}건` },
-            { label: '비목 수', value: `${mergePlan.codeBook.length}개` },
+            { label: '비목 수', value: `${mergePlan.importedCodeBook.length}개` },
             { label: '신규 추가', value: `${mergePlan.summary.createCount}건` },
-            { label: '기존 업데이트', value: `${mergePlan.summary.updateCount}건` },
+            { label: '기존 교체', value: `${mergePlan.summary.updateCount}건` },
           ],
           budgetPlanMerge: mergePlan,
         };
@@ -408,10 +408,10 @@ export function GoogleSheetMigrationWizard({
         }
         case 'budget_plan': {
           const budgetPlanMerge = reviewState.budgetPlanMerge;
-          if (!budgetPlanMerge || budgetPlanMerge.mergedRows.length === 0) throw new Error('가져올 예산 행이 없습니다.');
-          await saveBudgetPlanRows(budgetPlanMerge.mergedRows);
-          await saveBudgetCodeBook(budgetPlanMerge.codeBook);
-          toast.success(`예산 ${budgetPlanMerge.summary.importedCount}건을 반영했습니다.`);
+          if (!budgetPlanMerge || budgetPlanMerge.importedRows.length === 0) throw new Error('가져올 예산 행이 없습니다.');
+          await saveBudgetPlanRows(budgetPlanMerge.importedRows);
+          await saveBudgetCodeBook(budgetPlanMerge.importedCodeBook);
+          toast.success(`예산 ${budgetPlanMerge.summary.importedCount}건으로 교체 반영했습니다.`);
           break;
         }
         case 'bank_statement': {

--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -45,7 +45,7 @@ import {
   type BankStatementSheet,
 } from '../platform/bank-statement';
 import { normalizeSpace } from '../platform/csv-utils';
-import { prepareSettlementImportRows } from '../platform/settlement-sheet-prepare';
+import { prepareSettlementImportRows, pruneEmptySettlementRows } from '../platform/settlement-sheet-prepare';
 import { useAuth } from './auth-store';
 import { useFirebase } from '../lib/firebase-context';
 import { getOrgCollectionPath, getOrgDocumentPath } from '../lib/firebase';
@@ -1059,7 +1059,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     const activeSheetName = sanitizeExpenseSheetName(activeSheet?.name, activeSheetId === 'default' ? '기본 탭' : '새 탭');
     const defaultLedgerId = ledgers.find((ledger) => ledger.projectId === portalUser?.projectId)?.id
       || (portalUser?.projectId ? `l-${portalUser.projectId}` : 'l-default');
-    const preparedRows = prepareSettlementImportRows(rows, {
+    const preparedRows = prepareSettlementImportRows(pruneEmptySettlementRows(rows), {
       projectId: portalUser?.projectId || '',
       defaultLedgerId,
       evidenceRequiredMap,

--- a/src/app/platform/google-sheet-migration.test.ts
+++ b/src/app/platform/google-sheet-migration.test.ts
@@ -88,6 +88,11 @@ describe('google-sheet-migration', () => {
       { code: '회의비', subCodes: ['다과비'] },
       { code: '홍보비', subCodes: ['보도자료'] },
     ]);
+    expect(plan.importedRows).toEqual(imported);
+    expect(plan.importedCodeBook).toEqual([
+      { code: '여비', subCodes: ['교통비'] },
+      { code: '홍보비', subCodes: ['보도자료'] },
+    ]);
   });
 
   it('parses evidence rule matrices with intermediate category columns', () => {

--- a/src/app/platform/google-sheet-migration.ts
+++ b/src/app/platform/google-sheet-migration.ts
@@ -47,6 +47,8 @@ export interface BudgetPlanMergeSummary {
 export interface BudgetPlanMergePlan {
   mergedRows: BudgetPlanRow[];
   codeBook: BudgetCodeEntry[];
+  importedRows: BudgetPlanRow[];
+  importedCodeBook: BudgetCodeEntry[];
   summary: BudgetPlanMergeSummary;
 }
 
@@ -316,6 +318,8 @@ export function planBudgetPlanMerge(
   return {
     mergedRows,
     codeBook: buildBudgetCodeBook(mergedRows),
+    importedRows: importedRows.map((row) => ({ ...row })),
+    importedCodeBook: buildBudgetCodeBook(importedRows),
     summary: {
       importedCount: importedRows.length,
       createCount,

--- a/src/app/platform/settlement-sheet-prepare.test.ts
+++ b/src/app/platform/settlement-sheet-prepare.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { getYearMondayWeeks } from './cashflow-weeks';
 import { SETTLEMENT_COLUMNS, type ImportRow } from './settlement-csv';
 import { buildSettlementActualSyncPayload } from './settlement-sheet-sync';
-import { prepareSettlementImportRows } from './settlement-sheet-prepare';
+import {
+  isSettlementRowMeaningful,
+  prepareSettlementImportRows,
+  pruneEmptySettlementRows,
+} from './settlement-sheet-prepare';
 
 function makeRow(values: Record<string, string>): ImportRow {
   return {
@@ -53,5 +57,23 @@ describe('prepareSettlementImportRows', () => {
     const payload = buildSettlementActualSyncPayload(prepared, getYearMondayWeeks(2026));
     expect(payload).toHaveLength(1);
     expect(payload[0]?.amounts.DIRECT_COST_OUT).toBe(33000);
+  });
+
+  it('drops rows that only contain derived or protected settlement fields', () => {
+    const meaningful = makeRow({
+      'No.': '1',
+      '거래일시': '2026-03-05',
+      '지급처': '카페 메리',
+    });
+    const derivedOnly = makeRow({
+      'No.': '2',
+      '필수증빙자료 리스트': '영수증',
+      '실제 구비 완료된 증빙자료 리스트': '영수증',
+      '준비필요자료': '결과보고서',
+    });
+
+    expect(isSettlementRowMeaningful(meaningful)).toBe(true);
+    expect(isSettlementRowMeaningful(derivedOnly)).toBe(false);
+    expect(pruneEmptySettlementRows([meaningful, derivedOnly])).toEqual([meaningful]);
   });
 });

--- a/src/app/platform/settlement-sheet-prepare.ts
+++ b/src/app/platform/settlement-sheet-prepare.ts
@@ -15,6 +15,29 @@ function getColumnIndex(header: string): number {
   return SETTLEMENT_COLUMNS.findIndex((column) => column.csvHeader === header);
 }
 
+const NON_SUBSTANTIVE_SETTLEMENT_HEADERS = new Set([
+  'No.',
+  '해당 주차',
+  '필수증빙자료 리스트',
+  '실제 구비 완료된 증빙자료 리스트',
+  '준비필요자료',
+  '증빙자료 드라이브',
+  '준비 필요자료',
+]);
+
+export function isSettlementRowMeaningful(row: ImportRow | null | undefined): boolean {
+  if (!row) return false;
+  return SETTLEMENT_COLUMNS.some((column, index) => {
+    if (NON_SUBSTANTIVE_SETTLEMENT_HEADERS.has(column.csvHeader)) return false;
+    return String(row.cells[index] ?? '').trim() !== '';
+  });
+}
+
+export function pruneEmptySettlementRows(rows: ImportRow[] | null | undefined): ImportRow[] {
+  if (!rows || rows.length === 0) return [];
+  return rows.filter((row) => isSettlementRowMeaningful(row));
+}
+
 function normalizeImportRow(row: ImportRow, fallbackIndex: number): ImportRow {
   return {
     tempId: row.tempId || `sheet-import-${fallbackIndex + 1}`,
@@ -80,12 +103,13 @@ export function prepareSettlementImportRows(
     evidenceRequiredMap?: Record<string, string>;
   },
 ): ImportRow[] {
-  if (!rows || rows.length === 0) return [];
+  const nonEmptyRows = pruneEmptySettlementRows(rows);
+  if (nonEmptyRows.length === 0) return [];
 
   const budgetCodeIdx = getColumnIndex('비목');
   const subCodeIdx = getColumnIndex('세목');
   const evidenceIdx = getColumnIndex('필수증빙자료 리스트');
-  const normalizedRows = renumberRows(rows.map((row, index) => normalizeImportRow(row, index)));
+  const normalizedRows = renumberRows(nonEmptyRows.map((row, index) => normalizeImportRow(row, index)));
   const withEvidenceMap = normalizedRows.map((row) => {
     if (budgetCodeIdx < 0 || subCodeIdx < 0 || evidenceIdx < 0) return row;
     const budgetCode = row.cells[budgetCodeIdx] || '';


### PR DESCRIPTION
## Summary\n- treat full tab clear as a true reset and persist only meaningful weekly expense rows\n- stop counting empty rows as valid in the settlement editor\n- make budget-sheet migration replace the current budget rows/codebook instead of accumulating stale entries\n\n## Verification\n- npx vitest run src/app/platform/settlement-sheet-prepare.test.ts src/app/platform/google-sheet-migration.test.ts\n- npm run build