### PR TITLE
fix(projects): 사업이관 메뉴 복구

### DIFF
--- a/src/app/components/layout/CommandPalette.tsx
+++ b/src/app/components/layout/CommandPalette.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router';
 import {
   LayoutDashboard, FolderKanban, BarChart3, FileCheck, Shield,
-  ClipboardList, Settings, Search, ArrowRight, ListChecks,
+  ClipboardList, Settings, Search, ArrowRight, ListChecks, ArrowLeftRight,
   Zap, Clock, AlertTriangle, Users, Hash,
 } from 'lucide-react';
 import { Dialog, DialogContent } from '../ui/dialog';
@@ -114,6 +114,7 @@ export function CommandPalette() {
     const nav: CommandItem[] = [
       { id: 'nav-dash', icon: LayoutDashboard, label: '대시보드', path: '/', category: '탐색', action: () => go('/'), keywords: ['dashboard', '홈'] },
       { id: 'nav-proj', icon: FolderKanban, label: '프로젝트 목록', path: '/projects', category: '탐색', action: () => go('/projects'), keywords: ['project', '사업'] },
+      { id: 'nav-migration', icon: ArrowLeftRight, label: '사업이관', path: '/projects/migration-audit', category: '탐색', action: () => go('/projects/migration-audit'), keywords: ['migration', '이관', '점검', 'audit'] },
       { id: 'nav-cash', icon: BarChart3, label: '캐시플로 추출', path: '/cashflow', category: '탐색', action: () => go('/cashflow'), keywords: ['cashflow', '현금흐름', '엑셀', '다운로드', 'export'] },
       { id: 'nav-evi', icon: FileCheck, label: '증빙/정산 관리', path: '/evidence', category: '탐색', action: () => go('/evidence'), keywords: ['evidence', '증빙'] },
       { id: 'nav-approval', icon: ListChecks, label: '승인 대기열', path: '/approvals', category: '탐색', action: () => go('/approvals'), keywords: ['approval', '승인', '대기열'] },

--- a/src/app/components/settings/DataMigrationTab.tsx
+++ b/src/app/components/settings/DataMigrationTab.tsx
@@ -441,9 +441,9 @@ export function DataMigrationTab() {
 
             <div className="flex items-center justify-between rounded-md border border-slate-200 bg-slate-50/70 p-3">
               <div className="space-y-1">
-                <p className="text-sm font-semibold text-slate-900">이관 점검 보수 경로</p>
+                <p className="text-sm font-semibold text-slate-900">사업이관 바로가기</p>
                 <p className="text-xs text-slate-600">
-                  프로젝트 이관 점검 콘솔은 설정 탭에서만 유지합니다. 일상 운영 메뉴에서는 숨겨집니다.
+                  프로젝트 이관 콘솔은 사업이관 메뉴와 설정 탭 양쪽에서 바로 열 수 있습니다.
                 </p>
               </div>
               <Link

--- a/src/app/platform/admin-nav.test.ts
+++ b/src/app/platform/admin-nav.test.ts
@@ -34,6 +34,14 @@ describe('admin nav access control', () => {
     expect(canAccessAdminPath('viewer', '/approvals')).toBe(false);
   });
 
+  it('restores migration audit as an admin-only menu route', () => {
+    expect(canShowAdminNavItem('admin', '/projects/migration-audit')).toBe(true);
+    expect(canShowAdminNavItem('finance', '/projects/migration-audit')).toBe(false);
+    expect(canShowAdminNavItem('pm', '/projects/migration-audit')).toBe(false);
+    expect(canAccessAdminPath('admin', '/projects/migration-audit')).toBe(true);
+    expect(canAccessAdminPath('finance', '/projects/migration-audit')).toBe(false);
+  });
+
   it('still rejects empty or unknown roles from admin nav', () => {
     expect(canShowAdminNavItem('', '/')).toBe(false);
     expect(canShowAdminNavItem(undefined, '/')).toBe(false);

--- a/src/app/platform/go-shortcuts.ts
+++ b/src/app/platform/go-shortcuts.ts
@@ -1,6 +1,7 @@
 const GO_SHORTCUT_TARGETS = {
   d: '/',
   p: '/projects',
+  m: '/projects/migration-audit',
   c: '/cashflow',
   e: '/evidence',
   s: '/settings',

--- a/src/app/platform/nav-config.ts
+++ b/src/app/platform/nav-config.ts
@@ -25,6 +25,7 @@ export const NAV_GROUPS: NavGroup[] = [
     items: [
       { to: '/', icon: LayoutDashboard, label: '대시보드' },
       { to: '/projects', icon: FolderKanban, label: '프로젝트' },
+      { to: '/projects/migration-audit', icon: ArrowLeftRight, label: '사업이관' },
       { to: '/board', icon: MessagesSquare, label: '전사 게시판' },
     ],
   },

--- a/src/app/platform/shortcut-policy.test.ts
+++ b/src/app/platform/shortcut-policy.test.ts
@@ -9,6 +9,7 @@ describe('shortcut policy', () => {
   it('shows admin-only shortcuts for admin roles', () => {
     const descs = flattenDescriptions(getShortcutGroupsForRole('admin'));
     expect(descs).toContain('설정으로 이동');
+    expect(descs).toContain('사업이관으로 이동');
     expect(descs).not.toContain('새 사업 등록');
   });
 
@@ -16,6 +17,7 @@ describe('shortcut policy', () => {
     const descs = flattenDescriptions(getShortcutGroupsForRole('finance'));
     expect(descs).toContain('프로젝트 목록으로 이동');
     expect(descs).not.toContain('설정으로 이동');
+    expect(descs).not.toContain('사업이관으로 이동');
     expect(descs).not.toContain('새 사업 등록');
     expect(descs).not.toContain('감사로그로 이동');
   });
@@ -24,6 +26,7 @@ describe('shortcut policy', () => {
     const descs = flattenDescriptions(getShortcutGroupsForRole('viewer'));
     expect(descs).toContain('커맨드 팔레트 열기');
     expect(descs).not.toContain('설정으로 이동');
+    expect(descs).not.toContain('사업이관으로 이동');
     expect(descs).not.toContain('새 사업 등록');
   });
 });

--- a/src/app/platform/shortcut-policy.ts
+++ b/src/app/platform/shortcut-policy.ts
@@ -46,6 +46,7 @@ const BASE_GROUPS: ShortcutGroup[] = [
     shortcuts: [
       { keys: ['G', 'D'], desc: '대시보드로 이동', to: '/' },
       { keys: ['G', 'P'], desc: '프로젝트 목록으로 이동', to: '/projects' },
+      { keys: ['G', 'M'], desc: '사업이관으로 이동', to: '/projects/migration-audit' },
       { keys: ['G', 'C'], desc: '캐시플로로 이동', to: '/cashflow' },
       { keys: ['G', 'E'], desc: '증빙/정산으로 이동', to: '/evidence' },
       { keys: ['G', 'S'], desc: '설정으로 이동', to: '/settings' },

--- a/tests/e2e/project-surface-trim.spec.ts
+++ b/tests/e2e/project-surface-trim.spec.ts
@@ -45,6 +45,15 @@ test('settings migration tab links to the maintenance-only migration audit surfa
   await expect(page).toHaveURL(/\/projects\/migration-audit$/);
 });
 
+test('admin navigation restores the migration audit menu', async ({ page }) => {
+  await loginAsAdmin(page);
+  await page.goto('/');
+
+  await expect(page.getByRole('link', { name: '사업이관' })).toBeVisible();
+  await page.getByRole('link', { name: '사업이관' }).click();
+  await expect(page).toHaveURL(/\/projects\/migration-audit$/);
+});
+
 test('project detail defaults to summary and ledger while secondary sections stay collapsed', async ({ page }) => {
   await loginAsAdmin(page);
   await page.goto('/projects');


### PR DESCRIPTION
## 요약\n- admin 사이드바에 사업이관 메뉴를 다시 노출\n- 커맨드 팔레트와 G M 단축 이동에 사업이관 진입 복구\n- 설정의 데이터 마이그레이션 탭 문구를 새 진입 구조에 맞게 수정\n\n## 검증\n- npx vitest run src/app/platform/admin-nav.test.ts src/app/platform/shortcut-policy.test.ts\n- npx playwright test tests/e2e/project-surface-trim.spec.ts --config playwright.harness.config.mjs\n- npm run build