### PR TITLE
docs: expand page patch notes coverage

### DIFF
--- a/docs/wiki/patch-notes/AGENTS.md
+++ b/docs/wiki/patch-notes/AGENTS.md
@@ -72,3 +72,4 @@
 - 파일명은 kebab-case
 - route/공간 의미가 드러나도록 `portal-*`, `admin-*` prefix 사용
 - 도메인 문서보다 화면 문서를 우선 생성
+- redirect나 alias route는 가능하면 기존 대표 화면 문서에 흡수하고, 별도 작업면이 있는 화면만 새 문서를 만든다.

--- a/docs/wiki/patch-notes/index.md
+++ b/docs/wiki/patch-notes/index.md
@@ -2,18 +2,60 @@
 
 화면 단위 변경 이력을 누적 관리하는 운영 위키입니다. 코드와 PR 사이에서 "이 페이지에서 최근 무엇이 바뀌었는가"를 빠르게 복기하고, "지금 실제로 되는 기능이 무엇인가"를 체크리스트로 확인하기 위한 문서 계층입니다.
 
-## Seed Pages
+## Admin Pages
 
 | Page | Route | Last Updated | 현재 구현 체크포인트 |
 | --- | --- | --- | --- |
+| [admin-dashboard](./pages/admin-dashboard.md) | `/` | 2026-04-14 | 운영 현황 요약, 주요 작업면 이동 |
+| [admin-project-list](./pages/admin-project-list.md) | `/projects` | 2026-04-14 | 사업 목록, 탭 필터, 상세/수정 이동 |
+| [admin-project-migration-audit](./pages/admin-project-migration-audit.md) | `/projects/migration-audit` | 2026-04-14 | 이관 큐, 상태 점검, 예외 대상 확인 |
+| [admin-project-detail](./pages/admin-project-detail.md) | `/projects/:projectId` | 2026-04-14 | 사업 상세, 수정 이동, 연결 작업면 진입 |
+| [admin-project-wizard](./pages/admin-project-wizard.md) | `/projects/new`, `/projects/:projectId/edit` | 2026-04-14 | 사업 생성/수정 wizard |
+| [admin-ledger-detail](./pages/admin-ledger-detail.md) | `/projects/:projectId/ledgers/:ledgerId` | 2026-04-14 | 원장 상세, 탭 전환 |
+| [admin-cashflow-export](./pages/admin-cashflow-export.md) | `/cashflow`, `/cashflow/projects` | 2026-04-14 | 사업별/전체 추출, 정산 기준 필터, projection-only export |
+| [admin-cashflow-project-sheet](./pages/admin-cashflow-project-sheet.md) | `/cashflow/projects/:projectId` | 2026-04-14 | compare mode, close 흐름, 주간 snapshot 해석 |
+| [admin-evidence-queue](./pages/admin-evidence-queue.md) | `/evidence` | 2026-04-14 | 증빙 큐, 상태 전환, 후속 처리 |
+| [admin-bank-reconciliation](./pages/admin-bank-reconciliation.md) | `/bank-reconciliation` | 2026-04-14 | 자동매칭/미매칭 검토, 개별 행 정리 |
+| [admin-participation](./pages/admin-participation.md) | `/participation` | 2026-04-14 | 참여인력 현황, 투입률, 편집 dialog |
+| [admin-koica-personnel](./pages/admin-koica-personnel.md) | `/koica-personnel` | 2026-04-14 | KOICA 전용 인력 관리 |
+| [admin-personnel-changes](./pages/admin-personnel-changes.md) | `/personnel-changes` | 2026-04-14 | 인력변경 요청, 문서 미리보기 |
+| [admin-budget-summary](./pages/admin-budget-summary.md) | `/budget-summary` | 2026-04-14 | 예산 요약, 관련 액션 |
+| [admin-expense-management](./pages/admin-expense-management.md) | `/expense-management` | 2026-04-14 | 사업비 관리 세트, 기간/메타데이터 관리 |
+| [admin-payroll](./pages/admin-payroll.md) | `/payroll` | 2026-04-14 | 급여 상태, 확인/마감 액션 |
+| [admin-approvals](./pages/admin-approvals.md) | `/approvals` | 2026-04-14 | 승인 대기 단일 surface |
+| [admin-users-auth-governance](./pages/admin-users-auth-governance.md) | `/users` | 2026-04-14 | drift 확인, deep sync, auth/member 정렬 운영 |
+| [admin-hr-announcements](./pages/admin-hr-announcements.md) | `/hr-announcements` | 2026-04-14 | 사내 공지 등록/수정 |
+| [admin-training-manage](./pages/admin-training-manage.md) | `/training` | 2026-04-14 | 교육 과정 등록/관리 |
+| [admin-audit-log](./pages/admin-audit-log.md) | `/audit` | 2026-04-14 | 감사 로그 조회, CSV export |
+| [admin-settings](./pages/admin-settings.md) | `/settings` | 2026-04-14 | 조직/구성원/템플릿/이관/권한 탭 |
+
+## Shared Pages
+
+| Page | Route | Last Updated | 현재 구현 체크포인트 |
+| --- | --- | --- | --- |
+| [shared-board-feed](./pages/shared-board-feed.md) | `/board`, `/portal/board` | 2026-04-14 | 정렬, 검색, 필터, 새 글 작성 |
+| [shared-board-post](./pages/shared-board-post.md) | `/board/:postId`, `/portal/board/:postId` | 2026-04-14 | 게시글 상세, 댓글, 반응, 수정/삭제 |
+
+## Portal Pages
+
+| Page | Route | Last Updated | 현재 구현 체크포인트 |
+| --- | --- | --- | --- |
+| [portal-dashboard](./pages/portal-dashboard.md) | `/portal` | 2026-04-14 | 내 사업 상태, 공지, 빠른 이동 |
+| [portal-onboarding](./pages/portal-onboarding.md) | `/portal/onboarding` | 2026-04-14 | 내 사업 선택, 초기 연결 |
+| [portal-project-settings](./pages/portal-project-settings.md) | `/portal/project-settings` | 2026-04-14 | 사업 설정/연결 정보 확인 |
+| [portal-submissions](./pages/portal-submissions.md) | `/portal/submissions` | 2026-04-14 | 수요일 기준 작성 여부, projection 수정 기준 표시 |
+| [portal-payroll](./pages/portal-payroll.md) | `/portal/payroll` | 2026-04-14 | 급여 상태, 확인/마감 인정 |
+| [portal-cashflow](./pages/portal-cashflow.md) | `/portal/cashflow` | 2026-04-14 | 포털 캐시플로 확인, 시트 import 보조 |
+| [portal-budget](./pages/portal-budget.md) | `/portal/budget` | 2026-04-14 | 가져오기 미리보기, 긴 모달 스크롤, 구조 저장 보호 |
 | [portal-weekly-expense](./pages/portal-weekly-expense.md) | `/portal/weekly-expenses` | 2026-04-14 | 기준본에서 이어쓰기, 저장 상태 구분, overwrite/backspace 복구 |
 | [portal-bank-statement](./pages/portal-bank-statement.md) | `/portal/bank-statements` | 2026-04-14 | 원본 업로드, intake queue 정리, 사업비 입력으로 이어가기 |
-| [portal-budget](./pages/portal-budget.md) | `/portal/budget` | 2026-04-14 | 가져오기 미리보기, 긴 모달 스크롤, 구조 저장 보호 |
+| [portal-personnel](./pages/portal-personnel.md) | `/portal/personnel` | 2026-04-14 | 인력 현황, 변경 요청 이동 |
+| [portal-change-requests](./pages/portal-change-requests.md) | `/portal/change-requests` | 2026-04-14 | 변경 요청 목록, 새 요청 생성 |
 | [portal-register-project](./pages/portal-register-project.md) | `/portal/register-project` | 2026-04-14 | 직접입력형 자금 흐름, 초안 저장, 계약 예외 처리 |
