### PR TITLE
feat: RBAC project-scoped access + audit CSV export

### DIFF
--- a/src/app/components/audit/AuditLogPage.tsx
+++ b/src/app/components/audit/AuditLogPage.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState } from 'react';
 import {
   BookOpen, Shield, Clock, User, FileText, FolderKanban,
   Search, Filter, CheckCircle2, XCircle, AlertTriangle,
-  ArrowUpDown, ChevronDown,
+  ArrowUpDown, ChevronDown, Download,
 } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Badge } from '../ui/badge';
@@ -148,6 +148,28 @@ export function AuditLogPage() {
     return map;
   }, [displayed]);
 
+  const exportCsv = () => {
+    const header = '시각,액션,엔티티,사용자,상세';
+    const rows = filtered.map((log) => {
+      const escape = (v: string) => `"${v.replace(/"/g, '""')}"`;
+      return [
+        log.timestamp,
+        log.action,
+        log.entityType,
+        log.userName || log.userId,
+        escape(log.details || ''),
+      ].join(',');
+    });
+    const csv = [header, ...rows].join('\n');
+    const blob = new Blob(['\uFEFF' + csv], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `audit-log-${new Date().toISOString().slice(0, 10)}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <div className="space-y-5">
       <PageHeader
@@ -156,6 +178,12 @@ export function AuditLogPage() {
         title="감사 로그"
         description="모든 데이터 변경 이력 추적 · 읽기 전용"
         badge={`${allLogs.length}건`}
+        actions={
+          <Button size="sm" variant="outline" onClick={exportCsv} className="gap-1">
+            <Download className="h-3.5 w-3.5" />
+            CSV 내보내기
+          </Button>
+        }
       />
 
       {/* Stats bar */}

--- a/src/app/platform/rbac.test.ts
+++ b/src/app/platform/rbac.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  canAccessProject,
   canAccessTenant,
   extractAuthContextFromClaims,
   hasPermission,
@@ -55,5 +56,22 @@ describe('rbac helpers', () => {
     expect(canAccessTenant({ actorRole: 'pm', actorTenantId: 't1', targetTenantId: 't1' })).toBe(true);
     expect(canAccessTenant({ actorRole: 'pm', actorTenantId: 't1', targetTenantId: 't2' })).toBe(false);
     expect(canAccessTenant({ actorRole: 'support', actorTenantId: 't1', targetTenantId: 't2' })).toBe(true);
+  });
+
+  it('checks project-scoped access based on role and assignment', () => {
+    // Admin can access any project without assignment
+    expect(canAccessProject({ actorRole: 'admin', permission: 'project:read', targetProjectId: 'p1' })).toBe(true);
+    expect(canAccessProject({ actorRole: 'finance', permission: 'project:write', targetProjectId: 'p1' })).toBe(true);
+
+    // PM needs assignment
+    expect(canAccessProject({ actorRole: 'pm', permission: 'project:write', targetProjectId: 'p1', assignedProjectIds: ['p1', 'p2'] })).toBe(true);
+    expect(canAccessProject({ actorRole: 'pm', permission: 'project:write', targetProjectId: 'p3', assignedProjectIds: ['p1', 'p2'] })).toBe(false);
+
+    // Viewer cannot write even with assignment
+    expect(canAccessProject({ actorRole: 'viewer', permission: 'project:write', targetProjectId: 'p1', assignedProjectIds: ['p1'] })).toBe(false);
+
+    // Viewer can read with assignment
+    expect(canAccessProject({ actorRole: 'viewer', permission: 'project:read', targetProjectId: 'p1', assignedProjectIds: ['p1'] })).toBe(true);
+    expect(canAccessProject({ actorRole: 'viewer', permission: 'project:read', targetProjectId: 'p2', assignedProjectIds: ['p1'] })).toBe(false);
   });
 });

--- a/src/app/platform/rbac.ts
+++ b/src/app/platform/rbac.ts
@@ -136,6 +136,29 @@ export function hasPermission(
   return granted.has(permission);
 }
 
+export type ProjectScopedPermission = 'project:read' | 'project:write' | 'project:evidence_drive:write';
+
+const CROSS_PROJECT_ROLES: PlatformRole[] = ['admin', 'finance', 'support', 'security', 'tenant_admin', 'auditor'];
+
+export function canAccessProject(options: {
+  actorRole: PlatformRole;
+  permission: ProjectScopedPermission;
+  assignedProjectIds?: string[];
+  targetProjectId: string;
+  extraPermissions?: PlatformPermission[];
+}): boolean {
+  if (!hasPermission(options.actorRole, options.permission, options.extraPermissions)) {
+    return false;
+  }
+  if (CROSS_PROJECT_ROLES.includes(options.actorRole)) {
+    return true;
+  }
+  if (!options.assignedProjectIds || options.assignedProjectIds.length === 0) {
+    return false;
+  }
+  return options.assignedProjectIds.includes(options.targetProjectId);
+}
+
 export function canAccessTenant(options: {
   actorRole: PlatformRole;
   actorTenantId?: string;


### PR DESCRIPTION
## Summary (KR2-1, KR2-4)
- `canAccessProject()`: project-scoped RBAC (privileged → 전체, PM/viewer → 할당 기반)
- AuditLogPage: CSV 내보내기 (BOM UTF-8, 필터링된 결과 기준)
- RBAC 단위 테스트 추가 (canAccessProject 7 assertions)

## Test plan
- [x] `npm test` — 64 passed (278 tests, +1 new)
- [x] `npm run build` — 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)