### PR TITLE
fix: stream contract pdf uploads through bff

### DIFF
--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -74,6 +74,7 @@ import {
 import { createGoogleSheetMigrationAiService } from './google-sheet-migration-ai.mjs';
 import { createProjectRequestContractAiService } from './project-request-contract-ai.mjs';
 import { createProjectRequestContractStorageService } from './project-request-contract-storage.mjs';
+import { extractTextFromPdfBuffer } from './pdf-text.mjs';
 
 function createHttpError(statusCode, message, code = 'request_error') {
   const error = new Error(message);
@@ -621,7 +622,7 @@ export function createBffApp(options = {}) {
       res.setHeader('Access-Control-Allow-Origin', allowAnyOrigin ? '*' : requestOrigin);
     }
     res.setHeader('Vary', 'Origin');
-    res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type, x-tenant-id, x-actor-id, x-actor-role, x-actor-email, x-request-id, idempotency-key, x-google-access-token');
+    res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type, x-tenant-id, x-actor-id, x-actor-role, x-actor-email, x-request-id, idempotency-key, x-google-access-token, x-file-name, x-file-type, x-file-size');
     res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PATCH,PUT,DELETE,OPTIONS');
     res.setHeader('X-Content-Type-Options', 'nosniff');
     res.setHeader('X-Frame-Options', 'DENY');
@@ -1249,6 +1250,49 @@ export function createBffApp(options = {}) {
     });
     res.status(200).json(uploaded);
   }));
