### PR TITLE
fix: harden pm payroll listeners

### DIFF
--- a/docs/operations/2026-04-15-pm-payroll-listen-hardening.md
+++ b/docs/operations/2026-04-15-pm-payroll-listen-hardening.md
@@ -1,0 +1,21 @@
+# 2026-04-15 PM Portal Payroll Listen Hardening
+
+## Problem
+Production PM portal still emits repeated Firestore Listen 400 errors after the cashflow listener hotfix. The remaining high-probability PM-global compound listeners are in `PayrollProvider`.
+
+## Hypothesis
+For PM users, these two live queries are still too production-sensitive:
+- `payroll_runs` by `projectId` ordered by `plannedPayDate desc`
+- `monthly_closes` by `projectId` ordered by `yearMonth desc`
+
+## Change
+- Keep admin/readAll behavior unchanged.
+- For PM path, remove `orderBy` from Firestore live queries.
+- Listen by `projectId` only, then sort client-side.
+- Add helper coverage so this policy is explicit and regression-tested.
+
+## Verification
+- Unit tests for PM-side sorting helpers.
+- Targeted provider tests if available.
+- `npm run build`.
+- Production deploy follow-up check for Listen 400 recurrence.

--- a/docs/wiki/patch-notes/log.md
+++ b/docs/wiki/patch-notes/log.md
@@ -1,5 +1,9 @@
 # Patch Notes Log
 
+## [2026-04-15] patch-note | portal-dashboard | payroll listen hardening
+- pages: [portal-dashboard](./pages/portal-dashboard.md)
+- summary: PM 포털 전역 payroll provider가 `projectId + orderBy` 복합 listen 없이 동작하도록 단순화해 남아 있던 Firestore Listen 400 후보를 추가로 제거했다.
+
 ## [2026-04-15] patch-note | admin-dashboard | 웰컴/검증 표면 제거
 - pages: [admin-dashboard](./pages/admin-dashboard.md)
 - summary: 어드민 첫 화면에서 웰컴 배너와 validation/reminder 보조 UI를 제거하고 KPI, 리스크, 집계, 작업 진입만 남는 운영판으로 더 압축했다.

--- a/docs/wiki/patch-notes/pages/portal-dashboard.md
+++ b/docs/wiki/patch-notes/pages/portal-dashboard.md
@@ -46,6 +46,7 @@
 - [x] 상단에 MYSC 로고만 남기고 부가 workspace 문구는 제거됨
 - [x] 첫 화면에서 중복 바로가기 CTA 없이 상태와 요약 정보 중심으로 확인 가능
 - [x] PM 홈 부팅이 cashflow 주차 listener의 연도 범위 index 상태에 직접 막히지 않음
+- [x] PM 포털 전역 payroll listener가 compound query 없이 project 기준 listen으로 동작함
 - [x] 자금 요약 4칸이 사업명 바로 아래에서 한 번에 확인 가능
 - [x] 프로젝트 상세와 이번 주 작업 상태를 한 slab 안의 좌우 축으로 확인 가능
 - [x] 좌우 패널 비중이 상태 정보 기준으로 재조정됨
@@ -72,6 +73,7 @@
 - [2026-04-14] command search에서 현재 담당 사업을 선택해도 이동이 막히지 않도록 `setActiveProject` no-op 케이스를 정리했다.
 - [2026-04-14] 상단 shell의 `My Work` 보조 라벨을 제거하고 현재 화면명만 남겼다.
 - [2026-04-15] PM 홈은 전역 cashflow 주차 구독이 project 기준 query만 사용하도록 바꿔, cashflow composite index drift가 있어도 포털 첫 화면 전체가 Listen 400 재시도로 흔들리지 않게 보강했다.
+- [2026-04-15] PM 포털 전역 payroll 구독도 `projectId + orderBy` 복합 listen을 제거하고 project 기준 listen 뒤 클라이언트 정렬로 단순화해, 남아 있던 Listen 400 후보를 더 줄였다.
 - [2026-04-14] `내 제출 현황`을 홈 하단의 compact 제출 상태 표로 흡수했고, 별도 탭과 직접 진입 라우트는 홈으로 정리했다.
 - [2026-04-14] 제출 통합 블록에서는 `인력변경 신청`, `사업비 입력(주간) 작성/제출`, `주간 제출 체크` 같은 중복 섹션을 제외하고 현재 주차 기준 핵심 상태만 남겼다.
 - [2026-04-14] 상단을 Salesforce 계열 SaaS처럼 `workspace bar + app tabs + project switcher` 구조로 재편했다.

