### PR TITLE
feat(infra): Firebase live cutover runbook and migration script

### DIFF
--- a/guidelines/Firebase-Live-Cutover-Runbook.md
+++ b/guidelines/Firebase-Live-Cutover-Runbook.md
@@ -1,0 +1,201 @@
+# Firebase Live Cutover Runbook
+
+## 목적
+
+더미/검증 데이터가 섞여 있는 기존 Firebase 프로젝트를 계속 정리하는 대신, **새 운영용 Firebase 프로젝트를 만든 뒤 실제 운영에 필요한 데이터만 선별 이관**한다.
+
+이 프로젝트는 이미 Firebase 런타임 연결과 rules/indexes 배포가 env 기반으로 분리돼 있다.
+
+- Firebase 클라이언트 연결: [src/app/lib/firebase.ts](/Users/boram/InnerPlatform-ft-izzie-latest/src/app/lib/firebase.ts)
+- Firestore rules: [firebase/firestore.rules](/Users/boram/InnerPlatform-ft-izzie-latest/firebase/firestore.rules)
+- Firestore indexes: [firebase/firestore.indexes.json](/Users/boram/InnerPlatform-ft-izzie-latest/firebase/firestore.indexes.json)
+- 자동 세팅: [scripts/firebase_autosetup.sh](/Users/boram/InnerPlatform-ft-izzie-latest/scripts/firebase_autosetup.sh)
+- 선별 이관 스크립트: [scripts/firestore_live_cutover.ts](/Users/boram/InnerPlatform-ft-izzie-latest/scripts/firestore_live_cutover.ts)
+
+## 권장 전략
+
+기존 프로젝트를 직접 청소하지 말고 다음 순서로 진행한다.
+
+1. 새 Firebase 프로젝트 생성
+2. 새 프로젝트에 동일한 Firestore rules/indexes/storage rules 배포
+3. `orgs/mysc` 아래에서 실제 운영에 필요한 프로젝트만 manifest로 선택
+4. dry-run으로 이관 범위를 검토
+5. commit으로 Firestore/Storage를 선별 복제
+6. Vercel production env를 새 Firebase 프로젝트로 전환
+7. 기존 Firebase 프로젝트는 읽기 전용 아카이브처럼 유지
+
+## 무엇을 옮길지
+
+기본적으로 아래는 **옮길 가치가 높다**.
+
+- `projects`
+- `project_requests`
+- `members` 중 선택된 프로젝트와 연결된 사용자
+- `projects/{projectId}/expense_sheets`
+- `projects/{projectId}/bank_statements`
+- `projects/{projectId}/budget_summary`
+- `projects/{projectId}/budget_code_book`
+- `ledgers`
+- `transactions`
+- `weekly_submission_status`
+- `cashflow_weeks`
+- 계약서 PDF Storage 경로 `orgs/{orgId}/project-request-contracts/...`
+
+기본적으로 아래는 **안 옮기는 쪽이 안전하다**.
+
+- 테스트/검증용 프로젝트
+- 임시 요청 문서
+- 불필요한 `audit_logs`
+- 일회성 검증 문서
+
+## 1. 새 Firebase 프로젝트 준비
+
+### 1-1. Firebase 프로젝트 생성
+
+Firebase Console에서 새 프로젝트를 만든다.
+
+### 1-2. 웹 앱과 config 확보
+
+웹 앱을 하나 생성하고 SDK config를 확보한다.
+
+### 1-3. 로컬 `.env` / `.firebaserc` 준비
+
+자동 설정이 가능하면:
+
+```bash
+npm run firebase:autosetup
+```
+
+수동 config가 이미 있으면:
+
+```bash
+npm run firebase:fill-env -- '{"apiKey":"...","authDomain":"...","projectId":"...","storageBucket":"...","messagingSenderId":"...","appId":"..."}'
+```
+
+### 1-4. rules / indexes / storage rules 배포
+
+```bash
+npm run firebase:bootstrap
+```
+
+### 1-5. 콘솔 수동 작업
+
+- Google Sign-In provider 활성화
+- Firebase Storage bucket 초기화
+- 필요한 경우 Authorized domains 추가
+
+## 2. 현재 프로젝트에서 live 후보 추출
+
+먼저 source 프로젝트를 훑어보고 어떤 프로젝트가 test/dummy처럼 보이는지 구분한다.
+
+```bash
+SOURCE_FIREBASE_PROJECT_ID=mysc-bmp-14173451 \
+npx tsx scripts/firestore_live_cutover.ts discover \
+  --source-project mysc-bmp-14173451 \
+  --org mysc \
+  --out guidelines/output/live-discovery.json
+```
+
+출력에는 `likelyTestData`와 heuristic 이유가 들어간다. 이 값은 **참고용**이고 최종 선별은 사람이 한다.
+
+## 3. manifest 작성
+
+샘플:
+
+- [scripts/firestore_live_cutover.manifest.sample.json](/Users/boram/InnerPlatform-ft-izzie-latest/scripts/firestore_live_cutover.manifest.sample.json)
+
+핵심 필드:
+
+- `projectIds`: 새 운영용으로 옮길 실제 프로젝트 ID
+- `memberUids`: 명시적으로 같이 데려갈 사용자 UID
+- `projectRequestIds`: 필요한 요청 문서가 있으면 명시
+- `includeContractStorage`: 계약서 PDF Storage 객체 복제 여부
+
+## 4. dry-run 검토
+
+```bash
+SOURCE_FIREBASE_PROJECT_ID=mysc-bmp-14173451 \
+DEST_FIREBASE_PROJECT_ID=my-new-live-project \
+npx tsx scripts/firestore_live_cutover.ts migrate \
+  --manifest scripts/firestore_live_cutover.manifest.sample.json \
+  --source-project mysc-bmp-14173451 \
+  --dest-project my-new-live-project
+```
+
+이 단계는 쓰지 않고, 몇 개의 문서와 storage object가 이동 대상인지 요약만 보여준다.
+
+## 5. 실제 이관
+
+### 5-1. 인증
+
+아래 둘 중 하나를 쓴다.
+
+- ADC (`gcloud auth application-default login`)
+- 혹은 source/destination 서비스 계정
+
+사용 가능한 env:
+
+- `SOURCE_FIREBASE_SERVICE_ACCOUNT_JSON`
+- `SOURCE_FIREBASE_SERVICE_ACCOUNT_BASE64`
+- `SOURCE_FIREBASE_SERVICE_ACCOUNT_PATH`
+- `DEST_FIREBASE_SERVICE_ACCOUNT_JSON`
+- `DEST_FIREBASE_SERVICE_ACCOUNT_BASE64`
+- `DEST_FIREBASE_SERVICE_ACCOUNT_PATH`
+
+Storage bucket이 기본 이름이 아니면 아래도 지정한다.
+
+- `SOURCE_FIREBASE_STORAGE_BUCKET`
+- `DEST_FIREBASE_STORAGE_BUCKET`
+
+### 5-2. commit 실행
+
+```bash
+SOURCE_FIREBASE_PROJECT_ID=mysc-bmp-14173451 \
+DEST_FIREBASE_PROJECT_ID=my-new-live-project \
+npx tsx scripts/firestore_live_cutover.ts migrate \
+  --manifest scripts/firestore_live_cutover.manifest.sample.json \
+  --source-project mysc-bmp-14173451 \
+  --dest-project my-new-live-project \
+  --commit
+```
+
+## 6. Vercel cutover
+
+새 Firebase 프로젝트로 바꾸려면 production env를 같이 바꿔야 한다.
+
+필수 client env:
+
+- `VITE_FIREBASE_API_KEY`
+- `VITE_FIREBASE_AUTH_DOMAIN`
+- `VITE_FIREBASE_PROJECT_ID`
+- `VITE_FIREBASE_STORAGE_BUCKET`
+- `VITE_FIREBASE_MESSAGING_SENDER_ID`
+- `VITE_FIREBASE_APP_ID`
+
+필수 server env:
+
+- `FIREBASE_SERVICE_ACCOUNT_JSON` 또는 `FIREBASE_SERVICE_ACCOUNT_BASE64`
+
+그 외:
+
+- `VITE_DEFAULT_ORG_ID=mysc`
+- Drive 연동을 그대로 쓸 거면 `GOOGLE_DRIVE_*` env는 유지 가능
+
+## 7. 컷오버 후 검증
+
+최소 검증:
+
+1. 로그인
+2. 프로젝트 목록 조회
+3. 사업 등록 제안 제출
+4. 계약서 업로드
+5. 주간 사업비 입력 조회
+6. 통장내역 / 예산 / 캐시플로우 조회
+7. 증빙 업로드 / 동기화
+
+## 8. 안전 원칙
+
+- 기존 production Firebase를 직접 정리하지 않는다
+- manifest 없이 전체 복사하지 않는다
+- dry-run 확인 없이 `--commit` 하지 않는다
+- cutover 직전엔 Vercel env와 Firebase Auth authorized domains를 같이 점검한다

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "firebase:fill-env": "bash scripts/firebase_fill_env_from_config.sh",
     "firebase:emulators:prepare": "bash scripts/firebase_emulator_bootstrap.sh",
     "firebase:emulators:start": "bash scripts/firebase_emulator_bootstrap.sh --start",
