### PR TITLE
fix: stabilize pm portal with safe fetch mode

### DIFF
--- a/docs/operations/2026-04-15-pm-portal-safe-fetch-stabilization.md
+++ b/docs/operations/2026-04-15-pm-portal-safe-fetch-stabilization.md
@@ -1,0 +1,19 @@
+# 2026-04-15 PM Portal Safe Fetch Stabilization
+
+## Problem
+PM portal still emits repeated Firestore Listen 400 errors in production. The issue is no longer isolated to one provider; PM path still mounts too many realtime listeners.
+
+## Strategy
+- Preserve live listeners for admin/readAll roles.
+- Switch PM path to safe fetch mode for the most important shared stores.
+- Use one-time `getDocs` / `getDoc` for PM portal boot and page data instead of `onSnapshot` where live updates are not critical.
+
+## Initial scope
+- PortalStore PM path
+- CashflowWeekProvider PM path
+- PayrollProvider PM path
+
+## Acceptance
+- PM portal loads core data without repeated Listen 400 loops.
+- Existing admin live workflows remain unchanged.
+- Tests and patch notes updated.

--- a/docs/wiki/patch-notes/log.md
+++ b/docs/wiki/patch-notes/log.md
@@ -1,5 +1,9 @@
 # Patch Notes Log
 
+## [2026-04-15] patch-note | portal-dashboard | PM safe fetch stabilization
+- pages: [portal-dashboard](./pages/portal-dashboard.md), [portal-bank-statement](./pages/portal-bank-statement.md), [portal-weekly-expense](./pages/portal-weekly-expense.md)
+- summary: PM/viewer 포털 경로의 portal store, board, training, HR surface는 역할 기반 safe fetch 모드로 전환해 반복 Firestore Listen 400이 포털 전체를 재시도 루프로 흔드는 구조를 줄였다.
+
 ## [2026-04-15] patch-note | portal-dashboard | payroll listen hardening
 - pages: [portal-dashboard](./pages/portal-dashboard.md)
 - summary: PM 포털 전역 payroll provider가 `projectId + orderBy` 복합 listen 없이 동작하도록 단순화해 남아 있던 Firestore Listen 400 후보를 추가로 제거했다.

--- a/docs/wiki/patch-notes/pages/portal-bank-statement.md
+++ b/docs/wiki/patch-notes/pages/portal-bank-statement.md
@@ -25,12 +25,14 @@
 - [x] 직접작성 사업도 같은 흐름에서 다룰 수 있음
 - [x] 환수행, 선사용금, 특이건 보조 액션 없이 기본 표 편집 흐름만 유지
 - [x] `cashflow항목` label과 내부 enum은 공용 policy 기준으로 해석됨
+- [x] PM 포털 safe fetch 모드에서도 통장내역 화면 진입과 direct handoff 부팅 가능
 - [ ] 마지막 행 드롭다운 잘림 이슈 완전 해소 확인 필요
 
 ## Recent Changes
 
 - [2026-04-15] `cashflow항목` line label/alias/category 해석이 공용 policy 레이어를 통하도록 정리했다.
 - [2026-04-15] 통장내역 저장 시 업로드한 은행 행을 현재 주간 사업비 탭 행으로 바로 merge하도록 바꿨다. Queue 없이 `통장내역 -> 사업비 입력(주간)` direct handoff가 이어진다.
+- [2026-04-15] PM 역할에서는 portal store가 realtime listen 대신 safe fetch로 초기 데이터를 불러오도록 바꿔, 포털 부팅 시 반복 Listen 400이 통장내역 화면까지 전파되는 위험을 줄였다.
 - [2026-04-14] 포털 session active project를 따라 현재 사업이 바뀌어도 같은 화면에서 다른 사업 통장내역을 바로 이어서 볼 수 있게 했다.
 - [2026-04-14] `신규 거래 처리 Queue` 카드와 queue-first wizard 액션을 제거하고, 통장내역 저장본에서 바로 사업비 입력으로 이어지는 단일 흐름으로 롤백했다.
 - [2026-04-14] 환수행, 선사용금, 특이건 보조 행 추가 액션을 현재 operator-facing 화면에서 제외했다.

--- a/docs/wiki/patch-notes/pages/portal-dashboard.md
+++ b/docs/wiki/patch-notes/pages/portal-dashboard.md
@@ -47,6 +47,7 @@
 - [x] 첫 화면에서 중복 바로가기 CTA 없이 상태와 요약 정보 중심으로 확인 가능
 - [x] PM 홈 부팅이 cashflow 주차 listener의 연도 범위 index 상태에 직접 막히지 않음
 - [x] PM 포털 전역 payroll listener가 compound query 없이 project 기준 listen으로 동작함
+- [x] PM 포털 주요 운영 데이터는 safe fetch 모드에서 realtime listen 없이도 부팅 가능
 - [x] 자금 요약 4칸이 사업명 바로 아래에서 한 번에 확인 가능
 - [x] 프로젝트 상세와 이번 주 작업 상태를 한 slab 안의 좌우 축으로 확인 가능
 - [x] 좌우 패널 비중이 상태 정보 기준으로 재조정됨
@@ -74,6 +75,7 @@
 - [2026-04-14] 상단 shell의 `My Work` 보조 라벨을 제거하고 현재 화면명만 남겼다.
 - [2026-04-15] PM 홈은 전역 cashflow 주차 구독이 project 기준 query만 사용하도록 바꿔, cashflow composite index drift가 있어도 포털 첫 화면 전체가 Listen 400 재시도로 흔들리지 않게 보강했다.
 - [2026-04-15] PM 포털 전역 payroll 구독도 `projectId + orderBy` 복합 listen을 제거하고 project 기준 listen 뒤 클라이언트 정렬로 단순화해, 남아 있던 Listen 400 후보를 더 줄였다.
+- [2026-04-15] PM/viewer 경로의 portal/board/hr/training 운영 surface는 역할 기반 safe fetch 모드에서 일회성 조회를 사용하도록 바꿔, 반복 Firestore Listen 400이 포털 전체를 흔드는 구조를 더 줄였다.
 - [2026-04-14] `내 제출 현황`을 홈 하단의 compact 제출 상태 표로 흡수했고, 별도 탭과 직접 진입 라우트는 홈으로 정리했다.
 - [2026-04-14] 제출 통합 블록에서는 `인력변경 신청`, `사업비 입력(주간) 작성/제출`, `주간 제출 체크` 같은 중복 섹션을 제외하고 현재 주차 기준 핵심 상태만 남겼다.
 - [2026-04-14] 상단을 Salesforce 계열 SaaS처럼 `workspace bar + app tabs + project switcher` 구조로 재편했다.

--- a/docs/wiki/patch-notes/pages/portal-weekly-expense.md
+++ b/docs/wiki/patch-notes/pages/portal-weekly-expense.md
@@ -26,12 +26,14 @@
 - [x] 상단 정책/하단 중복 요약 bar 없이 헤더 정보만으로 현재 상태 파악 가능
 - [x] overwrite/backspace 입력 가능
 - [x] 통장내역 저장본에서 queue-first wizard 없이 바로 주간 입력으로 이어가기 가능
+- [x] PM 포털 safe fetch 모드에서도 주간 입력 화면 부팅 가능
 - [ ] 입력 보조 드롭다운/팝오버 잘림 이슈 완전 해소 확인 필요
 
 ## Recent Changes
 
 - [2026-04-14] 포털 session active project 전환과 함께 현재 사업 기준 입력 상태 요약과 진행 step strip을 안정적으로 다시 연결했다.
 - [2026-04-15] 통장내역 저장 직후 신규 은행 행이 현재 주간 사업비 탭에 바로 나타나도록 연결했다. 별도 Queue나 triage wizard 없이 이 화면에서 바로 편집을 이어간다.
