### PR TITLE
feat: add contract-first project request wizard

### DIFF
--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -47,6 +47,7 @@ import {
   ledgerUpsertSchema,
   memberRoleUpdateSchema,
   parseWithSchema,
+  projectRequestContractAnalyzeSchema,
   projectDriveRootLinkSchema,
   projectUpsertSchema,
   transactionStateSchema,
@@ -70,6 +71,7 @@ import {
   createGoogleSheetsService,
 } from './google-sheets.mjs';
 import { createGoogleSheetMigrationAiService } from './google-sheet-migration-ai.mjs';
+import { createProjectRequestContractAiService } from './project-request-contract-ai.mjs';
 
 function createHttpError(statusCode, message, code = 'request_error') {
   const error = new Error(message);
@@ -565,6 +567,7 @@ export function createBffApp(options = {}) {
   const driveService = options.driveService || createGoogleDriveService();
   const googleSheetsService = options.googleSheetsService || createGoogleSheetsService();
   const googleSheetMigrationAiService = options.googleSheetMigrationAiService || createGoogleSheetMigrationAiService();
+  const projectRequestContractAiService = options.projectRequestContractAiService || createProjectRequestContractAiService();
   const allowedOrigins = parseAllowedOrigins(options.allowedOrigins || process.env.BFF_ALLOWED_ORIGINS);
   const relationRulesPolicyPath = options.relationRulesPolicyPath || resolveRelationRulesPolicyPath();
   const workQueueBatchSizeRaw = Number.parseInt(process.env.BFF_WORK_QUEUE_BATCH || '100', 10);
@@ -1207,6 +1210,20 @@ export function createBffApp(options = {}) {
       spreadsheetTitle: parsed.spreadsheetTitle,
       selectedSheetName: parsed.selectedSheetName,
       matrix: parsed.matrix,
+    });
+    res.status(200).json(analysis);
+  }));
+
+  app.post('/api/v1/project-requests/contract/analyze', asyncHandler(async (req, res) => {
+    assertActorRoleAllowed(req, ROUTE_ROLES.readCore, 'analyze project request contract');
+    const parsed = parseWithSchema(
+      projectRequestContractAnalyzeSchema,
+      req.body,
+      'Invalid project request contract analysis payload',
+    );
+    const analysis = await projectRequestContractAiService.analyzeContract({
+      fileName: parsed.fileName,
+      documentText: parsed.documentText || '',
     });
     res.status(200).json(analysis);
   }));