-| [portal-submissions](./pages/portal-submissions.md) | `/portal/submissions` | 2026-04-14 | 수요일 기준 작성 여부, projection 수정 기준 표시 |
-| [admin-cashflow-export](./pages/admin-cashflow-export.md) | `/cashflow` | 2026-04-14 | 사업별/전체 추출, 정산 기준 필터, projection-only export |
-| [admin-cashflow-project-sheet](./pages/admin-cashflow-project-sheet.md) | `/cashflow/projects/:projectId` | 2026-04-14 | compare mode, close 흐름, 주간 snapshot 해석 |
-| [admin-users-auth-governance](./pages/admin-users-auth-governance.md) | `/users` | 2026-04-14 | drift 확인, deep sync, auth/member 정렬 운영 |
+| [portal-project-edit](./pages/portal-project-edit.md) | `/portal/edit-project` | 2026-04-14 | 포털 자기 사업 수정 |
+| [portal-training](./pages/portal-training.md) | `/portal/training` | 2026-04-14 | 교육 목록, 탭 전환 |
+| [portal-career-profile](./pages/portal-career-profile.md) | `/portal/career-profile` | 2026-04-14 | 경력 프로필 조회/편집 |
+| [portal-guide-chat](./pages/portal-guide-chat.md) | `/portal/guide-chat` | 2026-04-14 | 가이드형 도움말 대화 |
 
 ## How To Use
 
@@ -23,6 +65,9 @@
 
 ## High Attention
 
+- [admin-project-list](./pages/admin-project-list.md)
+- [admin-approvals](./pages/admin-approvals.md)
+- [admin-settings](./pages/admin-settings.md)
 - [portal-weekly-expense](./pages/portal-weekly-expense.md)
 - [portal-budget](./pages/portal-budget.md)
 - [portal-bank-statement](./pages/portal-bank-statement.md)

--- a/docs/wiki/patch-notes/log.md
+++ b/docs/wiki/patch-notes/log.md
@@ -38,3 +38,7 @@
 - pages: [portal-submissions](./pages/portal-submissions.md)
 - commits: `afc2098`
 - summary: 이번주 작성 여부와 최근 업데이트(Projection) 기준을 화면에서 더 명확하게 읽히도록 정리했다.
+
+## [2026-04-14] patch-note | patch-notes-wiki | 라우트 전반 문서 커버리지 확장
+- pages: admin/portal 주요 운영 화면 전체
+- summary: seed 8개를 넘어서 현재 실제 라우트에 연결된 운영 화면을 거의 전부 체크리스트 문서로 확장했다.

--- a/docs/wiki/patch-notes/pages/admin-approvals.md
+++ b/docs/wiki/patch-notes/pages/admin-approvals.md
@@ -1,0 +1,52 @@
+# Admin Approvals
+
+- route: `/approvals`
+- primary users: admin
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+사업비 승인 대기와 인력변경 승인 대기를 한 화면에서 처리하는 단일 승인 surface다.
+
+## Current UX Summary
+
+- 승인 대기 항목을 카드/섹션으로 본다.
+- 처리 이력보다는 현재 대기 건 처리에 집중한다.
+
+## Current Feature Checklist
+
+- [x] 승인 대기 항목 확인 가능
+- [x] 프로젝트 요청 승인 섹션 확인 가능
+- [x] 사업비 승인 대기 검토 가능
+- [x] 인력변경 승인 대기 검토 가능
+- [x] 승인/반려 코멘트 입력 가능
+- [x] 관련 프로젝트/인력변경 화면으로 이동 가능
+- [x] 대기건수 KPI 확인 가능
+- [x] 단일 운영 surface로 사용 가능
+- [x] 별도 처리 이력 탭 없이 현재 처리 중심 구조 유지
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+- [2026-04-09] approvals surface trim 이후 단일 운영면으로 정리됐다.
+
+## Known Notes
+
+- 최근 운영 정리에서 history 탭을 빼고 현재 대기 처리 중심으로 정리됐다.
+
+## Related Files
+
+- `src/app/components/approval/AdminApprovalPage.tsx`
+
+## Related Tests
+
+- `tests/e2e/admin-ops-surface.spec.ts`
+
+## Related QA / Ops Context
+
+- 승인 surface 단순화는 운영 밀도와 직접 연결된다.
+
+## Next Watch Points
+
+- 승인 대기 중심 구조가 다시 복잡한 다중 탭 구조로 회귀하지 않는지

--- a/docs/wiki/patch-notes/pages/admin-audit-log.md
+++ b/docs/wiki/patch-notes/pages/admin-audit-log.md
@@ -1,0 +1,50 @@
+# Admin Audit Log
+
+- route: `/audit`
+- primary users: admin, 감사/운영 담당자
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+감사 로그를 조회하고 필요 시 CSV로 내보내는 관리자 화면이다.
+
+## Current UX Summary
+
+- 로그 목록과 필터를 통해 이벤트를 본다.
+- CSV export 버튼으로 내보낼 수 있다.
+
+## Current Feature Checklist
+
+- [x] 감사 로그 조회 가능
+- [x] 검색 가능
+- [x] 액션 필터 가능
+- [x] 대상 필터 가능
+- [x] 날짜별 timeline 확인 가능
+- [x] CSV export 가능
+- [x] 운영 감사 추적 화면으로 사용 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+- [2026-03-18] audit log CSV export가 추가됐다.
+
+## Known Notes
+
+- 권한/정산/설정 변경 추적 시 같이 보는 화면이다.
+
+## Related Files
+
+- `src/app/components/audit/AuditLogPage.tsx`
+
+## Related Tests
+
+- 현재 감사 로그 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 운영 변화의 근거를 사후 확인할 때 보는 관리자 문서다.
+
+## Next Watch Points
+
+- CSV export와 필터 결과가 계속 맞는지

--- a/docs/wiki/patch-notes/pages/admin-bank-reconciliation.md
+++ b/docs/wiki/patch-notes/pages/admin-bank-reconciliation.md
@@ -1,0 +1,50 @@
+# Admin Bank Reconciliation
+
+- route: `/bank-reconciliation`
+- primary users: admin, finance
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+은행 내역과 시스템 정산 데이터를 대사하고, 미매칭 항목을 정리하는 관리자 화면이다.
+
+## Current UX Summary
+
+- 업로드한 내역을 기준으로 자동 매칭/미매칭 상태를 본다.
+- 개별 행을 검토하고 정리한다.
+
+## Current Feature Checklist
+
+- [x] 통장내역 업로드 가능
+- [x] 프로젝트/상태 필터 가능
+- [x] 매칭 KPI 확인 가능
+- [x] 미매칭 항목 검토 가능
+- [x] 개별 행 정리 가능
+- [x] 대조 상태별 목록 확인 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+- [2026-03-26] 업로드 후 행 삭제 버튼이 추가됐다.
+
+## Known Notes
+
+- 변경 이력은 상대적으로 적지만 독립 운영면으로 가치가 높다.
+
+## Related Files
+
+- `src/app/components/cashflow/BankReconciliationPage.tsx`
+
+## Related Tests
+
+- `src/app/platform/bank-reconciliation.test.ts`
+- `src/app/platform/bank-import-cashflow.test.ts`
+
+## Related QA / Ops Context
+
+- 은행 원본과 캐시플로/정산 결과가 맞지 않을 때 보는 관리자용 확인면이다.
+
+## Next Watch Points
+
+- 업로드 후 개별 행 정리 동작이 계속 유지되는지

