### PR TITLE
fix: make portal realtime mode route-aware

### DIFF
--- a/docs/wiki/patch-notes/log.md
+++ b/docs/wiki/patch-notes/log.md
@@ -1,5 +1,9 @@
 # Patch Notes Log
 
+## [2026-04-15] patch-note | portal-dashboard | route-aware realtime mode fix
+- pages: [portal-dashboard](./pages/portal-dashboard.md)
+- summary: 포털 전역 provider가 route 변경으로 다시 평가되지 않아 이전 admin/live mode가 `/portal`에서도 남아 있던 문제를 수정하고, pathname 구독 기반으로 safe fetch 판단이 즉시 갱신되도록 바꿨다.
+
 ## [2026-04-15] patch-note | portal-onboarding, portal-project-select | 시작 카드 실제 라우트 복구
 - pages: [portal-onboarding](./pages/portal-onboarding.md), [portal-project-select](./pages/portal-project-select.md)
 - summary: 포털 시작 선택 카드가 deep route에서도 fallback 선택 화면에 다시 덮이지 않도록 standalone entry 경로 판정을 layout과 navigation 정책에서 공통화했고, `기존 사업 선택`은 실제 사업 선택 step으로 연결했다.

--- a/docs/wiki/patch-notes/pages/portal-dashboard.md
+++ b/docs/wiki/patch-notes/pages/portal-dashboard.md
@@ -78,6 +78,7 @@
 - [2026-04-15] PM 포털 전역 payroll 구독도 `projectId + orderBy` 복합 listen을 제거하고 project 기준 listen 뒤 클라이언트 정렬로 단순화해, 남아 있던 Listen 400 후보를 더 줄였다.
 - [2026-04-15] PM/viewer 경로의 portal/board/hr/training 운영 surface는 역할 기반 safe fetch 모드에서 일회성 조회를 사용하도록 바꿔, 반복 Firestore Listen 400이 포털 전체를 흔드는 구조를 더 줄였다.
 - [2026-04-15] 포털 홈이 직접 붙이던 `transactions` realtime listener를 제거하고, `/portal` 경로에서는 거래 집계도 fetch 기반으로만 읽게 바꿨다.
+- [2026-04-15] 포털 전역 provider들이 `window.location.pathname`를 한 번 읽고 끝내는 대신 route change를 구독하도록 바꿔, admin/live 판단이 이전 화면 기준으로 고정된 채 `/portal`에서 realtime listen이 다시 살아나는 문제를 막았다.
 - [2026-04-14] `내 제출 현황`을 홈 하단의 compact 제출 상태 표로 흡수했고, 별도 탭과 직접 진입 라우트는 홈으로 정리했다.
 - [2026-04-14] 제출 통합 블록에서는 `인력변경 신청`, `사업비 입력(주간) 작성/제출`, `주간 제출 체크` 같은 중복 섹션을 제외하고 현재 주차 기준 핵심 상태만 남겼다.
 - [2026-04-14] 상단을 Salesforce 계열 SaaS처럼 `workspace bar + app tabs + project switcher` 구조로 재편했다.

--- a/src/app/data/board-store.tsx
+++ b/src/app/data/board-store.tsx
@@ -21,6 +21,7 @@ import { getOrgCollectionPath, getOrgDocumentPath } from '../lib/firebase';
 import { useFirebase } from '../lib/firebase-context';
 import { buildVoteDelta, normalizeTags } from './board.helpers';
 import { canUseRealtimeListeners } from './firestore-realtime-mode';
+import { useRealtimeRoutePathname } from './realtime-route';
 
 type VoteDirection = 'up' | 'down';
 
