### PR TITLE
fix: 긴 포털 모달 스크롤 복구

### DIFF
--- a/src/app/components/cashflow/ImportEditorRow.tsx
+++ b/src/app/components/cashflow/ImportEditorRow.tsx
@@ -32,6 +32,7 @@ import {
   toFieldSlug,
 } from '../../platform/settlement-grid-helpers';
 import { resolveEvidenceRequiredDesc } from '../../platform/settlement-sheet-prepare';
+import { resolveSelectPopupPosition } from './select-popup-position';
 import { Button } from '../ui/button';
 import {
   DropdownMenu,
@@ -70,20 +71,32 @@ function SelectCell({
 }) {
   const btnRef = useRef<HTMLButtonElement | null>(null);
   const [popupRect, setPopupRect] = useState<{ left: number; top: number } | null>(null);
+  const popupWidth = 160;
+  const popupHeight = Math.min(320, 32 * (options.length + 1));
 
   useLayoutEffect(() => {
     if (!isOpen) return;
     const rect = btnRef.current?.getBoundingClientRect();
     if (!rect) return;
-    setPopupRect({ left: rect.left, top: rect.bottom + 4 });
-  }, [isOpen]);
+    setPopupRect(resolveSelectPopupPosition({
+      triggerRect: rect,
+      viewport: { width: window.innerWidth, height: window.innerHeight },
+      popupWidth,
+      popupHeight,
+    }));
+  }, [isOpen, popupHeight, popupWidth]);
 
   useEffect(() => {
     if (!isOpen) return;
     const update = () => {
       const rect = btnRef.current?.getBoundingClientRect();
       if (!rect) return;
-      setPopupRect({ left: rect.left, top: rect.bottom + 4 });
+      setPopupRect(resolveSelectPopupPosition({
+        triggerRect: rect,
+        viewport: { width: window.innerWidth, height: window.innerHeight },
+        popupWidth,
+        popupHeight,
+      }));
     };
     window.addEventListener('scroll', update, true);
     window.addEventListener('resize', update);
@@ -91,7 +104,7 @@ function SelectCell({
       window.removeEventListener('scroll', update, true);
       window.removeEventListener('resize', update);
     };
-  }, [isOpen]);
+  }, [isOpen, popupHeight, popupWidth]);
 
   const openPicker = (e: ReactMouseEvent<HTMLButtonElement>) => {
     e.preventDefault();

--- a/src/app/components/cashflow/select-popup-position.test.ts
+++ b/src/app/components/cashflow/select-popup-position.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSelectPopupPosition } from './select-popup-position';
+
+describe('resolveSelectPopupPosition', () => {
+  it('opens upward when there is not enough viewport space below the trigger', () => {
+    const result = resolveSelectPopupPosition({
+      triggerRect: {
+        left: 120,
+        top: 740,
+        right: 200,
+        bottom: 764,
+        width: 80,
+        height: 24,
+        x: 120,
+        y: 740,
+        toJSON: () => ({}),
+      },
+      viewport: {
+        width: 1280,
+        height: 800,
+      },
+      popupWidth: 160,
+      popupHeight: 280,
+    });
+
+    expect(result.top).toBeLessThan(740);
+  });
+
+  it('clamps horizontally so the popup stays inside the viewport', () => {
+    const result = resolveSelectPopupPosition({
+      triggerRect: {
+        left: 1180,
+        top: 120,
+        right: 1260,
+        bottom: 144,
+        width: 80,
+        height: 24,
+        x: 1180,
+        y: 120,
+        toJSON: () => ({}),
+      },
+      viewport: {
+        width: 1280,
+        height: 800,
+      },
+      popupWidth: 160,
+      popupHeight: 280,
+    });
+
+    expect(result.left).toBeLessThanOrEqual(1280 - 160 - 8);
+  });
+});

--- a/src/app/components/cashflow/select-popup-position.ts
+++ b/src/app/components/cashflow/select-popup-position.ts
@@ -1,0 +1,30 @@
+export interface PopupViewport {
+  width: number;
+  height: number;
+}
+
+export interface PopupPositionInput {
+  triggerRect: DOMRect;
+  viewport: PopupViewport;
+  popupWidth: number;
+  popupHeight: number;
+  gap?: number;
+  margin?: number;
+}
+
+export function resolveSelectPopupPosition(input: PopupPositionInput): { left: number; top: number } {
+  const gap = input.gap ?? 4;
+  const margin = input.margin ?? 8;
+  const maxLeft = Math.max(margin, input.viewport.width - input.popupWidth - margin);
+  const left = Math.min(Math.max(input.triggerRect.left, margin), maxLeft);
+
+  const spaceBelow = input.viewport.height - input.triggerRect.bottom - margin;
+  const canOpenBelow = spaceBelow >= Math.min(input.popupHeight, 240);
+  const preferredTop = canOpenBelow
+    ? input.triggerRect.bottom + gap
+    : input.triggerRect.top - input.popupHeight - gap;
+  const maxTop = Math.max(margin, input.viewport.height - input.popupHeight - margin);
+  const top = Math.min(Math.max(preferredTop, margin), maxTop);
+
+  return { left, top };
+}

--- a/src/app/components/portal/BankImportTriageWizard.tsx
+++ b/src/app/components/portal/BankImportTriageWizard.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
 import { AlertTriangle, ArrowRight, Clock3, FileWarning, Wallet } from 'lucide-react';
-import type { BankImportIntakeItem, CashflowCategory } from '../../data/types';
-import { CASHFLOW_CATEGORY_LABELS } from '../../data/types';
+import type { BankImportIntakeItem } from '../../data/types';
 import { isBankImportManualFieldsComplete } from '../../platform/bank-import-triage';
 import { groupExpenseIntakeItemsForSurface, resolveBankImportWizardStatus } from '../../platform/bank-intake-surface';
+import {
+  resolveBankImportCashflowLineId,
+  resolveBankImportCashflowOptionsForAmount,
+  resolveBankImportCashflowSelection,
+} from '../../platform/bank-import-cashflow';
 import { resolveEvidenceChecklist } from '../../platform/evidence-helpers';
 import { resolveEvidenceRequiredDesc } from '../../platform/settlement-sheet-prepare';
 import { Badge } from '../ui/badge';
@@ -20,25 +24,6 @@ interface BankImportTriageWizardProps {
   onSyncEvidence?: (id: string, updates: Partial<BankImportIntakeItem>) => Promise<void>;
   evidenceRequiredMap: Record<string, string>;
 }