--- a/docs/wiki/patch-notes/pages/admin-budget-summary.md
+++ b/docs/wiki/patch-notes/pages/admin-budget-summary.md
@@ -1,0 +1,50 @@
+# Admin Budget Summary
+
+- route: `/budget-summary`
+- primary users: admin, finance
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+예산 전체 현황을 요약해 보고, 관련 가져오기/비교/정리 작업으로 이어지는 관리자 화면이다.
+
+## Current UX Summary
+
+- 예산 요약 카드와 표를 본다.
+- 관련 가져오기/비교 작업으로 이동한다.
+
+## Current Feature Checklist
+
+- [x] KPI 카드 확인 가능
+- [x] 메타 영역 확인 가능
+- [x] 예산 테이블 탐색 가능
+- [x] 예산 구성 분석 확인 가능
+- [x] 업데이트 기록 확인 가능
+- [x] 행 상세 dialog 열기 가능
+- [x] 예산 정리 작업의 관리자 진입면으로 사용 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+- [2026-03-26] 메타 영역과 basis 표시 표현이 정리됐다.
+
+## Known Notes
+
+- portal budget과 달리 관리자 관점의 요약 면이다.
+
+## Related Files
+
+- `src/app/components/budget/BudgetSummaryPage.tsx`
+
+## Related Tests
+
+- 현재 예산 요약 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 예산총괄, 구조관리, 가져오기 관련 운영 흐름과 연결된다.
+
+## Next Watch Points
+
+- portal budget과 관리자 예산 요약의 역할 경계가 계속 분명한지

--- a/docs/wiki/patch-notes/pages/admin-dashboard.md
+++ b/docs/wiki/patch-notes/pages/admin-dashboard.md
@@ -1,0 +1,50 @@
+# Admin Dashboard
+
+- route: `/`
+- primary users: admin, finance, 운영 리더
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+관리자 공간의 첫 진입 화면으로, 전반적인 운영 상태를 요약하고 주요 작업면으로 이동시키는 허브다.
+
+## Current UX Summary
+
+- 핵심 상태 카드와 검증/안내 패널을 한 화면에서 본다.
+- 프로젝트, 승인, 정산, 설정 같은 주요 작업면으로 빠르게 이동한다.
+
+## Current Feature Checklist
+
+- [x] 전반적인 운영 현황 요약 확인 가능
+- [x] 주요 작업면으로 빠른 이동 가능
+- [x] 승인/증빙/반려/캐시플로/참여율 alert strip 확인 가능
+- [x] HR 알림 패널 확인 가능
+- [x] 인건비 notice 및 liquidity risk surface 확인 가능
+- [x] validation summary 확인 가능
+- [x] 관리자 첫 진입 허브로 사용 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+- [2026-04-06] payroll liquidity risk surface와 guided onboarding 계열 연결이 강화됐다.
+
+## Known Notes
+
+- 이 문서는 개별 기능보다는 운영 허브 성격이 강하다.
+
+## Related Files
+
+- `src/app/components/dashboard/DashboardPage.tsx`
+
+## Related Tests
+
+- 현재 대시보드 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 여러 운영 화면으로 퍼지는 허브라 링크 구조가 바뀌면 다른 화면 문서도 같이 봐야 한다.
+
+## Next Watch Points
+
+- 대시보드 링크와 실제 라우트 연결이 계속 맞는지

--- a/docs/wiki/patch-notes/pages/admin-evidence-queue.md
+++ b/docs/wiki/patch-notes/pages/admin-evidence-queue.md
@@ -1,0 +1,50 @@
+# Admin Evidence Queue
+
+- route: `/evidence`
+- primary users: admin, 증빙 운영 담당자
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+증빙 큐를 보고 대기 상태, 연결 상태, 처리 우선순위를 운영하는 관리자 화면이다.
+
+## Current UX Summary
+
+- 탭 기반으로 증빙 큐를 나눠 본다.
+- 증빙 검토와 후속 조치를 위한 운영 화면으로 사용한다.
+
+## Current Feature Checklist
+
+- [x] 증빙 미완료/승인대기/반려 탭 전환 가능
+- [x] 프로젝트 필터 가능
+- [x] 거래처/프로젝트 검색 가능
+- [x] 누락 증빙 항목 확인 가능
+- [x] Drive 링크 열기 가능
+- [x] row에서 원장 상세 이동 가능
+- [x] 증빙 대기/검토 흐름 운영 가능
+- [x] 정산/사업비 입력 후속 처리와 연결 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+
+## Known Notes
+
+- 증빙 큐는 portal 주간 입력과 강하게 연결된다.
+
+## Related Files
+
+- `src/app/components/evidence/EvidenceQueuePage.tsx`
+
+## Related Tests
+
+- 현재 증빙 큐 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 증빙/드라이브 관련 QA 이슈와 함께 보아야 한다.
+
+## Next Watch Points
+
+- 큐 상태 용어가 portal 쪽 표현과 어긋나지 않는지

--- a/docs/wiki/patch-notes/pages/admin-expense-management.md
+++ b/docs/wiki/patch-notes/pages/admin-expense-management.md
@@ -1,0 +1,50 @@
+# Admin Expense Management
+
+- route: `/expense-management`
+- primary users: admin, finance
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+사업비 세트와 기간, 운영용 정산 묶음을 관리하는 관리자 화면이다.
+
+## Current UX Summary
+
+- 관리 세트 목록을 보고 새 세트를 만든다.
+- 기간과 제목 같은 운영 메타데이터를 관리한다.
+
+## Current Feature Checklist
+
+- [x] 세트 검색/상태/프로젝트 필터 가능
+- [x] 새 관리 세트 생성 가능
+- [x] 항목 추가/수정 dialog 사용 가능
+- [x] 제출/승인/반려 상태 처리 가능
+- [x] 반려 사유 입력 가능
+- [x] 카드/현금 등 지급수단 표시 확인 가능
+- [x] 제목/기간 등 운영 메타데이터 관리 가능
+- [x] 관리자 관점의 사업비 운영 화면으로 사용 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+
+## Known Notes
+
+- portal weekly expense와 달리 관리 단위 자체를 만드는 화면이다.
+
+## Related Files
+
+- `src/app/components/expense/ExpenseManagementPage.tsx`
+
+## Related Tests
+
+- 현재 사업비 관리 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 사업비 입력 구조와 묶음 설계가 바뀌면 영향을 받는다.
+
+## Next Watch Points
+
+- 세트 생성/편집 메타데이터가 실제 운영 화면과 계속 일치하는지

--- a/docs/wiki/patch-notes/pages/admin-hr-announcements.md
+++ b/docs/wiki/patch-notes/pages/admin-hr-announcements.md
@@ -1,0 +1,50 @@
+# Admin HR Announcements
+
+- route: `/hr-announcements`
+- primary users: admin, HR 운영 담당자
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+사내 공지를 등록, 수정, 게시하는 관리자 화면이다.
+
+## Current UX Summary
+
+- 공지 목록을 보고 새 공지를 작성한다.
+- 버튼과 dialog를 통해 공지 작업을 수행한다.
+
+## Current Feature Checklist
+
+- [x] 공지 목록 확인 가능
+- [x] 새 공지 작성 가능
+- [x] 직원 선택과 일정/내용 입력 가능
+- [x] 공지별 alert 목록 확인 가능
+- [x] 미확인 alert acknowledge 가능
+- [x] change request 생성 상태 확인 가능
+- [x] resolved 처리 가능
+- [x] HR 운영 공지 surface로 사용 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+
+## Known Notes
+
+- 포털 대시보드에서 보는 공지와 관리면 역할이 다르다.
+
+## Related Files
+
+- `src/app/components/hr/AdminHrAnnouncementPage.tsx`
+
+## Related Tests
+
+- 현재 HR 공지 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 전사 공지 운영 변경이 있으면 함께 보는 관리자 문서다.
+
+## Next Watch Points
+
+- 공지 생성/수정 dialog 흐름이 계속 유지되는지

