### PR TITLE
[codex] fix portal loading loop from unstable project scope

### DIFF
--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -95,6 +95,7 @@ import { buildBudgetLabelKey, normalizeBudgetLabel } from '../platform/budget-la
 import {
   resolveActivePortalProjectId,
   resolvePortalProjectCandidates,
+  serializePortalProjectScope,
 } from '../platform/portal-project-selection';
 
 export interface PortalUser {
@@ -639,6 +640,10 @@ export function PortalProvider({ children }: { children: ReactNode }) {
   const scopedProjectIds = useMemo(
     () => portalProjectCandidates.searchProjects.map((project) => project.id),
     [portalProjectCandidates.searchProjects],
+  );
+  const scopedProjectIdsSignature = useMemo(
+    () => serializePortalProjectScope(scopedProjectIds),
+    [scopedProjectIds],
   );
 
   const activeProjectId = useMemo(() => resolveActivePortalProjectId({
@@ -1444,7 +1449,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
       unsubsRef.current.forEach((unsub) => unsub());
       unsubsRef.current = [];
     };
-  }, [authLoading, isMemberLoading, isAuthenticated, authUser, currentProjectId, firestoreEnabled, db, orgId, scopedProjectIds, isDevHarnessUser, portalUser?.projectIds]);
+  }, [authLoading, isMemberLoading, isAuthenticated, authUser, currentProjectId, firestoreEnabled, db, orgId, scopedProjectIdsSignature, isDevHarnessUser, portalUser?.projectIds]);
 
   useEffect(() => {
     if (authLoading || isMemberLoading || !isAuthenticated || !authUser) return;

--- a/src/app/platform/portal-project-selection.test.ts
+++ b/src/app/platform/portal-project-selection.test.ts
@@ -4,6 +4,7 @@ import {
   resolveActivePortalProjectId,
   resolvePortalProjectCandidates,
   resolvePortalProjectSelectPath,
+  serializePortalProjectScope,
   resolvePortalProjectSwitchPath,
 } from './portal-project-selection';
 
@@ -77,5 +78,16 @@ describe('portal project selection helpers', () => {
     expect(resolvePortalProjectSwitchPath('/portal/cashflow')).toBe('/portal/cashflow');
     expect(resolvePortalProjectSwitchPath('/portal/project-select')).toBe('/portal');
     expect(resolvePortalProjectSwitchPath('/portal/project-select?redirect=%2Fportal%2Fbudget')).toBe('/portal');
+  });
+
+  it('serializes project scope from ids only so unrelated project metadata churn does not change the scope key', () => {
+    const initialScope = serializePortalProjectScope([' p-assigned ', 'p-managed', 'p-assigned']);
+    const sameIdsDifferentObjects = serializePortalProjectScope(['p-managed', 'p-assigned']);
+    const changedScope = serializePortalProjectScope(['p-managed', 'p-other']);
+
+    expect(initialScope).toBe('p-assigned|p-managed');
+    expect(sameIdsDifferentObjects).toBe('p-assigned|p-managed');
+    expect(changedScope).toBe('p-managed|p-other');
+    expect(initialScope).not.toBe(changedScope);
   });
 });

--- a/src/app/platform/portal-project-selection.ts
+++ b/src/app/platform/portal-project-selection.ts
@@ -90,6 +90,12 @@ export function resolveActivePortalProjectId(input: {
   return candidateProjectIds[0] || '';
 }
 
+export function serializePortalProjectScope(projectIds?: string[]): string {
+  return [...normalizeProjectIds(projectIds || [])]
+    .sort((left, right) => left.localeCompare(right, 'ko'))
+    .join('|');
+}
+
 export function resolvePortalProjectSelectPath(requestedPath?: string): string {
   const pathname = typeof requestedPath === 'string' ? requestedPath.trim() : '';
   if (!isPortalPath(pathname)) return PORTAL_PROJECT_SELECT_PATH;


### PR DESCRIPTION
## Summary
This PR narrows a portal regression introduced after `a687057` by stabilizing the project-scope dependency that drives the main portal loading/listen effect.

In the regressed flow, the portal store derived `scopedProjectIds` from `portalProjectCandidates.searchProjects`, and that candidate list was rebuilt from the live global `projects` snapshot. The loading/listen effect depended directly on the `scopedProjectIds` array, so unrelated `projects` collection churn could retrigger the effect, flip `setIsLoading(true)` again, tear down subscriptions, and make the portal look like it was stuck loading.

## User impact
For PM / business users this showed up as the portal appearing to reload or stay in a loading state when project documents changed in the background. A later redirect-oriented change made that symptom more visible, but this scope dependency was the more likely root cause.

## Root cause
The portal was coupling an operational subscription effect to an unstable array dependency:

- `projects` realtime snapshot changed
- `portalProjectCandidates.searchProjects` rebuilt
- `scopedProjectIds` got a new array identity
- the main portal loading effect reran even when the actual project id set had not changed

That meant metadata churn in the global project pool could behave like a scope change.

## Fix
The fix keeps the current session-active-project behavior intact, but makes the effect depend on a stable scope signature derived from normalized project ids only.

Concretely:

- add `serializePortalProjectScope()` in `portal-project-selection.ts`
- normalize, dedupe, and sort ids before generating the scope signature
- make the portal loading/listen effect depend on that signature instead of the raw `scopedProjectIds` array

This preserves reruns when the actual scope changes, while ignoring unrelated object churn or ordering noise from the global `projects` snapshot.

## Validation
I ran the following checks locally in this worktree:

- `npx vitest run src/app/platform/portal-project-selection.test.ts`
- `npx vitest run src/app/platform/portal-project-selection.test.ts src/app/platform/portal-shell-actions.test.ts src/app/platform/portal-happy-path.test.ts`
- `npm run build`

## Notes
This is intentionally a narrow operational fix. It does not change the broader portal architecture or the session active project UX. It only stops the main portal effect from treating unrelated project metadata churn as a loading-scope change.
