### PR TITLE
[codex] streamline weekly submission checklist UX

### DIFF
--- a/src/app/components/portal/PortalSubmissionsPage.tsx
+++ b/src/app/components/portal/PortalSubmissionsPage.tsx
@@ -5,8 +5,7 @@ import { PageHeader } from '../layout/PageHeader';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
-import { Checkbox } from '../ui/checkbox';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -57,7 +56,27 @@ function formatKstDateTime(value: string | undefined): { date: string; time: str
   };
 }
 
-function StatusAuditMeta(props: {
+function pickLatestAuditMeta(props: {
+  editedAt?: string;
+  editedByName?: string;
+  updatedAt?: string;
+  updatedByName?: string;
+}) {
+  const items = [
+    props.updatedAt
+      ? { title: '최종 제출 반영', at: props.updatedAt, byName: props.updatedByName || '-' }
+      : null,
+    props.editedAt
+      ? { title: '최종 수정 상태 반영', at: props.editedAt, byName: props.editedByName || '-' }
+      : null,
+  ].filter(Boolean) as Array<{ title: string; at: string; byName: string }>;
+
+  if (items.length === 0) return null;
+  items.sort((left, right) => String(right.at).localeCompare(String(left.at)));
+  return items[0];
+}
+
+function AuditMetaLine(props: {
   title: string;
   at?: string;
   byName?: string;
@@ -66,15 +85,15 @@ function StatusAuditMeta(props: {
   if (!formatted && !props.byName) return null;
 
   return (
-    <div className="mt-1.5 rounded-md border border-border/40 bg-muted/20 px-2 py-1.5 text-left text-[9px] leading-4 text-muted-foreground">
+    <div className="pt-1.5 text-left text-[9px] leading-4 text-muted-foreground">
       <div className="text-foreground/80" style={{ fontWeight: 700 }}>{props.title}</div>
       {formatted && (
         <div className="mt-0.5">
           <div>{formatted.date}</div>
-          <div>{formatted.time}</div>
+          <div>{formatted.time} · {props.byName || '-'}</div>
         </div>
       )}
-      <div className="mt-0.5">처리자 {props.byName || '-'}</div>
+      {!formatted && <div className="mt-0.5">{props.byName || '-'}</div>}
     </div>
   );
 }
@@ -317,8 +336,13 @@ export function PortalSubmissionsPage() {
             )}
           </div>
 
-          <div className="text-[10px] text-muted-foreground">
-            수정 여부는 드롭다운으로 직접 선택하고, 하단 상태는 제출 체크 여부를 표시합니다.
+          <div className="flex flex-wrap items-center gap-2 text-[10px] text-muted-foreground">
+            <span className="inline-flex items-center rounded-full bg-sky-500/10 px-2 py-0.5 text-sky-700 dark:text-sky-300" style={{ fontWeight: 700 }}>
+              수정 상태 직접 선택
+            </span>
+            <span className="inline-flex items-center rounded-full bg-emerald-500/10 px-2 py-0.5 text-emerald-700 dark:text-emerald-300" style={{ fontWeight: 700 }}>
+              제출 상태 별도 체크
+            </span>
           </div>
 
           <div className="overflow-x-auto">
@@ -339,103 +363,107 @@ export function PortalSubmissionsPage() {
                   const expenseDone = Boolean(status?.expenseUpdated);
                   const projectionEdited = resolveEditedState(status?.projectionEdited, hasWeekAmounts(weekSheet?.projection));
                   const expenseEdited = resolveEditedState(status?.expenseEdited, hasWeekAmounts(weekSheet?.actual));
+                  const projectionAudit = pickLatestAuditMeta({
+                    editedAt: status?.projectionEditedAt,
+                    editedByName: status?.projectionEditedByName,
+                    updatedAt: status?.projectionUpdatedAt,
+                    updatedByName: status?.projectionUpdatedByName,
+                  });
+                  const expenseAudit = pickLatestAuditMeta({
+                    editedAt: status?.expenseEditedAt,
+                    editedByName: status?.expenseEditedByName,
+                    updatedAt: status?.expenseUpdatedAt,
+                    updatedByName: status?.expenseUpdatedByName,
+                  });
                   return (
                     <tr key={p.id} className="border-t border-border/30">
-                      <td className="px-3 py-2">
+                      <td className="px-3 py-3 align-top">
                         <div className="text-[12px]" style={{ fontWeight: 700 }}>{p.name}</div>
                         <div className="text-[10px] text-muted-foreground">{p.shortName || p.id}</div>
                       </td>
-                      <td className="px-3 py-2 text-center">
-                        <div className="inline-flex items-start gap-2">
-                          <Checkbox
-                            checked={projectionDone}
+                      <td className="px-3 py-3 align-top text-center">
+                        <div className="mx-auto flex max-w-[172px] flex-col items-stretch gap-2">
+                          <ToggleGroup
+                            type="single"
+                            value={projectionEdited ? 'edited' : 'not-edited'}
+                            variant="outline"
+                            size="sm"
+                            className="w-full"
+                            onValueChange={(value) => {
+                              if (!value) return;
+                              handleEditedChange({
+                                projectId: p.id,
+                                field: 'projection',
+                                nextValue: value === 'edited',
+                              });
+                            }}
+                            disabled={editSavingKey === `${p.id}:projection`}
+                          >
+                            <ToggleGroupItem value="edited" className={`px-2 text-[10px] ${projectionEdited ? 'bg-sky-500/15 text-sky-700 dark:text-sky-300' : ''}`}>
+                              수정 O
+                            </ToggleGroupItem>
+                            <ToggleGroupItem value="not-edited" className={`px-2 text-[10px] ${!projectionEdited ? 'bg-slate-500/10 text-slate-700 dark:text-slate-300' : ''}`}>
+                              수정 X
+                            </ToggleGroupItem>
+                          </ToggleGroup>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className={`h-7 rounded-full px-2 text-[10px] ${projectionDone ? 'border-emerald-200 bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/15 dark:text-emerald-300' : 'border-slate-200 bg-slate-500/5 text-slate-600 hover:bg-slate-500/10 dark:text-slate-300'}`}
                             disabled={confirmSaving}
-                            onCheckedChange={() => openConfirm({
+                            onClick={() => openConfirm({
                               projectId: p.id,
                               projectName: p.name,
                               field: 'projection',
                               nextValue: !projectionDone,
                             })}
-                          />
-                          <div className="text-left">
-                            <Select
-                              value={projectionEdited ? 'edited' : 'not-edited'}
-                              onValueChange={(value) => handleEditedChange({
-                                projectId: p.id,
-                                field: 'projection',
-                                nextValue: value === 'edited',
-                              })}
-                              disabled={editSavingKey === `${p.id}:projection`}
-                            >
-                              <SelectTrigger size="sm" className="h-7 min-w-[104px] px-2 text-[10px]">
-                                <SelectValue />
-                              </SelectTrigger>
-                              <SelectContent>
-                                <SelectItem value="edited">수정 O</SelectItem>
-                                <SelectItem value="not-edited">수정 X</SelectItem>
-                              </SelectContent>
-                            </Select>
-                            <div className={`mt-1 text-[10px] ${projectionDone ? 'text-emerald-700 dark:text-emerald-300' : 'text-muted-foreground'}`} style={{ fontWeight: 700 }}>
-                              {projectionDone ? '완료' : '미완료'}
-                            </div>
-                          </div>
+                          >
+                            {projectionDone ? '제출 완료' : '미완료'}
+                          </Button>
+                          {projectionAudit && <AuditMetaLine {...projectionAudit} />}
                         </div>
-                        <StatusAuditMeta
-                          title="수정 상태 반영"
-                          at={status?.projectionEditedAt}
-                          byName={status?.projectionEditedByName}
-                        />
-                        <StatusAuditMeta
-                          title="제출 상태 반영"
-                          at={status?.projectionUpdatedAt}
-                          byName={status?.projectionUpdatedByName}
-                        />
                       </td>
-                      <td className="px-3 py-2 text-center">
-                        <div className="inline-flex items-start gap-2">
-                          <Checkbox
-                            checked={expenseDone}
+                      <td className="px-3 py-3 align-top text-center">
+                        <div className="mx-auto flex max-w-[172px] flex-col items-stretch gap-2">
+                          <ToggleGroup
+                            type="single"
+                            value={expenseEdited ? 'edited' : 'not-edited'}
+                            variant="outline"
+                            size="sm"
+                            className="w-full"
+                            onValueChange={(value) => {
+                              if (!value) return;
+                              handleEditedChange({
+                                projectId: p.id,
+                                field: 'expense',
+                                nextValue: value === 'edited',
+                              });
+                            }}
+                            disabled={editSavingKey === `${p.id}:expense`}
+                          >
+                            <ToggleGroupItem value="edited" className={`px-2 text-[10px] ${expenseEdited ? 'bg-sky-500/15 text-sky-700 dark:text-sky-300' : ''}`}>
+                              수정 O
+                            </ToggleGroupItem>
+                            <ToggleGroupItem value="not-edited" className={`px-2 text-[10px] ${!expenseEdited ? 'bg-slate-500/10 text-slate-700 dark:text-slate-300' : ''}`}>
+                              수정 X
+                            </ToggleGroupItem>
+                          </ToggleGroup>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className={`h-7 rounded-full px-2 text-[10px] ${expenseDone ? 'border-emerald-200 bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/15 dark:text-emerald-300' : 'border-slate-200 bg-slate-500/5 text-slate-600 hover:bg-slate-500/10 dark:text-slate-300'}`}
                             disabled={confirmSaving}
-                            onCheckedChange={() => openConfirm({
+                            onClick={() => openConfirm({
                               projectId: p.id,
                               projectName: p.name,
                               field: 'expense',
                               nextValue: !expenseDone,
                             })}
-                          />
-                          <div className="text-left">
-                            <Select
-                              value={expenseEdited ? 'edited' : 'not-edited'}
-                              onValueChange={(value) => handleEditedChange({
-                                projectId: p.id,
-                                field: 'expense',
-                                nextValue: value === 'edited',
-                              })}
-                              disabled={editSavingKey === `${p.id}:expense`}
-                            >
-                              <SelectTrigger size="sm" className="h-7 min-w-[104px] px-2 text-[10px]">
-                                <SelectValue />
-                              </SelectTrigger>
-                              <SelectContent>
-                                <SelectItem value="edited">수정 O</SelectItem>
-                                <SelectItem value="not-edited">수정 X</SelectItem>
-                              </SelectContent>
-                            </Select>
-                            <div className={`mt-1 text-[10px] ${expenseDone ? 'text-emerald-700 dark:text-emerald-300' : 'text-muted-foreground'}`} style={{ fontWeight: 700 }}>
-                              {expenseDone ? '완료' : '미완료'}
-                            </div>
-                          </div>
+                          >
+                            {expenseDone ? '제출 완료' : '미완료'}
+                          </Button>
+                          {expenseAudit && <AuditMetaLine {...expenseAudit} />}
                         </div>
-                        <StatusAuditMeta
-                          title="수정 상태 반영"
-                          at={status?.expenseEditedAt}
-                          byName={status?.expenseEditedByName}
-                        />
-                        <StatusAuditMeta
-                          title="제출 상태 반영"
-                          at={status?.expenseUpdatedAt}
-                          byName={status?.expenseUpdatedByName}
-                        />
                       </td>
                     </tr>
                   );


### PR DESCRIPTION
## PR 요약

주간 제출 체크 테이블의 셀 구성이 과하게 무거워져서, 사용자가 `수정 상태`, `제출 상태`, `이력 정보`를 한 번에 해석해야 하는 문제가 있었습니다. 기존 UI는 드롭다운, 체크박스, 상태 문구, 감사 정보 박스가 한 셀 안에 함께 쌓여 있어 반복 입력 속도와 표 스캔성이 모두 떨어졌습니다.

이번 변경은 상호작용 우선순위를 다시 정리하는 데 집중했습니다. `수정 O/X`는 즉시 선택 가능한 2분할 토글로 바꾸고, `제출 완료/미완료`는 별도 상태 버튼으로 분리했습니다. 또한 감사 정보는 두 개의 박스형 메타 영역 대신 최신 반영 이력 한 줄만 남겨, 셀이 조작 중심으로 보이도록 정리했습니다.

## 사용자 영향

이제 PM은 각 셀에서 먼저 `수정 상태`를 빠르게 선택하고, 그 다음 `제출 상태`를 독립적으로 처리할 수 있습니다. `수정했지만 제출은 아직 안 함`, `수정은 없지만 제출 체크는 완료`, `둘 다 완료` 같은 상태가 더 직관적으로 드러납니다. 최신 이력은 남기되 조작 요소와 시각적으로 경쟁하지 않도록 낮은 강도로 표현됩니다.

## 변경 내용

- `수정 O/X`를 드롭다운에서 `ToggleGroup` 기반 2분할 선택으로 변경했습니다.
- `완료/미완료` 표시를 체크박스 중심 UI에서 별도 상태 버튼으로 바꿨습니다.
- 최신 감사 정보만 남기고, 중복되는 메타 박스 2개를 제거했습니다.
- 테이블 상단에 `수정 상태 직접 선택`, `제출 상태 별도 체크` 레전드를 추가해 해석 비용을 낮췄습니다.

## 검증

- `./node_modules/.bin/tsc --noEmit`
- `npm run build`