--- a/docs/wiki/patch-notes/pages/admin-koica-personnel.md
+++ b/docs/wiki/patch-notes/pages/admin-koica-personnel.md
@@ -1,0 +1,49 @@
+# Admin Koica Personnel
+
+- route: `/koica-personnel`
+- primary users: admin, KOICA 인력 관리 담당자
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+KOICA 전용 인력 데이터를 관리하고 상태/문서를 검토하는 관리자 화면이다.
+
+## Current UX Summary
+
+- 카드와 탭 기반으로 KOICA 인력 현황을 본다.
+- 프로젝트 특화 인력 관리 흐름을 다룬다.
+
+## Current Feature Checklist
+
+- [x] project/person 탭 전환 가능
+- [x] 이름/사업 검색 가능
+- [x] 등급별 소계 확인 가능
+- [x] 현행/변경 인력 비교 가능
+- [x] 실급여 입력 가능
+- [x] 비용 차이 KPI 확인 가능
+- [x] 관리자 전용 인력 운영 화면으로 사용 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+
+## Known Notes
+
+- 일반 participation과 달리 KOICA 전용 구조를 가진다.
+
+## Related Files
+
+- `src/app/components/koica/KoicaPersonnelPage.tsx`
+
+## Related Tests
+
+- 현재 KOICA 인력 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- KOICA 전용 인력 운영 요구가 있을 때 함께 참고하는 문서다.
+
+## Next Watch Points
+
+- KOICA 전용 항목과 일반 인력 관리 정책이 섞이지 않는지

--- a/docs/wiki/patch-notes/pages/admin-ledger-detail.md
+++ b/docs/wiki/patch-notes/pages/admin-ledger-detail.md
@@ -1,0 +1,49 @@
+# Admin Ledger Detail
+
+- route: `/projects/:projectId/ledgers/:ledgerId`
+- primary users: admin, finance
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+개별 원장 상세를 보고 탭별로 정산 관련 데이터를 검토하는 관리자 화면이다.
+
+## Current UX Summary
+
+- 원장 수준의 상세 데이터를 본다.
+- 탭 전환으로 관련 정보 묶음을 분리해서 확인한다.
+
+## Current Feature Checklist
+
+- [x] 거래 KPI 카드 확인 가능
+- [x] 거래처/메모 검색 가능
+- [x] 거래 추가 dialog 사용 가능
+- [x] 제출/승인/반려 상태 처리 가능
+- [x] 상세 side panel 확인 가능
+- [x] 메모/코멘트 기록 가능
+- [x] 프로젝트 단위 정산 문맥에서 원장 검토 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+
+## Known Notes
+
+- 원장 상세는 캐시플로/예산/증빙 흐름의 하위 작업면이다.
+
+## Related Files
+
+- `src/app/components/ledgers/LedgerDetailPage.tsx`
+
+## Related Tests
+
+- 현재 원장 상세 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 세부 원장 오류나 정산 검토 이슈가 들어오면 함께 확인해야 하는 화면이다.
+
+## Next Watch Points
+
+- 원장 탭 구조가 실제 정산 운영 흐름과 맞는지

--- a/docs/wiki/patch-notes/pages/admin-participation.md
+++ b/docs/wiki/patch-notes/pages/admin-participation.md
@@ -1,0 +1,49 @@
+# Admin Participation
+
+- route: `/participation`
+- primary users: admin, 인력 투입률 관리 담당자
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+참여인력과 투입률을 보고 편집하고, 관련 운영 정책을 반영하는 관리자 화면이다.
+
+## Current UX Summary
+
+- 탭과 카드 기반으로 참여인력 현황을 본다.
+- 참여인력 추가/수정 관련 dialog를 사용한다.
+
+## Current Feature Checklist
+
+- [x] KPI와 danger/warning 카드 확인 가능
+- [x] 인원별/사업별/교차검증 탭 전환 가능
+- [x] 이름/사업 검색 가능
+- [x] 멤버 상세 dialog 확인 가능
+- [x] 위험 리포트 다운로드 가능
+- [x] 과투입 경고 확인 가능
+- [x] 프로젝트 운영 기준으로 인력 배치 관리 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+
+## Known Notes
+
+- 사업 등록과 personnel-change 흐름과 함께 보는 경우가 많다.
+
+## Related Files
+
+- `src/app/components/participation/ParticipationPage.tsx`
+
+## Related Tests
+
+- 현재 참여인력 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 참여인력/인력투입률 관련 운영 요청이 들어올 때 기준 화면이다.
+
+## Next Watch Points
+
+- 참여인력 편집 dialog와 목록 상태가 계속 일치하는지

--- a/docs/wiki/patch-notes/pages/admin-payroll.md
+++ b/docs/wiki/patch-notes/pages/admin-payroll.md
@@ -1,0 +1,49 @@
+# Admin Payroll
+
+- route: `/payroll`
+- primary users: admin, finance, 급여 운영 담당자
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+급여 관련 운영 상태를 보고 확인/마감 조치를 수행하는 관리자 화면이다.
+
+## Current UX Summary
+
+- PageHeader와 카드, 탭으로 급여 상태를 본다.
+- 확인/인정/마감 액션을 버튼으로 수행한다.
+
+## Current Feature Checklist
+
+- [x] payroll/monthly 탭 전환 가능
+- [x] 유동성 위험 queue 확인 가능
+- [x] 프로젝트별 인건비 상태 확인 가능
+- [x] 인건비 사용내역 dialog 열기 가능
+- [x] 지급 확정 처리 가능
+- [x] 월간 정산 완료 처리 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+- [2026-04-06] liquidity risk queue가 추가됐다.
+
+## Known Notes
+
+- portal payroll과 비슷한 도메인이지만 관리자 승인/운영 조치가 중심이다.
+
+## Related Files
+
+- `src/app/components/payroll/AdminPayrollPage.tsx`
+
+## Related Tests
+
+- 현재 관리자 급여 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 월 마감/급여 확인 요청이 들어오면 portal 쪽과 같이 본다.
+
+## Next Watch Points
+
+- 급여 확인과 월 마감 액션이 실제 운영 정책과 계속 맞는지

--- a/docs/wiki/patch-notes/pages/admin-personnel-changes.md
+++ b/docs/wiki/patch-notes/pages/admin-personnel-changes.md
@@ -1,0 +1,50 @@
+# Admin Personnel Changes
+
+- route: `/personnel-changes`
+- primary users: admin, 인사 변경 검토 담당자
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+인력변경 요청과 관련 문서를 검토하고 승인 전 확인을 수행하는 관리자 화면이다.
+
+## Current UX Summary
+
+- 문서 미리보기와 버튼 액션이 함께 제공된다.
+- 요청 건을 보면서 증빙/첨부를 검토한다.
+
+## Current Feature Checklist
+
+- [x] 인력변경 요청 검색 가능
+- [x] before/after 비교 가능
+- [x] 첨부 문서 미리보기 가능
+- [x] 첨부 문서 다운로드 가능
+- [x] 승인/반려/수정요청 가능
+- [x] 미제출 서류 KPI 확인 가능
+- [x] 관련 사업 링크 확인 가능
+- [x] 인사 운영 검토 화면으로 사용 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+
+## Known Notes
+
+- approvals와 가까운 화면이지만 문서 검토 깊이가 더 크다.
+
+## Related Files
+
+- `src/app/components/koica/PersonnelChangePage.tsx`
+
+## Related Tests
+
+- 현재 인력변경 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 인력변경 승인 대기 운영 흐름과 함께 본다.
+
+## Next Watch Points
+
+- 문서 미리보기 조작과 승인 흐름이 계속 안정적인지

