### PR TITLE
fix: remove residual portal realtime listeners

### DIFF
--- a/docs/operations/2026-04-15-portal-direct-listen-safe-fetch.md
+++ b/docs/operations/2026-04-15-portal-direct-listen-safe-fetch.md
@@ -1,0 +1,25 @@
+# PM Portal Direct Listen Safe Fetch Hotfix
+
+## Goal
+
+- `/portal` 홈과 인건비 화면에 남아 있는 direct Firestore realtime listener를 제거한다.
+- PM/viewer 경로에서 반복되는 `Firestore Listen 400`을 더 줄인다.
+
+## Scope
+
+- `src/app/components/portal/PortalDashboard.tsx`
+- `src/app/components/portal/PortalPayrollPage.tsx`
+- 공용 역할 정책 재사용
+- 관련 patch note 갱신
+
+## Approach
+
+- `admin`, `tenant_admin`, `finance`, `auditor`만 realtime 유지
+- `pm`, `viewer`는 `getDocs` 기반 safe fetch 사용
+- 홈과 인건비 화면 모두 `transactions`를 direct realtime listen 대신 role-based fetch로 전환
+
+## Verification
+
+- 대상 컴포넌트 테스트 또는 source contract test
+- `npm run build`
+- 필요 시 production canary 재확인

--- a/docs/wiki/patch-notes/index.md
+++ b/docs/wiki/patch-notes/index.md
@@ -6,7 +6,8 @@
 
 | Page | Route | Last Updated | 현재 구현 체크포인트 |
 | --- | --- | --- | --- |
-| [portal-dashboard](./pages/portal-dashboard.md) | `/portal` | 2026-04-14 | 가이드 제거, 현재 상태 중심, 최소 CTA 유지 |
+| [portal-dashboard](./pages/portal-dashboard.md) | `/portal` | 2026-04-15 | 포털 홈 safe fetch, 현재 상태 중심, 최소 CTA 유지 |
+| [portal-payroll](./pages/portal-payroll.md) | `/portal/payroll` | 2026-04-15 | 포털 경로 fetch 기반 거래 조회, 지급일/공지 확인 유지 |
 | [portal-weekly-expense](./pages/portal-weekly-expense.md) | `/portal/weekly-expenses` | 2026-04-14 | 기준본에서 이어쓰기, 저장 상태 구분, overwrite/backspace 복구 |
 | [portal-bank-statement](./pages/portal-bank-statement.md) | `/portal/bank-statements` | 2026-04-14 | 원본 업로드, intake queue 정리, 사업비 입력으로 이어가기 |
 | [portal-budget](./pages/portal-budget.md) | `/portal/budget` | 2026-04-14 | 가져오기 미리보기, 긴 모달 스크롤, 구조 저장 보호 |

--- a/docs/wiki/patch-notes/log.md
+++ b/docs/wiki/patch-notes/log.md
@@ -4,6 +4,10 @@
 - pages: [portal-onboarding](./pages/portal-onboarding.md)
 - summary: 포털 미등록 사용자가 온보딩 선택 카드에서 `기존 사업 선택`, `증빙 업로드`, `새 사업 등록`을 눌렀을 때 강제 온보딩 리다이렉트에 다시 덮이지 않고 실제 다음 화면으로 이동하도록 복구했다.
 
+## [2026-04-15] patch-note | portal-dashboard, portal-payroll | residual portal listen 제거
+- pages: [portal-dashboard](./pages/portal-dashboard.md), [portal-payroll](./pages/portal-payroll.md)
+- summary: `/portal` 홈과 인건비 화면이 직접 붙이던 `transactions` realtime listener를 제거하고, 포털 경로에서는 route-aware safe fetch만 사용하도록 고정했다.
+
 ## [2026-04-15] patch-note | portal-dashboard | PM safe fetch stabilization
 - pages: [portal-dashboard](./pages/portal-dashboard.md), [portal-bank-statement](./pages/portal-bank-statement.md), [portal-weekly-expense](./pages/portal-weekly-expense.md)
 - summary: PM/viewer 포털 경로의 portal store, board, training, HR surface는 역할 기반 safe fetch 모드로 전환해 반복 Firestore Listen 400이 포털 전체를 재시도 루프로 흔드는 구조를 줄였다.

