### PR TITLE
fix(portal): 예산 구조 저장 유효성 검증 추가

### DIFF
--- a/src/app/components/portal/PortalBudget.tsx
+++ b/src/app/components/portal/PortalBudget.tsx
@@ -49,6 +49,7 @@ import {
   aggregateBudgetActualsFromSettlementRowsLocally,
 } from '../../platform/settlement-calculation-kernel';
 import { moveBudgetSubCode, moveBudgetSubCodeToIndex } from '../../platform/budget-code-book-order';
+import { validateBudgetCodeBookDraft } from '../../platform/budget-code-book-validation';
 import { buildBudgetLabelKey, normalizeBudgetLabel } from '../../platform/budget-labels';
 import { parseBudgetPlanMatrix, planBudgetPlanMerge } from '../../platform/google-sheet-migration';
 import { parseLocalWorkbookFile, type LocalWorkbookSheet } from '../../platform/local-workbook';
@@ -320,6 +321,10 @@ export function PortalBudget() {
     () => parseBudgetCodeImportText(codeBookImportText),
     [codeBookImportText],
   );
+  const codeBookValidation = useMemo(
+    () => validateBudgetCodeBookDraft(draftCodeBook),
+    [draftCodeBook],
+  );
   const budgetImportSelectedSheet = useMemo(
     () => budgetImportSheets.find((sheet) => sheet.name === budgetImportSheetName) || budgetImportSheets[0] || null,
     [budgetImportSheets, budgetImportSheetName],
@@ -561,6 +566,10 @@ export function PortalBudget() {
       const copy = prev.map((c) => ({ code: c.code, subCodes: [...c.subCodes] }));
       const entry = copy[idx];
       if (!entry) return prev;
+      if (entry.subCodes.length <= 1) {
+        toast.error('각 비목에는 세목이 최소 1개 필요합니다.');
+        return prev;
+      }
       const removed = entry.subCodes[subIdx] || '';
       entry.subCodes = entry.subCodes.filter((_, i) => i !== subIdx);
       if (entry.code && removed) removeDraftRows(entry.code, removed);
@@ -806,6 +815,13 @@ export function PortalBudget() {
 
   const saveSettings = useCallback(async () => {
     if (!saveBudgetPlanRows && !saveBudgetCodeBook) return;
+    if (codeBookMode) {
+      const validation = validateBudgetCodeBookDraft(draftCodeBook);
+      if (!validation.isValid) {
+        toast.error(validation.errors[0] || '비목/세목 구조를 확인해 주세요.');
+        return;
+      }
+    }
     const normalized: BudgetPlanRow[] = editMode ? draftRows.map((row) => {
       const budgetCode = normalizeBudgetLabel(String(row.budgetCode || '').trim());
       const subCode = normalizeBudgetLabel(String(row.subCode || '').trim());
@@ -1477,6 +1493,9 @@ export function PortalBudget() {
                       {codeBookReplaceMode ? (
                         <p className="text-[10px] text-amber-600">가져온 구조 초안이 반영된 상태입니다. 저장하면 현재 비목/세목 구조가 교체됩니다.</p>
                       ) : null}
+                      {!codeBookValidation.isValid ? (
+                        <p className="text-[10px] text-rose-600">{codeBookValidation.errors[0]}</p>
+                      ) : null}
                     </div>
                     <Button variant="outline" size="sm" className="h-7 text-[11px] gap-1" onClick={addBudgetCode}>
                       <Plus className="w-3.5 h-3.5" />
@@ -1689,7 +1708,12 @@ export function PortalBudget() {
                 <Button variant="outline" size="sm" className="h-8 text-[12px]" onClick={cancelEdit}>
                   취소
                 </Button>
-                <Button size="sm" className="h-8 text-[12px]" onClick={saveSettings} disabled={settingsSaving}>
+                <Button
+                  size="sm"
+                  className="h-8 text-[12px]"
+                  onClick={saveSettings}
+                  disabled={settingsSaving || !codeBookValidation.isValid}
+                >
                   {settingsSaving ? '저장 중...' : '저장'}
                 </Button>
               </div>

--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -86,6 +86,7 @@ import { includesProject, normalizeProjectIds, resolvePrimaryProjectId } from '.
 import { canEnterPortalWorkspace } from '../platform/navigation';
 import { readDevAuthHarnessConfig } from '../platform/dev-harness';
 import { reportError } from '../platform/observability';
+import { validateBudgetCodeBookDraft } from '../platform/budget-code-book-validation';
 import { buildBudgetLabelKey, normalizeBudgetLabel } from '../platform/budget-labels';
 
 export interface PortalUser {
@@ -1738,11 +1739,11 @@ export function PortalProvider({ children }: { children: ReactNode }) {
 
   const saveBudgetCodeBook = useCallback(async (rows: BudgetCodeEntry[], renames: BudgetCodeRename[] = []) => {
     const now = new Date().toISOString();
-    const sanitized = normalizeBudgetCodeBook(rows);
-    if (sanitized.length === 0) {
-      toast.error('비목/세목이 비어 있습니다.');
-      return;
+    const validation = validateBudgetCodeBookDraft(rows);
+    if (!validation.isValid) {
+      throw new Error(validation.errors[0] || '비목/세목 구조를 확인해 주세요.');
     }
+    const sanitized = normalizeBudgetCodeBook(rows);
     if (isDevHarnessUser || !db || !portalUser?.projectId) {
       setBudgetCodeBook(sanitized);
       return;

--- a/src/app/platform/budget-code-book-validation.test.ts
+++ b/src/app/platform/budget-code-book-validation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { validateBudgetCodeBookDraft } from './budget-code-book-validation';
+
+describe('validateBudgetCodeBookDraft', () => {
+  it('rejects budget codes without any sub codes', () => {
+    const result = validateBudgetCodeBookDraft([
+      { code: '회계감사비용', subCodes: [] },
+    ]);
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors[0]).toContain('세목을 1개 이상');
+  });
+
+  it('rejects blank sub code labels', () => {
+    const result = validateBudgetCodeBookDraft([
+      { code: '교육운영비', subCodes: [''] },
+    ]);
+
+    expect(result.isValid).toBe(false);
+    expect(result.errors[0]).toContain('세목명');
+  });
+
+  it('accepts budget codes that have at least one named sub code', () => {
+    const result = validateBudgetCodeBookDraft([
+      { code: '교육운영비', subCodes: ['강사비'] },
+      { code: '출장비', subCodes: ['교통비', '숙박비'] },
+    ]);
+
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+});

--- a/src/app/platform/budget-code-book-validation.ts
+++ b/src/app/platform/budget-code-book-validation.ts
@@ -1,0 +1,47 @@
+import type { BudgetCodeEntry } from '../data/types';
+import { normalizeBudgetLabel } from './budget-labels';
+
+export interface BudgetCodeBookValidationResult {
+  isValid: boolean;
+  errors: string[];
+}
+
+function displayCodeLabel(entry: BudgetCodeEntry, index: number): string {
+  const trimmed = String(entry.code || '').trim();
+  return trimmed || `${index + 1}번째 비목`;
+}
+
+export function validateBudgetCodeBookDraft(entries: BudgetCodeEntry[]): BudgetCodeBookValidationResult {
+  const errors: string[] = [];
+
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return {
+      isValid: false,
+      errors: ['비목을 1개 이상 입력해 주세요.'],
+    };
+  }
+
+  entries.forEach((entry, index) => {
+    const code = normalizeBudgetLabel(entry.code || '');
+    const label = displayCodeLabel(entry, index);
+    if (!code) {
+      errors.push(`${index + 1}번째 비목명을 입력해 주세요.`);
+      return;
+    }
+
+    const subCodes = Array.isArray(entry.subCodes) ? entry.subCodes : [];
+    if (subCodes.length === 0) {
+      errors.push(`${label}에 세목을 1개 이상 추가해 주세요.`);
+      return;
+    }
+
+    if (subCodes.some((subCode) => !normalizeBudgetLabel(subCode || ''))) {
+      errors.push(`${label}의 비어 있는 세목명을 입력해 주세요.`);
+    }
+  });
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+  };
+}


### PR DESCRIPTION
## 요약\n- portal 예산 구조 관리에서 세목 없는 비목 저장을 막음\n- 저장 전 유효성 문구와 저장 버튼 비활성화를 추가\n- store 저장 레이어도 동일 검증을 사용하도록 정리\n\n## 검증\n- npx vitest run src/app/platform/budget-code-book-validation.test.ts\n- npm run build