### PR TITLE
fix(projects): 프로젝트 등록 다음 버튼 + 자동 초기화 버그 수정

### DIFF
--- a/src/app/components/projects/ProjectWizard.tsx
+++ b/src/app/components/projects/ProjectWizard.tsx
@@ -16,7 +16,7 @@ import {
   XCircle,
 } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 import { toast } from 'sonner';
 import { useAppStore } from '../../data/store';
 import { resolveApiErrorMessage } from '../../platform/api-error-message';
@@ -117,10 +117,19 @@ interface ProjectWizardProps {
 
 export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: ProjectWizardProps) {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { addProject, updateProject, members } = useAppStore();
 
-  const [currentStep, setCurrentStep] = useState(0);
+  const stepFromUrl = parseInt(searchParams.get('step') ?? '0', 10);
+  const [currentStep, setCurrentStep] = useState(
+    Number.isFinite(stepFromUrl) && stepFromUrl >= 0 && stepFromUrl < STEPS.length ? stepFromUrl : 0
+  );
   const [saving, setSaving] = useState(false);
+
+  const goToStep = useCallback((step: number) => {
+    setCurrentStep(step);
+    setSearchParams(prev => { prev.set('step', String(step)); return prev; }, { replace: true });
+  }, [setSearchParams]);
   const [targetPhase, setTargetPhase] = useState<ProjectPhase>(editProject?.phase || initialPhase);
   const [formData, setFormData] = useState<WizardFormData>(() => {
     if (editProject) {
@@ -258,7 +267,7 @@ export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: Projec
     } finally {
       setSaving(false);
     }
-  }, [saving, formData, calculatedProfit, editProject, addProject, updateProject, navigate]);
+  }, [saving, formData, calculatedProfit, editProject, addProject, updateProject, navigate, setSearchParams]);
 
   // Format number input
   const fmtInput = (n: number) => n > 0 ? n.toLocaleString('ko-KR') : '';
@@ -815,7 +824,7 @@ export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: Projec
           return (
             <div key={step.id} className="flex items-center">
               <button
-                onClick={() => setCurrentStep(i)}
+                onClick={() => goToStep(i)}
                 className={`flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs transition-all ${isActive
                     ? 'bg-primary text-primary-foreground'
                     : isCompleted
@@ -862,7 +871,7 @@ export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: Projec
       <div className="flex items-center justify-between">
         <Button
           variant="outline"
-          onClick={() => setCurrentStep(Math.max(0, currentStep - 1))}
+          onClick={() => goToStep(Math.max(0, currentStep - 1))}
           disabled={currentStep === 0 || saving}
           className="gap-1"
         >
@@ -893,7 +902,7 @@ export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: Projec
             </>
           ) : (
             <Button
-              onClick={() => setCurrentStep(Math.min(STEPS.length - 1, currentStep + 1))}
+              onClick={() => goToStep(Math.min(STEPS.length - 1, currentStep + 1))}
               disabled={saving}
               className="gap-1"
             >


### PR DESCRIPTION
## 버그 요약

axr-qa 채널에서 보고된 버그: 프로젝트 등록 과정 중 **'다음' 버튼이 활성화되지 않는 문제** (2026-03-31, 2건 발생)

## 원인 분석

`currentStep`이 `useState(0)`으로만 관리되어, Firestore 실시간 구독(`useAppStore`)에 의한 컴포넌트 **리마운트 시 0으로 초기화**됨. 사용자 입장에서는 다음 버튼을 눌렀지만 화면이 초기 단계로 돌아가는 현상으로 보임.

## 수정 내용

- `currentStep`을 URL 파라미터(`?step=N`)로 영속화 (`useSearchParams` 활용)
- `goToStep()` 헬퍼 함수로 `setCurrentStep` + `setSearchParams` 동기화
- 이전/다음 버튼, 단계 인디케이터 클릭 모두 `goToStep()` 사용
- 저장 중(`saving`) disabled 상태 유지

## 테스트

- [x] 136개 기존 테스트 전체 통과
- [x] TypeScript 컴파일 에러 없음 (ProjectWizard.tsx 범위)

## 리뷰 요청

간단한 변경이나 실시간 구독 환경에서 충분히 검증 후 머지 부탁드립니다.