### PR TITLE
fix: harden pm portal cashflow listener

### DIFF
--- a/docs/wiki/patch-notes/log.md
+++ b/docs/wiki/patch-notes/log.md
@@ -138,3 +138,7 @@
 ## [2026-04-15] patch-note | portal-bank-statement, portal-weekly-expense | direct handoff row projection
 - pages: [portal-bank-statement](./pages/portal-bank-statement.md), [portal-weekly-expense](./pages/portal-weekly-expense.md)
 - summary: 통장내역 저장 시 신규 은행 행을 현재 주간 사업비 탭으로 바로 merge하도록 바꿔, Queue 없이 `통장내역 -> 사업비 입력(주간)` 운영 경로가 실제로 이어지게 복구했다.
+
+## [2026-04-15] patch-note | portal-cashflow, portal-dashboard | PM cashflow listen hardening
+- pages: [portal-cashflow](./pages/portal-cashflow.md), [portal-dashboard](./pages/portal-dashboard.md)
+- summary: PM용 cashflow 주차 구독은 Firestore에서 project 기준으로만 listen하고, 연도 범위는 클라이언트에서 필터링하도록 바꿔 PM 포털 부팅이 cashflow composite index drift에 직접 막히지 않게 보강했다.

--- a/docs/wiki/patch-notes/pages/portal-cashflow.md
+++ b/docs/wiki/patch-notes/pages/portal-cashflow.md
@@ -3,7 +3,7 @@
 - route: `/portal/cashflow`
 - primary users: PM, projection 입력 담당자
 - status: active
-- last updated: 2026-04-14
+- last updated: 2026-04-15
 
 ## Purpose
 
@@ -21,11 +21,13 @@
 - [x] 기존 Google Sheets / `.xlsx` / `.csv` 가져오기 가능
 - [x] 상단 explainer 카드 없이 compact import action 유지
 - [x] 가져오기 이후 주간 제출 상태와 연결 가능
+- [x] PM 포털 부팅 시 cashflow 실시간 구독이 연도 범위 composite index에 직접 의존하지 않음
 - [ ] import wizard 내부 안내 문구 추가 감산 여지 있음
 
 ## Recent Changes
 
 - [2026-04-14] migration 설명 카드와 긴 형식 안내를 제거하고 compact import action만 남겼다.
+- [2026-04-15] PM용 cashflow 주차 구독은 Firestore에서 project 기준으로만 listen하고, 연도 범위는 클라이언트에서 필터링하도록 바꿔 PM 포털 전체가 cashflow index drift에 덜 민감하게 만들었다.
 
 ## Known Notes
 

--- a/docs/wiki/patch-notes/pages/portal-dashboard.md
+++ b/docs/wiki/patch-notes/pages/portal-dashboard.md
@@ -3,7 +3,7 @@
 - route: `/portal`
 - primary users: PM
 - status: active
-- last updated: 2026-04-14
+- last updated: 2026-04-15
 
 ## Purpose
 
@@ -45,6 +45,7 @@
 - [x] 프로젝트 정보와 주간 상태를 첫 화면 한 장의 헤더 슬랩에서 확인 가능
 - [x] 상단에 MYSC 로고만 남기고 부가 workspace 문구는 제거됨
 - [x] 첫 화면에서 중복 바로가기 CTA 없이 상태와 요약 정보 중심으로 확인 가능
+- [x] PM 홈 부팅이 cashflow 주차 listener의 연도 범위 index 상태에 직접 막히지 않음
 - [x] 자금 요약 4칸이 사업명 바로 아래에서 한 번에 확인 가능
 - [x] 프로젝트 상세와 이번 주 작업 상태를 한 slab 안의 좌우 축으로 확인 가능
 - [x] 좌우 패널 비중이 상태 정보 기준으로 재조정됨
@@ -70,6 +71,7 @@
 - [2026-04-14] 헤더 우측의 중복 `사업비 입력` CTA를 제거하고, command search가 담당 사업 전체를 검색해 해당 사업으로 바로 전환되도록 확장했다.
 - [2026-04-14] command search에서 현재 담당 사업을 선택해도 이동이 막히지 않도록 `setActiveProject` no-op 케이스를 정리했다.
 - [2026-04-14] 상단 shell의 `My Work` 보조 라벨을 제거하고 현재 화면명만 남겼다.
+- [2026-04-15] PM 홈은 전역 cashflow 주차 구독이 project 기준 query만 사용하도록 바꿔, cashflow composite index drift가 있어도 포털 첫 화면 전체가 Listen 400 재시도로 흔들리지 않게 보강했다.
 - [2026-04-14] `내 제출 현황`을 홈 하단의 compact 제출 상태 표로 흡수했고, 별도 탭과 직접 진입 라우트는 홈으로 정리했다.
 - [2026-04-14] 제출 통합 블록에서는 `인력변경 신청`, `사업비 입력(주간) 작성/제출`, `주간 제출 체크` 같은 중복 섹션을 제외하고 현재 주차 기준 핵심 상태만 남겼다.
 - [2026-04-14] 상단을 Salesforce 계열 SaaS처럼 `workspace bar + app tabs + project switcher` 구조로 재편했다.

--- a/src/app/data/cashflow-weeks-store.tsx
+++ b/src/app/data/cashflow-weeks-store.tsx
@@ -22,7 +22,7 @@ import {
 } from 'firebase/firestore';
 import { useAuth } from './auth-store';
 import type { CashflowSheetLineId, CashflowWeekSheet, VarianceFlag, VarianceFlagEvent } from './types';