--- a/docs/wiki/patch-notes/pages/admin-project-detail.md
+++ b/docs/wiki/patch-notes/pages/admin-project-detail.md
@@ -1,0 +1,52 @@
+# Admin Project Detail
+
+- route: `/projects/:projectId`
+- primary users: admin, finance, 프로젝트 운영 담당자
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+개별 사업의 기본 정보, 운영 상태, 연결된 작업면 진입을 확인하는 상세 화면이다.
+
+## Current UX Summary
+
+- 사업 핵심 메타데이터를 요약해서 본다.
+- 목록으로 돌아가거나 수정 화면으로 이동한다.
+- 연결된 정산/원장 흐름으로 이어진다.
+
+## Current Feature Checklist
+
+- [x] 사업 핵심 정보 카드 확인 가능
+- [x] 목록으로 복귀 가능
+- [x] 수정 화면 진입 가능
+- [x] 시작/종료 상태 변경 가능
+- [x] 휴지통 이동/복구 가능
+- [x] 원장 목록 확인 가능
+- [x] 원장 생성 dialog 사용 가능
+- [x] 원장 상세 이동 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+- [2026-04-09] admin project surface trim 이후 상세 운영 흐름이 정리됐다.
+
+## Known Notes
+
+- 상세 화면은 자체 입력보다 다른 작업면으로 이동시키는 역할이 크다.
+
+## Related Files
+
+- `src/app/components/projects/ProjectDetailPage.tsx`
+
+## Related Tests
+
+- 현재 상세 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 프로젝트명/기관명/재무 정보 변경 이슈가 들어오면 상세와 수정 화면을 같이 봐야 한다.
+
+## Next Watch Points
+
+- 상세 화면에서 제공하는 링크가 실제 후속 작업면과 맞는지

--- a/docs/wiki/patch-notes/pages/admin-project-list.md
+++ b/docs/wiki/patch-notes/pages/admin-project-list.md
@@ -1,0 +1,51 @@
+# Admin Project List
+
+- route: `/projects`
+- primary users: admin, finance, 운영 담당자
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+사업 목록을 상태별로 보고, 검색/필터링하고, 상세나 수정 화면으로 들어가는 관리자용 목록 화면이다.
+
+## Current UX Summary
+
+- 탭별로 사업 상태를 나눠 본다.
+- 검색 조건과 필터를 조합해 원하는 사업을 찾는다.
+- 상세 보기나 수정으로 이동한다.
+
+## Current Feature Checklist
+
+- [x] 사업 목록 조회 가능
+- [x] 확정/예정/휴지통 탭 전환 가능
+- [x] 검색 및 필터 초기화 가능
+- [x] 사업명/발주기관/담당자 검색 가능
+- [x] 사업 상세 이동 가능
+- [x] 사업 수정 진입 가능
+- [x] 휴지통 복구 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+- [2026-04-09] admin project surface trim 이후 목록 중심 운영 흐름이 정리됐다.
+
+## Known Notes
+
+- 신규 사업 생성 진입은 별도 redirect route를 통해 wizard로 연결된다.
+
+## Related Files
+
+- `src/app/components/projects/ProjectListPage.tsx`
+
+## Related Tests
+
+- 현재 목록 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 프로젝트 등록/개설, 계약서 업로드, 배정 관련 QA와 자주 이어진다.
+
+## Next Watch Points
+
+- 필터와 탭 상태가 상세/수정 이동 후에도 사용자 기대와 맞는지

--- a/docs/wiki/patch-notes/pages/admin-project-migration-audit.md
+++ b/docs/wiki/patch-notes/pages/admin-project-migration-audit.md
@@ -1,0 +1,53 @@
+# Admin Project Migration Audit
+
+- route: `/projects/migration-audit`
+- primary users: admin, 데이터 이관 운영자
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+프로젝트 이관 상태를 점검하고 큐를 보며 데이터 이전 작업을 운영하는 감사/정리 화면이다.
+
+## Current UX Summary
+
+- 이관 대상과 상태를 큐 기반으로 본다.
+- 이관 진행 상황과 예외 대상을 분리해서 다룬다.
+
+## Current Feature Checklist
+
+- [x] 이관 대상 큐 확인 가능
+- [x] queue row 검색/필터 가능
+- [x] current-only missing row 식별 가능
+- [x] 기존 프로젝트 연결 가능
+- [x] 새 프로젝트 즉시 생성 후 연결 가능
+- [x] 등록 제안 수정 가능
+- [x] 폐기 후 상태 반영 가능
+- [x] 프로젝트 이관 운영 화면으로 사용 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+- [2026-04-07] current-only missing row 기준이 반영됐다.
+- [2026-04-06] resolve workspace와 migration audit UX가 정리됐다.
+
+## Known Notes
+
+- 일반 운영자보다 이관 작업 시기에만 자주 보는 화면이다.
+
+## Related Files
+
+- `src/app/components/projects/ProjectMigrationAuditPage.tsx`
+- `src/app/components/projects/migration-audit/MigrationAuditQueueRail.tsx`
+
+## Related Tests
+
+- 현재 이관 감사 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 사업 이관 메뉴 복구 요청이 있었던 만큼 라우트 가시성과 메뉴 노출이 중요하다.
+
+## Next Watch Points
+
+- 이관 메뉴가 다시 사라지거나 권한에서 누락되지 않는지

--- a/docs/wiki/patch-notes/pages/admin-project-wizard.md
+++ b/docs/wiki/patch-notes/pages/admin-project-wizard.md
@@ -1,0 +1,51 @@
+# Admin Project Wizard
+
+- route: `/projects/new`, `/projects/:projectId/edit`
+- primary users: admin
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+사업 생성 또는 기존 사업 수정에 필요한 단계형 wizard 화면이다.
+
+## Current UX Summary
+
+- 신규 생성과 수정이 같은 단계형 흐름을 공유한다.
+- 사업 기본 정보, 재무 기준, 운영 설정 값을 단계별로 편집한다.
+
+## Current Feature Checklist
+
+- [x] 신규 사업 생성 가능
+- [x] 기존 사업 수정 가능
+- [x] 기본정보 step 입력 가능
+- [x] 계약/일정 step 입력 가능
+- [x] 통장/정산 step 입력 가능
+- [x] 팀/담당자 step 입력 가능
+- [x] 재무/입금계획 step 입력 가능
+- [x] review 후 저장/확정 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+
+## Known Notes
+
+- `/projects/new`는 별도 redirect를 거치지만 실질 작업면은 이 wizard다.
+
+## Related Files
+
+- `src/app/components/projects/ProjectWizardPage.tsx`
+- `src/app/components/projects/ProjectRegisterRedirectPage.tsx`
+
+## Related Tests
+
+- 현재 wizard 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 사업 등록/수정 정책과 입력 필수값 변경은 wizard 해석에 바로 영향을 준다.
+
+## Next Watch Points
+
+- 신규 생성과 수정 모드의 필드/저장 동작이 계속 일치하는지

