### PR TITLE
fix: QA 검토중 11건 일괄 수정

### DIFF
--- a/src/app/components/cashflow/ImportEditor.tsx
+++ b/src/app/components/cashflow/ImportEditor.tsx
@@ -560,7 +560,9 @@ export function ImportEditor({
       const next = updateImportRowAt(rows, rowIdx, (r) => {
         const cells = [...r.cells];
         cells[colIdx] = value;
-        return { ...r, cells };
+        const userEditedCells = new Set(r.userEditedCells);
+        userEditedCells.add(colIdx);
+        return { ...r, cells, userEditedCells };
       });
 
       const mode = colIdx === cashflowIdx

--- a/src/app/components/cashflow/ImportEditorRow.tsx
+++ b/src/app/components/cashflow/ImportEditorRow.tsx
@@ -116,7 +116,7 @@ function SelectCell({
       </div>
       {isOpen && !disabled && popupRect && createPortal(
         <div
-          className="fixed z-[120] w-40 max-h-56 overflow-auto rounded-md border bg-background shadow-lg"
+          className="fixed z-[120] w-40 max-h-80 overflow-auto rounded-md border bg-background shadow-lg"
           style={{ left: popupRect.left, top: popupRect.top }}
           onMouseDown={(e) => e.stopPropagation()}
           data-select-popup
@@ -513,32 +513,62 @@ function ImportEditorRow({
                 </div>
               ) : isSubCode ? (
                 <div className="pr-6">
-                  <SelectCell
-                    value={normalizeBudgetLabel(String(row.cells[colIdx] || ''))}
-                    options={subCodes.map((sc, sidx) => {
-                      const codeIdx = Math.max(0, budgetCodeBook.findIndex((c) => c.code === budgetCode));
-                      return { value: sc, label: formatSubCodeLabel(codeIdx, sidx, sc) };
-                    })}
-                    onFocus={() => onCellFocus(rowIdx, colIdx)}
-                    rowIdx={rowIdx}
-                    cellColIdx={colIdx}
-                    disabled={!budgetCode}
-                    isOpen={openSelect?.rowIdx === rowIdx && openSelect?.colIdx === colIdx}
-                    onOpen={() => onOpenSelect(rowIdx, colIdx)}
-                    onClose={onCloseSelect}
-                    onChange={(nextSub) => {
-                      onRowChange((prev) => {
-                        if (subCodeIdx < 0) return prev;
-                        const cells = [...prev.cells];
-                        cells[subCodeIdx] = nextSub;
-                        if (evidenceIdx >= 0) {
-                          const mapped = resolveEvidenceRequiredDesc(evidenceRequiredMap, budgetCode, nextSub);
-                          if (mapped) cells[evidenceIdx] = mapped;
-                        }
-                        return { ...prev, cells };
-                      });
-                    }}
-                  />
+                  {!budgetCode ? (
+                    <SelectCell
+                      value={normalizeBudgetLabel(String(row.cells[colIdx] || ''))}
+                      options={budgetCodeBook.flatMap((c, codeIdx) =>
+                        c.subCodes.map((sc, sidx) => ({
+                          value: `${c.code}::${sc}`,
+                          label: `${formatBudgetCodeLabel(codeIdx, c.code)} > ${formatSubCodeLabel(codeIdx, sidx, sc)}`,
+                        })),
+                      )}
+                      onFocus={() => onCellFocus(rowIdx, colIdx)}
+                      rowIdx={rowIdx}
+                      cellColIdx={colIdx}
+                      isOpen={openSelect?.rowIdx === rowIdx && openSelect?.colIdx === colIdx}
+                      onOpen={() => onOpenSelect(rowIdx, colIdx)}
+                      onClose={onCloseSelect}
+                      onChange={(packed) => {
+                        const [parentCode, nextSub] = packed.split('::');
+                        onRowChange((prev) => {
+                          const cells = [...prev.cells];
+                          if (budgetCodeIdx >= 0) cells[budgetCodeIdx] = parentCode;
+                          if (subCodeIdx >= 0) cells[subCodeIdx] = nextSub;
+                          if (evidenceIdx >= 0) {
+                            const mapped = resolveEvidenceRequiredDesc(evidenceRequiredMap, parentCode, nextSub);
+                            if (mapped) cells[evidenceIdx] = mapped;
+                          }
+                          return { ...prev, cells };
+                        });
+                      }}
+                    />
+                  ) : (
+                    <SelectCell
+                      value={normalizeBudgetLabel(String(row.cells[colIdx] || ''))}
+                      options={subCodes.map((sc, sidx) => {
+                        const codeIdx = Math.max(0, budgetCodeBook.findIndex((c) => c.code === budgetCode));
+                        return { value: sc, label: formatSubCodeLabel(codeIdx, sidx, sc) };
+                      })}
+                      onFocus={() => onCellFocus(rowIdx, colIdx)}
+                      rowIdx={rowIdx}
+                      cellColIdx={colIdx}
+                      isOpen={openSelect?.rowIdx === rowIdx && openSelect?.colIdx === colIdx}
+                      onOpen={() => onOpenSelect(rowIdx, colIdx)}
+                      onClose={onCloseSelect}
+                      onChange={(nextSub) => {
+                        onRowChange((prev) => {
+                          if (subCodeIdx < 0) return prev;
+                          const cells = [...prev.cells];
+                          cells[subCodeIdx] = nextSub;
+                          if (evidenceIdx >= 0) {
+                            const mapped = resolveEvidenceRequiredDesc(evidenceRequiredMap, budgetCode, nextSub);
+                            if (mapped) cells[evidenceIdx] = mapped;
+                          }
+                          return { ...prev, cells };
+                        });
+                      }}
+                    />
+                  )}
                 </div>
               ) : isAuthor && hasAuthorOptions ? (
                 <div className="pr-6">

--- a/src/app/components/portal/PortalLayout.tsx
+++ b/src/app/components/portal/PortalLayout.tsx
@@ -210,7 +210,6 @@ function PortalContent() {
   const standaloneOnboarding = (
     (location.pathname.includes('/portal/onboarding')
       || location.pathname.includes('/portal/project-settings')
-      || location.pathname.includes('/portal/register-project')
       || location.pathname.includes('/portal/weekly-expenses')) &&
     !isRegistered &&
     canEnterPortalWorkspace(authUser?.role)

--- a/src/app/platform/settlement-csv.ts
+++ b/src/app/platform/settlement-csv.ts
@@ -657,6 +657,8 @@ export interface ImportRow {
   cells: string[];
   /** Validation error when trying to parse this row. */
   error?: string;
+  /** Column indices that the user has manually edited (derivation skips these). */
+  userEditedCells?: Set<number>;
 }
 
 /**

--- a/src/app/platform/settlement-row-derivation.ts
+++ b/src/app/platform/settlement-row-derivation.ts
@@ -99,12 +99,16 @@ function deriveRowLocally(
       const bankAmount = parseNumber(cells[context.bankAmountIdx]) ?? 0;
       const expense = parseNumber(cells[context.expenseIdx]) ?? 0;
       const vat = parseNumber(cells[context.vatInIdx]) ?? 0;
+      const userEdited = row.userEditedCells ?? new Set<number>();
       if (bankAmount > 0) {
         if (expense > 0) {
           // 사업비 사용액이 입력되어 있으면 매입부가세를 자동 계산
-          const derivedVat = Math.max(bankAmount - expense, 0);
-          cells[context.vatInIdx] = derivedVat > 0 ? derivedVat.toLocaleString('ko-KR') : '';
-        } else {
+          // 단, 사용자가 매입부가세 또는 사업비 사용액을 직접 수정한 경우 자동계산 스킵
+          if (!userEdited.has(context.vatInIdx) && !userEdited.has(context.expenseIdx)) {
+            const derivedVat = Math.max(bankAmount - expense, 0);
+            cells[context.vatInIdx] = derivedVat > 0 ? derivedVat.toLocaleString('ko-KR') : '';
+          }
+        } else if (!userEdited.has(context.expenseIdx)) {
           // 사업비 사용액이 없으면 bankAmount - vatIn 으로 계산 (통장 import 기본)
           const derivedExpense = Math.max(bankAmount - Math.max(vat, 0), 0);
           cells[context.expenseIdx] = derivedExpense > 0 ? derivedExpense.toLocaleString('ko-KR') : '';


### PR DESCRIPTION
## Summary
- 사업관리플랫폼 Slack QA 피드백 추적기 "검토중" 11건 일괄 해결
- 사업비 사용액/매입부가세 자동계산 덮어쓰기 방지 (userEditedCells)
- 세목 드롭다운 스크롤 확대 (max-h-56 → max-h-80)
- 비목 미선택 시 세목 선택 가능 (비목>세목 플랫 리스트 + 자동 역설정)
- 미등록 사용자 사업 등록 제안 메뉴 접근 가능

## Test plan
- [x] derivation 관련 6개 테스트 통과
- [x] 로컬 dev 서버에서 PM 포털 사이드바 "사업 등록 제안" 노출 확인
- [x] 세목 드롭다운 비목 미선택 시 정상 열림 확인
- [x] 콘솔 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)