### PR TITLE
fix: encode contract upload filename headers

### DIFF
--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -105,6 +105,16 @@ function readOptionalText(value) {
   return typeof value === 'string' ? value.trim() : '';
 }
 
+function decodeHeaderValue(value) {
+  const text = readOptionalText(value);
+  if (!text) return '';
+  try {
+    return decodeURIComponent(text);
+  } catch {
+    return text;
+  }
+}
+
 function parseAllowedOrigins(value) {
   const rawValue = String(value || '');
   const parsed = rawValue
@@ -1257,7 +1267,7 @@ export function createBffApp(options = {}) {
     asyncHandler(async (req, res) => {
       const { tenantId, actorId } = req.context;
       assertActorRoleAllowed(req, ROUTE_ROLES.writeCore, 'process project request contract');
-      const fileName = readOptionalText(req.header('x-file-name')) || 'contract.pdf';
+      const fileName = decodeHeaderValue(req.header('x-file-name')) || 'contract.pdf';
       const mimeType = readOptionalText(req.header('x-file-type')) || req.header('content-type') || 'application/pdf';
       const fileSizeHeader = Number.parseInt(readOptionalText(req.header('x-file-size')), 10);
       const fileBuffer = Buffer.isBuffer(req.body) ? req.body : Buffer.from(req.body || []);

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -242,7 +242,7 @@ describe('platform-bff-client', () => {
   });
 
   it('calls project request contract process endpoint with binary body', async () => {
-    const file = new File(['pdf-bytes'], 'contract.pdf', { type: 'application/pdf' });
+    const file = new File(['pdf-bytes'], '계약서 샘플.pdf', { type: 'application/pdf' });
     const client = {
       post: vi.fn(),
       get: vi.fn(),
@@ -292,7 +292,7 @@ describe('platform-bff-client', () => {
       body: file,
       headers: expect.objectContaining({
         'content-type': 'application/octet-stream',
-        'x-file-name': 'contract.pdf',
+        'x-file-name': encodeURIComponent('계약서 샘플.pdf'),
         'x-file-type': 'application/pdf',
       }),
     }));

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -357,6 +357,10 @@ function resolveClient(client?: PlatformApiClientLike): PlatformApiClientLike {
   return client || createPlatformApiClient();
 }
 
+function encodeHeaderValue(value: string): string {
+  return encodeURIComponent(value);
+}
+
 export async function upsertProjectViaBff(params: {
   tenantId: string;
   actor: ActorLike;
@@ -622,7 +626,7 @@ export async function processProjectRequestContractViaBff(params: {
       actor: toRequestActor(params.actor),
       headers: {
         'content-type': 'application/octet-stream',
-        'x-file-name': params.file.name,
+        'x-file-name': encodeHeaderValue(params.file.name),
         'x-file-type': params.file.type || 'application/pdf',
         'x-file-size': String(params.file.size || 0),
       },


### PR DESCRIPTION
## Summary\n- encode non-ASCII contract file names before sending them in upload headers\n- decode the file name on the BFF side before storage/analysis\n- add a regression test for Korean PDF file names\n\n## Verification\n- npx vitest run src/app/lib/platform-bff-client.test.ts server/bff/project-request-contract-storage.test.ts server/bff/project-request-contract-ai.test.ts src/app/components/portal/project-proposal.test.ts\n- node --check server/bff/app.mjs\n- npm run build