### PR TITLE
fix: 포털 가이드 자동 팝업 제거

### DIFF
--- a/src/app/components/cashflow/ImportEditorRow.tsx
+++ b/src/app/components/cashflow/ImportEditorRow.tsx
@@ -32,6 +32,7 @@ import {
   toFieldSlug,
 } from '../../platform/settlement-grid-helpers';
 import { resolveEvidenceRequiredDesc } from '../../platform/settlement-sheet-prepare';
+import { resolveSelectPopupPosition } from './select-popup-position';
 import { Button } from '../ui/button';
 import {
   DropdownMenu,
@@ -70,20 +71,32 @@ function SelectCell({
 }) {
   const btnRef = useRef<HTMLButtonElement | null>(null);
   const [popupRect, setPopupRect] = useState<{ left: number; top: number } | null>(null);
+  const popupWidth = 160;
+  const popupHeight = Math.min(320, 32 * (options.length + 1));
 
   useLayoutEffect(() => {
     if (!isOpen) return;
     const rect = btnRef.current?.getBoundingClientRect();
     if (!rect) return;
-    setPopupRect({ left: rect.left, top: rect.bottom + 4 });
-  }, [isOpen]);
+    setPopupRect(resolveSelectPopupPosition({
+      triggerRect: rect,
+      viewport: { width: window.innerWidth, height: window.innerHeight },
+      popupWidth,
+      popupHeight,
+    }));
+  }, [isOpen, popupHeight, popupWidth]);
 
   useEffect(() => {
     if (!isOpen) return;
     const update = () => {
       const rect = btnRef.current?.getBoundingClientRect();
       if (!rect) return;
-      setPopupRect({ left: rect.left, top: rect.bottom + 4 });
+      setPopupRect(resolveSelectPopupPosition({
+        triggerRect: rect,
+        viewport: { width: window.innerWidth, height: window.innerHeight },
+        popupWidth,
+        popupHeight,
+      }));
     };
     window.addEventListener('scroll', update, true);
     window.addEventListener('resize', update);
@@ -91,7 +104,7 @@ function SelectCell({
       window.removeEventListener('scroll', update, true);
       window.removeEventListener('resize', update);
     };
-  }, [isOpen]);
+  }, [isOpen, popupHeight, popupWidth]);
 
   const openPicker = (e: ReactMouseEvent<HTMLButtonElement>) => {
     e.preventDefault();

--- a/src/app/components/cashflow/select-popup-position.test.ts
+++ b/src/app/components/cashflow/select-popup-position.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSelectPopupPosition } from './select-popup-position';
+
+describe('resolveSelectPopupPosition', () => {
+  it('opens upward when there is not enough viewport space below the trigger', () => {
+    const result = resolveSelectPopupPosition({
+      triggerRect: {
+        left: 120,
+        top: 740,
+        right: 200,
+        bottom: 764,
+        width: 80,
+        height: 24,
+        x: 120,
+        y: 740,
+        toJSON: () => ({}),
+      },
+      viewport: {
+        width: 1280,
+        height: 800,
+      },
+      popupWidth: 160,
+      popupHeight: 280,
+    });
+
+    expect(result.top).toBeLessThan(740);
+  });
+
+  it('clamps horizontally so the popup stays inside the viewport', () => {
+    const result = resolveSelectPopupPosition({
+      triggerRect: {
+        left: 1180,
+        top: 120,
+        right: 1260,
+        bottom: 144,
+        width: 80,
+        height: 24,
+        x: 1180,
+        y: 120,
+        toJSON: () => ({}),
+      },
+      viewport: {
+        width: 1280,
+        height: 800,
+      },
+      popupWidth: 160,
+      popupHeight: 280,
+    });
+
+    expect(result.left).toBeLessThanOrEqual(1280 - 160 - 8);
+  });
+});

--- a/src/app/components/cashflow/select-popup-position.ts
+++ b/src/app/components/cashflow/select-popup-position.ts
@@ -1,0 +1,30 @@
+export interface PopupViewport {
+  width: number;
+  height: number;
+}
+
+export interface PopupPositionInput {
+  triggerRect: DOMRect;
+  viewport: PopupViewport;
+  popupWidth: number;
+  popupHeight: number;
+  gap?: number;
+  margin?: number;
+}
+
+export function resolveSelectPopupPosition(input: PopupPositionInput): { left: number; top: number } {
+  const gap = input.gap ?? 4;
+  const margin = input.margin ?? 8;
+  const maxLeft = Math.max(margin, input.viewport.width - input.popupWidth - margin);
+  const left = Math.min(Math.max(input.triggerRect.left, margin), maxLeft);
+
+  const spaceBelow = input.viewport.height - input.triggerRect.bottom - margin;
+  const canOpenBelow = spaceBelow >= Math.min(input.popupHeight, 240);
+  const preferredTop = canOpenBelow
+    ? input.triggerRect.bottom + gap
+    : input.triggerRect.top - input.popupHeight - gap;
+  const maxTop = Math.max(margin, input.viewport.height - input.popupHeight - margin);
+  const top = Math.min(Math.max(preferredTop, margin), maxTop);
+
+  return { left, top };
+}

--- a/src/app/components/portal/BankImportTriageWizard.tsx
+++ b/src/app/components/portal/BankImportTriageWizard.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
 import { AlertTriangle, ArrowRight, Clock3, FileWarning, Wallet } from 'lucide-react';
-import type { BankImportIntakeItem, CashflowCategory } from '../../data/types';
-import { CASHFLOW_CATEGORY_LABELS } from '../../data/types';
+import type { BankImportIntakeItem } from '../../data/types';
 import { isBankImportManualFieldsComplete } from '../../platform/bank-import-triage';
 import { groupExpenseIntakeItemsForSurface, resolveBankImportWizardStatus } from '../../platform/bank-intake-surface';