--- a/docs/wiki/patch-notes/pages/admin-settings.md
+++ b/docs/wiki/patch-notes/pages/admin-settings.md
@@ -1,0 +1,51 @@
+# Admin Settings
+
+- route: `/settings`
+- primary users: admin
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+조직 정보, 구성원, 원장 템플릿, 데이터 마이그레이션, 권한 설정을 관리하는 관리자 설정 화면이다.
+
+## Current UX Summary
+
+- 탭 기반으로 설정 범주를 나눠 본다.
+- 조직, 구성원, 템플릿, 이관, 권한을 같은 화면에서 다룬다.
+
+## Current Feature Checklist
+
+- [x] 조직 정보 탭 확인 가능
+- [x] 구성원 탭 확인 가능
+- [x] 구성원 요약에서 `/users`로 점프 가능
+- [x] 원장 템플릿 탭 확인 가능
+- [x] 데이터 마이그레이션 탭 확인 가능
+- [x] 권한 설정 탭 확인 가능
+- [x] admin-only 접근 가드 유지
+- [x] 불필요한 Firebase/브랜딩/가이드 탭 제거 상태 유지
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+- [2026-04-09] settings surface trim 이후 운영 탭 위주로 정리됐다.
+
+## Known Notes
+
+- 최근 운영 정리에서 primary surface는 실운영 탭 위주로 축소됐다.
+
+## Related Files
+
+- `src/app/components/settings/SettingsPage.tsx`
+
+## Related Tests
+
+- `tests/e2e/admin-ops-surface.spec.ts`
+
+## Related QA / Ops Context
+
+- 구성원과 권한 설정은 `/users` auth governance 문서와 함께 봐야 한다.
+
+## Next Watch Points
+
+- 설정 탭 구성이 다시 운영 외 탭으로 번지지 않는지

--- a/docs/wiki/patch-notes/pages/admin-training-manage.md
+++ b/docs/wiki/patch-notes/pages/admin-training-manage.md
@@ -1,0 +1,49 @@
+# Admin Training Manage
+
+- route: `/training`
+- primary users: admin, 교육 운영 담당자
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+사내 교육 과정을 등록하고 운영 상태를 관리하는 관리자 화면이다.
+
+## Current UX Summary
+
+- 강의 등록 dialog와 목록 관리가 함께 있다.
+- 교육 운영 상태를 보면서 등록/수정한다.
+
+## Current Feature Checklist
+
+- [x] 강의 검색 가능
+- [x] 강의 등록 가능
+- [x] 기간/강사 validation 확인 가능
+- [x] 교육 현황 KPI 확인 가능
+- [x] 리스트 탐색 가능
+- [x] portal training/career profile과 데이터 일관성 확인 가능
+- [x] 관리자 교육 관리 화면으로 사용 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+
+## Known Notes
+
+- portal training과는 달리 운영자 측 관리 기능이 중심이다.
+
+## Related Files
+
+- `src/app/components/training/TrainingManagePage.tsx`
+
+## Related Tests
+
+- 현재 교육 관리 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 사내 교육 운영 정책이 바뀌면 portal training과 같이 봐야 한다.
+
+## Next Watch Points
+
+- 강의 등록 dialog와 목록 상태가 계속 일치하는지

--- a/docs/wiki/patch-notes/pages/portal-career-profile.md
+++ b/docs/wiki/patch-notes/pages/portal-career-profile.md
@@ -1,0 +1,49 @@
+# Portal Career Profile
+
+- route: `/portal/career-profile`
+- primary users: 포털 사용자
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+사용자 자신의 경력 프로필을 보고 수정하는 화면이다.
+
+## Current UX Summary
+
+- 프로필 기본 정보, 경력, 이력 항목을 편집한다.
+- 편집 모드와 저장 버튼이 분리되어 있다.
+
+## Current Feature Checklist
+
+- [x] 기본정보 편집/저장 가능
+- [x] 학력 추가 가능
+- [x] 직장경력 추가 가능
+- [x] 자격증 추가 가능
+- [x] 프로젝트 참여 이력 조회 가능
+- [x] 사내 교육 이력 탭 확인 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+- [2026-02-24] career profile 페이지가 추가되고 2026-02-25 정합성이 정리됐다.
+
+## Known Notes
+
+- 다른 운영 화면보다 개인 프로필 성격이 강하다.
+
+## Related Files
+
+- `src/app/components/portal/CareerProfilePage.tsx`
+
+## Related Tests
+
+- 현재 경력 프로필 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 포털 자기정보 관리 영역으로 따로 봐야 하는 문서다.
+
+## Next Watch Points
+
+- 편집 모드 전환과 저장 흐름이 계속 안정적인지

--- a/docs/wiki/patch-notes/pages/portal-cashflow.md
+++ b/docs/wiki/patch-notes/pages/portal-cashflow.md
@@ -1,0 +1,49 @@
+# Portal Cashflow
+
+- route: `/portal/cashflow`
+- primary users: PM
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+포털 사용자가 자기 사업의 캐시플로 관련 상태를 보고, 필요한 경우 외부 시트 기반 작업으로 이어가는 화면이다.
+
+## Current UX Summary
+
+- 캐시플로 관련 정보를 본다.
+- Google Sheet import 같은 보조 액션을 사용한다.
+
+## Current Feature Checklist
+
+- [x] 미배정 사업 guard 반영
+- [x] Google Sheets/`xlsx`/`csv` 가져오기 진입 가능
+- [x] compare mode/guide preview 노출 가능
+- [x] projection 시트 편집/저장 가능
+- [x] migration wizard 적용 후 시트 반영 가능
+- [x] PM 관점의 캐시플로 확인면으로 사용 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+- [2026-04-04] compare mode, guide preview, migration entrypoint가 정리됐다.
+
+## Known Notes
+
+- admin cashflow export와는 별개로 PM 관점 확인 면이다.
+
+## Related Files
+
+- `src/app/components/portal/PortalCashflowPage.tsx`
+
+## Related Tests
+
+- 현재 포털 캐시플로 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 주간 actual 반영과 projection 비교 흐름과 문맥이 이어진다.
+
+## Next Watch Points
+
+- 외부 시트 import 보조 동작이 계속 유효한지

--- a/docs/wiki/patch-notes/pages/portal-change-requests.md
+++ b/docs/wiki/patch-notes/pages/portal-change-requests.md
@@ -1,0 +1,50 @@
+# Portal Change Requests
+
+- route: `/portal/change-requests`
+- primary users: PM
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+포털 사용자가 인력변경 등 요청을 만들고 상태를 확인하는 화면이다.
+
+## Current UX Summary
+
+- 요청 목록과 alert를 본다.
+- dialog를 통해 새 요청을 만든다.
+
+## Current Feature Checklist
+
+- [x] 새 인력변경 요청 draft 생성 가능
+- [x] HR 알림에서 바로 요청 시작 가능
+- [x] 알림 확인/닫기/다시보기 가능
+- [x] 상태 KPI 확인 가능
+- [x] 요청 제출 confirm 가능
+- [x] 상세 timeline 확인 가능
+- [x] 프로젝트 설정/인력 화면과 연결 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+- [2026-02-25] auth/project selection flow 반영으로 안정성이 보강됐다.
+
+## Known Notes
+
+- 인력 알림과 요청 생성이 같이 묶여 있다.
+
+## Related Files
+
+- `src/app/components/portal/PortalChangeRequests.tsx`
+
+## Related Tests
+
+- 현재 변경 요청 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 인력변경 운영 요청이 들어오면 portal과 admin personnel-changes를 같이 봐야 한다.
+
+## Next Watch Points
+
+- 요청 생성 dialog와 alert 흐름이 계속 맞는지

--- a/docs/wiki/patch-notes/pages/portal-dashboard.md
+++ b/docs/wiki/patch-notes/pages/portal-dashboard.md
@@ -1,0 +1,48 @@
+# Portal Dashboard
+
+- route: `/portal`
+- primary users: PM, 포털 사용자
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+포털 첫 진입 화면으로, 내 사업 상태와 공지, 다음 작업으로의 이동을 안내하는 허브다.
+
+## Current UX Summary
+
+- 연결된 사업 상태를 요약한다.
+- 공지와 빠른 이동 버튼으로 다음 작업을 안내한다.
+
+## Current Feature Checklist
+
+- [x] 사업 미배정 empty state 확인 가능
+- [x] `/portal/project-settings` 이동 가능
+- [x] 중요 공지에서 인건비/월간정산 확인 처리 가능
+- [x] HR 알림에서 `/portal/change-requests` 이동 가능
+- [x] 인건비 지급 queue 카드에서 상세/통장내역 이동 가능
+- [x] 미션 가이드 모달과 KPI/빠른 액션 사용 가능
+
+## Recent Changes
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+- [2026-04-06] 미션 가이드가 modal flow로 이동했고 payroll liquidity surface가 추가됐다.
+
+## Known Notes
+
+- 사업이 아직 연결되지 않은 사용자에게는 다른 진입 메시지를 보여준다.
+
+## Related Files
+
+- `src/app/components/portal/PortalDashboard.tsx`
+
+## Related Tests
+
+- 현재 포털 대시보드 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 포털 첫 진입 UX가 바뀌면 onboarding과 project-settings도 같이 봐야 한다.
+
+## Next Watch Points
+
+- 연결 전/후 상태별 안내가 계속 적절한지