@@ -90,8 +91,9 @@ const INITIAL_POSTS: BoardPost[] = [
 export function BoardProvider({ children }: { children: ReactNode }) {
   const { db, isOnline, orgId } = useFirebase();
   const { user } = useAuth();
+  const pathname = useRealtimeRoutePathname();
   const firestoreEnabled = featureFlags.firestoreCoreEnabled && isOnline && !!db && !!user?.uid;
-  const liveMode = canUseRealtimeListeners(user?.role);
+  const liveMode = canUseRealtimeListeners(user?.role, pathname);
 
   const [posts, setPosts] = useState<BoardPost[]>(INITIAL_POSTS);
   const [localVotesByPostId, setLocalVotesByPostId] = useState<Record<string, -1 | 0 | 1>>({});

--- a/src/app/data/cashflow-weeks-store.tsx
+++ b/src/app/data/cashflow-weeks-store.tsx
@@ -36,6 +36,7 @@ import { addMonthsToYearMonth, getSeoulTodayIso } from '../platform/business-day
 import { getMonthMondayWeeks } from '../platform/cashflow-weeks';
 import { normalizeProjectIds } from './project-assignment';
 import { canUseRealtimeListeners } from './firestore-realtime-mode';
+import { useRealtimeRoutePathname } from './realtime-route';
 
 interface CashflowWeekState {
   yearMonth: string; // selected month ("YYYY-MM")
@@ -89,7 +90,8 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
     () => normalizeProjectIds([...(Array.isArray(user?.projectIds) ? user?.projectIds : []), myProjectId]),
     [user?.projectIds, myProjectId],
   );
-  const readAll = canUseRealtimeListeners(role);
+  const pathname = useRealtimeRoutePathname();
+  const readAll = canUseRealtimeListeners(role, pathname);
 
   const [yearMonth, setYearMonthState] = useState(() => getSeoulTodayIso().slice(0, 7));
   const [weeks, setWeeks] = useState<CashflowWeekSheet[]>([]);

--- a/src/app/data/firestore-realtime-providers.test.ts
+++ b/src/app/data/firestore-realtime-providers.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const providerFiles = [
+  'board-store.tsx',
+  'cashflow-weeks-store.tsx',
+  'hr-announcements-store.tsx',
+  'payroll-store.tsx',
+  'portal-store.tsx',
+  'training-store.tsx',
+] as const;
+
+describe('route-aware firestore realtime providers', () => {
+  for (const file of providerFiles) {
+    it(`${file} uses route-aware realtime mode`, () => {
+      const source = readFileSync(resolve(import.meta.dirname, file), 'utf8');
+
+      expect(source).toContain('useRealtimeRoutePathname');
+      expect(source).toMatch(/canUseRealtimeListeners\([^,\n]+,\s*pathname\)/);
+    });
+  }
+});

--- a/src/app/data/hr-announcements-store.tsx
+++ b/src/app/data/hr-announcements-store.tsx
@@ -19,6 +19,7 @@ import { featureFlags } from '../config/feature-flags';
 import { getOrgCollectionPath, getOrgDocumentPath } from '../lib/firebase';
 import { buildProjectAlerts, deriveAffectedProjectIds } from './hr-announcements.helpers';
 import { canUseRealtimeListeners } from './firestore-realtime-mode';
+import { useRealtimeRoutePathname } from './realtime-route';
 
 export type HrEventType = 'RESIGNATION' | 'LEAVE' | 'TRANSFER' | 'ROLE_CHANGE' | 'RETURN';
 
@@ -203,8 +204,9 @@ const INITIAL_ALERTS: ProjectChangeAlert[] = [
 export function HrAnnouncementProvider({ children }: { children: ReactNode }) {
   const { isAuthenticated, isLoading: authLoading, user } = useAuth();
   const { db, isOnline, orgId } = useFirebase();
+  const pathname = useRealtimeRoutePathname();
   const firestoreEnabled = featureFlags.firestoreCoreEnabled && isOnline && !!db;
-  const liveMode = canUseRealtimeListeners(user?.role);
+  const liveMode = canUseRealtimeListeners(user?.role, pathname);
 
   const [announcements, setAnnouncements] = useState<HrAnnouncement[]>(INITIAL_ANNOUNCEMENTS);
   const [alerts, setAlerts] = useState<ProjectChangeAlert[]>(INITIAL_ALERTS);

--- a/src/app/data/payroll-store.tsx
+++ b/src/app/data/payroll-store.tsx
@@ -35,6 +35,7 @@ import {
 } from '../platform/business-days';
 import { sortMonthlyClosesByYearMonth, sortPayrollRunsByPlannedPayDate } from './payroll.helpers';
 import { canUseRealtimeListeners } from './firestore-realtime-mode';
+import { useRealtimeRoutePathname } from './realtime-route';
 
 const DEFAULT_TIMEZONE = 'Asia/Seoul';
 const DEFAULT_LEAD_DAYS = 3;
@@ -73,7 +74,8 @@ export function PayrollProvider({ children }: { children: ReactNode }) {
 
   const role = user?.role;
   const myProjectId = user?.projectId || '';
-  const readAll = canUseRealtimeListeners(role);
+  const pathname = useRealtimeRoutePathname();
+  const readAll = canUseRealtimeListeners(role, pathname);
 
   useEffect(() => {
     unsubsRef.current.forEach((u) => u());

--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -94,6 +94,7 @@ import { reportError } from '../platform/observability';
 import { validateBudgetCodeBookDraft } from '../platform/budget-code-book-validation';
 import { buildBudgetLabelKey, normalizeBudgetLabel } from '../platform/budget-labels';
 import { canUseRealtimeListeners } from './firestore-realtime-mode';
+import { useRealtimeRoutePathname } from './realtime-route';
 import {
   resolveActivePortalProjectId,
   resolvePortalProjectCandidates,
@@ -672,9 +673,10 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     return projects.find((project) => project.id === activeProjectId) || null;
   }, [activeProjectId, projects]);
   const currentProjectId = activeProjectId;
+  const pathname = useRealtimeRoutePathname();
   const livePortalMode = useMemo(
-    () => canUseRealtimeListeners(portalUser?.role || authUser?.role),
-    [authUser?.role, portalUser?.role],
+    () => canUseRealtimeListeners(portalUser?.role || authUser?.role, pathname),
+    [authUser?.role, pathname, portalUser?.role],
   );
 
   useEffect(() => {

--- a/src/app/data/realtime-route.ts
+++ b/src/app/data/realtime-route.ts
@@ -1,0 +1,50 @@
+import { useSyncExternalStore } from 'react';
+
+const LOCATION_CHANGE_EVENT = 'mysc:location-change';
+
+let historyPatched = false;
+
+function dispatchLocationChange() {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(LOCATION_CHANGE_EVENT));
+}
+
+function patchHistoryEvents() {
+  if (historyPatched || typeof window === 'undefined') return;
+  historyPatched = true;
+
+  const originalPushState = window.history.pushState.bind(window.history);
+  const originalReplaceState = window.history.replaceState.bind(window.history);
+
+  window.history.pushState = ((...args: Parameters<History['pushState']>) => {
+    const result = originalPushState(...args);
+    dispatchLocationChange();
+    return result;
+  }) as History['pushState'];
+
+  window.history.replaceState = ((...args: Parameters<History['replaceState']>) => {
+    const result = originalReplaceState(...args);
+    dispatchLocationChange();
+    return result;
+  }) as History['replaceState'];
+}
+
+function subscribe(onStoreChange: () => void) {
+  if (typeof window === 'undefined') return () => {};
+  patchHistoryEvents();
+  window.addEventListener(LOCATION_CHANGE_EVENT, onStoreChange);
+  window.addEventListener('popstate', onStoreChange);
+  return () => {
+    window.removeEventListener(LOCATION_CHANGE_EVENT, onStoreChange);
+    window.removeEventListener('popstate', onStoreChange);
+  };
+}
+
+function getSnapshot() {
+  if (typeof window === 'undefined') return '';
+  return window.location.pathname || '';
+}
+
+export function useRealtimeRoutePathname(): string {
+  return useSyncExternalStore(subscribe, getSnapshot, () => '');
+}

--- a/src/app/data/training-store.tsx
+++ b/src/app/data/training-store.tsx
@@ -20,6 +20,7 @@ import { featureFlags } from '../config/feature-flags';
 import { getOrgCollectionPath } from '../lib/firebase';
 import { toast } from 'sonner';
 import { canUseRealtimeListeners } from './firestore-realtime-mode';
+import { useRealtimeRoutePathname } from './realtime-route';
 
 // ── State / Actions ──
 
@@ -57,7 +58,8 @@ export function TrainingProvider({ children }: { children: ReactNode }) {
 
   const firestoreEnabled = featureFlags.firestoreCoreEnabled && !!db;
   const tenantId = orgId;
-  const liveMode = canUseRealtimeListeners(authUser?.role);
+  const pathname = useRealtimeRoutePathname();
+  const liveMode = canUseRealtimeListeners(authUser?.role, pathname);
 
   // Firestore 실시간 구독
   useEffect(() => {


### PR DESCRIPTION
Related #207

## Summary
- make portal-wide realtime mode react to route changes instead of reading pathname once at provider render time
- pass explicit pathname into board, payroll, cashflow, HR, training, and portal providers before deciding live mode
- add regression coverage that all portal-relevant providers use route-aware realtime gating

## Verification
- npx vitest run src/app/data/firestore-realtime-mode.test.ts src/app/data/firestore-realtime-providers.test.ts src/app/components/portal/PortalRealtimeSafety.test.ts src/app/platform/check-patch-notes-guard.test.ts src/app/components/portal/PortalDashboard.layout.test.ts
- npm run build
