### PR TITLE
chore: GitHub Actions CI + Firestore rules hardening + Ctrl+X

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - run: npm ci
+
+      - name: Unit tests
+        run: npm test
+
+      - name: RBAC policy verify
+        run: npm run policy:verify
+
+      - name: Production build
+        run: npm run build

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -67,15 +67,13 @@ service cloud.firestore {
     }
 
     function canReadProjectResource(orgId, projectId) {
-      // Internal MYSC rollout mode: once authenticated with a company account,
-      // all project-scoped portal resources are readable without member/project mapping.
-      return isSignedIn();
+      return isSignedIn()
+        && (isPrivileged(orgId) || isProjectAssigned(orgId, projectId));
     }
 
     function canWriteProjectResource(orgId, projectId) {
-      // Internal MYSC rollout mode: allow all signed-in company users to use
-      // project-scoped portal features without per-project assignment.
-      return isSignedIn();
+      return isSignedIn()
+        && (isPrivileged(orgId) || (role(orgId) == 'pm' && isProjectAssigned(orgId, projectId)));
     }
 
     function projectIdFromTransaction(orgId, txId) {

--- a/src/app/components/cashflow/SettlementLedgerPage.tsx
+++ b/src/app/components/cashflow/SettlementLedgerPage.tsx
@@ -1792,6 +1792,17 @@ function ImportEditor({
         },
       },
       {
+        combo: { key: 'x', mod: true },
+        run: (_ev) => {
+          if (!selection) return false;
+          // Copy first
+          handleCopy(_ev as unknown as KeyboardEvent<HTMLDivElement>);
+          // Then clear
+          void clearSelectedCells();
+          return true;
+        },
+      },
+      {
         combo: { key: 'Escape' },
         run: (_ev) => {
           if (!selectionRef.current) return false;


### PR DESCRIPTION
## Summary (Phase 2 Sprint 2+4)
- **CI**: `.github/workflows/ci.yml` — PR마다 test + policy:verify + build
- **보안**: Firestore `canReadProjectResource` → privileged OR project assigned
- **보안**: Firestore `canWriteProjectResource` → privileged OR (PM AND assigned)
- **UX**: Ctrl+X 잘라내기 (copy → clear)

## Test plan
- [x] `npm test` — 64 passed, 0 failed
- [x] `npm run build` — 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)