### PR TITLE
portal: audit weekly expense amount edits

### DIFF
--- a/src/app/components/cashflow/SettlementLedgerPage.tsx
+++ b/src/app/components/cashflow/SettlementLedgerPage.tsx
@@ -78,6 +78,8 @@ import type { EvidenceUploadDraft } from './SettlementEvidenceUploadDialog';
 import { CellCommentButton } from './CellCommentButton';
 import { SettlementWeekSection } from './SettlementWeekSection';
 import {
+  buildTransactionEditHistoryEntries,
+  findLatestFieldEdit,
   fmt,
   METHOD_LABELS,
   METHOD_OPTIONS,
@@ -619,20 +621,7 @@ export function SettlementLedgerPage({
 
       // Build edit history entries for changed fields
       const now = new Date().toISOString();
-      const newEntries: NonNullable<Transaction['editHistory']> = [];
-      const existingRecord = existing as unknown as Record<string, unknown>;
-      for (const [key, newValue] of Object.entries(normalizedUpdates)) {
-        const oldValue = existingRecord[key];
-        if (oldValue !== newValue) {
-          newEntries.push({
-            field: key,
-            before: oldValue,
-            after: newValue,
-            editedBy: currentUserName,
-            editedAt: now,
-          });
-        }
-      }
+      const newEntries = buildTransactionEditHistoryEntries(existing, normalizedUpdates, currentUserName, now);
 
       const enhancedUpdates: Partial<Transaction> = {
         ...normalizedUpdates,
@@ -2641,6 +2630,10 @@ function ImportEditorRow({
   const [driveAction, setDriveAction] = useState<'' | 'provision' | 'sync'>('');
   const hasSourceTransaction = Boolean(persistedTransactionId);
   const canUseDrive = hasSourceTransaction || !!onEnsurePersistedTransaction;
+  const expenseAudit = useMemo(
+    () => findLatestFieldEdit(persistedTransaction, 'amounts.expenseAmount'),
+    [persistedTransaction],
+  );
   const persistedDriveStatusLabel = persistedTransaction?.evidenceDriveSyncStatus === 'UPLOADED'
     ? '업로드됨'
     : persistedTransaction?.evidenceDriveSyncStatus === 'SYNCED'
@@ -2872,6 +2865,7 @@ function ImportEditorRow({
         const isCashflow = colIdx === cashflowIdx;
         const isAuthor = colIdx === authorIdx;
         const isDriveLink = col.csvHeader === '증빙자료 드라이브';
+        const isExpenseAmount = col.csvHeader === '사업비 사용액';
         const isSettlementNote = col.csvHeader === '비고';
         const hasAuthorOptions = (authorOptions || []).length > 0;
         return (
@@ -3117,6 +3111,24 @@ function ImportEditorRow({
                     onChange={(e) => onCellChange(colIdx, e.target.value)}
                     placeholder={hasSourceTransaction ? '' : '행 저장 후 Drive 사용 가능'}
                   />
+                </div>
+              ) : isExpenseAmount ? (
+                <div className="space-y-0.5 pr-6">
+                  <input
+                    type="text"
+                    value={row.cells[colIdx] || ''}
+                    className="w-full bg-transparent outline-none text-[11px] px-1 py-0.5"
+                    data-cell-row={rowIdx}
+                    data-cell-col={colIdx}
+                    onFocus={() => onCellFocus(rowIdx, colIdx)}
+                    onPaste={(e) => handlePaste(colIdx, e)}
+                    onChange={(e) => onCellChange(colIdx, formatNumberInput(e.target.value))}
+                  />
+                  {expenseAudit && (
+                    <div className="px-1 text-[9px] leading-tight text-muted-foreground">
+                      최종 수정 {expenseAudit.editedBy} · {formatCommentTime(expenseAudit.editedAt)}
+                    </div>
+                  )}
                 </div>
               ) : (
                 <input

--- a/src/app/components/cashflow/SettlementTransactionRow.tsx
+++ b/src/app/components/cashflow/SettlementTransactionRow.tsx
@@ -10,12 +10,15 @@ import {
 import { buildDriveTransactionFolderName } from '../../platform/drive-evidence';
 import { CASHFLOW_LINE_OPTIONS } from '../../platform/settlement-csv';
 import {
+  findLatestFieldEdit,
+  formatCommentTime,
   fmt,
   METHOD_OPTIONS,
   normalizeMethodValue,
   TX_STATE_BADGE,
   isEditable,
 } from '../../platform/settlement-grid-helpers';
+import { parseNumber } from '../../platform/csv-utils';
 import { Button } from '../ui/button';
 import { Checkbox } from '../ui/checkbox';
 
@@ -66,6 +69,7 @@ export function SettlementTransactionRow({
   const autoCompletedDesc = tx.evidenceAutoListedDesc || '';
   const manualCompletedDesc = resolveEvidenceCompletedManualDesc(tx);
   const effectiveCompletedDesc = resolveEvidenceCompletedDesc(tx);
+  const expenseAudit = findLatestFieldEdit(tx, 'amounts.expenseAmount');
   const suggestedFolderName = tx.evidenceDriveFolderName || buildDriveTransactionFolderName(tx);
   const driveStatusLabel = tx.evidenceDriveSyncStatus === 'UPLOADED'
     ? '업로드됨'
@@ -111,6 +115,38 @@ export function SettlementTransactionRow({
   const numberCell = (value: number | undefined) => (
     <td className="px-1 py-0.5 border-b border-r text-right tabular-nums">
       <span className="text-[11px]">{fmt(value)}</span>
+    </td>
+  );
+
+  const expenseAmountCell = (value: number | undefined) => (
+    <td className="px-1 py-0.5 border-b border-r text-right tabular-nums align-top">
+      <div className="space-y-0.5">
+        <input
+          key={`expense-${tx.id}-${value ?? ''}`}
+          type="text"
+          defaultValue={fmt(value)}
+          className="w-full bg-transparent outline-none text-[11px] px-1 py-0.5 text-right"
+          onBlur={(e) => {
+            const nextAmount = parseNumber(e.target.value) ?? 0;
+            if (nextAmount !== (value ?? 0)) {
+              void Promise.resolve(onUpdate({
+                amounts: {
+                  ...tx.amounts,
+                  expenseAmount: nextAmount,
+                },
+              })).catch((error) => {
+                console.error('[SettlementLedger] update transaction failed:', error);
+              });
+            }
+            e.target.value = fmt(nextAmount);
+          }}
+        />
+        {expenseAudit && (
+          <div className="text-[9px] leading-tight text-muted-foreground">
+            최종 수정 {expenseAudit.editedBy} · {formatCommentTime(expenseAudit.editedAt)}
+          </div>
+        )}
+      </div>
     </td>
   );
 
@@ -233,7 +269,7 @@ export function SettlementTransactionRow({
       {numberCell(tx.amounts?.bankAmount)}
       {numberCell(tx.amounts?.depositAmount)}
       {numberCell(tx.amounts?.vatRefund)}
-      {numberCell(tx.amounts?.expenseAmount)}
+      {expenseAmountCell(tx.amounts?.expenseAmount)}
       {numberCell(tx.amounts?.vatIn)}
       {textCell(tx.counterparty, 'counterparty')}
       {textCell(tx.memo, 'memo', 'min-w-[150px]')}

--- a/src/app/platform/settlement-grid-helpers.test.ts
+++ b/src/app/platform/settlement-grid-helpers.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import type { Transaction } from '../data/types';
+import {
+  buildTransactionEditHistoryEntries,
+  findLatestFieldEdit,
+} from './settlement-grid-helpers';
+
+function makeTransaction(): Transaction {
+  return {
+    id: 'tx-1',
+    ledgerId: 'ledger-1',
+    projectId: 'project-1',
+    state: 'SUBMITTED',
+    dateTime: '2026-03-23',
+    weekCode: '2026-W12',
+    direction: 'OUT',
+    method: 'TRANSFER',
+    cashflowCategory: 'OUTSOURCING',
+    cashflowLabel: '직접사업비',
+    counterparty: '거래처',
+    memo: '메모',
+    amounts: {
+      bankAmount: 100000,
+      depositAmount: 0,
+      expenseAmount: 100000,
+      vatIn: 10000,
+      vatOut: 0,
+      vatRefund: 0,
+      balanceAfter: 900000,
+    },
+    evidenceRequired: [],
+    evidenceStatus: 'MISSING',
+    evidenceMissing: [],
+    attachmentsCount: 0,
+    createdBy: 'seed',
+    createdAt: '2026-03-23T01:00:00.000Z',
+    updatedBy: 'seed',
+    updatedAt: '2026-03-23T01:00:00.000Z',
+  };
+}
+
+describe('settlement-grid-helpers', () => {
+  it('builds nested audit entries for expense amount changes', () => {
+    const existing = makeTransaction();
+
+    const entries = buildTransactionEditHistoryEntries(
+      existing,
+      {
+        amounts: {
+          ...existing.amounts,
+          expenseAmount: 80000,
+        },
+      },
+      '보람',
+      '2026-03-23T02:00:00.000Z',
+    );
+
+    expect(entries).toEqual([
+      {
+        field: 'amounts.expenseAmount',
+        before: 100000,
+        after: 80000,
+        editedBy: '보람',
+        editedAt: '2026-03-23T02:00:00.000Z',
+      },
+    ]);
+  });
+
+  it('finds the latest audit entry for a field', () => {
+    const transaction = makeTransaction();
+    transaction.editHistory = [
+      {
+        field: 'amounts.expenseAmount',
+        before: 100000,
+        after: 90000,
+        editedBy: '초기수정자',
+        editedAt: '2026-03-23T02:00:00.000Z',
+      },
+      {
+        field: 'memo',
+        before: '메모',
+        after: '메모 수정',
+        editedBy: '다른수정자',
+        editedAt: '2026-03-23T03:00:00.000Z',
+      },
+      {
+        field: 'amounts.expenseAmount',
+        before: 90000,
+        after: 75000,
+        editedBy: '최종수정자',
+        editedAt: '2026-03-23T04:00:00.000Z',
+      },
+    ];
+
+    expect(findLatestFieldEdit(transaction, 'amounts.expenseAmount')).toEqual({
+      field: 'amounts.expenseAmount',
+      before: 90000,
+      after: 75000,
+      editedBy: '최종수정자',
+      editedAt: '2026-03-23T04:00:00.000Z',
+    });
+  });
+});

--- a/src/app/platform/settlement-grid-helpers.ts
+++ b/src/app/platform/settlement-grid-helpers.ts
@@ -1,4 +1,4 @@
-import type { TransactionState } from '../data/types';
+import type { Transaction, TransactionState } from '../data/types';
 import { getMonthMondayWeeks, type MonthMondayWeek } from './cashflow-weeks';
 
 // ── Number formatting ──
@@ -63,6 +63,59 @@ export function buildSheetRowCommentId(tempId: string): string {
 
 export function formatCommentTime(value: string): string {
   return value ? value.slice(0, 16).replace('T', ' ') : '';
+}
+
+export function findLatestFieldEdit(
+  transaction: Pick<Transaction, 'editHistory'> | undefined,
+  field: string,
+): NonNullable<Transaction['editHistory']>[number] | null {
+  const history = transaction?.editHistory || [];
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const entry = history[index];
+    if (entry?.field === field) return entry;
+  }
+  return null;
+}
+
+export function buildTransactionEditHistoryEntries(
+  existing: Transaction,
+  updates: Partial<Transaction>,
+  editedBy: string,
+  editedAt: string,
+): NonNullable<Transaction['editHistory']> {
+  const entries: NonNullable<Transaction['editHistory']> = [];
+
+  for (const [key, newValue] of Object.entries(updates)) {
+    if (key === 'amounts' && newValue && typeof newValue === 'object') {
+      const nextAmounts = newValue as Partial<Transaction['amounts']>;
+      for (const [amountKey, amountValue] of Object.entries(nextAmounts)) {
+        const previousAmount = existing.amounts?.[amountKey as keyof Transaction['amounts']];
+        if (previousAmount !== amountValue) {
+          entries.push({
+            field: `amounts.${amountKey}`,
+            before: previousAmount,
+            after: amountValue,
+            editedBy,
+            editedAt,
+          });
+        }
+      }
+      continue;
+    }
+
+    const previousValue = (existing as unknown as Record<string, unknown>)[key];
+    if (previousValue !== newValue) {
+      entries.push({
+        field: key,
+        before: previousValue,
+        after: newValue,
+        editedBy,
+        editedAt,
+      });
+    }
+  }
+
+  return entries;
 }
 
 // ── Grid constants ──


### PR DESCRIPTION
## Summary
- allow direct editing of expense amount in weekly expense transaction rows
- record nested audit history for expense amount edits
- show the latest editor and timestamp in weekly rows and source-linked spreadsheet rows

## Verification
- npm test -- src/app/platform/settlement-grid-helpers.test.ts
- ./node_modules/.bin/tsc --noEmit
- npm run build