--- a/docs/wiki/patch-notes/pages/portal-guide-chat.md
+++ b/docs/wiki/patch-notes/pages/portal-guide-chat.md
@@ -1,0 +1,49 @@
+# Portal Guide Chat
+
+- route: `/portal/guide-chat`
+- primary users: 포털 사용자
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+포털 사용자가 가이드형 질문/답변 인터페이스를 통해 도움을 받는 화면이다.
+
+## Current UX Summary
+
+- PageHeader 아래에서 가이드 대화 흐름을 제공한다.
+- 버튼 중심의 대화 시작/재시도/보조 액션이 있다.
+
+## Current Feature Checklist
+
+- [x] BFF 비활성 gate 처리 가능
+- [x] 가이드 미등록/캘리브레이션 중 gate 처리 가능
+- [x] 현재 가이드 제목 노출 가능
+- [x] 질문 전송과 Enter 제출 가능
+- [x] Q&A history 로드 가능
+- [x] 응답 생성 중/오류 메시지 처리 가능
+- [x] 포털 self-serve 지원 화면으로 사용 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+
+## Known Notes
+
+- 일반 운영 입력 화면보다 보조 안내 성격이 강하다.
+
+## Related Files
+
+- `src/app/components/guide-chat/GuideChatPage.tsx`
+
+## Related Tests
+
+- 현재 guide chat 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 사용자가 어디서 막히는지 파악할 때 보조적으로 참고할 수 있다.
+
+## Next Watch Points
+
+- 안내 문구와 실제 포털 흐름이 계속 어긋나지 않는지

--- a/docs/wiki/patch-notes/pages/portal-onboarding.md
+++ b/docs/wiki/patch-notes/pages/portal-onboarding.md
@@ -1,0 +1,48 @@
+# Portal Onboarding
+
+- route: `/portal/onboarding`
+- primary users: PM, 신규 포털 사용자
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+내 사업을 선택하고 포털 사용을 시작하는 초기 연결 화면이다.
+
+## Current UX Summary
+
+- 내 사업 선택을 중심으로 구성된다.
+- 선택 후 포털 사용 흐름으로 이어진다.
+
+## Current Feature Checklist
+
+- [x] 로그인/권한 gate 반영
+- [x] 사업 1개 이상 선택 가능
+- [x] 주사업 지정 가능
+- [x] 온보딩 시작 화면으로 사용 가능
+- [x] 저장 후 `/portal` 리다이렉트 가능
+- [x] 사업이 없을 때 `/portal/register-project` 유도 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+
+## Known Notes
+
+- 포털 대시보드와 달리 초기 연결 전용 화면이다.
+
+## Related Files
+
+- `src/app/components/portal/PortalOnboarding.tsx`
+
+## Related Tests
+
+- 현재 온보딩 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 사업 연결이 안 된 사용자 경험과 직접 연결된다.
+
+## Next Watch Points
+
+- 사업 선택 이후 이동 흐름이 끊기지 않는지

--- a/docs/wiki/patch-notes/pages/portal-payroll.md
+++ b/docs/wiki/patch-notes/pages/portal-payroll.md
@@ -1,0 +1,50 @@
+# Portal Payroll
+
+- route: `/portal/payroll`
+- primary users: PM, 급여 확인 담당자
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+포털 사용자가 급여 관련 상태를 확인하고 인정/마감 전 확인 작업을 수행하는 화면이다.
+
+## Current UX Summary
+
+- PageHeader와 카드로 급여 상태를 본다.
+- 급여 확인과 월 마감 인정 액션이 제공된다.
+
+## Current Feature Checklist
+
+- [x] 지급일 등록/저장 가능
+- [x] 지급 창 D-3~D+3 liquidity 상태 확인 가능
+- [x] 잔액 부족/지급 미확인 등 위험 배지 확인 가능
+- [x] 인건비 지급 확인 처리 가능
+- [x] 월간정산 확인 처리 가능
+- [x] 통장내역/주간사업비로 이동 가능
+- [x] 포털 관점 급여 운영 화면으로 사용 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+- [2026-04-06] liquidity risk queue가 포털에도 연결됐다.
+
+## Known Notes
+
+- admin payroll과 같은 도메인이지만 사용자 관점 확인 flow가 중심이다.
+
+## Related Files
+
+- `src/app/components/portal/PortalPayrollPage.tsx`
+
+## Related Tests
+
+- 현재 포털 급여 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 급여 확인과 월 마감 운영 요청에 직접 연결된다.
+
+## Next Watch Points
+
+- 포털과 관리자 급여 화면의 역할 경계가 계속 분명한지

--- a/docs/wiki/patch-notes/pages/portal-personnel.md
+++ b/docs/wiki/patch-notes/pages/portal-personnel.md
@@ -1,0 +1,49 @@
+# Portal Personnel
+
+- route: `/portal/personnel`
+- primary users: PM
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+포털 사용자가 자기 사업의 참여인력 상태를 보고, 변경 요청 흐름으로 이어지는 화면이다.
+
+## Current UX Summary
+
+- 인력 현황을 요약해서 본다.
+- 필요 시 변경 요청 화면으로 이동한다.
+
+## Current Feature Checklist
+
+- [x] 사업 미선택 guard 반영
+- [x] 현재 사업 인력 목록 표시 가능
+- [x] 역할/상태 배지 확인 가능
+- [x] 인력 없음 empty state 확인 가능
+- [x] 프로젝트 설정 화면으로 이동 가능
+- [x] 변경 요청 화면으로 이동 가능
+- [x] 포털 인력 현황 화면으로 사용 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+
+## Known Notes
+
+- 관리자 인력 화면보다 사용자 안내와 요청 연결이 중심이다.
+
+## Related Files
+
+- `src/app/components/portal/PortalPersonnel.tsx`
+
+## Related Tests
+
+- 현재 포털 인력 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- change-requests와 직접 연결되는 문서다.
+
+## Next Watch Points
+
+- 인력 현황과 변경 요청 진입선이 계속 명확한지

--- a/docs/wiki/patch-notes/pages/portal-project-edit.md
+++ b/docs/wiki/patch-notes/pages/portal-project-edit.md
@@ -1,0 +1,49 @@
+# Portal Project Edit
+
+- route: `/portal/edit-project`
+- primary users: PM
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+포털 사용자가 자기 사업 정보를 편집하거나 수정 요청 흐름을 다루는 화면이다.
+
+## Current UX Summary
+
+- 사업 관련 값 편집을 수행한다.
+- 카드와 버튼 중심의 수정 UI를 사용한다.
+
+## Current Feature Checklist
+
+- [x] 기본정보 수정 가능
+- [x] 계약금액/부가세/기간 등 재무정보 수정 가능
+- [x] 정산유형/정산기준/통장유형/자금 입력방식 변경 가능
+- [x] settlement policy 필드 수정 가능
+- [x] 팀 구성 수정 가능
+- [x] BFF 저장 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+- [2026-04-03] direct entry fund workflow과 관련 수정 흐름이 반영됐다.
+
+## Known Notes
+
+- admin wizard와 달리 자기 사업 범위 편집에 가깝다.
+
+## Related Files
+
+- `src/app/components/portal/PortalProjectEdit.tsx`
+
+## Related Tests
+
+- 현재 포털 사업 수정 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 사업 설정/수정 요청 흐름과 함께 본다.
+
+## Next Watch Points
+
+- 포털 자기 사업 수정 권한이 계속 의도대로 제한되는지

