### PR TITLE
feat(portal): add project edit page and finance Slack notification

### DIFF
--- a/server/bff/app.integration.test.ts
+++ b/server/bff/app.integration.test.ts
@@ -119,6 +119,60 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
     });
   });
 
+  it('delivers project registration Slack notifications for stored project requests', async () => {
+    const projectRegistrationSlackService = {
+      enabled: true,
+      notifyMessage: vi.fn(async () => {}),
+    };
+    const notifyApi = request(createBffApp({
+      projectId,
+      workerSecret,
+      db,
+      projectRegistrationSlackService,
+    }));
+
+    await db.doc(`orgs/${tenantId}/projectRequests/pr_notify_001`).set({
+      id: 'pr_notify_001',
+      tenantId,
+      status: 'APPROVED',
+      approvedProjectId: 'p_notify_001',
+      requestedByName: '보람',
+      requestedByEmail: 'boram@example.com',
+      payload: {
+        name: '2026 CTS2',
+        officialContractName: 'CTS 역량강화 사업',
+        clientOrg: 'CTS',
+        department: '개발협력센터',
+        managerName: '보람',
+        teamName: 'AXR팀',
+        contractStart: '2026-04-01',
+        contractEnd: '2026-12-31',
+        contractAmount: 120000000,
+        projectPurpose: '역량강화 교육 운영',
+      },
+      createdAt: '2026-03-31T10:00:00.000Z',
+      updatedAt: '2026-03-31T10:00:00.000Z',
+    }, { merge: true });
+
+    const response = await notifyApi
+      .post('/api/v1/project-requests/pr_notify_001/notify-registration')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-request-notify-001' })
+      .send({});
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      ok: true,
+      enabled: true,
+      delivered: true,
+      requestId: 'pr_notify_001',
+      projectId: 'p_notify_001',
+    });
+    expect(projectRegistrationSlackService.notifyMessage).toHaveBeenCalledTimes(1);
+    expect(projectRegistrationSlackService.notifyMessage).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('2026 CTS2'),
+    }));
+  });
+
   it('previews google sheet rows for an existing project', async () => {
     const googleSheetsService = {
       previewSpreadsheet: vi.fn(async ({ value, sheetName }) => ({

--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -637,6 +637,15 @@ export function createBffApp(options = {}) {
   const clientErrorMaxAttempts = Number.isFinite(clientErrorMaxAttemptsRaw) && clientErrorMaxAttemptsRaw > 0 ? clientErrorMaxAttemptsRaw : 5;
   const workerSecret = readOptionalText(options.workerSecret || process.env.BFF_WORKER_SECRET || process.env.CRON_SECRET);
   const slackAlertService = options.slackAlertService || createSlackAlertService();
+  const projectRegistrationSlackService = options.projectRegistrationSlackService || createSlackAlertService({
+    webhookUrl: options.projectRegistrationSlackWebhookUrl || process.env.PROJECT_REGISTRATION_SLACK_WEBHOOK_URL,
+    botToken: options.projectRegistrationSlackBotToken
+      || process.env.PROJECT_REGISTRATION_SLACK_BOT_TOKEN
+      || process.env.SLACK_ALERT_BOT_TOKEN,
+    channelId: options.projectRegistrationSlackChannelId
+      || process.env.PROJECT_REGISTRATION_SLACK_CHANNEL_ID
+      || 'C09BJ767XCM',
+  });
 
   async function resolveMemberIdentity({ tenantId, actorId }) {
     const normalizedTenantId = readOptionalText(tenantId);
@@ -1325,7 +1334,7 @@ export function createBffApp(options = {}) {
     db, now, idempotencyService, auditChainService, piiProtector,
     driveService, googleSheetsService, googleSheetMigrationAiService,
     projectRequestContractAiService, projectRequestContractStorageService,
-    projectSheetSourceStorageService,
+    projectSheetSourceStorageService, projectRegistrationSlackService,
   });
   mountLedgerRoutes(app, { db, now, idempotencyService, auditChainService, piiProtector });
   mountTransactionRoutes(app, { db, now, idempotencyService, auditChainService, piiProtector, rbacPolicy, driveService });

--- a/server/bff/routes/projects.mjs
+++ b/server/bff/routes/projects.mjs
@@ -24,6 +24,67 @@ import {
   projectDriveRootLinkSchema,
 } from '../schemas.mjs';
 
+function trimSlackText(value, maxLength = 200) {
+  const text = readOptionalText(value);
+  if (!text) return '-';
+  return text.length > maxLength ? `${text.slice(0, maxLength - 1)}…` : text;
+}
+
+function formatKrw(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return '-';
+  return `${value.toLocaleString('ko-KR')}원`;
+}
+
+function formatProjectPeriod(start, end) {
+  const normalizedStart = readOptionalText(start);
+  const normalizedEnd = readOptionalText(end);
+  if (normalizedStart && normalizedEnd) return `${normalizedStart} ~ ${normalizedEnd}`;
+  return normalizedStart || normalizedEnd || '-';
+}
+
+function buildProjectRegistrationSlackPayload(projectRequest) {
+  const payload = projectRequest?.payload && typeof projectRequest.payload === 'object'
+    ? projectRequest.payload
+    : {};
+  const projectName = trimSlackText(payload.name, 120);
+  const officialContractName = trimSlackText(payload.officialContractName, 220);
+  const clientOrg = trimSlackText(payload.clientOrg, 160);
+  const department = trimSlackText(payload.department, 120);
+  const managerName = trimSlackText(payload.managerName, 120);
+  const teamName = trimSlackText(payload.teamName, 120);
+  const requester = trimSlackText(projectRequest?.requestedByName, 120);
+  const requesterEmail = trimSlackText(projectRequest?.requestedByEmail, 160);
+  const projectId = trimSlackText(projectRequest?.approvedProjectId, 120);
+  const purpose = trimSlackText(payload.projectPurpose, 280);
+  const lines = [
+    '*[InnerPlatform] 신규 프로젝트 등록 완료*',
+    `프로젝트명: \`${projectName}\``,
+    `계약명: ${officialContractName}`,
+    `발주기관: ${clientOrg}`,
+    `담당조직: ${department}`,
+    `메인 담당자: ${managerName}`,
+    `팀장/팀명: ${teamName}`,
+    `계약기간: ${formatProjectPeriod(payload.contractStart, payload.contractEnd)}`,
+    `계약금액: ${formatKrw(payload.contractAmount)}`,
+    `사업목적: ${purpose}`,
+    `요청자: ${requester} (${requesterEmail})`,
+    `projectId: \`${projectId}\``,
+  ];
+
+  return {
+    text: `[InnerPlatform] 신규 프로젝트 등록 완료: ${projectName}`,
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: lines.join('\n'),
+        },
+      },
+    ],
+  };
+}
+
 export function mountProjectRoutes(app, {
   db, now, idempotencyService, auditChainService, piiProtector,
   driveService,
@@ -32,6 +93,7 @@ export function mountProjectRoutes(app, {
   projectRequestContractAiService,
   projectRequestContractStorageService,
   projectSheetSourceStorageService,
+  projectRegistrationSlackService,
 }) {
   // ── GET /api/v1/projects ─────────────────────────────────────────────────────
   app.get('/api/v1/projects', asyncHandler(async (req, res) => {
@@ -290,6 +352,48 @@ export function mountProjectRoutes(app, {
       res.status(200).json({ contractDocument, analysis });
     }),
   );
+
+  app.post('/api/v1/project-requests/:requestId/notify-registration', createMutatingRoute(idempotencyService, async (req) => {
+    const { tenantId } = req.context;
+    assertActorRoleAllowed(req, PROJECT_REQUEST_ROUTE_ROLES, 'notify project registration');
+    const requestId = readOptionalText(req.params.requestId);
+
+    if (!requestId) {
+      throw createHttpError(400, 'project request id is required', 'missing_project_request_id');
+    }
+
+    if (!projectRegistrationSlackService?.enabled || typeof projectRegistrationSlackService.notifyMessage !== 'function') {
+      return {
+        status: 200,
+        body: {
+          ok: true,
+          enabled: false,
+          delivered: false,
+          reason: 'slack_not_configured',
+          requestId,
+        },
+      };
+    }
+
+    const requestSnap = await db.doc(`orgs/${tenantId}/projectRequests/${requestId}`).get();
+    if (!requestSnap.exists) {
+      throw createHttpError(404, `Project request not found: ${requestId}`, 'not_found');
+    }
+
+    const projectRequest = requestSnap.data() || {};
+    await projectRegistrationSlackService.notifyMessage(buildProjectRegistrationSlackPayload(projectRequest));
+
+    return {
+      status: 200,
+      body: {
+        ok: true,
+        enabled: true,
+        delivered: true,
+        requestId,
+        projectId: readOptionalText(projectRequest.approvedProjectId) || null,
+      },
+    };
+  }));
 
   // ── Evidence drive root (project-level) ─────────────────────────────────────
   app.post('/api/v1/projects/:projectId/evidence-drive/root/provision', createMutatingRoute(idempotencyService, async (req) => {

--- a/server/bff/slack-alerts.mjs
+++ b/server/bff/slack-alerts.mjs
@@ -90,6 +90,51 @@ export function createSlackAlertService({
     ? 'webhook'
     : (normalizedBotToken && normalizedChannelId ? 'bot' : 'disabled');
 
+  async function sendPayload(payload) {
+    if (mode === 'disabled') {
+      throw new Error('Slack delivery target is not configured');
+    }
+    if (typeof fetchImpl !== 'function') {
+      throw new Error('Fetch is not available for Slack delivery');
+    }
+
+    if (mode === 'webhook') {
+      const response = await fetchImpl(normalizedWebhookUrl, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        throw new Error(`Slack webhook failed (${response.status}) ${truncate(body, 200)}`.trim());
+      }
+      return;
+    }
+
+    const response = await fetchImpl('https://slack.com/api/chat.postMessage', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        'authorization': `Bearer ${normalizedBotToken}`,
+      },
+      body: JSON.stringify({
+        channel: normalizedChannelId,
+        text: payload.text,
+        blocks: payload.blocks,
+        unfurl_links: false,
+        unfurl_media: false,
+      }),
+    });
+
+    const body = await response.json().catch(() => null);
+    if (!response.ok || !body?.ok) {
+      throw new Error(`Slack chat.postMessage failed (${response.status}) ${truncate(body?.error || '', 200)}`.trim());
+    }
+  }
+
   return {
     enabled: mode !== 'disabled' && typeof fetchImpl === 'function',
     minLevel: normalizedMinLevel,
@@ -100,50 +145,15 @@ export function createSlackAlertService({
       return levelRank(event?.level) >= levelRank(normalizedMinLevel);
     },
 
+    async notifyMessage(payload) {
+      const normalizedPayload = payload && typeof payload === 'object' ? payload : {};
+      const text = truncate(normalizedPayload.text || '', 3000) || 'InnerPlatform notification';
+      const blocks = Array.isArray(normalizedPayload.blocks) ? normalizedPayload.blocks : undefined;
+      await sendPayload({ text, ...(blocks ? { blocks } : {}) });
+    },
+
     async notifyClientError(event) {
-      if (mode === 'disabled') {
-        throw new Error('Slack delivery target is not configured');
-      }
-      if (typeof fetchImpl !== 'function') {
-        throw new Error('Fetch is not available for Slack delivery');
-      }
-
-      if (mode === 'webhook') {
-        const response = await fetchImpl(normalizedWebhookUrl, {
-          method: 'POST',
-          headers: {
-            'content-type': 'application/json',
-          },
-          body: JSON.stringify(buildSlackPayload(event)),
-        });
-
-        if (!response.ok) {
-          const body = await response.text().catch(() => '');
-          throw new Error(`Slack webhook failed (${response.status}) ${truncate(body, 200)}`.trim());
-        }
-        return;
-      }
-
-      const payload = buildSlackPayload(event);
-      const response = await fetchImpl('https://slack.com/api/chat.postMessage', {
-        method: 'POST',
-        headers: {
-          'content-type': 'application/json; charset=utf-8',
-          'authorization': `Bearer ${normalizedBotToken}`,
-        },
-        body: JSON.stringify({
-          channel: normalizedChannelId,
-          text: payload.text,
-          blocks: payload.blocks,
-          unfurl_links: false,
-          unfurl_media: false,
-        }),
-      });
-
-      const body = await response.json().catch(() => null);
-      if (!response.ok || !body?.ok) {
-        throw new Error(`Slack chat.postMessage failed (${response.status}) ${truncate(body?.error || '', 200)}`.trim());
-      }
+      await sendPayload(buildSlackPayload(event));
     },
   };
 }

--- a/server/bff/slack-alerts.test.ts
+++ b/server/bff/slack-alerts.test.ts
@@ -83,4 +83,39 @@ describe('createSlackAlertService', () => {
     expect(body.channel).toBe('C1234567890');
     expect(body.text).toContain('[InnerPlatform][WARNING]');
   });
+
+  it('sends custom Slack messages through notifyMessage', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, ts: '789.012' }),
+    }));
+    const service = createSlackAlertService({
+      webhookUrl: '',
+      botToken: 'xoxb-test-token',
+      channelId: 'C09BJ767XCM',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await service.notifyMessage({
+      text: '[InnerPlatform] 신규 프로젝트 등록 완료: 2026 CTS2',
+      blocks: [
+        {
+          type: 'section',
+          text: {
+            type: 'mrkdwn',
+            text: '*[InnerPlatform] 신규 프로젝트 등록 완료*',
+          },
+        },
+      ],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe('https://slack.com/api/chat.postMessage');
+    const body = JSON.parse(String(init.body));
+    expect(body.channel).toBe('C09BJ767XCM');
+    expect(body.text).toContain('2026 CTS2');
+    expect(body.blocks[0].text.text).toContain('신규 프로젝트 등록 완료');
+  });
 });

--- a/src/app/components/portal/PortalLayout.tsx
+++ b/src/app/components/portal/PortalLayout.tsx
@@ -4,7 +4,7 @@ import {
   LayoutDashboard, Calculator,
   LogOut,
   FolderKanban, Menu,
-  Plus,
+  Plus, Pencil,
   CircleDollarSign,
   BarChart3,
   ClipboardList,
@@ -69,6 +69,7 @@ const NAV_SECTIONS = [
     title: '사업 배정 및 등록',
     items: [
       { to: '/portal/project-settings', icon: Settings2, label: '사업 배정 수정', exact: true },
+      { to: '/portal/edit-project', icon: Pencil, label: '프로젝트 정보 수정' },
       { to: '/portal/register-project', icon: Plus, label: '사업 등록 제안', accent: true },
     ],
   },

--- a/src/app/components/portal/PortalProjectEdit.tsx
+++ b/src/app/components/portal/PortalProjectEdit.tsx
@@ -1,0 +1,375 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router';
+import {
+  ArrowLeft,
+  Building2,
+  Loader2,
+  Save,
+  Users,
+  Wallet,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import { useAuth } from '../../data/auth-store';
+import { usePortalStore } from '../../data/portal-store';
+import { useFirebase } from '../../lib/firebase-context';
+import { getAuthInstance } from '../../lib/firebase';
+import { upsertProjectViaBff } from '../../lib/platform-bff-client';
+import {
+  PROJECT_TYPE_LABELS,
+  SETTLEMENT_TYPE_LABELS,
+  BASIS_LABELS,
+  ACCOUNT_TYPE_LABELS,
+  type ProjectType,
+  type SettlementType,
+  type Basis,
+  type AccountType,
+} from '../../data/types';
+import { PROJECT_DEPARTMENT_OPTIONS } from '../../data/project-department-options';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { Label } from '../ui/label';
+import { Textarea } from '../ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../ui/select';
+
+function fmtKRW(value: number) {
+  if (!value) return '0';
+  return value.toLocaleString('ko-KR');
+}
+
+export function PortalProjectEdit() {
+  const navigate = useNavigate();
+  const { orgId } = useFirebase();
+  const { user: authUser } = useAuth();
+  const { myProject } = usePortalStore();
+  const [saving, setSaving] = useState(false);
+
+  const [form, setForm] = useState({
+    name: '',
+    officialContractName: '',
+    type: 'D1' as ProjectType,
+    department: '',
+    clientOrg: '',
+    contractAmount: 0,
+    salesVatAmount: 0,
+    contractStart: '',
+    contractEnd: '',
+    settlementType: 'TYPE1' as SettlementType,
+    basis: '공급가액' as Basis,
+    accountType: 'DEDICATED' as AccountType,
+    managerName: '',
+    teamName: '',
+    participantCondition: '',
+    projectPurpose: '',
+    note: '',
+  });
+
+  useEffect(() => {
+    if (myProject) {
+      setForm({
+        name: myProject.name || '',
+        officialContractName: myProject.officialContractName || '',
+        type: myProject.type || 'D1',
+        department: myProject.department || '',
+        clientOrg: myProject.clientOrg || '',
+        contractAmount: myProject.contractAmount || 0,
+        salesVatAmount: myProject.salesVatAmount || 0,
+        contractStart: myProject.contractStart || '',
+        contractEnd: myProject.contractEnd || '',
+        settlementType: myProject.settlementType || 'TYPE1',
+        basis: myProject.basis || '공급가액',
+        accountType: myProject.accountType || 'DEDICATED',
+        managerName: myProject.managerName || '',
+        teamName: myProject.teamName || '',
+        participantCondition: myProject.participantCondition || '',
+        projectPurpose: myProject.projectPurpose || '',
+        note: (myProject as any).note || '',
+      });
+    }
+  }, [myProject]);
+
+  if (!myProject) {
+    return (
+      <div className="min-h-[40vh] flex items-center justify-center">
+        <p className="text-muted-foreground text-sm">배정된 프로젝트가 없습니다.</p>
+      </div>
+    );
+  }
+
+  const handleSave = async () => {
+    if (!orgId || !myProject || !authUser?.uid) return;
+    setSaving(true);
+    try {
+      const idToken = authUser.idToken || await getAuthInstance()?.currentUser?.getIdToken() || undefined;
+      await upsertProjectViaBff({
+        tenantId: orgId,
+        actor: {
+          uid: authUser.uid,
+          email: authUser.email,
+          role: authUser.role,
+          idToken,
+        },
+        project: {
+          ...myProject,
+          expectedVersion: myProject.version ?? 1,
+          id: myProject.id,
+          name: form.name.trim(),
+          officialContractName: form.officialContractName.trim(),
+          type: form.type,
+          department: form.department,
+          clientOrg: form.clientOrg.trim(),
+          contractAmount: form.contractAmount,
+          salesVatAmount: form.salesVatAmount,
+          contractStart: form.contractStart,
+          contractEnd: form.contractEnd,
+          settlementType: form.settlementType,
+          basis: form.basis,
+          accountType: form.accountType,
+          managerName: form.managerName.trim(),
+          teamName: form.teamName.trim(),
+          participantCondition: form.participantCondition.trim(),
+          projectPurpose: form.projectPurpose.trim(),
+        },
+      });
+      toast.success('프로젝트 정보가 저장되었습니다.');
+    } catch (err) {
+      toast.error('저장에 실패했습니다. 다시 시도해주세요.');
+      console.error('[PortalProjectEdit] save failed:', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const update = <K extends keyof typeof form>(key: K, value: (typeof form)[K]) =>
+    setForm((prev) => ({ ...prev, [key]: value }));
+
+  return (
+    <div className="max-w-3xl mx-auto py-8 px-4">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6">
+        <Button variant="ghost" size="sm" onClick={() => navigate('/portal')}>
+          <ArrowLeft className="w-4 h-4 mr-1" /> 돌아가기
+        </Button>
+        <div>
+          <h1 className="text-xl font-bold">프로젝트 정보 수정</h1>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            현재 프로젝트: {myProject.name}
+          </p>
+        </div>
+      </div>
+
+      {/* 기본 정보 */}
+      <Card className="mb-4">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <Building2 className="w-4 h-4" /> 기본 정보
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <Label className="text-xs">프로젝트명 (등록명)</Label>
+              <Input
+                value={form.name}
+                onChange={(e) => update('name', e.target.value)}
+                placeholder="예: 2026 CTS2"
+                className="text-sm"
+              />
+            </div>
+            <div>
+              <Label className="text-xs">계약서 상 정식명</Label>
+              <Input
+                value={form.officialContractName}
+                onChange={(e) => update('officialContractName', e.target.value)}
+                className="text-sm"
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <Label className="text-xs">사업 유형</Label>
+              <Select value={form.type} onValueChange={(v) => update('type', v as ProjectType)}>
+                <SelectTrigger className="text-sm"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {Object.entries(PROJECT_TYPE_LABELS).map(([k, v]) => (
+                    <SelectItem key={k} value={k}>{v}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label className="text-xs">담당조직</Label>
+              <Select value={form.department} onValueChange={(v) => update('department', v)}>
+                <SelectTrigger className="text-sm"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {PROJECT_DEPARTMENT_OPTIONS.map((d) => (
+                    <SelectItem key={d} value={d}>{d}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <div>
+            <Label className="text-xs">발주기관 (계약기관)</Label>
+            <Input
+              value={form.clientOrg}
+              onChange={(e) => update('clientOrg', e.target.value)}
+              className="text-sm"
+            />
+          </div>
+          <div>
+            <Label className="text-xs">사업 목적</Label>
+            <Textarea
+              value={form.projectPurpose}
+              onChange={(e) => update('projectPurpose', e.target.value)}
+              className="text-sm min-h-[60px]"
+              rows={2}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* 재무 정보 */}
+      <Card className="mb-4">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <Wallet className="w-4 h-4" /> 재무 정보
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <Label className="text-xs">계약금액 (원)</Label>
+              <Input
+                type="number"
+                value={form.contractAmount || ''}
+                onChange={(e) => update('contractAmount', Number(e.target.value))}
+                className="text-sm"
+              />
+              <p className="text-[10px] text-muted-foreground mt-0.5">{fmtKRW(form.contractAmount)}원</p>
+            </div>
+            <div>
+              <Label className="text-xs">매출부가세 (원)</Label>
+              <Input
+                type="number"
+                value={form.salesVatAmount || ''}
+                onChange={(e) => update('salesVatAmount', Number(e.target.value))}
+                className="text-sm"
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <Label className="text-xs">계약 시작일</Label>
+              <Input
+                type="date"
+                value={form.contractStart}
+                onChange={(e) => update('contractStart', e.target.value)}
+                className="text-sm"
+              />
+            </div>
+            <div>
+              <Label className="text-xs">계약 종료일</Label>
+              <Input
+                type="date"
+                value={form.contractEnd}
+                onChange={(e) => update('contractEnd', e.target.value)}
+                className="text-sm"
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-3 gap-3">
+            <div>
+              <Label className="text-xs">정산 유형</Label>
+              <Select value={form.settlementType} onValueChange={(v) => update('settlementType', v as SettlementType)}>
+                <SelectTrigger className="text-sm"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {Object.entries(SETTLEMENT_TYPE_LABELS).map(([k, v]) => (
+                    <SelectItem key={k} value={k}>{v}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label className="text-xs">정산 기준</Label>
+              <Select value={form.basis} onValueChange={(v) => update('basis', v as Basis)}>
+                <SelectTrigger className="text-sm"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {Object.entries(BASIS_LABELS).map(([k, v]) => (
+                    <SelectItem key={k} value={k}>{v}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label className="text-xs">통장 유형</Label>
+              <Select value={form.accountType} onValueChange={(v) => update('accountType', v as AccountType)}>
+                <SelectTrigger className="text-sm"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {Object.entries(ACCOUNT_TYPE_LABELS).map(([k, v]) => (
+                    <SelectItem key={k} value={k}>{v}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* 팀 구성 */}
+      <Card className="mb-6">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm flex items-center gap-2">
+            <Users className="w-4 h-4" /> 팀 구성
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <Label className="text-xs">메인 담당자</Label>
+              <Input
+                value={form.managerName}
+                onChange={(e) => update('managerName', e.target.value)}
+                className="text-sm"
+              />
+            </div>
+            <div>
+              <Label className="text-xs">사내기업팀 (팀장)</Label>
+              <Input
+                value={form.teamName}
+                onChange={(e) => update('teamName', e.target.value)}
+                className="text-sm"
+              />
+            </div>
+          </div>
+          <div>
+            <Label className="text-xs">참여기업 조건</Label>
+            <Textarea
+              value={form.participantCondition}
+              onChange={(e) => update('participantCondition', e.target.value)}
+              className="text-sm min-h-[60px]"
+              rows={2}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* 저장 버튼 */}
+      <div className="flex justify-end gap-2">
+        <Button variant="outline" onClick={() => navigate('/portal')}>
+          취소
+        </Button>
+        <Button onClick={handleSave} disabled={saving || !form.name.trim()}>
+          {saving ? <Loader2 className="w-4 h-4 mr-1 animate-spin" /> : <Save className="w-4 h-4 mr-1" />}
+          저장
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/portal/PortalProjectRegister.tsx
+++ b/src/app/components/portal/PortalProjectRegister.tsx
@@ -23,6 +23,7 @@ import { useAuth } from '../../data/auth-store';
 import { useFirebase } from '../../lib/firebase-context';
 import { getAuthInstance } from '../../lib/firebase';
 import {
+  notifyProjectRequestRegistrationViaBff,
   processProjectRequestContractViaBff,
   type ProjectRequestContractAnalysisResult,
 } from '../../lib/platform-bff-client';
@@ -488,6 +489,30 @@ export function PortalProjectRegister() {
         toast.error('사업 등록 제안 저장에 실패했습니다. 다시 시도해 주세요.');
         return;
       }
+
+      const currentAuthUser = authUser;
+      if (currentAuthUser) {
+        try {
+          const idToken = currentAuthUser.idToken || await getAuthInstance()?.currentUser?.getIdToken() || undefined;
+          const notification = await notifyProjectRequestRegistrationViaBff({
+            tenantId: orgId,
+            actor: {
+              uid: currentAuthUser.uid,
+              email: currentAuthUser.email,
+              role: currentAuthUser.role,
+              idToken,
+            },
+            projectRequestId: createdId,
+          });
+          if (!notification.delivered) {
+            toast.warning('사업 등록은 저장됐지만 재경팀 슬랙 알림은 아직 설정되지 않았습니다.');
+          }
+        } catch (notificationError) {
+          console.error('[PortalProjectRegister] project registration Slack notification failed:', notificationError);
+          toast.warning('사업 등록은 저장됐지만 재경팀 슬랙 알림 전송은 실패했습니다.');
+        }
+      }
+
       setForm(payload);
       setSubmitted(true);
       toast.success('사업 등록 제안이 저장되었습니다. 관리자 검토를 기다려주세요.');

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -6,6 +6,7 @@ import {
   analyzeProjectRequestContractViaBff,
   changeTransactionStateViaBff,
   linkProjectEvidenceDriveRootViaBff,
+  notifyProjectRequestRegistrationViaBff,
   overrideTransactionEvidenceDriveCategoriesViaBff,
   previewGoogleSheetImportViaBff,
   processProjectRequestContractViaBff,
@@ -307,6 +308,37 @@ describe('platform-bff-client', () => {
       }),
     }));
     expect(result.analysis.fields.officialContractName.value).toBe('공식 계약명');
+  });
+
+  it('calls project registration notification endpoint', async () => {
+    const client = asMockClient({
+      post: vi.fn(async () => ({
+        data: {
+          ok: true,
+          enabled: true,
+          delivered: true,
+          requestId: 'pr-123',
+          projectId: 'p-123',
+        },
+      })),
+      get: vi.fn(),
+      request: vi.fn(),
+    });
+
+    const result = await notifyProjectRequestRegistrationViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'u001', role: 'pm', idToken: 'token-abc' },
+      projectRequestId: 'pr-123',
+      client,
+    });
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/project-requests/pr-123/notify-registration', expect.objectContaining({
+      tenantId: 'mysc',
+      body: {},
+      idempotencyKey: 'project-request-registration-notify:pr-123',
+    }));
+    expect(result.delivered).toBe(true);
+    expect(result.projectId).toBe('p-123');
   });
 
   it('calls evidence drive provision/sync endpoints', async () => {

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -25,6 +25,7 @@ export interface UpsertProjectPayload {
   id: string;
   name: string;
   expectedVersion?: number;
+  [key: string]: unknown;
 }
 
 export interface UpsertLedgerPayload {
@@ -126,6 +127,15 @@ export interface ProjectSheetSourceUploadPayload {
 }
 
 export interface ProjectRequestContractAnalysisResult extends ProjectRequestContractAnalysis {}
+
+export interface ProjectRequestRegistrationNotificationResult {
+  ok: boolean;
+  enabled: boolean;
+  delivered: boolean;
+  requestId: string;
+  projectId: string | null;
+  reason?: string;
+}
 
 function normalizeStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
@@ -671,6 +681,27 @@ export async function processProjectRequestContractViaBff(params: {
     contractDocument: response.data.contractDocument,
     analysis: normalizeProjectRequestContractAnalysisResult(response.data.analysis),
   };
+}
+
+export async function notifyProjectRequestRegistrationViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectRequestId: string;
+  client?: PlatformApiClientLike;
+}): Promise<ProjectRequestRegistrationNotificationResult> {
+  const apiClient = resolveClient(params.client);
+  const response = await apiClient.post<ProjectRequestRegistrationNotificationResult>(
+    `/api/v1/project-requests/${encodeURIComponent(params.projectRequestId)}/notify-registration`,
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      body: {},
+      idempotencyKey: `project-request-registration-notify:${params.projectRequestId}`,
+      timeoutMs: 10000,
+      retries: 0,
+    },
+  );
+  return response.data;
 }
 
 export async function linkProjectEvidenceDriveRootViaBff(params: {

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -40,6 +40,7 @@ const PortalBudget = lazy(() => import('./components/portal/PortalBudget').then(
 const PortalPersonnel = lazy(() => import('./components/portal/PortalPersonnel').then(m => ({ default: m.PortalPersonnel })));
 const PortalChangeRequests = lazy(() => import('./components/portal/PortalChangeRequests').then(m => ({ default: m.PortalChangeRequests })));
 const PortalProjectRegister = lazy(() => import('./components/portal/PortalProjectRegister').then(m => ({ default: m.PortalProjectRegister })));
+const PortalProjectEdit = lazy(() => import('./components/portal/PortalProjectEdit').then(m => ({ default: m.PortalProjectEdit })));
 const PortalPayrollPage = lazy(() => import('./components/portal/PortalPayrollPage').then(m => ({ default: m.PortalPayrollPage })));
 const PortalCashflowPage = lazy(() => import('./components/portal/PortalCashflowPage').then(m => ({ default: m.PortalCashflowPage })));
 const PortalSubmissionsPage = lazy(() => import('./components/portal/PortalSubmissionsPage').then(m => ({ default: m.PortalSubmissionsPage })));
@@ -126,6 +127,7 @@ export const router = createBrowserRouter([
       { path: 'personnel', element: <S C={PortalPersonnel} /> },
       { path: 'change-requests', element: <S C={PortalChangeRequests} /> },
       { path: 'register-project', element: <S C={PortalProjectRegister} /> },
+      { path: 'edit-project', element: <S C={PortalProjectEdit} /> },
       { path: 'training', element: <S C={PortalTrainingPage} /> },
       { path: 'career-profile', element: <S C={CareerProfilePage} /> },
       { path: 'guide-chat', element: <S C={GuideChatPage} /> },


### PR DESCRIPTION
## Summary
- add a portal project edit page and navigation entry for PM users
- notify finance Slack when a project registration request is created
- route project edits through the BFF project upsert path instead of direct Firestore writes
- add unit tests for the new Slack notification path and BFF client helper

## Verification
- npx vitest run src/app/lib/platform-bff-client.test.ts server/bff/slack-alerts.test.ts
- npx tsc --noEmit | rg "PortalProjectEdit|PortalProjectRegister|platform-bff-client|slack-alerts|routes/projects|app.integration.test|app.mjs"

## Notes
- gstack browse was used against a local dev harness to check route impact, but the harness stayed on a loading state for /portal/edit-project without seeded portal auth state, so browser verification was limited to route reachability and no immediate console crash on first load.