### PR TITLE
fix: auth/RBAC 정합성 정리

### DIFF
--- a/server/bff/__tests__/bff-security-scenarios.test.ts
+++ b/server/bff/__tests__/bff-security-scenarios.test.ts
@@ -270,46 +270,47 @@ describe('Auth 보안 시나리오', () => {
   });
 
   // -----------------------------------------------------------------------
-  // 1-3. 역할 에스컬레이션 (토큰 role vs 헤더 role 불일치)
+  // 1-3. Firebase 토큰 사용 시 역할/이메일은 헤더가 아니라 토큰을 기준으로 한다.
   // -----------------------------------------------------------------------
 
-  describe('역할 에스컬레이션 시도', () => {
-    it('viewer 토큰으로 admin 역할 주장 → 403 role_mismatch', async () => {
-      await expect(
-        resolveRequestIdentity({
-          authMode: 'firebase_required',
-          readHeaderValue: createHeaders({
-            authorization: 'Bearer valid-token',
-            'x-tenant-id': 'mysc',
-            'x-actor-role': 'admin',
-          }),
-          verifyToken: makeVerifyToken({
-            uid: 'viewer-user-123',
-            tenantId: 'mysc',
-            role: 'viewer',
-            email: 'viewer@mysc.co.kr',
-          }),
+  describe('Firebase 토큰 + 헤더 불일치', () => {
+    it('viewer 토큰으로 admin 헤더를 보내도 토큰 role을 사용한다', async () => {
+      const identity = await resolveRequestIdentity({
+        authMode: 'firebase_required',
+        readHeaderValue: createHeaders({
+          authorization: 'Bearer valid-token',
+          'x-tenant-id': 'mysc',
+          'x-actor-role': 'admin',
         }),
-      ).rejects.toMatchObject({ statusCode: 403, code: 'role_mismatch' });
+        verifyToken: makeVerifyToken({
+          uid: 'viewer-user-123',
+          tenantId: 'mysc',
+          role: 'viewer',
+          email: 'viewer@mysc.co.kr',
+        }),
+      });
+
+      expect(identity.actorRole).toBe('pm');
+      expect(identity.actorEmail).toBe('viewer@mysc.co.kr');
     });
 
-    it('pm 토큰으로 finance 역할 주장 → 403 role_mismatch', async () => {
-      await expect(
-        resolveRequestIdentity({
-          authMode: 'firebase_required',
-          readHeaderValue: createHeaders({
-            authorization: 'Bearer valid-token',
-            'x-tenant-id': 'mysc',
-            'x-actor-role': 'finance',
-          }),
-          verifyToken: makeVerifyToken({
-            uid: 'pm-user-456',
-            tenantId: 'mysc',
-            role: 'pm',
-            email: 'pm@mysc.co.kr',
-          }),
+    it('pm 토큰에 finance 헤더를 섞어도 토큰 role을 유지한다', async () => {
+      const identity = await resolveRequestIdentity({
+        authMode: 'firebase_required',
+        readHeaderValue: createHeaders({
+          authorization: 'Bearer valid-token',
+          'x-tenant-id': 'mysc',
+          'x-actor-role': 'finance',
         }),
-      ).rejects.toMatchObject({ statusCode: 403, code: 'role_mismatch' });
+        verifyToken: makeVerifyToken({
+          uid: 'pm-user-456',
+          tenantId: 'mysc',
+          role: 'pm',
+          email: 'pm@mysc.co.kr',
+        }),
+      });
+
+      expect(identity.actorRole).toBe('pm');
     });
   });
 
@@ -355,23 +356,23 @@ describe('Auth 보안 시나리오', () => {
       ).rejects.toMatchObject({ statusCode: 403, code: 'actor_mismatch' });
     });
 
-    it('이메일 위조 (토큰 email과 헤더 email 불일치) → 403 email_mismatch', async () => {
-      await expect(
-        resolveRequestIdentity({
-          authMode: 'firebase_required',
-          readHeaderValue: createHeaders({
-            authorization: 'Bearer valid-token',
-            'x-tenant-id': 'mysc',
-            'x-actor-email': 'spoofed@mysc.co.kr',
-          }),
-          verifyToken: makeVerifyToken({
-            uid: 'user-x',
-            tenantId: 'mysc',
-            role: 'pm',
-            email: 'real@mysc.co.kr',
-          }),
+    it('이메일 헤더를 위조해도 토큰 email을 사용한다', async () => {
+      const identity = await resolveRequestIdentity({
+        authMode: 'firebase_required',
+        readHeaderValue: createHeaders({
+          authorization: 'Bearer valid-token',
+          'x-tenant-id': 'mysc',
+          'x-actor-email': 'spoofed@mysc.co.kr',
         }),
-      ).rejects.toMatchObject({ statusCode: 403, code: 'email_mismatch' });
+        verifyToken: makeVerifyToken({
+          uid: 'user-x',
+          tenantId: 'mysc',
+          role: 'pm',
+          email: 'real@mysc.co.kr',
+        }),
+      });
+
+      expect(identity.actorEmail).toBe('real@mysc.co.kr');
     });
   });
 

--- a/server/bff/app.integration.test.ts
+++ b/server/bff/app.integration.test.ts
@@ -1262,6 +1262,70 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
     expect(roleChangeLog).toBeTruthy();
   });
 
+  it('uses member fallback for firebase auth when token role is missing and ignores spoofed header role', async () => {
+    await db.doc(`orgs/${tenantId}/members/u-firebase-roleless`).set({
+      uid: 'u-firebase-roleless',
+      tenantId,
+      role: 'pm',
+      email: 'roleless@mysc.co.kr',
+      updatedAt: new Date().toISOString(),
+    });
+
+    await db.doc(`orgs/${tenantId}/members/u-target`).set({
+      uid: 'u-target',
+      tenantId,
+      role: 'viewer',
+      email: 'target@example.com',
+      updatedAt: new Date().toISOString(),
+    });
+
+    const firebaseApi = request(createBffApp({
+      projectId,
+      workerSecret,
+      db,
+      authMode: 'firebase_required',
+      tokenVerifier: async () => ({
+        uid: 'u-firebase-roleless',
+        tenantId,
+        email: 'roleless@mysc.co.kr',
+      }),
+    }));
+
+    const denied = await firebaseApi
+      .patch('/api/v1/members/u-target/role')
+      .set({
+        authorization: 'Bearer firebase-token',
+        'x-tenant-id': tenantId,
+        'x-actor-id': 'u-firebase-roleless',
+        'x-actor-role': 'admin',
+        'x-actor-email': 'spoofed@mysc.co.kr',
+        'idempotency-key': 'idem-firebase-roleless-denied',
+      })
+      .send({ role: 'finance', reason: 'spoofed header should not escalate' });
+
+    expect(denied.status).toBe(403);
+
+    await db.doc(`orgs/${tenantId}/members/u-firebase-roleless`).set({
+      role: 'admin',
+      updatedAt: new Date().toISOString(),
+    }, { merge: true });
+
+    const allowed = await firebaseApi
+      .patch('/api/v1/members/u-target/role')
+      .set({
+        authorization: 'Bearer firebase-token',
+        'x-tenant-id': tenantId,
+        'x-actor-id': 'u-firebase-roleless',
+        'x-actor-role': 'pm',
+        'x-actor-email': 'spoofed@mysc.co.kr',
+        'idempotency-key': 'idem-firebase-roleless-allowed',
+      })
+      .send({ role: 'finance', reason: 'member fallback admin should allow' });
+
+    expect(allowed.status).toBe(200);
+    expect(allowed.body.role).toBe('finance');
+  });
+
   it('blocks demoting the last remaining admin (lockout protection)', async () => {
     await db.doc(`orgs/${tenantId}/members/u-admin-1`).set({
       uid: 'u-admin-1',

--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -510,7 +510,7 @@ function assertActorPermissionAllowed(policy, req, requiredPermission, action) {
   }
 }
 
-async function resolveApiRequestContext(req, {
+export async function resolveApiRequestContext(req, {
   authMode,
   verifyToken,
   resolveMemberIdentity,
@@ -532,12 +532,12 @@ async function resolveApiRequestContext(req, {
   let actorRole = identity.actorRole;
   let actorEmail = identity.actorEmail;
 
-  if ((!actorRole || !actorEmail) && identity.source === 'firebase' && typeof resolveMemberIdentity === 'function') {
+  if (identity.source === 'firebase' && typeof resolveMemberIdentity === 'function') {
     const memberIdentity = await resolveMemberIdentity({
       tenantId: identity.tenantId,
       actorId: identity.actorId,
     });
-    actorRole = actorRole || normalizeRole(memberIdentity?.role) || undefined;
+    actorRole = normalizeRole(memberIdentity?.role) || actorRole || undefined;
     actorEmail = actorEmail || readOptionalText(memberIdentity?.email).toLowerCase() || undefined;
   }
 

--- a/server/bff/auth.mjs
+++ b/server/bff/auth.mjs
@@ -159,18 +159,7 @@ export async function resolveRequestIdentity(params) {
     throw createAuthError(403, 'Header actor does not match token subject', 'actor_mismatch');
   }
 
-  const claimRole = extractRoleFromClaims(claims);
-  const headerRole = normalizeRole(readHeader(readHeaderValue, 'x-actor-role'));
-  if (claimRole && headerRole && claimRole !== headerRole) {
-    throw createAuthError(403, 'Header role does not match token role', 'role_mismatch');
-  }
-
   const claimEmail = normalizeEmail(claims?.email || '');
-  const headerEmail = normalizeEmail(readHeader(readHeaderValue, 'x-actor-email'));
-  if (claimEmail && headerEmail && claimEmail !== headerEmail) {
-    throw createAuthError(403, 'Header email does not match token email', 'email_mismatch');
-  }
-
   const allowedDomains = parseAllowedEmailDomains(process.env.BFF_ALLOWED_EMAIL_DOMAINS);
   if (!claimEmail) {
     throw createAuthError(403, 'Token does not include a valid email', 'missing_email');
@@ -179,13 +168,14 @@ export async function resolveRequestIdentity(params) {
     throw createAuthError(403, 'Email domain is not allowed', 'email_domain_not_allowed');
   }
 
+  const claimRole = extractRoleFromClaims(claims);
   const resolvedTenantId = assertTenantId(claimTenantId || headerTenantId);
   return {
     source: 'firebase',
     tenantId: resolvedTenantId,
     actorId: claimActorId,
-    actorRole: claimRole || headerRole || undefined,
-    actorEmail: claimEmail || headerEmail || undefined,
+    actorRole: claimRole || undefined,
+    actorEmail: claimEmail || undefined,
     tokenClaims: claims,
   };
 }

--- a/server/bff/request-context.test.ts
+++ b/server/bff/request-context.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveApiRequestContext } from './app.mjs';
+
+function createReq(headers: Record<string, string>, method: string = 'PATCH') {
+  const normalized = new Map<string, string>();
+  for (const [key, value] of Object.entries(headers)) {
+    normalized.set(key.toLowerCase(), value);
+  }
+  return {
+    method,
+    header(name: string) {
+      return normalized.get(name.toLowerCase());
+    },
+  };
+}
+
+describe('resolveApiRequestContext', () => {
+  it('prefers member role over firebase token role for final RBAC', async () => {
+    const req = createReq({
+      authorization: 'Bearer token',
+      'x-tenant-id': 'mysc',
+      'x-actor-id': 'u-member',
+      'idempotency-key': 'idem-request-context-role',
+    });
+
+    const context = await resolveApiRequestContext(req as any, {
+      authMode: 'firebase_required',
+      verifyToken: vi.fn(async () => ({
+        uid: 'u-member',
+        tenantId: 'mysc',
+        role: 'pm',
+        email: 'member@mysc.co.kr',
+      })),
+      resolveMemberIdentity: vi.fn(async () => ({
+        role: 'admin',
+        email: 'member@mysc.co.kr',
+      })),
+    });
+
+    expect(context.actorRole).toBe('admin');
+    expect(context.actorEmail).toBe('member@mysc.co.kr');
+  });
+});

--- a/src/app/data/auth-bootstrap.test.ts
+++ b/src/app/data/auth-bootstrap.test.ts
@@ -6,6 +6,13 @@ describe('auth bootstrap admins', () => {
     const emails = parseBootstrapAdminEmails({});
     expect(emails).toContain('admin@mysc.co.kr');
     expect(emails).toContain('ai@mysc.co.kr');
+    expect(emails).toContain('ylee@mysc.co.kr');
+    expect(emails).toContain('jyoo@mysc.co.kr');
+    expect(emails).toContain('jslee@mysc.co.kr');
+    expect(emails).toContain('jhsong@mysc.co.kr');
+    expect(emails).toContain('jybaek@mysc.co.kr');
+    expect(emails).toContain('fin@mysc.co.kr');
+    expect(emails).toContain('hwkim@mysc.co.kr');
   });
 
   it('merges and normalizes env bootstrap admin emails', () => {

--- a/src/app/data/auth-bootstrap.ts
+++ b/src/app/data/auth-bootstrap.ts
@@ -4,6 +4,13 @@ import { normalizeEmail } from './auth-helpers';
 export const DEFAULT_BOOTSTRAP_ADMIN_EMAILS: readonly string[] = [
   'admin@mysc.co.kr',
   'ai@mysc.co.kr',
+  'ylee@mysc.co.kr',
+  'jyoo@mysc.co.kr',
+  'jslee@mysc.co.kr',
+  'jhsong@mysc.co.kr',
+  'jybaek@mysc.co.kr',
+  'fin@mysc.co.kr',
+  'hwkim@mysc.co.kr',
   'mwbyun1220@mysc.co.kr',
 ];
 

--- a/src/app/data/auth-role-resolution.test.ts
+++ b/src/app/data/auth-role-resolution.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { resolveEffectiveAuthRole } from './auth-role-resolution';
+
+describe('resolveEffectiveAuthRole', () => {
+  it('keeps an explicit member role ahead of bootstrap admin and claims', () => {
+    expect(resolveEffectiveAuthRole({
+      memberRole: 'pm',
+      claimRole: 'admin',
+      directoryRole: 'finance',
+      bootstrapAdmin: true,
+    })).toBe('pm');
+  });
+
+  it('uses claim role when member role is missing', () => {
+    expect(resolveEffectiveAuthRole({
+      memberRole: '',
+      claimRole: 'finance',
+      directoryRole: 'pm',
+      bootstrapAdmin: false,
+    })).toBe('finance');
+  });
+
+  it('uses bootstrap admin only as a fallback for missing member and claim roles', () => {
+    expect(resolveEffectiveAuthRole({
+      memberRole: '',
+      claimRole: '',
+      directoryRole: 'pm',
+      bootstrapAdmin: true,
+    })).toBe('admin');
+  });
+});

--- a/src/app/data/auth-role-resolution.ts
+++ b/src/app/data/auth-role-resolution.ts
@@ -1,0 +1,40 @@
+import type { UserRole } from './types';
+
+function normalizeUserRole(role: string | undefined): UserRole | undefined {
+  const normalized = typeof role === 'string' ? role.trim().toLowerCase() : '';
+  const effectiveRole = normalized === 'viewer' ? 'pm' : normalized;
+
+  if (
+    effectiveRole === 'admin'
+    || effectiveRole === 'tenant_admin'
+    || effectiveRole === 'finance'
+    || effectiveRole === 'pm'
+    || effectiveRole === 'auditor'
+    || effectiveRole === 'support'
+    || effectiveRole === 'security'
+  ) {
+    return effectiveRole as UserRole;
+  }
+
+  return undefined;
+}
+
+export function resolveEffectiveAuthRole(options: {
+  memberRole?: string;
+  claimRole?: string;
+  directoryRole?: string;
+  bootstrapAdmin?: boolean;
+}): UserRole {
+  const memberRole = normalizeUserRole(options.memberRole);
+  if (memberRole) return memberRole;
+
+  const claimRole = normalizeUserRole(options.claimRole);
+  if (claimRole) return claimRole;
+
+  if (options.bootstrapAdmin) return 'admin';
+
+  const directoryRole = normalizeUserRole(options.directoryRole);
+  if (directoryRole) return directoryRole;
+
+  return 'pm';
+}

--- a/src/app/data/auth-store.tsx
+++ b/src/app/data/auth-store.tsx
@@ -27,6 +27,7 @@ import {
   type RoleDirectoryEntry,
 } from './auth-helpers';
 import { isBootstrapAdminEmail } from './auth-bootstrap';
+import { resolveEffectiveAuthRole } from './auth-role-resolution';
 import { buildLegacyMemberDocId, mergeMemberRecordSources } from './member-documents';
 import { normalizeProjectIds, resolvePrimaryProjectId } from './project-assignment';
 import {
@@ -261,12 +262,11 @@ function mapFirebaseUserToAuthUser(
     mergedProjectIds,
     workspace.portalProfile?.projectId || member?.projectId,
   );
-  const role =
-    isBootstrapAdminEmail(normalizedEmail)
-      ? 'admin'
-      : toUserRole(member?.role) ||
-        resolveRoleFromDirectory(firebaseUser.email || '', ROLE_DIRECTORY) ||
-        'pm';
+  const role = resolveEffectiveAuthRole({
+    memberRole: member?.role,
+    directoryRole: resolveRoleFromDirectory(firebaseUser.email || '', ROLE_DIRECTORY),
+    bootstrapAdmin: isBootstrapAdminEmail(normalizedEmail),
+  });
   return {
     uid: firebaseUser.uid,
     name: member?.name || firebaseUser.displayName || '사용자',
@@ -327,13 +327,12 @@ async function upsertMemberFromFirebase(
     uid: firebaseUser.uid,
     name: firebaseUser.displayName || existing?.name || '사용자',
     email: normalizedEmail,
-    role:
-      bootstrapAdmin
-        ? 'admin'
-        : toUserRole(roleFromClaims) ||
-          toUserRole(existing?.role) ||
-          resolveRoleFromDirectory(firebaseUser.email || '', ROLE_DIRECTORY) ||
-          'pm',
+    role: resolveEffectiveAuthRole({
+      memberRole: existing?.role,
+      claimRole: roleFromClaims,
+      directoryRole: resolveRoleFromDirectory(firebaseUser.email || '', ROLE_DIRECTORY),
+      bootstrapAdmin,
+    }),
     tenantId,
     status: existing?.status || 'ACTIVE',
     projectId: primaryProjectId,

--- a/src/app/platform/firestore-rules-policy.test.ts
+++ b/src/app/platform/firestore-rules-policy.test.ts
@@ -28,6 +28,13 @@ describe('firestore rules policy alignment', () => {
   it('bootstrap admin emails match auth-bootstrap defaults', () => {
     expect(DEFAULT_BOOTSTRAP_ADMIN_EMAILS).toContain('admin@mysc.co.kr');
     expect(DEFAULT_BOOTSTRAP_ADMIN_EMAILS).toContain('ai@mysc.co.kr');
+    expect(DEFAULT_BOOTSTRAP_ADMIN_EMAILS).toContain('ylee@mysc.co.kr');
+    expect(DEFAULT_BOOTSTRAP_ADMIN_EMAILS).toContain('jyoo@mysc.co.kr');
+    expect(DEFAULT_BOOTSTRAP_ADMIN_EMAILS).toContain('jslee@mysc.co.kr');
+    expect(DEFAULT_BOOTSTRAP_ADMIN_EMAILS).toContain('jhsong@mysc.co.kr');
+    expect(DEFAULT_BOOTSTRAP_ADMIN_EMAILS).toContain('jybaek@mysc.co.kr');
+    expect(DEFAULT_BOOTSTRAP_ADMIN_EMAILS).toContain('fin@mysc.co.kr');
+    expect(DEFAULT_BOOTSTRAP_ADMIN_EMAILS).toContain('hwkim@mysc.co.kr');
   });
 
   // ── canWrite roles (admin, finance, pm — viewer excluded) ──


### PR DESCRIPTION
## 요약
- bootstrap admin 후보 이메일 기본값을 main 기준으로 정리했습니다.
- Firebase 토큰 사용 시 `x-actor-role`/`x-actor-email` 헤더를 신뢰하지 않도록 바꿨습니다.
- BFF 최종 권한은 Firebase claim보다 Firestore member role을 우선 반영하도록 정리했습니다.
- auth-store에서 stale claim이 기존 member role을 덮어쓰지 않도록 role precedence를 분리했습니다.

## 왜 필요한가
- `jslee@mysc.co.kr`처럼 로컬/배포/bootstrap/member role이 서로 어긋난 계정에서 admin cashflow export 노출과 서버 RBAC가 일관되지 않았습니다.
- 기존 구조는 claim이 비어 있을 때 헤더 role을 사실상 신뢰하거나, stale claim이 member role을 다시 덮어쓸 여지가 있었습니다.

## 검증
- `npm test -- --run server/bff/request-context.test.ts server/bff/__tests__/bff-security-scenarios.test.ts src/app/data/auth-role-resolution.test.ts src/app/data/auth-bootstrap.test.ts src/app/platform/firestore-rules-policy.test.ts`
- `npm run build`

## 메모
- `server/bff/app.integration.test.ts`의 새 케이스는 Firestore emulator가 없는 환경에서는 skip됩니다.
- 실운영에서 실제 접근 권한을 맞추려면 대상 계정의 `orgs/mysc/members/{uid}.role` backfill이 별도로 필요합니다.