+import {
+  resolveBankImportCashflowLineId,
+  resolveBankImportCashflowOptionsForAmount,
+  resolveBankImportCashflowSelection,
+} from '../../platform/bank-import-cashflow';
 import { resolveEvidenceChecklist } from '../../platform/evidence-helpers';
 import { resolveEvidenceRequiredDesc } from '../../platform/settlement-sheet-prepare';
 import { Badge } from '../ui/badge';
@@ -20,25 +24,6 @@ interface BankImportTriageWizardProps {
   onSyncEvidence?: (id: string, updates: Partial<BankImportIntakeItem>) => Promise<void>;
   evidenceRequiredMap: Record<string, string>;
 }
-
-const CASHFLOW_OPTIONS: CashflowCategory[] = [
-  'CONTRACT_PAYMENT',
-  'INTERIM_PAYMENT',
-  'FINAL_PAYMENT',
-  'LABOR_COST',
-  'OUTSOURCING',
-  'EQUIPMENT',
-  'TRAVEL',
-  'SUPPLIES',
-  'COMMUNICATION',
-  'RENT',
-  'UTILITY',
-  'TAX_PAYMENT',
-  'VAT_REFUND',
-  'INSURANCE',
-  'MISC_INCOME',
-  'MISC_EXPENSE',
-];
 
 function formatMoney(value: number): string {
   return value.toLocaleString('ko-KR');
@@ -122,6 +107,10 @@ export function BankImportTriageWizard({
     ...selectedItem,
     manualFields: activeManualFields || selectedItem.manualFields,
   }) : null;
+  const cashflowOptions = useMemo(
+    () => (selectedItem ? resolveBankImportCashflowOptionsForAmount(selectedItem.bankSnapshot.signedAmount) : []),
+    [selectedItem],
+  );
 
   const advanceSelection = () => {
     if (!selectedItem) return;
@@ -449,20 +438,28 @@ export function BankImportTriageWizard({
                               <span className="text-[11px] font-medium text-slate-600">cashflow 항목</span>
                               <select
                                 data-testid="bank-import-cashflow-category"
-                                value={activeManualFields.cashflowCategory || ''}
+                                value={resolveBankImportCashflowLineId(activeManualFields, selectedItem.bankSnapshot.signedAmount) || ''}
                                 onChange={(event) => setDrafts((prev) => ({
                                   ...prev,
                                   [selectedItem.id]: {
                                     ...activeManualFields,
-                                    cashflowCategory: event.target.value as CashflowCategory,
+                                    ...(event.target.value
+                                      ? resolveBankImportCashflowSelection(
+                                          event.target.value as typeof cashflowOptions[number]['value'],
+                                          selectedItem.bankSnapshot.signedAmount,
+                                        )
+                                      : {
+                                          cashflowLineId: undefined,
+                                          cashflowCategory: undefined,
+                                        }),
                                   },
                                 }))}
                                 className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-[13px] outline-none transition focus:border-slate-400"
                               >
                                 <option value="">선택하세요</option>
-                                {CASHFLOW_OPTIONS.map((option) => (
-                                  <option key={option} value={option}>
-                                    {CASHFLOW_CATEGORY_LABELS[option]}
+                                {cashflowOptions.map((option) => (
+                                  <option key={option.value} value={option.value}>
+                                    {option.label}
                                   </option>
                                 ))}
                               </select>

--- a/src/app/components/portal/PortalMissionGuideLauncher.tsx
+++ b/src/app/components/portal/PortalMissionGuideLauncher.tsx
@@ -37,7 +37,7 @@ export function PortalMissionGuideLauncher({
   useEffect(() => {
     const acknowledged = readPortalGuideAcknowledged(scope);
     setDontShowAgain(acknowledged);
-    setOpen(!acknowledged);
+    setOpen(false);
   }, [scope]);
 
   const handleOpenChange = (nextOpen: boolean) => {
@@ -50,7 +50,8 @@ export function PortalMissionGuideLauncher({
   return (
     <>
       <div
-        data-testid={`portal-mission-guide-launcher-${guideId}`}
+        data-testid="portal-mission-guide"
+        data-guide-launcher-id={guideId}
         className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-indigo-200/70 bg-gradient-to-r from-indigo-50/90 via-white to-teal-50/70 px-4 py-3 shadow-sm"
       >
         <div className="min-w-0 space-y-1">

--- a/src/app/data/portal-store.intake.test.ts
+++ b/src/app/data/portal-store.intake.test.ts
@@ -4,6 +4,7 @@ import {
   buildBankImportIntakeDoc,
   mergeBankImportIntakeItem,
   normalizeBankImportIntakeItem,
+  reconcileBankImportUploadItems,
   serializeBankImportIntakeItemForPersistence,
 } from './portal-store.intake';
 
@@ -156,6 +157,54 @@ describe('portal-store intake persistence', () => {
         memo: '기존 메모',
         evidenceCompletedDesc: '출장신청서',
       }),
+    }));
+  });
+
+  it('preserves the latest manual fields when a bank upload rebuilds an existing intake item', () => {
+    const current = makeItem({
+      manualFields: {
+        expenseAmount: 120000,
+        budgetCategory: '여비',
+        budgetSubCategory: '교통비',
+        cashflowCategory: 'TRAVEL',
+        cashflowLineId: 'DIRECT_COST_OUT',
+        memo: '사람이 직접 수정한 메모',
+        evidenceCompletedDesc: '출장신청서',
+      },
+      updatedAt: '2026-04-06T01:00:00.000Z',
+    });
+    const rebuilt = makeItem({
+      bankSnapshot: {
+        accountNumber: '111-222-333',
+        dateTime: '2026-04-06 10:00',
+        counterparty: '메리 사업팀',
+        memo: '재업로드된 통장 메모',
+        signedAmount: -120000,
+        balanceAfter: 890000,
+      },
+      manualFields: {},
+      evidenceStatus: 'MISSING',
+      updatedAt: '2026-04-06T02:00:00.000Z',
+      lastUploadBatchId: 'batch-2',
+    });
+
+    const reconciled = reconcileBankImportUploadItems([current], [rebuilt]);
+
+    expect(reconciled).toHaveLength(1);
+    expect(reconciled[0]).toEqual(expect.objectContaining({
+      bankSnapshot: expect.objectContaining({
+        memo: '재업로드된 통장 메모',
+        balanceAfter: 890000,
+      }),
+      lastUploadBatchId: 'batch-2',
+      manualFields: expect.objectContaining({
+        budgetCategory: '여비',
+        budgetSubCategory: '교통비',
+        cashflowLineId: 'DIRECT_COST_OUT',
+        memo: '사람이 직접 수정한 메모',
+        evidenceCompletedDesc: '출장신청서',
+      }),
+      evidenceStatus: 'MISSING',
     }));
   });
 });

--- a/src/app/data/portal-store.intake.ts
+++ b/src/app/data/portal-store.intake.ts
@@ -1,3 +1,4 @@
+import { resolveBankImportProjectionStatus } from '../platform/bank-import-triage';
 import type { BankImportIntakeItem, BankImportManualFields, BankImportSnapshot } from './types';
 
 function normalizeString(value: unknown): string {
@@ -14,6 +15,22 @@ function normalizeManualFields(value: unknown): BankImportManualFields {
   if (Number.isFinite(candidate.expenseAmount)) next.expenseAmount = Number(candidate.expenseAmount);
   if (normalizeString(candidate.budgetCategory)) next.budgetCategory = normalizeString(candidate.budgetCategory);
   if (normalizeString(candidate.budgetSubCategory)) next.budgetSubCategory = normalizeString(candidate.budgetSubCategory);
+  if (
+    candidate.cashflowLineId === 'MYSC_PREPAY_IN'
+    || candidate.cashflowLineId === 'SALES_IN'
+    || candidate.cashflowLineId === 'SALES_VAT_IN'
+    || candidate.cashflowLineId === 'TEAM_SUPPORT_IN'
+    || candidate.cashflowLineId === 'BANK_INTEREST_IN'
+    || candidate.cashflowLineId === 'DIRECT_COST_OUT'
+    || candidate.cashflowLineId === 'INPUT_VAT_OUT'
+    || candidate.cashflowLineId === 'MYSC_LABOR_OUT'
+    || candidate.cashflowLineId === 'MYSC_PROFIT_OUT'
+    || candidate.cashflowLineId === 'SALES_VAT_OUT'
+    || candidate.cashflowLineId === 'TEAM_SUPPORT_OUT'
+    || candidate.cashflowLineId === 'BANK_INTEREST_OUT'
+  ) {
+    next.cashflowLineId = candidate.cashflowLineId;
+  }
   if (
     candidate.cashflowCategory === 'CONTRACT_PAYMENT'
     || candidate.cashflowCategory === 'INTERIM_PAYMENT'
@@ -136,6 +153,49 @@ export function mergeBankImportIntakeItem(
       ...(updates.manualFields || {}),
     },
   });
+}
+
+function sortBankImportIntakeItems(items: BankImportIntakeItem[]): BankImportIntakeItem[] {
+  return [...items].sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
+}
+
+export function reconcileBankImportUploadItems(
+  currentItems: BankImportIntakeItem[],
+  rebuiltItems: BankImportIntakeItem[],
+): BankImportIntakeItem[] {
+  const currentById = new Map(currentItems.map((item) => [item.id, item] as const));
+  const currentBySourceTxId = new Map(currentItems.map((item) => [item.sourceTxId, item] as const));
+  const nextMap = new Map(currentItems.map((item) => [item.id, item] as const));
+
+  rebuiltItems.forEach((rebuiltItem) => {
+    const currentItem = currentById.get(rebuiltItem.id) || currentBySourceTxId.get(rebuiltItem.sourceTxId) || null;
+    if (!currentItem) {
+      nextMap.set(rebuiltItem.id, rebuiltItem);
+      return;
+    }
+
+    const preservedManualFields = Object.keys(currentItem.manualFields || {}).length > 0
+      ? { ...currentItem.manualFields }
+      : { ...rebuiltItem.manualFields };
+    const evidenceStatus = currentItem.evidenceStatus || rebuiltItem.evidenceStatus;
+    const reconciled = normalizeBankImportIntakeItem({
+      ...rebuiltItem,
+      manualFields: preservedManualFields,
+      evidenceStatus,
+      projectionStatus: resolveBankImportProjectionStatus({
+        matchState: rebuiltItem.matchState,
+        manualFields: preservedManualFields,
+        evidenceStatus,
+      }),
+      existingExpenseSheetId: currentItem.existingExpenseSheetId || rebuiltItem.existingExpenseSheetId,
+      existingExpenseRowTempId: currentItem.existingExpenseRowTempId || rebuiltItem.existingExpenseRowTempId,
+      createdAt: currentItem.createdAt || rebuiltItem.createdAt,
+    }) || rebuiltItem;
+
+    nextMap.set(reconciled.id, reconciled);
+  });
+
+  return sortBankImportIntakeItems(Array.from(nextMap.values()));
 }
 
 export function buildBankImportIntakeDoc(params: {

--- a/src/app/data/portal-store.persistence.test.ts
+++ b/src/app/data/portal-store.persistence.test.ts
@@ -128,6 +128,30 @@ describe('upsertExpenseSheetProjectionRowBySourceTxId', () => {
     expect(result.projectedRow.cells[19]).toBe('출장신청서, 영수증');
   });
 
+  it('prefers explicit cashflow line ids over legacy category fallbacks when projecting rows', () => {
+    const result = upsertExpenseSheetProjectionRowBySourceTxId({
+      rows: [
+        {
+          tempId: 'row-bank',
+          sourceTxId: 'bank:fp-1',
+          cells: Array.from({ length: 27 }, () => ''),
+        },
+      ],
+      item: makeIntakeItem({
+        manualFields: {
+          expenseAmount: 15000,
+          budgetCategory: '인건비',
+          budgetSubCategory: '강사비',
+          cashflowCategory: 'TRAVEL',
+          cashflowLineId: 'MYSC_LABOR_OUT',
+        },
+      }),
+      evidenceRequiredDesc: '계약서',
+    });
+
+    expect(result.projectedRow.cells[8]).toBe('MYSC 인건비');
+  });
+
   it('inserts a new bank-origin row when the source transaction is not projected yet', () => {
     const result = upsertExpenseSheetProjectionRowBySourceTxId({
       rows: [

--- a/src/app/data/portal-store.persistence.ts
+++ b/src/app/data/portal-store.persistence.ts
@@ -1,7 +1,13 @@
-import { createEmptyImportRow, SETTLEMENT_COLUMNS, type ImportRow } from '../platform/settlement-csv';
+import {
+  createEmptyImportRow,
+  getCashflowLineLabelForExport,
+  SETTLEMENT_COLUMNS,
+  type ImportRow,
+} from '../platform/settlement-csv';
 import { findWeekForDate, getYearMondayWeeks } from '../platform/cashflow-weeks';
 import { resolveEvidenceChecklist } from '../platform/evidence-helpers';
-import type { BankImportIntakeItem, CashflowCategory, EvidenceStatus, WeeklySubmissionStatus } from './types';
+import { resolveBankImportCashflowLineId } from '../platform/bank-import-cashflow';
+import type { BankImportIntakeItem, EvidenceStatus, WeeklySubmissionStatus } from './types';
 
 interface ExpenseSheetTabSnapshot {
   id: string;
@@ -14,34 +20,6 @@ interface ExpenseSheetTabSnapshot {
 
 function findColumnIndex(header: string): number {
   return SETTLEMENT_COLUMNS.findIndex((column) => column.csvHeader === header);
-}
-
-function cashflowCategoryToRowLabel(category: CashflowCategory | undefined): string {
-  switch (category) {
-    case 'CONTRACT_PAYMENT':
-    case 'INTERIM_PAYMENT':
-    case 'FINAL_PAYMENT':
-      return '매출액(입금)';
-    case 'LABOR_COST':
-      return 'MYSC인건비';
-    case 'TAX_PAYMENT':
-      return '매입부가세';
-    case 'VAT_REFUND':
-      return '매출부가세(입금)';
-    case 'MISC_INCOME':
-      return '팀지원금(입금)';
-    case 'OUTSOURCING':
-    case 'EQUIPMENT':
-    case 'TRAVEL':
-    case 'SUPPLIES':
-    case 'COMMUNICATION':
-    case 'RENT':
-    case 'UTILITY':
-    case 'INSURANCE':
-    case 'MISC_EXPENSE':
-    default:
-      return '직접사업비';
-  }
 }
 
 function buildProjectionRowFromIntake(
@@ -88,7 +66,11 @@ function buildProjectionRowFromIntake(
   }
   if (budgetIdx >= 0) cells[budgetIdx] = item.manualFields.budgetCategory || '';
   if (subBudgetIdx >= 0) cells[subBudgetIdx] = item.manualFields.budgetSubCategory || '';
-  if (cashflowIdx >= 0) cells[cashflowIdx] = cashflowCategoryToRowLabel(item.manualFields.cashflowCategory);
+  if (cashflowIdx >= 0) {
+    cells[cashflowIdx] = getCashflowLineLabelForExport(
+      resolveBankImportCashflowLineId(item.manualFields, item.bankSnapshot.signedAmount),
+    );
+  }
   if (balanceIdx >= 0) {
     cells[balanceIdx] = Number.isFinite(item.bankSnapshot.balanceAfter)
       ? item.bankSnapshot.balanceAfter.toLocaleString('ko-KR')

--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -70,6 +70,7 @@ import {
   buildBankImportIntakeDoc,
   mergeBankImportIntakeItem,
   normalizeBankImportIntakeItem,
+  reconcileBankImportUploadItems,
 } from './portal-store.intake';
 import { useAuth } from './auth-store';
 import { useFirebase } from '../lib/firebase-context';
@@ -571,10 +572,15 @@ export function PortalProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(false);
   const [isMemberLoading, setIsMemberLoading] = useState(true);
   const unsubsRef = useRef<Unsubscribe[]>([]);
+  const expenseIntakeItemsRef = useRef<BankImportIntakeItem[]>([]);
   const expenseSheetsRef = useRef<ExpenseSheetTab[]>([]);
   const activeExpenseSheetIdRef = useRef(activeExpenseSheetId);
   const expenseSheetRowsRef = useRef<ImportRow[] | null>(expenseSheetRows);
   const devHarnessHydratedProjectIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    expenseIntakeItemsRef.current = expenseIntakeItems;
+  }, [expenseIntakeItems]);
 
   useEffect(() => {
     expenseSheetsRef.current = expenseSheets;
@@ -2095,23 +2101,18 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     const intakeItems = buildBankImportIntakeItemsFromBankSheet({
       projectId: portalUser?.projectId || '',
       sheet: sanitizedSheet,
-      existingItems: expenseIntakeItems,
-      existingRows: expenseSheetRows,
-      existingExpenseSheetId: activeExpenseSheetId || 'default',
+      existingItems: expenseIntakeItemsRef.current,
+      existingRows: expenseSheetRowsRef.current,
+      existingExpenseSheetId: activeExpenseSheetIdRef.current || 'default',
       lastUploadBatchId: uploadBatchId,
       now,
       updatedBy: portalUser?.name || authUser?.name || '',
     });
+    const reconciledIntakeItems = reconcileBankImportUploadItems(expenseIntakeItemsRef.current, intakeItems);
     if (isDevHarnessUser || !db || !portalUser?.projectId) {
       setBankStatementRows(sanitizedSheet);
-      setExpenseIntakeItems((prev) => {
-        const nextMap = new Map(prev.map((item) => [item.id, item] as const));
-        intakeItems.forEach((item) => {
-          nextMap.set(item.id, item);
-        });
-        return Array.from(nextMap.values())
-          .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
-      });
+      expenseIntakeItemsRef.current = reconciledIntakeItems;
+      setExpenseIntakeItems(reconciledIntakeItems);
       return;
     }
     const payload = withTenantScope(orgId, {
@@ -2128,21 +2129,15 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     );
     setBankStatementRows(sanitizedSheet);
     await Promise.all(
-      intakeItems.map((item) => setDoc(
+      reconciledIntakeItems.map((item) => setDoc(
         doc(db, `${getOrgDocumentPath(orgId, 'projects', portalUser.projectId)}/expense_intake/${item.id}`),
         buildBankImportIntakeDoc({ orgId, item }),
         { merge: true },
       )),
     );
-    setExpenseIntakeItems((prev) => {
-      const nextMap = new Map(prev.map((item) => [item.id, item] as const));
-      intakeItems.forEach((item) => {
-        nextMap.set(item.id, item);
-      });
-      return Array.from(nextMap.values())
-        .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
-    });
-  }, [db, orgId, portalUser?.projectId, portalUser?.name, authUser?.name, expenseIntakeItems, expenseSheetRows, activeExpenseSheetId, isDevHarnessUser]);
+    expenseIntakeItemsRef.current = reconciledIntakeItems;
+    setExpenseIntakeItems(reconciledIntakeItems);
+  }, [db, orgId, portalUser?.projectId, portalUser?.name, authUser?.name, isDevHarnessUser]);
 
   const upsertExpenseIntakeItems = useCallback(async (items: BankImportIntakeItem[]) => {
     if (!Array.isArray(items) || items.length === 0) return;
@@ -2153,12 +2148,14 @@ export function PortalProvider({ children }: { children: ReactNode }) {
 
     if (isDevHarnessUser || !db || !portalUser?.projectId) {
       setExpenseIntakeItems((prev) => {
-        const nextMap = new Map(prev.map((item) => [item.id, item] as const));
+        const nextMap = new Map(expenseIntakeItemsRef.current.map((item) => [item.id, item] as const));
         normalizedItems.forEach((item) => {
           nextMap.set(item.id, item);
         });
-        return Array.from(nextMap.values())
+        const nextItems = Array.from(nextMap.values())
           .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
+        expenseIntakeItemsRef.current = nextItems;
+        return nextItems;
       });
       return;
     }
@@ -2171,26 +2168,30 @@ export function PortalProvider({ children }: { children: ReactNode }) {
       )),
     );
     setExpenseIntakeItems((prev) => {
-      const nextMap = new Map(prev.map((item) => [item.id, item] as const));
+      const nextMap = new Map(expenseIntakeItemsRef.current.map((item) => [item.id, item] as const));
       normalizedItems.forEach((item) => {
         nextMap.set(item.id, item);
       });
-      return Array.from(nextMap.values())
+      const nextItems = Array.from(nextMap.values())
         .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
+      expenseIntakeItemsRef.current = nextItems;
+      return nextItems;
     });
   }, [db, isDevHarnessUser, orgId, portalUser?.projectId]);
 
   const saveExpenseIntakeDraft = useCallback(async (id: string, updates: Partial<BankImportIntakeItem>) => {
-    const currentItem = expenseIntakeItems.find((item) => item.id === id);
+    const currentItem = expenseIntakeItemsRef.current.find((item) => item.id === id);
     if (!currentItem) return;
 
     const mergedCandidate = mergeBankImportIntakeItem(currentItem, updates);
     if (!mergedCandidate) return;
 
     if (isDevHarnessUser || !db || !portalUser?.projectId) {
-      setExpenseIntakeItems((prev) => prev
+      const nextItems = expenseIntakeItemsRef.current
         .map((item) => (item.id === id ? mergedCandidate : item))
-        .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || ''))));
+        .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
+      expenseIntakeItemsRef.current = nextItems;
+      setExpenseIntakeItems(nextItems);
       return;
     }
 
@@ -2199,15 +2200,17 @@ export function PortalProvider({ children }: { children: ReactNode }) {
       buildBankImportIntakeDoc({ orgId, item: mergedCandidate }),
       { merge: true },
     );
-    setExpenseIntakeItems((prev) => prev
+    const nextItems = expenseIntakeItemsRef.current
       .map((item) => (item.id === id ? mergedCandidate : item))
-      .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || ''))));
-  }, [db, expenseIntakeItems, isDevHarnessUser, orgId, portalUser?.projectId]);
+      .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
+    expenseIntakeItemsRef.current = nextItems;
+    setExpenseIntakeItems(nextItems);
+  }, [db, isDevHarnessUser, orgId, portalUser?.projectId]);
 
   const updateExpenseIntakeItem = saveExpenseIntakeDraft;
 
   const projectExpenseIntakeItem = useCallback(async (id: string, updates?: Partial<BankImportIntakeItem>) => {
-    const currentItem = expenseIntakeItems.find((item) => item.id === id);
+    const currentItem = expenseIntakeItemsRef.current.find((item) => item.id === id);
     if (!currentItem) return;
     const mergedCandidate = updates ? mergeBankImportIntakeItem(currentItem, updates) : currentItem;
     if (!mergedCandidate) return;
@@ -2269,9 +2272,11 @@ export function PortalProvider({ children }: { children: ReactNode }) {
       if (targetSheetId === activeExpenseSheetIdRef.current) {
         setExpenseSheetRows(projection.rows);
       }
-      setExpenseIntakeItems((prev) => prev
+      const nextItems = expenseIntakeItemsRef.current
         .map((item) => (item.id === id ? projectedItem : item))
-        .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || ''))));
+        .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
+      expenseIntakeItemsRef.current = nextItems;
+      setExpenseIntakeItems(nextItems);
       return;
     }
 
@@ -2301,13 +2306,15 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     if (targetSheetId === activeExpenseSheetIdRef.current) {
       setExpenseSheetRows(projection.rows);
     }
-    setExpenseIntakeItems((prev) => prev
+    const nextItems = expenseIntakeItemsRef.current
       .map((item) => (item.id === id ? projectedItem : item))
-      .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || ''))));
-  }, [activeExpenseSheetId, authUser?.name, db, evidenceRequiredMap, expenseIntakeItems, isDevHarnessUser, orgId, portalUser?.name, portalUser?.projectId]);
+      .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
+    expenseIntakeItemsRef.current = nextItems;
+    setExpenseIntakeItems(nextItems);
+  }, [authUser?.name, db, evidenceRequiredMap, isDevHarnessUser, orgId, portalUser?.name, portalUser?.projectId]);
 
   const syncExpenseIntakeEvidence = useCallback(async (id: string, updates: Partial<BankImportIntakeItem>) => {
-    const currentItem = expenseIntakeItems.find((item) => item.id === id);
+    const currentItem = expenseIntakeItemsRef.current.find((item) => item.id === id);
     if (!currentItem) return;
 
     const now = new Date().toISOString();
@@ -2327,9 +2334,11 @@ export function PortalProvider({ children }: { children: ReactNode }) {
       if (activeExpenseSheetIdRef.current === (nextState.item.existingExpenseSheetId || activeExpenseSheetIdRef.current)) {
         setExpenseSheetRows(nextState.activeRows);
       }
-      setExpenseIntakeItems((prev) => prev
+      const nextItems = expenseIntakeItemsRef.current
         .map((item) => (item.id === id ? nextState.item : item))
-        .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || ''))));
+        .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
+      expenseIntakeItemsRef.current = nextItems;
+      setExpenseIntakeItems(nextItems);
       return;
     }
 