--- a/docs/wiki/patch-notes/pages/portal-dashboard.md
+++ b/docs/wiki/patch-notes/pages/portal-dashboard.md
@@ -48,6 +48,7 @@
 - [x] PM 홈 부팅이 cashflow 주차 listener의 연도 범위 index 상태에 직접 막히지 않음
 - [x] PM 포털 전역 payroll listener가 compound query 없이 project 기준 listen으로 동작함
 - [x] PM 포털 주요 운영 데이터는 safe fetch 모드에서 realtime listen 없이도 부팅 가능
+- [x] 포털 홈의 거래 집계는 direct `onSnapshot` 없이 fetch 기반으로 로드됨
 - [x] 자금 요약 4칸이 사업명 바로 아래에서 한 번에 확인 가능
 - [x] 프로젝트 상세와 이번 주 작업 상태를 한 slab 안의 좌우 축으로 확인 가능
 - [x] 좌우 패널 비중이 상태 정보 기준으로 재조정됨
@@ -76,6 +77,7 @@
 - [2026-04-15] PM 홈은 전역 cashflow 주차 구독이 project 기준 query만 사용하도록 바꿔, cashflow composite index drift가 있어도 포털 첫 화면 전체가 Listen 400 재시도로 흔들리지 않게 보강했다.
 - [2026-04-15] PM 포털 전역 payroll 구독도 `projectId + orderBy` 복합 listen을 제거하고 project 기준 listen 뒤 클라이언트 정렬로 단순화해, 남아 있던 Listen 400 후보를 더 줄였다.
 - [2026-04-15] PM/viewer 경로의 portal/board/hr/training 운영 surface는 역할 기반 safe fetch 모드에서 일회성 조회를 사용하도록 바꿔, 반복 Firestore Listen 400이 포털 전체를 흔드는 구조를 더 줄였다.
+- [2026-04-15] 포털 홈이 직접 붙이던 `transactions` realtime listener를 제거하고, `/portal` 경로에서는 거래 집계도 fetch 기반으로만 읽게 바꿨다.
 - [2026-04-14] `내 제출 현황`을 홈 하단의 compact 제출 상태 표로 흡수했고, 별도 탭과 직접 진입 라우트는 홈으로 정리했다.
 - [2026-04-14] 제출 통합 블록에서는 `인력변경 신청`, `사업비 입력(주간) 작성/제출`, `주간 제출 체크` 같은 중복 섹션을 제외하고 현재 주차 기준 핵심 상태만 남겼다.
 - [2026-04-14] 상단을 Salesforce 계열 SaaS처럼 `workspace bar + app tabs + project switcher` 구조로 재편했다.

--- a/docs/wiki/patch-notes/pages/portal-payroll.md
+++ b/docs/wiki/patch-notes/pages/portal-payroll.md
@@ -1,0 +1,41 @@
+# Portal Payroll
+
+- route: `/portal/payroll`
+- primary users: PM
+- status: active
+- last updated: 2026-04-15
+
+## Purpose
+
+프로젝트별 인건비 지급일, 지급 예정 공지, 월간 정산 완료 확인을 한 화면에서 다루는 포털 운영면이다.
+
+## Current UX Summary
+
+- 지급일 등록, 다음 공지 예정일, 잔액 여력 큐를 한 화면에서 확인한다.
+- `/portal` 계열에서는 실시간 Firestore listen 대신 일회성 fetch로 거래 내역을 읽어 포털 안정성을 우선한다.
+- 확인이 필요한 지급/월마감 공지만 상단에 노출하고, 나머지는 폼과 상태 카드 중심으로 유지한다.
+
+## Current Feature Checklist
+
+- [x] 프로젝트별 인건비 지급일 저장 가능
+- [x] 이번 달 지급 예정일과 공지 예정일 미리보기 가능
+- [x] 지급 예정 공지 확인 처리 가능
+- [x] 월간 정산 완료 확인 처리 가능
+- [x] 프로젝트 거래 내역을 기준으로 지급 여력 상태 계산 가능
+- [x] `/portal/payroll`에서는 realtime listen 없이 fetch 기반으로 안정적으로 부팅 가능
+
+## Recent Changes
+
+- [2026-04-15] 포털 경로에서는 `transactions`를 `onSnapshot`으로 구독하지 않고 `getDocs` 일회성 조회로 읽도록 바꿨다.
+- [2026-04-15] 반복 Firestore `Listen 400` 재시도 후보를 줄이기 위해 지급 화면도 `/portal` safe fetch 정책을 따르게 했다.
+
+## Related Files
+
+- `src/app/components/portal/PortalPayrollPage.tsx`
+- `src/app/data/payroll-store.tsx`
+- `src/app/data/firestore-realtime-mode.ts`
+
+## Next Watch Points
+
+- 지급 화면에서도 stale role 때문에 realtime이 다시 살아나지 않는지
+- 지급일 저장 후 여력 상태 계산이 fetch 기반에서도 기대한 순서로 보이는지