+    "firestore:live-cutover": "npx tsx scripts/firestore_live_cutover.ts",
     "firestore:backup:schedule": "bash scripts/firestore_backup_schedule.sh",
     "firestore:backup:rehearsal": "bash scripts/firestore_backup_rehearsal.sh",
     "monitoring:setup:alerts": "bash scripts/setup_monitoring_alerts.sh",

--- a/scripts/firestore_live_cutover.manifest.sample.json
+++ b/scripts/firestore_live_cutover.manifest.sample.json
@@ -1,0 +1,20 @@
+{
+  "orgId": "mysc",
+  "projectIds": [
+    "p1773638600519"
+  ],
+  "memberUids": [
+    "8ocLxUWmBmglNEyNlXCVyfIRFyt1"
+  ],
+  "projectRequestIds": [
+    "pr-1773638600519"
+  ],
+  "includeProjectRequests": true,
+  "includeProjectSubcollections": true,
+  "includeWeeklySubmissionStatus": true,
+  "includeCashflowWeeks": true,
+  "includeComments": true,
+  "includeEvidences": true,
+  "includeAuditLogs": false,
+  "includeContractStorage": true
+}

--- a/scripts/firestore_live_cutover.ts
+++ b/scripts/firestore_live_cutover.ts
@@ -1,0 +1,681 @@
+#!/usr/bin/env npx tsx
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+type JsonMap = Record<string, unknown>;
+
+export interface LiveCutoverManifest {
+  orgId: string;
+  projectIds: string[];
+  memberUids: string[];
+  projectRequestIds: string[];
+  includeProjectRequests: boolean;
+  includeProjectSubcollections: boolean;
+  includeWeeklySubmissionStatus: boolean;
+  includeCashflowWeeks: boolean;
+  includeComments: boolean;
+  includeEvidences: boolean;
+  includeAuditLogs: boolean;
+  includeContractStorage: boolean;
+}
+
+interface ProjectLike {
+  id: string;
+  name?: string;
+  officialContractName?: string;
+  clientOrg?: string;
+  status?: string;
+  phase?: string;
+  createdAt?: string;
+}
+
+interface ProjectDiscoveryEntry {
+  id: string;
+  name: string;
+  officialContractName: string;
+  clientOrg: string;
+  status: string;
+  phase: string;
+  createdAt: string;
+  likelyTestData: boolean;
+  reasons: string[];
+}
+
+interface PlannedDoc {
+  path: string;
+  data: JsonMap;
+}
+
+interface MigrationPlan {
+  docs: PlannedDoc[];
+  storagePaths: string[];
+  summary: Record<string, number>;
+}
+
+const DEFAULT_SUBCOLLECTIONS = [
+  'expense_sheets',
+  'bank_statements',
+  'budget_summary',
+  'budget_code_book',
+] as const;
+
+const args = process.argv.slice(2);
+
+if (isEntrypoint()) {
+  main().catch((error) => {
+    console.error('❌ live cutover failed:', error);
+    process.exit(1);
+  });
+}
+
+async function main() {
+  const command = args[0];
+  if (!command || command === '--help' || command === '-h') {
+    printHelp();
+    return;
+  }
+
+  if (command === 'discover') {
+    await runDiscover();
+    return;
+  }
+
+  if (command === 'migrate') {
+    await runMigrate();
+    return;
+  }
+
+  throw new Error(`Unknown command: ${command}`);
+}
+
+async function runDiscover() {
+  loadEnvFiles([resolve('.env'), resolve('.env.local')]);
+  const orgId = getFlagValue('--org') || process.env.SOURCE_DEFAULT_ORG_ID || process.env.VITE_DEFAULT_ORG_ID || 'mysc';
+  const sourceProjectId = requiredValue(
+    getFlagValue('--source-project') || process.env.SOURCE_FIREBASE_PROJECT_ID || process.env.VITE_FIREBASE_PROJECT_ID,
+    'SOURCE_FIREBASE_PROJECT_ID or --source-project',
+  );
+  const outPath = getFlagValue('--out');
+
+  const admin = await import('firebase-admin');
+  const sourceApp = initNamedAdminApp(admin.default, 'live-cutover-source', {
+    projectId: sourceProjectId,
+    envPrefix: 'SOURCE',
+  });
+  const sourceDb = sourceApp.firestore();
+
+  const projectSnap = await sourceDb.collection(`orgs/${orgId}/projects`).get();
+  const discoveries = projectSnap.docs.map((doc) => buildProjectDiscoveryEntry(doc.id, doc.data() || {}));
+  discoveries.sort((a, b) => {
+    const aScore = a.likelyTestData ? 1 : 0;
+    const bScore = b.likelyTestData ? 1 : 0;
+    if (aScore !== bScore) return aScore - bScore;
+    return safeLocaleCompare(a.name || a.officialContractName || a.id, b.name || b.officialContractName || b.id);
+  });
+
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    sourceProjectId,
+    orgId,
+    totalProjects: discoveries.length,
+    likelyLiveCount: discoveries.filter((item) => !item.likelyTestData).length,
+    likelyTestCount: discoveries.filter((item) => item.likelyTestData).length,
+    projects: discoveries,
+  };
+
+  console.log(`🔎 Source Firebase project: ${sourceProjectId}`);
+  console.log(`🏢 Org: ${orgId}`);
+  console.log(`📁 Projects: ${discoveries.length}`);
+  console.log(`   - likely live: ${payload.likelyLiveCount}`);
+  console.log(`   - likely test: ${payload.likelyTestCount}`);
+  console.log('');
+  discoveries.slice(0, 50).forEach((item) => {
+    const label = item.likelyTestData ? 'TEST?' : 'LIVE?';
+    const reason = item.reasons.length ? ` | ${item.reasons.join(', ')}` : '';
+    console.log(`- [${label}] ${item.id} | ${item.name || item.officialContractName || '(unnamed)'}${reason}`);
+  });
+  if (discoveries.length > 50) {
+    console.log(`... ${discoveries.length - 50} more`);
+  }
+
+  if (outPath) {
+    const resolvedOut = resolve(outPath);
+    mkdirSync(dirname(resolvedOut), { recursive: true });
+    writeFileSync(resolvedOut, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+    console.log(`\n📝 Discovery written to ${resolvedOut}`);
+  }
+}
+
+async function runMigrate() {
+  loadEnvFiles([resolve('.env'), resolve('.env.local')]);
+  const manifestPath = requiredValue(getFlagValue('--manifest'), '--manifest');
+  const commit = args.includes('--commit');
+  const sourceProjectId = requiredValue(
+    getFlagValue('--source-project') || process.env.SOURCE_FIREBASE_PROJECT_ID,
+    'SOURCE_FIREBASE_PROJECT_ID or --source-project',
+  );
+  const destProjectId = requiredValue(
+    getFlagValue('--dest-project') || process.env.DEST_FIREBASE_PROJECT_ID,
+    'DEST_FIREBASE_PROJECT_ID or --dest-project',
+  );
+
+  const manifest = normalizeManifest(
+    JSON.parse(readFileSync(resolve(manifestPath), 'utf8')) as Partial<LiveCutoverManifest>,
+  );
+
+  const admin = await import('firebase-admin');
+  const sourceApp = initNamedAdminApp(admin.default, 'live-cutover-source', {
+    projectId: sourceProjectId,
+    envPrefix: 'SOURCE',
+  });
+  const destApp = initNamedAdminApp(admin.default, 'live-cutover-dest', {
+    projectId: destProjectId,
+    envPrefix: 'DEST',
+  });
+
+  const sourceDb = sourceApp.firestore();
+  const destDb = destApp.firestore();
+
+  const plan = await buildMigrationPlan({
+    sourceDb,
+    orgId: manifest.orgId,
+    manifest,
+  });
+
+  console.log('🚚 Live cutover plan');
+  console.log(`  - source: ${sourceProjectId}`);
+  console.log(`  - destination: ${destProjectId}`);
+  console.log(`  - orgId: ${manifest.orgId}`);
+  console.log(`  - projectIds: ${manifest.projectIds.join(', ')}`);
+  console.log(`  - docs: ${plan.docs.length}`);
+  console.log(`  - storage objects: ${plan.storagePaths.length}`);
+  console.log(
+    `  - summary: ${Object.entries(plan.summary)
+      .map(([key, value]) => `${key}:${value}`)
+      .join(', ')}`,
+  );
+
+  if (!commit) {
+    console.log('\n🟢 Dry-run only. Add --commit to write the destination project.');
+    return;
+  }
+
+  await writeDocs(destDb, plan.docs);
+  await copyStorageObjects({
+    sourceApp,
+    destApp,
+    sourceProjectId,
+    destProjectId,
+    storagePaths: plan.storagePaths,
+  });
+
+  console.log('\n✅ Live cutover completed.');
+}
+
+export function normalizeManifest(input: Partial<LiveCutoverManifest>): LiveCutoverManifest {
+  const projectIds = uniqueStrings(input.projectIds);
+  if (projectIds.length === 0) {
+    throw new Error('Manifest must include at least one projectIds entry');
+  }
+
+  return {
+    orgId: normalizeString(input.orgId) || 'mysc',
+    projectIds,
+    memberUids: uniqueStrings(input.memberUids),
+    projectRequestIds: uniqueStrings(input.projectRequestIds),
+    includeProjectRequests: normalizeBoolean(input.includeProjectRequests, true),
+    includeProjectSubcollections: normalizeBoolean(input.includeProjectSubcollections, true),
+    includeWeeklySubmissionStatus: normalizeBoolean(input.includeWeeklySubmissionStatus, true),
+    includeCashflowWeeks: normalizeBoolean(input.includeCashflowWeeks, true),
+    includeComments: normalizeBoolean(input.includeComments, true),
+    includeEvidences: normalizeBoolean(input.includeEvidences, true),
+    includeAuditLogs: normalizeBoolean(input.includeAuditLogs, false),
+    includeContractStorage: normalizeBoolean(input.includeContractStorage, true),
+  };
+}
+
+export function buildProjectDiscoveryEntry(id: string, raw: JsonMap): ProjectDiscoveryEntry {
+  const name = normalizeString(raw.name);
+  const officialContractName = normalizeString(raw.officialContractName);
+  const clientOrg = normalizeString(raw.clientOrg);
+  const status = normalizeString(raw.status);
+  const phase = normalizeString(raw.phase);
+  const createdAt = normalizeString(raw.createdAt);
+  const joined = `${id} ${name} ${officialContractName} ${clientOrg}`.toLowerCase();
+  const reasons: string[] = [];
+
+  const keywordRules = [
+    { pattern: /test|dummy|demo|sample|staging|qa|fixture|sandbox/, reason: 'english_test_keyword' },
+    { pattern: /테스트|더미|샘플|검증|데모|임시|리허설|업로드 검증|qa/, reason: 'korean_test_keyword' },
+  ];
+  keywordRules.forEach((rule) => {
+    if (rule.pattern.test(joined)) reasons.push(rule.reason);
+  });
+  if (!id.startsWith('p')) reasons.push('non_standard_project_id');
+  if (!status && !phase) reasons.push('missing_status_phase');
+
+  return {
+    id,
+    name,
+    officialContractName,
+    clientOrg,
+    status,
+    phase,
+    createdAt,
+    likelyTestData: reasons.length > 0,
+    reasons,
+  };
+}
+
+export function extractContractStoragePaths(records: Array<JsonMap | null | undefined>): string[] {
+  const paths = new Set<string>();
+  for (const record of records) {
+    if (!record) continue;
+    collectStoragePath(paths, record.contractDocument);
+    if (record.payload && typeof record.payload === 'object') {
+      collectStoragePath(paths, (record.payload as JsonMap).contractDocument);
+    }
+  }
+  return [...paths].sort((a, b) => safeLocaleCompare(a, b));
+}
+
+async function buildMigrationPlan(options: {
+  sourceDb: FirebaseFirestore.Firestore;
+  orgId: string;
+  manifest: LiveCutoverManifest;
+}): Promise<MigrationPlan> {
+  const { sourceDb, orgId, manifest } = options;
+  const docs = new Map<string, JsonMap>();
+  const summary: Record<string, number> = {};
+
+  const addDoc = (path: string, data: JsonMap) => {
+    const existed = docs.has(path);
+    docs.set(path, data);
+    if (existed) return;
+    const collectionKey = summarizeCollectionPath(path);
+    summary[collectionKey] = (summary[collectionKey] || 0) + 1;
+  };
+
+  const projectRecords: JsonMap[] = [];
+  for (const projectId of manifest.projectIds) {
+    const ref = sourceDb.doc(`orgs/${orgId}/projects/${projectId}`);
+    const snap = await ref.get();
+    if (!snap.exists) {
+      throw new Error(`Project not found in source: ${projectId}`);
+    }
+    const data = stripUndefined(snap.data() || {});
+    projectRecords.push(data);
+    addDoc(ref.path, data);
+
+    if (manifest.includeProjectSubcollections) {
+      for (const subcollection of DEFAULT_SUBCOLLECTIONS) {
+        const subSnap = await ref.collection(subcollection).get();
+        subSnap.forEach((doc) => {
+          addDoc(doc.ref.path, stripUndefined(doc.data() || {}));
+        });
+      }
+    }
+  }
+
+  const projectIdSet = new Set(manifest.projectIds);
+  const requestsToCopy = new Set(manifest.projectRequestIds);
+  const requestRecords: JsonMap[] = [];
+
+  if (manifest.includeProjectRequests || requestsToCopy.size > 0) {
+    const requestSnap = await sourceDb.collection(`orgs/${orgId}/project_requests`).get();
+    requestSnap.forEach((doc) => {
+      const data = stripUndefined(doc.data() || {});
+      const approvedProjectId = normalizeString(data.approvedProjectId);
+      if (projectIdSet.has(approvedProjectId) || requestsToCopy.has(doc.id)) {
+        requestRecords.push(data);
+        addDoc(doc.ref.path, data);
+      }
+    });
+  }
+
+  const ledgers = await fetchDocsByProjectId(sourceDb, `orgs/${orgId}/ledgers`, manifest.projectIds);
+  ledgers.forEach((item) => addDoc(item.path, item.data));
+
+  const transactions = await fetchDocsByProjectId(sourceDb, `orgs/${orgId}/transactions`, manifest.projectIds);
+  transactions.forEach((item) => addDoc(item.path, item.data));
+  const transactionIds = transactions.map((item) => item.id);
+
+  if (manifest.includeWeeklySubmissionStatus) {
+    const weekly = await fetchDocsByProjectId(sourceDb, `orgs/${orgId}/weekly_submission_status`, manifest.projectIds);
+    weekly.forEach((item) => addDoc(item.path, item.data));
+  }
+
+  if (manifest.includeCashflowWeeks) {
+    const cashflow = await fetchDocsByProjectId(sourceDb, `orgs/${orgId}/cashflow_weeks`, manifest.projectIds);
+    cashflow.forEach((item) => addDoc(item.path, item.data));
+  }
+
+  if (manifest.includeComments) {
+    const commentsByProject = await fetchDocsByProjectId(sourceDb, `orgs/${orgId}/comments`, manifest.projectIds);
+    commentsByProject.forEach((item) => addDoc(item.path, item.data));
+    if (transactionIds.length > 0) {
+      const commentsByTransaction = await fetchDocsByFieldValues(
+        sourceDb,
+        `orgs/${orgId}/comments`,
+        'transactionId',
+        transactionIds,
+      );
+      commentsByTransaction.forEach((item) => addDoc(item.path, item.data));
+    }
+  }
+
+  if (manifest.includeEvidences && transactionIds.length > 0) {
+    const evidences = await fetchDocsByFieldValues(
+      sourceDb,
+      `orgs/${orgId}/evidences`,
+      'transactionId',
+      transactionIds,
+    );
+    evidences.forEach((item) => addDoc(item.path, item.data));
+  }
+
+  if (manifest.includeAuditLogs) {
+    const auditLogs = await fetchDocsByProjectId(sourceDb, `orgs/${orgId}/audit_logs`, manifest.projectIds);
+    auditLogs.forEach((item) => addDoc(item.path, item.data));
+  }
+
+  const memberSnap = await sourceDb.collection(`orgs/${orgId}/members`).get();
+  memberSnap.forEach((doc) => {
+    const data = stripUndefined(doc.data() || {});
+    if (shouldCopyMemberDoc(data, doc.id, projectIdSet, new Set(manifest.memberUids))) {
+      addDoc(doc.ref.path, sanitizeMemberDocForProjects(data, projectIdSet));
+    }
+  });
+
+  const storagePaths = manifest.includeContractStorage
+    ? extractContractStoragePaths([...projectRecords, ...requestRecords])
+    : [];
+
+  return {
+    docs: [...docs.entries()]
+      .map(([path, data]) => ({ path, data }))
+      .sort((a, b) => safeLocaleCompare(a.path, b.path)),
+    storagePaths,
+    summary,
+  };
+}
+
+function shouldCopyMemberDoc(
+  data: JsonMap,
+  uid: string,
+  projectIds: Set<string>,
+  explicitMemberUids: Set<string>,
+) {
+  if (explicitMemberUids.has(uid)) return true;
+  const primary = normalizeString(data.projectId);
+  if (primary && projectIds.has(primary)) return true;
+  const many = Array.isArray(data.projectIds) ? data.projectIds.map((item) => normalizeString(item)).filter(Boolean) : [];
+  return many.some((item) => projectIds.has(item));
+}
+
+export function sanitizeMemberDocForProjects(data: JsonMap, projectIds: Set<string>) {
+  const next = stripUndefined(data);
+  const filteredProjectIds = Array.isArray(next.projectIds)
+    ? next.projectIds.map((item) => normalizeString(item)).filter((item) => projectIds.has(item))
+    : [];
+  const currentProjectId = normalizeString(next.projectId);
+  const normalizedPrimary = projectIds.has(currentProjectId)
+    ? currentProjectId
+    : filteredProjectIds[0] || '';
+
+  next.projectIds = filteredProjectIds;
+  next.projectId = normalizedPrimary;
+  if (next.projectNames && typeof next.projectNames === 'object') {
+    next.projectNames = Object.fromEntries(
+      Object.entries(next.projectNames as JsonMap).filter(([key]) => projectIds.has(key)),
+    );
+  }
+
+  if (next.portalProfile && typeof next.portalProfile === 'object') {
+    const profile = { ...(next.portalProfile as JsonMap) };
+    const profileProjectIds = Array.isArray(profile.projectIds)
+      ? profile.projectIds.map((item) => normalizeString(item)).filter((item) => projectIds.has(item))
+      : filteredProjectIds;
+    const profileNames = profile.projectNames && typeof profile.projectNames === 'object'
+      ? Object.fromEntries(
+          Object.entries(profile.projectNames as JsonMap).filter(([key]) => projectIds.has(key)),
+        )
+      : {};
+    const profilePrimary = projectIds.has(normalizeString(profile.projectId))
+      ? normalizeString(profile.projectId)
+      : profileProjectIds[0] || normalizedPrimary;
+
+    profile.projectIds = profileProjectIds;
+    profile.projectId = profilePrimary;
+    profile.projectNames = profileNames;
+    next.portalProfile = profile;
+  }
+
+  return next;
+}
+
+async function fetchDocsByProjectId(
+  db: FirebaseFirestore.Firestore,
+  collectionPath: string,
+  projectIds: string[],
+) {
+  return fetchDocsByFieldValues(db, collectionPath, 'projectId', projectIds);
+}
+
+async function fetchDocsByFieldValues(
+  db: FirebaseFirestore.Firestore,
+  collectionPath: string,
+  field: string,
+  values: string[],
+) {
+  const results = new Map<string, { id: string; path: string; data: JsonMap }>();
+  for (const chunk of chunkArray(uniqueStrings(values), 10)) {
+    if (chunk.length === 0) continue;
+    const snap = await db.collection(collectionPath).where(field, 'in', chunk).get();
+    snap.forEach((doc) => {
+      results.set(doc.ref.path, {
+        id: doc.id,
+        path: doc.ref.path,
+        data: stripUndefined(doc.data() || {}),
+      });
+    });
+  }
+  return [...results.values()];
+}
+
+async function writeDocs(db: FirebaseFirestore.Firestore, docs: PlannedDoc[]) {
+  const BATCH_SIZE = 300;
+  for (let index = 0; index < docs.length; index += BATCH_SIZE) {
+    const chunk = docs.slice(index, index + BATCH_SIZE);
+    const batch = db.batch();
+    chunk.forEach((item) => {
+      batch.set(db.doc(item.path), item.data, { merge: true });
+    });
+    await batch.commit();
+    console.log(`  - wrote batch ${Math.floor(index / BATCH_SIZE) + 1}: ${chunk.length} docs`);
+  }
+}
+
+async function copyStorageObjects(options: {
+  sourceApp: import('firebase-admin/app').App;
+  destApp: import('firebase-admin/app').App;
+  sourceProjectId: string;
+  destProjectId: string;
+  storagePaths: string[];
+}) {
+  const { sourceApp, destApp, sourceProjectId, destProjectId, storagePaths } = options;
+  if (storagePaths.length === 0) return;
+
+  const { getStorage } = await import('firebase-admin/storage');
+  const sourceBucketName = process.env.SOURCE_FIREBASE_STORAGE_BUCKET || `${sourceProjectId}.firebasestorage.app`;
+  const destBucketName = process.env.DEST_FIREBASE_STORAGE_BUCKET || `${destProjectId}.firebasestorage.app`;
+  const sourceBucket = getStorage(sourceApp).bucket(sourceBucketName);
+  const destBucket = getStorage(destApp).bucket(destBucketName);
+
+  for (const storagePath of storagePaths) {
+    await sourceBucket.file(storagePath).copy(destBucket.file(storagePath));
+    console.log(`  - copied storage object: ${storagePath}`);
+  }
+}
+
+function initNamedAdminApp(
+  admin: typeof import('firebase-admin').default,
+  appName: string,
+  options: { projectId: string; envPrefix: 'SOURCE' | 'DEST' },
+) {
+  const existing = admin.apps.find((app) => app.name === appName);
+  if (existing) return existing;
+
+  const serviceAccount = readServiceAccount(options.envPrefix);
+  if (serviceAccount) {
+    return admin.initializeApp(
+      {
+        credential: admin.credential.cert(serviceAccount as any),
+        projectId: options.projectId,
+        storageBucket: process.env[`${options.envPrefix}_FIREBASE_STORAGE_BUCKET`] || undefined,
+      },
+      appName,
+    );
+  }
+
+  return admin.initializeApp(
+    {
+      credential: admin.credential.applicationDefault(),
+      projectId: options.projectId,
+      storageBucket: process.env[`${options.envPrefix}_FIREBASE_STORAGE_BUCKET`] || undefined,
+    },
+    appName,
+  );
+}
+
+function readServiceAccount(prefix: 'SOURCE' | 'DEST') {
+  const jsonValue = normalizeString(process.env[`${prefix}_FIREBASE_SERVICE_ACCOUNT_JSON`]);
+  if (jsonValue) {
+    return normalizeServiceAccount(JSON.parse(jsonValue));
+  }
+
+  const base64Value = normalizeString(process.env[`${prefix}_FIREBASE_SERVICE_ACCOUNT_BASE64`]);
+  if (base64Value) {
+    return normalizeServiceAccount(JSON.parse(Buffer.from(base64Value, 'base64').toString('utf8')));
+  }
+
+  const pathValue = normalizeString(process.env[`${prefix}_FIREBASE_SERVICE_ACCOUNT_PATH`]);
+  if (pathValue) {
+    return normalizeServiceAccount(JSON.parse(readFileSync(resolve(pathValue), 'utf8')));
+  }
+
+  return null;
+}
+
+function normalizeServiceAccount(raw: JsonMap | null) {
+  if (!raw) return null;
+  const next = { ...raw };
+  if (typeof next.private_key === 'string') {
+    next.private_key = next.private_key.replace(/\\n/g, '\n');
+  }
+  return next;
+}
+
+function loadEnvFiles(paths: string[]) {
+  for (const filePath of paths) {
+    if (!existsSync(filePath)) continue;
+    const lines = readFileSync(filePath, 'utf8').split(/\r?\n/);
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const eq = trimmed.indexOf('=');
+      if (eq <= 0) continue;
+      const key = trimmed.slice(0, eq).trim();
+      if (process.env[key]) continue;
+      let value = trimmed.slice(eq + 1).trim();
+      if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1);
+      }
+      process.env[key] = value;
+    }
+  }
+}
+
+function collectStoragePath(bucket: Set<string>, docValue: unknown) {
+  if (!docValue || typeof docValue !== 'object') return;
+  const path = normalizeString((docValue as JsonMap).path);
+  if (path) bucket.add(path);
+}
+
+function summarizeCollectionPath(path: string) {
+  const parts = path.split('/');
+  return parts[parts.length - 2] || path;
+}
+
+function stripUndefined(input: JsonMap): JsonMap {
+  return JSON.parse(JSON.stringify(input)) as JsonMap;
+}
+
+function requiredValue(value: string | undefined, name: string) {
+  const normalized = normalizeString(value);
+  if (!normalized) throw new Error(`Missing required value: ${name}`);
+  return normalized;
+}
+
+function normalizeBoolean(value: unknown, fallback: boolean) {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true') return true;
+    if (normalized === 'false') return false;
+  }
+  return fallback;
+}
+
+function normalizeString(value: unknown) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function uniqueStrings(values: unknown) {
+  const items = Array.isArray(values) ? values : [];
+  return [...new Set(items.map((item) => normalizeString(item)).filter(Boolean))];
+}
+
+function chunkArray<T>(items: T[], size: number) {
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+function safeLocaleCompare(left: string, right: string) {
+  return left.localeCompare(right, 'ko');
+}
+
+function isEntrypoint() {
+  const entryArg = process.argv[1];
+  if (!entryArg) return false;
+  return pathToFileURL(resolve(entryArg)).href === import.meta.url;
+}
+
+function getFlagValue(flag: string) {
+  const index = args.indexOf(flag);
+  if (index === -1 || index + 1 >= args.length) return undefined;
+  return args[index + 1];
+}
+
+function printHelp() {
+  console.log(`Usage:
+  npx tsx scripts/firestore_live_cutover.ts discover --source-project <firebaseProjectId> [--org mysc] [--out file]
+  npx tsx scripts/firestore_live_cutover.ts migrate --manifest <manifest.json> --source-project <sourceId> --dest-project <destId> [--commit]
+
+Environment variables:
+  SOURCE_FIREBASE_PROJECT_ID
+  DEST_FIREBASE_PROJECT_ID
+  SOURCE_FIREBASE_SERVICE_ACCOUNT_JSON | SOURCE_FIREBASE_SERVICE_ACCOUNT_BASE64 | SOURCE_FIREBASE_SERVICE_ACCOUNT_PATH
+  DEST_FIREBASE_SERVICE_ACCOUNT_JSON   | DEST_FIREBASE_SERVICE_ACCOUNT_BASE64   | DEST_FIREBASE_SERVICE_ACCOUNT_PATH
+  SOURCE_FIREBASE_STORAGE_BUCKET
+  DEST_FIREBASE_STORAGE_BUCKET
+
+Notes:
+  - migrate defaults to dry-run unless --commit is passed.
+  - contract PDFs referenced by project/project_request docs are copied when includeContractStorage is true.
+`);
+}

--- a/src/app/platform/firestore-live-cutover.test.ts
+++ b/src/app/platform/firestore-live-cutover.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildProjectDiscoveryEntry,
+  extractContractStoragePaths,
+  normalizeManifest,
+  sanitizeMemberDocForProjects,
+} from '../../../scripts/firestore_live_cutover';
+
+describe('normalizeManifest', () => {
+  it('applies safe defaults', () => {
+    const manifest = normalizeManifest({
+      orgId: 'mysc',
+      projectIds: ['p1', 'p1', 'p2'],
+    });
+
+    expect(manifest.projectIds).toEqual(['p1', 'p2']);
+    expect(manifest.includeProjectRequests).toBe(true);
+    expect(manifest.includeAuditLogs).toBe(false);
+    expect(manifest.includeContractStorage).toBe(true);
+  });
+
+  it('throws when no project ids are provided', () => {
+    expect(() => normalizeManifest({ orgId: 'mysc', projectIds: [] })).toThrow(/projectIds/);
+  });
+});
+
+describe('buildProjectDiscoveryEntry', () => {
+  it('flags likely test data using name heuristics', () => {
+    const entry = buildProjectDiscoveryEntry('demo-1', {
+      name: '업로드 검증 프로젝트',
+      clientOrg: '테스트 기관',
+    });
+
+    expect(entry.likelyTestData).toBe(true);
+    expect(entry.reasons).toContain('korean_test_keyword');
+    expect(entry.reasons).toContain('non_standard_project_id');
+  });
+
+  it('does not flag a normal live project by default', () => {
+    const entry = buildProjectDiscoveryEntry('p1773638600519', {
+      name: '경기사경(환경)',
+      officialContractName: '2025 경기도사회적경제원 사회환경 문제해결 지원사업',
+      status: 'CONTRACT_PENDING',
+      phase: 'CONFIRMED',
+    });
+
+    expect(entry.likelyTestData).toBe(false);
+    expect(entry.reasons).toEqual([]);
+  });
+});
+
+describe('extractContractStoragePaths', () => {
+  it('collects unique storage paths from project and request payload docs', () => {
+    const paths = extractContractStoragePaths([
+      {
+        contractDocument: {
+          path: 'orgs/mysc/project-request-contracts/u1/a.pdf',
+        },
+      },
+      {
+        payload: {
+          contractDocument: {
+            path: 'orgs/mysc/project-request-contracts/u1/b.pdf',
+          },
+        },
+      },
+      {
+        contractDocument: {
+          path: 'orgs/mysc/project-request-contracts/u1/a.pdf',
+        },
+      },
+    ]);
+
+    expect(paths).toEqual([
+      'orgs/mysc/project-request-contracts/u1/a.pdf',
+      'orgs/mysc/project-request-contracts/u1/b.pdf',
+    ]);
+  });
+});
+
+describe('sanitizeMemberDocForProjects', () => {
+  it('removes unrelated project ids from member docs', () => {
+    const next = sanitizeMemberDocForProjects(
+      {
+        projectId: 'import-projects-1',
+        projectIds: ['import-projects-1', 'p1773651024850'],
+        projectNames: {
+          'import-projects-1': '더미',
+          p1773651024850: '2026 다자간협력',
+        },
+        portalProfile: {
+          projectId: 'import-projects-1',
+          projectIds: ['import-projects-1', 'p1773651024850'],
+          projectNames: {
+            'import-projects-1': '더미',
+            p1773651024850: '2026 다자간협력',
+          },
+        },
+      },
+      new Set(['p1773651024850']),
+    );
+
+    expect(next.projectId).toBe('p1773651024850');
+    expect(next.projectIds).toEqual(['p1773651024850']);
+    expect(next.projectNames).toEqual({
+      p1773651024850: '2026 다자간협력',
+    });
+    expect(next.portalProfile).toEqual({
+      projectId: 'p1773651024850',
+      projectIds: ['p1773651024850'],
+      projectNames: {
+        p1773651024850: '2026 다자간협력',
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- 더미/검증 데이터가 섞인 기존 Firebase 프로젝트 대신 새 운영 프로젝트로 선별 이관하는 스크립트 추가
- manifest 기반으로 이관 범위를 dry-run/commit으로 단계적으로 검토 가능
- 이관 절차 가이드 문서(`Firebase-Live-Cutover-Runbook.md`) 포함

## Test plan
- [ ] `firestore:live-cutover` 스크립트 dry-run 실행 확인
- [ ] manifest 샘플 기반 이관 범위 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)