### PR TITLE
feat: make help widget responsive with onboarding guidance

### DIFF
--- a/server/bff/claude-sdk-help.mjs
+++ b/server/bff/claude-sdk-help.mjs
@@ -34,11 +34,11 @@ const SOURCE_FILES = [
 ];
 
 const QUICKSTART_STEPS = [
-  '로그인 후 먼저 `사업 설정`에서 내 사업과 주사업을 확인합니다. 사업이 안 보이면 여기서 배정 상태부터 맞춥니다.',
-  '같은 화면에서 `기본 폴더 생성`을 눌러 사업별 증빙 루트 폴더를 준비합니다. 이 단계가 끝나야 주간 시트의 증빙 흐름이 안정적입니다.',
-  '주간 사업비 입력에서는 행을 작성한 뒤 `생성 → 업로드 → 동기화` 순서로 사용합니다.',
+  '먼저 `사업 설정`에서 내 사업과 주사업을 확인하고 `기본 폴더 생성`으로 사업별 증빙 루트 폴더를 준비합니다.',
+  '`통장내역` 화면에서 엑셀이나 통장 원본을 업로드하면 주간 사업비 입력의 초안 정리에 도움이 됩니다.',
+  '`주간 사업비 입력`에서 비목/세목, 거래처, 적요를 정리하고 필요한 행을 저장합니다.',
+  '증빙은 각 행에서 `생성 → 업로드 → 동기화` 순서로 사용합니다. 업로드는 파일 저장, 동기화는 목록 반영입니다.',
   '기존 Google Sheets를 옮길 때는 `Google Sheets Migration Wizard`에서 링크 입력 → 탭 선택 → 미리보기 → 안전 반영 순서로 진행합니다.',
-  '업로드했는데 목록이 안 바뀌면 `동기화`를 다시 눌러 Drive 파일 목록을 재반영합니다.',
 ];
 
 const STARTER_QUESTIONS = [
@@ -199,7 +199,7 @@ export function createClaudeSdkHelpService(options = {}) {
   return {
     getMeta() {
       return {
-        title: '플랫폼 사용 도움봇',
+        title: '사업관리 메리',
         description: '실제 홈페이지 흐름을 기준으로 사업 설정, Drive 연결, Migration, 주간 사업비 입력 사용법을 안내합니다.',
         sourceFiles: SOURCE_FILES,
         quickstartSteps: QUICKSTART_STEPS,

--- a/server/bff/claude-sdk-help.test.ts
+++ b/server/bff/claude-sdk-help.test.ts
@@ -13,9 +13,9 @@ describe('claude-sdk-help', () => {
     });
 
     const meta = service.getMeta();
-    expect(meta.title).toBe('플랫폼 사용 도움봇');
+    expect(meta.title).toBe('사업관리 메리');
     expect(meta.sourceFiles.length).toBeGreaterThanOrEqual(5);
-    expect(meta.quickstartSteps.some((step) => step.includes('기본 폴더 생성'))).toBe(true);
+    expect(meta.quickstartSteps.some((step) => step.includes('통장내역'))).toBe(true);
     expect(meta.starterQuestions.some((item) => item.includes('구글드라이브 연결'))).toBe(true);
   });
 

--- a/src/app/components/guide-chat/ClaudeSdkHelpPage.tsx
+++ b/src/app/components/guide-chat/ClaudeSdkHelpPage.tsx
@@ -111,7 +111,7 @@ export function ClaudeSdkHelpPage() {
         <PageHeader
           icon={Bot}
           iconGradient="linear-gradient(135deg, #2563eb, #8b5cf6)"
-          title="플랫폼 사용 도움봇"
+          title="사업관리 메리"
           description="실제 홈페이지 흐름 기준으로 사업 설정, Drive 연결, Migration, 증빙 업로드 사용법을 안내합니다"
         />
         <Card>
@@ -132,7 +132,7 @@ export function ClaudeSdkHelpPage() {
       <PageHeader
         icon={Bot}
         iconGradient="linear-gradient(135deg, #2563eb, #8b5cf6)"
-        title="플랫폼 사용 도움봇"
+        title="사업관리 메리"
         description="실제 홈페이지 흐름 기준으로 사업 설정, Drive 연결, Migration, 증빙 업로드 사용법을 안내합니다"
       />
 
@@ -238,7 +238,7 @@ export function ClaudeSdkHelpPage() {
                     {message.role === 'assistant' && (
                       <div className="mt-2 flex items-center gap-2 text-[10px] text-muted-foreground">
                         <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
-                          {message.provider === 'anthropic' ? 'Claude 답변' : '기본 안내'}
+                          {message.provider === 'anthropic' ? 'Merry 답변' : 'Merry 안내'}
                         </Badge>
                         {message.tokensUsed ? <span>{message.tokensUsed.toLocaleString()} tokens</span> : null}
                       </div>

--- a/src/app/components/guide-chat/ClaudeSdkHelpWidget.tsx
+++ b/src/app/components/guide-chat/ClaudeSdkHelpWidget.tsx
@@ -139,13 +139,13 @@ export function ClaudeSdkHelpWidget() {
       </div>
 
       <Sheet open={open} onOpenChange={setOpen}>
-        <SheetContent side="right" className="w-full sm:max-w-xl p-0">
+        <SheetContent side="right" className="flex h-[100dvh] w-full max-w-full flex-col p-0 sm:max-w-xl">
           <SheetHeader className="border-b border-border/60">
             <div className="flex items-start justify-between gap-3 pr-8">
               <div className="space-y-1">
                 <SheetTitle className="flex items-center gap-2">
                   <MessageCircleQuestion className="h-4 w-4" />
-                  플랫폼 사용 도움봇
+                  사업관리 메리
                 </SheetTitle>
                 <SheetDescription>
                   실제 홈페이지 흐름 기준으로 사업 설정, Drive 연결, Migration, 증빙 업로드 사용법을 안내합니다.
@@ -154,8 +154,8 @@ export function ClaudeSdkHelpWidget() {
             </div>
           </SheetHeader>
 
-          <div className="flex h-full flex-col">
-            <div className="border-b border-border/60 p-4">
+          <div className="flex min-h-0 flex-1 flex-col">
+            <div className="shrink-0 border-b border-border/60 p-4">
               <div className="mb-3 flex items-center gap-2">
                 <Badge variant="secondary">사용법 중심</Badge>
                 <Badge variant="outline">실제 화면 흐름 기반</Badge>
@@ -168,9 +168,25 @@ export function ClaudeSdkHelpWidget() {
                 </div>
               ) : meta ? (
                 <div className="space-y-2">
-                  <div className="text-xs font-semibold">추천 질문</div>
+                  <div className="rounded-xl border bg-muted/30 p-3 text-[11px] text-muted-foreground">
+                    <div className="mb-2 flex items-center gap-1 font-semibold text-foreground">
+                      <Sparkles className="h-3.5 w-3.5" />
+                      기본 사용 가이드
+                    </div>
+                    <ol className="space-y-1.5">
+                      {meta.quickstartSteps.slice(0, 4).map((step, index) => (
+                        <li key={step} className="flex gap-2">
+                          <span className="mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full bg-primary/10 text-[10px] font-semibold text-primary">
+                            {index + 1}
+                          </span>
+                          <span>{step}</span>
+                        </li>
+                      ))}
+                    </ol>
+                  </div>
+                  <div className="text-xs font-semibold">바로 물어보기</div>
                   <div className="flex flex-wrap gap-2">
-                    {meta.starterQuestions.slice(0, 3).map((item) => (
+                    {meta.starterQuestions.slice(0, 4).map((item) => (
                       <Button
                         key={item}
                         type="button"
@@ -184,18 +200,11 @@ export function ClaudeSdkHelpWidget() {
                       </Button>
                     ))}
                   </div>
-                  <div className="rounded-xl border bg-muted/30 p-3 text-[11px] text-muted-foreground">
-                    <div className="mb-1 flex items-center gap-1 font-semibold text-foreground">
-                      <Sparkles className="h-3.5 w-3.5" />
-                      빠른 시작
-                    </div>
-                    <div>{meta.quickstartSteps[0]}</div>
-                  </div>
                 </div>
               ) : null}
             </div>
 
-            <div className="flex-1 overflow-y-auto p-4 space-y-3">
+            <div className="min-h-0 flex-1 overflow-y-auto p-4 space-y-3">
               {messages.length === 0 ? (
                 <div className="rounded-2xl border border-dashed p-4 text-sm text-muted-foreground">
                   예: “구글드라이브 연결은 어디서 하고 기본 폴더 생성은 어떻게 해?”
@@ -216,7 +225,7 @@ export function ClaudeSdkHelpWidget() {
                       <pre className="whitespace-pre-wrap break-words font-sans">{message.content}</pre>
                       {message.role === 'assistant' && message.provider && (
                         <div className="mt-2 text-[10px] text-muted-foreground">
-                          {message.provider === 'anthropic' ? 'Claude 답변' : '기본 안내'}
+                          {message.provider === 'anthropic' ? 'Merry 답변' : 'Merry 안내'}
                         </div>
                       )}
                     </div>
@@ -238,12 +247,12 @@ export function ClaudeSdkHelpWidget() {
             </div>
 
             {error && (
-              <div className="border-t border-border/60 bg-destructive/10 px-4 py-2 text-xs text-destructive">
+              <div className="shrink-0 border-t border-border/60 bg-destructive/10 px-4 py-2 text-xs text-destructive">
                 {error}
               </div>
             )}
 
-            <div className="border-t border-border/60 p-3">
+            <div className="shrink-0 border-t border-border/60 p-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))]">
               <div className="flex gap-2">
                 <Input
                   value={question}


### PR DESCRIPTION
## Summary
- make the floating help widget responsive so scroll and input remain visible
- rename the assistant to 사업관리 메리 / Merry 답변
- add a 기본 사용 가이드 section focused on onboarding from project setup and bank statement upload

## Validation
- npx vitest run server/bff/claude-sdk-help.test.ts
- npm run build