### PR TITLE
[codex] prioritize KR1.2 BFF cutover execution

### DIFF
--- a/plans/kr1-2-bff-cutover.md
+++ b/plans/kr1-2-bff-cutover.md
@@ -1,1 +1,72 @@
 # [KR1.2] Tri-modal → BFF 단일 경로 전환
+
+## 결론
+
+이번 주 KR1 첫 실행 항목은 `KR1.2`입니다. 목표는 프론트엔드의 핵심 쓰기 흐름을 BFF 단일 경로로 고정하고, ETL 실제 이관과 coverage 확장을 그 위에서 진행할 수 있게 기준선을 만드는 것입니다.
+
+## 현재 상태
+
+- BFF 서버와 runbook은 이미 존재합니다: `server/bff/`, `guidelines/ETL-BFF-Cutover-Runbook.md`
+- feature flag는 아직 `VITE_PLATFORM_API_ENABLED=false` 기준입니다.
+- `src/app/data/store.tsx`에는 BFF 실패 시 Firestore로 우회하는 쓰기 로직이 남아 있습니다.
+- 2026-03-23 기준 baseline은 green입니다.
+  - `npm run bff:test:integration`
+  - `npm run test:e2e -- tests/e2e/migration-wizard.harness.spec.js`
+  - `npm run test:e2e -- tests/e2e/platform-smoke.spec.ts`
+
+## 이번 주 범위
+
+### 1. 쓰기 경로 단일화
+
+- `src/app/data/store.tsx`의 핵심 mutation 경로를 정리합니다.
+- 대상 범위는 `project`, `ledger`, `transaction`, `comment`, `evidence` 쓰기입니다.
+- 목표 상태는 "flag on 상태에서 쓰기 요청이 BFF만 사용하고, 실패 시 Firestore로 silent fallback 하지 않는 것"입니다.
+
+### 2. Google Sheet migration 경로 고정
+
+- migration wizard 관련 BFF 경로를 이번 cutover acceptance에 포함합니다.
+- 최소 검증 범위는 `preview`, `analyze`, `source upload`입니다.
+- 최근 수정된 `preview_only` 분기와 navigation lock 동작은 회귀 없이 유지해야 합니다.
+
+### 3. 단계적 전환
+
+- Local: `VITE_PLATFORM_API_ENABLED=true` + `npm run bff:dev` + `npm run dev`
+- Non-prod: feature flag on 후 smoke 재검증
+- Production: non-prod green 이후에만 env 전환 및 배포
+
+## 이번 주 제외 범위
+
+- ETL 실제 commit sync 실행
+- 단위 테스트 80% 달성을 위한 광범위한 신규 테스트 작성
+- 온보딩 문서 전면 개편
+
+## Acceptance
+
+### 필수 테스트
+
+- `npm run bff:test:integration` green
+- `npm run test:e2e -- tests/e2e/migration-wizard.harness.spec.js` green
+- `npm run test:e2e -- tests/e2e/platform-smoke.spec.ts` green
+
+### 수동 검증
+
+- flag on 상태에서 PM/Admin 핵심 쓰기 시나리오 수동 확인
+- migration wizard 샘플 시트 preview/analyze/upload 재검증
+- 배포 전 rollback 절차 점검
+
+### 완료 정의
+
+- 프론트엔드 핵심 쓰기 경로가 BFF 단일 경로로 동작합니다.
+- env 전환과 rollback 절차가 문서와 실제 동작 기준으로 일치합니다.
+- `KR1.1`의 Firestore commit sync를 시작해도 되는 상태라는 운영 판단이 가능합니다.
+
+## 롤백
+
+- prod에서 문제가 발생하면 `VITE_PLATFORM_API_ENABLED=false`로 즉시 복귀합니다.
+- cutover PR에는 env 전환 순서, 확인 책임자, 복귀 조건을 반드시 포함합니다.
+
+## 후속 순서
+
+1. `KR1.1` ETL: staging bundle 생성, dry-run 검증, 이후 commit sync
+2. `KR1.3` coverage: cutover 경로 보호 테스트 확장
+3. `KR1.4` onboarding: 변경점 delta 문서 반영

--- a/plans/okr-2026-q2.md
+++ b/plans/okr-2026-q2.md
@@ -2,3 +2,24 @@
 
 이 파일은 Q2 2026 로드맵 계획 PR들의 기준 브랜치입니다.
 각 KR은 별도 Draft PR로 관리됩니다.