--- a/src/app/components/portal/PortalDashboard.tsx
+++ b/src/app/components/portal/PortalDashboard.tsx
@@ -8,10 +8,9 @@ import {
 } from 'lucide-react';
 import {
   collection,
-  onSnapshot,
+  getDocs,
   query,
   where,
-  type Unsubscribe,
 } from 'firebase/firestore';
 import { toast } from 'sonner';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
@@ -140,24 +139,28 @@ export function PortalDashboard() {
       return;
     }
 
-    const unsubs: Unsubscribe[] = [];
+    let isCancelled = false;
 
     const txQuery = query(
       collection(db, getOrgCollectionPath(orgId, 'transactions')),
       where('projectId', '==', myProject.id),
     );
 
-    unsubs.push(
-      onSnapshot(txQuery, (snap) => {
+    void getDocs(txQuery)
+      .then((snap) => {
+        if (isCancelled) return;
         setLiveTransactions(snap.docs.map((d) => d.data() as Transaction));
-      }, (err) => {
-        console.error('[PortalDashboard] transactions listen error:', err);
+      })
+      .catch((err) => {
+        if (isCancelled) return;
+        console.error('[PortalDashboard] transactions fetch error:', err);
         toast.error('거래 데이터를 불러오지 못했습니다');
         setLiveTransactions(null);
-      }),
-    );
+      });
 
-    return () => unsubs.forEach((u) => u());
+    return () => {
+      isCancelled = true;
+    };
   }, [db, firestoreEnabled, orgId, myProject.id]);
 
   const myTx = (liveTransactions ?? TRANSACTIONS).filter(t => t.projectId === myProject.id);

--- a/src/app/components/portal/PortalPayrollPage.tsx
+++ b/src/app/components/portal/PortalPayrollPage.tsx
@@ -3,10 +3,9 @@ import { useNavigate } from 'react-router';
 import { CalendarDays, CheckCircle2, CircleDollarSign, Info, AlertTriangle, ArrowRight } from 'lucide-react';
 import {
   collection,
-  onSnapshot,
+  getDocs,
   query,
   where,
-  type Unsubscribe,
 } from 'firebase/firestore';
 import { toast } from 'sonner';
 import { PageHeader } from '../layout/PageHeader';
@@ -84,23 +83,27 @@ export function PortalPayrollPage() {
       return;
     }
 
-    const unsubs: Unsubscribe[] = [];
+    let isCancelled = false;
     const txQuery = query(
       collection(db, getOrgCollectionPath(orgId, 'transactions')),
       where('projectId', '==', projectId),
     );
 
-    unsubs.push(
-      onSnapshot(txQuery, (snap) => {
+    void getDocs(txQuery)
+      .then((snap) => {
+        if (isCancelled) return;
         setLiveTransactions(snap.docs.map((doc) => doc.data() as Transaction));
-      }, (err) => {
-        console.error('[PortalPayrollPage] transactions listen error:', err);
+      })
+      .catch((err) => {
+        if (isCancelled) return;
+        console.error('[PortalPayrollPage] transactions fetch error:', err);
         toast.error('인건비 지급용 거래 내역을 불러오지 못했습니다');
         setLiveTransactions(null);
-      }),
-    );
+      });
 