-import { shouldCreateDocOnUpdateError } from './cashflow-weeks.helpers';
+import { filterCashflowWeeksForYear, shouldCreateDocOnUpdateError } from './cashflow-weeks.helpers';
 import {
   buildCashflowWeekUpdatePatch,
   buildInitialCashflowWeekDoc,
@@ -142,14 +142,11 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
     setIsLoading(true);
 
     const base = collection(db, getOrgCollectionPath(orgId, 'cashflowWeeks'));
-    const year = yearMonth.slice(0, 4);
-    const yearStart = `${year}-01`;
-    const yearEnd = `${year}-12`;
     const q = readAll
       ? query(
         base,
-        where('yearMonth', '>=', yearStart),
-        where('yearMonth', '<=', yearEnd),
+        where('yearMonth', '>=', `${yearMonth.slice(0, 4)}-01`),
+        where('yearMonth', '<=', `${yearMonth.slice(0, 4)}-12`),
         limit(2500),
       )
       : (projectIds.length > 0
@@ -157,27 +154,26 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
           ? query(
             base,
             where('projectId', '==', projectIds[0]),
-            where('yearMonth', '>=', yearStart),
-            where('yearMonth', '<=', yearEnd),
             limit(2500),
           )
           : query(
             base,
             where('projectId', 'in', projectIds.slice(0, 10)),
-            where('yearMonth', '>=', yearStart),
-            where('yearMonth', '<=', yearEnd),
             limit(2500),
           ))
         : query(
           base,
-          where('yearMonth', '>=', yearStart),
-          where('yearMonth', '<=', yearEnd),
           limit(2500),
         ));
 
     unsubsRef.current.push(
       onSnapshot(q, (snap) => {
-        const docs = snap.docs.map((d) => d.data() as CashflowWeekSheet);
+        const docs = (readAll
+          ? snap.docs.map((d) => d.data() as CashflowWeekSheet)
+          : filterCashflowWeeksForYear(
+            snap.docs.map((d) => d.data() as CashflowWeekSheet),
+            yearMonth,
+          ));
         docs.sort((a, b) => {
           if (a.projectId !== b.projectId) return String(a.projectId).localeCompare(String(b.projectId));
           return (a.weekNo || 0) - (b.weekNo || 0);

--- a/src/app/data/cashflow-weeks.helpers.test.ts
+++ b/src/app/data/cashflow-weeks.helpers.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { resolveFirestoreErrorCode, shouldCreateDocOnUpdateError } from './cashflow-weeks.helpers';
+import {
+  filterCashflowWeeksForYear,
+  resolveFirestoreErrorCode,
+  shouldCreateDocOnUpdateError,
+} from './cashflow-weeks.helpers';
 
 describe('cashflow weeks helpers', () => {
   it('resolves firestore error codes', () => {
@@ -13,5 +17,18 @@ describe('cashflow weeks helpers', () => {
     expect(shouldCreateDocOnUpdateError({ code: 'permission-denied' })).toBe(false);
     expect(shouldCreateDocOnUpdateError({})).toBe(false);
   });
-});
 
+  it('filters cashflow weeks to the requested year on the client', () => {
+    const rows = [
+      { id: 'a', projectId: 'p1', yearMonth: '2025-12', weekNo: 5 },
+      { id: 'b', projectId: 'p1', yearMonth: '2026-01', weekNo: 1 },
+      { id: 'c', projectId: 'p1', yearMonth: '2026-08', weekNo: 2 },
+      { id: 'd', projectId: 'p1', yearMonth: '2027-01', weekNo: 1 },
+    ] as any[];
+
+    expect(filterCashflowWeeksForYear(rows, '2026-04')).toEqual([
+      { id: 'b', projectId: 'p1', yearMonth: '2026-01', weekNo: 1 },
+      { id: 'c', projectId: 'p1', yearMonth: '2026-08', weekNo: 2 },
+    ]);
+  });
+});

--- a/src/app/data/cashflow-weeks.helpers.ts
+++ b/src/app/data/cashflow-weeks.helpers.ts
@@ -8,3 +8,15 @@ export function shouldCreateDocOnUpdateError(error: unknown): boolean {
   return resolveFirestoreErrorCode(error) === 'not-found';
 }
 
+export function filterCashflowWeeksForYear<
+  T extends { yearMonth?: string | null },
+>(rows: T[], selectedYearMonth: string): T[] {
+  const year = typeof selectedYearMonth === 'string' ? selectedYearMonth.slice(0, 4) : '';
+  if (!/^\d{4}$/.test(year)) return [];
+  const yearStart = `${year}-01`;
+  const yearEnd = `${year}-12`;
+  return rows.filter((row) => {
+    const value = typeof row?.yearMonth === 'string' ? row.yearMonth : '';
+    return value >= yearStart && value <= yearEnd;
+  });
+}


### PR DESCRIPTION
## Summary\n- PM 포털 부팅 경로에서 cashflow 주차 listen이 연도 범위 composite index에 직접 의존하지 않도록 완화\n- PM path는 Firestore에서 project 기준으로만 listen하고 연도 범위는 클라이언트에서 필터링\n- patch-note wiki에 운영 메모 반영\n\n## Why\n- closes #188\n- PM 포털 진입 시 Firestore Listen 400 반복으로 화면이 불안정해지는 리포트를 핫픽스로 차단\n\n## Verification\n- npm test -- src/app/data/cashflow-weeks.helpers.test.ts\n- npm test -- src/app/data/cashflow-weeks.helpers.test.ts src/app/platform/check-patch-notes-guard.test.ts\n- npm run build\n