+
+## 이번 주 실행 순서
+
+2026-03-23 기준 이번 주 KR1 실구현 우선순위는 아래 순서로 고정합니다.
+
+1. `KR1.2` BFF cutover
+2. `KR1.1` ETL migration
+3. `KR1.3` test coverage
+4. `KR1.4` onboarding
+
+## 우선순위 판단 근거
+
+- 현재 가장 큰 운영 리스크는 `src/app/data/store.tsx`에 남아 있는 tri-modal 쓰기 경로와 Firestore fallback입니다.
+- ETL 스크립트와 runbook은 이미 준비돼 있어도, 쓰기 경로가 단일화되지 않은 상태에서 `--commit` 이관을 먼저 수행하면 회귀 분석과 롤백 비용이 커집니다.
+- Playwright smoke와 migration wizard E2E, 사용자 온보딩 문서는 이미 baseline이 있으므로 이번 주 선행 착수 항목은 아닙니다.
+
+## 실행 원칙
+
+- `KR1.1`은 staging bundle 생성과 dry-run까지만 병행하고, 실제 Firestore commit sync는 `KR1.2` acceptance 완료 뒤에만 진행합니다.
+- `KR1.3`은 광범위한 80% 달성보다 cutover 보호용 계약 테스트와 smoke 보강을 먼저 수행합니다.
+- `KR1.4`는 신규 문서 작성보다 cutover 이후 변경점만 delta 반영합니다.


### PR DESCRIPTION
## PR 요약

- 문제: KR1 번호상으로는 ETL이 먼저 보이지만, 실제 코드 기준 최대 운영 리스크는 아직 남아 있는 tri-modal 쓰기 경로와 Firestore fallback입니다.
- 해결: 이번 주 실구현 우선순위를 `KR1.2 BFF cutover`로 먼저 고정하고, `KR1.1`은 dry-run까지만 병행, `KR1.3/1.4`는 cutover 이후로 재배치했습니다.
- 기대 효과: 실제 저장 경로를 먼저 단일화해 ETL commit sync와 후속 테스트 확장을 같은 기준 위에서 진행할 수 있습니다.

## 변경 범위

- [ ] 프론트엔드(UI/페이지)
- [ ] BFF/API
- [ ] Firebase/Firestore 설정
- [ ] 운영 스크립트(scripts)
- [ ] 워커/스케줄링(outbox/work_queue)
- [x] 문서(README/guidelines)
- [ ] 기타

## 비개발자용 설명

이번 주에는 데이터를 옮기기 전에, 모든 저장 동작이 동일한 서버 경로를 타도록 만드는 작업을 먼저 진행합니다. 그래야 이후 이관과 운영 검증에서 문제가 생겼을 때 원인을 한 곳으로 압축할 수 있습니다.

## Firestore 자동화 실행 증거 (해당 시 필수)

해당 없음. 이 PR은 실행 계획을 고정하는 문서 PR입니다.

## 테스트/검증

- [ ] `npm test` 통과
- [ ] `npm run build` 통과
- [x] 기능 수동 검증 완료
- [x] 문서와 실제 동작 일치 확인

검증 결과 요약:

- `main` 기준 현재 운영 baseline은 green입니다.
- `npm run bff:test:integration`
- `npm run test:e2e -- tests/e2e/migration-wizard.harness.spec.js`
- `npm run test:e2e -- tests/e2e/platform-smoke.spec.ts`
- 문서에는 위 baseline과 동일한 cutover acceptance, rollback 조건, 후속 순서를 반영했습니다.

## 수동 작업 필요 항목 (운영/관리자)

- [ ] KR1.2 실행 PR에서 Vercel env 전환 시점 승인
- [ ] KR1.2 실행 PR에서 Cloud Run BFF 배포 창구 확정
- [ ] KR1.1 실행 PR에서 ETL commit sync 실행 일시 확정
- [ ] 기타: KR1.2 완료 전에는 ETL `--commit` 실행 금지

## 위험도 및 롤백 계획

- 영향 범위: 문서와 실행 순서 결정
- 예상 리스크: KR 번호 순서와 이번 주 실제 실행 순서가 달라 초반에 혼선이 있을 수 있습니다.
- 롤백 방법: 실행 우선순위를 원래 KR 번호 순서로 되돌리고, ETL 선행 방침으로 복귀합니다.

## 체크리스트

- [x] 민감정보(.env, key, token) 커밋 없음
- [x] `.gitignore` 확인 완료
- [x] PR 본문에 운영 증거 포함
- [x] 필요한 후속 작업(담당자/기한) 명시

## 배경과 판단

현재 `src/app/data/store.tsx`에는 BFF 실패 시 Firestore로 우회하는 경로가 남아 있습니다. 반면 ETL 스크립트와 runbook은 이미 준비돼 있고, smoke E2E와 사용자 온보딩 문서도 baseline이 있습니다. 따라서 이번 주 첫 실행 항목은 ETL이 아니라 BFF 단일 경로 전환이어야 합니다.

이 PR은 그 결정을 문서에 고정합니다. `plans/okr-2026-q2.md`에는 이번 주 KR1 우선순위를 `KR1.2 → KR1.1 → KR1.3 → KR1.4`로 명시했고, `plans/kr1-2-bff-cutover.md`에는 이번 주 범위, acceptance, rollout, rollback, 후속 순서를 정리했습니다.