+- [2026-04-15] PM 역할에서는 portal store가 주요 운영 데이터를 realtime listen 대신 safe fetch로 초기 로딩해, 포털 부팅 중 반복 Listen 400이 사업비 입력 화면까지 흔드는 구조를 줄였다.
 - [2026-04-14] 미처리 거래 queue strip과 triage wizard 진입을 제거하고, 통장내역 저장본에서 바로 현재 탭 입력으로 이어가는 흐름으로 롤백했다.
 - [2026-04-14] 미저장 편집이 남은 상태에서 통장내역이나 사이드바로 이동하면 확인 다이얼로그를 띄우도록 복구했다.
 - [2026-04-14] bank import triage wizard의 cashflow category 선택값을 정리하고, fullscreen wizard와 주간 입력 화면 간 회귀 E2E를 다시 통과시켰다.

--- a/src/app/data/board-store.tsx
+++ b/src/app/data/board-store.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useCallback, useContext, useEffect, useMemo, useR
 import {
   collection,
   doc,
+  getDocs,
   increment,
   limit,
   onSnapshot,
@@ -19,6 +20,7 @@ import type { BoardChannel, BoardComment, BoardPost } from './types';
 import { getOrgCollectionPath, getOrgDocumentPath } from '../lib/firebase';
 import { useFirebase } from '../lib/firebase-context';
 import { buildVoteDelta, normalizeTags } from './board.helpers';
+import { canUseRealtimeListeners } from './firestore-realtime-mode';
 
 type VoteDirection = 'up' | 'down';
 
@@ -89,6 +91,7 @@ export function BoardProvider({ children }: { children: ReactNode }) {
   const { db, isOnline, orgId } = useFirebase();
   const { user } = useAuth();
   const firestoreEnabled = featureFlags.firestoreCoreEnabled && isOnline && !!db && !!user?.uid;
+  const liveMode = canUseRealtimeListeners(user?.role);
 
   const [posts, setPosts] = useState<BoardPost[]>(INITIAL_POSTS);
   const [localVotesByPostId, setLocalVotesByPostId] = useState<Record<string, -1 | 0 | 1>>({});
@@ -119,20 +122,28 @@ export function BoardProvider({ children }: { children: ReactNode }) {
       limit(300),
     );
 
-    unsubsRef.current.push(
-      onSnapshot(postsQuery, (snap) => {
-        const list = snap.docs.map((d) => d.data() as BoardPost);
-        setPosts(list);
-      }, (err) => {
-        console.error('[Board] posts listen error:', err);
-      }),
-    );
+    if (liveMode) {
+      unsubsRef.current.push(
+        onSnapshot(postsQuery, (snap) => {
+          const list = snap.docs.map((d) => d.data() as BoardPost);
+          setPosts(list);
+        }, (err) => {
+          console.error('[Board] posts listen error:', err);
+        }),
+      );
+    } else {
+      void getDocs(postsQuery).then((snap) => {
+        setPosts(snap.docs.map((d) => d.data() as BoardPost));
+      }).catch((err) => {
+        console.error('[Board] posts fetch error:', err);
+      });
+    }
 
     return () => {
       unsubsRef.current.forEach((unsub) => unsub());
       unsubsRef.current = [];
     };
-  }, [firestoreEnabled, db, orgId]);
+  }, [firestoreEnabled, db, orgId, liveMode]);
 
   const createPost = useCallback(async (data: {
     title: string;

--- a/src/app/data/cashflow-weeks-store.tsx
+++ b/src/app/data/cashflow-weeks-store.tsx
@@ -12,6 +12,7 @@ import {
   collection,
   doc,
   getDoc,
+  getDocs,
   limit,
   onSnapshot,
   query,
@@ -34,15 +35,7 @@ import { getOrgCollectionPath, getOrgDocumentPath } from '../lib/firebase';
 import { addMonthsToYearMonth, getSeoulTodayIso } from '../platform/business-days';
 import { getMonthMondayWeeks } from '../platform/cashflow-weeks';
 import { normalizeProjectIds } from './project-assignment';
-
-function normalizeRole(value: unknown): string {
-  return typeof value === 'string' ? value.trim().toLowerCase() : '';
-}
-
-function canReadAll(role: unknown): boolean {
-  const normalized = normalizeRole(role);
-  return normalized === 'admin' || normalized === 'tenant_admin' || normalized === 'finance' || normalized === 'auditor';
-}
+import { canUseRealtimeListeners } from './firestore-realtime-mode';
 
 interface CashflowWeekState {
   yearMonth: string; // selected month ("YYYY-MM")
@@ -96,7 +89,7 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
     () => normalizeProjectIds([...(Array.isArray(user?.projectIds) ? user?.projectIds : []), myProjectId]),
     [user?.projectIds, myProjectId],
   );
-  const readAll = canReadAll(role);
+  const readAll = canUseRealtimeListeners(role);
 
   const [yearMonth, setYearMonthState] = useState(() => getSeoulTodayIso().slice(0, 7));
   const [weeks, setWeeks] = useState<CashflowWeekSheet[]>([]);
@@ -166,26 +159,40 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
           limit(2500),
         ));
 
-    unsubsRef.current.push(
-      onSnapshot(q, (snap) => {
-        const docs = (readAll
-          ? snap.docs.map((d) => d.data() as CashflowWeekSheet)
-          : filterCashflowWeeksForYear(
-            snap.docs.map((d) => d.data() as CashflowWeekSheet),
-            yearMonth,
-          ));
+    if (readAll) {
+      unsubsRef.current.push(
+        onSnapshot(q, (snap) => {
+          const docs = snap.docs.map((d) => d.data() as CashflowWeekSheet);
+          docs.sort((a, b) => {
+            if (a.projectId !== b.projectId) return String(a.projectId).localeCompare(String(b.projectId));
+            return (a.weekNo || 0) - (b.weekNo || 0);
+          });
+          setWeeks(docs);
+          setIsLoading(false);
+        }, (err) => {
+          console.error('[CashflowWeeks] listen error:', err);
+          setWeeks([]);
+          setIsLoading(false);
+        }),
+      );
+    } else {
+      void getDocs(q).then((snap) => {
+        const docs = filterCashflowWeeksForYear(
+          snap.docs.map((d) => d.data() as CashflowWeekSheet),
+          yearMonth,
+        );
         docs.sort((a, b) => {
           if (a.projectId !== b.projectId) return String(a.projectId).localeCompare(String(b.projectId));
           return (a.weekNo || 0) - (b.weekNo || 0);
         });
         setWeeks(docs);
         setIsLoading(false);
-      }, (err) => {
-        console.error('[CashflowWeeks] listen error:', err);
+      }).catch((err) => {
+        console.error('[CashflowWeeks] fetch error:', err);
         setWeeks([]);
         setIsLoading(false);
-      }),
-    );
+      });
+    }
 
     return () => {
       unsubsRef.current.forEach((u) => u());

--- a/src/app/data/firestore-realtime-mode.test.ts
+++ b/src/app/data/firestore-realtime-mode.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { canUseRealtimeListeners, normalizeRealtimeRole, shouldUseSafeFetchMode } from './firestore-realtime-mode';
+
+describe('firestore realtime mode', () => {
+  it('allows live listeners only for privileged roles', () => {
+    expect(canUseRealtimeListeners('admin')).toBe(true);
+    expect(canUseRealtimeListeners('tenant_admin')).toBe(true);
+    expect(canUseRealtimeListeners('finance')).toBe(true);
+    expect(canUseRealtimeListeners('auditor')).toBe(true);
+    expect(canUseRealtimeListeners('pm')).toBe(false);
+    expect(canUseRealtimeListeners('viewer')).toBe(false);
+    expect(canUseRealtimeListeners('')).toBe(false);
+  });
+
+  it('normalizes role strings', () => {
+    expect(normalizeRealtimeRole(' Finance ')).toBe('finance');
+    expect(normalizeRealtimeRole(null)).toBe('');
+  });
+
+  it('routes PM roles to safe fetch mode', () => {
+    expect(shouldUseSafeFetchMode('pm')).toBe(true);
+    expect(shouldUseSafeFetchMode('viewer')).toBe(true);
+    expect(shouldUseSafeFetchMode('admin')).toBe(false);
+  });
+});

--- a/src/app/data/firestore-realtime-mode.ts
+++ b/src/app/data/firestore-realtime-mode.ts
@@ -1,0 +1,15 @@
+export function normalizeRealtimeRole(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+export function canUseRealtimeListeners(role: unknown): boolean {
+  const normalized = normalizeRealtimeRole(role);
+  return normalized === 'admin'
+    || normalized === 'tenant_admin'
+    || normalized === 'finance'
+    || normalized === 'auditor';
+}
+
+export function shouldUseSafeFetchMode(role: unknown): boolean {
+  return !canUseRealtimeListeners(role);
+}

--- a/src/app/data/hr-announcements-store.tsx
+++ b/src/app/data/hr-announcements-store.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useState, useCallback, useEffect, use
 import {
   collection,
   doc,
+  getDocs,
   onSnapshot,
   orderBy,
   query,
@@ -17,6 +18,7 @@ import { useFirebase } from '../lib/firebase-context';
 import { featureFlags } from '../config/feature-flags';
 import { getOrgCollectionPath, getOrgDocumentPath } from '../lib/firebase';
 import { buildProjectAlerts, deriveAffectedProjectIds } from './hr-announcements.helpers';
+import { canUseRealtimeListeners } from './firestore-realtime-mode';
 
 export type HrEventType = 'RESIGNATION' | 'LEAVE' | 'TRANSFER' | 'ROLE_CHANGE' | 'RETURN';
 
@@ -202,6 +204,7 @@ export function HrAnnouncementProvider({ children }: { children: ReactNode }) {
   const { isAuthenticated, isLoading: authLoading, user } = useAuth();
   const { db, isOnline, orgId } = useFirebase();
   const firestoreEnabled = featureFlags.firestoreCoreEnabled && isOnline && !!db;
+  const liveMode = canUseRealtimeListeners(user?.role);
 
   const [announcements, setAnnouncements] = useState<HrAnnouncement[]>(INITIAL_ANNOUNCEMENTS);
   const [alerts, setAlerts] = useState<ProjectChangeAlert[]>(INITIAL_ALERTS);
@@ -233,29 +236,42 @@ export function HrAnnouncementProvider({ children }: { children: ReactNode }) {
       orderBy('createdAt', 'desc'),
     );
 
-    unsubsRef.current.push(
-      onSnapshot(announcementQuery, (snap) => {
-        const list = snap.docs.map((docItem) => docItem.data() as HrAnnouncement);
-        setAnnouncements(list);
-      }, (err) => {
-        console.error('[HR] announcements listen error:', err);
-      }),
-    );
+    if (liveMode) {
+      unsubsRef.current.push(
+        onSnapshot(announcementQuery, (snap) => {
+          const list = snap.docs.map((docItem) => docItem.data() as HrAnnouncement);
+          setAnnouncements(list);
+        }, (err) => {
+          console.error('[HR] announcements listen error:', err);
+        }),
+      );
 
-    unsubsRef.current.push(
-      onSnapshot(alertQuery, (snap) => {
-        const list = snap.docs.map((docItem) => docItem.data() as ProjectChangeAlert);
-        setAlerts(list);
-      }, (err) => {
-        console.error('[HR] alerts listen error:', err);
-      }),
-    );
+      unsubsRef.current.push(
+        onSnapshot(alertQuery, (snap) => {
+          const list = snap.docs.map((docItem) => docItem.data() as ProjectChangeAlert);
+          setAlerts(list);
+        }, (err) => {
+          console.error('[HR] alerts listen error:', err);
+        }),
+      );
+    } else {
+      void getDocs(announcementQuery).then((snap) => {
+        setAnnouncements(snap.docs.map((docItem) => docItem.data() as HrAnnouncement));
+      }).catch((err) => {
+        console.error('[HR] announcements fetch error:', err);
+      });
+      void getDocs(alertQuery).then((snap) => {
+        setAlerts(snap.docs.map((docItem) => docItem.data() as ProjectChangeAlert));
+      }).catch((err) => {
+        console.error('[HR] alerts fetch error:', err);
+      });
+    }
 
     return () => {
       unsubsRef.current.forEach((unsub) => unsub());
       unsubsRef.current = [];
     };
-  }, [authLoading, isAuthenticated, user, firestoreEnabled, db, orgId]);
+  }, [authLoading, isAuthenticated, user, firestoreEnabled, db, orgId, liveMode]);
 
   const createAnnouncement = useCallback((
     data: Omit<HrAnnouncement, 'id' | 'announcedAt' | 'affectedProjectIds' | 'resolved'>,

--- a/src/app/data/payroll-store.tsx
+++ b/src/app/data/payroll-store.tsx
@@ -11,6 +11,8 @@ import React, {
 import {
   collection,
   doc,
+  getDoc,
+  getDocs,
   limit,
   onSnapshot,
   orderBy,
@@ -32,15 +34,7 @@ import {
   subtractBusinessDays,
 } from '../platform/business-days';
 import { sortMonthlyClosesByYearMonth, sortPayrollRunsByPlannedPayDate } from './payroll.helpers';
-
-function normalizeRole(value: unknown): string {
-  return typeof value === 'string' ? value.trim().toLowerCase() : '';
-}
-
-function canReadAll(role: unknown): boolean {
-  const normalized = normalizeRole(role);
-  return normalized === 'admin' || normalized === 'tenant_admin' || normalized === 'finance' || normalized === 'auditor';
-}
+import { canUseRealtimeListeners } from './firestore-realtime-mode';
 
 const DEFAULT_TIMEZONE = 'Asia/Seoul';
 const DEFAULT_LEAD_DAYS = 3;
@@ -79,7 +73,7 @@ export function PayrollProvider({ children }: { children: ReactNode }) {
 
   const role = user?.role;
   const myProjectId = user?.projectId || '';
-  const readAll = canReadAll(role);
+  const readAll = canUseRealtimeListeners(role);
 
   useEffect(() => {
     unsubsRef.current.forEach((u) => u());
@@ -151,25 +145,19 @@ export function PayrollProvider({ children }: { children: ReactNode }) {
         limit(18),
       );
 
-      unsubsRef.current.push(
-        onSnapshot(scheduleRef, (snap) => {
-          if (!snap.exists()) {
-            setSchedules([]);
-            return;
-          }
-          setSchedules([snap.data() as PayrollSchedule]);
-        }, (err) => console.error('[Payroll] schedule listen error:', err)),
-      );
-      unsubsRef.current.push(
-        onSnapshot(runQuery, (snap) => {
-          setRuns(sortPayrollRunsByPlannedPayDate(snap.docs.map((d) => d.data() as PayrollRun)));
-        }, (err) => console.error('[Payroll] runs listen error:', err)),
-      );
-      unsubsRef.current.push(
-        onSnapshot(closeQuery, (snap) => {
-          setMonthlyCloses(sortMonthlyClosesByYearMonth(snap.docs.map((d) => d.data() as MonthlyClose)));
-        }, (err) => console.error('[Payroll] monthly closes listen error:', err)),
-      );
+      void getDoc(scheduleRef).then((snap) => {
+        if (!snap.exists()) {
+          setSchedules([]);
+          return;
+        }
+        setSchedules([snap.data() as PayrollSchedule]);
+      }).catch((err) => console.error('[Payroll] schedule fetch error:', err));
+      void getDocs(runQuery).then((snap) => {
+        setRuns(sortPayrollRunsByPlannedPayDate(snap.docs.map((d) => d.data() as PayrollRun)));
+      }).catch((err) => console.error('[Payroll] runs fetch error:', err));
+      void getDocs(closeQuery).then((snap) => {
+        setMonthlyCloses(sortMonthlyClosesByYearMonth(snap.docs.map((d) => d.data() as MonthlyClose)));
+      }).catch((err) => console.error('[Payroll] monthly closes fetch error:', err));
     } else {
       setSchedules([]);
       setRuns([]);

--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -5,6 +5,7 @@ import {
   doc,
   documentId,
   getDoc,
+  getDocs,
   limit,
   onSnapshot,
   query,
@@ -92,6 +93,7 @@ import { readDevAuthHarnessConfig } from '../platform/dev-harness';
 import { reportError } from '../platform/observability';
 import { validateBudgetCodeBookDraft } from '../platform/budget-code-book-validation';
 import { buildBudgetLabelKey, normalizeBudgetLabel } from '../platform/budget-labels';
+import { canUseRealtimeListeners } from './firestore-realtime-mode';
 import {
   resolveActivePortalProjectId,
   resolvePortalProjectCandidates,
@@ -652,6 +654,10 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     return projects.find((project) => project.id === activeProjectId) || null;
   }, [activeProjectId, projects]);
   const currentProjectId = activeProjectId;
+  const livePortalMode = useMemo(
+    () => canUseRealtimeListeners(portalUser?.role || authUser?.role),
+    [authUser?.role, portalUser?.role],
+  );
 
   useEffect(() => {
     const uid = authUser?.uid;
@@ -860,6 +866,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     unsubsRef.current.forEach((unsub) => unsub());
     unsubsRef.current = [];
+    let cancelled = false;
 
     if (authLoading || isMemberLoading || !isAuthenticated || !authUser) {
       setProjects([]);
@@ -968,45 +975,55 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     const markReady = () => {
       if (projectReady && ledgerReady && expenseReady && changeReady && partReady && txReady) setIsLoading(false);
     };
-
-    // 전사 프로젝트 전체 표시 — 분기 없이 항상 전체 조회
-    unsubsRef.current.push(
-      onSnapshot(
-        query(collection(db, getOrgCollectionPath(orgId, 'projects')), limit(500)),
-        (snap) => {
-          const map = new Map<string, Project>();
-          snap.docs.forEach((docItem) => {
-            const data = docItem.data() as Project;
-            const id = data.id || docItem.id;
-            map.set(id, { ...data, id });
-          });
-          setProjects(Array.from(map.values()).sort((a, b) =>
-            String(a.name || '').localeCompare(String(b.name || '')),
-          ));
-          projectReady = true;
-          markReady();
+    const ifActive = (action: () => void) => {
+      if (!cancelled) action();
+    };
+    const handleProjectsResult = (docs: Array<{ id: string; data(): unknown }>) => {
+      ifActive(() => {
+        const map = new Map<string, Project>();
+        docs.forEach((docItem) => {
+          const data = docItem.data() as Project;
+          const id = data.id || docItem.id;
+          map.set(id, { ...data, id });
+        });
+        setProjects(Array.from(map.values()).sort((a, b) =>
+          String(a.name || '').localeCompare(String(b.name || '')),
+        ));
+        projectReady = true;
+        markReady();
+      });
+    };
+    const handleProjectsError = (err: unknown) => {
+      reportError(err, {
+        message: '[PortalStore] projects listen error:',
+        options: {
+          level: 'error',
+          tags: {
+            surface: 'portal_store',
+            action: 'projects_listen',
+          },
+          extra: {
+            orgId,
+            actorId: authUser.uid,
+          },
         },
-        (err) => {
-          reportError(err, {
-            message: '[PortalStore] projects listen error:',
-            options: {
-              level: 'error',
-              tags: {
-                surface: 'portal_store',
-                action: 'projects_listen',
-              },
-              extra: {
-                orgId,
-                actorId: authUser.uid,
-              },
-            },
-          });
-          setProjects([]);
-          projectReady = true;
-          markReady();
-        },
-      ),
-    );
+      });
+      ifActive(() => {
+        setProjects([]);
+        projectReady = true;
+        markReady();
+      });
+    };
+    const projectsQuery = query(collection(db, getOrgCollectionPath(orgId, 'projects')), limit(500));
+    if (livePortalMode) {
+      unsubsRef.current.push(
+        onSnapshot(projectsQuery, (snap) => handleProjectsResult(snap.docs), handleProjectsError),
+      );
+    } else {
+      getDocs(projectsQuery)
+        .then((snap) => handleProjectsResult(snap.docs))
+        .catch(handleProjectsError);
+    }
 
     if (!currentProjectId) {
       setLedgers([]);
@@ -1041,76 +1058,84 @@ export function PortalProvider({ children }: { children: ReactNode }) {
         collection(db, getOrgCollectionPath(orgId, 'partEntries')),
         where('projectId', '==', currentProjectId),
       );
-
-      unsubsRef.current.push(
-        onSnapshot(ledgerQuery, (snap) => {
-          const list = snap.docs
+      const handleLedgerResult = (docs: Array<{ data(): unknown }>) => {
+        ifActive(() => {
+          const list = docs
             .map((docItem) => docItem.data() as Ledger)
             .sort((a, b) => String(a.name || '').localeCompare(String(b.name || '')));
           setLedgers(list);
           ledgerReady = true;
           markReady();
-        }, (err) => {
-          console.error('[PortalStore] ledgers listen error:', err);
-          if (!isPermissionDenied(err)) {
-            toast.error('원장 데이터를 불러오지 못했습니다');
-          }
+        });
+      };
+      const handleLedgerError = (err: unknown) => {
+        console.error('[PortalStore] ledgers listen error:', err);
+        if (!isPermissionDenied(err)) {
+          toast.error('원장 데이터를 불러오지 못했습니다');
+        }
+        ifActive(() => {
           setLedgers(LEDGERS.filter((l) => l.projectId === currentProjectId));
           ledgerReady = true;
           markReady();
-        }),
-      );
-
-      unsubsRef.current.push(
-        onSnapshot(expenseQuery, (snap) => {
-          const list = snap.docs
+        });
+      };
+      const handleExpenseResult = (docs: Array<{ data(): unknown }>) => {
+        ifActive(() => {
+          const list = docs
             .map((docItem) => docItem.data() as ExpenseSet)
             .sort((a, b) => String(b.updatedAt || '').localeCompare(String(a.updatedAt || '')));
           setExpenseSets(list);
           expenseReady = true;
           markReady();
-        }, (err) => {
-          console.error('[PortalStore] expenseSets listen error:', err);
-          toast.error('사업비 데이터를 불러오지 못했습니다');
+        });
+      };
+      const handleExpenseError = (err: unknown) => {
+        console.error('[PortalStore] expenseSets listen error:', err);
+        toast.error('사업비 데이터를 불러오지 못했습니다');
+        ifActive(() => {
           expenseReady = true;
           markReady();
-        }),
-      );
-
-      unsubsRef.current.push(
-        onSnapshot(changeRequestQuery, (snap) => {
-          const list = snap.docs
+        });
+      };
+      const handleChangeRequestResult = (docs: Array<{ data(): unknown }>) => {
+        ifActive(() => {
+          const list = docs
             .map((docItem) => docItem.data() as ChangeRequest)
             .sort((a, b) => String(b.requestedAt || '').localeCompare(String(a.requestedAt || '')));
           setChangeRequests(list);
           changeReady = true;
           markReady();
-        }, (err) => {
-          console.error('[PortalStore] changeRequests listen error:', err);
-          toast.error('인력변경 데이터를 불러오지 못했습니다');
+        });
+      };
+      const handleChangeRequestError = (err: unknown) => {
+        console.error('[PortalStore] changeRequests listen error:', err);
+        toast.error('인력변경 데이터를 불러오지 못했습니다');
+        ifActive(() => {
           changeReady = true;
           markReady();
-        }),
-      );
-
-      unsubsRef.current.push(
-        onSnapshot(participationQuery, (snap) => {
-          const list = snap.docs
+        });
+      };
+      const handleParticipationResult = (docs: Array<{ data(): unknown }>) => {
+        ifActive(() => {
+          const list = docs
             .map((docItem) => docItem.data() as ParticipationEntry)
             .sort((a, b) => String(b.updatedAt || '').localeCompare(String(a.updatedAt || '')));
           setParticipationEntries(list);
           partReady = true;
           markReady();
-        }, (err) => {
-          console.error('[PortalStore] participation entries listen error:', err);
-          if (!isPermissionDenied(err)) {
-            toast.error('인력 데이터를 불러오지 못했습니다. 기본 데이터를 표시합니다.');
-          }
+        });
+      };
+      const handleParticipationError = (err: unknown) => {
+        console.error('[PortalStore] participation entries listen error:', err);
+        if (!isPermissionDenied(err)) {
+          toast.error('인력 데이터를 불러오지 못했습니다. 기본 데이터를 표시합니다.');
+        }
+        ifActive(() => {
           setParticipationEntries(PARTICIPATION_ENTRIES.filter((entry) => entry.projectId === currentProjectId));
           partReady = true;
           markReady();
-        }),
-      );
+        });
+      };
 
       const txQuery = query(
         collection(db, getOrgCollectionPath(orgId, 'transactions')),
@@ -1143,139 +1168,140 @@ export function PortalProvider({ children }: { children: ReactNode }) {
         `${getOrgDocumentPath(orgId, 'projects', currentProjectId)}/budget_code_book/default`,
       );
       const weeklySubmissionBase = collection(db, getOrgCollectionPath(orgId, 'weeklySubmissionStatus'));
-
-      unsubsRef.current.push(
-        onSnapshot(txQuery, (snap) => {
-          const list = snap.docs
+      const handleTransactionResult = (docs: Array<{ data(): unknown }>) => {
+        ifActive(() => {
+          const list = docs
             .map((docItem) => docItem.data() as Transaction)
             .sort((a, b) => String(b.dateTime || '').localeCompare(String(a.dateTime || '')));
           setTransactions(list);
           txReady = true;
           markReady();
-        }, (err) => {
-          console.error('[PortalStore] transactions listen error:', err);
-          if (!isPermissionDenied(err)) {
-            toast.error('거래 데이터를 불러오지 못했습니다');
-          }
+        });
+      };
+      const handleTransactionError = (err: unknown) => {
+        console.error('[PortalStore] transactions listen error:', err);
+        if (!isPermissionDenied(err)) {
+          toast.error('거래 데이터를 불러오지 못했습니다');
+        }
+        ifActive(() => {
           setTransactions(TRANSACTIONS.filter((t) => t.projectId === currentProjectId));
           txReady = true;
           markReady();
-        }),
-      );
-
-      unsubsRef.current.push(
-        onSnapshot(commentQuery, (snap) => {
-          const list = snap.docs
+        });
+      };
+      const handleCommentResult = (docs: Array<{ data(): unknown }>) => {
+        ifActive(() => {
+          const list = docs
             .map((docItem) => docItem.data() as Comment)
             .sort((a, b) => String(a.createdAt || '').localeCompare(String(b.createdAt || '')));
           setComments(list);
-        }, (err) => {
-          console.error('[PortalStore] comments listen error:', err);
-          setComments([]);
-        }),
-      );
-
-      unsubsRef.current.push(
-        onSnapshot(evidenceMapRef, (snap) => {
+        });
+      };
+      const handleCommentError = (err: unknown) => {
+        console.error('[PortalStore] comments listen error:', err);
+        ifActive(() => setComments([]));
+      };
+      const handleEvidenceMapResult = (snap: { exists(): boolean; data(): unknown }) => {
+        ifActive(() => {
           if (!snap.exists()) {
             setEvidenceRequiredMap({});
             return;
           }
           const data = snap.data() as { map?: Record<string, string> };
           setEvidenceRequiredMap(data?.map || {});
-        }, (err) => {
-          console.error('[PortalStore] evidence map listen error:', err);
-          setEvidenceRequiredMap({});
-        }),
-      );
-
-	      unsubsRef.current.push(
-	        onSnapshot(sheetSourceCollection, (snap) => {
-	          const list = snap.docs
-	            .map((docItem) => {
-	              const data = docItem.data() as Partial<ProjectSheetSourceSnapshot> & {
-	                previewMatrixRows?: Array<{ cells?: unknown }>;
-	              };
-	              const previewMatrix = Array.isArray(data.previewMatrix)
-	                ? data.previewMatrix.map((row) => (Array.isArray(row) ? row.map((cell) => String(cell ?? '')) : []))
-	                : Array.isArray(data.previewMatrixRows)
-	                  ? data.previewMatrixRows.map((row) => {
-	                      const cells = row && typeof row === 'object' ? row.cells : undefined;
-	                      return Array.isArray(cells) ? cells.map((cell) => String(cell ?? '')) : [];
-	                    })
-	                  : [];
-	              return {
-	                sourceType: (data.sourceType || docItem.id) as ProjectSheetSourceType,
-	                projectId: String(data.projectId || currentProjectId || ''),
+        });
+      };
+      const handleEvidenceMapError = (err: unknown) => {
+        console.error('[PortalStore] evidence map listen error:', err);
+        ifActive(() => setEvidenceRequiredMap({}));
+      };
+      const handleSheetSourceResult = (docs: Array<{ id: string; data(): unknown }>) => {
+        ifActive(() => {
+          const list = docs
+            .map((docItem) => {
+              const data = docItem.data() as Partial<ProjectSheetSourceSnapshot> & {
+                previewMatrixRows?: Array<{ cells?: unknown }>;
+              };
+              const previewMatrix = Array.isArray(data.previewMatrix)
+                ? data.previewMatrix.map((row) => (Array.isArray(row) ? row.map((cell) => String(cell ?? '')) : []))
+                : Array.isArray(data.previewMatrixRows)
+                  ? data.previewMatrixRows.map((row) => {
+                      const cells = row && typeof row === 'object' ? row.cells : undefined;
+                      return Array.isArray(cells) ? cells.map((cell) => String(cell ?? '')) : [];
+                    })
+                  : [];
+              return {
+                sourceType: (data.sourceType || docItem.id) as ProjectSheetSourceType,
+                projectId: String(data.projectId || currentProjectId || ''),
                 sheetName: String(data.sheetName || ''),
                 fileName: String(data.fileName || ''),
                 storagePath: String(data.storagePath || ''),
                 downloadURL: String(data.downloadURL || ''),
                 contentType: String(data.contentType || ''),
                 uploadedAt: String(data.uploadedAt || ''),
-	                rowCount: Number.isFinite(Number(data.rowCount)) ? Number(data.rowCount) : 0,
-	                columnCount: Number.isFinite(Number(data.columnCount)) ? Number(data.columnCount) : 0,
-	                matchedColumns: Array.isArray(data.matchedColumns) ? data.matchedColumns.map((value) => String(value || '')) : [],
-	                unmatchedColumns: Array.isArray(data.unmatchedColumns) ? data.unmatchedColumns.map((value) => String(value || '')) : [],
-	                previewMatrix,
-	                ...(data.applyTarget ? { applyTarget: String(data.applyTarget) } : {}),
-	                ...(data.lastAppliedAt ? { lastAppliedAt: String(data.lastAppliedAt) } : {}),
-	                ...(data.updatedAt ? { updatedAt: String(data.updatedAt) } : {}),
+                rowCount: Number.isFinite(Number(data.rowCount)) ? Number(data.rowCount) : 0,
+                columnCount: Number.isFinite(Number(data.columnCount)) ? Number(data.columnCount) : 0,
+                matchedColumns: Array.isArray(data.matchedColumns) ? data.matchedColumns.map((value) => String(value || '')) : [],
+                unmatchedColumns: Array.isArray(data.unmatchedColumns) ? data.unmatchedColumns.map((value) => String(value || '')) : [],
+                previewMatrix,
+                ...(data.applyTarget ? { applyTarget: String(data.applyTarget) } : {}),
+                ...(data.lastAppliedAt ? { lastAppliedAt: String(data.lastAppliedAt) } : {}),
+                ...(data.updatedAt ? { updatedAt: String(data.updatedAt) } : {}),
                 ...(data.updatedBy ? { updatedBy: String(data.updatedBy) } : {}),
               } satisfies ProjectSheetSourceSnapshot;
             })
             .sort((a, b) => String(b.uploadedAt || '').localeCompare(String(a.uploadedAt || '')));
           setSheetSources(list);
-        }, (err) => {
-          reportError(err, {
-            message: '[PortalStore] sheet source listen error:',
-            options: {
-              level: 'error',
-              tags: {
-                surface: 'portal_store',
-                action: 'sheet_source_listen',
-              },
-              extra: {
-                orgId,
-                actorId: authUser.uid,
-                projectId: currentProjectId,
-              },
+        });
+      };
+      const handleSheetSourceError = (err: unknown) => {
+        reportError(err, {
+          message: '[PortalStore] sheet source listen error:',
+          options: {
+            level: 'error',
+            tags: {
+              surface: 'portal_store',
+              action: 'sheet_source_listen',
             },
-          });
-          setSheetSources([]);
-        }),
-      );
-
-      unsubsRef.current.push(
-        onSnapshot(collection(db, `${getOrgDocumentPath(orgId, 'projects', currentProjectId)}/expense_intake`), (snap) => {
-          const nextItems = snap.docs
-            .map((docItem) => normalizeBankImportIntakeItem({ id: docItem.id, ...docItem.data() }))
+            extra: {
+              orgId,
+              actorId: authUser.uid,
+              projectId: currentProjectId,
+            },
+          },
+        });
+        ifActive(() => setSheetSources([]));
+      };
+      const handleExpenseIntakeResult = (docs: Array<{ id: string; data(): unknown }>) => {
+        ifActive(() => {
+          const nextItems = docs
+            .map((docItem) => normalizeBankImportIntakeItem({ id: docItem.id, ...(docItem.data() as Record<string, unknown>) }))
             .filter((item): item is BankImportIntakeItem => item !== null)
             .sort((left, right) => String(right.updatedAt || '').localeCompare(String(left.updatedAt || '')));
           setExpenseIntakeItems(nextItems);
-        }, (err) => {
-          reportError(err, {
-            message: '[PortalStore] expense intake listen error:',
-            options: {
-              level: 'error',
-              tags: {
-                surface: 'portal_store',
-                action: 'expense_intake_listen',
-              },
-              extra: {
-                orgId,
-                actorId: authUser.uid,
-                projectId: currentProjectId,
-              },
+        });
+      };
+      const handleExpenseIntakeError = (err: unknown) => {
+        reportError(err, {
+          message: '[PortalStore] expense intake listen error:',
+          options: {
+            level: 'error',
+            tags: {
+              surface: 'portal_store',
+              action: 'expense_intake_listen',
             },
-          });
-          setExpenseIntakeItems([]);
-        }),
-      );
-
-      unsubsRef.current.push(
-        onSnapshot(expenseSheetCollection, (snap) => {
-          const docs = snap.docs
+            extra: {
+              orgId,
+              actorId: authUser.uid,
+              projectId: currentProjectId,
+            },
+          },
+        });
+        ifActive(() => setExpenseIntakeItems([]));
+      };
+      const handleExpenseSheetResult = (docs: Array<{ id: string; data(): unknown }>) => {
+        ifActive(() => {
+          const nextDocs = docs
             .map<ExpenseSheetTab | null>((docItem) => {
               const data = docItem.data() as {
                 name?: string;
@@ -1286,7 +1312,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
                 deletedAt?: string;
               };
               if (data?.deletedAt) return null;
-              const nextSheet: ExpenseSheetTab = {
+              return {
                 id: docItem.id,
                 name: sanitizeExpenseSheetName(data?.name, docItem.id === 'default' ? '기본 탭' : '새 탭'),
                 rows: normalizeExpenseSheetRows(data?.rows),
@@ -1294,7 +1320,6 @@ export function PortalProvider({ children }: { children: ReactNode }) {
                 createdAt: data?.createdAt,
                 updatedAt: data?.updatedAt,
               };
-              return nextSheet;
             })
             .filter((sheet): sheet is ExpenseSheetTab => sheet !== null)
             .sort((a, b) => {
@@ -1303,7 +1328,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
             });
           const nextState = reconcileExpenseSheetTabsFromSnapshot({
             currentSheets: expenseSheetsRef.current,
-            nextSheets: docs,
+            nextSheets: nextDocs,
             activeExpenseSheetId: activeExpenseSheetIdRef.current,
           });
           if (nextState.sheetsChanged) {
@@ -1314,29 +1339,31 @@ export function PortalProvider({ children }: { children: ReactNode }) {
             activeExpenseSheetIdRef.current = nextState.activeExpenseSheetId;
             setActiveExpenseSheetIdState(nextState.activeExpenseSheetId);
           }
-        }, (err) => {
-          reportError(err, {
-            message: '[PortalStore] expense sheet listen error:',
-            options: {
-              level: 'error',
-              tags: {
-                surface: 'portal_store',
-                action: 'expense_sheet_listen',
-              },
-              extra: {
-                orgId,
-                actorId: authUser.uid,
-                projectId: currentProjectId,
-              },
+        });
+      };
+      const handleExpenseSheetError = (err: unknown) => {
+        reportError(err, {
+          message: '[PortalStore] expense sheet listen error:',
+          options: {
+            level: 'error',
+            tags: {
+              surface: 'portal_store',
+              action: 'expense_sheet_listen',
             },
-          });
+            extra: {
+              orgId,
+              actorId: authUser.uid,
+              projectId: currentProjectId,
+            },
+          },
+        });
+        ifActive(() => {
           setExpenseSheets([]);
           setExpenseSheetRows(null);
-        }),
-      );
-
-      unsubsRef.current.push(
-        onSnapshot(bankStatementRef, (snap) => {
+        });
+      };
+      const handleBankStatementResult = (snap: { exists(): boolean; data(): unknown }) => {
+        ifActive(() => {
           if (!snap.exists()) {
             setBankStatementRows(null);
             return;
@@ -1361,42 +1388,42 @@ export function PortalProvider({ children }: { children: ReactNode }) {
               : columns.map(() => ''),
           }));
           setBankStatementRows({ columns, rows });
-        }, (err) => {
-          reportError(err, {
-            message: '[PortalStore] bank statement listen error:',
-            options: {
-              level: 'error',
-              tags: {
-                surface: 'portal_store',
-                action: 'bank_statement_listen',
-              },
-              extra: {
-                orgId,
-                actorId: authUser.uid,
-                projectId: currentProjectId,
-              },
+        });
+      };
+      const handleBankStatementError = (err: unknown) => {
+        reportError(err, {
+          message: '[PortalStore] bank statement listen error:',
+          options: {
+            level: 'error',
+            tags: {
+              surface: 'portal_store',
+              action: 'bank_statement_listen',
             },
-          });
-          setBankStatementRows(null);
-        }),
-      );
-
-      unsubsRef.current.push(
-        onSnapshot(budgetPlanRef, (snap) => {
+            extra: {
+              orgId,
+              actorId: authUser.uid,
+              projectId: currentProjectId,
+            },
+          },
+        });
+        ifActive(() => setBankStatementRows(null));
+      };
+      const handleBudgetPlanResult = (snap: { exists(): boolean; data(): unknown }) => {
+        ifActive(() => {
           if (!snap.exists()) {
             setBudgetPlanRows(null);
             return;
           }
           const data = snap.data() as { rows?: BudgetPlanRow[] };
           setBudgetPlanRows(Array.isArray(data?.rows) ? data.rows : null);
-        }, (err) => {
-          console.error('[PortalStore] budget plan listen error:', err);
-          setBudgetPlanRows(null);
-        }),
-      );
-
-      unsubsRef.current.push(
-        onSnapshot(budgetCodeBookRef, (snap) => {
+        });
+      };
+      const handleBudgetPlanError = (err: unknown) => {
+        console.error('[PortalStore] budget plan listen error:', err);
+        ifActive(() => setBudgetPlanRows(null));
+      };
+      const handleBudgetCodeBookResult = (snap: { exists(): boolean; data(): unknown }) => {
+        ifActive(() => {
           if (!snap.exists()) {
             setBudgetCodeBook(BUDGET_CODE_BOOK);
             return;
@@ -1407,44 +1434,92 @@ export function PortalProvider({ children }: { children: ReactNode }) {
             : (BUDGET_CODE_BOOK as unknown as BudgetCodeEntry[]);
           const normalized = normalizeBudgetCodeBook(source);
           setBudgetCodeBook(normalized.length > 0 ? normalized : normalizeBudgetCodeBook(BUDGET_CODE_BOOK as unknown as BudgetCodeEntry[]));
-        }, (err) => {
-          console.error('[PortalStore] budget code book listen error:', err);
-          setBudgetCodeBook(normalizeBudgetCodeBook(BUDGET_CODE_BOOK as unknown as BudgetCodeEntry[]));
-        }),
-      );
+        });
+      };
+      const handleBudgetCodeBookError = (err: unknown) => {
+        console.error('[PortalStore] budget code book listen error:', err);
+        ifActive(() => setBudgetCodeBook(normalizeBudgetCodeBook(BUDGET_CODE_BOOK as unknown as BudgetCodeEntry[])));
+      };
+      const handleWeeklySubmissionResult = (docs: Array<{ id: string; data(): unknown }>) => {
+        ifActive(() => {
+          const list = docs.map((d) => {
+            const data = d.data() as WeeklySubmissionStatus;
+            return { ...data, id: data.id || d.id };
+          });
+          list.sort((a, b) => {
+            if (a.projectId !== b.projectId) return String(a.projectId).localeCompare(String(b.projectId));
+            if (a.yearMonth !== b.yearMonth) return String(b.yearMonth || '').localeCompare(String(a.yearMonth || ''));
+            return (a.weekNo || 0) - (b.weekNo || 0);
+          });
+          setWeeklySubmissionStatuses(list);
+        });
+      };
+      const handleWeeklySubmissionError = (err: unknown) => {
+        console.error('[PortalStore] weekly submission listen error:', err);
+        ifActive(() => setWeeklySubmissionStatuses([]));
+      };
 
-      if (scopedProjectIds.length > 0) {
-        const weekQuery = scopedProjectIds.length === 1
-          ? query(weeklySubmissionBase, where('projectId', '==', scopedProjectIds[0]))
-          : query(weeklySubmissionBase, where('projectId', 'in', scopedProjectIds.slice(0, 10)));
-
+      if (livePortalMode) {
+        unsubsRef.current.push(onSnapshot(ledgerQuery, (snap) => handleLedgerResult(snap.docs), handleLedgerError));
+        unsubsRef.current.push(onSnapshot(expenseQuery, (snap) => handleExpenseResult(snap.docs), handleExpenseError));
+        unsubsRef.current.push(onSnapshot(changeRequestQuery, (snap) => handleChangeRequestResult(snap.docs), handleChangeRequestError));
+        unsubsRef.current.push(onSnapshot(participationQuery, (snap) => handleParticipationResult(snap.docs), handleParticipationError));
+        unsubsRef.current.push(onSnapshot(txQuery, (snap) => handleTransactionResult(snap.docs), handleTransactionError));
+        unsubsRef.current.push(onSnapshot(commentQuery, (snap) => handleCommentResult(snap.docs), handleCommentError));
+        unsubsRef.current.push(onSnapshot(evidenceMapRef, handleEvidenceMapResult, handleEvidenceMapError));
+        unsubsRef.current.push(onSnapshot(sheetSourceCollection, (snap) => handleSheetSourceResult(snap.docs), handleSheetSourceError));
         unsubsRef.current.push(
-          onSnapshot(weekQuery, (snap) => {
-            const list = snap.docs.map((d) => {
-              const data = d.data() as WeeklySubmissionStatus;
-              return { ...data, id: data.id || d.id };
-            });
-            list.sort((a, b) => {
-              if (a.projectId !== b.projectId) return String(a.projectId).localeCompare(String(b.projectId));
-              if (a.yearMonth !== b.yearMonth) return String(b.yearMonth || '').localeCompare(String(a.yearMonth || ''));
-              return (a.weekNo || 0) - (b.weekNo || 0);
-            });
-            setWeeklySubmissionStatuses(list);
-          }, (err) => {
-            console.error('[PortalStore] weekly submission listen error:', err);
-            setWeeklySubmissionStatuses([]);
-          }),
+          onSnapshot(
+            collection(db, `${getOrgDocumentPath(orgId, 'projects', currentProjectId)}/expense_intake`),
+            (snap) => handleExpenseIntakeResult(snap.docs),
+            handleExpenseIntakeError,
+          ),
         );
+        unsubsRef.current.push(onSnapshot(expenseSheetCollection, (snap) => handleExpenseSheetResult(snap.docs), handleExpenseSheetError));
+        unsubsRef.current.push(onSnapshot(bankStatementRef, handleBankStatementResult, handleBankStatementError));
+        unsubsRef.current.push(onSnapshot(budgetPlanRef, handleBudgetPlanResult, handleBudgetPlanError));
+        unsubsRef.current.push(onSnapshot(budgetCodeBookRef, handleBudgetCodeBookResult, handleBudgetCodeBookError));
+        if (scopedProjectIds.length > 0) {
+          const weekQuery = scopedProjectIds.length === 1
+            ? query(weeklySubmissionBase, where('projectId', '==', scopedProjectIds[0]))
+            : query(weeklySubmissionBase, where('projectId', 'in', scopedProjectIds.slice(0, 10)));
+          unsubsRef.current.push(onSnapshot(weekQuery, (snap) => handleWeeklySubmissionResult(snap.docs), handleWeeklySubmissionError));
+        } else {
+          setWeeklySubmissionStatuses([]);
+        }
       } else {
-        setWeeklySubmissionStatuses([]);
+        getDocs(ledgerQuery).then((snap) => handleLedgerResult(snap.docs)).catch(handleLedgerError);
+        getDocs(expenseQuery).then((snap) => handleExpenseResult(snap.docs)).catch(handleExpenseError);
+        getDocs(changeRequestQuery).then((snap) => handleChangeRequestResult(snap.docs)).catch(handleChangeRequestError);
+        getDocs(participationQuery).then((snap) => handleParticipationResult(snap.docs)).catch(handleParticipationError);
+        getDocs(txQuery).then((snap) => handleTransactionResult(snap.docs)).catch(handleTransactionError);
+        getDocs(commentQuery).then((snap) => handleCommentResult(snap.docs)).catch(handleCommentError);
+        getDoc(evidenceMapRef).then(handleEvidenceMapResult).catch(handleEvidenceMapError);
+        getDocs(sheetSourceCollection).then((snap) => handleSheetSourceResult(snap.docs)).catch(handleSheetSourceError);
+        getDocs(collection(db, `${getOrgDocumentPath(orgId, 'projects', currentProjectId)}/expense_intake`))
+          .then((snap) => handleExpenseIntakeResult(snap.docs))
+          .catch(handleExpenseIntakeError);
+        getDocs(expenseSheetCollection).then((snap) => handleExpenseSheetResult(snap.docs)).catch(handleExpenseSheetError);
+        getDoc(bankStatementRef).then(handleBankStatementResult).catch(handleBankStatementError);
+        getDoc(budgetPlanRef).then(handleBudgetPlanResult).catch(handleBudgetPlanError);
+        getDoc(budgetCodeBookRef).then(handleBudgetCodeBookResult).catch(handleBudgetCodeBookError);
+        if (scopedProjectIds.length > 0) {
+          const weekQuery = scopedProjectIds.length === 1
+            ? query(weeklySubmissionBase, where('projectId', '==', scopedProjectIds[0]))
+            : query(weeklySubmissionBase, where('projectId', 'in', scopedProjectIds.slice(0, 10)));
+          getDocs(weekQuery).then((snap) => handleWeeklySubmissionResult(snap.docs)).catch(handleWeeklySubmissionError);
+        } else {
+          setWeeklySubmissionStatuses([]);
+        }
       }
     }
 
     return () => {
+      cancelled = true;
       unsubsRef.current.forEach((unsub) => unsub());
       unsubsRef.current = [];
     };
-  }, [authLoading, isMemberLoading, isAuthenticated, authUser, currentProjectId, firestoreEnabled, db, orgId, scopedProjectIds, isDevHarnessUser, portalUser?.projectIds]);
+  }, [authLoading, isMemberLoading, isAuthenticated, authUser, currentProjectId, firestoreEnabled, db, orgId, scopedProjectIds, isDevHarnessUser, portalUser?.projectIds, livePortalMode]);
 
   useEffect(() => {
     if (authLoading || isMemberLoading || !isAuthenticated || !authUser) return;

--- a/src/app/data/training-store.tsx
+++ b/src/app/data/training-store.tsx
@@ -3,6 +3,7 @@ import {
   collection,
   doc,
   addDoc,
+  getDocs,
   updateDoc,
   onSnapshot,
   query,
@@ -18,6 +19,7 @@ import { useFirebase } from '../lib/firebase-context';
 import { featureFlags } from '../config/feature-flags';
 import { getOrgCollectionPath } from '../lib/firebase';
 import { toast } from 'sonner';
+import { canUseRealtimeListeners } from './firestore-realtime-mode';
 
 // ── State / Actions ──
 
@@ -55,53 +57,66 @@ export function TrainingProvider({ children }: { children: ReactNode }) {
 
   const firestoreEnabled = featureFlags.firestoreCoreEnabled && !!db;
   const tenantId = orgId;
+  const liveMode = canUseRealtimeListeners(authUser?.role);
 
   // Firestore 실시간 구독
   useEffect(() => {
     if (!firestoreEnabled || !db || !authUser) return;
 
+    const coursesRef = collection(db, getOrgCollectionPath(tenantId, 'trainingCourses'));
+    const enrollRef = collection(db, getOrgCollectionPath(tenantId, 'trainingEnrollments'));
     const unsubs: Unsubscribe[] = [];
 
-    // 강의 목록 구독
-    const coursesRef = collection(db, getOrgCollectionPath(tenantId, 'trainingCourses'));
-    unsubs.push(
-      onSnapshot(query(coursesRef, orderBy('startDate', 'desc')), (snap) => {
-        setCourses(snap.docs.map((d) => ({ id: d.id, ...d.data() } as TrainingCourse)));
-      }, (err) => {
-        console.error('[Training] courses subscription error:', err);
-        setCourses(MOCK_TRAINING_COURSES);
-      })
-    );
-
-    // 내 수강 신청 구독 (portal용)
-    const enrollRef = collection(db, getOrgCollectionPath(tenantId, 'trainingEnrollments'));
-    unsubs.push(
-      onSnapshot(
-        query(enrollRef, where('memberId', '==', authUser.uid)),
-        (snap) => {
-          setMyEnrollments(snap.docs.map((d) => ({ id: d.id, ...d.data() } as TrainingEnrollment)));
-        },
-        (err) => {
-          console.error('[Training] myEnrollments subscription error:', err);
-          setMyEnrollments(MOCK_TRAINING_ENROLLMENTS.filter((e) => e.memberId === authUser.uid));
-        }
-      )
-    );
-
-    // 전체 수강 신청 구독 (admin용)
-    if (authUser.role === 'admin' || authUser.role === 'tenant_admin') {
+    if (liveMode) {
       unsubs.push(
-        onSnapshot(query(enrollRef, orderBy('enrolledAt', 'desc')), (snap) => {
-          setAllEnrollments(snap.docs.map((d) => ({ id: d.id, ...d.data() } as TrainingEnrollment)));
+        onSnapshot(query(coursesRef, orderBy('startDate', 'desc')), (snap) => {
+          setCourses(snap.docs.map((d) => ({ id: d.id, ...d.data() } as TrainingCourse)));
         }, (err) => {
-          console.error('[Training] allEnrollments subscription error:', err);
-          setAllEnrollments(MOCK_TRAINING_ENROLLMENTS);
+          console.error('[Training] courses subscription error:', err);
+          setCourses(MOCK_TRAINING_COURSES);
         })
       );
+
+      unsubs.push(
+        onSnapshot(
+          query(enrollRef, where('memberId', '==', authUser.uid)),
+          (snap) => {
+            setMyEnrollments(snap.docs.map((d) => ({ id: d.id, ...d.data() } as TrainingEnrollment)));
+          },
+          (err) => {
+            console.error('[Training] myEnrollments subscription error:', err);
+            setMyEnrollments(MOCK_TRAINING_ENROLLMENTS.filter((e) => e.memberId === authUser.uid));
+          }
+        )
+      );
+
+      if (authUser.role === 'admin' || authUser.role === 'tenant_admin') {
+        unsubs.push(
+          onSnapshot(query(enrollRef, orderBy('enrolledAt', 'desc')), (snap) => {
+            setAllEnrollments(snap.docs.map((d) => ({ id: d.id, ...d.data() } as TrainingEnrollment)));
+          }, (err) => {
+            console.error('[Training] allEnrollments subscription error:', err);
+            setAllEnrollments(MOCK_TRAINING_ENROLLMENTS);
+          })
+        );
+      }
+    } else {
+      void getDocs(query(coursesRef, orderBy('startDate', 'desc'))).then((snap) => {
+        setCourses(snap.docs.map((d) => ({ id: d.id, ...d.data() } as TrainingCourse)));
+      }).catch((err) => {
+        console.error('[Training] courses fetch error:', err);
+        setCourses(MOCK_TRAINING_COURSES);
+      });
+      void getDocs(query(enrollRef, where('memberId', '==', authUser.uid))).then((snap) => {
+        setMyEnrollments(snap.docs.map((d) => ({ id: d.id, ...d.data() } as TrainingEnrollment)));
+      }).catch((err) => {
+        console.error('[Training] myEnrollments fetch error:', err);
+        setMyEnrollments(MOCK_TRAINING_ENROLLMENTS.filter((e) => e.memberId === authUser.uid));
+      });
     }
 
     return () => unsubs.forEach((u) => u());
-  }, [authUser?.uid, authUser?.role, firestoreEnabled, db, tenantId]);
+  }, [authUser?.uid, authUser?.role, firestoreEnabled, db, tenantId, liveMode]);
 
   // Local fallback: 내 수강 초기화
   useEffect(() => {


### PR DESCRIPTION
## Summary
- follow up on #193 with a stability-first PM portal hotfix
- reduce PM-path firestore realtime listeners in shared stores
- use safe fetch mode where live updates are not required for PM flow stability

Related #193
