### PR TITLE
hotfix: unblock project request contract uploads

### DIFF
--- a/server/bff/app.integration.test.ts
+++ b/server/bff/app.integration.test.ts
@@ -272,6 +272,74 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
     expect(snap.data()?.applyTarget).toBe('expense_sheet');
   });
 
+  it('allows viewer role to process project request contract uploads', async () => {
+    const projectRequestContractStorageService = {
+      uploadContract: vi.fn(async ({ fileName, mimeType, fileSize }) => ({
+        path: `orgs/${tenantId}/project-request-contracts/${actorId}/${fileName}`,
+        name: fileName,
+        downloadURL: `https://example.com/contracts/${encodeURIComponent(fileName)}`,
+        size: fileSize,
+        contentType: mimeType,
+        uploadedAt: '2026-03-23T08:40:00.000Z',
+      })),
+    };
+    const projectRequestContractAiService = {
+      analyzeContract: vi.fn(async ({ fileName, documentText }) => ({
+        provider: 'heuristic',
+        model: 'deterministic-fallback',
+        summary: `${fileName} 요약`,
+        warnings: [],
+        nextActions: [],
+        extractedAt: '2026-03-23T08:40:00.000Z',
+        fields: {
+          officialContractName: { value: '공식 계약명', confidence: 'medium', evidence: documentText || fileName },
+          suggestedProjectName: { value: '신규 사업', confidence: 'medium', evidence: fileName },
+          clientOrg: { value: '발주처', confidence: 'low', evidence: '' },
+          projectPurpose: { value: '', confidence: 'low', evidence: '' },
+          description: { value: '', confidence: 'low', evidence: '' },
+          contractStart: { value: '', confidence: 'low', evidence: '' },
+          contractEnd: { value: '', confidence: 'low', evidence: '' },
+          contractAmount: { value: null, confidence: 'low', evidence: '' },
+          salesVatAmount: { value: null, confidence: 'low', evidence: '' },
+        },
+      })),
+    };
+    const contractApi = request(createBffApp({
+      projectId,
+      workerSecret,
+      db,
+      projectRequestContractStorageService,
+      projectRequestContractAiService,
+    }));
+
+    const upload = await contractApi
+      .post('/api/v1/project-requests/contract/process')
+      .set({
+        ...defaultHeaders,
+        'x-actor-role': 'viewer',
+        'content-type': 'application/octet-stream',
+        'x-file-name': encodeURIComponent('viewer-contract.pdf'),
+        'x-file-type': 'application/pdf',
+        'x-file-size': '9',
+        'idempotency-key': 'idem-project-request-contract-001',
+      })
+      .send(Buffer.from('%PDF-test'));
+
+    expect(upload.status).toBe(200);
+    expect(upload.body.contractDocument.name).toBe('viewer-contract.pdf');
+    expect(upload.body.analysis.fields.officialContractName.value).toBe('공식 계약명');
+    expect(projectRequestContractStorageService.uploadContract).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId,
+      actorId,
+      fileName: 'viewer-contract.pdf',
+      mimeType: 'application/pdf',
+      fileSize: 9,
+    }));
+    expect(projectRequestContractAiService.analyzeContract).toHaveBeenCalledWith(expect.objectContaining({
+      fileName: 'viewer-contract.pdf',
+    }));
+  });
+
   it('rejects disallowed CORS origin', async () => {
     const corsApi = request(createBffApp({
       projectId,

--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -299,6 +299,7 @@ const CORE_WRITE_ROUTE_ROLES = ['admin', 'finance', 'pm', 'auditor', 'tenant_adm
 const ROUTE_ROLES = {
   readCore: ALL_INTERNAL_ROUTE_ROLES,
   writeCore: CORE_WRITE_ROUTE_ROLES,
+  writeProjectRequestContract: ALL_INTERNAL_ROUTE_ROLES,
   writeTransaction: ALL_INTERNAL_ROUTE_ROLES,
   writeProjectDrive: ALL_INTERNAL_ROUTE_ROLES,
   writeEvidenceDrive: ALL_INTERNAL_ROUTE_ROLES,
@@ -1533,7 +1534,7 @@ export function createBffApp(options = {}) {
 
   app.post('/api/v1/project-requests/contract/upload', asyncHandler(async (req, res) => {
     const { tenantId, actorId } = req.context;
-    assertActorRoleAllowed(req, ROUTE_ROLES.writeCore, 'upload project request contract');
+    assertActorRoleAllowed(req, ROUTE_ROLES.writeProjectRequestContract, 'upload project request contract');
     const parsed = parseWithSchema(
       projectRequestContractUploadSchema,
       req.body,
@@ -1555,7 +1556,7 @@ export function createBffApp(options = {}) {
     express.raw({ type: ['application/octet-stream', 'application/pdf'], limit: process.env.BFF_JSON_LIMIT || '25mb' }),
     asyncHandler(async (req, res) => {
       const { tenantId, actorId } = req.context;
-      assertActorRoleAllowed(req, ROUTE_ROLES.writeCore, 'process project request contract');
+      assertActorRoleAllowed(req, ROUTE_ROLES.writeProjectRequestContract, 'process project request contract');
       const fileName = decodeHeaderValue(req.header('x-file-name')) || 'contract.pdf';
       const mimeType = readOptionalText(req.header('x-file-type')) || req.header('content-type') || 'application/pdf';
       const fileSizeHeader = Number.parseInt(readOptionalText(req.header('x-file-size')), 10);

--- a/src/app/components/portal/PortalProjectRegister.tsx
+++ b/src/app/components/portal/PortalProjectRegister.tsx
@@ -26,6 +26,8 @@ import {
   processProjectRequestContractViaBff,
   type ProjectRequestContractAnalysisResult,
 } from '../../lib/platform-bff-client';
+import { resolveApiErrorMessage } from '../../platform/api-error-message';
+import { PlatformApiError } from '../../platform/api-client';
 import {
   ACCOUNT_TYPE_LABELS,
   BASIS_LABELS,
@@ -64,6 +66,8 @@ import {
 type Step = 'contract' | 'basic' | 'financial' | 'team' | 'review';
 type ContractAnalysisState = 'idle' | 'extracting' | 'analyzing' | 'ready' | 'error';
 type AnalysisFieldKey = keyof ProjectRequestContractAnalysis['fields'];
+const MAX_CONTRACT_UPLOAD_SIZE_BYTES = 4 * 1024 * 1024;
+const MAX_CONTRACT_UPLOAD_SIZE_LABEL = '4MB';
 
 const STEPS: Array<{
   key: Step;
@@ -282,6 +286,18 @@ function createEmptyTeamMember(): ProjectTeamMemberAssignment {
   };
 }
 
+function resolveContractUploadErrorMessage(error: unknown) {
+  if (error instanceof PlatformApiError) {
+    if (error.status === 413) {
+      return `계약서 PDF는 ${MAX_CONTRACT_UPLOAD_SIZE_LABEL} 이하만 업로드할 수 있습니다. 파일을 압축하거나 필요한 페이지만 추려 다시 시도해 주세요.`;
+    }
+    if (error.status === 403) {
+      return '현재 로그인 상태로 계약서 업로드를 완료하지 못했습니다. 페이지를 새로고침한 뒤 다시 시도해 주세요.';
+    }
+  }
+  return resolveApiErrorMessage(error, '계약서 업로드에 실패했습니다. 다시 시도해 주세요.');
+}
+
 export function PortalProjectRegister() {
   const navigate = useNavigate();
   const { user: authUser } = useAuth();
@@ -392,6 +408,14 @@ export function PortalProjectRegister() {
       input.value = '';
       return;
     }
+    if (file.size > MAX_CONTRACT_UPLOAD_SIZE_BYTES) {
+      const message = `계약서 PDF는 ${MAX_CONTRACT_UPLOAD_SIZE_LABEL} 이하만 업로드할 수 있습니다. 파일을 압축하거나 필요한 페이지만 추려 다시 시도해 주세요.`;
+      setContractAnalysisState('error');
+      setAnalysisError(message);
+      toast.error(message);
+      input.value = '';
+      return;
+    }
     setIsUploadingContract(true);
     setContractAnalysisState('extracting');
     setAnalysisError('');
@@ -435,8 +459,9 @@ export function PortalProjectRegister() {
         setAnalysisError('선택한 파일을 브라우저가 읽지 못했습니다. 파일을 다시 선택하거나 다른 PDF로 시도해 주세요.');
         toast.error('파일을 읽지 못했습니다. 같은 파일을 다시 선택하거나 다시 다운로드한 PDF로 시도해 주세요.');
       } else {
-        setAnalysisError('계약서 업로드에 실패했습니다. 다시 시도해 주세요.');
-        toast.error('계약서 업로드에 실패했습니다. 다시 시도해 주세요.');
+        const message = resolveContractUploadErrorMessage(error);
+        setAnalysisError(message);
+        toast.error(message);
       }
     } finally {
       setIsUploadingContract(false);


### PR DESCRIPTION
## PR 요약

Closes 118

포털 `사업 등록 제안`에서 계약서 PDF 업로드가 `403` 또는 `413`으로 실패하던 문제를 hotfix로 정리했습니다.

이번 문제는 최근 주간 제출 체크 UI 변경과는 별개였습니다. 실제 원인은 계약서 업로드 경로의 권한 설계와 Vercel request body limit 대응 부재였습니다. 포털에서는 `viewer`도 해당 화면에 접근할 수 있지만, BFF 업로드 엔드포인트는 `writeCore`로 묶여 있어 `viewer`를 차단하고 있었습니다. 또한 큰 PDF는 Vercel 함수 본문 제한에 걸리는데, 프런트에서는 사전 차단이나 원인별 안내가 없었습니다.

## 변경 내용

- BFF에 `writeProjectRequestContract` 권한 그룹을 추가하고, 계약서 업로드/처리 경로에서 `viewer`를 허용했습니다.
- 포털 계약서 업로드 UI에서 4MB 초과 PDF를 업로드 전에 차단하도록 했습니다.
- `413`과 `403`에 대해 사용자에게 더 구체적인 안내 문구를 보이도록 정리했습니다.
- Firestore emulator 기반 BFF 통합 테스트에 `viewer` 계약서 업로드 성공 케이스를 추가했습니다.

## 검증

- `npm run build`
- `npm run bff:test:integration`
