### PR TITLE
fix: upload project request contracts through bff

### DIFF
--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -48,6 +48,7 @@ import {
   memberRoleUpdateSchema,
   parseWithSchema,
   projectRequestContractAnalyzeSchema,
+  projectRequestContractUploadSchema,
   projectDriveRootLinkSchema,
   projectUpsertSchema,
   transactionStateSchema,
@@ -72,6 +73,7 @@ import {
 } from './google-sheets.mjs';
 import { createGoogleSheetMigrationAiService } from './google-sheet-migration-ai.mjs';
 import { createProjectRequestContractAiService } from './project-request-contract-ai.mjs';
+import { createProjectRequestContractStorageService } from './project-request-contract-storage.mjs';
 
 function createHttpError(statusCode, message, code = 'request_error') {
   const error = new Error(message);
@@ -568,6 +570,7 @@ export function createBffApp(options = {}) {
   const googleSheetsService = options.googleSheetsService || createGoogleSheetsService();
   const googleSheetMigrationAiService = options.googleSheetMigrationAiService || createGoogleSheetMigrationAiService();
   const projectRequestContractAiService = options.projectRequestContractAiService || createProjectRequestContractAiService();
+  const projectRequestContractStorageService = options.projectRequestContractStorageService || createProjectRequestContractStorageService({ projectId });
   const allowedOrigins = parseAllowedOrigins(options.allowedOrigins || process.env.BFF_ALLOWED_ORIGINS);
   const relationRulesPolicyPath = options.relationRulesPolicyPath || resolveRelationRulesPolicyPath();
   const workQueueBatchSizeRaw = Number.parseInt(process.env.BFF_WORK_QUEUE_BATCH || '100', 10);
@@ -1226,6 +1229,25 @@ export function createBffApp(options = {}) {
       documentText: parsed.documentText || '',
     });
     res.status(200).json(analysis);
+  }));
+
+  app.post('/api/v1/project-requests/contract/upload', asyncHandler(async (req, res) => {
+    const { tenantId, actorId } = req.context;
+    assertActorRoleAllowed(req, ROUTE_ROLES.writeCore, 'upload project request contract');
+    const parsed = parseWithSchema(
+      projectRequestContractUploadSchema,
+      req.body,
+      'Invalid project request contract upload payload',
+    );
+    const uploaded = await projectRequestContractStorageService.uploadContract({
+      tenantId,
+      actorId,
+      fileName: parsed.fileName,
+      mimeType: parsed.mimeType,
+      fileSize: parsed.fileSize,
+      contentBase64: parsed.contentBase64,
+    });
+    res.status(200).json(uploaded);
   }));
 
   app.get('/api/v1/ledgers', asyncHandler(async (req, res) => {

--- a/server/bff/project-request-contract-storage.mjs
+++ b/server/bff/project-request-contract-storage.mjs
@@ -1,0 +1,79 @@
+import { randomUUID } from 'node:crypto';
+import { getStorage } from 'firebase-admin/storage';
+import { getOrInitAdminApp, resolveProjectId } from './firestore.mjs';
+
+function readOptionalText(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeSafeFileName(fileName) {
+  const trimmed = readOptionalText(fileName) || 'contract.pdf';
+  const normalized = trimmed
+    .replace(/\s+/g, '_')
+    .replace(/[^\w.\-가-힣()]+/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return normalized || `contract_${Date.now()}.pdf`;
+}
+
+function resolveBucketName(env = process.env) {
+  return readOptionalText(env.FIREBASE_STORAGE_BUCKET)
+    || readOptionalText(env.VITE_FIREBASE_STORAGE_BUCKET)
+    || `${resolveProjectId(env)}.firebasestorage.app`;
+}
+
+function buildDownloadUrl(bucketName, objectPath, token) {
+  return `https://firebasestorage.googleapis.com/v0/b/${encodeURIComponent(bucketName)}/o/${encodeURIComponent(objectPath)}?alt=media&token=${encodeURIComponent(token)}`;
+}
+
+export function createProjectRequestContractStorageService(options = {}) {
+  const bucketName = options.bucketName || resolveBucketName(options.env || process.env);
+  const adminApp = options.adminApp || getOrInitAdminApp({ projectId: options.projectId });
+  const storage = options.storage || getStorage(adminApp);
+  const bucket = storage.bucket(bucketName);
+
+  return {
+    async uploadContract(input) {
+      const tenantId = readOptionalText(input?.tenantId) || 'mysc';
+      const actorId = readOptionalText(input?.actorId) || 'system';
+      const fileName = normalizeSafeFileName(input?.fileName);
+      const mimeType = readOptionalText(input?.mimeType) || 'application/pdf';
+      const fileSize = Number.isFinite(input?.fileSize) ? input.fileSize : 0;
+      const contentBase64 = readOptionalText(input?.contentBase64);
+      if (!contentBase64) {
+        throw new Error('contentBase64 is required');
+      }
+
+      const uploadedAt = new Date().toISOString();
+      const token = randomUUID();
+      const path = `orgs/${tenantId}/project-request-contracts/${actorId}/${Date.now()}-${fileName}`;
+      const file = bucket.file(path);
+      const buffer = Buffer.from(contentBase64, 'base64');
+
+      await file.save(buffer, {
+        resumable: false,
+        metadata: {
+          contentType: mimeType,
+          metadata: {
+            firebaseStorageDownloadTokens: token,
+          },
+        },
+      });
+
+      return {
+        path,
+        name: readOptionalText(input?.fileName) || fileName,
+        downloadURL: buildDownloadUrl(bucketName, path, token),
+        size: fileSize || buffer.byteLength,
+        contentType: mimeType,
+        uploadedAt,
+      };
+    },
+  };
+}
+
+export {
+  normalizeSafeFileName,
+  resolveBucketName,
+  buildDownloadUrl,
+};

--- a/server/bff/project-request-contract-storage.test.ts
+++ b/server/bff/project-request-contract-storage.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createProjectRequestContractStorageService,
+  normalizeSafeFileName,
+} from './project-request-contract-storage.mjs';
+
+describe('project-request-contract-storage', () => {
+  it('normalizes file names for storage paths', () => {
+    expect(normalizeSafeFileName('   계약서   (2025)  최종본.pdf')).toBe('계약서_(2025)_최종본.pdf');
+  });
+
+  it('uploads a contract via injected storage bucket', async () => {
+    const save = vi.fn(async () => undefined);
+    const bucket = {
+      file: vi.fn(() => ({ save })),
+    };
+    const storage = {
+      bucket: vi.fn(() => bucket),
+    };
+
+    const service = createProjectRequestContractStorageService({
+      projectId: 'mysc-bmp-14173451',
+      bucketName: 'mysc-bmp-14173451.firebasestorage.app',
+      storage,
+    });
+
+    const result = await service.uploadContract({
+      tenantId: 'mysc',
+      actorId: 'u001',
+      fileName: 'contract.pdf',
+      mimeType: 'application/pdf',
+      fileSize: 16,
+      contentBase64: Buffer.from('fake-pdf', 'utf8').toString('base64'),
+    });
+
+    expect(storage.bucket).toHaveBeenCalledWith('mysc-bmp-14173451.firebasestorage.app');
+    expect(save).toHaveBeenCalled();
+    expect(result.path).toContain('orgs/mysc/project-request-contracts/u001/');
+    expect(result.downloadURL).toContain('firebasestorage.googleapis.com');
+  });
+});

--- a/server/bff/schemas.mjs
+++ b/server/bff/schemas.mjs
@@ -76,6 +76,13 @@ export const projectRequestContractAnalyzeSchema = z.object({
   documentText: z.string().max(200000).optional(),
 }).strict();
 
+export const projectRequestContractUploadSchema = z.object({
+  fileName: NON_EMPTY_STRING.max(300),
+  mimeType: NON_EMPTY_STRING.max(200),
+  fileSize: z.number().int().nonnegative(),
+  contentBase64: NON_EMPTY_STRING,
+}).strict();
+
 export const claudeSdkHelpAskSchema = z.object({
   question: NON_EMPTY_STRING.max(2000),
   history: z.array(

--- a/src/app/components/portal/PortalProjectRegister.tsx
+++ b/src/app/components/portal/PortalProjectRegister.tsx
@@ -15,16 +15,16 @@ import {
 } from 'lucide-react';
 import { useMemo, useRef, useState, type ChangeEvent, type ReactNode } from 'react';
 import { useNavigate } from 'react-router';
-import { getDownloadURL, ref as storageRef, uploadBytes } from 'firebase/storage';
 import { toast } from 'sonner';
 import { usePortalStore } from '../../data/portal-store';
 import { useAuth } from '../../data/auth-store';
 import { useFirebase } from '../../lib/firebase-context';
-import { getAuthInstance, getStorageInstance } from '../../lib/firebase';
+import { getAuthInstance } from '../../lib/firebase';
 import { extractTextFromPdf } from '../../lib/pdf-extract';
 import {
   analyzeProjectRequestContractViaBff,
   type ProjectRequestContractAnalysisResult,
+  uploadProjectRequestContractViaBff,
 } from '../../lib/platform-bff-client';
 import {
   ACCOUNT_TYPE_LABELS,
@@ -169,6 +169,97 @@ function confidenceBadgeClass(confidence: ProjectRequestContractAnalysis['fields
   return 'bg-slate-500/15 text-slate-700 dark:text-slate-300';
 }
 
+function resolveContractUploadUiState(
+  contractAnalysisState: ContractAnalysisState,
+  hasContractDocument: boolean,
+) {
+  if (contractAnalysisState === 'extracting') {
+    return {
+      cardClass: 'border-teal-300 bg-teal-50/70 dark:border-teal-700/50 dark:bg-teal-950/20',
+      surfaceClass: 'border-teal-300/70 bg-white/85 dark:border-teal-700/50 dark:bg-teal-950/30',
+      badgeClass: 'bg-teal-500/15 text-teal-700 dark:text-teal-300',
+      buttonClass: 'bg-teal-600 text-white hover:bg-teal-700',
+      statusLabel: 'PDF 텍스트 추출 중',
+      title: '계약서를 읽는 중입니다',
+      description: 'PDF 텍스트를 먼저 추출한 뒤, AI 초안 생성 단계로 넘어갑니다.',
+      ctaLabel: '처리 중...',
+    };
+  }
+  if (contractAnalysisState === 'analyzing') {
+    return {
+      cardClass: 'border-teal-300 bg-teal-50/70 dark:border-teal-700/50 dark:bg-teal-950/20',
+      surfaceClass: 'border-teal-300/70 bg-white/85 dark:border-teal-700/50 dark:bg-teal-950/30',
+      badgeClass: 'bg-teal-500/15 text-teal-700 dark:text-teal-300',
+      buttonClass: 'bg-teal-600 text-white hover:bg-teal-700',
+      statusLabel: 'AI 초안 생성 중',
+      title: '기본 정보를 채우는 중입니다',
+      description: '공식 계약명, 계약 대상, 기간, 금액을 자동으로 읽어 초안을 만들고 있습니다.',
+      ctaLabel: '분석 중...',
+    };
+  }
+  if (hasContractDocument && contractAnalysisState === 'ready') {
+    return {
+      cardClass: 'border-emerald-300 bg-emerald-50/80 dark:border-emerald-700/50 dark:bg-emerald-950/20',
+      surfaceClass: 'border-emerald-300/70 bg-white/90 dark:border-emerald-700/50 dark:bg-emerald-950/30',
+      badgeClass: 'bg-emerald-500/15 text-emerald-700 dark:text-emerald-300',
+      buttonClass: 'bg-emerald-600 text-white hover:bg-emerald-700',
+      statusLabel: '업로드 및 초안 생성 완료',
+      title: '계약서 업로드가 완료됐습니다',
+      description: '오른쪽 AI 초안을 확인하고, 아래 단계에서 사람 기준으로 한 번만 검토하면 됩니다.',
+      ctaLabel: '계약서 다시 업로드',
+    };
+  }
+  if (hasContractDocument) {
+    return {
+      cardClass: 'border-amber-300 bg-amber-50/80 dark:border-amber-700/50 dark:bg-amber-950/20',
+      surfaceClass: 'border-amber-300/70 bg-white/90 dark:border-amber-700/50 dark:bg-amber-950/30',
+      badgeClass: 'bg-amber-500/15 text-amber-700 dark:text-amber-300',
+      buttonClass: 'bg-amber-600 text-white hover:bg-amber-700',
+      statusLabel: '업로드 완료',
+      title: '계약서는 올라갔지만 확인이 더 필요합니다',
+      description: 'AI 초안 생성이 실패했거나 일부만 읽혔을 수 있습니다. 직접 보완하거나 다시 업로드할 수 있습니다.',
+      ctaLabel: '계약서 다시 업로드',
+    };
+  }
+  if (contractAnalysisState === 'error') {
+    return {
+      cardClass: 'border-rose-300 bg-rose-50/80 dark:border-rose-700/50 dark:bg-rose-950/20',
+      surfaceClass: 'border-rose-300/70 bg-white/90 dark:border-rose-700/50 dark:bg-rose-950/30',
+      badgeClass: 'bg-rose-500/15 text-rose-700 dark:text-rose-300',
+      buttonClass: 'bg-rose-600 text-white hover:bg-rose-700',
+      statusLabel: '업로드 오류',
+      title: '계약서 업로드를 다시 시도해 주세요',
+      description: 'PDF 업로드나 AI 초안 생성 중 문제가 있었습니다. 계약서를 다시 올리면 바로 재시도할 수 있습니다.',
+      ctaLabel: '계약서 다시 업로드',
+    };
+  }
+  return {
+    cardClass: 'border-teal-200 bg-gradient-to-br from-teal-50/80 via-white to-cyan-50/70 dark:border-teal-800/40 dark:from-teal-950/20 dark:via-background dark:to-cyan-950/10',
+    surfaceClass: 'border-teal-200/80 bg-white/90 dark:border-teal-800/40 dark:bg-teal-950/20',
+    badgeClass: 'bg-teal-500/15 text-teal-700 dark:text-teal-300',
+    buttonClass: 'bg-teal-600 text-white hover:bg-teal-700',
+    statusLabel: '업로드 필요',
+    title: '먼저 계약서 PDF를 올려 주세요',
+    description: '이 단계가 끝나면 공식 계약명, 계약 대상, 기간, 금액 초안을 자동으로 채워서 다음 입력 부담을 줄입니다.',
+    ctaLabel: '계약서 PDF 업로드 시작',
+  };
+}
+
+async function readFileAsBase64(file: File): Promise<string> {
+  const dataUrl = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error || new Error('파일 읽기에 실패했습니다.'));
+    reader.onload = () => resolve(String(reader.result || ''));
+    reader.readAsDataURL(file);
+  });
+
+  const [, base64 = ''] = dataUrl.split(',', 2);
+  if (!base64) {
+    throw new Error(`파일 인코딩에 실패했습니다: ${file.name}`);
+  }
+  return base64;
+}
+
 export function PortalProjectRegister() {
   const navigate = useNavigate();
   const { user: authUser } = useAuth();
@@ -203,6 +294,8 @@ export function PortalProjectRegister() {
 
   const analysis = form.contractAnalysis || null;
   const analysisField = (key: AnalysisFieldKey) => analysis?.fields[key] || null;
+  const hasContractDocument = Boolean(form.contractDocument);
+  const contractUploadUi = resolveContractUploadUiState(contractAnalysisState, hasContractDocument);
 
   const canProceed = () => {
     if (step === 'contract') {
@@ -242,33 +335,28 @@ export function PortalProjectRegister() {
       toast.error('로그인 정보를 확인할 수 없습니다.');
       return;
     }
-    const storage = getStorageInstance();
-    if (!storage) {
-      toast.error('파일 업로드를 위한 저장소를 초기화할 수 없습니다.');
-      return;
-    }
-
     setIsUploadingContract(true);
     setContractAnalysisState('extracting');
     setAnalysisError('');
 
     try {
-      const uploadedAt = new Date().toISOString();
-      const safeName = file.name.replace(/[^\w.\-가-힣() ]+/g, '_');
-      const path = `orgs/${orgId}/project-request-contracts/${authUser.uid}/${Date.now()}-${safeName}`;
-      const ref = storageRef(storage, path);
-      const snapshot = await uploadBytes(ref, file, {
-        contentType: file.type || 'application/pdf',
+      const idToken = authUser.idToken || await getAuthInstance()?.currentUser?.getIdToken() || undefined;
+      const contentBase64 = await readFileAsBase64(file);
+      const contractDocument = await uploadProjectRequestContractViaBff({
+        tenantId: orgId,
+        actor: {
+          uid: authUser.uid,
+          email: authUser.email,
+          role: authUser.role,
+          idToken,
+        },
+        upload: {
+          fileName: file.name,
+          mimeType: file.type || 'application/pdf',
+          fileSize: file.size,
+          contentBase64,
+        },
       });
-      const downloadURL = await getDownloadURL(snapshot.ref);
-      const contractDocument = {
-        path,
-        name: file.name,
-        downloadURL,
-        size: file.size,
-        contentType: file.type || 'application/pdf',
-        uploadedAt,
-      };
 
       let documentText = '';
       try {
@@ -281,7 +369,6 @@ export function PortalProjectRegister() {
 
       let nextAnalysis: ProjectRequestContractAnalysisResult | null = null;
       try {
-        const idToken = authUser.idToken || await getAuthInstance()?.currentUser?.getIdToken() || undefined;
         nextAnalysis = await analyzeProjectRequestContractViaBff({
           tenantId: orgId,
           actor: {
@@ -461,9 +548,14 @@ export function PortalProjectRegister() {
         <CardContent className="space-y-5 p-5">
           {step === 'contract' && (
             <div className="grid gap-4 xl:grid-cols-[1.2fr,0.8fr]">
-              <Card className="border-dashed border-border/80">
+              <Card className={contractUploadUi.cardClass}>
                 <CardHeader className="pb-2">
-                  <CardTitle className="text-[13px]">1. 계약서 업로드</CardTitle>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <CardTitle className="text-[13px]">1. 계약서 업로드</CardTitle>
+                    <Badge className={`border-0 ${contractUploadUi.badgeClass}`}>
+                      {contractUploadUi.statusLabel}
+                    </Badge>
+                  </div>
                   <p className="text-[11px] text-muted-foreground">
                     계약서 PDF를 먼저 올리면 공식 계약명, 계약 대상, 기간, 금액 초안을 자동으로 채웁니다.
                   </p>
@@ -476,54 +568,73 @@ export function PortalProjectRegister() {
                     className="hidden"
                     onChange={handleContractDocumentSelect}
                   />
-                  <div className="rounded-xl border border-dashed border-border p-4">
-                    <div className="flex flex-wrap items-center gap-2">
+                  <div className={`rounded-2xl border border-dashed p-5 shadow-sm transition-colors ${contractUploadUi.surfaceClass}`}>
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div className="space-y-1">
+                        <div className="text-[15px]" style={{ fontWeight: 700 }}>{contractUploadUi.title}</div>
+                        <p className="max-w-xl text-[11px] leading-5 text-muted-foreground">
+                          {contractUploadUi.description}
+                        </p>
+                      </div>
+                      <div className="flex flex-wrap gap-2">
+                        <Badge className={`border-0 ${contractUploadUi.badgeClass}`}>PDF 1개 필수</Badge>
+                        <Badge className="border-0 bg-slate-500/15 text-slate-700 dark:text-slate-300">업로드 후 AI 초안 자동 생성</Badge>
+                      </div>
+                    </div>
+
+                    <div className="mt-5">
                       <Button
                         type="button"
-                        variant="outline"
-                        className="h-9 gap-1.5 text-[12px]"
+                        className={`h-14 w-full gap-2 text-[14px] shadow-sm ${contractUploadUi.buttonClass}`}
                         onClick={() => contractFileInputRef.current?.click()}
                         disabled={isUploadingContract}
                       >
-                        {isUploadingContract ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Upload className="h-3.5 w-3.5" />}
-                        {isUploadingContract ? '업로드 중...' : '계약서 PDF 업로드'}
+                        {isUploadingContract ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
+                        {contractUploadUi.ctaLabel}
                       </Button>
-                      {form.contractDocument ? (
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          className="h-9 text-[12px]"
-                          onClick={() => {
-                            setForm((prev) => ({ ...prev, contractDocument: null, contractAnalysis: null }));
-                            setContractAnalysisState('idle');
-                            setAnalysisError('');
-                          }}
-                        >
-                          첨부 제거
-                        </Button>
-                      ) : null}
                     </div>
-                    <p className="mt-3 text-[11px] text-muted-foreground">
-                      계약이 확정되었다는 서류를 업로드해 주세요. 날인이 되어 있지 않아도 됩니다.
-                    </p>
+
+                    <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
+                      <span>계약이 확정되었다는 서류를 업로드해 주세요.</span>
+                      <span>날인이 되어 있지 않아도 됩니다.</span>
+                      <span>스캔본도 가능하지만 텍스트 PDF가 더 잘 읽힙니다.</span>
+                    </div>
                     {form.contractDocument ? (
-                      <div className="mt-4 rounded-lg bg-muted/40 px-3 py-3 text-[11px]">
-                        <div style={{ fontWeight: 600 }}>{form.contractDocument.name}</div>
-                        <div className="mt-1 text-muted-foreground">
-                          {(form.contractDocument.size / 1024 / 1024).toFixed(2)} MB · {form.contractDocument.uploadedAt.slice(0, 10)}
+                      <div className="mt-4 rounded-xl border border-border/60 bg-background/80 px-4 py-3 text-[11px]">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div>
+                            <div style={{ fontWeight: 700 }}>{form.contractDocument.name}</div>
+                            <div className="mt-1 text-muted-foreground">
+                              {(form.contractDocument.size / 1024 / 1024).toFixed(2)} MB · {form.contractDocument.uploadedAt.slice(0, 10)}
+                            </div>
+                          </div>
+                          <div className="flex flex-wrap gap-2">
+                            <a
+                              href={form.contractDocument.downloadURL}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="inline-flex h-8 items-center rounded-md border border-border px-3 text-[11px] text-teal-600 transition-colors hover:bg-teal-50 dark:hover:bg-teal-950/20"
+                            >
+                              업로드된 파일 보기
+                            </a>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              className="h-8 text-[11px]"
+                              onClick={() => {
+                                setForm((prev) => ({ ...prev, contractDocument: null, contractAnalysis: null }));
+                                setContractAnalysisState('idle');
+                                setAnalysisError('');
+                              }}
+                            >
+                              첨부 제거
+                            </Button>
+                          </div>
                         </div>
-                        <a
-                          href={form.contractDocument.downloadURL}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="mt-2 inline-block text-teal-600 hover:underline"
-                        >
-                          업로드된 파일 보기
-                        </a>
                       </div>
                     ) : (
-                      <div className="mt-4 rounded-lg bg-amber-50 px-3 py-2 text-[11px] text-amber-700 dark:bg-amber-950/20 dark:text-amber-300">
-                        제출 전까지 계약서 PDF 1개 업로드가 필요합니다.
+                      <div className="mt-4 rounded-xl bg-amber-50 px-4 py-3 text-[11px] text-amber-700 dark:bg-amber-950/20 dark:text-amber-300">
+                        아직 계약서 PDF가 없습니다. 위 버튼으로 먼저 업로드를 시작해 주세요.
                       </div>
                     )}
                   </div>

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -12,6 +12,7 @@ import {
   provisionTransactionEvidenceDriveViaBff,
   readPlatformApiRuntimeConfig,
   syncTransactionEvidenceDriveViaBff,
+  uploadProjectRequestContractViaBff,
   toRequestActor,
   uploadTransactionEvidenceDriveViaBff,
   upsertLedgerViaBff,
@@ -197,6 +198,46 @@ describe('platform-bff-client', () => {
     }));
     expect(result.fields.officialContractName.value).toBe('뷰티풀 커넥트 운영 계약');
     expect(result.fields.contractAmount.value).toBe(120000000);
+  });
+
+  it('calls project request contract upload endpoint', async () => {
+    const client = {
+      post: vi.fn(async () => ({
+        data: {
+          path: 'orgs/mysc/project-request-contracts/u001/contract.pdf',
+          name: 'contract.pdf',
+          downloadURL: 'https://example.com/contract.pdf',
+          size: 1234,
+          contentType: 'application/pdf',
+          uploadedAt: '2026-03-16T10:00:00.000Z',
+        },
+      })),
+      get: vi.fn(),
+      request: vi.fn(),
+    };
+
+    const result = await uploadProjectRequestContractViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'u001', role: 'pm', idToken: 'token-abc' },
+      upload: {
+        fileName: 'contract.pdf',
+        mimeType: 'application/pdf',
+        fileSize: 1234,
+        contentBase64: 'ZmFrZS1wZGY=',
+      },
+      client,
+    });
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/project-requests/contract/upload', expect.objectContaining({
+      tenantId: 'mysc',
+      body: {
+        fileName: 'contract.pdf',
+        mimeType: 'application/pdf',
+        fileSize: 1234,
+        contentBase64: 'ZmFrZS1wZGY=',
+      },
+    }));
+    expect(result.downloadURL).toContain('contract.pdf');
   });
 
   it('calls evidence drive provision/sync endpoints', async () => {

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -60,6 +60,13 @@ export interface CreateEvidencePayload {
   [key: string]: unknown;
 }
 
+export interface ProjectRequestContractUploadPayload {
+  fileName: string;
+  mimeType: string;
+  fileSize: number;
+  contentBase64: string;
+}
+
 export interface ProvisionProjectEvidenceDriveRootResult {
   projectId: string;
   folderId: string;
@@ -552,6 +559,32 @@ export async function analyzeProjectRequestContractViaBff(params: {
     },
   );
   return normalizeProjectRequestContractAnalysisResult(response.data);
+}
+
+export async function uploadProjectRequestContractViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  upload: ProjectRequestContractUploadPayload;
+  client?: PlatformApiClientLike;
+}) {
+  const apiClient = resolveClient(params.client);
+  const response = await apiClient.post<{
+    path: string;
+    name: string;
+    downloadURL: string;
+    size: number;
+    contentType: string;
+    uploadedAt: string;
+  }>(
+    '/api/v1/project-requests/contract/upload',
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      body: params.upload,
+      timeoutMs: 45000,
+    },
+  );
+  return response.data;
 }
 
 export async function linkProjectEvidenceDriveRootViaBff(params: {


### PR DESCRIPTION
## Summary\n- route project request contract uploads through the BFF instead of direct browser Firebase Storage writes\n- add a storage-backed upload endpoint and tests\n- make the contract upload CTA clearer and stateful in the wizard\n\n## Verification\n- npx vitest run server/bff/project-request-contract-storage.test.ts server/bff/project-request-contract-ai.test.ts src/app/lib/platform-bff-client.test.ts src/app/components/portal/project-proposal.test.ts\n- node --check server/bff/project-request-contract-storage.mjs\n- node --check server/bff/app.mjs\n- npm run build