--- a/server/bff/project-request-contract-ai.mjs
+++ b/server/bff/project-request-contract-ai.mjs
@@ -1,0 +1,406 @@
+import Anthropic from '@anthropic-ai/sdk';
+
+const MODEL = process.env.ANTHROPIC_PROJECT_REQUEST_MODEL || process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-20250514';
+const MAX_TOKENS = 1800;
+const MAX_TEXT_CHARS = 18000;
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function readOptionalText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeWhitespace(value) {
+  return readOptionalText(String(value ?? '')).replace(/\s+/g, ' ').trim();
+}
+
+function truncateText(value, maxLength = MAX_TEXT_CHARS) {
+  const normalized = readOptionalText(value);
+  if (!normalized) return '';
+  return normalized.length > maxLength ? normalized.slice(0, maxLength) : normalized;
+}
+
+function emptyTextSuggestion() {
+  return { value: '', confidence: 'low', evidence: '' };
+}
+
+function emptyNumberSuggestion() {
+  return { value: null, confidence: 'low', evidence: '' };
+}
+
+function stripPdfExtension(fileName) {
+  return readOptionalText(fileName).replace(/\.pdf$/i, '');
+}
+
+function sanitizeProjectName(value) {
+  const normalized = normalizeWhitespace(value)
+    .replace(/[()[\]{}]/g, ' ')
+    .replace(/(계약서|협약서|용역|과업|운영|계약|협약|사업)/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!normalized) return '';
+  return normalized.replace(/\s+/g, '').slice(0, 10);
+}
+
+function normalizeDate(value) {
+  const normalized = readOptionalText(value).replace(/\s+/g, '');
+  if (!normalized) return '';
+
+  const patterns = [
+    /(\d{4})[.\-/년](\d{1,2})[.\-/월](\d{1,2})일?/,
+    /(\d{4})(\d{2})(\d{2})/,
+  ];
+
+  for (const pattern of patterns) {
+    const match = normalized.match(pattern);
+    if (!match) continue;
+    const year = Number.parseInt(match[1], 10);
+    const month = Number.parseInt(match[2], 10);
+    const day = Number.parseInt(match[3], 10);
+    if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) continue;
+    if (month < 1 || month > 12 || day < 1 || day > 31) continue;
+    return `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+  }
+
+  return '';
+}
+
+function parseCurrency(value) {
+  const digits = readOptionalText(value).replace(/[^0-9.-]/g, '');
+  if (!digits) return null;
+  const parsed = Number.parseFloat(digits);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function extractByPatterns(text, patterns) {
+  for (const pattern of patterns) {
+    const match = text.match(pattern);
+    if (!match) continue;
+    const value = normalizeWhitespace(match[1] || '');
+    if (value) {
+      return {
+        value,
+        evidence: normalizeWhitespace(match[0] || value),
+      };
+    }
+  }
+  return null;
+}
+
+function extractDateRange(text) {
+  const rangePatterns = [
+    /(\d{4}[.\-/년]\s*\d{1,2}[.\-/월]\s*\d{1,2}일?)\s*(?:~|부터|[-–])\s*(\d{4}[.\-/년]\s*\d{1,2}[.\-/월]\s*\d{1,2}일?)/,
+  ];
+  for (const pattern of rangePatterns) {
+    const match = text.match(pattern);
+    if (!match) continue;
+    const start = normalizeDate(match[1]);
+    const end = normalizeDate(match[2]);
+    if (start || end) {
+      return {
+        start,
+        end,
+        evidence: normalizeWhitespace(match[0] || ''),
+      };
+    }
+  }
+  return null;
+}
+
+function buildHeuristicTextSuggestion(value, evidence, confidence = 'medium') {
+  return {
+    value: normalizeWhitespace(value),
+    confidence,
+    evidence: normalizeWhitespace(evidence || value),
+  };
+}
+
+function buildHeuristicNumberSuggestion(value, evidence, confidence = 'medium') {
+  return {
+    value: typeof value === 'number' && Number.isFinite(value) ? value : null,
+    confidence,
+    evidence: normalizeWhitespace(evidence),
+  };
+}
+
+function buildFallbackProjectRequestContractAnalysis(input, timestamp = nowIso()) {
+  const fileName = stripPdfExtension(input?.fileName || '');
+  const documentText = truncateText(input?.documentText || '');
+  const condensedText = documentText.replace(/\n+/g, ' ');
+  const firstParagraph = normalizeWhitespace(documentText.split(/\n{2,}/)[0] || documentText.slice(0, 300));
+
+  const officialContractMatch = extractByPatterns(documentText, [
+    /(?:계약명|계약서명|사업명|용역명|과업명)\s*[:：]?\s*([^\n]{4,80})/,
+  ]) || extractByPatterns(condensedText, [
+    /([가-힣A-Za-z0-9\s()\-·]+(?:계약|협약|용역|과업)[가-힣A-Za-z0-9\s()\-·]{0,20})/,
+  ]);
+  const clientOrgMatch = extractByPatterns(documentText, [
+    /(?:발주기관|발주처|수요기관|계약상대자|계약 대상)\s*[:：]?\s*([^\n]{2,60})/,
+    /(?:갑)\s*[:：]?\s*([^\n]{2,60})/,
+  ]);
+  const purposeMatch = extractByPatterns(documentText, [
+    /(?:사업 목적|과업 목적|목적)\s*[:：]?\s*([^\n]{10,200})/,
+  ]);
+  const descriptionMatch = extractByPatterns(documentText, [
+    /(?:주요 내용|사업 내용|과업 내용|수행 내용)\s*[:：]?\s*([^\n]{10,260})/,
+  ]);
+  const contractAmountMatch = extractByPatterns(condensedText, [
+    /(?:총\s*계약금액|계약금액|총액)\s*[:：]?\s*([0-9,]+)\s*원/,
+    /([0-9,]+)\s*원\s*(?:정|부가세 포함|계약금액)/,
+  ]);
+  const salesVatMatch = extractByPatterns(condensedText, [
+    /(?:매출\s*부가세|부가세|부가가치세|VAT)\s*[:：]?\s*([0-9,]+)\s*원/i,
+  ]);
+  const dateRange = extractDateRange(documentText);
+
+  const officialContractName = officialContractMatch?.value || fileName;
+  const suggestedProjectName = sanitizeProjectName(officialContractName || fileName);
+  const warnings = [];
+  const nextActions = [];
+
+  if (documentText.length < 120) {
+    warnings.push('PDF에서 추출된 텍스트가 적습니다. 스캔본이면 사람이 직접 기본 정보를 한 번 더 확인하는 것이 안전합니다.');
+  }
+  if (!officialContractMatch?.value) {
+    warnings.push('공식 계약명은 파일명 기준 초안입니다. 계약서 상의 공식 명칭과 같은지 확인해 주세요.');
+  }
+  if (!contractAmountMatch?.value) {
+    warnings.push('계약금액은 문서에서 확실히 읽히지 않았습니다. 사람이 직접 입력해 주세요.');
+  }
+
+  nextActions.push('계약서 초안을 확인한 뒤, 담당팀·정산유형·통장 유형은 사람이 직접 선택해 주세요.');
+  nextActions.push('등록 프로젝트명은 10자 이내 별칭이라서 공식 계약명과 다를 수 있습니다. 팀에서 쓰는 짧은 이름으로 조정해 주세요.');
+
+  return {
+    provider: 'heuristic',
+    model: 'deterministic-fallback',
+    summary: officialContractName
+      ? `계약서에서 "${officialContractName}" 중심의 초안을 만들었습니다. 금액·기간·계약 대상은 계약서 원문과 한 번 더 대조하는 것이 안전합니다.`
+      : '계약서에서 기본 정보를 일부 추출했습니다. 사람이 주요 항목을 한 번 더 확인해 주세요.',
+    warnings,
+    nextActions,
+    extractedAt: timestamp,
+    fields: {
+      officialContractName: buildHeuristicTextSuggestion(
+        officialContractName,
+        officialContractMatch?.evidence || fileName,
+        officialContractMatch?.value ? 'medium' : 'low',
+      ),
+      suggestedProjectName: buildHeuristicTextSuggestion(
+        suggestedProjectName,
+        officialContractName || fileName,
+        suggestedProjectName ? 'medium' : 'low',
+      ),
+      clientOrg: buildHeuristicTextSuggestion(
+        clientOrgMatch?.value || '',
+        clientOrgMatch?.evidence || '',
+        clientOrgMatch?.value ? 'medium' : 'low',
+      ),
+      projectPurpose: buildHeuristicTextSuggestion(
+        purposeMatch?.value || '',
+        purposeMatch?.evidence || '',
+        purposeMatch?.value ? 'medium' : 'low',
+      ),
+      description: buildHeuristicTextSuggestion(
+        descriptionMatch?.value || firstParagraph,
+        descriptionMatch?.evidence || firstParagraph,
+        descriptionMatch?.value ? 'medium' : firstParagraph ? 'low' : 'low',
+      ),
+      contractStart: buildHeuristicTextSuggestion(
+        dateRange?.start || '',
+        dateRange?.evidence || '',
+        dateRange?.start ? 'medium' : 'low',
+      ),
+      contractEnd: buildHeuristicTextSuggestion(
+        dateRange?.end || '',
+        dateRange?.evidence || '',
+        dateRange?.end ? 'medium' : 'low',
+      ),
+      contractAmount: buildHeuristicNumberSuggestion(
+        parseCurrency(contractAmountMatch?.value),
+        contractAmountMatch?.evidence || '',
+        contractAmountMatch?.value ? 'medium' : 'low',
+      ),
+      salesVatAmount: buildHeuristicNumberSuggestion(
+        parseCurrency(salesVatMatch?.value),
+        salesVatMatch?.evidence || '',
+        salesVatMatch?.value ? 'medium' : 'low',
+      ),
+    },
+  };
+}
+
+let _anthropic = null;
+function getClient() {
+  if (!_anthropic) {
+    const key = process.env.ANTHROPIC_API_KEY;
+    if (!key) return null;
+    _anthropic = new Anthropic({ apiKey: key });
+  }
+  return _anthropic;
+}
+
+function extractJson(text) {
+  const raw = readOptionalText(text);
+  if (!raw) return null;
+  const fenced = raw.match(/```json\s*([\s\S]*?)```/i);
+  const candidate = fenced ? fenced[1] : raw;
+  const start = candidate.indexOf('{');
+  const end = candidate.lastIndexOf('}');
+  if (start < 0 || end <= start) return null;
+  try {
+    return JSON.parse(candidate.slice(start, end + 1));
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeConfidence(value, fallback = 'medium') {
+  return value === 'high' || value === 'medium' || value === 'low' ? value : fallback;
+}
+
+function sanitizeTextSuggestion(value, fallback) {
+  if (!value || typeof value !== 'object') return fallback;
+  return {
+    value: normalizeWhitespace(value.value || fallback.value),
+    confidence: sanitizeConfidence(readOptionalText(value.confidence), fallback.confidence),
+    evidence: normalizeWhitespace(value.evidence || fallback.evidence),
+  };
+}
+
+function sanitizeNumberSuggestion(value, fallback) {
+  if (!value || typeof value !== 'object') return fallback;
+  const parsed = typeof value.value === 'number' && Number.isFinite(value.value) ? value.value : parseCurrency(value.value);
+  return {
+    value: parsed,
+    confidence: sanitizeConfidence(readOptionalText(value.confidence), fallback.confidence),
+    evidence: normalizeWhitespace(value.evidence || fallback.evidence),
+  };
+}
+
+function sanitizeStringArray(value, fallback = []) {
+  if (!Array.isArray(value)) return fallback;
+  return value
+    .map((item) => normalizeWhitespace(item))
+    .filter(Boolean)
+    .slice(0, 6);
+}
+
+function buildPrompt(input, fallback) {
+  const previewText = truncateText(input.documentText || '');
+  const fallbackJson = JSON.stringify(fallback);
+  const examplesXml = [
+    [
+      '<example>',
+      '<document_name>뷰티풀커넥트_계약서.pdf</document_name>',
+      '<document_excerpt>사업명: 뷰티풀 커넥트 운영 계약 발주기관: 아모레퍼시픽재단 계약기간: 2026.03.01 ~ 2026.12.31 총 계약금액: 120,000,000원 부가세: 12,000,000원 사업 목적: 청년 창업가의 지역 연결을 지원한다.</document_excerpt>',
+      '<ideal_json>{"summary":"계약서 주요 항목을 읽어 기본 정보를 채울 수 있습니다.","warnings":[],"nextActions":["담당팀과 정산유형은 사람이 직접 선택하세요."],"fields":{"officialContractName":{"value":"뷰티풀 커넥트 운영 계약","confidence":"high","evidence":"사업명: 뷰티풀 커넥트 운영 계약"},"suggestedProjectName":{"value":"뷰티풀커넥트","confidence":"high","evidence":"뷰티풀 커넥트 운영 계약"},"clientOrg":{"value":"아모레퍼시픽재단","confidence":"high","evidence":"발주기관: 아모레퍼시픽재단"},"projectPurpose":{"value":"청년 창업가의 지역 연결을 지원한다.","confidence":"high","evidence":"사업 목적: 청년 창업가의 지역 연결을 지원한다."},"description":{"value":"","confidence":"low","evidence":""},"contractStart":{"value":"2026-03-01","confidence":"high","evidence":"계약기간: 2026.03.01 ~ 2026.12.31"},"contractEnd":{"value":"2026-12-31","confidence":"high","evidence":"계약기간: 2026.03.01 ~ 2026.12.31"},"contractAmount":{"value":120000000,"confidence":"high","evidence":"총 계약금액: 120,000,000원"},"salesVatAmount":{"value":12000000,"confidence":"high","evidence":"부가세: 12,000,000원"}}}</ideal_json>',
+      '</example>',
+    ].join('\n'),
+    [
+      '<example>',
+      '<document_name>scan_only_contract.pdf</document_name>',
+      '<document_excerpt></document_excerpt>',
+      '<ideal_json>{"summary":"텍스트 추출이 거의 없어 사람 확인이 필요합니다.","warnings":["스캔본이면 공식 계약명과 금액을 직접 확인하세요."],"nextActions":["계약서 원문을 보고 기본 정보를 직접 보완하세요."],"fields":{"officialContractName":{"value":"scan_only_contract","confidence":"low","evidence":"파일명"},"suggestedProjectName":{"value":"scanonlyco","confidence":"low","evidence":"파일명"},"clientOrg":{"value":"","confidence":"low","evidence":""},"projectPurpose":{"value":"","confidence":"low","evidence":""},"description":{"value":"","confidence":"low","evidence":""},"contractStart":{"value":"","confidence":"low","evidence":""},"contractEnd":{"value":"","confidence":"low","evidence":""},"contractAmount":{"value":null,"confidence":"low","evidence":""},"salesVatAmount":{"value":null,"confidence":"low","evidence":""}}}</ideal_json>',
+      '</example>',
+    ].join('\n'),
+  ].join('\n');
+
+  return [
+    '<role>',
+    '당신은 MYSC 사업관리 플랫폼의 계약서 초안 추출 assistant 입니다.',
+    '계약서에서 사업 등록 제안 폼의 기본값을 보수적으로 추출합니다.',
+    '</role>',
+    '<success_criteria>',
+    '사용자가 계약서를 업로드한 뒤 바로 검토할 수 있는 초안을 만듭니다.',
+    '모호하면 빈 값 또는 낮은 confidence를 사용하세요.',
+    '반드시 한국어 JSON만 반환하세요.',
+    '</success_criteria>',
+    '<field_rules>',
+    '<rule>officialContractName은 계약서 상의 공식 명칭입니다.</rule>',
+    '<rule>suggestedProjectName은 내부 등록용 10자 이내 짧은 이름입니다.</rule>',
+    '<rule>department, settlementType, accountType은 추측하지 않습니다.</rule>',
+    '<rule>날짜는 YYYY-MM-DD 형식입니다.</rule>',
+    '<rule>금액은 숫자만 반환합니다.</rule>',
+    '</field_rules>',
+    '<output_schema>',
+    '{"summary":"string","warnings":["string"],"nextActions":["string"],"fields":{"officialContractName":{"value":"string","confidence":"high|medium|low","evidence":"string"},"suggestedProjectName":{"value":"string","confidence":"high|medium|low","evidence":"string"},"clientOrg":{"value":"string","confidence":"high|medium|low","evidence":"string"},"projectPurpose":{"value":"string","confidence":"high|medium|low","evidence":"string"},"description":{"value":"string","confidence":"high|medium|low","evidence":"string"},"contractStart":{"value":"YYYY-MM-DD or empty","confidence":"high|medium|low","evidence":"string"},"contractEnd":{"value":"YYYY-MM-DD or empty","confidence":"high|medium|low","evidence":"string"},"contractAmount":{"value":"number|null","confidence":"high|medium|low","evidence":"string"},"salesVatAmount":{"value":"number|null","confidence":"high|medium|low","evidence":"string"}}}',
+    '</output_schema>',
+    '<examples>',
+    examplesXml,
+    '</examples>',
+    '<fallback_reference>',
+    fallbackJson,
+    '</fallback_reference>',
+    '<document_name>',
+    readOptionalText(input.fileName) || 'contract.pdf',
+    '</document_name>',
+    '<document_excerpt>',
+    previewText,
+    '</document_excerpt>',
+  ].join('\n');
+}
+
+function sanitizeAnalysis(value, fallback, timestamp = nowIso()) {
+  const raw = value && typeof value === 'object' ? value : {};
+  return {
+    provider: 'anthropic',
+    model: MODEL,
+    summary: normalizeWhitespace(raw.summary || fallback.summary),
+    warnings: sanitizeStringArray(raw.warnings, fallback.warnings),
+    nextActions: sanitizeStringArray(raw.nextActions, fallback.nextActions),
+    extractedAt: timestamp,
+    fields: {
+      officialContractName: sanitizeTextSuggestion(raw.fields?.officialContractName, fallback.fields.officialContractName),
+      suggestedProjectName: sanitizeTextSuggestion(raw.fields?.suggestedProjectName, fallback.fields.suggestedProjectName),
+      clientOrg: sanitizeTextSuggestion(raw.fields?.clientOrg, fallback.fields.clientOrg),
+      projectPurpose: sanitizeTextSuggestion(raw.fields?.projectPurpose, fallback.fields.projectPurpose),
+      description: sanitizeTextSuggestion(raw.fields?.description, fallback.fields.description),
+      contractStart: sanitizeTextSuggestion(raw.fields?.contractStart, fallback.fields.contractStart),
+      contractEnd: sanitizeTextSuggestion(raw.fields?.contractEnd, fallback.fields.contractEnd),
+      contractAmount: sanitizeNumberSuggestion(raw.fields?.contractAmount, fallback.fields.contractAmount),
+      salesVatAmount: sanitizeNumberSuggestion(raw.fields?.salesVatAmount, fallback.fields.salesVatAmount),
+    },
+  };
+}
+
+export function createProjectRequestContractAiService(options = {}) {
+  const timestamp = options.now || nowIso;
+
+  return {
+    async analyzeContract(input) {
+      const fallback = buildFallbackProjectRequestContractAnalysis(input, timestamp());
+      const client = getClient();
+      if (!client) return fallback;
+
+      try {
+        const response = await client.messages.create({
+          model: MODEL,
+          max_tokens: MAX_TOKENS,
+          messages: [{
+            role: 'user',
+            content: buildPrompt(input, fallback),
+          }],
+        });
+
+        const rawText = response.content
+          .filter((part) => part?.type === 'text')
+          .map((part) => part.text)
+          .join('\n');
+        const parsed = extractJson(rawText);
+        if (!parsed) return fallback;
+        return sanitizeAnalysis(parsed, fallback, timestamp());
+      } catch (error) {
+        console.error('[project-request-contract-ai] anthropic analyze failed:', error);
+        return fallback;
+      }
+    },
+  };
+}
+
+export {
+  buildFallbackProjectRequestContractAnalysis,
+  sanitizeProjectName,
+};

--- a/server/bff/project-request-contract-ai.test.ts
+++ b/server/bff/project-request-contract-ai.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildFallbackProjectRequestContractAnalysis,
+  createProjectRequestContractAiService,
+  sanitizeProjectName,
+} from './project-request-contract-ai.mjs';
+
+describe('project-request-contract-ai', () => {
+  it('normalizes a short internal project name from contract title', () => {
+    expect(sanitizeProjectName('뷰티풀 커넥트 운영 계약서')).toBe('뷰티풀커넥트');
+  });
+
+  it('builds fallback analysis from contract text', () => {
+    const analysis = buildFallbackProjectRequestContractAnalysis({
+      fileName: '뷰티풀커넥트_계약서.pdf',
+      documentText: [
+        '사업명: 뷰티풀 커넥트 운영 계약',
+        '발주기관: 아모레퍼시픽재단',
+        '계약기간: 2026.03.01 ~ 2026.12.31',
+        '총 계약금액: 120,000,000원',
+        '부가세: 12,000,000원',
+        '사업 목적: 청년 창업가의 지역 연결을 지원한다.',
+      ].join('\n'),
+    }, '2026-03-16T09:00:00.000Z');
+
+    expect(analysis.provider).toBe('heuristic');
+    expect(analysis.fields.officialContractName.value).toContain('뷰티풀 커넥트');
+    expect(analysis.fields.clientOrg.value).toBe('아모레퍼시픽재단');
+    expect(analysis.fields.contractStart.value).toBe('2026-03-01');
+    expect(analysis.fields.contractEnd.value).toBe('2026-12-31');
+    expect(analysis.fields.contractAmount.value).toBe(120000000);
+  });
+
+  it('falls back when anthropic key is missing', async () => {
+    const service = createProjectRequestContractAiService({
+      now: () => '2026-03-16T09:00:00.000Z',
+    });
+    const analysis = await service.analyzeContract({
+      fileName: 'contract.pdf',
+      documentText: '계약명: 테스트 사업 운영 계약 계약금액: 500,000원',
+    });
+
+    expect(analysis.provider).toBe('heuristic');
+    expect(analysis.extractedAt).toBe('2026-03-16T09:00:00.000Z');
+  });
+});

--- a/server/bff/schemas.mjs
+++ b/server/bff/schemas.mjs
@@ -71,6 +71,11 @@ export const googleSheetImportAnalyzeSchema = z.object({
   matrix: z.array(z.array(z.string())).min(1),
 }).strict();
 
+export const projectRequestContractAnalyzeSchema = z.object({
+  fileName: NON_EMPTY_STRING.max(300),
+  documentText: z.string().max(200000).optional(),
+}).strict();
+
 export const claudeSdkHelpAskSchema = z.object({
   question: NON_EMPTY_STRING.max(2000),
   history: z.array(

--- a/src/app/components/portal/PortalProjectRegister.tsx
+++ b/src/app/components/portal/PortalProjectRegister.tsx
@@ -1,47 +1,74 @@
-import { useRef, useState, type ChangeEvent } from 'react';
-import { useNavigate } from 'react-router';
 import {
-  FolderKanban, ArrowLeft, ArrowRight, CheckCircle2,
-  Building2, Calendar, Wallet, FileText,
-  Users, Briefcase, ClipboardList, AlertTriangle,
-  Loader2, Send, Upload,
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  Building2,
+  CheckCircle2,
+  ClipboardList,
+  FileText,
+  Loader2,
+  Send,
+  Sparkles,
+  Upload,
+  Users,
+  Wallet,
 } from 'lucide-react';
+import { useMemo, useRef, useState, type ChangeEvent, type ReactNode } from 'react';
+import { useNavigate } from 'react-router';
+import { getDownloadURL, ref as storageRef, uploadBytes } from 'firebase/storage';
+import { toast } from 'sonner';
+import { usePortalStore } from '../../data/portal-store';
+import { useAuth } from '../../data/auth-store';
+import { useFirebase } from '../../lib/firebase-context';
+import { getAuthInstance, getStorageInstance } from '../../lib/firebase';
+import { extractTextFromPdf } from '../../lib/pdf-extract';
+import {
+  analyzeProjectRequestContractViaBff,
+  type ProjectRequestContractAnalysisResult,
+} from '../../lib/platform-bff-client';
+import {
+  ACCOUNT_TYPE_LABELS,
+  BASIS_LABELS,
+  PROJECT_TYPE_LABELS,
+  SETTLEMENT_TYPE_LABELS,
+  type AccountType,
+  type Basis,
+  type ProjectRequestContractAnalysis,
+  type SettlementType,
+  type ProjectType,
+} from '../../data/types';
+import { PROJECT_DEPARTMENT_OPTIONS } from '../../data/project-department-options';
+import { type ProjectProposalDraft } from './project-proposal';
+import { Progress } from '../ui/progress';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
 import { Textarea } from '../ui/textarea';
-import { Separator } from '../ui/separator';
 import {
-  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from '../ui/select';
-import { usePortalStore } from '../../data/portal-store';
-import { useAuth } from '../../data/auth-store';
-import { useFirebase } from '../../lib/firebase-context';
-import { getStorageInstance } from '../../lib/firebase';
-import { getDownloadURL, ref as storageRef, uploadBytes } from 'firebase/storage';
-import {
-  PROJECT_TYPE_LABELS, SETTLEMENT_TYPE_LABELS, ACCOUNT_TYPE_LABELS,
-  BASIS_LABELS,
-  type ProjectType,
-} from '../../data/types';
-import { toast } from 'sonner';
-import { type ProjectProposalDraft } from './project-proposal';
-import { PROJECT_DEPARTMENT_OPTIONS } from '../../data/project-department-options';
 
-// ═══════════════════════════════════════════════════════════════
-// PortalProjectRegister — 포털 사용자의 사업 등록 제안
-// 간소화된 사업 등록 폼 → PENDING 상태로 admin에게 전달
-// ═══════════════════════════════════════════════════════════════
+type Step = 'contract' | 'basic' | 'financial' | 'team' | 'review';
+type ContractAnalysisState = 'idle' | 'extracting' | 'analyzing' | 'ready' | 'error';
+type AnalysisFieldKey = keyof ProjectRequestContractAnalysis['fields'];
 
-type Step = 'basic' | 'financial' | 'team' | 'review';
-
-const STEPS: { key: Step; label: string; icon: typeof FolderKanban }[] = [
-  { key: 'basic', label: '기본 정보', icon: FolderKanban },
-  { key: 'financial', label: '재무 정보', icon: Wallet },
-  { key: 'team', label: '팀 구성', icon: Users },
-  { key: 'review', label: '검토 및 제출', icon: ClipboardList },
+const STEPS: Array<{
+  key: Step;
+  label: string;
+  icon: typeof FileText;
+  desc: string;
+}> = [
+  { key: 'contract', label: '계약서 업로드', icon: FileText, desc: 'PDF 업로드와 AI 기본값 생성' },
+  { key: 'basic', label: '기본 정보', icon: Building2, desc: '계약명, 등록명, 계약 대상' },
+  { key: 'financial', label: '재무 정보', icon: Wallet, desc: '기간, 계약금액, 정산 기준' },
+  { key: 'team', label: '팀 구성', icon: Users, desc: '담당자와 참고사항' },
+  { key: 'review', label: '검토 및 제출', icon: ClipboardList, desc: '최종 확인 후 제출' },
 ];
 
 const initialProposal: ProjectProposalDraft = {
@@ -69,29 +96,138 @@ const initialProposal: ProjectProposalDraft = {
   participantCondition: '',
   note: '',
   contractDocument: null,
+  contractAnalysis: null,
 };
+
+function fmtKRW(value: number) {
+  if (!value) return '0';
+  return value.toLocaleString('ko-KR');
+}
+
+function isTextBlank(value: string | null | undefined) {
+  return !String(value || '').trim();
+}
+
+function toSuggestedProjectName(value: string) {
+  const normalized = String(value || '')
+    .replace(/\s+/g, '')
+    .replace(/[()[\]{}]/g, '')
+    .replace(/(계약서|협약서|용역|과업|계약|협약|사업|운영)$/g, '')
+    .trim();
+  return normalized.slice(0, 10);
+}
+
+function mergeAnalysisIntoDraft(
+  draft: ProjectProposalDraft,
+  analysis: ProjectRequestContractAnalysisResult,
+  options?: { overwriteExisting?: boolean },
+): ProjectProposalDraft {
+  const overwriteExisting = Boolean(options?.overwriteExisting);
+  const next = { ...draft, contractAnalysis: analysis };
+  const shouldApplyText = (value: string, current: string) => overwriteExisting || isTextBlank(current);
+  const shouldApplyNumber = (value: number | null, current: number) => value !== null && (overwriteExisting || !current);
+
+  if (shouldApplyText(analysis.fields.officialContractName.value, draft.officialContractName)) {
+    next.officialContractName = analysis.fields.officialContractName.value;
+  }
+  if (shouldApplyText(analysis.fields.suggestedProjectName.value, draft.name)) {
+    next.name = toSuggestedProjectName(analysis.fields.suggestedProjectName.value || analysis.fields.officialContractName.value);
+  }
+  if (shouldApplyText(analysis.fields.clientOrg.value, draft.clientOrg)) {
+    next.clientOrg = analysis.fields.clientOrg.value;
+  }
+  if (shouldApplyText(analysis.fields.projectPurpose.value, draft.projectPurpose)) {
+    next.projectPurpose = analysis.fields.projectPurpose.value;
+  }
+  if (shouldApplyText(analysis.fields.description.value, draft.description)) {
+    next.description = analysis.fields.description.value;
+  }
+  if (shouldApplyText(analysis.fields.contractStart.value, draft.contractStart)) {
+    next.contractStart = analysis.fields.contractStart.value;
+  }
+  if (shouldApplyText(analysis.fields.contractEnd.value, draft.contractEnd)) {
+    next.contractEnd = analysis.fields.contractEnd.value;
+  }
+  if (shouldApplyNumber(analysis.fields.contractAmount.value, draft.contractAmount)) {
+    next.contractAmount = analysis.fields.contractAmount.value || 0;
+  }
+  if (shouldApplyNumber(analysis.fields.salesVatAmount.value, draft.salesVatAmount)) {
+    next.salesVatAmount = analysis.fields.salesVatAmount.value || 0;
+  }
+  return next;
+}
+
+function confidenceLabel(confidence: ProjectRequestContractAnalysis['fields'][AnalysisFieldKey]['confidence']) {
+  if (confidence === 'high') return '높음';
+  if (confidence === 'medium') return '보통';
+  return '낮음';
+}
+
+function confidenceBadgeClass(confidence: ProjectRequestContractAnalysis['fields'][AnalysisFieldKey]['confidence']) {
+  if (confidence === 'high') return 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300';
+  if (confidence === 'medium') return 'bg-amber-500/15 text-amber-700 dark:text-amber-300';
+  return 'bg-slate-500/15 text-slate-700 dark:text-slate-300';
+}
 
 export function PortalProjectRegister() {
   const navigate = useNavigate();
   const { user: authUser } = useAuth();
   const { orgId } = useFirebase();
   const { portalUser, projects, createProjectRequest } = usePortalStore();
-  const [step, setStep] = useState<Step>('basic');
+
+  const [step, setStep] = useState<Step>('contract');
   const [form, setForm] = useState<ProjectProposalDraft>({
     ...initialProposal,
-    managerName: portalUser?.name || '',
+    managerName: portalUser?.name || authUser?.name || '',
   });
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const [isUploadingContract, setIsUploadingContract] = useState(false);
+  const [contractAnalysisState, setContractAnalysisState] = useState<ContractAnalysisState>('idle');
+  const [analysisError, setAnalysisError] = useState('');
   const contractFileInputRef = useRef<HTMLInputElement | null>(null);
 
-  const currentStepIdx = STEPS.findIndex(s => s.key === step);
+  const currentStepIdx = STEPS.findIndex((item) => item.key === step);
+  const currentStep = STEPS[currentStepIdx];
+  const CurrentStepIcon = currentStep.icon;
+  const progress = ((currentStepIdx + 1) / STEPS.length) * 100;
+
+  const projectNameOptions = useMemo(
+    () => Array.from(new Set(projects.map((project) => String(project.name || '').trim()).filter(Boolean))).sort((a, b) => a.localeCompare(b, 'ko')),
+    [projects],
+  );
+  const clientOrgOptions = useMemo(
+    () => Array.from(new Set(projects.map((project) => String(project.clientOrg || '').trim()).filter(Boolean))).sort((a, b) => a.localeCompare(b, 'ko')),
+    [projects],
+  );
+
+  const analysis = form.contractAnalysis || null;
+  const analysisField = (key: AnalysisFieldKey) => analysis?.fields[key] || null;
+
   const canProceed = () => {
-    if (step === 'basic') return form.name.trim() && form.officialContractName.trim() && form.clientOrg.trim() && form.type && form.department;
-    if (step === 'financial') return form.contractAmount > 0 && form.contractStart && form.contractEnd;
-    if (step === 'team') return form.managerName;
+    if (step === 'contract') {
+      return Boolean(form.contractDocument) && !isUploadingContract && contractAnalysisState !== 'extracting' && contractAnalysisState !== 'analyzing';
+    }
+    if (step === 'basic') {
+      return Boolean(form.department && form.officialContractName.trim() && form.name.trim() && form.clientOrg.trim() && form.type);
+    }
+    if (step === 'financial') {
+      return form.contractAmount > 0 && Boolean(form.contractStart) && Boolean(form.contractEnd);
+    }
+    if (step === 'team') {
+      return Boolean(form.managerName.trim());
+    }
     return true;
+  };
+
+  const update = (key: keyof ProjectProposalDraft, value: ProjectProposalDraft[keyof ProjectProposalDraft]) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const applyContractAnalysis = (overwriteExisting: boolean) => {
+    if (!analysis) return;
+    setForm((prev) => mergeAnalysisIntoDraft(prev, analysis, { overwriteExisting }));
+    toast.success(overwriteExisting ? 'AI 초안을 다시 반영했습니다.' : '빈 항목에 AI 초안을 반영했습니다.');
   };
 
   const handleContractDocumentSelect = async (event: ChangeEvent<HTMLInputElement>) => {
@@ -113,6 +249,9 @@ export function PortalProjectRegister() {
     }
 
     setIsUploadingContract(true);
+    setContractAnalysisState('extracting');
+    setAnalysisError('');
+
     try {
       const uploadedAt = new Date().toISOString();
       const safeName = file.name.replace(/[^\w.\-가-힣() ]+/g, '_');
@@ -122,17 +261,63 @@ export function PortalProjectRegister() {
         contentType: file.type || 'application/pdf',
       });
       const downloadURL = await getDownloadURL(snapshot.ref);
-      update('contractDocument', {
+      const contractDocument = {
         path,
         name: file.name,
         downloadURL,
         size: file.size,
         contentType: file.type || 'application/pdf',
         uploadedAt,
+      };
+
+      let documentText = '';
+      try {
+        documentText = await extractTextFromPdf(file);
+      } catch (error) {
+        console.warn('[PortalProjectRegister] pdf text extraction failed:', error);
+      }
+
+      setContractAnalysisState('analyzing');
+
+      let nextAnalysis: ProjectRequestContractAnalysisResult | null = null;
+      try {
+        const idToken = authUser.idToken || await getAuthInstance()?.currentUser?.getIdToken() || undefined;
+        nextAnalysis = await analyzeProjectRequestContractViaBff({
+          tenantId: orgId,
+          actor: {
+            uid: authUser.uid,
+            email: authUser.email,
+            role: authUser.role,
+            idToken,
+          },
+          fileName: file.name,
+          documentText: documentText || file.name,
+        });
+      } catch (error) {
+        console.error('[PortalProjectRegister] contract analysis failed:', error);
+        setAnalysisError('업로드는 완료됐지만 AI 초안 생성에 실패했습니다. 직접 입력하거나 다시 시도해 주세요.');
+      }
+
+      setForm((prev) => {
+        const base = {
+          ...prev,
+          contractDocument,
+          contractAnalysis: nextAnalysis || null,
+        };
+        return nextAnalysis ? mergeAnalysisIntoDraft(base, nextAnalysis, { overwriteExisting: false }) : base;
       });
-      toast.success(`계약서 업로드 완료: ${file.name}`);
+
+      if (nextAnalysis) {
+        setContractAnalysisState('ready');
+        toast.success(`계약서 업로드 및 AI 초안 생성 완료: ${file.name}`);
+      } else {
+        setContractAnalysisState('error');
+        toast.success(`계약서 업로드 완료: ${file.name}`);
+      }
     } catch (error) {
       console.error('[PortalProjectRegister] contract upload failed:', error);
+      setContractAnalysisState('error');
+      setAnalysisError('계약서 업로드에 실패했습니다. 다시 시도해 주세요.');
       toast.error('계약서 업로드에 실패했습니다. 다시 시도해 주세요.');
     } finally {
       setIsUploadingContract(false);
@@ -142,59 +327,56 @@ export function PortalProjectRegister() {
   const handleSubmit = async () => {
     if (isSubmitting) return;
     if (!form.contractDocument) {
-      setStep('financial');
-      toast.error('계약서 등 PDF를 업로드해 주세요.');
+      setStep('contract');
+      toast.error('계약서 등 PDF를 먼저 업로드해 주세요.');
       return;
     }
-    setIsSubmitting(true);
 
+    setIsSubmitting(true);
     try {
       const createdId = await createProjectRequest(form);
       if (!createdId) {
         toast.error('사업 등록 제안 저장에 실패했습니다. 다시 시도해 주세요.');
         return;
       }
-
       setSubmitted(true);
       toast.success('사업 등록 제안이 저장되었습니다. 관리자 검토를 기다려주세요.');
-    } catch (err: any) {
-      console.error(err);
-      toast.error(err?.message || '사업 등록 제안 저장에 실패했습니다');
+    } catch (error: any) {
+      console.error('[PortalProjectRegister] create project request failed:', error);
+      toast.error(error?.message || '사업 등록 제안 저장에 실패했습니다.');
     } finally {
       setIsSubmitting(false);
     }
   };
 
-  const fmtKRW = (n: number) => {
-    if (!n) return '0';
-    return n.toLocaleString('ko-KR');
-  };
-
-  const update = (key: keyof ProjectProposalDraft, value: any) => {
-    setForm(prev => ({ ...prev, [key]: value }));
-  };
-  const projectNameOptions = Array.from(new Set(projects.map((project) => String(project.name || '').trim()).filter(Boolean))).sort((a, b) => a.localeCompare(b, 'ko'));
-  const clientOrgOptions = Array.from(new Set(projects.map((project) => String(project.clientOrg || '').trim()).filter(Boolean))).sort((a, b) => a.localeCompare(b, 'ko'));
-
   if (submitted) {
     return (
-      <div className="max-w-lg mx-auto py-16 text-center">
+      <div className="mx-auto max-w-lg py-16 text-center">
         <div
-          className="w-16 h-16 rounded-full mx-auto mb-4 flex items-center justify-center"
+          className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full"
           style={{ background: 'linear-gradient(135deg, #059669, #0d9488)' }}
         >
-          <CheckCircle2 className="w-8 h-8 text-white" />
+          <CheckCircle2 className="h-8 w-8 text-white" />
         </div>
-        <h2 className="text-[18px] mb-2" style={{ fontWeight: 700 }}>사업 등록 제안 완료</h2>
-        <p className="text-[13px] text-muted-foreground mb-1">
-          <span style={{ fontWeight: 600 }}>"{form.name}"</span> 사업 등록 제안이 성공적으로 전달되었습니다.
+        <h2 className="text-[18px]" style={{ fontWeight: 700 }}>사업 등록 제안 완료</h2>
+        <p className="mt-2 text-[13px] text-muted-foreground">
+          <span style={{ fontWeight: 600 }}>&quot;{form.name}&quot;</span> 사업 등록 제안이 저장되었습니다.
         </p>
-        <p className="text-[12px] text-muted-foreground mb-6">
-          관리자가 검토 후 승인/반려 결과를 알려드립니다.
-        </p>
-        <div className="flex justify-center gap-2">
+        <p className="mt-1 text-[12px] text-muted-foreground">관리자 검토 후 포털에서 바로 관리할 수 있습니다.</p>
+        <div className="mt-6 flex justify-center gap-2">
           <Button variant="outline" onClick={() => navigate('/portal')}>대시보드로</Button>
-          <Button onClick={() => { setSubmitted(false); setForm({ ...initialProposal, managerName: portalUser?.name || '' }); setStep('basic'); }}>
+          <Button
+            onClick={() => {
+              setSubmitted(false);
+              setForm({
+                ...initialProposal,
+                managerName: portalUser?.name || authUser?.name || '',
+              });
+              setStep('contract');
+              setContractAnalysisState('idle');
+              setAnalysisError('');
+            }}
+          >
             추가 등록
           </Button>
         </div>
@@ -203,88 +385,289 @@ export function PortalProjectRegister() {
   }
 
   return (
-    <div className="max-w-3xl mx-auto space-y-5">
-      {/* Header */}
+    <div className="mx-auto max-w-5xl space-y-5">
       <div className="flex items-center gap-3">
-        <Button variant="ghost" size="sm" className="h-8 text-[12px] gap-1" onClick={() => navigate('/portal')}>
-          <ArrowLeft className="w-3.5 h-3.5" /> 돌아가기
+        <Button variant="ghost" size="sm" className="h-8 gap-1 text-[12px]" onClick={() => navigate('/portal')}>
+          <ArrowLeft className="h-3.5 w-3.5" />
+          돌아가기
         </Button>
       </div>
 
-      <div>
-        <h1 className="text-[18px]" style={{ fontWeight: 700 }}>사업 등록 제안</h1>
-        <p className="text-[12px] text-muted-foreground mt-0.5">
-          새로운 사업을 등록하려면 아래 정보를 입력해 주세요. 관리자 승인 후 포털에서 관리할 수 있습니다.
-        </p>
-      </div>
-
-      {/* Step Indicator */}
-      <div className="flex items-center gap-1">
-        {STEPS.map((s, i) => {
-          const isCurrent = s.key === step;
-          const isDone = i < currentStepIdx;
-          return (
-            <div key={s.key} className="flex items-center gap-1 flex-1">
-              <button
-                onClick={() => {
-                  if (i <= currentStepIdx) setStep(s.key);
-                }}
-                className={`
-                  flex items-center gap-1.5 px-3 py-2 rounded-lg text-[11px] w-full transition-colors
-                  ${isCurrent ? 'bg-teal-50 dark:bg-teal-950/30 text-teal-700 dark:text-teal-300 border border-teal-200/60 dark:border-teal-800/40' :
-                    isDone ? 'bg-emerald-50 dark:bg-emerald-950/20 text-emerald-600 dark:text-emerald-400' :
-                    'bg-muted/30 text-muted-foreground'}
-                `}
-                style={{ fontWeight: isCurrent ? 600 : 400 }}
-              >
-                <div className={`w-5 h-5 rounded-full flex items-center justify-center shrink-0 text-[9px] ${
-                  isDone ? 'bg-emerald-500 text-white' : isCurrent ? 'bg-teal-500 text-white' : 'bg-muted text-muted-foreground'
-                }`} style={{ fontWeight: 700 }}>
-                  {isDone ? <CheckCircle2 className="w-3 h-3" /> : i + 1}
-                </div>
-                <span className="hidden sm:inline">{s.label}</span>
-              </button>
-              {i < STEPS.length - 1 && (
-                <div className={`h-px flex-1 min-w-[16px] ${isDone ? 'bg-emerald-300 dark:bg-emerald-700' : 'bg-border'}`} />
-              )}
+      <Card className="border-border/60">
+        <CardHeader className="gap-4 pb-4">
+          <div className="space-y-1">
+            <CardTitle className="text-[18px]" style={{ fontWeight: 700 }}>사업 등록 제안</CardTitle>
+            <p className="text-[12px] text-muted-foreground">
+              계약서를 먼저 올리면 AI가 기본 정보를 채우고, 사람이 검토한 뒤 제출하는 방식입니다.
+            </p>
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between text-[11px] text-muted-foreground">
+              <span>{currentStepIdx + 1} / {STEPS.length} 단계</span>
+              <span>{currentStep.label}</span>
             </div>
-          );
-        })}
-      </div>
+            <Progress value={progress} className="h-2" />
+          </div>
+          <div className="grid gap-2 md:grid-cols-5">
+            {STEPS.map((item, index) => {
+              const Icon = item.icon;
+              const active = item.key === step;
+              const done = index < currentStepIdx;
+              return (
+                <button
+                  key={item.key}
+                  type="button"
+                  onClick={() => {
+                    if (index <= currentStepIdx) setStep(item.key);
+                  }}
+                  className={[
+                    'rounded-xl border px-3 py-3 text-left transition-colors',
+                    active
+                      ? 'border-teal-500/40 bg-teal-50 text-teal-700 dark:border-teal-700 dark:bg-teal-950/30 dark:text-teal-300'
+                      : done
+                        ? 'border-emerald-500/20 bg-emerald-50 text-emerald-700 dark:border-emerald-800/40 dark:bg-emerald-950/20 dark:text-emerald-300'
+                        : 'border-border/60 bg-background text-foreground',
+                  ].join(' ')}
+                >
+                  <div className="flex items-center gap-2">
+                    <div
+                      className={[
+                        'flex h-7 w-7 items-center justify-center rounded-full text-[10px]',
+                        done ? 'bg-emerald-500 text-white' : active ? 'bg-teal-500 text-white' : 'bg-muted text-muted-foreground',
+                      ].join(' ')}
+                      style={{ fontWeight: 700 }}
+                    >
+                      {done ? <CheckCircle2 className="h-4 w-4" /> : index + 1}
+                    </div>
+                    <Icon className="h-4 w-4" />
+                  </div>
+                  <div className="mt-2 text-[12px]" style={{ fontWeight: 600 }}>{item.label}</div>
+                  <div className="mt-1 text-[10px] text-muted-foreground">{item.desc}</div>
+                </button>
+              );
+            })}
+          </div>
+        </CardHeader>
+      </Card>
 
-      {/* Step Content */}
-      <Card>
-        <CardContent className="p-5">
+      <Card className="border-border/60">
+        <CardHeader className="pb-2">
+          <div className="flex items-center gap-2">
+            <CurrentStepIcon className="h-4 w-4 text-teal-600" />
+            <CardTitle className="text-[15px]" style={{ fontWeight: 700 }}>{currentStep.label}</CardTitle>
+          </div>
+          <p className="text-[11px] text-muted-foreground">{currentStep.desc}</p>
+        </CardHeader>
+        <CardContent className="space-y-5 p-5">
+          {step === 'contract' && (
+            <div className="grid gap-4 xl:grid-cols-[1.2fr,0.8fr]">
+              <Card className="border-dashed border-border/80">
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-[13px]">1. 계약서 업로드</CardTitle>
+                  <p className="text-[11px] text-muted-foreground">
+                    계약서 PDF를 먼저 올리면 공식 계약명, 계약 대상, 기간, 금액 초안을 자동으로 채웁니다.
+                  </p>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <input
+                    ref={contractFileInputRef}
+                    type="file"
+                    accept="application/pdf,.pdf"
+                    className="hidden"
+                    onChange={handleContractDocumentSelect}
+                  />
+                  <div className="rounded-xl border border-dashed border-border p-4">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="h-9 gap-1.5 text-[12px]"
+                        onClick={() => contractFileInputRef.current?.click()}
+                        disabled={isUploadingContract}
+                      >
+                        {isUploadingContract ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Upload className="h-3.5 w-3.5" />}
+                        {isUploadingContract ? '업로드 중...' : '계약서 PDF 업로드'}
+                      </Button>
+                      {form.contractDocument ? (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          className="h-9 text-[12px]"
+                          onClick={() => {
+                            setForm((prev) => ({ ...prev, contractDocument: null, contractAnalysis: null }));
+                            setContractAnalysisState('idle');
+                            setAnalysisError('');
+                          }}
+                        >
+                          첨부 제거
+                        </Button>
+                      ) : null}
+                    </div>
+                    <p className="mt-3 text-[11px] text-muted-foreground">
+                      계약이 확정되었다는 서류를 업로드해 주세요. 날인이 되어 있지 않아도 됩니다.
+                    </p>
+                    {form.contractDocument ? (
+                      <div className="mt-4 rounded-lg bg-muted/40 px-3 py-3 text-[11px]">
+                        <div style={{ fontWeight: 600 }}>{form.contractDocument.name}</div>
+                        <div className="mt-1 text-muted-foreground">
+                          {(form.contractDocument.size / 1024 / 1024).toFixed(2)} MB · {form.contractDocument.uploadedAt.slice(0, 10)}
+                        </div>
+                        <a
+                          href={form.contractDocument.downloadURL}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="mt-2 inline-block text-teal-600 hover:underline"
+                        >
+                          업로드된 파일 보기
+                        </a>
+                      </div>
+                    ) : (
+                      <div className="mt-4 rounded-lg bg-amber-50 px-3 py-2 text-[11px] text-amber-700 dark:bg-amber-950/20 dark:text-amber-300">
+                        제출 전까지 계약서 PDF 1개 업로드가 필요합니다.
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="rounded-xl border border-border/60 bg-muted/20 p-4">
+                    <div className="flex items-center gap-2 text-[12px]" style={{ fontWeight: 600 }}>
+                      <Sparkles className="h-4 w-4 text-teal-600" />
+                      2. AI 기본값 채우기
+                    </div>
+                    <div className="mt-2 text-[11px] text-muted-foreground">
+                      업로드 후 공식 계약명, 등록 프로젝트명, 계약 대상, 계약 기간, 계약금액 초안을 자동으로 채웁니다.
+                    </div>
+                    <div className="mt-3 flex flex-wrap gap-2 text-[11px]">
+                      <Badge className="border-0 bg-slate-500/15 text-slate-700 dark:text-slate-300">사람 검토 필수</Badge>
+                      <Badge className="border-0 bg-teal-500/15 text-teal-700 dark:text-teal-300">담당팀/정산유형은 수동 선택</Badge>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+
+              <Card className="border-border/60">
+                <CardHeader className="pb-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <CardTitle className="text-[13px]">계약서 AI 초안</CardTitle>
+                    {analysis ? (
+                      <Badge className="border-0 bg-teal-500/15 text-teal-700 dark:text-teal-300">
+                        {analysis.provider === 'anthropic' ? 'Claude 분석' : '기본 분석'}
+                      </Badge>
+                    ) : null}
+                  </div>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  {contractAnalysisState === 'extracting' || contractAnalysisState === 'analyzing' ? (
+                    <div className="rounded-xl border border-border/60 bg-muted/20 px-4 py-6 text-center">
+                      <Loader2 className="mx-auto h-5 w-5 animate-spin text-teal-600" />
+                      <p className="mt-3 text-[12px]" style={{ fontWeight: 600 }}>
+                        {contractAnalysisState === 'extracting' ? 'PDF 텍스트 추출 중…' : 'AI가 계약서 초안을 만들고 있습니다…'}
+                      </p>
+                      <p className="mt-1 text-[11px] text-muted-foreground">
+                        공식 계약명, 계약 대상, 기간, 금액을 기본 정보에 먼저 채웁니다.
+                      </p>
+                    </div>
+                  ) : analysis ? (
+                    <>
+                      <div className="rounded-xl bg-teal-50 px-3 py-3 text-[11px] text-teal-800 dark:bg-teal-950/20 dark:text-teal-200">
+                        <div className="flex items-center justify-between gap-2">
+                          <span style={{ fontWeight: 600 }}>AI 요약</span>
+                          <span className="text-[10px] text-teal-700/80 dark:text-teal-200/80">{analysis.extractedAt.slice(0, 16).replace('T', ' ')}</span>
+                        </div>
+                        <p className="mt-2 leading-5">{analysis.summary}</p>
+                      </div>
+
+                      <div className="space-y-2 rounded-xl border border-border/60 p-3">
+                        <div className="text-[11px]" style={{ fontWeight: 600 }}>바로 채운 항목</div>
+                        <SuggestedField label="공식 계약명" field={analysis.fields.officialContractName} />
+                        <SuggestedField label="등록 프로젝트명" field={analysis.fields.suggestedProjectName} />
+                        <SuggestedField label="계약 대상" field={analysis.fields.clientOrg} />
+                        <SuggestedField label="프로젝트 목적" field={analysis.fields.projectPurpose} />
+                        <SuggestedField label="주요 내용" field={analysis.fields.description} />
+                        <SuggestedField label="계약 시작일" field={analysis.fields.contractStart} />
+                        <SuggestedField label="계약 종료일" field={analysis.fields.contractEnd} />
+                        <SuggestedField label="계약금액" field={analysis.fields.contractAmount} />
+                        <SuggestedField label="매출 부가세" field={analysis.fields.salesVatAmount} />
+                      </div>
+
+                      {analysis.warnings.length > 0 ? (
+                        <div className="rounded-xl bg-amber-50 px-3 py-3 text-[11px] text-amber-800 dark:bg-amber-950/20 dark:text-amber-200">
+                          <div style={{ fontWeight: 600 }}>확인 필요</div>
+                          <ul className="mt-2 space-y-1 list-disc pl-4">
+                            {analysis.warnings.map((warning) => (
+                              <li key={warning}>{warning}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      ) : null}
+
+                      {analysis.nextActions.length > 0 ? (
+                        <div className="rounded-xl border border-border/60 bg-muted/20 px-3 py-3 text-[11px]">
+                          <div style={{ fontWeight: 600 }}>다음으로 할 일</div>
+                          <ul className="mt-2 space-y-1 list-disc pl-4 text-muted-foreground">
+                            {analysis.nextActions.map((item) => (
+                              <li key={item}>{item}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      ) : null}
+
+                      <div className="flex flex-wrap gap-2">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="h-8 text-[11px]"
+                          onClick={() => applyContractAnalysis(true)}
+                        >
+                          AI 초안 다시 반영
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-8 text-[11px]"
+                          onClick={() => applyContractAnalysis(false)}
+                        >
+                          빈 항목만 채우기
+                        </Button>
+                      </div>
+                    </>
+                  ) : (
+                    <div className="rounded-xl border border-border/60 bg-muted/20 px-4 py-6 text-[11px] text-muted-foreground">
+                      계약서를 업로드하면 AI가 기본 정보를 먼저 채워 줍니다. 스캔본이면 일부 항목은 사람이 직접 보완해야 할 수 있습니다.
+                    </div>
+                  )}
+
+                  {analysisError ? (
+                    <div className="rounded-xl bg-rose-50 px-3 py-3 text-[11px] text-rose-700 dark:bg-rose-950/20 dark:text-rose-300">
+                      {analysisError}
+                    </div>
+                  ) : null}
+                </CardContent>
+              </Card>
+            </div>
+          )}
+
           {step === 'basic' && (
             <div className="space-y-4">
-              <div className="flex items-center gap-2 mb-3">
-                <FolderKanban className="w-4 h-4 text-teal-600" />
-                <h3 className="text-[14px]" style={{ fontWeight: 600 }}>기본 정보</h3>
-              </div>
-
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div>
                   <Label className="text-[11px]">신청자(별명)</Label>
                   <Input
                     value={portalUser?.name || authUser?.name || ''}
                     readOnly
-                    className="h-9 text-[12px] mt-1 bg-muted/40"
+                    className="mt-1 h-9 bg-muted/40 text-[12px]"
                   />
                 </div>
                 <div>
                   <Label className="text-[11px]">담당팀 *</Label>
-                  <Select
-                    value={form.department || undefined}
-                    onValueChange={(value) => update('department', value)}
-                  >
-                    <SelectTrigger className="h-9 text-[12px] mt-1">
+                  <Select value={form.department || undefined} onValueChange={(value) => update('department', value)}>
+                    <SelectTrigger className="mt-1 h-9 text-[12px]">
                       <SelectValue placeholder="담당팀 선택" />
                     </SelectTrigger>
                     <SelectContent>
                       {PROJECT_DEPARTMENT_OPTIONS.map((department) => (
-                        <SelectItem key={department} value={department}>
-                          {department}
-                        </SelectItem>
+                        <SelectItem key={department} value={department}>{department}</SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
@@ -292,149 +675,148 @@ export function PortalProjectRegister() {
               </div>
 
               <div>
-                <Label className="text-[11px]">공식 계약명 *</Label>
+                <FieldLabel label="공식 계약명 *" field={analysisField('officialContractName')} />
                 <Input
                   value={form.officialContractName}
-                  onChange={e => update('officialContractName', e.target.value)}
-                  placeholder="계약서 상의 공식 명칭을 그대로 입력해 주세요. 헷갈리면 OCR/PDF 제목 기준으로 적어도 괜찮습니다."
-                  className="h-9 text-[12px] mt-1"
+                  onChange={(event) => update('officialContractName', event.target.value)}
+                  placeholder="계약서 상의 공식 명칭"
+                  className="mt-1 h-9 text-[12px]"
                 />
-                <p className="text-[10px] text-muted-foreground mt-1">
-                  계약서 상의 공식 명칭이라고 꼭 명시해 주세요. 헷갈리면 OCR/PDF 제목 기준으로 적어도 괜찮습니다.
-                </p>
+                <FieldEvidence field={analysisField('officialContractName')} />
               </div>
 
               <div>
-                <Label className="text-[11px]">등록 프로젝트명 (10글자 이내) *</Label>
+                <FieldLabel label="등록 프로젝트명 (10글자 이내) *" field={analysisField('suggestedProjectName')} />
                 <datalist id="project-name-options">
-                  {projectNameOptions.map((name) => (
-                    <option key={name} value={name} />
-                  ))}
+                  {projectNameOptions.map((name) => <option key={name} value={name} />)}
                 </datalist>
                 <Input
                   value={form.name}
-                  onChange={e => update('name', e.target.value.slice(0, 10))}
+                  onChange={(event) => update('name', event.target.value.slice(0, 10))}
                   placeholder="예: 뷰티풀커넥트"
                   list="project-name-options"
-                  className="h-9 text-[12px] mt-1"
+                  className="mt-1 h-9 text-[12px]"
                 />
-                <p className="text-[10px] text-muted-foreground mt-1">{form.name.length}/10자</p>
+                <div className="mt-1 flex items-center justify-between text-[10px] text-muted-foreground">
+                  <span>계약서 공식 명칭과 별도로, 내부에서 짧게 쓰는 이름을 적어 주세요.</span>
+                  <span>{form.name.length}/10자</span>
+                </div>
               </div>
 
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div>
                   <Label className="text-[11px]">프로젝트 유형 *</Label>
-                  <Select value={form.type} onValueChange={v => update('type', v)}>
-                    <SelectTrigger className="h-9 text-[12px] mt-1">
+                  <Select value={form.type} onValueChange={(value) => update('type', value)}>
+                    <SelectTrigger className="mt-1 h-9 text-[12px]">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {(Object.entries(PROJECT_TYPE_LABELS) as [ProjectType, string][]).map(([k, v]) => (
-                        <SelectItem key={k} value={k}>{v}</SelectItem>
+                      {(Object.entries(PROJECT_TYPE_LABELS) as [ProjectType, string][]).map(([key, value]) => (
+                        <SelectItem key={key} value={key}>{value}</SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
                 </div>
                 <div>
-                  <Label className="text-[11px]">계약 대상 *</Label>
+                  <FieldLabel label="계약 대상 *" field={analysisField('clientOrg')} />
                   <datalist id="client-org-options">
-                    {clientOrgOptions.map((name) => (
-                      <option key={name} value={name} />
-                    ))}
+                    {clientOrgOptions.map((name) => <option key={name} value={name} />)}
                   </datalist>
                   <Input
                     value={form.clientOrg}
-                    onChange={e => update('clientOrg', e.target.value)}
+                    onChange={(event) => update('clientOrg', event.target.value)}
                     placeholder="예: KOICA, 서울시, 아모레퍼시픽재단"
                     list="client-org-options"
-                    className="h-9 text-[12px] mt-1"
+                    className="mt-1 h-9 text-[12px]"
                   />
+                  <FieldEvidence field={analysisField('clientOrg')} />
                 </div>
               </div>
 
               <div>
-                <Label className="text-[11px]">프로젝트 목적</Label>
+                <FieldLabel label="프로젝트 목적" field={analysisField('projectPurpose')} />
                 <Textarea
                   value={form.projectPurpose}
-                  onChange={e => update('projectPurpose', e.target.value)}
+                  onChange={(event) => update('projectPurpose', event.target.value)}
                   placeholder="예: 어떤 대상에게 어떤 가치를 제공하는 사업인지 적어 주세요."
-                  className="text-[12px] mt-1 min-h-[72px]"
+                  className="mt-1 min-h-[90px] text-[12px]"
                 />
+                <FieldEvidence field={analysisField('projectPurpose')} />
               </div>
 
               <div>
-                <Label className="text-[11px]">프로젝트 주요 내용</Label>
+                <FieldLabel label="프로젝트 주요 내용" field={analysisField('description')} />
                 <Textarea
                   value={form.description}
-                  onChange={e => update('description', e.target.value)}
+                  onChange={(event) => update('description', event.target.value)}
                   placeholder="프로젝트 주요 수행 내용, 범위, 산출물 등을 적어 주세요."
-                  className="text-[12px] mt-1 min-h-[80px]"
+                  className="mt-1 min-h-[110px] text-[12px]"
                 />
+                <FieldEvidence field={analysisField('description')} />
               </div>
             </div>
           )}
 
           {step === 'financial' && (
             <div className="space-y-4">
-              <div className="flex items-center gap-2 mb-3">
-                <Wallet className="w-4 h-4 text-teal-600" />
-                <h3 className="text-[14px]" style={{ fontWeight: 600 }}>재무 정보</h3>
-              </div>
-
-              <div>
-                <Label className="text-[11px]">계약금액 (계약서 내 기재된 총 금액) *</Label>
-                <Input
-                  type="number"
-                  value={form.contractAmount || ''}
-                  onChange={e => update('contractAmount', Number(e.target.value) || 0)}
-                  placeholder="0"
-                  className="h-9 text-[12px] mt-1"
-                />
-                {form.contractAmount > 0 && (
-                  <p className="text-[10px] text-muted-foreground mt-0.5">{fmtKRW(form.contractAmount)}원</p>
-                )}
-              </div>
-
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div>
-                  <Label className="text-[11px]">계약 시작일 *</Label>
+                  <FieldLabel label="계약 시작일 *" field={analysisField('contractStart')} />
                   <Input
                     type="date"
                     value={form.contractStart}
-                    onChange={e => update('contractStart', e.target.value)}
-                    className="h-9 text-[12px] mt-1"
+                    onChange={(event) => update('contractStart', event.target.value)}
+                    className="mt-1 h-9 text-[12px]"
                   />
+                  <FieldEvidence field={analysisField('contractStart')} />
                 </div>
                 <div>
-                  <Label className="text-[11px]">계약 종료일 *</Label>
+                  <FieldLabel label="계약 종료일 *" field={analysisField('contractEnd')} />
                   <Input
                     type="date"
                     value={form.contractEnd}
-                    onChange={e => update('contractEnd', e.target.value)}
-                    className="h-9 text-[12px] mt-1"
+                    onChange={(event) => update('contractEnd', event.target.value)}
+                    className="mt-1 h-9 text-[12px]"
                   />
+                  <FieldEvidence field={analysisField('contractEnd')} />
                 </div>
               </div>
 
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+              <div>
+                <FieldLabel label="계약금액 (계약서 내 기재된 총 금액) *" field={analysisField('contractAmount')} />
+                <Input
+                  type="number"
+                  value={form.contractAmount || ''}
+                  onChange={(event) => update('contractAmount', Number(event.target.value) || 0)}
+                  placeholder="0"
+                  className="mt-1 h-9 text-[12px]"
+                />
+                <div className="mt-1 flex items-center justify-between text-[10px] text-muted-foreground">
+                  <FieldEvidence field={analysisField('contractAmount')} />
+                  {form.contractAmount > 0 ? <span>{fmtKRW(form.contractAmount)}원</span> : null}
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
                 <div>
-                  <Label className="text-[11px]">매출 부가세</Label>
+                  <FieldLabel label="매출 부가세" field={analysisField('salesVatAmount')} />
                   <Input
                     type="number"
                     value={form.salesVatAmount || ''}
-                    onChange={e => update('salesVatAmount', Number(e.target.value) || 0)}
+                    onChange={(event) => update('salesVatAmount', Number(event.target.value) || 0)}
                     placeholder="0"
-                    className="h-9 text-[12px] mt-1"
+                    className="mt-1 h-9 text-[12px]"
                   />
+                  <FieldEvidence field={analysisField('salesVatAmount')} />
                 </div>
                 <div>
                   <Label className="text-[11px]">총수익</Label>
                   <Input
                     type="number"
                     value={form.totalRevenueAmount || ''}
-                    onChange={e => update('totalRevenueAmount', Number(e.target.value) || 0)}
+                    onChange={(event) => update('totalRevenueAmount', Number(event.target.value) || 0)}
                     placeholder="0"
-                    className="h-9 text-[12px] mt-1"
+                    className="mt-1 h-9 text-[12px]"
                   />
                 </div>
                 <div>
@@ -442,155 +824,96 @@ export function PortalProjectRegister() {
                   <Input
                     type="number"
                     value={form.supportAmount || ''}
-                    onChange={e => update('supportAmount', Number(e.target.value) || 0)}
+                    onChange={(event) => update('supportAmount', Number(event.target.value) || 0)}
                     placeholder="0"
-                    className="h-9 text-[12px] mt-1"
+                    className="mt-1 h-9 text-[12px]"
                   />
                 </div>
               </div>
 
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
                 <div>
-                  <Label className="text-[11px]">정산유형</Label>
-                  <Select value={form.settlementType} onValueChange={v => update('settlementType', v)}>
-                    <SelectTrigger className="h-9 text-[12px] mt-1">
+                  <Label className="text-[11px]">정산 유형</Label>
+                  <Select value={form.settlementType} onValueChange={(value) => update('settlementType', value as SettlementType)}>
+                    <SelectTrigger className="mt-1 h-9 text-[12px]">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {(Object.entries(SETTLEMENT_TYPE_LABELS) as [SettlementType, string][]).map(([k, v]) => (
-                        <SelectItem key={k} value={k}>{v}</SelectItem>
+                      {(Object.entries(SETTLEMENT_TYPE_LABELS) as [SettlementType, string][]).map(([key, value]) => (
+                        <SelectItem key={key} value={key}>{value}</SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
                 </div>
                 <div>
-                  <Label className="text-[11px]">기준</Label>
-                  <Select value={form.basis} onValueChange={v => update('basis', v)}>
-                    <SelectTrigger className="h-9 text-[12px] mt-1">
+                  <Label className="text-[11px]">정산 기준</Label>
+                  <Select value={form.basis} onValueChange={(value) => update('basis', value as Basis)}>
+                    <SelectTrigger className="mt-1 h-9 text-[12px]">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {(Object.entries(BASIS_LABELS) as [Basis, string][]).map(([k, v]) => (
-                        <SelectItem key={k} value={k}>{v}</SelectItem>
+                      {(Object.entries(BASIS_LABELS) as [Basis, string][]).map(([key, value]) => (
+                        <SelectItem key={key} value={key}>{value}</SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
                 </div>
-              </div>
-
-              <div className="grid grid-cols-2 gap-4">
                 <div>
                   <Label className="text-[11px]">통장 유형</Label>
-                  <Select value={form.accountType} onValueChange={v => update('accountType', v)}>
-                    <SelectTrigger className="h-9 text-[12px] mt-1">
+                  <Select value={form.accountType} onValueChange={(value) => update('accountType', value as AccountType)}>
+                    <SelectTrigger className="mt-1 h-9 text-[12px]">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
-                      {(Object.entries(ACCOUNT_TYPE_LABELS) as [AccountType, string][]).map(([k, v]) => (
-                        <SelectItem key={k} value={k}>{v}</SelectItem>
+                      {(Object.entries(ACCOUNT_TYPE_LABELS) as [AccountType, string][]).map(([key, value]) => (
+                        <SelectItem key={key} value={key}>{value}</SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
                 </div>
-                <div>
-                  <Label className="text-[11px]">선금/중도금/잔금 비율(%) 및 금액, 입금예상시점</Label>
-                  <Input
-                    value={form.paymentPlanDesc}
-                    onChange={e => update('paymentPlanDesc', e.target.value)}
-                    placeholder="예: 선금 50%(5천만원, 4월), 잔금 50%(6월 예정)"
-                    className="h-9 text-[12px] mt-1"
-                  />
-                </div>
+              </div>
+
+              <div>
+                <Label className="text-[11px]">선금/중도금/잔금 비율(%) 및 금액, 입금예상시점</Label>
+                <Textarea
+                  value={form.paymentPlanDesc}
+                  onChange={(event) => update('paymentPlanDesc', event.target.value)}
+                  placeholder="예: 선금 50%(5천만원, 4월), 중도금 30%(6월), 잔금 20%(완료 후 2주)"
+                  className="mt-1 min-h-[82px] text-[12px]"
+                />
               </div>
 
               <div>
                 <Label className="text-[11px]">사업비 수령 방식 및 정산 기준</Label>
                 <Textarea
                   value={form.settlementGuide}
-                  onChange={e => update('settlementGuide', e.target.value)}
+                  onChange={(event) => update('settlementGuide', event.target.value)}
                   placeholder="예: 이나라도움 수령, 공급가액 기준, 선지급 후 정산"
-                  className="text-[12px] mt-1 min-h-[72px]"
+                  className="mt-1 min-h-[82px] text-[12px]"
                 />
-              </div>
-
-              <div className="rounded-lg border border-dashed border-border p-4 space-y-3">
-                <div className="flex items-center gap-2">
-                  <FileText className="w-4 h-4 text-teal-600" />
-                  <div>
-                    <p className="text-[12px]" style={{ fontWeight: 600 }}>계약서 등 (PDF로 업로드) *</p>
-                    <p className="text-[11px] text-muted-foreground">
-                      계약이 확정되었다는 서류를 업로드해 주세요. 날인이 되어 있지 않아도 됩니다.
-                    </p>
-                  </div>
-                </div>
-                <input
-                  ref={contractFileInputRef}
-                  type="file"
-                  accept="application/pdf,.pdf"
-                  className="hidden"
-                  onChange={handleContractDocumentSelect}
-                />
-                <div className="flex flex-wrap items-center gap-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    className="h-9 text-[12px] gap-1.5"
-                    onClick={() => contractFileInputRef.current?.click()}
-                    disabled={isUploadingContract}
-                  >
-                    {isUploadingContract ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Upload className="w-3.5 h-3.5" />}
-                    {isUploadingContract ? '업로드 중...' : 'PDF 업로드'}
-                  </Button>
-                  {form.contractDocument && (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="h-9 text-[12px]"
-                      onClick={() => update('contractDocument', null)}
-                    >
-                      첨부 제거
-                    </Button>
-                  )}
-                </div>
-                {form.contractDocument ? (
-                  <div className="rounded-md bg-muted/40 px-3 py-2 text-[11px] space-y-1">
-                    <div style={{ fontWeight: 600 }}>{form.contractDocument.name}</div>
-                    <div className="text-muted-foreground">
-                      {(form.contractDocument.size / 1024 / 1024).toFixed(2)} MB · {form.contractDocument.uploadedAt.slice(0, 10)}
-                    </div>
-                    <a
-                      href={form.contractDocument.downloadURL}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="text-teal-600 hover:underline"
-                    >
-                      업로드된 파일 보기
-                    </a>
-                  </div>
-                ) : (
-                  <p className="text-[11px] text-amber-700">제출 전까지 PDF 1개 업로드가 필요합니다.</p>
-                )}
               </div>
             </div>
           )}
 
           {step === 'team' && (
             <div className="space-y-4">
-              <div className="flex items-center gap-2 mb-3">
-                <Users className="w-4 h-4 text-teal-600" />
-                <h3 className="text-[14px]" style={{ fontWeight: 600 }}>팀 구성</h3>
-              </div>
-
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div>
                   <Label className="text-[11px]">PM (메인 담당자) *</Label>
                   <Input
                     value={form.managerName}
-                    onChange={e => update('managerName', e.target.value)}
+                    onChange={(event) => update('managerName', event.target.value)}
                     placeholder="메인 담당자명"
-                    className="h-9 text-[12px] mt-1"
+                    className="mt-1 h-9 text-[12px]"
+                  />
+                </div>
+                <div>
+                  <Label className="text-[11px]">참여기업 조건</Label>
+                  <Input
+                    value={form.participantCondition}
+                    onChange={(event) => update('participantCondition', event.target.value)}
+                    placeholder="참여기업 자격 조건"
+                    className="mt-1 h-9 text-[12px]"
                   />
                 </div>
               </div>
@@ -599,19 +922,9 @@ export function PortalProjectRegister() {
                 <Label className="text-[11px]">팀원 구성</Label>
                 <Textarea
                   value={form.teamMembers}
-                  onChange={e => update('teamMembers', e.target.value)}
+                  onChange={(event) => update('teamMembers', event.target.value)}
                   placeholder="투입 예정 인력 (이름, 역할 등)"
-                  className="text-[12px] mt-1 min-h-[60px]"
-                />
-              </div>
-
-              <div>
-                <Label className="text-[11px]">참여기업 조건</Label>
-                <Input
-                  value={form.participantCondition}
-                  onChange={e => update('participantCondition', e.target.value)}
-                  placeholder="참여기업 자격 조건"
-                  className="h-9 text-[12px] mt-1"
+                  className="mt-1 min-h-[90px] text-[12px]"
                 />
               </div>
 
@@ -619,9 +932,9 @@ export function PortalProjectRegister() {
                 <Label className="text-[11px]">기타 참고사항</Label>
                 <Textarea
                   value={form.note}
-                  onChange={e => update('note', e.target.value)}
+                  onChange={(event) => update('note', event.target.value)}
                   placeholder="관리자에게 전달할 추가 참고사항"
-                  className="text-[12px] mt-1 min-h-[60px]"
+                  className="mt-1 min-h-[90px] text-[12px]"
                 />
               </div>
             </div>
@@ -629,117 +942,90 @@ export function PortalProjectRegister() {
 
           {step === 'review' && (
             <div className="space-y-4">
-              <div className="flex items-center gap-2 mb-3">
-                <ClipboardList className="w-4 h-4 text-teal-600" />
-                <h3 className="text-[14px]" style={{ fontWeight: 600 }}>검토 및 제출</h3>
-              </div>
-
-              <div className="p-3 rounded-lg bg-amber-50 dark:bg-amber-950/20 border border-amber-200/60 dark:border-amber-800/40 text-[11px] text-amber-700 dark:text-amber-300">
-                <AlertTriangle className="w-4 h-4 inline mr-1" />
-                제출 후에는 수정이 불가합니다. 정보를 다시 확인해 주세요.
-              </div>
-              {!form.contractDocument && (
-                <div className="p-3 rounded-lg bg-rose-50 border border-rose-200 text-[11px] text-rose-700">
-                  계약서 등 PDF가 아직 업로드되지 않았습니다. 이전 단계로 돌아가 첨부 후 제출해 주세요.
+              <div className="rounded-xl border border-amber-200/70 bg-amber-50 px-4 py-3 text-[11px] text-amber-800 dark:border-amber-800/50 dark:bg-amber-950/20 dark:text-amber-200">
+                <div className="flex items-center gap-2" style={{ fontWeight: 600 }}>
+                  <AlertTriangle className="h-4 w-4" />
+                  제출 전 최종 확인
                 </div>
-              )}
+                <p className="mt-1">계약서 공식 명칭, 등록 프로젝트명, 계약금액, 기간을 한 번 더 확인한 뒤 제출해 주세요.</p>
+              </div>
 
-              {/* 요약 카드 */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-                {/* 기본 정보 */}
-                <Card className="border-border/40">
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-[11px] flex items-center gap-1.5">
-                      <FolderKanban className="w-3.5 h-3.5 text-teal-600" />
-                      기본 정보
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-2">
-                    <ReviewRow label="신청자" value={portalUser?.name || authUser?.name || '-'} />
-                    <ReviewRow label="공식계약명" value={form.officialContractName} />
-                    <ReviewRow label="등록명" value={form.name} />
-                    <ReviewRow label="유형" value={PROJECT_TYPE_LABELS[form.type]} />
-                    <ReviewRow label="계약대상" value={form.clientOrg} />
-                    <ReviewRow label="담당팀" value={form.department || '-'} />
-                    {form.projectPurpose && <ReviewRow label="목적" value={form.projectPurpose} />}
-                    {form.description && <ReviewRow label="주요내용" value={form.description} />}
-                  </CardContent>
-                </Card>
+              <div className="grid gap-3 lg:grid-cols-2">
+                <SummaryCard title="기본 정보">
+                  <ReviewRow label="신청자" value={portalUser?.name || authUser?.name || '-'} />
+                  <ReviewRow label="담당팀" value={form.department || '-'} />
+                  <ReviewRow label="공식 계약명" value={form.officialContractName || '-'} />
+                  <ReviewRow label="등록명" value={form.name || '-'} />
+                  <ReviewRow label="프로젝트 유형" value={PROJECT_TYPE_LABELS[form.type]} />
+                  <ReviewRow label="계약 대상" value={form.clientOrg || '-'} />
+                  <ReviewRow label="프로젝트 목적" value={form.projectPurpose || '-'} />
+                  <ReviewRow label="주요 내용" value={form.description || '-'} />
+                </SummaryCard>
 
-                {/* 재무 정보 */}
-                <Card className="border-border/40">
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-[11px] flex items-center gap-1.5">
-                      <Wallet className="w-3.5 h-3.5 text-teal-600" />
-                      재무 정보
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-2">
-                    <ReviewRow label="계약금액" value={`${fmtKRW(form.contractAmount)}원`} highlight />
-                    <ReviewRow label="매출부가세" value={`${fmtKRW(form.salesVatAmount)}원`} />
-                    <ReviewRow label="총수익" value={`${fmtKRW(form.totalRevenueAmount)}원`} />
-                    <ReviewRow label="지원금" value={`${fmtKRW(form.supportAmount)}원`} />
-                    <ReviewRow label="계약기간" value={`${form.contractStart} ~ ${form.contractEnd}`} />
-                    <ReviewRow label="정산유형" value={SETTLEMENT_TYPE_LABELS[form.settlementType]} />
-                    <ReviewRow label="기준" value={BASIS_LABELS[form.basis]} />
-                    <ReviewRow label="통장유형" value={ACCOUNT_TYPE_LABELS[form.accountType]} />
-                    {form.paymentPlanDesc && <ReviewRow label="입금계획" value={form.paymentPlanDesc} />}
-                    {form.settlementGuide && <ReviewRow label="수령/정산" value={form.settlementGuide} />}
-                    <ReviewRow label="첨부파일" value={form.contractDocument?.name || '미업로드'} />
-                  </CardContent>
-                </Card>
+                <SummaryCard title="재무 정보">
+                  <ReviewRow label="계약 시작일" value={form.contractStart || '-'} />
+                  <ReviewRow label="계약 종료일" value={form.contractEnd || '-'} />
+                  <ReviewRow label="계약금액" value={`${fmtKRW(form.contractAmount)}원`} highlight />
+                  <ReviewRow label="매출 부가세" value={`${fmtKRW(form.salesVatAmount)}원`} />
+                  <ReviewRow label="총수익" value={`${fmtKRW(form.totalRevenueAmount)}원`} />
+                  <ReviewRow label="지원금" value={`${fmtKRW(form.supportAmount)}원`} />
+                  <ReviewRow label="정산 유형" value={SETTLEMENT_TYPE_LABELS[form.settlementType]} />
+                  <ReviewRow label="정산 기준" value={BASIS_LABELS[form.basis]} />
+                  <ReviewRow label="통장 유형" value={ACCOUNT_TYPE_LABELS[form.accountType]} />
+                  <ReviewRow label="입금 계획" value={form.paymentPlanDesc || '-'} />
+                  <ReviewRow label="사업비 수령/정산" value={form.settlementGuide || '-'} />
+                </SummaryCard>
 
-                {/* 팀 정보 */}
-                <Card className="border-border/40 md:col-span-2">
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-[11px] flex items-center gap-1.5">
-                      <Users className="w-3.5 h-3.5 text-teal-600" />
-                      팀 구성
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="space-y-2">
-                    <ReviewRow label="PM" value={form.managerName} />
-                    {form.teamMembers && <ReviewRow label="팀원" value={form.teamMembers} />}
-                    {form.participantCondition && <ReviewRow label="참여조건" value={form.participantCondition} />}
-                    {form.note && <ReviewRow label="메모" value={form.note} />}
-                  </CardContent>
-                </Card>
+                <SummaryCard title="팀 구성">
+                  <ReviewRow label="PM" value={form.managerName || '-'} />
+                  <ReviewRow label="팀원" value={form.teamMembers || '-'} />
+                  <ReviewRow label="참여조건" value={form.participantCondition || '-'} />
+                  <ReviewRow label="참고사항" value={form.note || '-'} />
+                </SummaryCard>
+
+                <SummaryCard title="계약서 및 AI 초안">
+                  <ReviewRow label="첨부 파일" value={form.contractDocument?.name || '미업로드'} />
+                  <ReviewRow label="AI 요약" value={analysis?.summary || '-'} />
+                  <ReviewRow label="확인 필요" value={analysis?.warnings.join(', ') || '-'} />
+                </SummaryCard>
               </div>
             </div>
           )}
         </CardContent>
       </Card>
 
-      {/* Navigation */}
       <div className="flex items-center justify-between">
         <Button
           variant="outline"
           size="sm"
-          className="h-9 text-[12px] gap-1"
+          className="h-9 gap-1 text-[12px]"
           disabled={currentStepIdx === 0}
           onClick={() => setStep(STEPS[currentStepIdx - 1].key)}
         >
-          <ArrowLeft className="w-3.5 h-3.5" /> 이전
+          <ArrowLeft className="h-3.5 w-3.5" />
+          이전
         </Button>
 
         {step === 'review' ? (
           <Button
             size="sm"
-            className="h-9 text-[12px] gap-1.5"
+            className="h-9 gap-1.5 text-[12px]"
             style={{ background: 'linear-gradient(135deg, #0d9488, #059669)' }}
             onClick={handleSubmit}
             disabled={isSubmitting || !form.contractDocument}
           >
-            <Send className="w-3.5 h-3.5" /> {isSubmitting ? '제출 중...' : '관리자에게 제출'}
+            {isSubmitting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Send className="h-3.5 w-3.5" />}
+            {isSubmitting ? '제출 중...' : '관리자에게 제출'}
           </Button>
         ) : (
           <Button
             size="sm"
-            className="h-9 text-[12px] gap-1"
+            className="h-9 gap-1 text-[12px]"
             disabled={!canProceed()}
             onClick={() => setStep(STEPS[currentStepIdx + 1].key)}
           >
-            다음 <ArrowRight className="w-3.5 h-3.5" />
+            다음
+            <ArrowRight className="h-3.5 w-3.5" />
           </Button>
         )}
       </div>
@@ -747,10 +1033,85 @@ export function PortalProjectRegister() {
   );
 }
 
+function FieldLabel({
+  label,
+  field,
+}: {
+  label: string;
+  field: ProjectRequestContractAnalysis['fields'][AnalysisFieldKey] | null;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <Label className="text-[11px]">{label}</Label>
+      {field?.value ? (
+        <Badge className={`border-0 text-[10px] ${confidenceBadgeClass(field.confidence)}`}>
+          AI 초안 · {confidenceLabel(field.confidence)}
+        </Badge>
+      ) : null}
+    </div>
+  );
+}
+
+function FieldEvidence({
+  field,
+}: {
+  field: ProjectRequestContractAnalysis['fields'][AnalysisFieldKey] | null;
+}) {
+  if (!field?.evidence) return null;
+  return (
+    <p className="mt-1 text-[10px] text-muted-foreground">
+      계약서 근거: {field.evidence}
+    </p>
+  );
+}
+
+function SuggestedField({
+  label,
+  field,
+}: {
+  label: string;
+  field: ProjectRequestContractAnalysis['fields'][AnalysisFieldKey];
+}) {
+  const value = typeof field.value === 'number'
+    ? `${fmtKRW(field.value)}원`
+    : field.value || '-';
+  return (
+    <div className="rounded-lg bg-muted/30 px-3 py-2 text-[11px]">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-muted-foreground">{label}</span>
+        <Badge className={`border-0 text-[10px] ${confidenceBadgeClass(field.confidence)}`}>
+          {confidenceLabel(field.confidence)}
+        </Badge>
+      </div>
+      <div className="mt-1" style={{ fontWeight: 600 }}>{value}</div>
+      {field.evidence ? (
+        <div className="mt-1 text-[10px] text-muted-foreground">{field.evidence}</div>
+      ) : null}
+    </div>
+  );
+}
+
+function SummaryCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <Card className="border-border/50">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-[12px]">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">{children}</CardContent>
+    </Card>
+  );
+}
+
 function ReviewRow({ label, value, highlight }: { label: string; value: string; highlight?: boolean }) {
   return (
     <div className="flex items-start gap-2 text-[11px]">
-      <span className="text-muted-foreground shrink-0 w-[70px]">{label}</span>
+      <span className="w-[88px] shrink-0 text-muted-foreground">{label}</span>
       <span className={highlight ? 'text-teal-600 dark:text-teal-400' : ''} style={{ fontWeight: highlight ? 600 : 500 }}>
         {value}
       </span>

--- a/src/app/components/portal/project-proposal.ts
+++ b/src/app/components/portal/project-proposal.ts
@@ -1,4 +1,14 @@
-import { ACCOUNT_TYPE_LABELS, BASIS_LABELS, PROJECT_TYPE_LABELS, SETTLEMENT_TYPE_LABELS, type AccountType, type Basis, type ProjectType, type SettlementType } from '../../data/types';
+import {
+  ACCOUNT_TYPE_LABELS,
+  BASIS_LABELS,
+  PROJECT_TYPE_LABELS,
+  SETTLEMENT_TYPE_LABELS,
+  type AccountType,
+  type Basis,
+  type ProjectRequestContractAnalysis,
+  type ProjectType,
+  type SettlementType,
+} from '../../data/types';
 
 export interface ProjectProposalDraft {
   name: string;
@@ -25,6 +35,7 @@ export interface ProjectProposalDraft {
   participantCondition: string;
   note: string;
   contractDocument: import('../../data/types').FileAttachment | null;
+  contractAnalysis?: ProjectRequestContractAnalysis | null;
 }
 
 export interface ProjectProposalPostPayload {

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -355,6 +355,40 @@ export interface FileAttachment {
   uploadedAt: string;
 }
 
+export type AiSuggestionConfidence = 'high' | 'medium' | 'low';
+
+export interface ProjectRequestContractTextSuggestion {
+  value: string;
+  confidence: AiSuggestionConfidence;
+  evidence: string;
+}
+
+export interface ProjectRequestContractNumberSuggestion {
+  value: number | null;
+  confidence: AiSuggestionConfidence;
+  evidence: string;
+}
+
+export interface ProjectRequestContractAnalysis {
+  provider: 'anthropic' | 'heuristic';
+  model: string;
+  summary: string;
+  warnings: string[];
+  nextActions: string[];
+  extractedAt: string;
+  fields: {
+    officialContractName: ProjectRequestContractTextSuggestion;
+    suggestedProjectName: ProjectRequestContractTextSuggestion;
+    clientOrg: ProjectRequestContractTextSuggestion;
+    projectPurpose: ProjectRequestContractTextSuggestion;
+    description: ProjectRequestContractTextSuggestion;
+    contractStart: ProjectRequestContractTextSuggestion;
+    contractEnd: ProjectRequestContractTextSuggestion;
+    contractAmount: ProjectRequestContractNumberSuggestion;
+    salesVatAmount: ProjectRequestContractNumberSuggestion;
+  };
+}
+
 export interface ProjectRequestPayload {
   name: string;
   officialContractName: string;
@@ -380,6 +414,7 @@ export interface ProjectRequestPayload {
   participantCondition: string;
   note: string;
   contractDocument: FileAttachment | null;
+  contractAnalysis?: ProjectRequestContractAnalysis | null;
 }
 
 export interface ProjectRequest {

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -3,6 +3,7 @@ import {
   addCommentViaBff,
   addEvidenceViaBff,
   analyzeGoogleSheetImportViaBff,
+  analyzeProjectRequestContractViaBff,
   changeTransactionStateViaBff,
   linkProjectEvidenceDriveRootViaBff,
   overrideTransactionEvidenceDriveCategoriesViaBff,
@@ -150,6 +151,52 @@ describe('platform-bff-client', () => {
 
     expect(comment.id).toBe('c001');
     expect(evidence.id).toBe('ev001');
+  });
+
+  it('calls project request contract analysis endpoint', async () => {
+    const client = {
+      post: vi.fn(async () => ({
+        data: {
+          provider: 'anthropic',
+          model: 'claude-sonnet',
+          summary: '초안 생성',
+          warnings: ['사람 확인 필요'],
+          nextActions: ['담당팀은 직접 선택하세요.'],
+          extractedAt: '2026-03-16T09:00:00.000Z',
+          fields: {
+            officialContractName: { value: '뷰티풀 커넥트 운영 계약', confidence: 'high', evidence: '사업명: 뷰티풀 커넥트 운영 계약' },
+            suggestedProjectName: { value: '뷰티풀커넥트', confidence: 'high', evidence: '사업명' },
+            clientOrg: { value: '아모레퍼시픽재단', confidence: 'high', evidence: '발주기관' },
+            projectPurpose: { value: '청년 창업가의 지역 연결 지원', confidence: 'medium', evidence: '사업 목적' },
+            description: { value: '', confidence: 'low', evidence: '' },
+            contractStart: { value: '2026-03-01', confidence: 'high', evidence: '계약기간' },
+            contractEnd: { value: '2026-12-31', confidence: 'high', evidence: '계약기간' },
+            contractAmount: { value: 120000000, confidence: 'high', evidence: '총 계약금액' },
+            salesVatAmount: { value: 12000000, confidence: 'medium', evidence: '부가세' },
+          },
+        },
+      })),
+      get: vi.fn(),
+      request: vi.fn(),
+    };
+
+    const result = await analyzeProjectRequestContractViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'u001', role: 'pm', idToken: 'token-abc' },
+      fileName: 'contract.pdf',
+      documentText: '사업명: 뷰티풀 커넥트 운영 계약',
+      client,
+    });
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/project-requests/contract/analyze', expect.objectContaining({
+      tenantId: 'mysc',
+      body: {
+        fileName: 'contract.pdf',
+        documentText: '사업명: 뷰티풀 커넥트 운영 계약',
+      },
+    }));
+    expect(result.fields.officialContractName.value).toBe('뷰티풀 커넥트 운영 계약');
+    expect(result.fields.contractAmount.value).toBe(120000000);
   });
 
   it('calls evidence drive provision/sync endpoints', async () => {

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -1,5 +1,8 @@
 import { featureFlags, parseFeatureFlag } from '../config/feature-flags';
-import type { TransactionState } from '../data/types';
+import type {
+  ProjectRequestContractAnalysis,
+  TransactionState,
+} from '../data/types';
 import { PlatformApiClient } from '../platform/api-client';
 import type { RequestActor } from '../platform/request-context';
 
@@ -103,6 +106,8 @@ export interface GoogleSheetMigrationAnalysisResult {
   headerPreview?: string[];
 }
 
+export interface ProjectRequestContractAnalysisResult extends ProjectRequestContractAnalysis {}
+
 function normalizeStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value
@@ -133,6 +138,28 @@ function normalizeSuggestedMappings(value: unknown): GoogleSheetMigrationAnalysi
     .filter((item): item is GoogleSheetMigrationAnalysisSuggestion => Boolean(item));
 }
 
+function normalizeAiConfidence(value: unknown): 'high' | 'medium' | 'low' {
+  return value === 'high' || value === 'medium' || value === 'low' ? value : 'low';
+}
+
+function normalizeProjectRequestTextSuggestion(value: unknown) {
+  const raw = value && typeof value === 'object' ? value as Record<string, unknown> : {};
+  return {
+    value: typeof raw.value === 'string' ? raw.value.trim() : '',
+    confidence: normalizeAiConfidence(raw.confidence),
+    evidence: typeof raw.evidence === 'string' ? raw.evidence.trim() : '',
+  };
+}
+
+function normalizeProjectRequestNumberSuggestion(value: unknown) {
+  const raw = value && typeof value === 'object' ? value as Record<string, unknown> : {};
+  return {
+    value: typeof raw.value === 'number' && Number.isFinite(raw.value) ? raw.value : null,
+    confidence: normalizeAiConfidence(raw.confidence),
+    evidence: typeof raw.evidence === 'string' ? raw.evidence.trim() : '',
+  };
+}
+
 export function normalizeGoogleSheetMigrationAnalysisResult(
   value: unknown,
 ): GoogleSheetMigrationAnalysisResult {
@@ -152,6 +179,36 @@ export function normalizeGoogleSheetMigrationAnalysisResult(
     nextActions: normalizeStringArray(raw.nextActions),
     suggestedMappings: normalizeSuggestedMappings(raw.suggestedMappings),
     headerPreview: normalizeStringArray(raw.headerPreview),
+  };
+}
+
+export function normalizeProjectRequestContractAnalysisResult(
+  value: unknown,
+): ProjectRequestContractAnalysisResult {
+  const raw = value && typeof value === 'object' ? value as Record<string, unknown> : {};
+  const fields = raw.fields && typeof raw.fields === 'object' ? raw.fields as Record<string, unknown> : {};
+  return {
+    provider: raw.provider === 'anthropic' ? 'anthropic' : 'heuristic',
+    model: typeof raw.model === 'string' && raw.model.trim() ? raw.model.trim() : 'unavailable',
+    summary: typeof raw.summary === 'string' && raw.summary.trim()
+      ? raw.summary.trim()
+      : '계약서 초안을 확인할 수 없어 직접 입력이 필요합니다.',
+    warnings: normalizeStringArray(raw.warnings),
+    nextActions: normalizeStringArray(raw.nextActions),
+    extractedAt: typeof raw.extractedAt === 'string' && raw.extractedAt.trim()
+      ? raw.extractedAt.trim()
+      : new Date().toISOString(),
+    fields: {
+      officialContractName: normalizeProjectRequestTextSuggestion(fields.officialContractName),
+      suggestedProjectName: normalizeProjectRequestTextSuggestion(fields.suggestedProjectName),
+      clientOrg: normalizeProjectRequestTextSuggestion(fields.clientOrg),
+      projectPurpose: normalizeProjectRequestTextSuggestion(fields.projectPurpose),
+      description: normalizeProjectRequestTextSuggestion(fields.description),
+      contractStart: normalizeProjectRequestTextSuggestion(fields.contractStart),
+      contractEnd: normalizeProjectRequestTextSuggestion(fields.contractEnd),
+      contractAmount: normalizeProjectRequestNumberSuggestion(fields.contractAmount),
+      salesVatAmount: normalizeProjectRequestNumberSuggestion(fields.salesVatAmount),
+    },
   };
 }
 
@@ -472,6 +529,29 @@ export async function analyzeGoogleSheetImportViaBff(params: {
     },
   );
   return normalizeGoogleSheetMigrationAnalysisResult(response.data);
+}
+
+export async function analyzeProjectRequestContractViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  fileName: string;
+  documentText?: string;
+  client?: PlatformApiClientLike;
+}): Promise<ProjectRequestContractAnalysisResult> {
+  const apiClient = resolveClient(params.client);
+  const response = await apiClient.post<ProjectRequestContractAnalysisResult>(
+    '/api/v1/project-requests/contract/analyze',
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      body: {
+        fileName: params.fileName,
+        ...(params.documentText ? { documentText: params.documentText } : {}),
+      },
+      timeoutMs: 45000,
+    },
+  );
+  return normalizeProjectRequestContractAnalysisResult(response.data);
 }
 
 export async function linkProjectEvidenceDriveRootViaBff(params: {


### PR DESCRIPTION
## Summary
- add a contract-first project request wizard for portal users
- upload the contract PDF first and generate AI-backed draft field suggestions
- persist contract analysis metadata with the project request payload

## Testing
- npx vitest run server/bff/project-request-contract-ai.test.ts src/app/lib/platform-bff-client.test.ts src/app/components/portal/project-proposal.test.ts
- node --check server/bff/project-request-contract-ai.mjs
- node --check server/bff/app.mjs
- npm run build