### PR TITLE
fix: stop unauthorized Claude help polling

### DIFF
--- a/src/app/components/guide-chat/ClaudeSdkHelpPage.tsx
+++ b/src/app/components/guide-chat/ClaudeSdkHelpPage.tsx
@@ -34,20 +34,27 @@ export function ClaudeSdkHelpPage() {
   const [loading, setLoading] = useState(true);
   const [asking, setAsking] = useState(false);
   const [error, setError] = useState('');
+  const attemptedMetaRef = useRef(false);
 
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const actorParams = useMemo(() => ({
     tenantId: orgId || 'mysc',
-    actor: { uid: user?.uid || '', email: user?.email || '', role: user?.role || '' },
-  }), [orgId, user]);
+    actor: {
+      uid: user?.uid || '',
+      email: user?.email || '',
+      role: user?.role || '',
+      idToken: user?.idToken,
+    },
+  }), [orgId, user?.uid, user?.email, user?.role, user?.idToken]);
 
   useEffect(() => {
-    if (!bffEnabled || !user) {
+    if (!bffEnabled || !user || !user.idToken || attemptedMetaRef.current) {
       setLoading(false);
       return;
     }
 
+    attemptedMetaRef.current = true;
     getClaudeSdkHelpMeta(actorParams)
       .then(setMeta)
       .catch((err) => setError((err as Error).message || '도움봇 정보를 불러오지 못했습니다.'))

--- a/src/app/components/guide-chat/ClaudeSdkHelpWidget.tsx
+++ b/src/app/components/guide-chat/ClaudeSdkHelpWidget.tsx
@@ -41,24 +41,39 @@ export function ClaudeSdkHelpWidget() {
   const [error, setError] = useState('');
   const [messages, setMessages] = useState<WidgetMessage[]>([]);
   const endRef = useRef<HTMLDivElement>(null);
+  const attemptedMetaRef = useRef(false);
 
   const hidden = !bffEnabled
     || !isAuthenticated
     || !user
+    || !user.idToken
     || location.pathname === '/login'
     || location.pathname === '/workspace-select';
 
   const actorParams = useMemo(() => ({
     tenantId: orgId || 'mysc',
-    actor: { uid: user?.uid || '', email: user?.email || '', role: user?.role || '' },
-  }), [orgId, user]);
+    actor: {
+      uid: user?.uid || '',
+      email: user?.email || '',
+      role: user?.role || '',
+      idToken: user?.idToken,
+    },
+  }), [orgId, user?.uid, user?.email, user?.role, user?.idToken]);
+
+  useEffect(() => {
+    if (!open) {
+      attemptedMetaRef.current = false;
+      setError('');
+    }
+  }, [open]);
 
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages.length, open]);
 
   useEffect(() => {
-    if (!open || meta || loadingMeta) return;
+    if (!open || meta || loadingMeta || attemptedMetaRef.current || !actorParams.actor.idToken) return;
+    attemptedMetaRef.current = true;
     setLoadingMeta(true);
     void getClaudeSdkHelpMeta(actorParams)
       .then(setMeta)


### PR DESCRIPTION
## Summary
- pass the Firebase ID token to Claude SDK help requests
- hide the floating help widget until auth token is ready
- prevent repeated unauthorized meta polling after an error

## Validation
- npm run build