+
+  app.post(
+    '/api/v1/project-requests/contract/process',
+    express.raw({ type: ['application/octet-stream', 'application/pdf'], limit: process.env.BFF_JSON_LIMIT || '25mb' }),
+    asyncHandler(async (req, res) => {
+      const { tenantId, actorId } = req.context;
+      assertActorRoleAllowed(req, ROUTE_ROLES.writeCore, 'process project request contract');
+      const fileName = readOptionalText(req.header('x-file-name')) || 'contract.pdf';
+      const mimeType = readOptionalText(req.header('x-file-type')) || req.header('content-type') || 'application/pdf';
+      const fileSizeHeader = Number.parseInt(readOptionalText(req.header('x-file-size')), 10);
+      const fileBuffer = Buffer.isBuffer(req.body) ? req.body : Buffer.from(req.body || []);
+
+      if (!fileBuffer.byteLength) {
+        throw createHttpError(400, 'Contract upload body is empty', 'empty_contract_upload');
+      }
+
+      const contractDocument = await projectRequestContractStorageService.uploadContract({
+        tenantId,
+        actorId,
+        fileName,
+        mimeType,
+        fileSize: Number.isFinite(fileSizeHeader) ? fileSizeHeader : fileBuffer.byteLength,
+        buffer: fileBuffer,
+      });
+
+      let documentText = '';
+      try {
+        documentText = await extractTextFromPdfBuffer(fileBuffer);
+      } catch (error) {
+        console.warn('[BFF] contract pdf text extraction failed:', error);
+      }
+
+      const analysis = await projectRequestContractAiService.analyzeContract({
+        fileName,
+        documentText: documentText || fileName,
+      });
+
+      res.status(200).json({
+        contractDocument,
+        analysis,
+      });
+    }),
+  );
 
   app.get('/api/v1/ledgers', asyncHandler(async (req, res) => {
     const { tenantId } = req.context;

--- a/server/bff/pdf-text.mjs
+++ b/server/bff/pdf-text.mjs
@@ -1,0 +1,21 @@
+export async function extractTextFromPdfBuffer(buffer) {
+  const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.mjs');
+  const data = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  const pdf = await pdfjsLib.getDocument({ data }).promise;
+
+  const pages = [];
+  for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber += 1) {
+    const page = await pdf.getPage(pageNumber);
+    const textContent = await page.getTextContent();
+    const pageText = textContent.items
+      .filter((item) => item && typeof item === 'object' && 'str' in item)
+      .map((item) => item.str)
+      .join(' ')
+      .trim();
+    if (pageText) {
+      pages.push(pageText);
+    }
+  }
+
+  return pages.join('\n\n');
+}

--- a/server/bff/project-request-contract-storage.mjs
+++ b/server/bff/project-request-contract-storage.mjs
@@ -39,18 +39,23 @@ export function createProjectRequestContractStorageService(options = {}) {
       const fileName = normalizeSafeFileName(input?.fileName);
       const mimeType = readOptionalText(input?.mimeType) || 'application/pdf';
       const fileSize = Number.isFinite(input?.fileSize) ? input.fileSize : 0;
+      const buffer = input?.buffer instanceof Uint8Array
+        ? Buffer.from(input.buffer)
+        : Buffer.isBuffer(input?.buffer)
+          ? input.buffer
+          : null;
       const contentBase64 = readOptionalText(input?.contentBase64);
-      if (!contentBase64) {
-        throw new Error('contentBase64 is required');
+      if (!buffer && !contentBase64) {
+        throw new Error('buffer or contentBase64 is required');
       }
 
       const uploadedAt = new Date().toISOString();
       const token = randomUUID();
       const path = `orgs/${tenantId}/project-request-contracts/${actorId}/${Date.now()}-${fileName}`;
       const file = bucket.file(path);
-      const buffer = Buffer.from(contentBase64, 'base64');
+      const uploadBuffer = buffer || Buffer.from(contentBase64, 'base64');
 
-      await file.save(buffer, {
+      await file.save(uploadBuffer, {
         resumable: false,
         metadata: {
           contentType: mimeType,
@@ -64,7 +69,7 @@ export function createProjectRequestContractStorageService(options = {}) {
         path,
         name: readOptionalText(input?.fileName) || fileName,
         downloadURL: buildDownloadUrl(bucketName, path, token),
-        size: fileSize || buffer.byteLength,
+        size: fileSize || uploadBuffer.byteLength,
         contentType: mimeType,
         uploadedAt,
       };

--- a/src/app/components/portal/PortalProjectRegister.tsx
+++ b/src/app/components/portal/PortalProjectRegister.tsx
@@ -20,11 +20,9 @@ import { usePortalStore } from '../../data/portal-store';
 import { useAuth } from '../../data/auth-store';
 import { useFirebase } from '../../lib/firebase-context';
 import { getAuthInstance } from '../../lib/firebase';
-import { extractTextFromPdf } from '../../lib/pdf-extract';
 import {
-  analyzeProjectRequestContractViaBff,
+  processProjectRequestContractViaBff,
   type ProjectRequestContractAnalysisResult,
-  uploadProjectRequestContractViaBff,
 } from '../../lib/platform-bff-client';
 import {
   ACCOUNT_TYPE_LABELS,
@@ -245,21 +243,6 @@ function resolveContractUploadUiState(
   };
 }
 
-function readArrayBufferAsBase64(buffer: ArrayBuffer, fileName: string): string {
-  const bytes = new Uint8Array(buffer);
-  const chunkSize = 0x8000;
-  let binary = '';
-  for (let index = 0; index < bytes.length; index += chunkSize) {
-    const chunk = bytes.subarray(index, index + chunkSize);
-    binary += String.fromCharCode(...chunk);
-  }
-  const base64 = btoa(binary);
-  if (!base64) {
-    throw new Error(`파일 인코딩에 실패했습니다: ${fileName}`);
-  }
-  return base64;
-}
-
 function isFileReadError(error: unknown): boolean {
   return error instanceof DOMException && error.name === 'NotReadableError';
 }
@@ -347,9 +330,7 @@ export function PortalProjectRegister() {
 
     try {
       const idToken = authUser.idToken || await getAuthInstance()?.currentUser?.getIdToken() || undefined;
-      const fileBuffer = await file.arrayBuffer();
-      const contentBase64 = readArrayBufferAsBase64(fileBuffer, file.name);
-      const contractDocument = await uploadProjectRequestContractViaBff({
+      const processed = await processProjectRequestContractViaBff({
         tenantId: orgId,
         actor: {
           uid: authUser.uid,
@@ -357,40 +338,10 @@ export function PortalProjectRegister() {
           role: authUser.role,
           idToken,
         },
-        upload: {
-          fileName: file.name,
-          mimeType: file.type || 'application/pdf',
-          fileSize: file.size,
-          contentBase64,
-        },
+        file,
       });
-
-      let documentText = '';
-      try {
-        documentText = await extractTextFromPdf(fileBuffer);
-      } catch (error) {
-        console.warn('[PortalProjectRegister] pdf text extraction failed:', error);
-      }
-
-      setContractAnalysisState('analyzing');
-
-      let nextAnalysis: ProjectRequestContractAnalysisResult | null = null;
-      try {
-        nextAnalysis = await analyzeProjectRequestContractViaBff({
-          tenantId: orgId,
-          actor: {
-            uid: authUser.uid,
-            email: authUser.email,
-            role: authUser.role,
-            idToken,
-          },
-          fileName: file.name,
-          documentText: documentText || file.name,
-        });
-      } catch (error) {
-        console.error('[PortalProjectRegister] contract analysis failed:', error);
-        setAnalysisError('업로드는 완료됐지만 AI 초안 생성에 실패했습니다. 직접 입력하거나 다시 시도해 주세요.');
-      }
+      const contractDocument = processed.contractDocument;
+      const nextAnalysis: ProjectRequestContractAnalysisResult | null = processed.analysis || null;
 
       setForm((prev) => {
         const base = {

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -8,6 +8,7 @@ import {
   linkProjectEvidenceDriveRootViaBff,
   overrideTransactionEvidenceDriveCategoriesViaBff,
   previewGoogleSheetImportViaBff,
+  processProjectRequestContractViaBff,
   provisionProjectEvidenceDriveRootViaBff,
   provisionTransactionEvidenceDriveViaBff,
   readPlatformApiRuntimeConfig,
@@ -238,6 +239,64 @@ describe('platform-bff-client', () => {
       },
     }));
     expect(result.downloadURL).toContain('contract.pdf');
+  });
+
+  it('calls project request contract process endpoint with binary body', async () => {
+    const file = new File(['pdf-bytes'], 'contract.pdf', { type: 'application/pdf' });
+    const client = {
+      post: vi.fn(),
+      get: vi.fn(),
+      request: vi.fn(async () => ({
+        data: {
+          contractDocument: {
+            path: 'orgs/mysc/project-request-contracts/u001/contract.pdf',
+            name: 'contract.pdf',
+            downloadURL: 'https://example.com/contract.pdf',
+            size: 1234,
+            contentType: 'application/pdf',
+            uploadedAt: '2026-03-16T10:00:00.000Z',
+          },
+          analysis: {
+            provider: 'heuristic',
+            model: 'deterministic-fallback',
+            summary: 'summary',
+            warnings: [],
+            nextActions: [],
+            extractedAt: '2026-03-16T10:00:00.000Z',
+            fields: {
+              officialContractName: { value: '공식 계약명', confidence: 'medium', evidence: '근거' },
+              suggestedProjectName: { value: '계약명', confidence: 'medium', evidence: '근거' },
+              clientOrg: { value: '', confidence: 'low', evidence: '' },
+              projectPurpose: { value: '', confidence: 'low', evidence: '' },
+              description: { value: '', confidence: 'low', evidence: '' },
+              contractStart: { value: '', confidence: 'low', evidence: '' },
+              contractEnd: { value: '', confidence: 'low', evidence: '' },
+              contractAmount: { value: null, confidence: 'low', evidence: '' },
+              salesVatAmount: { value: null, confidence: 'low', evidence: '' },
+            },
+          },
+        },
+      })),
+    };
+
+    const result = await processProjectRequestContractViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'u001', role: 'pm', idToken: 'token-abc' },
+      file,
+      client,
+    });
+
+    expect(client.request).toHaveBeenCalledWith('/api/v1/project-requests/contract/process', expect.objectContaining({
+      method: 'POST',
+      tenantId: 'mysc',
+      body: file,
+      headers: expect.objectContaining({
+        'content-type': 'application/octet-stream',
+        'x-file-name': 'contract.pdf',
+        'x-file-type': 'application/pdf',
+      }),
+    }));
+    expect(result.analysis.fields.officialContractName.value).toBe('공식 계약명');
   });
 
   it('calls evidence drive provision/sync endpoints', async () => {

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -587,6 +587,56 @@ export async function uploadProjectRequestContractViaBff(params: {
   return response.data;
 }
 
+export async function processProjectRequestContractViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  file: File;
+  client?: PlatformApiClientLike;
+}): Promise<{
+  contractDocument: {
+    path: string;
+    name: string;
+    downloadURL: string;
+    size: number;
+    contentType: string;
+    uploadedAt: string;
+  };
+  analysis: ProjectRequestContractAnalysisResult;
+}> {
+  const apiClient = resolveClient(params.client);
+  const response = await apiClient.request<{
+    contractDocument: {
+      path: string;
+      name: string;
+      downloadURL: string;
+      size: number;
+      contentType: string;
+      uploadedAt: string;
+    };
+    analysis: ProjectRequestContractAnalysisResult;
+  }>(
+    '/api/v1/project-requests/contract/process',
+    {
+      method: 'POST',
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      headers: {
+        'content-type': 'application/octet-stream',
+        'x-file-name': params.file.name,
+        'x-file-type': params.file.type || 'application/pdf',
+        'x-file-size': String(params.file.size || 0),
+      },
+      body: params.file,
+      timeoutMs: 45000,
+      retries: 0,
+    },
+  );
+  return {
+    contractDocument: response.data.contractDocument,
+    analysis: normalizeProjectRequestContractAnalysisResult(response.data.analysis),
+  };
+}
+
 export async function linkProjectEvidenceDriveRootViaBff(params: {
   tenantId: string;
   actor: ActorLike;

--- a/src/app/platform/api-client.ts
+++ b/src/app/platform/api-client.ts
@@ -27,6 +27,14 @@ export interface PlatformRequestOptions {
   retryOnStatuses?: number[];
 }
 
+function isBinaryBody(value: unknown): value is Blob | ArrayBuffer | Uint8Array {
+  return (
+    (typeof Blob !== 'undefined' && value instanceof Blob)
+    || value instanceof ArrayBuffer
+    || value instanceof Uint8Array
+  );
+}
+
 export interface PlatformApiClientOptions {
   baseUrl?: string;
   fetchImpl?: typeof fetch;
@@ -224,7 +232,7 @@ export class PlatformApiClient {
     let body: BodyInit | undefined;
 
     if (options.body !== undefined && options.body !== null) {
-      if (options.body instanceof FormData) {
+      if (options.body instanceof FormData || isBinaryBody(options.body)) {
         body = options.body;
       } else {
         if (!headers.has('content-type')) {


### PR DESCRIPTION
## Summary\n- stream contract pdf files directly to the BFF instead of reading them into JS first\n- process upload and contract analysis on the server side\n- extend the API client to pass through binary request bodies\n\n## Verification\n- npx vitest run src/app/lib/platform-bff-client.test.ts server/bff/project-request-contract-storage.test.ts server/bff/project-request-contract-ai.test.ts src/app/components/portal/project-proposal.test.ts\n- node --check server/bff/pdf-text.mjs\n- node --check server/bff/app.mjs\n- npm run build