### PR TITLE
fix: stabilize contract analysis actions

### DIFF
--- a/server/bff/project-request-contract-ai.mjs
+++ b/server/bff/project-request-contract-ai.mjs
@@ -44,6 +44,19 @@ function sanitizeProjectName(value) {
   return normalized.replace(/\s+/g, '').slice(0, 10);
 }
 
+function sanitizeOfficialContractName(value) {
+  const normalized = normalizeWhitespace(value)
+    .replace(/[()[\]{}]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!normalized) return '';
+  const stripped = normalized
+    .replace(/\s*(계약서|협약서|제안서|합의서|신청서|확인서|각서|문서)(\s*(초안|사본|원본|최종본|최종))?\s*$/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return stripped || normalized;
+}
+
 function normalizeDate(value) {
   const normalized = readOptionalText(value).replace(/\s+/g, '');
   if (!normalized) return '';
@@ -155,7 +168,8 @@ function buildFallbackProjectRequestContractAnalysis(input, timestamp = nowIso()
   ]);
   const dateRange = extractDateRange(documentText);
 
-  const officialContractName = officialContractMatch?.value || fileName;
+  const rawOfficialContractName = officialContractMatch?.value || fileName;
+  const officialContractName = sanitizeOfficialContractName(rawOfficialContractName);
   const suggestedProjectName = sanitizeProjectName(officialContractName || fileName);
   const warnings = [];
   const nextActions = [];
@@ -296,7 +310,7 @@ function buildPrompt(input, fallback) {
       '<example>',
       '<document_name>뷰티풀커넥트_계약서.pdf</document_name>',
       '<document_excerpt>사업명: 뷰티풀 커넥트 운영 계약 발주기관: 아모레퍼시픽재단 계약기간: 2026.03.01 ~ 2026.12.31 총 계약금액: 120,000,000원 부가세: 12,000,000원 사업 목적: 청년 창업가의 지역 연결을 지원한다.</document_excerpt>',
-      '<ideal_json>{"summary":"계약서 주요 항목을 읽어 기본 정보를 채울 수 있습니다.","warnings":[],"nextActions":["담당팀과 정산유형은 사람이 직접 선택하세요."],"fields":{"officialContractName":{"value":"뷰티풀 커넥트 운영 계약","confidence":"high","evidence":"사업명: 뷰티풀 커넥트 운영 계약"},"suggestedProjectName":{"value":"뷰티풀커넥트","confidence":"high","evidence":"뷰티풀 커넥트 운영 계약"},"clientOrg":{"value":"아모레퍼시픽재단","confidence":"high","evidence":"발주기관: 아모레퍼시픽재단"},"projectPurpose":{"value":"청년 창업가의 지역 연결을 지원한다.","confidence":"high","evidence":"사업 목적: 청년 창업가의 지역 연결을 지원한다."},"description":{"value":"","confidence":"low","evidence":""},"contractStart":{"value":"2026-03-01","confidence":"high","evidence":"계약기간: 2026.03.01 ~ 2026.12.31"},"contractEnd":{"value":"2026-12-31","confidence":"high","evidence":"계약기간: 2026.03.01 ~ 2026.12.31"},"contractAmount":{"value":120000000,"confidence":"high","evidence":"총 계약금액: 120,000,000원"},"salesVatAmount":{"value":12000000,"confidence":"high","evidence":"부가세: 12,000,000원"}}}</ideal_json>',
+      '<ideal_json>{"summary":"계약서 주요 항목을 읽어 기본 정보를 채울 수 있습니다.","warnings":[],"nextActions":["담당팀과 정산유형은 사람이 직접 선택하세요."],"fields":{"officialContractName":{"value":"뷰티풀 커넥트 운영 계약","confidence":"high","evidence":"사업명: 뷰티풀 커넥트 운영 계약서"},"suggestedProjectName":{"value":"뷰티풀커넥트","confidence":"high","evidence":"뷰티풀 커넥트 운영 계약"},"clientOrg":{"value":"아모레퍼시픽재단","confidence":"high","evidence":"발주기관: 아모레퍼시픽재단"},"projectPurpose":{"value":"청년 창업가의 지역 연결을 지원한다.","confidence":"high","evidence":"사업 목적: 청년 창업가의 지역 연결을 지원한다."},"description":{"value":"","confidence":"low","evidence":""},"contractStart":{"value":"2026-03-01","confidence":"high","evidence":"계약기간: 2026.03.01 ~ 2026.12.31"},"contractEnd":{"value":"2026-12-31","confidence":"high","evidence":"계약기간: 2026.03.01 ~ 2026.12.31"},"contractAmount":{"value":120000000,"confidence":"high","evidence":"총 계약금액: 120,000,000원"},"salesVatAmount":{"value":12000000,"confidence":"high","evidence":"부가세: 12,000,000원"}}}</ideal_json>',
       '</example>',
     ].join('\n'),
     [
@@ -320,6 +334,7 @@ function buildPrompt(input, fallback) {
     '</success_criteria>',
     '<field_rules>',
     '<rule>officialContractName은 계약서 상의 공식 명칭입니다.</rule>',
+    '<rule>officialContractName에서는 협약서, 계약서, 제안서처럼 문서 형식/종류를 나타내는 단어를 제외합니다.</rule>',
     '<rule>suggestedProjectName은 내부 등록용 10자 이내 짧은 이름입니다.</rule>',
     '<rule>department, settlementType, accountType은 추측하지 않습니다.</rule>',
     '<rule>날짜는 YYYY-MM-DD 형식입니다.</rule>',
@@ -345,6 +360,12 @@ function buildPrompt(input, fallback) {
 
 function sanitizeAnalysis(value, fallback, timestamp = nowIso()) {
   const raw = value && typeof value === 'object' ? value : {};
+  const officialContractName = sanitizeTextSuggestion(raw.fields?.officialContractName, fallback.fields.officialContractName);
+  officialContractName.value = sanitizeOfficialContractName(officialContractName.value);
+  const suggestedProjectName = sanitizeTextSuggestion(raw.fields?.suggestedProjectName, fallback.fields.suggestedProjectName);
+  if (!suggestedProjectName.value) {
+    suggestedProjectName.value = sanitizeProjectName(officialContractName.value);
+  }
   return {
     provider: 'anthropic',
     model: MODEL,
@@ -353,8 +374,8 @@ function sanitizeAnalysis(value, fallback, timestamp = nowIso()) {
     nextActions: sanitizeStringArray(raw.nextActions, fallback.nextActions),
     extractedAt: timestamp,
     fields: {
-      officialContractName: sanitizeTextSuggestion(raw.fields?.officialContractName, fallback.fields.officialContractName),
-      suggestedProjectName: sanitizeTextSuggestion(raw.fields?.suggestedProjectName, fallback.fields.suggestedProjectName),
+      officialContractName,
+      suggestedProjectName,
       clientOrg: sanitizeTextSuggestion(raw.fields?.clientOrg, fallback.fields.clientOrg),
       projectPurpose: sanitizeTextSuggestion(raw.fields?.projectPurpose, fallback.fields.projectPurpose),
       description: sanitizeTextSuggestion(raw.fields?.description, fallback.fields.description),
@@ -402,5 +423,6 @@ export function createProjectRequestContractAiService(options = {}) {
 
 export {
   buildFallbackProjectRequestContractAnalysis,
+  sanitizeOfficialContractName,
   sanitizeProjectName,
 };

--- a/server/bff/project-request-contract-ai.test.ts
+++ b/server/bff/project-request-contract-ai.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildFallbackProjectRequestContractAnalysis,
   createProjectRequestContractAiService,
+  sanitizeOfficialContractName,
   sanitizeProjectName,
 } from './project-request-contract-ai.mjs';
 
@@ -10,11 +11,16 @@ describe('project-request-contract-ai', () => {
     expect(sanitizeProjectName('뷰티풀 커넥트 운영 계약서')).toBe('뷰티풀커넥트');
   });
 
+  it('strips document form words from official contract name', () => {
+    expect(sanitizeOfficialContractName('뷰티풀 커넥트 운영 협약서')).toBe('뷰티풀 커넥트 운영');
+    expect(sanitizeOfficialContractName('청년 창업 지원 사업 계약서 최종본')).toBe('청년 창업 지원 사업');
+  });
+
   it('builds fallback analysis from contract text', () => {
     const analysis = buildFallbackProjectRequestContractAnalysis({
       fileName: '뷰티풀커넥트_계약서.pdf',
       documentText: [
-        '사업명: 뷰티풀 커넥트 운영 계약',
+        '사업명: 뷰티풀 커넥트 운영 협약서',
         '발주기관: 아모레퍼시픽재단',
         '계약기간: 2026.03.01 ~ 2026.12.31',
         '총 계약금액: 120,000,000원',
@@ -24,7 +30,7 @@ describe('project-request-contract-ai', () => {
     }, '2026-03-16T09:00:00.000Z');
 
     expect(analysis.provider).toBe('heuristic');
-    expect(analysis.fields.officialContractName.value).toContain('뷰티풀 커넥트');
+    expect(analysis.fields.officialContractName.value).toBe('뷰티풀 커넥트 운영');
     expect(analysis.fields.clientOrg.value).toBe('아모레퍼시픽재단');
     expect(analysis.fields.contractStart.value).toBe('2026-03-01');
     expect(analysis.fields.contractEnd.value).toBe('2026-12-31');

--- a/src/app/components/portal/GoogleSheetMigrationWizard.tsx
+++ b/src/app/components/portal/GoogleSheetMigrationWizard.tsx
@@ -1045,7 +1045,7 @@ function GoogleSheetMigrationAiInlineCard({
         <p className="font-semibold">AI 빠른 분석</p>
         {safeAnalysis && (
           <Badge variant={safeAnalysis.provider === 'anthropic' ? 'default' : 'outline'} className="text-[10px]">
-            {safeAnalysis.provider === 'anthropic' ? 'Claude 분석' : '규칙 기반'}
+            {safeAnalysis.provider === 'anthropic' ? 'Merry의 분석' : '규칙 기반'}
           </Badge>
         )}
       </div>
@@ -1094,7 +1094,7 @@ function GoogleSheetMigrationAiPanel({
         <p className="font-medium text-slate-900">AI migration assistant</p>
         {safeAnalysis && (
           <Badge variant={safeAnalysis.provider === 'anthropic' ? 'default' : 'outline'} className="text-[10px]">
-            {safeAnalysis.provider === 'anthropic' ? 'Claude 분석' : '규칙 기반'}
+            {safeAnalysis.provider === 'anthropic' ? 'Merry의 분석' : '규칙 기반'}
           </Badge>
         )}
       </div>

--- a/src/app/components/portal/PortalProjectRegister.tsx
+++ b/src/app/components/portal/PortalProjectRegister.tsx
@@ -55,6 +55,7 @@ import {
 type Step = 'contract' | 'basic' | 'financial' | 'team' | 'review';
 type ContractAnalysisState = 'idle' | 'extracting' | 'analyzing' | 'ready' | 'error';
 type AnalysisFieldKey = keyof ProjectRequestContractAnalysis['fields'];
+type AnalysisApplyMode = 'overwrite' | 'fill' | null;
 
 const STEPS: Array<{
   key: Step;
@@ -115,6 +116,19 @@ function toSuggestedProjectName(value: string) {
   return normalized.slice(0, 10);
 }
 
+function sanitizeOfficialContractName(value: string) {
+  const normalized = String(value || '')
+    .replace(/[()[\]{}]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!normalized) return '';
+  const stripped = normalized
+    .replace(/\s*(계약서|협약서|제안서|합의서|신청서|확인서|각서|문서)(\s*(초안|사본|원본|최종본|최종))?\s*$/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return stripped || normalized;
+}
+
 function mergeAnalysisIntoDraft(
   draft: ProjectProposalDraft,
   analysis: ProjectRequestContractAnalysisResult,
@@ -124,12 +138,15 @@ function mergeAnalysisIntoDraft(
   const next = { ...draft, contractAnalysis: analysis };
   const shouldApplyText = (value: string, current: string) => overwriteExisting || isTextBlank(current);
   const shouldApplyNumber = (value: number | null, current: number) => value !== null && (overwriteExisting || !current);
+  const officialContractName = sanitizeOfficialContractName(analysis.fields.officialContractName.value);
+  const suggestedProjectName =
+    analysis.fields.suggestedProjectName.value || officialContractName;
 
-  if (shouldApplyText(analysis.fields.officialContractName.value, draft.officialContractName)) {
-    next.officialContractName = analysis.fields.officialContractName.value;
+  if (shouldApplyText(officialContractName, draft.officialContractName)) {
+    next.officialContractName = officialContractName;
   }
-  if (shouldApplyText(analysis.fields.suggestedProjectName.value, draft.name)) {
-    next.name = toSuggestedProjectName(analysis.fields.suggestedProjectName.value || analysis.fields.officialContractName.value);
+  if (shouldApplyText(suggestedProjectName, draft.name)) {
+    next.name = toSuggestedProjectName(suggestedProjectName);
   }
   if (shouldApplyText(analysis.fields.clientOrg.value, draft.clientOrg)) {
     next.clientOrg = analysis.fields.clientOrg.value;
@@ -153,6 +170,25 @@ function mergeAnalysisIntoDraft(
     next.salesVatAmount = analysis.fields.salesVatAmount.value || 0;
   }
   return next;
+}
+
+function hasAnalysisMergeChanges(
+  draft: ProjectProposalDraft,
+  analysis: ProjectRequestContractAnalysisResult,
+  options?: { overwriteExisting?: boolean },
+) {
+  const merged = mergeAnalysisIntoDraft(draft, analysis, options);
+  return (
+    merged.officialContractName !== draft.officialContractName ||
+    merged.name !== draft.name ||
+    merged.clientOrg !== draft.clientOrg ||
+    merged.projectPurpose !== draft.projectPurpose ||
+    merged.description !== draft.description ||
+    merged.contractStart !== draft.contractStart ||
+    merged.contractEnd !== draft.contractEnd ||
+    merged.contractAmount !== draft.contractAmount ||
+    merged.salesVatAmount !== draft.salesVatAmount
+  );
 }
 
 function confidenceLabel(confidence: ProjectRequestContractAnalysis['fields'][AnalysisFieldKey]['confidence']) {
@@ -263,7 +299,9 @@ export function PortalProjectRegister() {
   const [isUploadingContract, setIsUploadingContract] = useState(false);
   const [contractAnalysisState, setContractAnalysisState] = useState<ContractAnalysisState>('idle');
   const [analysisError, setAnalysisError] = useState('');
+  const [analysisApplyMode, setAnalysisApplyMode] = useState<AnalysisApplyMode>(null);
   const contractFileInputRef = useRef<HTMLInputElement | null>(null);
+  const analysisApplyLockRef = useRef(false);
 
   const currentStepIdx = STEPS.findIndex((item) => item.key === step);
   const currentStep = STEPS[currentStepIdx];
@@ -305,9 +343,23 @@ export function PortalProjectRegister() {
   };
 
   const applyContractAnalysis = (overwriteExisting: boolean) => {
-    if (!analysis) return;
-    setForm((prev) => mergeAnalysisIntoDraft(prev, analysis, { overwriteExisting }));
-    toast.success(overwriteExisting ? 'AI 초안을 다시 반영했습니다.' : '빈 항목에 AI 초안을 반영했습니다.');
+    if (!analysis || analysisApplyLockRef.current) return;
+    const nextMode: AnalysisApplyMode = overwriteExisting ? 'overwrite' : 'fill';
+    analysisApplyLockRef.current = true;
+    setAnalysisApplyMode(nextMode);
+
+    const changed = hasAnalysisMergeChanges(form, analysis, { overwriteExisting });
+    if (changed) {
+      setForm((prev) => mergeAnalysisIntoDraft(prev, analysis, { overwriteExisting }));
+      toast.success(overwriteExisting ? 'Merry의 분석을 다시 반영했습니다.' : '빈 항목에만 Merry의 분석을 반영했습니다.');
+    } else {
+      toast.message(overwriteExisting ? '다시 반영할 새 Merry 분석이 없습니다.' : '채울 수 있는 빈 항목이 없습니다.');
+    }
+
+    globalThis.setTimeout(() => {
+      analysisApplyLockRef.current = false;
+      setAnalysisApplyMode(null);
+    }, 900);
   };
 
   const handleContractDocumentSelect = async (event: ChangeEvent<HTMLInputElement>) => {
@@ -359,6 +411,7 @@ export function PortalProjectRegister() {
         setContractAnalysisState('error');
         toast.success(`계약서 업로드 완료: ${file.name}`);
       }
+      setStep('basic');
     } catch (error) {
       console.error('[PortalProjectRegister] contract upload failed:', error);
       setContractAnalysisState('error');
@@ -622,10 +675,10 @@ export function PortalProjectRegister() {
               <Card className="border-border/60">
                 <CardHeader className="pb-2">
                   <div className="flex items-center justify-between gap-2">
-                    <CardTitle className="text-[13px]">계약서 AI 초안</CardTitle>
+                    <CardTitle className="text-[13px]">Merry의 분석 초안</CardTitle>
                     {analysis ? (
                       <Badge className="border-0 bg-teal-500/15 text-teal-700 dark:text-teal-300">
-                        {analysis.provider === 'anthropic' ? 'Claude 분석' : '기본 분석'}
+                        {analysis.provider === 'anthropic' ? 'Merry의 분석' : 'Merry 기본 분석'}
                       </Badge>
                     ) : null}
                   </div>
@@ -693,8 +746,9 @@ export function PortalProjectRegister() {
                           size="sm"
                           className="h-8 text-[11px]"
                           onClick={() => applyContractAnalysis(true)}
+                          disabled={Boolean(analysisApplyMode) || isUploadingContract || contractAnalysisState !== 'ready'}
                         >
-                          AI 초안 다시 반영
+                          {analysisApplyMode === 'overwrite' ? '다시 반영 중...' : 'Merry 분석 다시 반영'}
                         </Button>
                         <Button
                           type="button"
@@ -702,8 +756,9 @@ export function PortalProjectRegister() {
                           size="sm"
                           className="h-8 text-[11px]"
                           onClick={() => applyContractAnalysis(false)}
+                          disabled={Boolean(analysisApplyMode) || isUploadingContract || contractAnalysisState !== 'ready'}
                         >
-                          빈 항목만 채우기
+                          {analysisApplyMode === 'fill' ? '채우는 중...' : '빈 항목만 채우기'}
                         </Button>
                       </div>
                     </>


### PR DESCRIPTION
## Summary\n- auto-advance to the basic info step after contract analysis completes\n- prevent repeated Merry analysis apply clicks and avoid no-op reapply churn\n- normalize official contract names to drop document-form suffixes and align branding to Merry\n\n## Verification\n- npx vitest run server/bff/project-request-contract-ai.test.ts\n- npm run build