--- a/docs/wiki/patch-notes/pages/portal-project-settings.md
+++ b/docs/wiki/patch-notes/pages/portal-project-settings.md
@@ -1,0 +1,51 @@
+# Portal Project Settings
+
+- route: `/portal/project-settings`
+- primary users: PM
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+포털 사용자가 자기 사업 관련 기본 설정과 연결 정보를 확인/조정하는 화면이다.
+
+## Current UX Summary
+
+- 사업 설정 상태를 본다.
+- 다른 포털 화면에서 이 설정 화면으로 이동하는 경우가 많다.
+
+## Current Feature Checklist
+
+- [x] 다중 사업 선택 가능
+- [x] 주사업 지정 가능
+- [x] 최근 사용한 사업 shortcut 사용 가능
+- [x] 검색/상태 필터/선택한 사업만 보기 가능
+- [x] 저장 후 포털 반영 가능
+- [x] 사업별 증빙 Drive 링크 저장 가능
+- [x] 기본 폴더 생성 가능
+- [x] 다른 포털 화면에서 설정 화면으로 이동 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+- [2026-04-04] 최근 사업 shortcut과 배정 검색이 강화됐다.
+
+## Known Notes
+
+- 포털 여러 화면의 fallback 링크 목적지다.
+
+## Related Files
+
+- `src/app/components/portal/PortalProjectSettings.tsx`
+
+## Related Tests
+
+- 현재 프로젝트 설정 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 사업 배정/수정 요청과 함께 읽는 경우가 많다.
+
+## Next Watch Points
+
+- 각 포털 화면에서 이 설정 화면으로 연결되는 경로가 유지되는지

--- a/docs/wiki/patch-notes/pages/portal-training.md
+++ b/docs/wiki/patch-notes/pages/portal-training.md
@@ -1,0 +1,49 @@
+# Portal Training
+
+- route: `/portal/training`
+- primary users: PM, 구성원
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+포털 사용자가 사내 교육 목록을 보고 신청/참여 상태를 확인하는 화면이다.
+
+## Current UX Summary
+
+- 탭 기반으로 전체 강의와 내 강의를 나눠 본다.
+- 강의 카드와 버튼 중심으로 상호작용한다.
+
+## Current Feature Checklist
+
+- [x] 이수 완료/수강 중/개설 강의 KPI 확인 가능
+- [x] 강의 검색 가능
+- [x] 카테고리/필수교육 필터 가능
+- [x] 전체 강의/내 수강 탭 전환 가능
+- [x] 수강 신청 confirm dialog 사용 가능
+- [x] 신청/이수 상태 배지 확인 가능
+- [x] 포털 교육 화면으로 사용 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+
+## Known Notes
+
+- 관리자 교육 관리와 사용자 교육 참여는 별도 문서로 관리한다.
+
+## Related Files
+
+- `src/app/components/portal/PortalTrainingPage.tsx`
+
+## Related Tests
+
+- 현재 포털 교육 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 교육 운영 정책 변화 시 admin training과 같이 본다.
+
+## Next Watch Points
+
+- 탭 구조와 강의 상태 라벨이 계속 분명한지

--- a/docs/wiki/patch-notes/pages/shared-board-feed.md
+++ b/docs/wiki/patch-notes/pages/shared-board-feed.md
@@ -1,0 +1,49 @@
+# Shared Board Feed
+
+- route: `/board`, `/portal/board`
+- primary users: admin, PM, 포털 사용자
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+전사 게시판의 목록 화면으로, 정렬/검색/필터와 새 글 작성을 제공한다.
+
+## Current UX Summary
+
+- HOT, 최신, TOP, 활동 기준으로 정렬한다.
+- 제목, 본문, 태그, 채널 기준 탐색을 지원한다.
+- 목록에서 상세 글로 이동한다.
+
+## Current Feature Checklist
+
+- [x] HOT/최신/TOP/활동 정렬 가능
+- [x] 제목/본문/태그 검색 가능
+- [x] 채널 필터 가능
+- [x] 새 글 작성 dialog 사용 가능
+- [x] 게시글 카드에서 상세 이동 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+
+## Known Notes
+
+- admin와 portal이 같은 게시판 목록 화면을 공유한다.
+
+## Related Files
+
+- `src/app/components/board/BoardFeedPage.tsx`
+- `src/app/data/board-store.tsx`
+
+## Related Tests
+
+- 현재 게시판 목록 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 전사 공지/게시판 운영 정책이 바뀌면 함께 보는 문서다.
+
+## Next Watch Points
+
+- admin와 portal 양쪽 진입에서 게시판 기능이 계속 동일한지

--- a/docs/wiki/patch-notes/pages/shared-board-post.md
+++ b/docs/wiki/patch-notes/pages/shared-board-post.md
@@ -1,0 +1,50 @@
+# Shared Board Post
+
+- route: `/board/:postId`, `/portal/board/:postId`
+- primary users: admin, PM, 포털 사용자
+- status: active
+- last updated: 2026-04-14
+
+## Purpose
+
+게시글 상세를 읽고 반응, 댓글, 수정/삭제 같은 세부 상호작용을 수행하는 화면이다.
+
+## Current UX Summary
+
+- 본문과 메타데이터를 읽는다.
+- 댓글과 답글 상호작용을 지원한다.
+- 본인 글에 한해 수정/삭제를 수행한다.
+
+## Current Feature Checklist
+
+- [x] 게시글 상세 조회 가능
+- [x] 추천/비추천 반응 가능
+- [x] 댓글 작성 가능
+- [x] 답글 작성 가능
+- [x] 본인 글 수정/삭제 가능
+- [x] not found 상태 처리 가능
+
+## Recent Changes
+
+- [2026-04-14] 전체 페이지 문서화 backfill 기준으로 현재 구현 체크리스트를 정리했다.
+
+## Known Notes
+
+- 목록 문서와 달리 CRUD와 반응/댓글 상호작용이 핵심이다.
+
+## Related Files
+
+- `src/app/components/board/BoardPostPage.tsx`
+- `src/app/data/board-store.tsx`
+
+## Related Tests
+
+- 현재 게시글 상세 화면 전용 패치노트 seed 테스트는 없다.
+
+## Related QA / Ops Context
+
+- 게시판 moderation 정책이 생기면 가장 먼저 영향받는 문서다.
+
+## Next Watch Points
+
+- 수정/삭제 권한과 댓글 상호작용이 admin/portal 양쪽에서 계속 일치하는지


### PR DESCRIPTION
## Summary
- expand the patch notes wiki from the initial seed into near-full operational route coverage
- add 32 more page notes across admin, portal, and shared board surfaces
- make checklists denser and more user-facing so non-developers can maintain them by adding/removing items

## What Changed
- admin pages now cover dashboard, projects, migration audit, ledger, evidence, reconciliation, participation, KOICA personnel, personnel changes, budget summary, expense management, payroll, approvals, HR announcements, training, audit, and settings
- portal pages now cover dashboard, onboarding, project settings, payroll, cashflow, personnel, change requests, project edit, training, career profile, and guide chat
- shared board list/detail pages were added for both admin and portal entrypoints

## Why
- the wiki should not stop at 8 seed pages if the goal is to be the operational source of truth for what is actually implemented
- each page note now works as a checklist that business users can edit directly when a capability is added, removed, or changed

## Notes
- docs-only PR
- no runtime code changes