--- a/scripts/check_patch_notes_guard.mjs
+++ b/scripts/check_patch_notes_guard.mjs
@@ -24,6 +24,10 @@ const SURFACE_TO_PATCH_NOTE_RULES = [
     page: 'docs/wiki/patch-notes/pages/portal-dashboard.md',
   },
   {
+    match: 'src/app/data/payroll-store.tsx',
+    page: 'docs/wiki/patch-notes/pages/portal-dashboard.md',
+  },
+  {
     match: 'src/app/components/participation/ParticipationPage.tsx',
     page: 'docs/wiki/patch-notes/pages/admin-participation.md',
   },

--- a/src/app/data/payroll-store.tsx
+++ b/src/app/data/payroll-store.tsx
@@ -31,6 +31,7 @@ import {
   getSeoulTodayIso,
   subtractBusinessDays,
 } from '../platform/business-days';
+import { sortMonthlyClosesByYearMonth, sortPayrollRunsByPlannedPayDate } from './payroll.helpers';
 
 function normalizeRole(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
@@ -122,12 +123,12 @@ export function PayrollProvider({ children }: { children: ReactNode }) {
       );
       unsubsRef.current.push(
         onSnapshot(runsQuery, (snap) => {
-          setRuns(snap.docs.map((d) => d.data() as PayrollRun));
+          setRuns(sortPayrollRunsByPlannedPayDate(snap.docs.map((d) => d.data() as PayrollRun)));
         }, (err) => console.error('[Payroll] runs listen error:', err)),
       );
       unsubsRef.current.push(
         onSnapshot(closeQuery, (snap) => {
-          setMonthlyCloses(snap.docs.map((d) => d.data() as MonthlyClose));
+          setMonthlyCloses(sortMonthlyClosesByYearMonth(snap.docs.map((d) => d.data() as MonthlyClose)));
         }, (err) => console.error('[Payroll] monthly closes listen error:', err)),
       );
 
@@ -142,13 +143,11 @@ export function PayrollProvider({ children }: { children: ReactNode }) {
       const runQuery = query(
         collection(db, getOrgCollectionPath(orgId, 'payrollRuns')),
         where('projectId', '==', myProjectId),
-        orderBy('plannedPayDate', 'desc'),
         limit(36),
       );
       const closeQuery = query(
         collection(db, getOrgCollectionPath(orgId, 'monthlyCloses')),
         where('projectId', '==', myProjectId),
-        orderBy('yearMonth', 'desc'),
         limit(18),
       );
 
@@ -163,12 +162,12 @@ export function PayrollProvider({ children }: { children: ReactNode }) {
       );
       unsubsRef.current.push(
         onSnapshot(runQuery, (snap) => {
-          setRuns(snap.docs.map((d) => d.data() as PayrollRun));
+          setRuns(sortPayrollRunsByPlannedPayDate(snap.docs.map((d) => d.data() as PayrollRun)));
         }, (err) => console.error('[Payroll] runs listen error:', err)),
       );
       unsubsRef.current.push(
         onSnapshot(closeQuery, (snap) => {
-          setMonthlyCloses(snap.docs.map((d) => d.data() as MonthlyClose));
+          setMonthlyCloses(sortMonthlyClosesByYearMonth(snap.docs.map((d) => d.data() as MonthlyClose)));
         }, (err) => console.error('[Payroll] monthly closes listen error:', err)),
       );
     } else {

--- a/src/app/data/payroll.helpers.test.ts
+++ b/src/app/data/payroll.helpers.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import type { MonthlyClose, PayrollRun } from './types';
+import { sortMonthlyClosesByYearMonth, sortPayrollRunsByPlannedPayDate } from './payroll.helpers';
+
+describe('payroll helpers', () => {
+  it('sorts payroll runs by planned pay date descending for PM listeners', () => {
+    const rows = [
+      {
+        id: 'r1',
+        projectId: 'p1',
+        yearMonth: '2026-03',
+        plannedPayDate: '2026-03-25',
+        noticeDate: '2026-03-20',
+        noticeLeadBusinessDays: 3,
+        acknowledged: false,
+        paidStatus: 'UNKNOWN',
+        createdAt: '2026-03-01T00:00:00.000Z',
+        updatedAt: '2026-03-02T00:00:00.000Z',
+      },
+      {
+        id: 'r2',
+        projectId: 'p1',
+        yearMonth: '2026-05',
+        plannedPayDate: '2026-05-25',
+        noticeDate: '2026-05-20',
+        noticeLeadBusinessDays: 3,
+        acknowledged: false,
+        paidStatus: 'UNKNOWN',
+        createdAt: '2026-05-01T00:00:00.000Z',
+        updatedAt: '2026-05-02T00:00:00.000Z',
+      },
+      {
+        id: 'r3',
+        projectId: 'p1',
+        yearMonth: '2026-04',
+        plannedPayDate: '2026-04-25',
+        noticeDate: '2026-04-20',
+        noticeLeadBusinessDays: 3,
+        acknowledged: false,
+        paidStatus: 'UNKNOWN',
+        createdAt: '2026-04-01T00:00:00.000Z',
+        updatedAt: '2026-04-02T00:00:00.000Z',
+      },
+    ] satisfies PayrollRun[];
+
+    expect(sortPayrollRunsByPlannedPayDate(rows).map((row) => row.id)).toEqual(['r2', 'r3', 'r1']);
+  });
+
+  it('sorts monthly closes by yearMonth descending for PM listeners', () => {
+    const rows = [
+      {
+        id: 'm1',
+        projectId: 'p1',
+        yearMonth: '2026-02',
+        status: 'DONE',
+        acknowledged: false,
+        createdAt: '2026-02-01T00:00:00.000Z',
+        updatedAt: '2026-02-02T00:00:00.000Z',
+      },
+      {
+        id: 'm2',
+        projectId: 'p1',
+        yearMonth: '2026-04',
+        status: 'DONE',
+        acknowledged: false,
+        createdAt: '2026-04-01T00:00:00.000Z',
+        updatedAt: '2026-04-02T00:00:00.000Z',
+      },
+      {
+        id: 'm3',
+        projectId: 'p1',
+        yearMonth: '2026-03',
+        status: 'DONE',
+        acknowledged: false,
+        createdAt: '2026-03-01T00:00:00.000Z',
+        updatedAt: '2026-03-02T00:00:00.000Z',
+      },
+    ] satisfies MonthlyClose[];
+
+    expect(sortMonthlyClosesByYearMonth(rows).map((row) => row.id)).toEqual(['m2', 'm3', 'm1']);
+  });
+});

--- a/src/app/data/payroll.helpers.ts
+++ b/src/app/data/payroll.helpers.ts
@@ -1,0 +1,19 @@
+import type { MonthlyClose, PayrollRun } from './types';
+
+export function sortPayrollRunsByPlannedPayDate(rows: PayrollRun[]): PayrollRun[] {
+  return [...rows].sort((a, b) => {
+    const payDateCompare = String(b.plannedPayDate || '').localeCompare(String(a.plannedPayDate || ''));
+    if (payDateCompare !== 0) return payDateCompare;
+    const yearMonthCompare = String(b.yearMonth || '').localeCompare(String(a.yearMonth || ''));
+    if (yearMonthCompare !== 0) return yearMonthCompare;
+    return String(b.updatedAt || '').localeCompare(String(a.updatedAt || ''));
+  });
+}
+
+export function sortMonthlyClosesByYearMonth(rows: MonthlyClose[]): MonthlyClose[] {
+  return [...rows].sort((a, b) => {
+    const yearMonthCompare = String(b.yearMonth || '').localeCompare(String(a.yearMonth || ''));
+    if (yearMonthCompare !== 0) return yearMonthCompare;
+    return String(b.updatedAt || '').localeCompare(String(a.updatedAt || ''));
+  });
+}


### PR DESCRIPTION
## Summary
- follow up on #190 after the cashflow-only hotfix proved insufficient in production
- simplify PM payroll listeners to project-scoped listens without Firestore `orderBy`
- sort PM payroll data client-side and add regression coverage

## Context
The previous hotfix reduced one likely source, but production still shows repeated Firestore Listen 400 errors on PM portal. The remaining PM-global compound listeners live in `PayrollProvider`.

Related #190
