### PR TITLE
feat(hr): HR domain MVP — types, rules, admin + portal pages

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -566,6 +566,28 @@ service cloud.firestore {
       allow update, delete: if false;
     }
 
+    // ── HR: Employees ──
+    match /orgs/{orgId}/hr_employees/{employeeId} {
+      allow read: if isSignedIn() && (isPrivileged(orgId) || request.auth.uid == resource.data.uid);
+      allow create, update: if isSignedIn() && isPrivileged(orgId) && requestHasValidTenant(orgId);
+      allow delete: if isSignedIn() && isAdmin(orgId);
+    }
+
+    // ── HR: Contracts ──
+    match /orgs/{orgId}/hr_contracts/{contractId} {
+      allow read: if isSignedIn() && isPrivileged(orgId);
+      allow create, update: if isSignedIn() && isPrivileged(orgId) && requestHasValidTenant(orgId);
+      allow delete: if isSignedIn() && isAdmin(orgId);
+    }
+
+    // ── HR: Leave requests ──
+    match /orgs/{orgId}/hr_leaves/{leaveId} {
+      allow read: if isSignedIn() && (isPrivileged(orgId) || request.auth.uid == resource.data.employeeUid);
+      allow create: if isSignedIn() && requestHasValidTenant(orgId);
+      allow update: if isSignedIn() && (isPrivileged(orgId) || request.auth.uid == resource.data.employeeUid);
+      allow delete: if isSignedIn() && isAdmin(orgId);
+    }
+
     match /orgs/{orgId}/{document=**} {
       allow read: if isSignedIn() && resourceHasValidTenant(orgId);
       allow create: if isSignedIn() && isAdmin(orgId) && requestHasValidTenant(orgId);

--- a/src/app/components/hr/HrEmployeeListPage.tsx
+++ b/src/app/components/hr/HrEmployeeListPage.tsx
@@ -1,0 +1,120 @@
+import { Plus, Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import type { HrEmployee } from '../../data/hr-types';
+import { EMPLOYMENT_STATUS_LABELS, CONTRACT_TYPE_LABELS } from '../../data/hr-types';
+import { Badge } from '../ui/badge';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+
+const STATUS_BADGE_CLS: Record<string, string> = {
+  ACTIVE: 'bg-emerald-100 text-emerald-700',
+  ON_LEAVE: 'bg-amber-100 text-amber-700',
+  RESIGNED: 'bg-slate-100 text-slate-500',
+  TERMINATED: 'bg-red-100 text-red-700',
+};
+
+interface HrEmployeeListPageProps {
+  employees: HrEmployee[];
+  onSelect: (employee: HrEmployee) => void;
+  onAdd: () => void;
+}
+
+export function HrEmployeeListPage({ employees, onSelect, onAdd }: HrEmployeeListPageProps) {
+  const [search, setSearch] = useState('');
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return employees;
+    const q = search.toLowerCase();
+    return employees.filter(
+      (e) =>
+        e.name.toLowerCase().includes(q)
+        || e.email.toLowerCase().includes(q)
+        || e.department.toLowerCase().includes(q)
+        || e.position.toLowerCase().includes(q),
+    );
+  }, [employees, search]);
+
+  const counts = useMemo(() => {
+    const map: Record<string, number> = {};
+    for (const e of employees) {
+      map[e.employmentStatus] = (map[e.employmentStatus] || 0) + 1;
+    }
+    return map;
+  }, [employees]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-bold">직원 관리</h2>
+          <div className="flex gap-2 mt-1">
+            {Object.entries(EMPLOYMENT_STATUS_LABELS).map(([key, label]) => (
+              <span key={key} className="text-xs text-muted-foreground">
+                {label} {counts[key] || 0}명
+              </span>
+            ))}
+          </div>
+        </div>
+        <Button size="sm" onClick={onAdd} className="gap-1">
+          <Plus className="h-3.5 w-3.5" />
+          직원 등록
+        </Button>
+      </div>
+
+      <div className="relative">
+        <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+        <Input
+          placeholder="이름, 이메일, 부서, 직위로 검색..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="pl-9 h-9"
+        />
+      </div>
+
+      <div className="border rounded-lg overflow-hidden">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="bg-muted/50 border-b">
+              <th className="text-left px-3 py-2 font-medium">이름</th>
+              <th className="text-left px-3 py-2 font-medium">부서</th>
+              <th className="text-left px-3 py-2 font-medium">직위</th>
+              <th className="text-left px-3 py-2 font-medium">계약유형</th>
+              <th className="text-left px-3 py-2 font-medium">입사일</th>
+              <th className="text-center px-3 py-2 font-medium">상태</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((emp) => (
+              <tr
+                key={emp.id}
+                className="border-b hover:bg-muted/30 cursor-pointer transition-colors"
+                onClick={() => onSelect(emp)}
+              >
+                <td className="px-3 py-2">
+                  <div className="font-medium">{emp.name}</div>
+                  <div className="text-xs text-muted-foreground">{emp.email}</div>
+                </td>
+                <td className="px-3 py-2 text-muted-foreground">{emp.department}</td>
+                <td className="px-3 py-2 text-muted-foreground">{emp.position}</td>
+                <td className="px-3 py-2 text-muted-foreground">{CONTRACT_TYPE_LABELS[emp.contractType]}</td>
+                <td className="px-3 py-2 text-muted-foreground">{emp.joinDate}</td>
+                <td className="px-3 py-2 text-center">
+                  <Badge className={`text-[10px] ${STATUS_BADGE_CLS[emp.employmentStatus] || ''}`}>
+                    {EMPLOYMENT_STATUS_LABELS[emp.employmentStatus]}
+                  </Badge>
+                </td>
+              </tr>
+            ))}
+            {filtered.length === 0 && (
+              <tr>
+                <td colSpan={6} className="px-3 py-8 text-center text-muted-foreground">
+                  {search ? '검색 결과가 없습니다' : '등록된 직원이 없습니다'}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/portal/PortalHrLeavePage.tsx
+++ b/src/app/components/portal/PortalHrLeavePage.tsx
@@ -1,0 +1,90 @@
+import { CalendarDays, Plus } from 'lucide-react';
+import { useState } from 'react';
+import type { HrLeave } from '../../data/hr-types';
+import { LEAVE_TYPE_LABELS, LEAVE_STATUS_LABELS } from '../../data/hr-types';
+import { Badge } from '../ui/badge';
+import { Button } from '../ui/button';
+
+const STATUS_CLS: Record<string, string> = {
+  PENDING: 'bg-amber-100 text-amber-700',
+  APPROVED: 'bg-emerald-100 text-emerald-700',
+  REJECTED: 'bg-red-100 text-red-700',
+  CANCELLED: 'bg-slate-100 text-slate-500',
+};
+
+interface PortalHrLeavePageProps {
+  leaves: HrLeave[];
+  remainingAnnual: number;
+  onRequestLeave: () => void;
+}
+
+export function PortalHrLeavePage({ leaves, remainingAnnual, onRequestLeave }: PortalHrLeavePageProps) {
+  const [year] = useState(new Date().getFullYear());
+  const yearLeaves = leaves.filter((l) => l.startDate.startsWith(String(year)));
+
+  const usedDays = yearLeaves
+    .filter((l) => l.status === 'APPROVED')
+    .reduce((sum, l) => sum + l.days, 0);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-bold">연차 관리</h2>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            {year}년 잔여 연차: <span className="font-bold text-foreground">{remainingAnnual}일</span> (사용 {usedDays}일)
+          </p>
+        </div>
+        <Button size="sm" onClick={onRequestLeave} className="gap-1">
+          <Plus className="h-3.5 w-3.5" />
+          연차 신청
+        </Button>
+      </div>
+
+      <div className="border rounded-lg overflow-hidden">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="bg-muted/50 border-b">
+              <th className="text-left px-3 py-2 font-medium">유형</th>
+              <th className="text-left px-3 py-2 font-medium">기간</th>
+              <th className="text-center px-3 py-2 font-medium">일수</th>
+              <th className="text-left px-3 py-2 font-medium">사유</th>
+              <th className="text-center px-3 py-2 font-medium">상태</th>
+            </tr>
+          </thead>
+          <tbody>
+            {yearLeaves.map((leave) => (
+              <tr key={leave.id} className="border-b hover:bg-muted/30">
+                <td className="px-3 py-2">
+                  <div className="flex items-center gap-1.5">
+                    <CalendarDays className="h-3.5 w-3.5 text-muted-foreground" />
+                    {LEAVE_TYPE_LABELS[leave.type]}
+                  </div>
+                </td>
+                <td className="px-3 py-2 text-muted-foreground">
+                  {leave.startDate} ~ {leave.endDate}
+                </td>
+                <td className="px-3 py-2 text-center">{leave.days}일</td>
+                <td className="px-3 py-2 text-muted-foreground truncate max-w-[200px]">
+                  {leave.reason || '-'}
+                </td>
+                <td className="px-3 py-2 text-center">
+                  <Badge className={`text-[10px] ${STATUS_CLS[leave.status] || ''}`}>
+                    {LEAVE_STATUS_LABELS[leave.status]}
+                  </Badge>
+                </td>
+              </tr>
+            ))}
+            {yearLeaves.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-3 py-8 text-center text-muted-foreground">
+                  {year}년 연차 사용 내역이 없습니다
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/data/hr-types.ts
+++ b/src/app/data/hr-types.ts
@@ -1,0 +1,78 @@
+export type EmploymentStatus = 'ACTIVE' | 'ON_LEAVE' | 'RESIGNED' | 'TERMINATED';
+export type ContractType = 'FULL_TIME' | 'PART_TIME' | 'CONTRACT' | 'INTERN';
+export type LeaveType = 'ANNUAL' | 'SICK' | 'MATERNITY' | 'PATERNITY' | 'UNPAID' | 'OTHER';
+export type LeaveStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'CANCELLED';
+
+export interface HrEmployee {
+  id: string;
+  orgId: string;
+  uid: string;
+  name: string;
+  email: string;
+  department: string;
+  position: string;
+  employmentStatus: EmploymentStatus;
+  contractType: ContractType;
+  joinDate: string;
+  resignDate?: string;
+  phone?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface HrContract {
+  id: string;
+  employeeId: string;
+  orgId: string;
+  contractType: ContractType;
+  startDate: string;
+  endDate?: string;
+  salary?: number;
+  notes?: string;
+  createdAt: string;
+}
+
+export interface HrLeave {
+  id: string;
+  employeeId: string;
+  orgId: string;
+  type: LeaveType;
+  status: LeaveStatus;
+  startDate: string;
+  endDate: string;
+  days: number;
+  reason?: string;
+  reviewedBy?: string;
+  reviewedAt?: string;
+  createdAt: string;
+}
+
+export const EMPLOYMENT_STATUS_LABELS: Record<EmploymentStatus, string> = {
+  ACTIVE: '재직',
+  ON_LEAVE: '휴직',
+  RESIGNED: '퇴직',
+  TERMINATED: '해고',
+};
+
+export const CONTRACT_TYPE_LABELS: Record<ContractType, string> = {
+  FULL_TIME: '정규직',
+  PART_TIME: '시간제',
+  CONTRACT: '계약직',
+  INTERN: '인턴',
+};
+
+export const LEAVE_TYPE_LABELS: Record<LeaveType, string> = {
+  ANNUAL: '연차',
+  SICK: '병가',
+  MATERNITY: '출산휴가',
+  PATERNITY: '배우자출산휴가',
+  UNPAID: '무급휴가',
+  OTHER: '기타',
+};
+
+export const LEAVE_STATUS_LABELS: Record<LeaveStatus, string> = {
+  PENDING: '대기',
+  APPROVED: '승인',
+  REJECTED: '반려',
+  CANCELLED: '취소',
+};


### PR DESCRIPTION
## Summary (KR4-1, KR4-4)
- HR 타입: HrEmployee, HrContract, HrLeave + 한국어 라벨
- Firestore rules: hr_employees, hr_contracts, hr_leaves 보안 규칙
- HrEmployeeListPage: Admin 직원 목록 (검색, 부서, 상태 배지)
- PortalHrLeavePage: Portal 연차 관리 (잔여/사용, 신청 내역)

## Test plan
- [x] `npm test` — 64 passed, 0 failed
- [x] `npm run build` — 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)