### PR TITLE
fix(portal): 제출 상태와 사업비 입력 키보드 버그 수정

### DIFF
--- a/src/app/components/cashflow/ImportEditor.tsx
+++ b/src/app/components/cashflow/ImportEditor.tsx
@@ -5,7 +5,7 @@ import type {
 } from 'react';
 import { Loader2, Maximize2, Minimize2, Plus, RotateCcw, Save, X } from 'lucide-react';
 import { toast } from 'sonner';
-import { detectKeyRuleContext, runKeyRules, type KeyRule } from '../../platform/settlement-grid-keymap';
+import { detectKeyRuleContext, runKeyRules, shouldHandleGridDeletion, type KeyRule } from '../../platform/settlement-grid-keymap';
 import { grid2tsv, html2grid, isSpreadsheetHtml, parseTsvRows } from '../../platform/settlement-grid-clipboard';
 import { BUDGET_CODE_BOOK } from '../../data/budget-data';
 import type {
@@ -1269,7 +1269,7 @@ export function ImportEditor({
       {
         combo: [{ key: 'Delete' }, { key: 'Backspace' }],
         run: (_ev, ruleCtx) => {
-          if (ruleCtx.isTextEditingTarget && !ruleCtx.hasMultiCellSelection && ruleCtx.inputHasPartialSelection) return false;
+          if (!shouldHandleGridDeletion(ruleCtx)) return false;
           if (!getActiveSelectionBounds()) return false;
           _ev.preventDefault();
           void clearSelectedCells();

--- a/src/app/components/portal/PortalSubmissionsPage.tsx
+++ b/src/app/components/portal/PortalSubmissionsPage.tsx
@@ -23,6 +23,7 @@ import { useCashflowWeeks } from '../../data/cashflow-weeks-store';
 import { getMonthMondayWeeks } from '../../platform/cashflow-weeks';
 import { addMonthsToYearMonth, getSeoulTodayIso } from '../../platform/business-days';
 import {
+  resolveWeeklyAccountingState,
   resolveWeeklyAccountingProductStatus,
   resolveWeeklyAccountingProductStatusDomHooks,
   resolveWeeklyAccountingSnapshot,

--- a/src/app/platform/settlement-grid-keymap.test.ts
+++ b/src/app/platform/settlement-grid-keymap.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { matchKeyCombo, runKeyRules, type KeyRule, type KeyRuleContext } from './settlement-grid-keymap';
+import {
+  matchKeyCombo,
+  runKeyRules,
+  shouldHandleGridDeletion,
+  type KeyRule,
+  type KeyRuleContext,
+} from './settlement-grid-keymap';
 
 function fakeKeyEvent(overrides: Partial<KeyboardEvent> = {}): KeyboardEvent {
   return {
@@ -94,6 +100,24 @@ describe('settlement-grid-keymap', () => {
       const result = runKeyRules(fakeKeyEvent({ key: 'Backspace' }), rules, baseCtx);
       expect(result).toBe(true);
       expect(called).toBe(true);
+    });
+  });
+
+  describe('shouldHandleGridDeletion', () => {
+    it('does not hijack backspace while typing in a single input cell', () => {
+      expect(shouldHandleGridDeletion({
+        isTextEditingTarget: true,
+        hasMultiCellSelection: false,
+        inputHasPartialSelection: false,
+      })).toBe(false);
+    });
+
+    it('still allows grid deletion for multi-cell selections', () => {
+      expect(shouldHandleGridDeletion({
+        isTextEditingTarget: true,
+        hasMultiCellSelection: true,
+        inputHasPartialSelection: false,
+      })).toBe(true);
     });
   });
 });

--- a/src/app/platform/settlement-grid-keymap.ts
+++ b/src/app/platform/settlement-grid-keymap.ts
@@ -44,6 +44,12 @@ export function runKeyRules(e: KeyboardEvent, rules: KeyRule[], ctx: KeyRuleCont
   return false;
 }
 
+export function shouldHandleGridDeletion(ctx: KeyRuleContext): boolean {
+  if (ctx.hasMultiCellSelection) return true;
+  if (ctx.isTextEditingTarget) return false;
+  return true;
+}
+
 export function detectKeyRuleContext(e: KeyboardEvent): KeyRuleContext {
   const target = e.target as HTMLElement | null;
   const isTextEditingTarget = Boolean(


### PR DESCRIPTION
## 요약
- PortalSubmissionsPage의 누락 import를 복구해 직접작성 사업에서도 제출 상태 화면이 열리도록 수정
- 사업비 입력 그리드에서 텍스트 입력 중 Backspace/Delete를 그리드가 가로채지 않도록 수정
- 실제 구비완료 증빙자료 리스트와 날짜 입력 셀에서 글자 단위 수정이 가능하도록 정리

## 검증
- npx vitest run src/app/platform/settlement-grid-keymap.test.ts
- npx playwright test tests/e2e/platform-smoke.spec.ts -g "8-1. PM can access submissions page with guided status surface" --config playwright.harness.config.mjs
- npm run build