### PR TITLE
test(e2e): 10 Playwright smoke scenarios for core flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "vite",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "npx playwright test --config playwright.harness.config.mjs",
     "bff:dev": "node server/bff/server.mjs",
     "bff:seed:demo": "node scripts/bff_seed_demo_data.mjs",
     "bff:test:integration": "bash scripts/test_bff_integration.sh",

--- a/tests/e2e/platform-smoke.spec.ts
+++ b/tests/e2e/platform-smoke.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect } from '@playwright/test';
+
+// ── Helper: dev auth harness login ──
+async function loginAsPm(page: import('@playwright/test').Page) {
+  await page.goto('/login');
+  await page.getByRole('button', { name: 'PM 샘플 로그인' }).click();
+  await expect(page).toHaveURL(/\/portal(?:$|\/)/);
+}
+
+async function loginAsAdmin(page: import('@playwright/test').Page) {
+  await page.goto('/login');
+  await page.getByRole('button', { name: '관리자 샘플 로그인' }).click();
+  await expect(page).toHaveURL(/^\//);
+}
+
+// ── 1. Login ──
+test('1. PM can login via dev auth harness', async ({ page }) => {
+  await loginAsPm(page);
+  await expect(page.locator('body')).toBeVisible();
+});
+
+test('2. Admin can login via dev auth harness', async ({ page }) => {
+  await loginAsAdmin(page);
+  await expect(page.locator('body')).toBeVisible();
+});
+
+// ── 3. Dashboard ──
+test('3. Admin dashboard loads with project stats', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/');
+  await expect(page.getByText('대시보드').first()).toBeVisible({ timeout: 15_000 });
+});
+
+// ── 4. Project list ──
+test('4. Admin can view project list', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/projects');
+  await expect(page.getByText('프로젝트').first()).toBeVisible({ timeout: 15_000 });
+});
+
+// ── 5. Cashflow ──
+test('5. Admin can navigate to cashflow page', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/cashflow');
+  await expect(page.locator('body')).toBeVisible({ timeout: 15_000 });
+});
+
+// ── 6. Portal weekly expenses ──
+test('6. PM can access weekly expense page', async ({ page }) => {
+  await loginAsPm(page);
+  await page.goto('/portal/weekly-expenses');
+  await expect(page.getByRole('heading', { name: '사업비 입력(주간)' })).toBeVisible({ timeout: 15_000 });
+});
+
+// ── 7. Portal budget ──
+test('7. PM can access budget page', async ({ page }) => {
+  await loginAsPm(page);
+  await page.goto('/portal/budget');
+  await expect(page.locator('body')).toBeVisible({ timeout: 15_000 });
+});
+
+// ── 8. Audit log ──
+test('8. Admin can view audit log', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/audit');
+  await expect(page.getByText('감사 로그').first()).toBeVisible({ timeout: 15_000 });
+});
+
+// ── 9. Settings ──
+test('9. Admin can access settings', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/settings');
+  await expect(page.locator('body')).toBeVisible({ timeout: 15_000 });
+});
+
+// ── 10. 404 handling ──
+test('10. Unknown route shows 404 page', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/nonexistent-page');
+  await expect(page.getByText(/404|찾을 수 없|존재하지 않/).first()).toBeVisible({ timeout: 15_000 });
+});


### PR DESCRIPTION
## Summary (KR1-3)
- 10 E2E Playwright smoke 시나리오 (login, dashboard, projects, cashflow, weekly expenses, budget, audit, settings, 404)
- `npm run test:e2e` 스크립트 추가
- dev auth harness 기반 (PM 샘플/관리자 샘플 로그인)

## Test plan
- [x] `npm test` — 66 passed (301 unit tests)
- [x] `npm run build` — 성공
- [ ] `npm run test:e2e` — dev server 환경에서 실행 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)