@@ -2364,10 +2373,12 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     if (activeExpenseSheetIdRef.current === targetSheetId) {
       setExpenseSheetRows(nextState.activeRows);
     }
-    setExpenseIntakeItems((prev) => prev
+    const nextItems = expenseIntakeItemsRef.current
       .map((item) => (item.id === id ? nextState.item : item))
-      .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || ''))));
-  }, [authUser?.name, db, evidenceRequiredMap, expenseIntakeItems, isDevHarnessUser, orgId, portalUser?.name, portalUser?.projectId]);
+      .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
+    expenseIntakeItemsRef.current = nextItems;
+    setExpenseIntakeItems(nextItems);
+  }, [authUser?.name, db, evidenceRequiredMap, isDevHarnessUser, orgId, portalUser?.name, portalUser?.projectId]);
 
   const persistTransaction = useCallback(async (txData: Transaction) => {
     if (!db) return;

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -812,6 +812,7 @@ export interface BankImportManualFields {
   expenseAmount?: number;
   budgetCategory?: string;
   budgetSubCategory?: string;
+  cashflowLineId?: CashflowSheetLineId;
   cashflowCategory?: CashflowCategory;
   memo?: string;
   evidenceCompletedDesc?: string;

--- a/src/app/platform/bank-import-cashflow.test.ts
+++ b/src/app/platform/bank-import-cashflow.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveBankImportCashflowLineId,
+  resolveBankImportCashflowOptionsForAmount,
+  resolveBankImportCashflowSelection,
+} from './bank-import-cashflow';
+
+describe('bank-import-cashflow helpers', () => {
+  it('shows only outflow sheet lines for expense rows', () => {
+    const options = resolveBankImportCashflowOptionsForAmount(-15000);
+
+    expect(options.map((option) => option.value)).toEqual([
+      'DIRECT_COST_OUT',
+      'INPUT_VAT_OUT',
+      'MYSC_LABOR_OUT',
+      'MYSC_PROFIT_OUT',
+      'SALES_VAT_OUT',
+      'TEAM_SUPPORT_OUT',
+      'BANK_INTEREST_OUT',
+    ]);
+  });
+
+  it('stores sheet line id alongside compatibility category', () => {
+    expect(resolveBankImportCashflowSelection('MYSC_LABOR_OUT', -120000)).toEqual({
+      cashflowLineId: 'MYSC_LABOR_OUT',
+      cashflowCategory: 'LABOR_COST',
+    });
+  });
+
+  it('falls back from legacy category to a stable sheet line id', () => {
+    expect(resolveBankImportCashflowLineId({
+      cashflowCategory: 'TRAVEL',
+    }, -15000)).toBe('DIRECT_COST_OUT');
+
+    expect(resolveBankImportCashflowLineId({
+      cashflowCategory: 'VAT_REFUND',
+    }, 50000)).toBe('SALES_VAT_IN');
+  });
+});

--- a/src/app/platform/bank-import-cashflow.ts
+++ b/src/app/platform/bank-import-cashflow.ts
@@ -1,0 +1,62 @@
+import type { BankImportManualFields, CashflowCategory, CashflowSheetLineId, Direction } from '../data/types';
+import { CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES, mapCategoryToSheetLine } from './cashflow-sheet';
+import { CASHFLOW_LINE_OPTIONS } from './settlement-csv';
+
+function resolveDirectionForAmount(signedAmount: number): Direction {
+  return signedAmount >= 0 ? 'IN' : 'OUT';
+}
+
+export function mapCashflowLineToCategory(
+  lineId: CashflowSheetLineId | undefined,
+  direction: Direction,
+): CashflowCategory {
+  if (!lineId) return direction === 'IN' ? 'MISC_INCOME' : 'MISC_EXPENSE';
+  switch (lineId) {
+    case 'MYSC_PREPAY_IN':
+    case 'SALES_IN':
+      return 'CONTRACT_PAYMENT';
+    case 'SALES_VAT_IN':
+      return 'VAT_REFUND';
+    case 'TEAM_SUPPORT_IN':
+    case 'BANK_INTEREST_IN':
+      return 'MISC_INCOME';
+    case 'DIRECT_COST_OUT':
+      return 'OUTSOURCING';
+    case 'INPUT_VAT_OUT':
+    case 'SALES_VAT_OUT':
+      return 'TAX_PAYMENT';
+    case 'MYSC_LABOR_OUT':
+      return 'LABOR_COST';
+    case 'MYSC_PROFIT_OUT':
+    case 'TEAM_SUPPORT_OUT':
+    case 'BANK_INTEREST_OUT':
+      return 'MISC_EXPENSE';
+    default:
+      return direction === 'IN' ? 'MISC_INCOME' : 'MISC_EXPENSE';
+  }
+}
+
+export function resolveBankImportCashflowOptionsForAmount(signedAmount: number) {
+  const allowed = new Set(signedAmount >= 0 ? CASHFLOW_IN_LINES : CASHFLOW_OUT_LINES);
+  return CASHFLOW_LINE_OPTIONS.filter((option) => allowed.has(option.value));
+}
+
+export function resolveBankImportCashflowSelection(
+  lineId: CashflowSheetLineId,
+  signedAmount: number,
+): Pick<BankImportManualFields, 'cashflowLineId' | 'cashflowCategory'> {
+  const direction = resolveDirectionForAmount(signedAmount);
+  return {
+    cashflowLineId: lineId,
+    cashflowCategory: mapCashflowLineToCategory(lineId, direction),
+  };
+}
+
+export function resolveBankImportCashflowLineId(
+  fields: Pick<BankImportManualFields, 'cashflowLineId' | 'cashflowCategory'> | null | undefined,
+  signedAmount: number,
+): CashflowSheetLineId | undefined {
+  if (fields?.cashflowLineId) return fields.cashflowLineId;
+  if (!fields?.cashflowCategory) return undefined;
+  return mapCategoryToSheetLine(resolveDirectionForAmount(signedAmount), fields.cashflowCategory);
+}

--- a/src/app/platform/bank-import-triage.ts
+++ b/src/app/platform/bank-import-triage.ts
@@ -29,7 +29,7 @@ export function isBankImportManualFieldsComplete(fields: BankImportManualFields 
   return Number.isFinite(fields.expenseAmount)
     && Boolean(normalizeSpace(fields.budgetCategory || ''))
     && Boolean(normalizeSpace(fields.budgetSubCategory || ''))
-    && Boolean(fields.cashflowCategory);
+    && Boolean(fields.cashflowLineId || fields.cashflowCategory);
 }
 
 function hasCriticalBankDrift(

--- a/src/app/platform/bank-statement.ts
+++ b/src/app/platform/bank-statement.ts
@@ -14,6 +14,7 @@ import {
   resolveBankImportMatchState,
   resolveBankImportProjectionStatus,
 } from './bank-import-triage';
+import { mapCashflowLineToCategory } from './bank-import-cashflow';
 
 // ── HTML-as-XLS parsing (KB, 신한 등 HTML 형식 은행 엑셀) ──
 
@@ -398,30 +399,7 @@ function pickAmount(
 
 function inferCashflowCategoryFromLineLabel(rawLineLabel: string, signedAmount: number): CashflowCategory | undefined {
   const lineId = parseCashflowLineLabel(rawLineLabel);
-  if (!lineId) return signedAmount >= 0 ? 'MISC_INCOME' : 'MISC_EXPENSE';
-  switch (lineId) {
-    case 'MYSC_PREPAY_IN':
-    case 'SALES_IN':
-      return 'CONTRACT_PAYMENT';
-    case 'SALES_VAT_IN':
-      return 'VAT_REFUND';
-    case 'TEAM_SUPPORT_IN':
-    case 'BANK_INTEREST_IN':
-      return 'MISC_INCOME';
-    case 'DIRECT_COST_OUT':
-      return 'OUTSOURCING';
-    case 'INPUT_VAT_OUT':
-    case 'SALES_VAT_OUT':
-      return 'TAX_PAYMENT';
-    case 'MYSC_LABOR_OUT':
-      return 'LABOR_COST';
-    case 'MYSC_PROFIT_OUT':
-    case 'TEAM_SUPPORT_OUT':
-    case 'BANK_INTEREST_OUT':
-      return 'MISC_EXPENSE';
-    default:
-      return signedAmount >= 0 ? 'MISC_INCOME' : 'MISC_EXPENSE';
-  }
+  return mapCashflowLineToCategory(lineId, signedAmount >= 0 ? 'IN' : 'OUT');
 }
 
 function resolveEvidenceStatusFromExpenseRow(row: ImportRow | null | undefined): EvidenceStatus {
@@ -458,7 +436,9 @@ function extractManualFieldsFromExpenseRow(row: ImportRow | null | undefined): B
   }
   if (cashflowIdx >= 0) {
     const value = normalizeSpace(String(row.cells[cashflowIdx] || ''));
+    const lineId = parseCashflowLineLabel(value);
     const category = inferCashflowCategoryFromLineLabel(value, signedAmount);
+    if (lineId) manualFields.cashflowLineId = lineId;
     if (category) manualFields.cashflowCategory = category;
   }
   if (noteIdx >= 0) {

--- a/src/app/platform/lazy-route.test.ts
+++ b/src/app/platform/lazy-route.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ComponentType } from 'react';
+import { loadLazyRouteModule } from './lazy-route';
+
+function Fallback() {
+  return null;
+}
+
+function Target() {
+  return null;
+}
+
+describe('loadLazyRouteModule', () => {
+  it('returns the named export when the chunk loads normally', async () => {
+    const result = await loadLazyRouteModule(
+      async () => ({ PortalSubmissionsPage: Target }),
+      'PortalSubmissionsPage',
+      Fallback,
+    );
+
+    expect(result.default).toBe(Target as ComponentType);
+  });
+
+  it('falls back cleanly when the chunk loader rejects', async () => {
+    const error = new Error('chunk load failed');
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await loadLazyRouteModule(
+      async () => {
+        throw error;
+      },
+      'PortalSubmissionsPage',
+      Fallback,
+      '[routes] failed to load PortalSubmissionsPage:',
+    );
+
+    expect(result.default).toBe(Fallback as ComponentType);
+    expect(spy).toHaveBeenCalledWith('[routes] failed to load PortalSubmissionsPage:', error);
+    spy.mockRestore();
+  });
+});

--- a/src/app/platform/lazy-route.ts
+++ b/src/app/platform/lazy-route.ts
@@ -1,0 +1,23 @@
+import type { ComponentType } from 'react';
+
+type LazyRouteModule = Record<string, unknown> & {
+  default?: ComponentType;
+};
+
+export async function loadLazyRouteModule<TModule extends LazyRouteModule>(
+  loader: () => Promise<TModule>,
+  exportName: keyof TModule | string,
+  fallback: ComponentType,
+  errorPrefix?: string,
+): Promise<{ default: ComponentType }> {
+  try {
+    const module = await loader();
+    const resolved = module?.[exportName as keyof TModule] || module?.default;
+    return { default: (resolved as ComponentType) || fallback };
+  } catch (error) {
+    if (errorPrefix) {
+      console.error(errorPrefix, error);
+    }
+    return { default: fallback };
+  }
+}

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, type ComponentType } from 'react';
 import { createBrowserRouter } from 'react-router';
 import { AppLayout } from './components/layout/AppLayout';
 import { PortalLayout } from './components/portal/PortalLayout';
+import { loadLazyRouteModule } from './platform/lazy-route';
 
 // Lazy-loaded pages — each becomes a separate chunk
 const LoginPage = lazy(() => import('./components/auth/LoginPage').then(m => ({ default: m.LoginPage })));
@@ -44,7 +45,12 @@ const PortalProjectRegister = lazy(() => import('./components/portal/PortalProje
 const PortalProjectEdit = lazy(() => import('./components/portal/PortalProjectEdit').then(m => ({ default: m.PortalProjectEdit })));
 const PortalPayrollPage = lazy(() => import('./components/portal/PortalPayrollPage').then(m => ({ default: m.PortalPayrollPage })));
 const PortalCashflowPage = lazy(() => import('./components/portal/PortalCashflowPage').then(m => ({ default: m.PortalCashflowPage })));
-const PortalSubmissionsPage = lazy(() => import('./components/portal/PortalSubmissionsPage').then(m => ({ default: m.PortalSubmissionsPage })));
+const PortalSubmissionsPage = lazy(() => loadLazyRouteModule(
+  () => import('./components/portal/PortalSubmissionsPage'),
+  'PortalSubmissionsPage',
+  RouteChunkFallback,
+  '[routes] failed to load PortalSubmissionsPage:',
+));
 const CareerProfilePage = lazy(() => import('./components/portal/CareerProfilePage').then(m => ({ default: m.CareerProfilePage })));
 const PortalTrainingPage = lazy(() => import('./components/portal/PortalTrainingPage').then(m => ({ default: m.PortalTrainingPage })));
 function RouteChunkFallback() {
@@ -55,15 +61,12 @@ function RouteChunkFallback() {
   );
 }
 
-const PortalWeeklyExpensePage = lazy(async () => {
-  try {
-    const module = await import('./components/portal/PortalWeeklyExpensePage');
-    return { default: module?.PortalWeeklyExpensePage ?? module?.default ?? RouteChunkFallback };
-  } catch (error) {
-    console.error('[routes] failed to load PortalWeeklyExpensePage:', error);
-    return { default: RouteChunkFallback };
-  }
-});
+const PortalWeeklyExpensePage = lazy(() => loadLazyRouteModule(
+  () => import('./components/portal/PortalWeeklyExpensePage'),
+  'PortalWeeklyExpensePage',
+  RouteChunkFallback,
+  '[routes] failed to load PortalWeeklyExpensePage:',
+));
 const PortalBankStatementPage = lazy(() => import('./components/portal/PortalBankStatementPage').then(m => ({ default: m.PortalBankStatementPage })));
 const GuideChatPage = lazy(() => import('./components/guide-chat/GuideChatPage').then(m => ({ default: m.GuideChatPage })));
 


### PR DESCRIPTION
## 변경 내용
- 포털 진입 시 자동으로 뜨던 Guided Start 미션 가이드 모달을 비활성화
- 필요할 때만 가이드 열기 버튼으로 수동 확인 가능하도록 유지
- 기존 smoke 기대값과 호환되도록 launcher surface에 기존 test id 유지

## 검증
- npm run build