-
-const CASHFLOW_OPTIONS: CashflowCategory[] = [
-  'CONTRACT_PAYMENT',
-  'INTERIM_PAYMENT',
-  'FINAL_PAYMENT',
-  'LABOR_COST',
-  'OUTSOURCING',
-  'EQUIPMENT',
-  'TRAVEL',
-  'SUPPLIES',
-  'COMMUNICATION',
-  'RENT',
-  'UTILITY',
-  'TAX_PAYMENT',
-  'VAT_REFUND',
-  'INSURANCE',
-  'MISC_INCOME',
-  'MISC_EXPENSE',
-];
 
 function formatMoney(value: number): string {
   return value.toLocaleString('ko-KR');
@@ -122,6 +107,10 @@ export function BankImportTriageWizard({
     ...selectedItem,
     manualFields: activeManualFields || selectedItem.manualFields,
   }) : null;
+  const cashflowOptions = useMemo(
+    () => (selectedItem ? resolveBankImportCashflowOptionsForAmount(selectedItem.bankSnapshot.signedAmount) : []),
+    [selectedItem],
+  );
 
   const advanceSelection = () => {
     if (!selectedItem) return;
@@ -449,20 +438,28 @@ export function BankImportTriageWizard({
                               <span className="text-[11px] font-medium text-slate-600">cashflow 항목</span>
                               <select
                                 data-testid="bank-import-cashflow-category"
-                                value={activeManualFields.cashflowCategory || ''}
+                                value={resolveBankImportCashflowLineId(activeManualFields, selectedItem.bankSnapshot.signedAmount) || ''}
                                 onChange={(event) => setDrafts((prev) => ({
                                   ...prev,
                                   [selectedItem.id]: {
                                     ...activeManualFields,
-                                    cashflowCategory: event.target.value as CashflowCategory,
+                                    ...(event.target.value
+                                      ? resolveBankImportCashflowSelection(
+                                          event.target.value as typeof cashflowOptions[number]['value'],
+                                          selectedItem.bankSnapshot.signedAmount,
+                                        )
+                                      : {
+                                          cashflowLineId: undefined,
+                                          cashflowCategory: undefined,
+                                        }),
                                   },
                                 }))}
                                 className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-[13px] outline-none transition focus:border-slate-400"
                               >
                                 <option value="">선택하세요</option>
-                                {CASHFLOW_OPTIONS.map((option) => (
-                                  <option key={option} value={option}>
-                                    {CASHFLOW_CATEGORY_LABELS[option]}
+                                {cashflowOptions.map((option) => (
+                                  <option key={option.value} value={option.value}>
+                                    {option.label}
                                   </option>
                                 ))}
                               </select>

--- a/src/app/components/portal/PortalBudget.tsx
+++ b/src/app/components/portal/PortalBudget.tsx
@@ -1155,11 +1155,11 @@ export function PortalBudget() {
         </Card>
 
         <Dialog open={budgetImportOpen} onOpenChange={(open) => !open && closeBudgetImport()}>
-          <DialogContent className="max-w-3xl max-h-[85vh] overflow-hidden">
-            <DialogHeader>
+          <DialogContent className="max-w-3xl max-h-[85vh] overflow-hidden flex flex-col">
+            <DialogHeader className="shrink-0">
               <DialogTitle className="text-[14px]">예산총괄 가져오기</DialogTitle>
             </DialogHeader>
-            <div className="flex max-h-[calc(85vh-4rem)] flex-col gap-3">
+            <div className="min-h-0 flex flex-1 flex-col gap-3 overflow-hidden">
               <div className="rounded-lg border border-border/60 bg-muted/20 px-3 py-2">
                 <p className="text-[11px] font-medium text-foreground">예산총괄 엑셀 또는 복붙 데이터를 미리본 뒤 안전하게 반영합니다.</p>
                 <p className="mt-1 text-[10px] text-muted-foreground">
@@ -1170,14 +1170,14 @@ export function PortalBudget() {
               <Tabs
                 value={budgetImportTab}
                 onValueChange={(value) => setBudgetImportTab(value as BudgetPlanImportTab)}
-                className="min-h-0 flex-1"
+                className="min-h-0 flex flex-1 flex-col overflow-hidden"
               >
                 <TabsList className="grid w-full grid-cols-2">
                   <TabsTrigger value="file" className="text-[11px]">엑셀/CSV 파일</TabsTrigger>
                   <TabsTrigger value="paste" className="text-[11px]">엑셀 붙여넣기</TabsTrigger>
                 </TabsList>
 
-                <TabsContent value="file" className="space-y-3">
+                <TabsContent value="file" className="mt-3 min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
                   {budgetSheetSources.length > 0 && (
                     <div className="rounded-md border border-emerald-200/70 bg-emerald-50/60 p-3">
                       <div className="flex items-center justify-between gap-2">
@@ -1270,7 +1270,7 @@ export function PortalBudget() {
                   ) : null}
                 </TabsContent>
 
-                <TabsContent value="paste" className="space-y-3">
+                <TabsContent value="paste" className="mt-3 min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
                   <div className="rounded-md border border-border/60 p-3 space-y-2">
                     <p className="text-[11px] font-medium">예산총괄 표를 그대로 복사해서 붙여넣을 수 있습니다.</p>
                     <p className="text-[10px] text-muted-foreground">
@@ -1450,7 +1450,7 @@ export function PortalBudget() {
                 )}
               </div>
 
-              <div className="flex justify-end gap-2 pt-2 border-t border-border/60">
+              <div className="flex shrink-0 justify-end gap-2 border-t border-border/60 pt-2">
                 <Button variant="outline" size="sm" className="h-8 text-[12px]" onClick={closeBudgetImport}>
                   취소
                 </Button>
@@ -1468,25 +1468,25 @@ export function PortalBudget() {
         </Dialog>
 
         <Dialog open={codeBookMode} onOpenChange={(open) => !open && cancelEdit()}>
-          <DialogContent className="max-w-2xl max-h-[85vh] overflow-hidden">
-            <DialogHeader>
+          <DialogContent className="max-w-2xl max-h-[85vh] overflow-hidden flex flex-col">
+            <DialogHeader className="shrink-0">
               <DialogTitle className="text-[14px]">예산 항목 구조 관리</DialogTitle>
             </DialogHeader>
-            <div className="flex max-h-[calc(85vh-4rem)] flex-col gap-3">
+            <div className="min-h-0 flex flex-1 flex-col gap-3 overflow-hidden">
               <div className="rounded-lg border border-border/60 bg-muted/20 px-3 py-2">
                 <p className="text-[11px] font-medium text-foreground">현재 예산 표에 쓰이는 비목/세목 구조를 관리합니다.</p>
                 <p className="mt-1 text-[10px] text-muted-foreground">
                   숫자 편집과 별개 흐름입니다. 붙여넣기 또는 CSV 가져오기는 현재 구조 초안을 교체하고, 저장 전까지는 실제 예산에 반영되지 않습니다.
                 </p>
               </div>
-              <Tabs value={codeBookEditorTab} onValueChange={(value) => setCodeBookEditorTab(value as 'manual' | 'paste' | 'csv')} className="min-h-0 flex-1">
+              <Tabs value={codeBookEditorTab} onValueChange={(value) => setCodeBookEditorTab(value as 'manual' | 'paste' | 'csv')} className="min-h-0 flex flex-1 flex-col overflow-hidden">
                 <TabsList className="grid w-full grid-cols-3">
                   <TabsTrigger value="manual" className="text-[11px]">직접 수정</TabsTrigger>
                   <TabsTrigger value="paste" className="text-[11px]">엑셀 붙여넣기</TabsTrigger>
                   <TabsTrigger value="csv" className="text-[11px]">CSV 가져오기</TabsTrigger>
                 </TabsList>
 
-                <TabsContent value="manual" className="min-h-0 flex-1 space-y-3">
+                <TabsContent value="manual" className="mt-3 min-h-0 flex flex-1 flex-col space-y-3 overflow-hidden">
                   <div className="flex items-center justify-between">
                     <div className="space-y-1">
                       <p className="text-[11px] text-muted-foreground">세목은 드래그해서 순서를 바꿀 수 있습니다.</p>
@@ -1595,7 +1595,7 @@ export function PortalBudget() {
                   </div>
                 </TabsContent>
 
-                <TabsContent value="paste" className="space-y-3">
+                <TabsContent value="paste" className="mt-3 min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
                   <div className="rounded-md border border-border/60 p-3 space-y-2">
                     <p className="text-[11px] font-medium">엑셀에서 두 열을 그대로 복사해 붙여넣을 수 있습니다.</p>
                     <p className="text-[10px] text-muted-foreground">
@@ -1647,7 +1647,7 @@ export function PortalBudget() {
                   </div>
                 </TabsContent>
 
-                <TabsContent value="csv" className="space-y-3">
+                <TabsContent value="csv" className="mt-3 min-h-0 flex-1 space-y-3 overflow-y-auto pr-1">
                   <div className="rounded-md border border-border/60 p-3 space-y-2">
                     <p className="text-[11px] font-medium">CSV 예시는 이 화면 안에서 바로 확인할 수 있습니다.</p>
                     <div className="rounded-md bg-slate-950 px-3 py-2 font-mono text-[10px] text-slate-50 whitespace-pre-wrap">

--- a/src/app/components/portal/PortalMissionGuideLauncher.tsx
+++ b/src/app/components/portal/PortalMissionGuideLauncher.tsx
@@ -37,7 +37,7 @@ export function PortalMissionGuideLauncher({
   useEffect(() => {
     const acknowledged = readPortalGuideAcknowledged(scope);
     setDontShowAgain(acknowledged);
-    setOpen(!acknowledged);
+    setOpen(false);
   }, [scope]);
 
   const handleOpenChange = (nextOpen: boolean) => {
@@ -50,7 +50,8 @@ export function PortalMissionGuideLauncher({
   return (
     <>
       <div
-        data-testid={`portal-mission-guide-launcher-${guideId}`}
+        data-testid="portal-mission-guide"
+        data-guide-launcher-id={guideId}
         className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-indigo-200/70 bg-gradient-to-r from-indigo-50/90 via-white to-teal-50/70 px-4 py-3 shadow-sm"
       >
         <div className="min-w-0 space-y-1">

--- a/src/app/components/portal/PortalWeeklyExpensePage.tsx
+++ b/src/app/components/portal/PortalWeeklyExpensePage.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useBlocker, useLocation, useNavigate } from 'react-router';
+import { useNavigate } from 'react-router';
 import {
   AlertTriangle,
   ArrowRight,
@@ -75,7 +75,6 @@ import { resolvePortalHappyPath } from '../../platform/portal-happy-path';
 import { resolvePortalMissionProgress } from '../../platform/portal-mission-guide';
 import { resolveWeeklyExpenseSavePolicy } from '../../platform/weekly-expense-save-policy';
 import { groupExpenseIntakeItemsForSurface } from '../../platform/bank-intake-surface';
-import { usePortalNavigationGuard } from './PortalLayout';
 const GoogleSheetMigrationWizard = lazy(
   () => import('./GoogleSheetMigrationWizard').then((module) => ({ default: module.GoogleSheetMigrationWizard })),
 );
@@ -83,29 +82,8 @@ const SettlementLedgerPage = lazy(
   () => import('../cashflow/SettlementLedgerPage').then((module) => ({ default: module.SettlementLedgerPage })),
 );
 
-type PendingUnsavedAction =
-  | {
-    kind: 'route';
-    path: string;
-    label: string;
-  }
-  | {
-    kind: 'sheet';
-    sheetId: string;
-    sheetName: string;
-  }
-  | {
-    kind: 'wizard';
-  }
-  | {
-    kind: 'blocker';
-    label: string;
-  };
-
 export function PortalWeeklyExpensePage() {
-  const location = useLocation();
   const navigate = useNavigate();
-  const { registerNavigationHandler } = usePortalNavigationGuard();
   const weeklyExpenseSavePolicy = resolveWeeklyExpenseSavePolicy();
   const { user: authUser, ensureGoogleWorkspaceAccess } = useAuth();
   const { orgId } = useFirebase();
@@ -151,11 +129,7 @@ export function PortalWeeklyExpensePage() {
   const [googleSheetImportOpen, setGoogleSheetImportOpen] = useState(false);
   const [triageWizardOpen, setTriageWizardOpen] = useState(false);
   const [pendingQuickInsert, setPendingQuickInsert] = useState<PendingQuickInsert | null>(null);
-  const [hasUnsavedSettlementChanges, setHasUnsavedSettlementChanges] = useState(false);
-  const [pendingUnsavedAction, setPendingUnsavedAction] = useState<PendingUnsavedAction | null>(null);
-  const [confirmedUnsavedAction, setConfirmedUnsavedAction] = useState<PendingUnsavedAction | null>(null);
-  const [discardChangesRequestToken, setDiscardChangesRequestToken] = useState(0);
-  const [allowUnsavedNavigation, setAllowUnsavedNavigation] = useState(false);
+  const [, setHasUnsavedSettlementChanges] = useState(false);
   const [participationRiskWarning, setParticipationRiskWarning] = useState<{
     yearMonth: string;
     weekNo: number;
@@ -175,7 +149,6 @@ export function PortalWeeklyExpensePage() {
     return visibleExpenseSheets.find((sheet) => sheet.id === activeExpenseSheetId)?.name || visibleExpenseSheets[0]?.name || '기본 탭';
   }, [visibleExpenseSheets, activeExpenseSheetId]);
   const bankStatementCount = bankStatementRows?.rows?.length || 0;
-  const blocker = useBlocker(hasUnsavedSettlementChanges && !allowUnsavedNavigation);
 
   const defaultLedgerId = useMemo(() => {
     const ledger = ledgers.find((l) => l.projectId === projectId);
@@ -738,106 +711,18 @@ export function PortalWeeklyExpensePage() {
     setGoogleSheetImportOpen(true);
   }, []);
 
-  useEffect(() => {
-    setAllowUnsavedNavigation(false);
-  }, [location.key]);
-
-  useEffect(() => {
-    if (blocker.state !== 'blocked') return;
-    const nextPath = `${blocker.location.pathname || ''}${blocker.location.search || ''}${blocker.location.hash || ''}` || '다른 화면';
-    setPendingUnsavedAction((current) => current || {
-      kind: 'blocker',
-      label: nextPath,
-    });
-  }, [blocker]);
-
-  useEffect(() => {
-    registerNavigationHandler((attempt) => {
-      const nextPath = `${attempt.path || ''}` || '다른 화면';
-      const currentPath = `${location.pathname || ''}${location.search || ''}${location.hash || ''}`;
-      if (!hasUnsavedSettlementChanges || nextPath === currentPath) return false;
-      setPendingUnsavedAction({ kind: 'route', path: attempt.path, label: attempt.label });
-      return true;
-    });
-    return () => {
-      registerNavigationHandler(null);
-    };
-  }, [hasUnsavedSettlementChanges, location.hash, location.pathname, location.search, registerNavigationHandler]);
-
-  useEffect(() => {
-    if (!confirmedUnsavedAction || hasUnsavedSettlementChanges) return;
-
-    if (confirmedUnsavedAction.kind === 'blocker') {
-      setAllowUnsavedNavigation(true);
-      blocker.proceed();
-      setConfirmedUnsavedAction(null);
-      return;
-    }
-
-    if (confirmedUnsavedAction.kind === 'sheet') {
-      setActiveExpenseSheet(confirmedUnsavedAction.sheetId);
-      setConfirmedUnsavedAction(null);
-      return;
-    }
-
-    if (confirmedUnsavedAction.kind === 'wizard') {
-      openGoogleSheetImport();
-      setConfirmedUnsavedAction(null);
-      return;
-    }
-
-    setAllowUnsavedNavigation(true);
-    navigate(confirmedUnsavedAction.path);
-    setConfirmedUnsavedAction(null);
-  }, [
-    blocker,
-    confirmedUnsavedAction,
-    hasUnsavedSettlementChanges,
-    navigate,
-    openGoogleSheetImport,
-    setActiveExpenseSheet,
-  ]);
-
   const requestRouteNavigation = useCallback((path: string, label: string) => {
-    if (hasUnsavedSettlementChanges) {
-      setPendingUnsavedAction({ kind: 'route', path, label });
-      return;
-    }
     navigate(path);
-  }, [hasUnsavedSettlementChanges, navigate]);
+  }, [navigate]);
 
   const requestSheetSwitch = useCallback((sheetId: string, sheetName: string) => {
     if (sheetId === activeExpenseSheetId) return;
-    if (hasUnsavedSettlementChanges) {
-      setPendingUnsavedAction({ kind: 'sheet', sheetId, sheetName });
-      return;
-    }
     setActiveExpenseSheet(sheetId);
-  }, [activeExpenseSheetId, hasUnsavedSettlementChanges, setActiveExpenseSheet]);
+  }, [activeExpenseSheetId, setActiveExpenseSheet]);
 
   const requestWizardOpen = useCallback(() => {
-    if (hasUnsavedSettlementChanges) {
-      setPendingUnsavedAction({ kind: 'wizard' });
-      return;
-    }
     openGoogleSheetImport();
-  }, [hasUnsavedSettlementChanges, openGoogleSheetImport]);
-
-  const resetUnsavedAction = useCallback(() => {
-    if (blocker.state === 'blocked') {
-      blocker.reset();
-    }
-    setPendingUnsavedAction(null);
-    setConfirmedUnsavedAction(null);
-  }, [blocker]);
-
-  const confirmUnsavedAction = useCallback(() => {
-    const action = pendingUnsavedAction;
-    setPendingUnsavedAction(null);
-    if (!action) return;
-    setConfirmedUnsavedAction(action);
-    setDiscardChangesRequestToken((current) => current + 1);
-  }, [pendingUnsavedAction]);
+  }, [openGoogleSheetImport]);
 
   if (!projectId) {
     return (
@@ -1195,7 +1080,7 @@ export function PortalWeeklyExpensePage() {
           onDeriveRows={deriveRowsWithLocalKernel}
           onPreviewActualSyncPayload={previewActualSyncWithLocalKernel}
           onDirtyStateChange={setHasUnsavedSettlementChanges}
-          discardChangesRequestToken={discardChangesRequestToken}
+          discardChangesRequestToken={0}
         />
       </Suspense>
       {googleSheetImportOpen && (
@@ -1236,30 +1121,6 @@ export function PortalWeeklyExpensePage() {
         onSyncEvidence={syncExpenseIntakeEvidence}
         evidenceRequiredMap={evidenceRequiredMap}
       />
-      <AlertDialog open={!!pendingUnsavedAction}>
-        <AlertDialogContent
-          data-testid="weekly-expense-unsaved-dialog"
-          onEscapeKeyDown={resetUnsavedAction}
-          onInteractOutside={(event) => event.preventDefault()}
-        >
-          <AlertDialogHeader>
-            <AlertDialogTitle>저장되지 않은 사업비 입력이 있습니다</AlertDialogTitle>
-            <AlertDialogDescription>
-              지금 이동하면 저장되지 않은 사업비 입력(주간) 편집 내용이 유실될 수 있습니다.
-              {pendingUnsavedAction?.kind === 'sheet' && ` ${pendingUnsavedAction.sheetName} 탭으로 바꾸기 전에 먼저 저장하거나, 변경을 버릴지 확인해 주세요.`}
-              {pendingUnsavedAction?.kind === 'route' && ` ${pendingUnsavedAction.label} 화면으로 이동하기 전에 먼저 저장하거나, 변경을 버릴지 확인해 주세요.`}
-              {pendingUnsavedAction?.kind === 'wizard' && ' Migration Wizard를 열기 전에 현재 편집 내용을 먼저 저장하거나, 변경을 버릴지 확인해 주세요.'}
-              {pendingUnsavedAction?.kind === 'blocker' && ` ${pendingUnsavedAction.label} 화면으로 이동하면 현재 편집 내용이 유실될 수 있습니다.`}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel onClick={resetUnsavedAction}>계속 편집</AlertDialogCancel>
-            <AlertDialogAction onClick={confirmUnsavedAction}>
-              변경 버리고 이동
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
       {/* 참여율 이상 탐지 경고 모달 */}
       <AlertDialog open={!!participationRiskWarning} onOpenChange={(open) => { if (!open) setParticipationRiskWarning(null); }}>
         <AlertDialogContent>

--- a/src/app/components/ui/dialog.tsx
+++ b/src/app/components/ui/dialog.tsx
@@ -62,7 +62,7 @@ const DialogContent = React.forwardRef<
         ref={ref}
         data-slot="dialog-content"
         className={cn(
-          "glass-heavy data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl p-6 shadow-2xl duration-200 sm:max-w-lg",
+          "glass-heavy data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[calc(100dvh-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto overscroll-contain rounded-2xl p-6 shadow-2xl duration-200 sm:max-w-lg",
           className,
         )}
         {...props}

--- a/src/app/data/portal-store.intake.test.ts
+++ b/src/app/data/portal-store.intake.test.ts
@@ -4,6 +4,7 @@ import {
   buildBankImportIntakeDoc,
   mergeBankImportIntakeItem,
   normalizeBankImportIntakeItem,
+  reconcileBankImportUploadItems,
   serializeBankImportIntakeItemForPersistence,
 } from './portal-store.intake';
 
@@ -156,6 +157,54 @@ describe('portal-store intake persistence', () => {
         memo: '기존 메모',
         evidenceCompletedDesc: '출장신청서',
       }),
+    }));
+  });
+
+  it('preserves the latest manual fields when a bank upload rebuilds an existing intake item', () => {
+    const current = makeItem({
+      manualFields: {
+        expenseAmount: 120000,
+        budgetCategory: '여비',
+        budgetSubCategory: '교통비',
+        cashflowCategory: 'TRAVEL',
+        cashflowLineId: 'DIRECT_COST_OUT',
+        memo: '사람이 직접 수정한 메모',
+        evidenceCompletedDesc: '출장신청서',
+      },
+      updatedAt: '2026-04-06T01:00:00.000Z',
+    });
+    const rebuilt = makeItem({
+      bankSnapshot: {
+        accountNumber: '111-222-333',
+        dateTime: '2026-04-06 10:00',
+        counterparty: '메리 사업팀',
+        memo: '재업로드된 통장 메모',
+        signedAmount: -120000,
+        balanceAfter: 890000,
+      },
+      manualFields: {},
+      evidenceStatus: 'MISSING',
+      updatedAt: '2026-04-06T02:00:00.000Z',
+      lastUploadBatchId: 'batch-2',
+    });
+
+    const reconciled = reconcileBankImportUploadItems([current], [rebuilt]);
+
+    expect(reconciled).toHaveLength(1);
+    expect(reconciled[0]).toEqual(expect.objectContaining({
+      bankSnapshot: expect.objectContaining({
+        memo: '재업로드된 통장 메모',
+        balanceAfter: 890000,
+      }),
+      lastUploadBatchId: 'batch-2',
+      manualFields: expect.objectContaining({
+        budgetCategory: '여비',
+        budgetSubCategory: '교통비',
+        cashflowLineId: 'DIRECT_COST_OUT',
+        memo: '사람이 직접 수정한 메모',
+        evidenceCompletedDesc: '출장신청서',
+      }),
+      evidenceStatus: 'MISSING',
     }));
   });
 });

--- a/src/app/data/portal-store.intake.ts
+++ b/src/app/data/portal-store.intake.ts
@@ -1,3 +1,4 @@
+import { resolveBankImportProjectionStatus } from '../platform/bank-import-triage';
 import type { BankImportIntakeItem, BankImportManualFields, BankImportSnapshot } from './types';
 
 function normalizeString(value: unknown): string {
@@ -14,6 +15,22 @@ function normalizeManualFields(value: unknown): BankImportManualFields {
   if (Number.isFinite(candidate.expenseAmount)) next.expenseAmount = Number(candidate.expenseAmount);
   if (normalizeString(candidate.budgetCategory)) next.budgetCategory = normalizeString(candidate.budgetCategory);
   if (normalizeString(candidate.budgetSubCategory)) next.budgetSubCategory = normalizeString(candidate.budgetSubCategory);
+  if (
+    candidate.cashflowLineId === 'MYSC_PREPAY_IN'
+    || candidate.cashflowLineId === 'SALES_IN'
+    || candidate.cashflowLineId === 'SALES_VAT_IN'
+    || candidate.cashflowLineId === 'TEAM_SUPPORT_IN'
+    || candidate.cashflowLineId === 'BANK_INTEREST_IN'
+    || candidate.cashflowLineId === 'DIRECT_COST_OUT'
+    || candidate.cashflowLineId === 'INPUT_VAT_OUT'
+    || candidate.cashflowLineId === 'MYSC_LABOR_OUT'
+    || candidate.cashflowLineId === 'MYSC_PROFIT_OUT'
+    || candidate.cashflowLineId === 'SALES_VAT_OUT'
+    || candidate.cashflowLineId === 'TEAM_SUPPORT_OUT'
+    || candidate.cashflowLineId === 'BANK_INTEREST_OUT'
+  ) {
+    next.cashflowLineId = candidate.cashflowLineId;
+  }
   if (
     candidate.cashflowCategory === 'CONTRACT_PAYMENT'
     || candidate.cashflowCategory === 'INTERIM_PAYMENT'
@@ -136,6 +153,49 @@ export function mergeBankImportIntakeItem(
       ...(updates.manualFields || {}),
     },
   });
+}
+
+function sortBankImportIntakeItems(items: BankImportIntakeItem[]): BankImportIntakeItem[] {
+  return [...items].sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
+}
+
+export function reconcileBankImportUploadItems(
+  currentItems: BankImportIntakeItem[],
+  rebuiltItems: BankImportIntakeItem[],
+): BankImportIntakeItem[] {
+  const currentById = new Map(currentItems.map((item) => [item.id, item] as const));
+  const currentBySourceTxId = new Map(currentItems.map((item) => [item.sourceTxId, item] as const));
+  const nextMap = new Map(currentItems.map((item) => [item.id, item] as const));
+
+  rebuiltItems.forEach((rebuiltItem) => {
+    const currentItem = currentById.get(rebuiltItem.id) || currentBySourceTxId.get(rebuiltItem.sourceTxId) || null;
+    if (!currentItem) {
+      nextMap.set(rebuiltItem.id, rebuiltItem);
+      return;
+    }
+
+    const preservedManualFields = Object.keys(currentItem.manualFields || {}).length > 0
+      ? { ...currentItem.manualFields }
+      : { ...rebuiltItem.manualFields };
+    const evidenceStatus = currentItem.evidenceStatus || rebuiltItem.evidenceStatus;
+    const reconciled = normalizeBankImportIntakeItem({
+      ...rebuiltItem,
+      manualFields: preservedManualFields,
+      evidenceStatus,
+      projectionStatus: resolveBankImportProjectionStatus({
+        matchState: rebuiltItem.matchState,
+        manualFields: preservedManualFields,
+        evidenceStatus,
+      }),
+      existingExpenseSheetId: currentItem.existingExpenseSheetId || rebuiltItem.existingExpenseSheetId,
+      existingExpenseRowTempId: currentItem.existingExpenseRowTempId || rebuiltItem.existingExpenseRowTempId,
+      createdAt: currentItem.createdAt || rebuiltItem.createdAt,
+    }) || rebuiltItem;
+
+    nextMap.set(reconciled.id, reconciled);
+  });
+
+  return sortBankImportIntakeItems(Array.from(nextMap.values()));
 }
 
 export function buildBankImportIntakeDoc(params: {

--- a/src/app/data/portal-store.persistence.test.ts
+++ b/src/app/data/portal-store.persistence.test.ts
@@ -128,6 +128,30 @@ describe('upsertExpenseSheetProjectionRowBySourceTxId', () => {
     expect(result.projectedRow.cells[19]).toBe('출장신청서, 영수증');
   });
 
+  it('prefers explicit cashflow line ids over legacy category fallbacks when projecting rows', () => {
+    const result = upsertExpenseSheetProjectionRowBySourceTxId({
+      rows: [
+        {
+          tempId: 'row-bank',
+          sourceTxId: 'bank:fp-1',
+          cells: Array.from({ length: 27 }, () => ''),
+        },
+      ],
+      item: makeIntakeItem({
+        manualFields: {
+          expenseAmount: 15000,
+          budgetCategory: '인건비',
+          budgetSubCategory: '강사비',
+          cashflowCategory: 'TRAVEL',
+          cashflowLineId: 'MYSC_LABOR_OUT',
+        },
+      }),
+      evidenceRequiredDesc: '계약서',
+    });
+
+    expect(result.projectedRow.cells[8]).toBe('MYSC 인건비');
+  });
+
   it('inserts a new bank-origin row when the source transaction is not projected yet', () => {
     const result = upsertExpenseSheetProjectionRowBySourceTxId({
       rows: [

--- a/src/app/data/portal-store.persistence.ts
+++ b/src/app/data/portal-store.persistence.ts
@@ -1,7 +1,13 @@
-import { createEmptyImportRow, SETTLEMENT_COLUMNS, type ImportRow } from '../platform/settlement-csv';
+import {
+  createEmptyImportRow,
+  getCashflowLineLabelForExport,
+  SETTLEMENT_COLUMNS,
+  type ImportRow,
+} from '../platform/settlement-csv';
 import { findWeekForDate, getYearMondayWeeks } from '../platform/cashflow-weeks';
 import { resolveEvidenceChecklist } from '../platform/evidence-helpers';
-import type { BankImportIntakeItem, CashflowCategory, EvidenceStatus, WeeklySubmissionStatus } from './types';
+import { resolveBankImportCashflowLineId } from '../platform/bank-import-cashflow';
+import type { BankImportIntakeItem, EvidenceStatus, WeeklySubmissionStatus } from './types';
 
 interface ExpenseSheetTabSnapshot {
   id: string;
@@ -14,34 +20,6 @@ interface ExpenseSheetTabSnapshot {
 
 function findColumnIndex(header: string): number {
   return SETTLEMENT_COLUMNS.findIndex((column) => column.csvHeader === header);
-}
-
-function cashflowCategoryToRowLabel(category: CashflowCategory | undefined): string {
-  switch (category) {
-    case 'CONTRACT_PAYMENT':
-    case 'INTERIM_PAYMENT':
-    case 'FINAL_PAYMENT':
-      return '매출액(입금)';
-    case 'LABOR_COST':
-      return 'MYSC인건비';
-    case 'TAX_PAYMENT':
-      return '매입부가세';
-    case 'VAT_REFUND':
-      return '매출부가세(입금)';
-    case 'MISC_INCOME':
-      return '팀지원금(입금)';
-    case 'OUTSOURCING':
-    case 'EQUIPMENT':
-    case 'TRAVEL':
-    case 'SUPPLIES':
-    case 'COMMUNICATION':
-    case 'RENT':
-    case 'UTILITY':
-    case 'INSURANCE':
-    case 'MISC_EXPENSE':
-    default:
-      return '직접사업비';
-  }
 }
 
 function buildProjectionRowFromIntake(
@@ -88,7 +66,11 @@ function buildProjectionRowFromIntake(
   }
   if (budgetIdx >= 0) cells[budgetIdx] = item.manualFields.budgetCategory || '';
   if (subBudgetIdx >= 0) cells[subBudgetIdx] = item.manualFields.budgetSubCategory || '';
-  if (cashflowIdx >= 0) cells[cashflowIdx] = cashflowCategoryToRowLabel(item.manualFields.cashflowCategory);
+  if (cashflowIdx >= 0) {
+    cells[cashflowIdx] = getCashflowLineLabelForExport(
+      resolveBankImportCashflowLineId(item.manualFields, item.bankSnapshot.signedAmount),
+    );
+  }
   if (balanceIdx >= 0) {
     cells[balanceIdx] = Number.isFinite(item.bankSnapshot.balanceAfter)
       ? item.bankSnapshot.balanceAfter.toLocaleString('ko-KR')

--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -70,6 +70,7 @@ import {
   buildBankImportIntakeDoc,
   mergeBankImportIntakeItem,
   normalizeBankImportIntakeItem,
+  reconcileBankImportUploadItems,
 } from './portal-store.intake';
 import { useAuth } from './auth-store';
 import { useFirebase } from '../lib/firebase-context';
@@ -571,10 +572,15 @@ export function PortalProvider({ children }: { children: ReactNode }) {
   const [isLoading, setIsLoading] = useState(false);
   const [isMemberLoading, setIsMemberLoading] = useState(true);
   const unsubsRef = useRef<Unsubscribe[]>([]);
+  const expenseIntakeItemsRef = useRef<BankImportIntakeItem[]>([]);
   const expenseSheetsRef = useRef<ExpenseSheetTab[]>([]);
   const activeExpenseSheetIdRef = useRef(activeExpenseSheetId);
   const expenseSheetRowsRef = useRef<ImportRow[] | null>(expenseSheetRows);
   const devHarnessHydratedProjectIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    expenseIntakeItemsRef.current = expenseIntakeItems;
+  }, [expenseIntakeItems]);
 
   useEffect(() => {
     expenseSheetsRef.current = expenseSheets;
@@ -2095,23 +2101,18 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     const intakeItems = buildBankImportIntakeItemsFromBankSheet({
       projectId: portalUser?.projectId || '',
       sheet: sanitizedSheet,
-      existingItems: expenseIntakeItems,
-      existingRows: expenseSheetRows,
-      existingExpenseSheetId: activeExpenseSheetId || 'default',
+      existingItems: expenseIntakeItemsRef.current,
+      existingRows: expenseSheetRowsRef.current,
+      existingExpenseSheetId: activeExpenseSheetIdRef.current || 'default',
       lastUploadBatchId: uploadBatchId,
       now,
       updatedBy: portalUser?.name || authUser?.name || '',
     });
+    const reconciledIntakeItems = reconcileBankImportUploadItems(expenseIntakeItemsRef.current, intakeItems);
     if (isDevHarnessUser || !db || !portalUser?.projectId) {
       setBankStatementRows(sanitizedSheet);
-      setExpenseIntakeItems((prev) => {
-        const nextMap = new Map(prev.map((item) => [item.id, item] as const));
-        intakeItems.forEach((item) => {
-          nextMap.set(item.id, item);
-        });
-        return Array.from(nextMap.values())
-          .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
-      });
+      expenseIntakeItemsRef.current = reconciledIntakeItems;
+      setExpenseIntakeItems(reconciledIntakeItems);
       return;
     }
     const payload = withTenantScope(orgId, {
@@ -2128,21 +2129,15 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     );
     setBankStatementRows(sanitizedSheet);
     await Promise.all(
-      intakeItems.map((item) => setDoc(
+      reconciledIntakeItems.map((item) => setDoc(
         doc(db, `${getOrgDocumentPath(orgId, 'projects', portalUser.projectId)}/expense_intake/${item.id}`),
         buildBankImportIntakeDoc({ orgId, item }),
         { merge: true },
       )),
     );
-    setExpenseIntakeItems((prev) => {
-      const nextMap = new Map(prev.map((item) => [item.id, item] as const));
-      intakeItems.forEach((item) => {
-        nextMap.set(item.id, item);
-      });
-      return Array.from(nextMap.values())
-        .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
-    });
-  }, [db, orgId, portalUser?.projectId, portalUser?.name, authUser?.name, expenseIntakeItems, expenseSheetRows, activeExpenseSheetId, isDevHarnessUser]);
+    expenseIntakeItemsRef.current = reconciledIntakeItems;
+    setExpenseIntakeItems(reconciledIntakeItems);
+  }, [db, orgId, portalUser?.projectId, portalUser?.name, authUser?.name, isDevHarnessUser]);
 
   const upsertExpenseIntakeItems = useCallback(async (items: BankImportIntakeItem[]) => {
     if (!Array.isArray(items) || items.length === 0) return;
@@ -2153,12 +2148,14 @@ export function PortalProvider({ children }: { children: ReactNode }) {
 
     if (isDevHarnessUser || !db || !portalUser?.projectId) {
       setExpenseIntakeItems((prev) => {
-        const nextMap = new Map(prev.map((item) => [item.id, item] as const));
+        const nextMap = new Map(expenseIntakeItemsRef.current.map((item) => [item.id, item] as const));
         normalizedItems.forEach((item) => {
           nextMap.set(item.id, item);
         });
-        return Array.from(nextMap.values())
+        const nextItems = Array.from(nextMap.values())
           .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
+        expenseIntakeItemsRef.current = nextItems;
+        return nextItems;
       });
       return;
     }
@@ -2171,26 +2168,30 @@ export function PortalProvider({ children }: { children: ReactNode }) {
       )),
     );
     setExpenseIntakeItems((prev) => {
-      const nextMap = new Map(prev.map((item) => [item.id, item] as const));
+      const nextMap = new Map(expenseIntakeItemsRef.current.map((item) => [item.id, item] as const));
       normalizedItems.forEach((item) => {
         nextMap.set(item.id, item);
       });
-      return Array.from(nextMap.values())
+      const nextItems = Array.from(nextMap.values())
         .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
+      expenseIntakeItemsRef.current = nextItems;
+      return nextItems;
     });
   }, [db, isDevHarnessUser, orgId, portalUser?.projectId]);
 
   const saveExpenseIntakeDraft = useCallback(async (id: string, updates: Partial<BankImportIntakeItem>) => {
-    const currentItem = expenseIntakeItems.find((item) => item.id === id);
+    const currentItem = expenseIntakeItemsRef.current.find((item) => item.id === id);
     if (!currentItem) return;
 
     const mergedCandidate = mergeBankImportIntakeItem(currentItem, updates);
     if (!mergedCandidate) return;
 
     if (isDevHarnessUser || !db || !portalUser?.projectId) {
-      setExpenseIntakeItems((prev) => prev
+      const nextItems = expenseIntakeItemsRef.current
         .map((item) => (item.id === id ? mergedCandidate : item))
-        .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || ''))));
+        .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
+      expenseIntakeItemsRef.current = nextItems;
+      setExpenseIntakeItems(nextItems);
       return;
     }
 
@@ -2199,15 +2200,17 @@ export function PortalProvider({ children }: { children: ReactNode }) {
       buildBankImportIntakeDoc({ orgId, item: mergedCandidate }),
       { merge: true },
     );
-    setExpenseIntakeItems((prev) => prev
+    const nextItems = expenseIntakeItemsRef.current
       .map((item) => (item.id === id ? mergedCandidate : item))
-      .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || ''))));
-  }, [db, expenseIntakeItems, isDevHarnessUser, orgId, portalUser?.projectId]);
+      .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
+    expenseIntakeItemsRef.current = nextItems;
+    setExpenseIntakeItems(nextItems);
+  }, [db, isDevHarnessUser, orgId, portalUser?.projectId]);
 
   const updateExpenseIntakeItem = saveExpenseIntakeDraft;
 
   const projectExpenseIntakeItem = useCallback(async (id: string, updates?: Partial<BankImportIntakeItem>) => {
-    const currentItem = expenseIntakeItems.find((item) => item.id === id);
+    const currentItem = expenseIntakeItemsRef.current.find((item) => item.id === id);
     if (!currentItem) return;
     const mergedCandidate = updates ? mergeBankImportIntakeItem(currentItem, updates) : currentItem;
     if (!mergedCandidate) return;
@@ -2269,9 +2272,11 @@ export function PortalProvider({ children }: { children: ReactNode }) {
       if (targetSheetId === activeExpenseSheetIdRef.current) {
         setExpenseSheetRows(projection.rows);
       }
-      setExpenseIntakeItems((prev) => prev
+      const nextItems = expenseIntakeItemsRef.current
         .map((item) => (item.id === id ? projectedItem : item))
-        .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || ''))));
+        .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
+      expenseIntakeItemsRef.current = nextItems;
+      setExpenseIntakeItems(nextItems);
       return;
     }
 
@@ -2301,13 +2306,15 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     if (targetSheetId === activeExpenseSheetIdRef.current) {
       setExpenseSheetRows(projection.rows);
     }
-    setExpenseIntakeItems((prev) => prev
+    const nextItems = expenseIntakeItemsRef.current
       .map((item) => (item.id === id ? projectedItem : item))
-      .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || ''))));
-  }, [activeExpenseSheetId, authUser?.name, db, evidenceRequiredMap, expenseIntakeItems, isDevHarnessUser, orgId, portalUser?.name, portalUser?.projectId]);
+      .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
+    expenseIntakeItemsRef.current = nextItems;
+    setExpenseIntakeItems(nextItems);
+  }, [authUser?.name, db, evidenceRequiredMap, isDevHarnessUser, orgId, portalUser?.name, portalUser?.projectId]);
 
   const syncExpenseIntakeEvidence = useCallback(async (id: string, updates: Partial<BankImportIntakeItem>) => {
-    const currentItem = expenseIntakeItems.find((item) => item.id === id);
+    const currentItem = expenseIntakeItemsRef.current.find((item) => item.id === id);
     if (!currentItem) return;
 
     const now = new Date().toISOString();
@@ -2327,9 +2334,11 @@ export function PortalProvider({ children }: { children: ReactNode }) {
       if (activeExpenseSheetIdRef.current === (nextState.item.existingExpenseSheetId || activeExpenseSheetIdRef.current)) {
         setExpenseSheetRows(nextState.activeRows);
       }
-      setExpenseIntakeItems((prev) => prev
+      const nextItems = expenseIntakeItemsRef.current
         .map((item) => (item.id === id ? nextState.item : item))
-        .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || ''))));
+        .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
+      expenseIntakeItemsRef.current = nextItems;
+      setExpenseIntakeItems(nextItems);
       return;
     }
 
@@ -2364,10 +2373,12 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     if (activeExpenseSheetIdRef.current === targetSheetId) {
       setExpenseSheetRows(nextState.activeRows);
     }
-    setExpenseIntakeItems((prev) => prev
+    const nextItems = expenseIntakeItemsRef.current
       .map((item) => (item.id === id ? nextState.item : item))
-      .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || ''))));
-  }, [authUser?.name, db, evidenceRequiredMap, expenseIntakeItems, isDevHarnessUser, orgId, portalUser?.name, portalUser?.projectId]);
+      .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
+    expenseIntakeItemsRef.current = nextItems;
+    setExpenseIntakeItems(nextItems);
+  }, [authUser?.name, db, evidenceRequiredMap, isDevHarnessUser, orgId, portalUser?.name, portalUser?.projectId]);
 
   const persistTransaction = useCallback(async (txData: Transaction) => {
     if (!db) return;

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -812,6 +812,7 @@ export interface BankImportManualFields {
   expenseAmount?: number;
   budgetCategory?: string;
   budgetSubCategory?: string;
+  cashflowLineId?: CashflowSheetLineId;
   cashflowCategory?: CashflowCategory;
   memo?: string;
   evidenceCompletedDesc?: string;

--- a/src/app/platform/bank-import-cashflow.test.ts
+++ b/src/app/platform/bank-import-cashflow.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolveBankImportCashflowLineId,
+  resolveBankImportCashflowOptionsForAmount,
+  resolveBankImportCashflowSelection,
+} from './bank-import-cashflow';
+
+describe('bank-import-cashflow helpers', () => {
+  it('shows only outflow sheet lines for expense rows', () => {
+    const options = resolveBankImportCashflowOptionsForAmount(-15000);
+
+    expect(options.map((option) => option.value)).toEqual([
+      'DIRECT_COST_OUT',
+      'INPUT_VAT_OUT',
+      'MYSC_LABOR_OUT',
+      'MYSC_PROFIT_OUT',
+      'SALES_VAT_OUT',
+      'TEAM_SUPPORT_OUT',
+      'BANK_INTEREST_OUT',
+    ]);
+  });
+
+  it('stores sheet line id alongside compatibility category', () => {
+    expect(resolveBankImportCashflowSelection('MYSC_LABOR_OUT', -120000)).toEqual({
+      cashflowLineId: 'MYSC_LABOR_OUT',
+      cashflowCategory: 'LABOR_COST',
+    });
+  });
+
+  it('falls back from legacy category to a stable sheet line id', () => {
+    expect(resolveBankImportCashflowLineId({
+      cashflowCategory: 'TRAVEL',
+    }, -15000)).toBe('DIRECT_COST_OUT');
+
+    expect(resolveBankImportCashflowLineId({
+      cashflowCategory: 'VAT_REFUND',
+    }, 50000)).toBe('SALES_VAT_IN');
+  });
+});

--- a/src/app/platform/bank-import-cashflow.ts
+++ b/src/app/platform/bank-import-cashflow.ts
@@ -1,0 +1,62 @@
+import type { BankImportManualFields, CashflowCategory, CashflowSheetLineId, Direction } from '../data/types';
+import { CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES, mapCategoryToSheetLine } from './cashflow-sheet';
+import { CASHFLOW_LINE_OPTIONS } from './settlement-csv';
+
+function resolveDirectionForAmount(signedAmount: number): Direction {
+  return signedAmount >= 0 ? 'IN' : 'OUT';
+}
+
+export function mapCashflowLineToCategory(
+  lineId: CashflowSheetLineId | undefined,
+  direction: Direction,
+): CashflowCategory {
+  if (!lineId) return direction === 'IN' ? 'MISC_INCOME' : 'MISC_EXPENSE';
+  switch (lineId) {
+    case 'MYSC_PREPAY_IN':
+    case 'SALES_IN':
+      return 'CONTRACT_PAYMENT';
+    case 'SALES_VAT_IN':
+      return 'VAT_REFUND';
+    case 'TEAM_SUPPORT_IN':
+    case 'BANK_INTEREST_IN':
+      return 'MISC_INCOME';
+    case 'DIRECT_COST_OUT':
+      return 'OUTSOURCING';
+    case 'INPUT_VAT_OUT':
+    case 'SALES_VAT_OUT':
+      return 'TAX_PAYMENT';
+    case 'MYSC_LABOR_OUT':
+      return 'LABOR_COST';
+    case 'MYSC_PROFIT_OUT':
+    case 'TEAM_SUPPORT_OUT':
+    case 'BANK_INTEREST_OUT':
+      return 'MISC_EXPENSE';
+    default:
+      return direction === 'IN' ? 'MISC_INCOME' : 'MISC_EXPENSE';
+  }
+}
+
+export function resolveBankImportCashflowOptionsForAmount(signedAmount: number) {
+  const allowed = new Set(signedAmount >= 0 ? CASHFLOW_IN_LINES : CASHFLOW_OUT_LINES);
+  return CASHFLOW_LINE_OPTIONS.filter((option) => allowed.has(option.value));
+}
+
+export function resolveBankImportCashflowSelection(
+  lineId: CashflowSheetLineId,
+  signedAmount: number,
+): Pick<BankImportManualFields, 'cashflowLineId' | 'cashflowCategory'> {
+  const direction = resolveDirectionForAmount(signedAmount);
+  return {
+    cashflowLineId: lineId,
+    cashflowCategory: mapCashflowLineToCategory(lineId, direction),
+  };
+}
+
+export function resolveBankImportCashflowLineId(
+  fields: Pick<BankImportManualFields, 'cashflowLineId' | 'cashflowCategory'> | null | undefined,
+  signedAmount: number,
+): CashflowSheetLineId | undefined {
+  if (fields?.cashflowLineId) return fields.cashflowLineId;
+  if (!fields?.cashflowCategory) return undefined;
+  return mapCategoryToSheetLine(resolveDirectionForAmount(signedAmount), fields.cashflowCategory);
+}

--- a/src/app/platform/bank-import-triage.ts
+++ b/src/app/platform/bank-import-triage.ts
@@ -29,7 +29,7 @@ export function isBankImportManualFieldsComplete(fields: BankImportManualFields 
   return Number.isFinite(fields.expenseAmount)
     && Boolean(normalizeSpace(fields.budgetCategory || ''))
     && Boolean(normalizeSpace(fields.budgetSubCategory || ''))
-    && Boolean(fields.cashflowCategory);
+    && Boolean(fields.cashflowLineId || fields.cashflowCategory);
 }
 
 function hasCriticalBankDrift(

--- a/src/app/platform/bank-statement.ts
+++ b/src/app/platform/bank-statement.ts
@@ -14,6 +14,7 @@ import {
   resolveBankImportMatchState,
   resolveBankImportProjectionStatus,
 } from './bank-import-triage';
+import { mapCashflowLineToCategory } from './bank-import-cashflow';
 
 // ── HTML-as-XLS parsing (KB, 신한 등 HTML 형식 은행 엑셀) ──
 
@@ -398,30 +399,7 @@ function pickAmount(
 
 function inferCashflowCategoryFromLineLabel(rawLineLabel: string, signedAmount: number): CashflowCategory | undefined {
   const lineId = parseCashflowLineLabel(rawLineLabel);
-  if (!lineId) return signedAmount >= 0 ? 'MISC_INCOME' : 'MISC_EXPENSE';
-  switch (lineId) {
-    case 'MYSC_PREPAY_IN':
-    case 'SALES_IN':
-      return 'CONTRACT_PAYMENT';
-    case 'SALES_VAT_IN':
-      return 'VAT_REFUND';
-    case 'TEAM_SUPPORT_IN':
-    case 'BANK_INTEREST_IN':
-      return 'MISC_INCOME';
-    case 'DIRECT_COST_OUT':
-      return 'OUTSOURCING';
-    case 'INPUT_VAT_OUT':
-    case 'SALES_VAT_OUT':
-      return 'TAX_PAYMENT';
-    case 'MYSC_LABOR_OUT':
-      return 'LABOR_COST';
-    case 'MYSC_PROFIT_OUT':
-    case 'TEAM_SUPPORT_OUT':
-    case 'BANK_INTEREST_OUT':
-      return 'MISC_EXPENSE';
-    default:
-      return signedAmount >= 0 ? 'MISC_INCOME' : 'MISC_EXPENSE';
-  }
+  return mapCashflowLineToCategory(lineId, signedAmount >= 0 ? 'IN' : 'OUT');
 }
 
 function resolveEvidenceStatusFromExpenseRow(row: ImportRow | null | undefined): EvidenceStatus {
@@ -458,7 +436,9 @@ function extractManualFieldsFromExpenseRow(row: ImportRow | null | undefined): B
   }
   if (cashflowIdx >= 0) {
     const value = normalizeSpace(String(row.cells[cashflowIdx] || ''));
+    const lineId = parseCashflowLineLabel(value);
     const category = inferCashflowCategoryFromLineLabel(value, signedAmount);
+    if (lineId) manualFields.cashflowLineId = lineId;
     if (category) manualFields.cashflowCategory = category;
   }
   if (noteIdx >= 0) {

--- a/src/app/platform/lazy-route.test.ts
+++ b/src/app/platform/lazy-route.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ComponentType } from 'react';
+import { loadLazyRouteModule } from './lazy-route';
+
+function Fallback() {
+  return null;
+}
+
+function Target() {
+  return null;
+}
+
+describe('loadLazyRouteModule', () => {
+  it('returns the named export when the chunk loads normally', async () => {
+    const result = await loadLazyRouteModule(
+      async () => ({ PortalSubmissionsPage: Target }),
+      'PortalSubmissionsPage',
+      Fallback,
+    );
+
+    expect(result.default).toBe(Target as ComponentType);
+  });
+
+  it('falls back cleanly when the chunk loader rejects', async () => {
+    const error = new Error('chunk load failed');
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const result = await loadLazyRouteModule(
+      async () => {
+        throw error;
+      },
+      'PortalSubmissionsPage',
+      Fallback,
+      '[routes] failed to load PortalSubmissionsPage:',
+    );
+
+    expect(result.default).toBe(Fallback as ComponentType);
+    expect(spy).toHaveBeenCalledWith('[routes] failed to load PortalSubmissionsPage:', error);
+    spy.mockRestore();
+  });
+});

--- a/src/app/platform/lazy-route.ts
+++ b/src/app/platform/lazy-route.ts
@@ -1,0 +1,23 @@
+import type { ComponentType } from 'react';
+
+type LazyRouteModule = Record<string, unknown> & {
+  default?: ComponentType;
+};
+
+export async function loadLazyRouteModule<TModule extends LazyRouteModule>(
+  loader: () => Promise<TModule>,
+  exportName: keyof TModule | string,
+  fallback: ComponentType,
+  errorPrefix?: string,
+): Promise<{ default: ComponentType }> {
+  try {
+    const module = await loader();
+    const resolved = module?.[exportName as keyof TModule] || module?.default;
+    return { default: (resolved as ComponentType) || fallback };
+  } catch (error) {
+    if (errorPrefix) {
+      console.error(errorPrefix, error);
+    }
+    return { default: fallback };
+  }
+}

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, type ComponentType } from 'react';
 import { createBrowserRouter } from 'react-router';
 import { AppLayout } from './components/layout/AppLayout';
 import { PortalLayout } from './components/portal/PortalLayout';
+import { loadLazyRouteModule } from './platform/lazy-route';
 
 // Lazy-loaded pages — each becomes a separate chunk
 const LoginPage = lazy(() => import('./components/auth/LoginPage').then(m => ({ default: m.LoginPage })));
@@ -44,7 +45,12 @@ const PortalProjectRegister = lazy(() => import('./components/portal/PortalProje
 const PortalProjectEdit = lazy(() => import('./components/portal/PortalProjectEdit').then(m => ({ default: m.PortalProjectEdit })));
 const PortalPayrollPage = lazy(() => import('./components/portal/PortalPayrollPage').then(m => ({ default: m.PortalPayrollPage })));
 const PortalCashflowPage = lazy(() => import('./components/portal/PortalCashflowPage').then(m => ({ default: m.PortalCashflowPage })));
-const PortalSubmissionsPage = lazy(() => import('./components/portal/PortalSubmissionsPage').then(m => ({ default: m.PortalSubmissionsPage })));
+const PortalSubmissionsPage = lazy(() => loadLazyRouteModule(
+  () => import('./components/portal/PortalSubmissionsPage'),
+  'PortalSubmissionsPage',
+  RouteChunkFallback,
+  '[routes] failed to load PortalSubmissionsPage:',
+));
 const CareerProfilePage = lazy(() => import('./components/portal/CareerProfilePage').then(m => ({ default: m.CareerProfilePage })));
 const PortalTrainingPage = lazy(() => import('./components/portal/PortalTrainingPage').then(m => ({ default: m.PortalTrainingPage })));
 function RouteChunkFallback() {
@@ -55,15 +61,12 @@ function RouteChunkFallback() {
   );
 }
 
-const PortalWeeklyExpensePage = lazy(async () => {
-  try {
-    const module = await import('./components/portal/PortalWeeklyExpensePage');
-    return { default: module?.PortalWeeklyExpensePage ?? module?.default ?? RouteChunkFallback };
-  } catch (error) {
-    console.error('[routes] failed to load PortalWeeklyExpensePage:', error);
-    return { default: RouteChunkFallback };
-  }
-});
+const PortalWeeklyExpensePage = lazy(() => loadLazyRouteModule(
+  () => import('./components/portal/PortalWeeklyExpensePage'),
+  'PortalWeeklyExpensePage',
+  RouteChunkFallback,
+  '[routes] failed to load PortalWeeklyExpensePage:',
+));
 const PortalBankStatementPage = lazy(() => import('./components/portal/PortalBankStatementPage').then(m => ({ default: m.PortalBankStatementPage })));
 const GuideChatPage = lazy(() => import('./components/guide-chat/GuideChatPage').then(m => ({ default: m.GuideChatPage })));
 


### PR DESCRIPTION
## 변경 내용
- 공통 DialogContent에 안전한 최대 높이와 세로 스크롤 기본값 추가
- 포털 예산 화면의 예산총괄 가져오기 / 예산 항목 구조 관리 모달을 헤더-본문-푸터 분리 레이아웃으로 조정
- 긴 내용이 들어가는 경우 본문만 스크롤되도록 정리해 하단 액션 버튼 접근성 개선

## 검증
- npm run build