### PR TITLE
feat: admin auth governance dashboard

### DIFF
--- a/server/bff/app.integration.test.ts
+++ b/server/bff/app.integration.test.ts
@@ -1326,6 +1326,111 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
     expect(allowed.body.role).toBe('finance');
   });
 
+  it('lists auth governance rows merged from auth users and member docs', async () => {
+    await db.doc(`orgs/${tenantId}/members/jslee_mysc_co_kr`).set({
+      uid: 'jslee_mysc_co_kr',
+      tenantId,
+      role: 'admin',
+      email: 'jslee@mysc.co.kr',
+      name: 'Legacy JS',
+    });
+    await db.doc(`orgs/${tenantId}/members/u-jslee`).set({
+      uid: 'u-jslee',
+      tenantId,
+      role: 'pm',
+      email: 'jslee@mysc.co.kr',
+      name: 'Canonical JS',
+      status: 'ACTIVE',
+    });
+
+    const governanceApi = request(createBffApp({
+      projectId,
+      workerSecret,
+      db,
+      authAdminService: {
+        listUsers: async () => ({
+          users: [{
+            uid: 'u-jslee',
+            email: 'jslee@mysc.co.kr',
+            displayName: 'JS Lee',
+            disabled: false,
+            customClaims: { role: 'pm', tenantId },
+          }],
+        }),
+      },
+    }));
+
+    const response = await governanceApi
+      .get('/api/v1/admin/auth-governance/users')
+      .set(defaultHeaders);
+
+    expect(response.status).toBe(200);
+    const row = response.body.items.find((item: any) => item.email === 'jslee@mysc.co.kr');
+    expect(row).toBeTruthy();
+    expect(row).toMatchObject({
+      authUid: 'u-jslee',
+      effectiveRole: 'pm',
+      driftFlags: expect.arrayContaining(['duplicate_member_docs', 'legacy_role_mismatch', 'bootstrap_admin_not_adopted']),
+    });
+    expect(response.body.summary.duplicateMemberDocs).toBeGreaterThanOrEqual(1);
+  });
+
+  it('deep syncs canonical member, legacy member, and custom claims together', async () => {
+    await db.doc(`orgs/${tenantId}/members/jhsong_mysc_co_kr`).set({
+      uid: 'jhsong_mysc_co_kr',
+      tenantId,
+      role: 'pm',
+      email: 'jhsong@mysc.co.kr',
+      name: 'Legacy Song',
+      status: 'ACTIVE',
+      projectIds: ['p-sync-1'],
+    });
+
+    const setCustomUserClaims = vi.fn(async () => {});
+    const governanceApi = request(createBffApp({
+      projectId,
+      workerSecret,
+      db,
+      authAdminService: {
+        listUsers: async () => ({
+          users: [{
+            uid: 'u-jhsong',
+            email: 'jhsong@mysc.co.kr',
+            displayName: 'JH Song',
+            disabled: false,
+            customClaims: { role: 'pm', tenantId },
+          }],
+        }),
+        setCustomUserClaims,
+      },
+    }));
+
+    const response = await governanceApi
+      .post('/api/v1/admin/auth-governance/users/jhsong%40mysc.co.kr/deep-sync')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-auth-governance-sync-001' })
+      .send({ role: 'admin', reason: 'cashflow export alignment' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.role).toBe('admin');
+    expect(response.body.mirroredLegacyCount).toBe(1);
+
+    const canonicalSnap = await db.doc(`orgs/${tenantId}/members/u-jhsong`).get();
+    expect(canonicalSnap.data()).toMatchObject({
+      uid: 'u-jhsong',
+      email: 'jhsong@mysc.co.kr',
+      role: 'admin',
+      projectIds: ['p-sync-1'],
+    });
+
+    const legacySnap = await db.doc(`orgs/${tenantId}/members/jhsong_mysc_co_kr`).get();
+    expect(legacySnap.data()).toMatchObject({
+      role: 'admin',
+      canonicalUid: 'u-jhsong',
+    });
+
+    expect(setCustomUserClaims).toHaveBeenCalledWith('u-jhsong', { role: 'admin', tenantId });
+  });
+
   it('blocks demoting the last remaining admin (lockout protection)', async () => {
     await db.doc(`orgs/${tenantId}/members/u-admin-1`).set({
       uid: 'u-admin-1',

--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -2,6 +2,7 @@ import express from 'express';
 import { randomUUID } from 'node:crypto';
 import { createFirestoreDb, isFirestoreEmulatorEnabled, resolveProjectId } from './firestore.mjs';
 import {
+  createFirebaseAuthAdminService,
   createFirebaseTokenVerifier,
   resolveAuthMode,
   resolveRequestIdentity,
@@ -629,6 +630,7 @@ export function createBffApp(options = {}) {
   const db = options.db || createFirestoreDb({ projectId });
   const authMode = options.authMode || resolveAuthMode();
   const verifyToken = options.tokenVerifier || createFirebaseTokenVerifier({ projectId });
+  const authAdminService = options.authAdminService || createFirebaseAuthAdminService({ projectId });
   const idempotencyService = createIdempotencyService(db);
   const auditChainService = createAuditChainService(db, { now });
   const piiProtector = options.piiProtector || createPiiProtector();
@@ -1351,7 +1353,15 @@ export function createBffApp(options = {}) {
   mountLedgerRoutes(app, { db, now, idempotencyService, auditChainService, piiProtector });
   mountTransactionRoutes(app, { db, now, idempotencyService, auditChainService, piiProtector, rbacPolicy, driveService });
   mountAuditRoutes(app, { db, auditChainService });
-  mountMemberRoutes(app, { db, now, idempotencyService, auditChainService, piiProtector, rbacPolicy });
+  mountMemberRoutes(app, {
+    db,
+    now,
+    idempotencyService,
+    auditChainService,
+    piiProtector,
+    rbacPolicy,
+    authAdminService,
+  });
 
   // ── Guide Q&A chatbot ──
   mountGuideChatRoutes(app, {

--- a/server/bff/auth-governance.mjs
+++ b/server/bff/auth-governance.mjs
@@ -1,0 +1,255 @@
+import { createHttpError, normalizeRole, readOptionalText } from './bff-utils.mjs';
+
+export const DEFAULT_BOOTSTRAP_ADMIN_EMAILS = [
+  'admin@mysc.co.kr',
+  'ai@mysc.co.kr',
+  'ylee@mysc.co.kr',
+  'jyoo@mysc.co.kr',
+  'jslee@mysc.co.kr',
+  'jhsong@mysc.co.kr',
+  'jybaek@mysc.co.kr',
+  'fin@mysc.co.kr',
+  'hwkim@mysc.co.kr',
+  'mwbyun1220@mysc.co.kr',
+];
+
+function normalizeEmail(value) {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function normalizeStatus(value) {
+  const normalized = readOptionalText(value).toUpperCase();
+  if (normalized === 'ACTIVE' || normalized === 'INACTIVE' || normalized === 'PENDING') return normalized;
+  return undefined;
+}
+
+function buildLegacyMemberDocId(email) {
+  const normalized = normalizeEmail(email);
+  if (!normalized) return '';
+  return normalized.replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+}
+
+function toMergeKey({ email, uid }) {
+  const normalizedEmail = normalizeEmail(email);
+  if (normalizedEmail) return normalizedEmail;
+  const normalizedUid = readOptionalText(uid);
+  return normalizedUid ? `uid:${normalizedUid}` : '';
+}
+
+function classifyMemberDoc(doc) {
+  const data = doc?.data || {};
+  const email = normalizeEmail(data.email);
+  const docId = readOptionalText(doc.docId);
+  const expectedLegacyId = buildLegacyMemberDocId(email);
+  const uid = readOptionalText(data.uid || docId);
+  return {
+    docId,
+    uid,
+    email,
+    role: normalizeRole(data.role || ''),
+    status: normalizeStatus(data.status) || null,
+    name: readOptionalText(data.name),
+    data,
+    isLegacy: !!expectedLegacyId && docId === expectedLegacyId,
+  };
+}
+
+function pickCanonicalMember(memberDocs, authUid) {
+  if (!Array.isArray(memberDocs) || memberDocs.length === 0) return null;
+  const normalizedAuthUid = readOptionalText(authUid);
+  if (normalizedAuthUid) {
+    const exact = memberDocs.find((doc) => doc.docId === normalizedAuthUid || doc.uid === normalizedAuthUid);
+    if (exact) return exact;
+  }
+  return memberDocs.find((doc) => !doc.isLegacy) || null;
+}
+
+function pickBaseMemberData(entry) {
+  return {
+    ...(entry.legacyMembers[0]?.data || {}),
+    ...(entry.canonicalMember?.data || {}),
+  };
+}
+
+function computeEffectiveRole(entry) {
+  return (
+    normalizeRole(entry.canonicalMember?.role || '')
+    || normalizeRole(entry.legacyMembers[0]?.role || '')
+    || normalizeRole(entry.claimRole || '')
+    || (entry.bootstrapAdmin ? 'admin' : '')
+    || 'pm'
+  );
+}
+
+function computeDriftFlags(entry) {
+  const flags = [];
+  if (!entry.authUid) flags.push('missing_auth');
+  if (!entry.canonicalMember) flags.push('missing_canonical_member');
+  if (!entry.canonicalMember && entry.legacyMembers.length > 0) flags.push('legacy_only');
+  if (entry.allMemberDocs.length > 1) flags.push('duplicate_member_docs');
+
+  const canonicalRole = normalizeRole(entry.canonicalMember?.role || '');
+  const legacyRole = normalizeRole(entry.legacyMembers[0]?.role || '');
+  if (canonicalRole && legacyRole && canonicalRole !== legacyRole) flags.push('legacy_role_mismatch');
+
+  if (entry.claimRole && entry.effectiveRole && normalizeRole(entry.claimRole) !== normalizeRole(entry.effectiveRole)) {
+    flags.push('claim_mismatch');
+  }
+
+  if (entry.bootstrapAdmin && entry.effectiveRole !== 'admin') {
+    flags.push('bootstrap_admin_not_adopted');
+  }
+
+  return flags;
+}
+
+export function parseBootstrapAdminEmails(env = process.env) {
+  const csv = typeof env.BOOTSTRAP_ADMIN_EMAILS === 'string'
+    ? env.BOOTSTRAP_ADMIN_EMAILS
+    : (typeof env.VITE_BOOTSTRAP_ADMIN_EMAILS === 'string' ? env.VITE_BOOTSTRAP_ADMIN_EMAILS : '');
+  const single = typeof env.BOOTSTRAP_ADMIN_EMAIL === 'string'
+    ? env.BOOTSTRAP_ADMIN_EMAIL
+    : (typeof env.VITE_BOOTSTRAP_ADMIN_EMAIL === 'string' ? env.VITE_BOOTSTRAP_ADMIN_EMAIL : '');
+
+  return Array.from(new Set([
+    ...DEFAULT_BOOTSTRAP_ADMIN_EMAILS,
+    ...String(csv || '').split(','),
+    single,
+  ].map(normalizeEmail).filter(Boolean)));
+}
+
+export function mergeAuthGovernanceDirectory({ authUsers = [], memberDocs = [], bootstrapAdminEmails = [] }) {
+  const bootstrapSet = new Set((bootstrapAdminEmails || []).map(normalizeEmail).filter(Boolean));
+  const buckets = new Map();
+
+  for (const authUser of authUsers) {
+    const entry = {
+      uid: readOptionalText(authUser.uid),
+      email: normalizeEmail(authUser.email),
+      displayName: readOptionalText(authUser.displayName),
+      disabled: Boolean(authUser.disabled),
+      customClaims: authUser.customClaims || {},
+    };
+    const key = toMergeKey({ email: entry.email, uid: entry.uid });
+    if (!key) continue;
+    const current = buckets.get(key) || { authUser: null, memberDocs: [] };
+    current.authUser = entry;
+    buckets.set(key, current);
+  }
+
+  for (const rawDoc of memberDocs) {
+    const doc = classifyMemberDoc(rawDoc);
+    const key = toMergeKey({ email: doc.email, uid: doc.uid });
+    if (!key) continue;
+    const current = buckets.get(key) || { authUser: null, memberDocs: [] };
+    current.memberDocs.push(doc);
+    buckets.set(key, current);
+  }
+
+  for (const email of bootstrapSet) {
+    const key = toMergeKey({ email });
+    if (!buckets.has(key)) {
+      buckets.set(key, { authUser: null, memberDocs: [] });
+    }
+  }
+
+  const entries = Array.from(buckets.entries()).map(([identityKey, bucket]) => {
+    const authUser = bucket.authUser;
+    const canonicalMember = pickCanonicalMember(bucket.memberDocs, authUser?.uid);
+    const legacyMembers = bucket.memberDocs.filter((doc) => canonicalMember?.docId !== doc.docId && doc.isLegacy);
+    const email = normalizeEmail(authUser?.email || canonicalMember?.email || legacyMembers[0]?.email || identityKey.replace(/^uid:/, ''));
+    const entry = {
+      identityKey,
+      email,
+      authUid: authUser?.uid || null,
+      displayName: readOptionalText(authUser?.displayName || canonicalMember?.name || legacyMembers[0]?.name) || email,
+      authDisabled: Boolean(authUser?.disabled),
+      bootstrapAdmin: bootstrapSet.has(email),
+      claimRole: normalizeRole(authUser?.customClaims?.role || '') || null,
+      claimTenantId: readOptionalText(authUser?.customClaims?.tenantId) || null,
+      canonicalMember,
+      legacyMembers,
+      allMemberDocs: bucket.memberDocs,
+      effectiveRole: 'pm',
+    };
+    entry.effectiveRole = computeEffectiveRole(entry);
+    entry.driftFlags = computeDriftFlags(entry);
+    entry.needsDeepSync = entry.driftFlags.length > 0;
+    return entry;
+  });
+
+  return entries.sort((a, b) => a.email.localeCompare(b.email, 'en'));
+}
+
+export function buildDeepSyncPlan({
+  entry,
+  targetRole,
+  tenantId,
+  actorId,
+  timestamp,
+  reason,
+}) {
+  const normalizedRole = normalizeRole(targetRole);
+  if (!normalizedRole) {
+    throw createHttpError(400, 'target role is required', 'invalid_role');
+  }
+
+  const email = normalizeEmail(entry?.email);
+  if (!email) {
+    throw createHttpError(400, 'email is required for deep sync', 'invalid_identity');
+  }
+
+  const base = pickBaseMemberData(entry);
+  const canonicalDocId = readOptionalText(entry?.authUid || entry?.canonicalMember?.docId || base.uid || buildLegacyMemberDocId(email));
+  const canonicalUid = readOptionalText(entry?.authUid || entry?.canonicalMember?.uid || canonicalDocId);
+  const displayName = readOptionalText(entry?.displayName || base.name || email);
+  const status = normalizeStatus(base.status) || 'ACTIVE';
+  const normalizedReason = readOptionalText(reason) || 'admin auth governance deep sync';
+
+  const canonicalPatch = {
+    ...base,
+    uid: canonicalUid,
+    name: displayName,
+    email,
+    role: normalizedRole,
+    tenantId,
+    status,
+    updatedAt: timestamp,
+    updatedBy: actorId,
+    roleChangedAt: timestamp,
+    roleChangedBy: actorId,
+    roleChangeReason: normalizedReason,
+  };
+
+  const legacyPatches = (entry?.legacyMembers || [])
+    .filter((member) => member.docId !== canonicalDocId)
+    .map((member) => ({
+      docId: member.docId,
+      patch: {
+        ...member.data,
+        uid: member.uid || member.docId,
+        canonicalUid,
+        name: displayName,
+        email,
+        role: normalizedRole,
+        tenantId,
+        status: normalizeStatus(member.status) || status,
+        updatedAt: timestamp,
+        updatedBy: actorId,
+        roleChangedAt: timestamp,
+        roleChangedBy: actorId,
+        roleChangeReason: normalizedReason,
+      },
+    }));
+
+  return {
+    identityKey: entry.identityKey,
+    email,
+    canonicalDocId,
+    canonicalPatch,
+    legacyPatches,
+    claims: canonicalUid && entry?.authUid
+      ? { role: normalizedRole, tenantId }
+      : null,
+  };
+}

--- a/server/bff/auth-governance.test.mjs
+++ b/server/bff/auth-governance.test.mjs
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildDeepSyncPlan,
+  mergeAuthGovernanceDirectory,
+  parseBootstrapAdminEmails,
+} from './auth-governance.mjs';
+
+describe('auth governance helpers', () => {
+  it('merges auth users with canonical and legacy member docs and surfaces drift flags', () => {
+    const entries = mergeAuthGovernanceDirectory({
+      authUsers: [
+        {
+          uid: 'uid-jslee',
+          email: 'jslee@mysc.co.kr',
+          displayName: 'JS Lee',
+          disabled: false,
+          customClaims: { role: 'pm', tenantId: 'mysc' },
+        },
+      ],
+      memberDocs: [
+        {
+          docId: 'uid-jslee',
+          data: {
+            uid: 'uid-jslee',
+            email: 'jslee@mysc.co.kr',
+            name: '이재성',
+            role: 'pm',
+            status: 'ACTIVE',
+          },
+        },
+        {
+          docId: 'jslee_mysc_co_kr',
+          data: {
+            uid: 'jslee_mysc_co_kr',
+            email: 'jslee@mysc.co.kr',
+            name: 'JS Legacy',
+            role: 'admin',
+          },
+        },
+      ],
+      bootstrapAdminEmails: ['jslee@mysc.co.kr'],
+    });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      email: 'jslee@mysc.co.kr',
+      authUid: 'uid-jslee',
+      bootstrapAdmin: true,
+      effectiveRole: 'pm',
+      driftFlags: expect.arrayContaining(['duplicate_member_docs', 'legacy_role_mismatch', 'bootstrap_admin_not_adopted']),
+    });
+    expect(entries[0].canonicalMember?.docId).toBe('uid-jslee');
+    expect(entries[0].legacyMembers).toHaveLength(1);
+    expect(entries[0].claimRole).toBe('pm');
+  });
+
+  it('includes bootstrap-only candidates even when auth and member docs are missing', () => {
+    const entries = mergeAuthGovernanceDirectory({
+      authUsers: [],
+      memberDocs: [],
+      bootstrapAdminEmails: ['fin@mysc.co.kr'],
+    });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      email: 'fin@mysc.co.kr',
+      authUid: null,
+      effectiveRole: 'admin',
+      driftFlags: expect.arrayContaining(['missing_auth', 'missing_canonical_member']),
+    });
+  });
+
+  it('builds a deep sync plan that writes canonical and legacy docs together', () => {
+    const [entry] = mergeAuthGovernanceDirectory({
+      authUsers: [
+        {
+          uid: 'uid-jhsong',
+          email: 'jhsong@mysc.co.kr',
+          displayName: 'JH Song',
+          disabled: false,
+          customClaims: { role: 'pm', tenantId: 'mysc' },
+        },
+      ],
+      memberDocs: [
+        {
+          docId: 'jhsong_mysc_co_kr',
+          data: {
+            uid: 'jhsong_mysc_co_kr',
+            email: 'jhsong@mysc.co.kr',
+            name: '송지현',
+            role: 'pm',
+            status: 'ACTIVE',
+            projectIds: ['p1', 'p2'],
+          },
+        },
+      ],
+      bootstrapAdminEmails: ['jhsong@mysc.co.kr'],
+    });
+
+    const plan = buildDeepSyncPlan({
+      entry,
+      targetRole: 'admin',
+      tenantId: 'mysc',
+      actorId: 'u-admin',
+      timestamp: '2026-04-13T06:00:00.000Z',
+      reason: 'cashflow export alignment',
+    });
+
+    expect(plan.identityKey).toBe('jhsong@mysc.co.kr');
+    expect(plan.canonicalDocId).toBe('uid-jhsong');
+    expect(plan.claims).toEqual({ role: 'admin', tenantId: 'mysc' });
+    expect(plan.canonicalPatch).toMatchObject({
+      uid: 'uid-jhsong',
+      email: 'jhsong@mysc.co.kr',
+      role: 'admin',
+      projectIds: ['p1', 'p2'],
+      roleChangeReason: 'cashflow export alignment',
+    });
+    expect(plan.legacyPatches).toHaveLength(1);
+    expect(plan.legacyPatches[0]).toMatchObject({
+      docId: 'jhsong_mysc_co_kr',
+      patch: expect.objectContaining({
+        canonicalUid: 'uid-jhsong',
+        role: 'admin',
+      }),
+    });
+  });
+
+  it('parses server bootstrap admin env values on top of defaults', () => {
+    const emails = parseBootstrapAdminEmails({
+      BOOTSTRAP_ADMIN_EMAILS: 'extra@mysc.co.kr',
+      BOOTSTRAP_ADMIN_EMAIL: 'one@mysc.co.kr',
+    });
+
+    expect(emails).toEqual(expect.arrayContaining([
+      'admin@mysc.co.kr',
+      'jslee@mysc.co.kr',
+      'extra@mysc.co.kr',
+      'one@mysc.co.kr',
+    ]));
+  });
+});

--- a/server/bff/auth.mjs
+++ b/server/bff/auth.mjs
@@ -97,6 +97,24 @@ export function createFirebaseTokenVerifier(options = {}) {
   return async (token) => auth.verifyIdToken(token, true);
 }
 
+export function createFirebaseAuthAdminService(options = {}) {
+  const app = getOrInitAdminApp({ projectId: options.projectId });
+  const auth = getAuth(app);
+
+  return {
+    async listUsers(maxResults = 1000, pageToken) {
+      return auth.listUsers(maxResults, pageToken);
+    },
+    async getUserByEmail(email) {
+      return auth.getUserByEmail(email);
+    },
+    async setCustomUserClaims(uid, claims) {
+      await auth.setCustomUserClaims(uid, claims);
+      return claims;
+    },
+  };
+}
+
 function resolveIdentityFromHeaders({ readHeaderValue }) {
   const tenantId = assertTenantId(readHeader(readHeaderValue, 'x-tenant-id'));
   const actorId = normalizeActorId(readHeader(readHeaderValue, 'x-actor-id'));

--- a/server/bff/routes/members.mjs
+++ b/server/bff/routes/members.mjs
@@ -5,11 +5,76 @@ import {
   asyncHandler, createMutatingRoute, assertActorRoleAllowed,
   ROUTE_ROLES, createHttpError, normalizeRole, encryptAuditEmail,
 } from '../bff-utils.mjs';
-import { parseWithSchema, memberRoleUpdateSchema } from '../schemas.mjs';
+import { parseWithSchema, memberDeepSyncSchema, memberRoleUpdateSchema } from '../schemas.mjs';
+import {
+  buildDeepSyncPlan,
+  mergeAuthGovernanceDirectory,
+  parseBootstrapAdminEmails,
+} from '../auth-governance.mjs';
+
+async function listAllAuthUsers(authAdminService) {
+  if (!authAdminService || typeof authAdminService.listUsers !== 'function') {
+    throw createHttpError(503, 'Firebase auth admin service is not configured', 'auth_admin_unavailable');
+  }
+
+  const users = [];
+  let pageToken;
+  do {
+    const page = await authAdminService.listUsers(1000, pageToken);
+    for (const user of page.users || []) {
+      users.push({
+        uid: user.uid,
+        email: user.email || '',
+        displayName: user.displayName || '',
+        disabled: Boolean(user.disabled),
+        customClaims: user.customClaims || {},
+      });
+    }
+    pageToken = page.pageToken;
+  } while (pageToken);
+  return users;
+}
+
+async function listMemberDocs(db, tenantId) {
+  const snap = await db.collection(`orgs/${tenantId}/members`).get();
+  return snap.docs.map((doc) => ({
+    docId: doc.id,
+    data: doc.data() || {},
+  }));
+}
+
+function buildGovernanceSummary(entries) {
+  return {
+    total: entries.length,
+    needsDeepSync: entries.filter((entry) => entry.needsDeepSync).length,
+    missingAuth: entries.filter((entry) => entry.driftFlags.includes('missing_auth')).length,
+    missingCanonicalMember: entries.filter((entry) => entry.driftFlags.includes('missing_canonical_member')).length,
+    duplicateMemberDocs: entries.filter((entry) => entry.driftFlags.includes('duplicate_member_docs')).length,
+    bootstrapCandidates: entries.filter((entry) => entry.bootstrapAdmin).length,
+  };
+}
 
 export function mountMemberRoutes(app, {
-  db, now, idempotencyService, auditChainService, piiProtector, rbacPolicy,
+  db, now, idempotencyService, auditChainService, piiProtector, rbacPolicy, authAdminService,
 }) {
+  app.get('/api/v1/admin/auth-governance/users', asyncHandler(async (req, res) => {
+    assertActorRoleAllowed(req, ROUTE_ROLES.memberWrite, 'read auth governance users');
+    const { tenantId } = req.context;
+    const [authUsers, memberDocs] = await Promise.all([
+      listAllAuthUsers(authAdminService),
+      listMemberDocs(db, tenantId),
+    ]);
+    const items = mergeAuthGovernanceDirectory({
+      authUsers,
+      memberDocs,
+      bootstrapAdminEmails: parseBootstrapAdminEmails(process.env),
+    });
+    res.status(200).json({
+      items,
+      summary: buildGovernanceSummary(items),
+    });
+  }));
+
   app.patch('/api/v1/members/:memberId/role', createMutatingRoute(idempotencyService, async (req) => {
     assertActorRoleAllowed(req, ROUTE_ROLES.memberWrite, 'update member roles');
     const { tenantId, actorId, actorRole, actorEmail, requestId } = req.context;
@@ -96,6 +161,114 @@ export function mountMemberRoutes(app, {
         id: memberId,
         previousRole: result.previousRole,
         role: targetRole,
+        updatedAt: timestamp,
+      },
+    };
+  }));
+
+  app.post('/api/v1/admin/auth-governance/users/:identityKey/deep-sync', createMutatingRoute(idempotencyService, async (req) => {
+    assertActorRoleAllowed(req, ROUTE_ROLES.memberWrite, 'deep sync auth governance user');
+    const { tenantId, actorId, actorRole, actorEmail, requestId } = req.context;
+    const timestamp = now();
+    const parsed = parseWithSchema(memberDeepSyncSchema, req.body, 'Invalid auth governance sync payload');
+    const targetRole = normalizeRole(parsed.role);
+
+    if (!canActorAssignRole(rbacPolicy, { actorRole, targetRole })) {
+      throw createHttpError(403, `Role '${actorRole || 'unknown'}' cannot assign '${targetRole}'`, 'forbidden');
+    }
+
+    const identityKey = decodeURIComponent(req.params.identityKey || '').trim().toLowerCase();
+    const [authUsers, memberDocs] = await Promise.all([
+      listAllAuthUsers(authAdminService),
+      listMemberDocs(db, tenantId),
+    ]);
+    const directory = mergeAuthGovernanceDirectory({
+      authUsers,
+      memberDocs,
+      bootstrapAdminEmails: parseBootstrapAdminEmails(process.env),
+    });
+    const entry = directory.find((item) => item.identityKey === identityKey);
+    if (!entry) {
+      throw createHttpError(404, `Auth governance user not found: ${identityKey}`, 'not_found');
+    }
+
+    if (entry.effectiveRole === 'admin' && targetRole !== 'admin') {
+      const adminsSnap = await db.collection(`orgs/${tenantId}/members`).where('role', '==', 'admin').limit(2).get();
+      if (adminsSnap.size <= 1) {
+        throw createHttpError(409, 'Cannot remove the last remaining admin', 'last_admin_lockout');
+      }
+    }
+
+    const plan = buildDeepSyncPlan({
+      entry,
+      targetRole,
+      tenantId,
+      actorId,
+      timestamp,
+      reason: parsed.reason?.trim() || null,
+    });
+
+    const outboxEvent = createOutboxEvent({
+      tenantId,
+      requestId,
+      eventType: 'member.role_changed',
+      entityType: 'member',
+      entityId: plan.canonicalDocId,
+      payload: {
+        actorRole: actorRole || null,
+        targetRole,
+        reason: parsed.reason?.trim() || null,
+        source: 'auth_governance_deep_sync',
+      },
+      createdAt: timestamp,
+    });
+
+    await db.runTransaction(async (tx) => {
+      tx.set(db.doc(`orgs/${tenantId}/members/${plan.canonicalDocId}`), plan.canonicalPatch, { merge: true });
+      for (const legacy of plan.legacyPatches) {
+        tx.set(db.doc(`orgs/${tenantId}/members/${legacy.docId}`), legacy.patch, { merge: true });
+      }
+      enqueueOutboxEventInTransaction(tx, db, outboxEvent);
+    });
+
+    if (plan.claims && entry.authUid) {
+      await authAdminService.setCustomUserClaims(entry.authUid, plan.claims);
+    }
+
+    const actorEmailEnc = await encryptAuditEmail(piiProtector, actorEmail);
+    await auditChainService.append({
+      tenantId,
+      entityType: 'member',
+      entityId: plan.canonicalDocId,
+      action: 'ROLE_CHANGE',
+      actorId,
+      actorRole,
+      actorEmailEnc,
+      requestId,
+      details: `구성원 deep sync: ${entry.effectiveRole} -> ${targetRole}`,
+      metadata: {
+        source: 'auth_governance_deep_sync',
+        previousRole: entry.effectiveRole,
+        nextRole: targetRole,
+        identityKey,
+        canonicalDocId: plan.canonicalDocId,
+        mirroredLegacyCount: plan.legacyPatches.length,
+        claimsUpdated: Boolean(plan.claims && entry.authUid),
+        reason: parsed.reason?.trim() || null,
+        outboxId: outboxEvent.id,
+      },
+      timestamp,
+    });
+
+    return {
+      status: 200,
+      body: {
+        identityKey,
+        email: plan.email,
+        canonicalDocId: plan.canonicalDocId,
+        role: targetRole,
+        mirroredLegacyCount: plan.legacyPatches.length,
+        claimsUpdated: Boolean(plan.claims && entry.authUid),
         updatedAt: timestamp,
       },
     };

--- a/server/bff/schemas.mjs
+++ b/server/bff/schemas.mjs
@@ -170,6 +170,8 @@ export const memberRoleUpdateSchema = z.object({
   reason: z.string().trim().min(1).max(500).optional(),
 }).strict();
 
+export const memberDeepSyncSchema = memberRoleUpdateSchema;
+
 export const cashflowExportSchema = z.object({
   scope: z.enum(['all', 'single']),
   projectId: z.string().trim().optional(),

--- a/src/app/components/users/UserManagementPage.tsx
+++ b/src/app/components/users/UserManagementPage.tsx
@@ -1,857 +1,595 @@
-import { useState, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
-  Users, UserPlus, Search, Shield, Edit3,
-  MoreHorizontal, Mail, Clock, CheckCircle2,
-  XCircle, Trash2,
-  ArrowUpDown, Filter,
-  Ban, RefreshCw,
+  AlertTriangle,
+  CheckCircle2,
+  Database,
+  GitMerge,
+  KeyRound,
+  RefreshCw,
+  Search,
+  Shield,
+  UserCog,
+  Users,
 } from 'lucide-react';
-import { ROLE_META } from '../../platform/role-meta';
-import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
+import { toast } from 'sonner';
+import { featureFlags } from '../../config/feature-flags';
+import { useAuth } from '../../data/auth-store';
+import type { UserRole } from '../../data/types';
+import { useFirebase } from '../../lib/firebase-context';
+import {
+  deepSyncAuthGovernanceUserViaBff,
+  fetchAuthGovernanceUsersViaBff,
+  type AuthGovernanceUserRow,
+  type AuthGovernanceSummary,
+} from '../../lib/platform-bff-client';
+import { PageHeader } from '../layout/PageHeader';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Input } from '../ui/input';
-import { Label } from '../ui/label';
-import { Separator } from '../ui/separator';
-import { Switch } from '../ui/switch';
-import {
-  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter,
-} from '../ui/dialog';
-import {
-  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
-} from '../ui/select';
-import {
-  DropdownMenu, DropdownMenuContent, DropdownMenuItem,
-  DropdownMenuSeparator, DropdownMenuTrigger,
-} from '../ui/dropdown-menu';
-import {
-  Tooltip, TooltipContent, TooltipProvider, TooltipTrigger,
-} from '../ui/tooltip';
-import { PageHeader } from '../layout/PageHeader';
 import { ScrollArea } from '../ui/scroll-area';
-import { toast } from 'sonner';
-import type { OrgMember, UserRole } from '../../data/types';
-import { useAppStore } from '../../data/store';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../ui/select';
+import { Separator } from '../ui/separator';
+import {
+  emptyGovernanceSummary,
+  filterGovernanceRows,
+  getRecommendedGovernanceRole,
+  type AuthGovernanceFilters,
+} from './auth-governance-view-model';
 
-// ═══════════════════════════════════════════════════════════════
-// 사용자 관리 페이지 — Admin
-// 사용자 계정 CRUD, 역할 배정, 프로젝트 배정, 활성화/비활성화
-// ═══════════════════════════════════════════════════════════════
+const ROLE_OPTIONS: Array<{ value: UserRole; label: string }> = [
+  { value: 'admin', label: '관리자' },
+  { value: 'finance', label: '재무팀' },
+  { value: 'pm', label: 'PM' },
+];
 
-interface ManagedUser {
-  uid: string;
-  name: string;
-  email: string;
-  role: UserRole;
-  status: 'ACTIVE' | 'INACTIVE' | 'PENDING';
-  department?: string;
-  phone?: string;
-  assignedProjects: string[];
-  createdAt: string;
-  lastLoginAt: string;
-  avatarUrl?: string;
-  note?: string;
-}
-
-type MemberDoc = OrgMember & Record<string, unknown>;
-
-
-const STATUS_LABELS: Record<string, string> = {
-  ACTIVE: '활성',
-  INACTIVE: '비활성',
-  PENDING: '승인대기',
+const DRIFT_LABELS: Record<string, string> = {
+  missing_auth: 'Auth 없음',
+  missing_canonical_member: 'Canonical 멤버 없음',
+  legacy_only: 'Legacy만 존재',
+  duplicate_member_docs: '중복 멤버 문서',
+  legacy_role_mismatch: 'Legacy role 불일치',
+  claim_mismatch: 'Claim 불일치',
+  bootstrap_admin_not_adopted: 'Bootstrap admin 미반영',
 };
 
-const STATUS_COLORS: Record<string, string> = {
-  ACTIVE: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/50 dark:text-emerald-400',
-  INACTIVE: 'bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-500',
-  PENDING: 'bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-400',
+const ROLE_BADGE_CLASS: Record<string, string> = {
+  admin: 'bg-stone-900 text-white',
+  finance: 'bg-stone-700 text-white',
+  pm: 'bg-stone-200 text-stone-900',
 };
 
-function normalizeStatus(value: unknown): ManagedUser['status'] {
-  if (value === 'PENDING' || value === 'INACTIVE' || value === 'ACTIVE') return value;
-  return 'ACTIVE';
+function roleLabel(role: string | null | undefined): string {
+  const normalized = (role || '').trim().toLowerCase();
+  return ROLE_OPTIONS.find((item) => item.value === normalized)?.label || (normalized || '미지정');
 }
 
-function toManagedUser(member: MemberDoc, index: number): ManagedUser {
-  const assignedProjects = Array.from(
-    new Set([
-      ...(Array.isArray(member.projectIds) ? member.projectIds : []),
-      typeof member.projectId === 'string' ? member.projectId : '',
-    ].filter((v): v is string => !!v)),
-  );
-
-  return {
-    uid: member.uid,
-    name: member.name,
-    email: member.email,
-    role: member.role === 'viewer' ? 'pm' : member.role,
-    status: normalizeStatus(member.status),
-    department: typeof member.department === 'string' ? member.department : undefined,
-    phone: typeof member.phone === 'string' ? member.phone : undefined,
-    assignedProjects,
-    createdAt: typeof member.createdAt === 'string' ? member.createdAt : `2024-01-${String((index % 28) + 1).padStart(2, '0')}T09:00:00Z`,
-    lastLoginAt: typeof member.lastLoginAt === 'string' ? member.lastLoginAt : '-',
-    avatarUrl: member.avatarUrl,
-    note: typeof member.note === 'string' ? member.note : undefined,
-  };
+function statusLabel(status: string | null | undefined): string {
+  if (status === 'ACTIVE') return '활성';
+  if (status === 'INACTIVE') return '비활성';
+  if (status === 'PENDING') return '대기';
+  return '미지정';
 }
 
-function toMemberDoc(user: ManagedUser): MemberDoc {
-  return {
-    uid: user.uid,
-    name: user.name,
-    email: user.email,
-    role: user.role,
-    avatarUrl: user.avatarUrl,
-    status: user.status,
-    department: user.department || '',
-    phone: user.phone || '',
-    projectIds: user.assignedProjects,
-    projectId: user.assignedProjects[0] || '',
-    createdAt: user.createdAt,
-    lastLoginAt: user.lastLoginAt === '-' ? '' : user.lastLoginAt,
-    note: user.note || '',
-  };
+function formatTimestamp(value: string | null | undefined): string {
+  if (!value) return '-';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return `${date.getFullYear()}.${String(date.getMonth() + 1).padStart(2, '0')}.${String(date.getDate()).padStart(2, '0')} ${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
 }
 
-export function UserManagementPage() {
-  const { members: storeMembers, projects, upsertMember, removeMember } = useAppStore();
-  const [searchText, setSearchText] = useState('');
-  const [filterRole, setFilterRole] = useState<string>('ALL');
-  const [filterStatus, setFilterStatus] = useState<string>('ALL');
-  const [selectedUser, setSelectedUser] = useState<ManagedUser | null>(null);
-  const [showCreateDialog, setShowCreateDialog] = useState(false);
-  const [showEditDialog, setShowEditDialog] = useState(false);
-  const [editingUser, setEditingUser] = useState<ManagedUser | null>(null);
-  const [sortField, setSortField] = useState<'name' | 'role' | 'lastLoginAt'>('name');
-  const [sortAsc, setSortAsc] = useState(true);
-
-  const users = useMemo(
-    () => (storeMembers as MemberDoc[]).map((m, i) => toManagedUser(m, i)),
-    [storeMembers],
-  );
-
-  // 새 사용자 폼
-  const [newForm, setNewForm] = useState({
-    name: '',
-    email: '',
-    role: 'pm' as UserRole,
-    department: '',
-    phone: '',
-    note: '',
-  });
-
-  // 필터링
-  const filteredUsers = useMemo(() => {
-    let list = users.filter(u => {
-      if (filterRole !== 'ALL' && u.role !== filterRole) return false;
-      if (filterStatus !== 'ALL' && u.status !== filterStatus) return false;
-      if (searchText) {
-        const q = searchText.toLowerCase();
-        return u.name.toLowerCase().includes(q) ||
-               u.email.toLowerCase().includes(q) ||
-               (u.department || '').toLowerCase().includes(q);
-      }
-      return true;
-    });
-    list.sort((a, b) => {
-      let cmp = 0;
-      if (sortField === 'name') cmp = a.name.localeCompare(b.name, 'ko');
-      else if (sortField === 'role') cmp = a.role.localeCompare(b.role);
-      else cmp = new Date(b.lastLoginAt).getTime() - new Date(a.lastLoginAt).getTime();
-      return sortAsc ? cmp : -cmp;
-    });
-    return list;
-  }, [users, filterRole, filterStatus, searchText, sortField, sortAsc]);
-
-  // KPI
-  const kpi = useMemo(() => ({
-    total: users.length,
-    active: users.filter(u => u.status === 'ACTIVE').length,
-    pending: users.filter(u => u.status === 'PENDING').length,
-    admins: users.filter(u => u.role === 'admin').length,
-    pms: users.filter(u => u.role === 'pm').length,
-    finance: users.filter(u => u.role === 'finance').length,
-  }), [users]);
-
-  const projectMap = useMemo(() => {
-    const m = new Map<string, string>();
-    projects.forEach(p => m.set(p.id, p.name));
-    return m;
-  }, [projects]);
-
-  // 사용자 생성
-  const handleCreate = () => {
-    if (!newForm.name || !newForm.email) return;
-    const newUser: ManagedUser = {
-      uid: `u-${Date.now().toString(36)}`,
-      name: newForm.name,
-      email: newForm.email,
-      role: newForm.role,
-      status: 'ACTIVE',
-      department: newForm.department,
-      phone: newForm.phone,
-      assignedProjects: [],
-      createdAt: new Date().toISOString(),
-      lastLoginAt: '-',
-      note: newForm.note,
-    };
-    upsertMember(toMemberDoc(newUser));
-    setShowCreateDialog(false);
-    setNewForm({ name: '', email: '', role: 'pm', department: '', phone: '', note: '' });
-    toast.success(`${newUser.name} 계정이 생성되었습니다`);
-  };
-
-  // 역할 변경
-  const handleRoleChange = (uid: string, newRole: UserRole) => {
-    const target = users.find((u) => u.uid === uid);
-    if (!target) return;
-    upsertMember(toMemberDoc({ ...target, role: newRole }));
-    toast.success('역할이 변경되었습니다');
-  };
-
-  // 상태 변경
-  const handleStatusToggle = (uid: string) => {
-    const target = users.find((u) => u.uid === uid);
-    if (!target) return;
-    const newStatus: ManagedUser['status'] = target.status === 'ACTIVE' ? 'INACTIVE' : 'ACTIVE';
-    upsertMember(toMemberDoc({ ...target, status: newStatus }));
-  };
-
-  // 승인
-  const handleApproveUser = (uid: string) => {
-    const target = users.find((u) => u.uid === uid);
-    if (!target) return;
-    upsertMember(toMemberDoc({ ...target, status: 'ACTIVE' }));
-    toast.success('사용자가 승인되었습니다');
-  };
-
-  // 사용자 수정
-  const handleSaveEdit = () => {
-    if (!editingUser) return;
-    upsertMember(toMemberDoc(editingUser));
-    setShowEditDialog(false);
-    setEditingUser(null);
-    toast.success('사용자 정보가 수정되었습니다');
-  };
-
-  // 삭제
-  const handleDelete = (uid: string) => {
-    removeMember(uid);
-    if (selectedUser?.uid === uid) setSelectedUser(null);
-    toast.success('사용자가 삭제되었습니다');
-  };
-
-  const formatDate = (iso: string) => {
-    if (iso === '-') return '-';
-    const d = new Date(iso);
-    return `${d.getFullYear()}.${String(d.getMonth() + 1).padStart(2, '0')}.${String(d.getDate()).padStart(2, '0')}`;
-  };
-
-  const formatRelative = (iso: string) => {
-    if (iso === '-') return '미접속';
-    const diff = Date.now() - new Date(iso).getTime();
-    const mins = Math.floor(diff / 60000);
-    if (mins < 60) return `${mins}분 전`;
-    const hours = Math.floor(mins / 60);
-    if (hours < 24) return `${hours}시간 전`;
-    const days = Math.floor(hours / 24);
-    return `${days}일 전`;
-  };
-
-  return (
-    <TooltipProvider delayDuration={200}>
-      <div className="space-y-5">
-        <PageHeader
-          icon={Users}
-          iconGradient="linear-gradient(135deg, #3b82f6 0%, #6366f1 100%)"
-          title="사용자 관리"
-          description="사용자 계정 등록·역할 배정·권한 관리"
-          badge={`${kpi.total}명`}
-          actions={
-            <Button
-              size="sm"
-              className="h-8 text-[12px] gap-1.5"
-              onClick={() => setShowCreateDialog(true)}
-            >
-              <UserPlus className="w-3.5 h-3.5" />
-              새 사용자 등록
-            </Button>
-          }
-        />
-
-        {/* KPI */}
-        <div className="grid grid-cols-2 lg:grid-cols-6 gap-3">
-          {[
-            { label: '전체', value: kpi.total, icon: Users, color: '#6366f1' },
-            { label: '활성', value: kpi.active, icon: CheckCircle2, color: '#059669' },
-            { label: '승인대기', value: kpi.pending, icon: Clock, color: '#d97706' },
-            { label: '관리자', value: kpi.admins, icon: ShieldCheck, color: '#8b5cf6' },
-            { label: 'PM', value: kpi.pms, icon: FolderKanban, color: '#3b82f6' },
-            { label: '재무팀', value: kpi.finance, icon: Activity, color: '#0d9488' },
-          ].map(k => (
-            <Card key={k.label}>
-              <CardContent className="p-3 flex items-center gap-2.5">
-                <div className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0" style={{ background: `${k.color}15` }}>
-                  <k.icon className="w-3.5 h-3.5" style={{ color: k.color }} />
-                </div>
-                <div>
-                  <p className="text-[10px] text-muted-foreground">{k.label}</p>
-                  <p className="text-[18px]" style={{ fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>{k.value}</p>
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
-
-        {/* 승인 대기 알림 */}
-        {kpi.pending > 0 && (
-          <Card className="border-amber-200/60 dark:border-amber-800/40 bg-amber-50/50 dark:bg-amber-950/10">
-            <CardContent className="p-3 flex items-center gap-3">
-              <Clock className="w-5 h-5 text-amber-500 shrink-0" />
-              <div className="flex-1">
-                <p className="text-[12px]" style={{ fontWeight: 600 }}>
-                  승인 대기 중인 사용자가 {kpi.pending}명 있습니다
-                </p>
-                <p className="text-[10px] text-muted-foreground">포털에서 가입한 사용자를 승인해주세요</p>
-              </div>
-              <Button size="sm" variant="outline" className="h-7 text-[11px]" onClick={() => setFilterStatus('PENDING')}>
-                확인하기
-              </Button>
-            </CardContent>
-          </Card>
-        )}
-
-        {/* Filter Bar */}
-        <Card>
-          <CardContent className="p-3">
-            <div className="flex flex-wrap items-center gap-2">
-              <div className="relative flex-1 min-w-[200px]">
-                <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground" />
-                <Input
-                  value={searchText}
-                  onChange={e => setSearchText(e.target.value)}
-                  placeholder="이름, 이메일, 부서 검색..."
-                  className="h-8 pl-8 text-[12px]"
-                />
-              </div>
-
-              <Select value={filterRole} onValueChange={v => setFilterRole(v)}>
-                <SelectTrigger className="h-8 w-[130px] text-[12px]">
-                  <SelectValue placeholder="역할" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="ALL">전체 역할</SelectItem>
-                  <SelectItem value="admin">관리자</SelectItem>
-                  <SelectItem value="finance">재무팀</SelectItem>
-                  <SelectItem value="pm">PM</SelectItem>
-                  <SelectItem value="auditor">감사</SelectItem>
-                </SelectContent>
-              </Select>
-
-              <Select value={filterStatus} onValueChange={v => setFilterStatus(v)}>
-                <SelectTrigger className="h-8 w-[130px] text-[12px]">
-                  <SelectValue placeholder="상태" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="ALL">전체 상태</SelectItem>
-                  <SelectItem value="ACTIVE">활성</SelectItem>
-                  <SelectItem value="INACTIVE">비활성</SelectItem>
-                  <SelectItem value="PENDING">승인대기</SelectItem>
-                </SelectContent>
-              </Select>
-
-              <Separator orientation="vertical" className="h-5 mx-1" />
-
-              <p className="text-[11px] text-muted-foreground">{filteredUsers.length}명</p>
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* Main Content */}
-        <div className="flex gap-4">
-          {/* 좌: 사용자 목록 */}
-          <div className={selectedUser ? 'w-[420px] shrink-0' : 'w-full'}>
-            {/* 정렬 헤더 */}
-            <div className="flex items-center gap-2 mb-2 text-[10px] text-muted-foreground">
-              {[
-                { key: 'name' as const, label: '이름순' },
-                { key: 'role' as const, label: '역할순' },
-                { key: 'lastLoginAt' as const, label: '최근접속순' },
-              ].map(s => (
-                <button
-                  key={s.key}
-                  onClick={() => { if (sortField === s.key) setSortAsc(!sortAsc); else { setSortField(s.key); setSortAsc(true); } }}
-                  className={`flex items-center gap-0.5 px-2 py-1 rounded transition-colors ${sortField === s.key ? 'bg-primary/10 text-primary' : 'hover:bg-muted'}`}
-                  style={{ fontWeight: sortField === s.key ? 600 : 400 }}
-                >
-                  <ArrowUpDown className="w-2.5 h-2.5" />
-                  {s.label}
-                </button>
-              ))}
-            </div>
-
-            <div className="space-y-2">
-              {filteredUsers.length === 0 ? (
-                <Card className="p-8 text-center">
-                  <Users className="w-8 h-8 mx-auto text-muted-foreground/30 mb-2" />
-                  <p className="text-[13px] text-muted-foreground">사용자가 없습니다</p>
-                </Card>
-              ) : (
-                filteredUsers.map(u => {
-                  const isSelected = selectedUser?.uid === u.uid;
-                  const RIcon = ROLE_META[u.role]?.Icon ?? Shield;
-                  return (
-                    <Card
-                      key={u.uid}
-                      className={`overflow-hidden cursor-pointer transition-all hover:shadow-sm ${isSelected ? 'ring-2 ring-primary/40 shadow-sm' : ''}`}
-                      onClick={() => setSelectedUser(u)}
-                    >
-                      <CardContent className="p-3">
-                        <div className="flex items-center gap-3">
-                          {/* Avatar */}
-                          <div
-                            className="w-9 h-9 rounded-full flex items-center justify-center shrink-0 text-white text-[12px]"
-                            style={{
-                              fontWeight: 700,
-                              background: u.role === 'admin' ? 'linear-gradient(135deg, #6366f1, #8b5cf6)' :
-                                         u.role === 'finance' ? 'linear-gradient(135deg, #059669, #0d9488)' :
-                                         u.role === 'pm' ? 'linear-gradient(135deg, #3b82f6, #6366f1)' :
-                                         'linear-gradient(135deg, #94a3b8, #64748b)',
-                            }}
-                          >
-                            {u.name.charAt(0)}
-                          </div>
-
-                          {/* Info */}
-                          <div className="min-w-0 flex-1">
-                            <div className="flex items-center gap-2 mb-0.5">
-                              <span className="text-[12px] truncate" style={{ fontWeight: 600 }}>{u.name}</span>
-                              <Badge className={`text-[8px] h-3.5 px-1.5 ${ROLE_META[u.role]?.badgeClass ?? ''}`}>
-                                {ROLE_META[u.role]?.label ?? u.role}
-                              </Badge>
-                              <Badge className={`text-[8px] h-3.5 px-1.5 ${STATUS_COLORS[u.status]}`}>
-                                {STATUS_LABELS[u.status]}
-                              </Badge>
-                            </div>
-                            <p className="text-[10px] text-muted-foreground truncate">{u.email}</p>
-                            <div className="flex items-center gap-3 mt-1 text-[9px] text-muted-foreground">
-                              {u.department && <span>{u.department}</span>}
-                              <span>접속: {formatRelative(u.lastLoginAt)}</span>
-                              <span>사업: {u.assignedProjects.length}건</span>
-                            </div>
-                          </div>
-
-                          {/* Actions */}
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <Button variant="ghost" size="sm" className="h-6 w-6 p-0 shrink-0" onClick={e => e.stopPropagation()}>
-                                <MoreHorizontal className="w-3.5 h-3.5" />
-                              </Button>
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent align="end" className="text-[12px]">
-                              <DropdownMenuItem onClick={(e) => { e.stopPropagation(); setEditingUser({ ...u }); setShowEditDialog(true); }}>
-                                <Edit3 className="w-3.5 h-3.5 mr-2" /> 정보 수정
-                              </DropdownMenuItem>
-                              <DropdownMenuItem onClick={(e) => { e.stopPropagation(); setSelectedUser(u); }}>
-                                <Eye className="w-3.5 h-3.5 mr-2" /> 상세 보기
-                              </DropdownMenuItem>
-                              {u.status === 'PENDING' && (
-                                <DropdownMenuItem onClick={(e) => { e.stopPropagation(); handleApproveUser(u.uid); }}>
-                                  <CheckCircle2 className="w-3.5 h-3.5 mr-2 text-emerald-600" /> 승인
-                                </DropdownMenuItem>
-                              )}
-                              <DropdownMenuSeparator />
-                              <DropdownMenuItem onClick={(e) => { e.stopPropagation(); handleStatusToggle(u.uid); }}>
-                                {u.status === 'ACTIVE' ? (
-                                  <><Ban className="w-3.5 h-3.5 mr-2 text-amber-600" /> 비활성화</>
-                                ) : (
-                                  <><RefreshCw className="w-3.5 h-3.5 mr-2 text-emerald-600" /> 활성화</>
-                                )}
-                              </DropdownMenuItem>
-                              {u.role !== 'admin' && (
-                                <DropdownMenuItem onClick={(e) => { e.stopPropagation(); handleDelete(u.uid); }} className="text-rose-600">
-                                  <Trash2 className="w-3.5 h-3.5 mr-2" /> 삭제
-                                </DropdownMenuItem>
-                              )}
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        </div>
-                      </CardContent>
-                    </Card>
-                  );
-                })
-              )}
-            </div>
-          </div>
-
-          {/* 우: 선택된 사용자 상세 */}
-          {selectedUser && (
-            <div className="flex-1 min-w-0">
-              <UserDetailPanel
-                user={selectedUser}
-                projectMap={projectMap}
-                onClose={() => setSelectedUser(null)}
-                onEdit={() => { setEditingUser({ ...selectedUser }); setShowEditDialog(true); }}
-                onRoleChange={(role) => { handleRoleChange(selectedUser.uid, role); setSelectedUser(prev => prev ? { ...prev, role } : null); }}
-                onStatusToggle={() => { handleStatusToggle(selectedUser.uid); setSelectedUser(prev => prev ? { ...prev, status: prev.status === 'ACTIVE' ? 'INACTIVE' : 'ACTIVE' } : null); }}
-              />
-            </div>
-          )}
-        </div>
-
-        {/* ── 새 사용자 생성 다이얼로그 ── */}
-        <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
-          <DialogContent className="max-w-md">
-            <DialogHeader>
-              <DialogTitle className="text-[14px] flex items-center gap-2">
-                <UserPlus className="w-4 h-4 text-primary" />
-                새 사용자 등록
-              </DialogTitle>
-            </DialogHeader>
-            <div className="space-y-4 py-2">
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <Label className="text-[11px]">이름 *</Label>
-                  <Input
-                    value={newForm.name}
-                    onChange={e => setNewForm(prev => ({ ...prev, name: e.target.value }))}
-                    placeholder="홍길동"
-                    className="h-8 text-[12px] mt-1"
-                  />
-                </div>
-                <div>
-                  <Label className="text-[11px]">이메일 *</Label>
-                  <Input
-                    type="email"
-                    value={newForm.email}
-                    onChange={e => setNewForm(prev => ({ ...prev, email: e.target.value }))}
-                    placeholder="user@mysc.co.kr"
-                    className="h-8 text-[12px] mt-1"
-                  />
-                </div>
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <Label className="text-[11px]">역할 *</Label>
-                  <Select value={newForm.role} onValueChange={v => setNewForm(prev => ({ ...prev, role: v as UserRole }))}>
-                    <SelectTrigger className="h-8 text-[12px] mt-1">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="admin">관리자</SelectItem>
-                      <SelectItem value="finance">재무팀</SelectItem>
-                      <SelectItem value="pm">PM (사업담당)</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-                <div>
-                  <Label className="text-[11px]">부서</Label>
-                  <Input
-                    value={newForm.department}
-                    onChange={e => setNewForm(prev => ({ ...prev, department: e.target.value }))}
-                    placeholder="소속 부서"
-                    className="h-8 text-[12px] mt-1"
-                  />
-                </div>
-              </div>
-              <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <Label className="text-[11px]">전화번호</Label>
-                  <Input
-                    value={newForm.phone}
-                    onChange={e => setNewForm(prev => ({ ...prev, phone: e.target.value }))}
-                    placeholder="010-0000-0000"
-                    className="h-8 text-[12px] mt-1"
-                  />
-                </div>
-                <div>
-                  <Label className="text-[11px]">메모</Label>
-                  <Input
-                    value={newForm.note}
-                    onChange={e => setNewForm(prev => ({ ...prev, note: e.target.value }))}
-                    placeholder="비고"
-                    className="h-8 text-[12px] mt-1"
-                  />
-                </div>
-              </div>
-
-              {/* Role description */}
-              <div className="p-3 rounded-lg bg-muted/40 text-[10px] text-muted-foreground space-y-1">
-                <p style={{ fontWeight: 600 }}>역할별 권한:</p>
-                <p><span className="text-foreground" style={{ fontWeight: 500 }}>관리자</span> — 모든 사업·재무·사용자 관리 권한</p>
-                <p><span className="text-foreground" style={{ fontWeight: 500 }}>재무팀</span> — 모든 사업의 재무 조회·승인·캐시플로 추출 권한</p>
-                <p><span className="text-foreground" style={{ fontWeight: 500 }}>PM</span> — 배정된 사업의 재무·인력 관리 권한</p>
-                <p><span className="text-foreground" style={{ fontWeight: 500 }}>감사</span> — 모든 사업 읽기 전용 + 감사로그</p>
-              </div>
-            </div>
-            <DialogFooter>
-              <Button variant="outline" size="sm" onClick={() => setShowCreateDialog(false)}>취소</Button>
-              <Button size="sm" onClick={handleCreate} disabled={!newForm.name || !newForm.email}>
-                <UserPlus className="w-3 h-3 mr-1" /> 등록
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-
-        {/* ── 사용자 수정 다이얼로그 ── */}
-        <Dialog open={showEditDialog} onOpenChange={v => { if (!v) { setShowEditDialog(false); setEditingUser(null); } }}>
-          <DialogContent className="max-w-md">
-            <DialogHeader>
-              <DialogTitle className="text-[14px] flex items-center gap-2">
-                <Edit3 className="w-4 h-4 text-primary" />
-                사용자 정보 수정
-              </DialogTitle>
-            </DialogHeader>
-            {editingUser && (
-              <div className="space-y-4 py-2">
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <Label className="text-[11px]">이름</Label>
-                    <Input
-                      value={editingUser.name}
-                      onChange={e => setEditingUser(prev => prev ? { ...prev, name: e.target.value } : null)}
-                      className="h-8 text-[12px] mt-1"
-                    />
-                  </div>
-                  <div>
-                    <Label className="text-[11px]">이메일</Label>
-                    <Input
-                      value={editingUser.email}
-                      onChange={e => setEditingUser(prev => prev ? { ...prev, email: e.target.value } : null)}
-                      className="h-8 text-[12px] mt-1"
-                    />
-                  </div>
-                </div>
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <Label className="text-[11px]">역할</Label>
-                    <Select value={editingUser.role} onValueChange={v => setEditingUser(prev => prev ? { ...prev, role: v as UserRole } : null)}>
-                      <SelectTrigger className="h-8 text-[12px] mt-1">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="admin">관리자</SelectItem>
-                        <SelectItem value="finance">재무팀</SelectItem>
-                        <SelectItem value="pm">PM (사업담당)</SelectItem>
-                        </SelectContent>
-                    </Select>
-                  </div>
-                  <div>
-                    <Label className="text-[11px]">부서</Label>
-                    <Input
-                      value={editingUser.department || ''}
-                      onChange={e => setEditingUser(prev => prev ? { ...prev, department: e.target.value } : null)}
-                      className="h-8 text-[12px] mt-1"
-                    />
-                  </div>
-                </div>
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <Label className="text-[11px]">전화번호</Label>
-                    <Input
-                      value={editingUser.phone || ''}
-                      onChange={e => setEditingUser(prev => prev ? { ...prev, phone: e.target.value } : null)}
-                      className="h-8 text-[12px] mt-1"
-                    />
-                  </div>
-                  <div>
-                    <Label className="text-[11px]">상태</Label>
-                    <Select value={editingUser.status} onValueChange={v => setEditingUser(prev => prev ? { ...prev, status: v as ManagedUser['status'] } : null)}>
-                      <SelectTrigger className="h-8 text-[12px] mt-1">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="ACTIVE">활성</SelectItem>
-                        <SelectItem value="INACTIVE">비활성</SelectItem>
-                        <SelectItem value="PENDING">승인대기</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                </div>
-                <div>
-                  <Label className="text-[11px]">메모</Label>
-                  <Input
-                    value={editingUser.note || ''}
-                    onChange={e => setEditingUser(prev => prev ? { ...prev, note: e.target.value } : null)}
-                    className="h-8 text-[12px] mt-1"
-                    placeholder="비고"
-                  />
-                </div>
-              </div>
-            )}
-            <DialogFooter>
-              <Button variant="outline" size="sm" onClick={() => { setShowEditDialog(false); setEditingUser(null); }}>취소</Button>
-              <Button size="sm" onClick={handleSaveEdit}>저장</Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
-      </div>
-    </TooltipProvider>
-  );
-}
-
-// ═══════════════════════════════════════════════════════════════
-// User Detail Panel
-// ═══════════════════════════════════════════════════════════════
-
-function UserDetailPanel({
-  user, projectMap, onClose, onEdit, onRoleChange, onStatusToggle,
+function KpiCard({
+  icon: Icon,
+  label,
+  value,
+  tone = 'default',
 }: {
-  user: ManagedUser;
-  projectMap: Map<string, string>;
-  onClose: () => void;
-  onEdit: () => void;
-  onRoleChange: (role: UserRole) => void;
-  onStatusToggle: () => void;
+  icon: typeof Users;
+  label: string;
+  value: number;
+  tone?: 'default' | 'danger';
 }) {
-  const RIcon = ROLE_ICONS[user.role];
   return (
-    <Card className="overflow-hidden">
-      {/* Header */}
-      <div className="p-4 border-b border-border/50">
-        <div className="flex items-start justify-between gap-3">
-          <div className="flex items-center gap-3">
-            <div
-              className="w-12 h-12 rounded-full flex items-center justify-center text-white text-[16px]"
-              style={{
-                fontWeight: 700,
-                background: user.role === 'admin' ? 'linear-gradient(135deg, #6366f1, #8b5cf6)' :
-                           user.role === 'finance' ? 'linear-gradient(135deg, #059669, #0d9488)' :
-                           user.role === 'pm' ? 'linear-gradient(135deg, #3b82f6, #6366f1)' :
-                           user.role === 'auditor' ? 'linear-gradient(135deg, #d97706, #f59e0b)' :
-                           'linear-gradient(135deg, #94a3b8, #64748b)',
-              }}
-            >
-              {user.name.charAt(0)}
-            </div>
-            <div>
-              <h3 className="text-[15px]" style={{ fontWeight: 700 }}>{user.name}</h3>
-              <div className="flex items-center gap-2 mt-0.5">
-                <Badge className={`text-[9px] h-4 px-1.5 ${ROLE_META[user.role]?.badgeClass ?? ''}`}>
-                  <RIcon className="w-2.5 h-2.5 mr-0.5" />
-                  {ROLE_META[user.role]?.label ?? user.role}
-                </Badge>
-                <Badge className={`text-[9px] h-4 px-1.5 ${STATUS_COLORS[user.status]}`}>
-                  {STATUS_LABELS[user.status]}
-                </Badge>
-              </div>
-            </div>
-          </div>
-          <div className="flex items-center gap-1">
-            <Button size="sm" variant="outline" className="h-7 text-[11px] gap-1" onClick={onEdit}>
-              <Edit3 className="w-3 h-3" /> 수정
-            </Button>
-            <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={onClose}>
-              <XCircle className="w-3.5 h-3.5" />
-            </Button>
-          </div>
+    <Card className={tone === 'danger' ? 'border-rose-200 bg-rose-50/60' : 'border-stone-200 bg-white'}>
+      <CardContent className="flex items-center gap-3 p-4">
+        <div className={tone === 'danger'
+          ? 'flex h-10 w-10 items-center justify-center rounded-xl bg-rose-100 text-rose-700'
+          : 'flex h-10 w-10 items-center justify-center rounded-xl bg-stone-100 text-stone-700'}
+        >
+          <Icon className="h-4 w-4" />
         </div>
-      </div>
-
-      <div className="p-4 space-y-4">
-        {/* 기본 정보 */}
         <div>
-          <h4 className="text-[11px] text-muted-foreground mb-2" style={{ fontWeight: 600 }}>기본 정보</h4>
-          <div className="grid grid-cols-2 gap-3">
-            <InfoRow icon={Mail} label="이메일" value={user.email} />
-            <InfoRow icon={Shield} label="부서" value={user.department || '-'} />
-            <InfoRow icon={Key} label="전화번호" value={user.phone || '-'} />
-            <InfoRow icon={Clock} label="가입일" value={new Date(user.createdAt).toLocaleDateString('ko-KR')} />
-          </div>
+          <div className="text-xs text-stone-500">{label}</div>
+          <div className="text-2xl font-semibold text-stone-950">{value}</div>
         </div>
-
-        <Separator />
-
-        {/* 역할 변경 */}
-        <div>
-          <h4 className="text-[11px] text-muted-foreground mb-2" style={{ fontWeight: 600 }}>역할 변경</h4>
-          <Select value={user.role} onValueChange={v => onRoleChange(v as UserRole)}>
-            <SelectTrigger className="h-8 text-[12px]">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="admin">관리자</SelectItem>
-              <SelectItem value="finance">재무팀</SelectItem>
-              <SelectItem value="pm">PM (사업담당)</SelectItem>
-              <SelectItem value="auditor">감사</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-
-        <Separator />
-
-        {/* 계정 상태 */}
-        <div className="flex items-center justify-between">
-          <div>
-            <h4 className="text-[11px]" style={{ fontWeight: 600 }}>계정 활성화</h4>
-            <p className="text-[10px] text-muted-foreground">비활성화된 계정은 로그인 불가</p>
-          </div>
-          <Switch
-            checked={user.status === 'ACTIVE'}
-            onCheckedChange={onStatusToggle}
-          />
-        </div>
-
-        <Separator />
-
-        {/* 배정 사업 */}
-        <div>
-          <h4 className="text-[11px] text-muted-foreground mb-2" style={{ fontWeight: 600 }}>
-            배정 사업 ({user.assignedProjects.length}건)
-          </h4>
-          <div className="space-y-1.5">
-            {user.assignedProjects.map(pid => (
-              <div key={pid} className="flex items-center gap-2 p-2 rounded-md bg-muted/30 text-[11px]">
-                <FolderKanban className="w-3 h-3 text-muted-foreground shrink-0" />
-                <span className="truncate">{projectMap.get(pid) || pid}</span>
-              </div>
-            ))}
-            {user.assignedProjects.length === 0 && (
-              <p className="text-[10px] text-muted-foreground">배정된 사업 없음</p>
-            )}
-          </div>
-        </div>
-
-        <Separator />
-
-        {/* 활동 내역 */}
-        <div>
-          <h4 className="text-[11px] text-muted-foreground mb-2" style={{ fontWeight: 600 }}>최근 활동</h4>
-          <div className="space-y-2">
-            <ActivityRow
-              icon={Clock}
-              text={`마지막 접속: ${user.lastLoginAt === '-' ? '미접속' : new Date(user.lastLoginAt).toLocaleDateString('ko-KR') + ' ' + new Date(user.lastLoginAt).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}`}
-            />
-            <ActivityRow
-              icon={UserCog}
-              text={`계정 생성: ${new Date(user.createdAt).toLocaleDateString('ko-KR')}`}
-            />
-          </div>
-        </div>
-      </div>
+      </CardContent>
     </Card>
   );
 }
 
-function InfoRow({ icon: Icon, label, value }: { icon: typeof Mail; label: string; value: string }) {
+function SourceBadge({ ok, label }: { ok: boolean; label: string }) {
   return (
-    <div className="flex items-start gap-2">
-      <Icon className="w-3 h-3 text-muted-foreground mt-0.5 shrink-0" />
-      <div>
-        <p className="text-[9px] text-muted-foreground">{label}</p>
-        <p className="text-[11px]" style={{ fontWeight: 500 }}>{value}</p>
-      </div>
-    </div>
+    <Badge className={ok ? 'bg-stone-900 text-white' : 'bg-amber-100 text-amber-800'}>
+      {label}
+    </Badge>
   );
 }
 
-function ActivityRow({ icon: Icon, text }: { icon: typeof Clock; text: string }) {
+export function UserManagementPage() {
+  const { user: authUser } = useAuth();
+  const { orgId } = useFirebase();
+  const [items, setItems] = useState<AuthGovernanceUserRow[]>([]);
+  const [summary, setSummary] = useState<AuthGovernanceSummary>(emptyGovernanceSummary);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedIdentityKey, setSelectedIdentityKey] = useState<string>('');
+  const [syncingIdentityKey, setSyncingIdentityKey] = useState<string>('');
+  const [bulkSyncing, setBulkSyncing] = useState(false);
+  const [draftRoles, setDraftRoles] = useState<Record<string, UserRole>>({});
+  const [filters, setFilters] = useState<AuthGovernanceFilters>({
+    searchText: '',
+    role: 'ALL',
+    drift: 'DRIFT_ONLY',
+    source: 'ALL',
+  });
+
+  const governanceEnabled = featureFlags.platformApiEnabled && !!authUser?.idToken;
+
+  const loadGovernance = async () => {
+    if (!authUser || !governanceEnabled) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetchAuthGovernanceUsersViaBff({
+        tenantId: orgId,
+        actor: authUser,
+      });
+      setItems(response.items);
+      setSummary(response.summary);
+      setDraftRoles((prev) => {
+        const next = { ...prev };
+        for (const row of response.items) {
+          if (!next[row.identityKey]) {
+            next[row.identityKey] = getRecommendedGovernanceRole(row);
+          }
+        }
+        return next;
+      });
+      setSelectedIdentityKey((prev) => {
+        if (prev && response.items.some((row) => row.identityKey === prev)) return prev;
+        return response.items[0]?.identityKey || '';
+      });
+    } catch (err: any) {
+      setError(err?.message || 'Auth governance 목록을 불러오지 못했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadGovernance();
+  }, [orgId, authUser?.uid, authUser?.idToken]);
+
+  const filteredRows = useMemo(
+    () => filterGovernanceRows(items, filters),
+    [items, filters],
+  );
+
+  const selectedRow = useMemo(
+    () => filteredRows.find((row) => row.identityKey === selectedIdentityKey)
+      || items.find((row) => row.identityKey === selectedIdentityKey)
+      || filteredRows[0]
+      || items[0]
+      || null,
+    [filteredRows, items, selectedIdentityKey],
+  );
+
+  useEffect(() => {
+    if (selectedRow && selectedRow.identityKey !== selectedIdentityKey) {
+      setSelectedIdentityKey(selectedRow.identityKey);
+    }
+  }, [selectedIdentityKey, selectedRow]);
+
+  const handleDeepSync = async (row: AuthGovernanceUserRow) => {
+    if (!authUser) return;
+    const role = draftRoles[row.identityKey] || getRecommendedGovernanceRole(row);
+    setSyncingIdentityKey(row.identityKey);
+    try {
+      await deepSyncAuthGovernanceUserViaBff({
+        tenantId: orgId,
+        actor: authUser,
+        identityKey: row.identityKey,
+        role,
+        reason: 'admin auth governance dashboard deep sync',
+      });
+      toast.success(`${row.email} 권한 정렬을 반영했습니다.`);
+      await loadGovernance();
+    } catch (err: any) {
+      toast.error(err?.message || '권한 정렬을 반영하지 못했습니다.');
+    } finally {
+      setSyncingIdentityKey('');
+    }
+  };
+
+  const handleBulkDeepSync = async () => {
+    if (!authUser) return;
+    const targets = filteredRows.filter((row) => row.needsDeepSync);
+    if (targets.length === 0) {
+      toast.info('현재 필터 기준으로 정렬할 대상이 없습니다.');
+      return;
+    }
+
+    setBulkSyncing(true);
+    try {
+      for (const row of targets) {
+        await deepSyncAuthGovernanceUserViaBff({
+          tenantId: orgId,
+          actor: authUser,
+          identityKey: row.identityKey,
+          role: draftRoles[row.identityKey] || getRecommendedGovernanceRole(row),
+          reason: 'admin auth governance dashboard bulk deep sync',
+        });
+      }
+      toast.success(`${targets.length}건의 권한 정렬을 반영했습니다.`);
+      await loadGovernance();
+    } catch (err: any) {
+      toast.error(err?.message || '일괄 정렬 중 오류가 발생했습니다.');
+    } finally {
+      setBulkSyncing(false);
+    }
+  };
+
+  if (!governanceEnabled) {
+    return (
+      <div className="space-y-5">
+        <PageHeader
+          icon={UserCog}
+          iconGradient="linear-gradient(135deg, #44403c 0%, #0c0a09 100%)"
+          title="Auth/RBAC 정렬 대시보드"
+          description="Firebase Auth와 member 문서를 함께 관리하는 운영 화면"
+        />
+        <Card className="border-stone-200">
+          <CardContent className="p-6 text-sm text-stone-600">
+            이 화면은 BFF와 Firebase ID 토큰이 활성화된 admin 환경에서만 동작합니다.
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
-      <Icon className="w-3 h-3 shrink-0" />
-      <span>{text}</span>
+    <div className="space-y-5">
+      <PageHeader
+        icon={UserCog}
+        iconGradient="linear-gradient(135deg, #44403c 0%, #0c0a09 100%)"
+        title="Auth/RBAC 정렬 대시보드"
+        description="Firebase Auth, canonical member, legacy member, custom claim drift를 한 화면에서 정렬합니다."
+        badge={`${summary.total}건`}
+        actions={(
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              className="h-9 gap-2 bg-stone-900 text-white hover:bg-stone-800"
+              onClick={() => void handleBulkDeepSync()}
+              disabled={loading || bulkSyncing}
+            >
+              <GitMerge className={`h-4 w-4 ${bulkSyncing ? 'animate-pulse' : ''}`} />
+              정렬 필요 전체 적용
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-9 gap-2 border-stone-300 bg-white text-stone-900"
+              onClick={() => void loadGovernance()}
+              disabled={loading || bulkSyncing}
+            >
+              <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+              새로고침
+            </Button>
+          </div>
+        )}
+      />
+
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-6">
+        <KpiCard icon={Users} label="전체 정렬 대상" value={summary.total} />
+        <KpiCard icon={GitMerge} label="정렬 필요" value={summary.needsDeepSync} tone={summary.needsDeepSync > 0 ? 'danger' : 'default'} />
+        <KpiCard icon={KeyRound} label="Auth 없음" value={summary.missingAuth} tone={summary.missingAuth > 0 ? 'danger' : 'default'} />
+        <KpiCard icon={Database} label="Canonical 없음" value={summary.missingCanonicalMember} tone={summary.missingCanonicalMember > 0 ? 'danger' : 'default'} />
+        <KpiCard icon={AlertTriangle} label="중복 member" value={summary.duplicateMemberDocs} tone={summary.duplicateMemberDocs > 0 ? 'danger' : 'default'} />
+        <KpiCard icon={Shield} label="Bootstrap 후보" value={summary.bootstrapCandidates} />
+      </div>
+
+      <Card className="border-stone-200">
+        <CardContent className="flex flex-wrap items-center gap-2 p-3">
+          <div className="relative min-w-[220px] flex-1">
+            <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-stone-400" />
+            <Input
+              value={filters.searchText}
+              onChange={(event) => setFilters((prev) => ({ ...prev, searchText: event.target.value }))}
+              placeholder="이메일, 이름, docId, drift 검색"
+              className="h-9 border-stone-300 pl-9"
+            />
+          </div>
+          <Select value={filters.role} onValueChange={(value) => setFilters((prev) => ({ ...prev, role: value as AuthGovernanceFilters['role'] }))}>
+            <SelectTrigger className="h-9 w-[150px] border-stone-300 bg-white">
+              <SelectValue placeholder="권한 추천값" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="ALL">전체 권한</SelectItem>
+              {ROLE_OPTIONS.map((item) => (
+                <SelectItem key={item.value} value={item.value}>{item.label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select value={filters.drift} onValueChange={(value) => setFilters((prev) => ({ ...prev, drift: value as AuthGovernanceFilters['drift'] }))}>
+            <SelectTrigger className="h-9 w-[150px] border-stone-300 bg-white">
+              <SelectValue placeholder="정렬 상태" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="ALL">전체 상태</SelectItem>
+              <SelectItem value="DRIFT_ONLY">정렬 필요만</SelectItem>
+              <SelectItem value="CLEAN_ONLY">정렬 완료만</SelectItem>
+            </SelectContent>
+          </Select>
+          <Select value={filters.source} onValueChange={(value) => setFilters((prev) => ({ ...prev, source: value as AuthGovernanceFilters['source'] }))}>
+            <SelectTrigger className="h-9 w-[170px] border-stone-300 bg-white">
+              <SelectValue placeholder="소스 상태" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="ALL">전체 소스</SelectItem>
+              <SelectItem value="AUTH_MISSING">Auth 없음</SelectItem>
+              <SelectItem value="MEMBER_MISSING">Canonical 없음</SelectItem>
+              <SelectItem value="BOOTSTRAP">Bootstrap 후보</SelectItem>
+            </SelectContent>
+          </Select>
+        </CardContent>
+      </Card>
+
+      {error && (
+        <Card className="border-rose-200 bg-rose-50/70">
+          <CardContent className="flex items-center gap-2 p-4 text-sm text-rose-700">
+            <AlertTriangle className="h-4 w-4" />
+            {error}
+          </CardContent>
+        </Card>
+      )}
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.3fr)_minmax(360px,0.9fr)]">
+        <Card className="border-stone-200">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm font-semibold text-stone-900">정렬 대상 목록</CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <ScrollArea className="h-[720px]">
+              <div className="divide-y divide-stone-200">
+                {filteredRows.map((row) => {
+                  const role = draftRoles[row.identityKey] || getRecommendedGovernanceRole(row);
+                  const selected = selectedRow?.identityKey === row.identityKey;
+                  return (
+                    <div
+                      key={row.identityKey}
+                      className={`cursor-pointer px-4 py-4 ${selected ? 'bg-stone-100' : 'bg-white hover:bg-stone-50'}`}
+                      onClick={() => setSelectedIdentityKey(row.identityKey)}
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div className="min-w-0 space-y-2">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <div className="text-sm font-semibold text-stone-950">{row.displayName}</div>
+                            <Badge className={row.needsDeepSync ? 'bg-amber-100 text-amber-800' : 'bg-emerald-100 text-emerald-800'}>
+                              {row.needsDeepSync ? '정렬 필요' : '정렬 완료'}
+                            </Badge>
+                            {row.bootstrapAdmin && (
+                              <Badge className="bg-stone-900 text-white">Bootstrap admin 후보</Badge>
+                            )}
+                          </div>
+                          <div className="text-sm text-stone-600">{row.email}</div>
+                          <div className="flex flex-wrap items-center gap-2 text-xs">
+                            <SourceBadge ok={Boolean(row.authUid)} label={row.authUid ? 'Auth 연결' : 'Auth 없음'} />
+                            <SourceBadge ok={Boolean(row.canonicalMember)} label={row.canonicalMember ? 'Canonical 있음' : 'Canonical 없음'} />
+                            <Badge className="bg-stone-100 text-stone-700">Legacy {row.legacyMembers.length}건</Badge>
+                            <Badge className={ROLE_BADGE_CLASS[row.effectiveRole] || 'bg-stone-200 text-stone-900'}>
+                              현재 판단 {roleLabel(row.effectiveRole)}
+                            </Badge>
+                            {row.claimRole && (
+                              <Badge className="bg-stone-100 text-stone-700">Claim {roleLabel(row.claimRole)}</Badge>
+                            )}
+                          </div>
+                          {row.driftFlags.length > 0 && (
+                            <div className="flex flex-wrap gap-1.5">
+                              {row.driftFlags.map((flag) => (
+                                <Badge key={flag} className="bg-amber-100 text-amber-800">
+                                  {DRIFT_LABELS[flag] || flag}
+                                </Badge>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                        <div className="flex shrink-0 flex-col items-end gap-2">
+                          <Select
+                            value={role}
+                            onValueChange={(value) => setDraftRoles((prev) => ({ ...prev, [row.identityKey]: value as UserRole }))}
+                          >
+                            <SelectTrigger
+                              className="h-9 w-[140px] border-stone-300 bg-white"
+                              onClick={(event) => event.stopPropagation()}
+                            >
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              {ROLE_OPTIONS.map((item) => (
+                                <SelectItem key={item.value} value={item.value}>{item.label}</SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          <Button
+                            size="sm"
+                            className="h-9 min-w-[140px] bg-stone-900 text-white hover:bg-stone-800"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              void handleDeepSync(row);
+                            }}
+                            disabled={syncingIdentityKey === row.identityKey}
+                          >
+                            {syncingIdentityKey === row.identityKey ? (
+                              <>
+                                <RefreshCw className="mr-2 h-3.5 w-3.5 animate-spin" />
+                                반영 중
+                              </>
+                            ) : (
+                              <>
+                                <GitMerge className="mr-2 h-3.5 w-3.5" />
+                                Deep Sync
+                              </>
+                            )}
+                          </Button>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+                {!loading && filteredRows.length === 0 && (
+                  <div className="px-4 py-16 text-center text-sm text-stone-500">
+                    조건에 맞는 정렬 대상이 없습니다.
+                  </div>
+                )}
+              </div>
+            </ScrollArea>
+          </CardContent>
+        </Card>
+
+        <Card className="border-stone-200">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm font-semibold text-stone-900">선택 사용자 정렬 상태</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {!selectedRow ? (
+              <div className="text-sm text-stone-500">대상을 선택하면 auth/member 정합성을 비교해서 보여줍니다.</div>
+            ) : (
+              <>
+                <div className="space-y-1">
+                  <div className="text-base font-semibold text-stone-950">{selectedRow.displayName}</div>
+                  <div className="text-sm text-stone-600">{selectedRow.email}</div>
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                  <Badge className={ROLE_BADGE_CLASS[selectedRow.effectiveRole] || 'bg-stone-200 text-stone-900'}>
+                    현재 판단 {roleLabel(selectedRow.effectiveRole)}
+                  </Badge>
+                  <Badge className="bg-stone-100 text-stone-700">
+                    추천 반영 {roleLabel(draftRoles[selectedRow.identityKey] || getRecommendedGovernanceRole(selectedRow))}
+                  </Badge>
+                </div>
+
+                <Separator />
+
+                <div className="space-y-3">
+                  <div>
+                    <div className="mb-1 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-stone-500">
+                      <KeyRound className="h-3.5 w-3.5" />
+                      Firebase Auth
+                    </div>
+                    <div className="rounded-xl border border-stone-200 bg-stone-50 p-3 text-sm text-stone-700">
+                      <div>UID: {selectedRow.authUid || '-'}</div>
+                      <div>Claim role: {roleLabel(selectedRow.claimRole)}</div>
+                      <div>Claim tenant: {selectedRow.claimTenantId || '-'}</div>
+                      <div>계정 상태: {selectedRow.authUid ? (selectedRow.authDisabled ? '비활성' : '활성') : '없음'}</div>
+                    </div>
+                  </div>
+
+                  <div>
+                    <div className="mb-1 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-stone-500">
+                      <Database className="h-3.5 w-3.5" />
+                      Canonical Member
+                    </div>
+                    <div className="rounded-xl border border-stone-200 bg-stone-50 p-3 text-sm text-stone-700">
+                      {selectedRow.canonicalMember ? (
+                        <>
+                          <div>docId: {selectedRow.canonicalMember.docId}</div>
+                          <div>role: {roleLabel(selectedRow.canonicalMember.role)}</div>
+                          <div>status: {statusLabel(selectedRow.canonicalMember.status)}</div>
+                          <div>name: {selectedRow.canonicalMember.name || '-'}</div>
+                        </>
+                      ) : (
+                        <div>canonical member 문서가 없습니다.</div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div>
+                    <div className="mb-1 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-stone-500">
+                      <GitMerge className="h-3.5 w-3.5" />
+                      Legacy Members
+                    </div>
+                    <div className="space-y-2">
+                      {selectedRow.legacyMembers.length > 0 ? selectedRow.legacyMembers.map((member) => (
+                        <div key={member.docId} className="rounded-xl border border-stone-200 bg-stone-50 p-3 text-sm text-stone-700">
+                          <div>docId: {member.docId}</div>
+                          <div>role: {roleLabel(member.role)}</div>
+                          <div>status: {statusLabel(member.status)}</div>
+                          <div>name: {member.name || '-'}</div>
+                        </div>
+                      )) : (
+                        <div className="rounded-xl border border-dashed border-stone-200 bg-white p-3 text-sm text-stone-500">
+                          legacy 문서는 없습니다.
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div>
+                    <div className="mb-1 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-stone-500">
+                      <AlertTriangle className="h-3.5 w-3.5" />
+                      Drift Flags
+                    </div>
+                    <div className="flex flex-wrap gap-1.5">
+                      {selectedRow.driftFlags.length > 0 ? selectedRow.driftFlags.map((flag) => (
+                        <Badge key={flag} className="bg-amber-100 text-amber-800">
+                          {DRIFT_LABELS[flag] || flag}
+                        </Badge>
+                      )) : (
+                        <Badge className="bg-emerald-100 text-emerald-800">
+                          <CheckCircle2 className="mr-1 h-3 w-3" />
+                          drift 없음
+                        </Badge>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                <Separator />
+
+                <div className="rounded-xl border border-stone-200 bg-stone-50 p-3 text-sm text-stone-700">
+                  <div className="font-medium text-stone-900">이 액션이 하는 일</div>
+                  <div className="mt-2 space-y-1">
+                    <div>1. Auth 계정 기준으로 canonical member 문서를 맞춥니다.</div>
+                    <div>2. legacy member 문서가 있으면 role과 canonical UID를 함께 미러링합니다.</div>
+                    <div>3. Firebase custom claim role/tenantId까지 같이 정렬합니다.</div>
+                  </div>
+                </div>
+
+                <div className="flex items-center justify-between gap-3">
+                  <div className="text-xs text-stone-500">
+                    마지막 추천 role은 {roleLabel(draftRoles[selectedRow.identityKey] || getRecommendedGovernanceRole(selectedRow))} 입니다.
+                  </div>
+                  <Button
+                    className="bg-stone-900 text-white hover:bg-stone-800"
+                    onClick={() => void handleDeepSync(selectedRow)}
+                    disabled={syncingIdentityKey === selectedRow.identityKey}
+                  >
+                    {syncingIdentityKey === selectedRow.identityKey ? '반영 중…' : '선택 사용자 Deep Sync'}
+                  </Button>
+                </div>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }

--- a/src/app/components/users/auth-governance-view-model.test.ts
+++ b/src/app/components/users/auth-governance-view-model.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { emptyGovernanceSummary, filterGovernanceRows, getRecommendedGovernanceRole } from './auth-governance-view-model';
+import type { AuthGovernanceUserRow } from '../../lib/platform-bff-client';
+
+const baseRow: AuthGovernanceUserRow = {
+  identityKey: 'jslee@mysc.co.kr',
+  email: 'jslee@mysc.co.kr',
+  authUid: 'uid-jslee',
+  displayName: 'JS Lee',
+  authDisabled: false,
+  bootstrapAdmin: true,
+  claimRole: 'pm',
+  claimTenantId: 'mysc',
+  canonicalMember: {
+    docId: 'uid-jslee',
+    uid: 'uid-jslee',
+    email: 'jslee@mysc.co.kr',
+    role: 'pm',
+    status: 'ACTIVE',
+    name: '이재성',
+  },
+  legacyMembers: [],
+  effectiveRole: 'pm',
+  driftFlags: ['bootstrap_admin_not_adopted'],
+  needsDeepSync: true,
+};
+
+describe('auth governance view model helpers', () => {
+  it('recommends admin for bootstrap admin candidates', () => {
+    expect(getRecommendedGovernanceRole(baseRow)).toBe('admin');
+  });
+
+  it('filters drift-only and text matches', () => {
+    const rows = [
+      baseRow,
+      {
+        ...baseRow,
+        identityKey: 'pm@mysc.co.kr',
+        email: 'pm@mysc.co.kr',
+        bootstrapAdmin: false,
+        effectiveRole: 'pm',
+        driftFlags: [],
+        needsDeepSync: false,
+      },
+    ];
+
+    const filtered = filterGovernanceRows(rows, {
+      searchText: 'jslee',
+      role: 'ALL',
+      drift: 'DRIFT_ONLY',
+      source: 'ALL',
+    });
+
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].email).toBe('jslee@mysc.co.kr');
+  });
+
+  it('returns an empty summary shape', () => {
+    expect(emptyGovernanceSummary()).toEqual({
+      total: 0,
+      needsDeepSync: 0,
+      missingAuth: 0,
+      missingCanonicalMember: 0,
+      duplicateMemberDocs: 0,
+      bootstrapCandidates: 0,
+    });
+  });
+});

--- a/src/app/components/users/auth-governance-view-model.ts
+++ b/src/app/components/users/auth-governance-view-model.ts
@@ -1,0 +1,60 @@
+import type { UserRole } from '../../data/types';
+import type { AuthGovernanceSummary, AuthGovernanceUserRow } from '../../lib/platform-bff-client';
+
+export interface AuthGovernanceFilters {
+  searchText: string;
+  role: 'ALL' | UserRole;
+  drift: 'ALL' | 'DRIFT_ONLY' | 'CLEAN_ONLY';
+  source: 'ALL' | 'AUTH_MISSING' | 'MEMBER_MISSING' | 'BOOTSTRAP';
+}
+
+function normalizeText(value: string | undefined): string {
+  return (value || '').trim().toLowerCase();
+}
+
+export function getRecommendedGovernanceRole(row: AuthGovernanceUserRow): UserRole {
+  const effective = (row.effectiveRole || '').trim().toLowerCase();
+  if (row.bootstrapAdmin) return 'admin';
+  if (effective === 'admin' || effective === 'finance' || effective === 'pm') {
+    return effective as UserRole;
+  }
+  return 'pm';
+}
+
+export function filterGovernanceRows(
+  rows: AuthGovernanceUserRow[],
+  filters: AuthGovernanceFilters,
+): AuthGovernanceUserRow[] {
+  const q = normalizeText(filters.searchText);
+  return rows.filter((row) => {
+    if (filters.role !== 'ALL' && getRecommendedGovernanceRole(row) !== filters.role) return false;
+    if (filters.drift === 'DRIFT_ONLY' && !row.needsDeepSync) return false;
+    if (filters.drift === 'CLEAN_ONLY' && row.needsDeepSync) return false;
+    if (filters.source === 'AUTH_MISSING' && !row.driftFlags.includes('missing_auth')) return false;
+    if (filters.source === 'MEMBER_MISSING' && !row.driftFlags.includes('missing_canonical_member')) return false;
+    if (filters.source === 'BOOTSTRAP' && !row.bootstrapAdmin) return false;
+    if (!q) return true;
+
+    const haystack = [
+      row.email,
+      row.displayName,
+      row.authUid || '',
+      row.canonicalMember?.docId || '',
+      row.canonicalMember?.name || '',
+      row.legacyMembers.map((item) => item.docId).join(' '),
+      row.driftFlags.join(' '),
+    ].join(' ').toLowerCase();
+    return haystack.includes(q);
+  });
+}
+
+export function emptyGovernanceSummary(): AuthGovernanceSummary {
+  return {
+    total: 0,
+    needsDeepSync: 0,
+    missingAuth: 0,
+    missingCanonicalMember: 0,
+    duplicateMemberDocs: 0,
+    bootstrapCandidates: 0,
+  };
+}

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -5,6 +5,8 @@ import {
   analyzeGoogleSheetImportViaBff,
   analyzeProjectRequestContractViaBff,
   changeTransactionStateViaBff,
+  deepSyncAuthGovernanceUserViaBff,
+  fetchAuthGovernanceUsersViaBff,
   linkProjectEvidenceDriveRootViaBff,
   notifyProjectRequestRegistrationViaBff,
   overrideTransactionEvidenceDriveCategoriesViaBff,
@@ -219,6 +221,76 @@ describe('platform-bff-client', () => {
 
     expect(comment.id).toBe('c001');
     expect(evidence.id).toBe('ev001');
+  });
+
+  it('fetches auth governance users through the bff client', async () => {
+    const client = asMockClient({
+      post: vi.fn(),
+      get: vi.fn(async () => ({
+        data: {
+          items: [{ identityKey: 'jslee@mysc.co.kr', email: 'jslee@mysc.co.kr', driftFlags: ['missing_auth'] }],
+          summary: {
+            total: 1,
+            needsDeepSync: 1,
+            missingAuth: 1,
+            missingCanonicalMember: 0,
+            duplicateMemberDocs: 0,
+            bootstrapCandidates: 1,
+          },
+        },
+      })),
+      request: vi.fn(),
+    });
+
+    const response = await fetchAuthGovernanceUsersViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'u-admin', role: 'admin', idToken: 'token-1' },
+      client,
+    });
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/admin/auth-governance/users', expect.objectContaining({
+      tenantId: 'mysc',
+      actor: expect.objectContaining({ id: 'u-admin', role: 'admin', idToken: 'token-1' }),
+    }));
+    expect(response.summary.total).toBe(1);
+  });
+
+  it('posts a deep sync request for an auth governance user', async () => {
+    const client = asMockClient({
+      post: vi.fn(async () => ({
+        data: {
+          identityKey: 'jslee@mysc.co.kr',
+          email: 'jslee@mysc.co.kr',
+          canonicalDocId: 'uid-jslee',
+          role: 'admin',
+          mirroredLegacyCount: 1,
+          claimsUpdated: true,
+          updatedAt: '2026-04-13T06:30:00.000Z',
+        },
+      })),
+      get: vi.fn(),
+      request: vi.fn(),
+    });
+
+    const response = await deepSyncAuthGovernanceUserViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'u-admin', role: 'admin', idToken: 'token-1' },
+      identityKey: 'jslee@mysc.co.kr',
+      role: 'admin',
+      reason: 'cashflow export alignment',
+      client,
+    });
+
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/v1/admin/auth-governance/users/jslee%40mysc.co.kr/deep-sync',
+      expect.objectContaining({
+        body: {
+          role: 'admin',
+          reason: 'cashflow export alignment',
+        },
+      }),
+    );
+    expect(response.claimsUpdated).toBe(true);
   });
 
   it('calls project request contract analysis endpoint', async () => {

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -146,6 +146,64 @@ export interface ProjectRequestRegistrationNotificationResult {
   reason?: string;
 }
 
+export type AuthGovernanceDriftFlag =
+  | 'missing_auth'
+  | 'missing_canonical_member'
+  | 'legacy_only'
+  | 'duplicate_member_docs'
+  | 'legacy_role_mismatch'
+  | 'claim_mismatch'
+  | 'bootstrap_admin_not_adopted';
+
+export interface AuthGovernanceMemberSnapshot {
+  docId: string;
+  uid: string;
+  email: string;
+  role: string;
+  status: string | null;
+  name: string;
+}
+
+export interface AuthGovernanceUserRow {
+  identityKey: string;
+  email: string;
+  authUid: string | null;
+  displayName: string;
+  authDisabled: boolean;
+  bootstrapAdmin: boolean;
+  claimRole: string | null;
+  claimTenantId: string | null;
+  canonicalMember: AuthGovernanceMemberSnapshot | null;
+  legacyMembers: AuthGovernanceMemberSnapshot[];
+  effectiveRole: string;
+  driftFlags: AuthGovernanceDriftFlag[];
+  needsDeepSync: boolean;
+}
+
+export interface AuthGovernanceSummary {
+  total: number;
+  needsDeepSync: number;
+  missingAuth: number;
+  missingCanonicalMember: number;
+  duplicateMemberDocs: number;
+  bootstrapCandidates: number;
+}
+
+export interface AuthGovernanceDirectoryResult {
+  items: AuthGovernanceUserRow[];
+  summary: AuthGovernanceSummary;
+}
+
+export interface AuthGovernanceDeepSyncResult {
+  identityKey: string;
+  email: string;
+  canonicalDocId: string;
+  role: string;
+  mirroredLegacyCount: number;
+  claimsUpdated: boolean;
+  updatedAt: string;
+}
+
 function normalizeStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return value
@@ -538,6 +596,47 @@ export async function addEvidenceViaBff(params: {
       tenantId: params.tenantId,
       actor: toRequestActor(params.actor),
       body: params.evidence,
+    },
+  );
+  return response.data;
+}
+
+export async function fetchAuthGovernanceUsersViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  client?: PlatformApiClientLike;
+}): Promise<AuthGovernanceDirectoryResult> {
+  const apiClient = resolveClient(params.client);
+  const response = await apiClient.get<AuthGovernanceDirectoryResult>(
+    '/api/v1/admin/auth-governance/users',
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      timeoutMs: 10000,
+    },
+  );
+  return response.data;
+}
+
+export async function deepSyncAuthGovernanceUserViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  identityKey: string;
+  role: string;
+  reason?: string;
+  client?: PlatformApiClientLike;
+}): Promise<AuthGovernanceDeepSyncResult> {
+  const apiClient = resolveClient(params.client);
+  const response = await apiClient.post<AuthGovernanceDeepSyncResult>(
+    `/api/v1/admin/auth-governance/users/${encodeURIComponent(params.identityKey)}/deep-sync`,
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      body: {
+        role: params.role,
+        ...(params.reason ? { reason: params.reason } : {}),
+      },
+      timeoutMs: 10000,
     },
   );
   return response.data;


### PR DESCRIPTION
## 요약
- `/users`를 shallow member 편집 화면에서 `Auth/RBAC 정렬 대시보드`로 재편했습니다.
- BFF가 Firebase Auth, canonical member, legacy member, bootstrap admin 후보, custom claim drift를 한 번에 합쳐서 내려줍니다.
- admin은 개별/일괄 deep sync로 canonical member, legacy member, custom claims를 함께 정렬할 수 있습니다.

## 변경점
- `GET /api/v1/admin/auth-governance/users`
- `POST /api/v1/admin/auth-governance/users/:identityKey/deep-sync`
- Firebase Auth admin service DI 추가
- auth governance merge/deep-sync helper 및 테스트 추가
- `/users` UI를 governance-first 운영 화면으로 교체

## 검증
- `npm test -- --run server/bff/auth-governance.test.mjs server/bff/request-context.test.ts src/app/lib/platform-bff-client.test.ts src/app/components/users/auth-governance-view-model.test.ts`
- `npm run build`

## 메모
- `server/bff/app.integration.test.ts`에 auth governance route 케이스를 추가했습니다. Firestore emulator가 없는 환경에서는 기존처럼 skip됩니다.
- 현재 실운영에서 member role을 직접 Firestore로 맞추던 흐름을 이 대시보드로 흡수하는 것이 목적입니다.