-    return () => unsubs.forEach((unsub) => unsub());
+    return () => {
+      isCancelled = true;
+    };
   }, [db, firestoreEnabled, orgId, projectId]);
 
   async function onSave() {

--- a/src/app/components/portal/PortalRealtimeSafety.test.ts
+++ b/src/app/components/portal/PortalRealtimeSafety.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const portalDashboardSource = readFileSync(
+  resolve(import.meta.dirname, 'PortalDashboard.tsx'),
+  'utf8',
+);
+
+const portalPayrollSource = readFileSync(
+  resolve(import.meta.dirname, 'PortalPayrollPage.tsx'),
+  'utf8',
+);
+
+describe('portal realtime safety', () => {
+  it('uses fetch-based transaction loading on the portal dashboard', () => {
+    expect(portalDashboardSource).toContain('getDocs(');
+    expect(portalDashboardSource).not.toContain('onSnapshot(txQuery');
+  });
+
+  it('uses fetch-based transaction loading on the portal payroll page', () => {
+    expect(portalPayrollSource).toContain('getDocs(');
+    expect(portalPayrollSource).not.toContain('onSnapshot(txQuery');
+  });
+});

--- a/src/app/data/firestore-realtime-mode.test.ts
+++ b/src/app/data/firestore-realtime-mode.test.ts
@@ -22,4 +22,11 @@ describe('firestore realtime mode', () => {
     expect(shouldUseSafeFetchMode('viewer')).toBe(true);
     expect(shouldUseSafeFetchMode('admin')).toBe(false);
   });
+
+  it('forces safe fetch mode on portal routes even for privileged roles', () => {
+    expect(canUseRealtimeListeners('admin', '/portal')).toBe(false);
+    expect(canUseRealtimeListeners('finance', '/portal/payroll')).toBe(false);
+    expect(shouldUseSafeFetchMode('admin', '/portal')).toBe(true);
+    expect(canUseRealtimeListeners('admin', '/admin')).toBe(true);
+  });
 });

--- a/src/app/data/firestore-realtime-mode.ts
+++ b/src/app/data/firestore-realtime-mode.ts
@@ -2,7 +2,21 @@ export function normalizeRealtimeRole(value: unknown): string {
   return typeof value === 'string' ? value.trim().toLowerCase() : '';
 }
 
-export function canUseRealtimeListeners(role: unknown): boolean {
+function normalizeRealtimePathname(value: unknown): string {
+  if (typeof value === 'string' && value.trim()) return value.trim().toLowerCase();
+  if (typeof window !== 'undefined' && typeof window.location?.pathname === 'string') {
+    return window.location.pathname.trim().toLowerCase();
+  }
+  return '';
+}
+
+function shouldForceSafeFetchForPath(pathname: unknown): boolean {
+  const normalized = normalizeRealtimePathname(pathname);
+  return normalized.startsWith('/portal') || normalized.startsWith('/viewer');
+}
+
+export function canUseRealtimeListeners(role: unknown, pathname?: unknown): boolean {
+  if (shouldForceSafeFetchForPath(pathname)) return false;
   const normalized = normalizeRealtimeRole(role);
   return normalized === 'admin'
     || normalized === 'tenant_admin'
@@ -10,6 +24,6 @@ export function canUseRealtimeListeners(role: unknown): boolean {
     || normalized === 'auditor';
 }
 
-export function shouldUseSafeFetchMode(role: unknown): boolean {
-  return !canUseRealtimeListeners(role);
+export function shouldUseSafeFetchMode(role: unknown, pathname?: unknown): boolean {
+  return !canUseRealtimeListeners(role, pathname);
 }


### PR DESCRIPTION
Related #203

## Summary
- remove residual PM realtime listeners from portal home and payroll pages
- reuse role-based safe fetch policy for direct portal surfaces
- reduce repeated Firestore Listen 400 on `/portal`

## Status
- draft PR before implementation