### PR TITLE
refactor: close portal read model phase1

### DIFF
--- a/docs/architecture/product-release-gates-runbook-2026-04-05.md
+++ b/docs/architecture/product-release-gates-runbook-2026-04-05.md
@@ -42,6 +42,14 @@ Included flows:
 
 ## Local Reproduction
 
+For the phase1 portal lane, use the canonical validation gate first:
+
+```bash
+npm run phase1:portal:validation-gate -- --json-out artifacts/phase1-portal-validation-gate.json
+```
+
+For the broader legacy product gate, run the Playwright specs directly:
+
 Run the product gate Playwright specs:
 
 ```bash

--- a/docs/operations/2026-04-16-portal-hardening-orchestration-model.md
+++ b/docs/operations/2026-04-16-portal-hardening-orchestration-model.md
@@ -1,0 +1,70 @@
+# Portal Hardening Orchestration Model
+
+Goal: keep portal hardening work in this repo split between one main agent that orchestrates and verifies, and subagents that each implement a single bounded slice.
+
+## Operating Model
+
+- Main agent owns scope, ordering, cross-file integration, final verification, and the decision to merge or re-slice.
+- Subagents own implementation for one slice only and should not expand scope beyond the assigned files and acceptance checks.
+- Documentation changes stay with the main agent unless a slice explicitly includes a doc update tied to the same change.
+
+## Task Slicing
+
+- Slice by one concern at a time: one route, one API contract, one harness fix, one release gate, or one doc update.
+- Keep a slice small enough to review in one pass, usually 1 to 3 files.
+- Do not combine read-model changes, write-path changes, and release-gate changes in the same slice.
+- If a slice needs shared config or test harness work, split that into its own slice first.
+
+## Ownership
+
+- Main agent:
+  - writes the slice brief
+  - assigns the subagent
+  - resolves conflicts across slices
+  - performs final integration and release verification
+  - owns the PR narrative and merge decision
+- Subagent:
+  - edits only the assigned files
+  - adds or updates tests for the assigned slice
+  - reports exact files changed and exact verification commands run
+  - stops when the slice is complete or blocked
+
+## Review Loop
+
+1. Main agent writes a concrete slice brief with goal, files, and required metrics.
+2. Subagent implements the slice and runs the requested checks.
+3. Main agent reviews the diff, test output, and metric deltas.
+4. If the slice is clean, it is merged into the working branch and the next slice starts.
+5. If scope drift or a failing metric appears, the slice is re-scoped before more code lands.
+
+## Required Test Metrics
+
+- Targeted portal smoke passes for the affected route or flow.
+- Console error count for the flow is zero.
+- Firestore `Listen 400` count is zero on the affected surface.
+- HAR or equivalent network budget is recorded before and after the slice.
+- Unit or integration coverage exists for any regression the slice introduces or fixes.
+- If a metric is not applicable, the PR notes why it was excluded.
+
+## Canonical Validation Command
+
+- Local single source of truth:
+  - `npm run phase1:portal:validation-gate -- --json-out artifacts/phase1-portal-validation-gate.json`
+- The script runs the phase1 unit/contract set, broad portal smoke + release gates, and production build in that order.
+- The JSON artifact is the handoff object the main agent reads before claiming a slice is stable.
+- Do not duplicate these commands in ad-hoc notes or subagent briefs. Reference the one script instead.
+
+## Branch and PR Discipline
+
+- Use one branch per slice or phase.
+- Keep each PR scoped to a single slice and its verification artifacts.
+- Rebase or refresh the branch before integration if the base branch moved.
+- Do not mix implementation slices with unrelated doc cleanup in the same PR.
+- Main agent owns final review, merge order, and rollback choice.
+
+## Portal Hardening Rules
+
+- Treat HAR regressions, Firestore listen churn, and route coupling as first-class acceptance failures.
+- Prefer short-lived branches for portal hardening because the repo is actively changing in parallel.
+- Never land a partial slice without the verification artifacts that prove the surface is stable.
+- Keep the release story aligned with the metrics, not with the amount of code changed.

--- a/docs/wiki/patch-notes/log.md
+++ b/docs/wiki/patch-notes/log.md
@@ -1,5 +1,17 @@
 # Patch Notes Log
 
+## [2026-04-16] patch-note | shared-portal-architecture | portal hardening orchestration model
+- pages: [shared-portal-architecture](./pages/shared-portal-architecture.md)
+- summary: 포털 하드닝 작업을 main-agent orchestration + subagent implementation slices 모델로 고정하고, task slicing, review loop, required test metrics, branch/PR discipline를 운영 문서로 분리했다.
+
+## [2026-04-16] patch-note | portal-project-select, portal-dashboard, portal-submissions, shared-portal-architecture | phase1 smoke closure and harness drift fix
+- pages: [portal-project-select](./pages/portal-project-select.md), [portal-dashboard](./pages/portal-dashboard.md), [portal-submissions](./pages/portal-submissions.md), [shared-portal-architecture](./pages/shared-portal-architecture.md)
+- summary: phase1 close 과정에서 `project-select` entry-context 실패 원인을 local dev harness의 API base URL drift로 확정했고, harness 모드에서는 현재 Vite origin을 우선 사용하도록 고쳤다. 동시에 Playwright harness를 serial worker + local API base 고정 계약으로 잠가 webserver refusal과 `ProjectDetailPage` dynamic import false negative를 분리했고, `/portal/submissions -> /portal` 경로에서 터지던 dashboard summary null-safety 회귀도 수정해 broad smoke와 release gate를 다시 green으로 닫았다.
+
+## [2026-04-16] patch-note | portal-dashboard, portal-payroll, portal-weekly-expense, portal-bank-statement, shared-portal-architecture | portal read model phase1
+- pages: [portal-dashboard](./pages/portal-dashboard.md), [portal-payroll](./pages/portal-payroll.md), [portal-weekly-expense](./pages/portal-weekly-expense.md), [portal-bank-statement](./pages/portal-bank-statement.md), [shared-portal-architecture](./pages/shared-portal-architecture.md)
+- summary: 포털 1차 read boundary를 BFF summary 계약으로 옮겨 `/portal`, `인건비`, `사업비 입력(주간)`, `통장내역`이 페이지 레벨 direct Firestore summary 해석 대신 `dashboard-summary`, `payroll-summary`, `weekly-expenses-summary`, `bank-statements-summary`를 우선 사용하도록 정리했다. entry shell과 route-scoped provider split 다음 단계로, 포털 read model API-first 전환을 실제 화면 계약에 연결한 첫 파동이다.
+
 ## [2026-04-16] patch-note | shared-portal-architecture | internal production SaaS 운영 기준 보정
 - pages: [shared-portal-architecture](./pages/shared-portal-architecture.md)
 - summary: `1000명 규모 내부 production SaaS` 기준으로 stable lane을 기본값으로 두고, low-risk 예외 경로만 owner/expiry/remove condition과 함께 time-boxed 허용하도록 운영 정책을 보정했다.

--- a/docs/wiki/patch-notes/pages/portal-bank-statement.md
+++ b/docs/wiki/patch-notes/pages/portal-bank-statement.md
@@ -3,7 +3,7 @@
 - route: `/portal/bank-statements`
 - primary users: PM, 운영 입력 담당자
 - status: active
-- last updated: 2026-04-15
+- last updated: 2026-04-16
 
 ## Purpose
 
@@ -26,6 +26,7 @@
 - [x] 환수행, 선사용금, 특이건 보조 액션 없이 기본 표 편집 흐름만 유지
 - [x] `cashflow항목` label과 내부 enum은 공용 policy 기준으로 해석됨
 - [x] PM 포털 safe fetch 모드에서도 통장내역 화면 진입과 direct handoff 부팅 가능
+- [x] 통장내역 화면은 `bank-statements-summary` BFF contract로 프로젝트 header와 handoff readiness를 우선 읽음
 - [ ] 마지막 행 드롭다운 잘림 이슈 완전 해소 확인 필요
 
 ## Recent Changes
@@ -33,6 +34,7 @@
 - [2026-04-15] `cashflow항목` line label/alias/category 해석이 공용 policy 레이어를 통하도록 정리했다.
 - [2026-04-15] 통장내역 저장 시 업로드한 은행 행을 현재 주간 사업비 탭 행으로 바로 merge하도록 바꿨다. Queue 없이 `통장내역 -> 사업비 입력(주간)` direct handoff가 이어진다.
 - [2026-04-15] PM 역할에서는 portal store가 realtime listen 대신 safe fetch로 초기 데이터를 불러오도록 바꿔, 포털 부팅 시 반복 Listen 400이 통장내역 화면까지 전파되는 위험을 줄였다.
+- [2026-04-16] `/portal/bank-statements`는 `bank-statements-summary` BFF endpoint를 추가해 프로젝트 header와 handoff readiness를 raw store shape보다 summary contract 기준으로 우선 렌더링하도록 옮기기 시작했다.
 - [2026-04-14] 포털 session active project를 따라 현재 사업이 바뀌어도 같은 화면에서 다른 사업 통장내역을 바로 이어서 볼 수 있게 했다.
 - [2026-04-14] `신규 거래 처리 Queue` 카드와 queue-first wizard 액션을 제거하고, 통장내역 저장본에서 바로 사업비 입력으로 이어지는 단일 흐름으로 롤백했다.
 - [2026-04-14] 환수행, 선사용금, 특이건 보조 행 추가 액션을 현재 operator-facing 화면에서 제외했다.

--- a/docs/wiki/patch-notes/pages/portal-dashboard.md
+++ b/docs/wiki/patch-notes/pages/portal-dashboard.md
@@ -3,7 +3,7 @@
 - route: `/portal`
 - primary users: PM
 - status: active
-- last updated: 2026-04-15
+- last updated: 2026-04-16
 
 ## Purpose
 
@@ -51,6 +51,7 @@
 - [x] 포털 홈의 거래 집계는 direct `onSnapshot` 없이 fetch 기반으로 로드됨
 - [x] 포털 홈은 route shell이 주입한 `portal-safe` access mode를 기준으로 부팅됨
 - [x] 포털 store는 pathname이나 `window.location`을 읽어 realtime 여부를 스스로 판단하지 않음
+- [x] 포털 홈은 `dashboard-summary` BFF read model contract를 우선 사용해 프로젝트 상태와 이번 주 작업 상태를 읽음
 - [x] 자금 요약 4칸이 사업명 바로 아래에서 한 번에 확인 가능
 - [x] 프로젝트 상세와 이번 주 작업 상태를 한 slab 안의 좌우 축으로 확인 가능
 - [x] 좌우 패널 비중이 상태 정보 기준으로 재조정됨
@@ -82,6 +83,8 @@
 - [2026-04-15] 포털 홈이 직접 붙이던 `transactions` realtime listener를 제거하고, `/portal` 경로에서는 거래 집계도 fetch 기반으로만 읽게 바꿨다.
 - [2026-04-15] 포털 전역 provider들이 `window.location.pathname`를 한 번 읽고 끝내는 대신 route change를 구독하도록 바꿔, admin/live 판단이 이전 화면 기준으로 고정된 채 `/portal`에서 realtime listen이 다시 살아나는 문제를 막았다.
 - [2026-04-15] App 루트 broad provider를 route shell로 분리하고, 포털은 `portal-safe` access mode를 주입받아 store가 URL self-inference 없이 동일한 fetch 정책을 따르게 정리했다.
+- [2026-04-16] `/portal`은 `dashboard-summary` BFF endpoint를 추가해 프로젝트 상태와 이번 주 작업 상태를 raw page 계산보다 summary contract 기준으로 우선 렌더링하도록 옮기기 시작했다.
+- [2026-04-16] phase1 smoke에서 `/portal/submissions -> /portal` 리다이렉트가 `dashboardSummary?.project.clientOrg` null-safety 누락 때문에 터지던 회귀를 수정했고, 프로젝트 상세는 read model fallback을 안전하게 읽도록 정리했다.
 - [2026-04-14] `내 제출 현황`을 홈 하단의 compact 제출 상태 표로 흡수했고, 별도 탭과 직접 진입 라우트는 홈으로 정리했다.
 - [2026-04-14] 제출 통합 블록에서는 `인력변경 신청`, `사업비 입력(주간) 작성/제출`, `주간 제출 체크` 같은 중복 섹션을 제외하고 현재 주차 기준 핵심 상태만 남겼다.
 - [2026-04-14] 상단을 Salesforce 계열 SaaS처럼 `workspace bar + app tabs + project switcher` 구조로 재편했다.

--- a/docs/wiki/patch-notes/pages/portal-payroll.md
+++ b/docs/wiki/patch-notes/pages/portal-payroll.md
@@ -3,7 +3,7 @@
 - route: `/portal/payroll`
 - primary users: PM
 - status: active
-- last updated: 2026-04-15
+- last updated: 2026-04-16
 
 ## Purpose
 
@@ -24,12 +24,14 @@
 - [x] 프로젝트 거래 내역을 기준으로 지급 여력 상태 계산 가능
 - [x] `/portal/payroll`에서는 realtime listen 없이 fetch 기반으로 안정적으로 부팅 가능
 - [x] 지급 화면도 route shell이 주입한 `portal-safe` access mode만 소비함
+- [x] 지급 화면은 `payroll-summary` BFF read model contract를 우선 사용해 현재 지급 상태와 queue를 읽음
 
 ## Recent Changes
 
 - [2026-04-15] 포털 경로에서는 `transactions`를 `onSnapshot`으로 구독하지 않고 `getDocs` 일회성 조회로 읽도록 바꿨다.
 - [2026-04-15] 반복 Firestore `Listen 400` 재시도 후보를 줄이기 위해 지급 화면도 `/portal` safe fetch 정책을 따르게 했다.
 - [2026-04-15] 지급 화면은 pathname 기반 realtime 추론을 제거하고, route shell에서 주입한 access policy를 기준으로 read-all/realtime 여부를 결정하도록 바꿨다.
+- [2026-04-16] `/portal/payroll`은 `payroll-summary` BFF endpoint를 추가해 지급일 설정 상태, 현재 지급 run, queue read surface를 summary contract 우선으로 읽게 옮기기 시작했다.
 
 ## Related Files
 

--- a/docs/wiki/patch-notes/pages/portal-project-select.md
+++ b/docs/wiki/patch-notes/pages/portal-project-select.md
@@ -34,6 +34,8 @@
 - [2026-04-15] standalone entry path를 layout과 navigation helper에서 같이 보도록 맞춰, 미등록 사용자가 이 경로로 이동한 뒤 다시 fallback 선택 화면에 덮이지 않도록 복구했다.
 - [2026-04-15] HAR 기준으로 Firestore `Listen/Write channel`이 과도하게 열리던 병목을 줄이기 위해, 이 화면을 lightweight entry shell로 분리하고 `entry-context`/`session-project` BFF 경로로 교체했다.
 - [2026-04-15] 외부 font CSS import를 제거하고 self-hosted Pretendard + immutable asset cache 정책을 같이 적용해 entry surface 초기 요청 무게를 줄였다.
+- [2026-04-16] phase1 smoke에서 `entry-context` fetch가 계속 실패하던 원인을 로컬 dev harness의 API base URL drift로 확정했고, harness 모드에서는 `VITE_PLATFORM_API_BASE_URL`보다 현재 Vite origin을 우선 사용하도록 고쳤다.
+- [2026-04-16] Playwright harness도 `VITE_PLATFORM_API_BASE_URL=http://localhost:4173`를 명시하고 serial worker로 고정해, `project-select` 실패와 `ProjectDetailPage` dynamic import false negative가 같은 harness drift에서 재발하지 않게 정리했다.
 - [2026-04-14] 이미 `project-select?redirect=...` 형태인 진입 URL은 redirect query를 보존하도록 라우팅 안정성을 보강했다.
 - [2026-04-14] 포털 진입을 `/portal/project-select` step으로 분리하고 세션 active project 선택 흐름을 신설했다.
 
@@ -43,6 +45,8 @@
 - `src/app/components/portal/PortalEntryLayout.tsx`
 - `src/app/components/portal/PortalLayout.tsx`
 - `src/app/lib/platform-bff-client.ts`
+- `src/app/platform/dev-harness-portal-api.ts`
+- `src/app/platform/harness-stability.contract.test.ts`
 - `src/app/platform/navigation.ts`
 - `src/app/platform/portal-project-selection.ts`
 - `server/bff/routes/portal-entry.mjs`
@@ -54,6 +58,8 @@
 - `src/app/components/portal/PortalProjectSelectPage.shell.test.ts`
 - `src/app/routes.provider-scope.test.ts`
 - `src/app/lib/platform-bff-client.test.ts`
+- `src/app/platform/dev-harness-portal-api.test.ts`
+- `src/app/platform/harness-stability.contract.test.ts`
 - `src/app/vercel.cache-policy.contract.test.ts`
 - `src/app/platform/navigation.test.ts`
 - `src/app/platform/portal-project-selection.test.ts`

--- a/docs/wiki/patch-notes/pages/portal-submissions.md
+++ b/docs/wiki/patch-notes/pages/portal-submissions.md
@@ -29,6 +29,7 @@
 ## Recent Changes
 
 - [2026-04-14] 포털 session active project를 따라 제출 현황이 현재 선택한 사업 기준으로 즉시 바뀌도록 맞췄다.
+- [2026-04-16] phase1 smoke에서 `/portal/submissions`가 홈으로 돌아온 뒤 dashboard summary read-model fallback 때문에 깨지던 회귀를 수정해, redirected submission surface가 다시 안정적으로 홈에 흡수되도록 복구했다.
 - [2026-04-14] header slab, 표 헤더, 상태칩, 탭, 보조 카드 톤을 dashboard와 같은 Salesforce형 enterprise palette로 정리했다.
 - [2026-04-14] 상단 설명 header, helper badge, 빈 상태 코칭 문구를 걷어내고 상태표/신청목록만 남겼다.
 - [2026-04-14] 제출/수정 audit line에서 이름이 없을 때 `-` placeholder를 찍지 않도록 정리했다.

--- a/docs/wiki/patch-notes/pages/portal-weekly-expense.md
+++ b/docs/wiki/patch-notes/pages/portal-weekly-expense.md
@@ -3,7 +3,7 @@
 - route: `/portal/weekly-expenses`
 - primary users: PM, 실무 입력 담당자
 - status: active
-- last updated: 2026-04-15
+- last updated: 2026-04-16
 
 ## Purpose
 
@@ -27,6 +27,7 @@
 - [x] overwrite/backspace 입력 가능
 - [x] 통장내역 저장본에서 queue-first wizard 없이 바로 주간 입력으로 이어가기 가능
 - [x] PM 포털 safe fetch 모드에서도 주간 입력 화면 부팅 가능
+- [x] 주간 입력 화면은 `weekly-expenses-summary` BFF contract로 프로젝트 header와 handoff surface를 우선 읽음
 - [ ] 입력 보조 드롭다운/팝오버 잘림 이슈 완전 해소 확인 필요
 
 ## Recent Changes
@@ -34,6 +35,7 @@
 - [2026-04-14] 포털 session active project 전환과 함께 현재 사업 기준 입력 상태 요약과 진행 step strip을 안정적으로 다시 연결했다.
 - [2026-04-15] 통장내역 저장 직후 신규 은행 행이 현재 주간 사업비 탭에 바로 나타나도록 연결했다. 별도 Queue나 triage wizard 없이 이 화면에서 바로 편집을 이어간다.
 - [2026-04-15] PM 역할에서는 portal store가 주요 운영 데이터를 realtime listen 대신 safe fetch로 초기 로딩해, 포털 부팅 중 반복 Listen 400이 사업비 입력 화면까지 흔드는 구조를 줄였다.
+- [2026-04-16] `/portal/weekly-expenses`는 `weekly-expenses-summary` BFF endpoint를 추가해 프로젝트 header와 handoff surface를 raw store shape보다 summary contract 기준으로 우선 렌더링하도록 옮기기 시작했다.
 - [2026-04-14] 미처리 거래 queue strip과 triage wizard 진입을 제거하고, 통장내역 저장본에서 바로 현재 탭 입력으로 이어가는 흐름으로 롤백했다.
 - [2026-04-14] 미저장 편집이 남은 상태에서 통장내역이나 사이드바로 이동하면 확인 다이얼로그를 띄우도록 복구했다.
 - [2026-04-14] bank import triage wizard의 cashflow category 선택값을 정리하고, fullscreen wizard와 주간 입력 화면 간 회귀 E2E를 다시 통과시켰다.

--- a/docs/wiki/patch-notes/pages/shared-portal-architecture.md
+++ b/docs/wiki/patch-notes/pages/shared-portal-architecture.md
@@ -3,7 +3,7 @@
 - route: `shared / architecture`
 - primary users: 운영자, 개발자, QA, 의사결정자
 - status: draft-active
-- last updated: 2026-04-15
+- last updated: 2026-04-16
 
 ## Purpose
 
@@ -32,6 +32,7 @@
 - [x] entry surface는 `entry-context` read model + `session-project` command API를 사용함
 - [x] onboarding surface는 `onboarding-context` read model + `portal/registration` command API를 사용함
 - [x] portal dashboard / submissions / weekly expense / bank statement / payroll summary read model 이행 계획이 정의됨
+- [x] phase 1a로 portal dashboard / payroll / weekly-expenses / bank-statements summary endpoint와 클라이언트 contract가 추가됨
 - [x] critical write path를 command API로 이동하는 단계가 플랜에 포함됨
 - [x] App 루트 broad provider tree가 admin/portal route shell로 분리됨
 - [x] route shell이 explicit Firestore access mode를 주입하고 store는 pathname self-inference를 하지 않음
@@ -40,6 +41,7 @@
 
 ## Recent Changes
 
+- [2026-04-16] portal hardening work now uses a main-agent orchestration model with subagents handling isolated implementation slices, and the required review loop / metrics / branch discipline is captured in a dedicated operations doc.
 - [2026-04-15] 포털 안정화 장기안으로 `Firestore 유지 + BFF/API-first hybrid`를 채택했다.
 - [2026-04-15] `Firestore direct 유지`, `AWS full replatform`, `AWS + Cloudflare hybrid`를 같은 기준으로 비교하고, 현재 권고 순서를 `하이브리드 안정화 -> AWS core backend -> 필요 시 Cloudflare edge layer`로 정리했다.
 - [2026-04-15] `client-direct architecture`를 끝내기 위해 지금 닫아야 할 결정과, 구현 단계에서 닫을 결정, 후속 인프라 결정으로 미룰 항목을 별도 decision-point 문서로 정리했다.
@@ -53,6 +55,11 @@
 - [2026-04-15] Phase 1a 구현으로 `/portal/project-select`를 lightweight entry shell로 분리하고, portal store bootstrap 대신 BFF `entry-context`/`session-project` 계약을 쓰도록 옮겼다.
 - [2026-04-15] follow-up으로 `/portal/onboarding`도 같은 entry shell과 BFF `onboarding-context`/`portal/registration` 계약으로 옮겨, 포털 entry surface의 핵심 경계를 일치시켰다.
 - [2026-04-15] entry hardening과 함께 self-hosted Pretendard + immutable asset cache 정책을 추가해, HAR에서 보인 entry surface 네트워크 낭비를 줄이는 방향으로 첫 조치를 넣었다.
+- [2026-04-16] phase 1 read-model slice로 `/api/v1/portal/dashboard-summary`, `/api/v1/portal/payroll-summary`, `/api/v1/portal/weekly-expenses-summary`, `/api/v1/portal/bank-statements-summary` endpoint와 대응 client contract를 추가했다.
+- [2026-04-16] portal dashboard / payroll / weekly-expenses / bank-statements는 위 summary endpoint를 우선 읽고, store state는 fallback 또는 write path 쪽으로만 남기는 방향으로 cutover를 시작했다.
+- [2026-04-16] phase1 close 과정에서 `project-select` smoke 실패 원인을 `VITE_PLATFORM_API_BASE_URL`이 local harness에서 죽어 있는 `127.0.0.1:8787`을 계속 가리키던 drift로 확정했고, harness 모드에서는 현재 Vite origin을 우선 사용하도록 정리했다.
+- [2026-04-16] broad smoke에서 보였던 `ProjectDetailPage` dynamic import failure와 webserver refusal은 별도 제품 회귀가 아니라 같은 harness drift/worker churn의 false negative로 분리했고, Playwright harness를 serial worker + local API base 고정 계약으로 잠갔다.
+- [2026-04-16] phase1 close 과정에서 `/portal/submissions -> /portal` 경로의 dashboard summary null-safety 회귀도 같이 수정해, broad smoke와 release gate를 실제 제품 상태 기준으로 다시 green으로 닫았다.
 
 ## Known Notes
 
@@ -63,6 +70,7 @@
 
 ## Related Files
 
+- `docs/operations/2026-04-16-portal-hardening-orchestration-model.md`
 - `docs/architecture/portal-stabilization-hybrid-rfc-2026-04-15.md`
 - `docs/architecture/portal-platform-options-2026-04-15.md`
 - `docs/architecture/client-direct-exit-decision-points-2026-04-15.md`
@@ -89,6 +97,7 @@
 
 ## Related QA / Ops Context
 
+- Portal hardening slices are now expected to be assigned one at a time, with the main agent holding integration and verification responsibility across route, read-model, write-path, and release-gate changes.
 - 반복적인 Firestore `Listen 400`, 포털 flicker, route/provider coupling 이슈가 누적되며 단기 핫픽스로는 한계가 분명해졌다.
 - 운영 화면이 raw Firestore query를 직접 조합하는 구조를 줄이고, 읽기 계약을 BFF로 모으는 것이 장기 안정화의 핵심으로 정리됐다.
 - 이번 phase는 provider를 옮기는 수준이 아니라, route shell이 data access policy를 명시적으로 주입하게 만든 첫 구조 변경이다.
@@ -96,6 +105,8 @@
 
 ## Next Watch Points
 
+- Slice boundaries stay narrow enough that one subagent can finish a change without cross-slice edits.
+- Main-agent verification continues to require the real smoke and HAR metrics, not just unit test success.
 - Phase 0~1이 실제로 broad provider tree를 얼마나 줄이는지
 - entry surface가 다시 Firestore direct read/write path를 끌어오지 않는지
 - read model endpoint가 raw model drift 없이 유지되는지

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "firebase:emulators:start": "bash scripts/firebase_emulator_bootstrap.sh --start",
     "qa:feedback:ingest": "npx tsx scripts/ingest_qa_feedback_tracker.ts",
     "phase:preflight": "npx tsx scripts/phase_preflight_qa.ts",
+    "phase1:portal:validation-gate": "npx tsx scripts/phase1_portal_validation_gate.ts",
     "phase1:extract:usage-ledger": "npx tsx scripts/extract_usage_ledger_phase1_fixture.ts",
     "rust:settlement:build": "cargo build --quiet --manifest-path rust/spreadsheet-calculation-core/Cargo.toml",
     "rust:settlement:test": "cargo test --manifest-path rust/spreadsheet-calculation-core/Cargo.toml",

--- a/playwright.harness.config.mjs
+++ b/playwright.harness.config.mjs
@@ -3,6 +3,7 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './tests/e2e',
   timeout: 60_000,
+  workers: 1,
   expect: {
     timeout: 10_000,
   },
@@ -13,7 +14,7 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
   webServer: {
-    command: 'VITE_DEV_AUTH_HARNESS_ENABLED=true npm run dev -- --host localhost --port 4173',
+    command: 'VITE_DEV_AUTH_HARNESS_ENABLED=true VITE_PLATFORM_API_BASE_URL=http://localhost:4173 npm run dev -- --host localhost --port 4173',
     url: 'http://localhost:4173/login',
     timeout: 120_000,
     reuseExistingServer: !process.env.CI,

--- a/scripts/phase1_portal_validation_gate.ts
+++ b/scripts/phase1_portal_validation_gate.ts
@@ -1,0 +1,195 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+export interface Phase1PortalValidationStep {
+  name: string;
+  command: string;
+}
+
+export interface Phase1PortalValidationStepResult extends Phase1PortalValidationStep {
+  exitCode: number;
+  durationMs: number;
+  passed: boolean;
+}
+
+export interface Phase1PortalValidationSummary {
+  suiteCount: number;
+  passedCount: number;
+  failedCount: number;
+  totalDurationMs: number;
+  generatedAt: string;
+}
+
+export interface Phase1PortalValidationResult {
+  steps: Phase1PortalValidationStepResult[];
+  summary: Phase1PortalValidationSummary;
+}
+
+export interface Phase1PortalValidationGateOptions {
+  steps?: Phase1PortalValidationStep[];
+  jsonOutPath?: string;
+  runCommand?: (command: string) => Promise<{ exitCode: number; durationMs: number }>;
+  writeJson?: (filePath: string, payload: Phase1PortalValidationResult) => Promise<void>;
+  now?: () => Date;
+  logger?: Pick<Console, 'log'>;
+}
+
+const DEFAULT_LOGGER = console;
+
+export const PHASE1_PORTAL_VALIDATION_STEPS: Phase1PortalValidationStep[] = [
+  {
+    name: 'phase1 unit and contract tests',
+    command:
+      'npm test -- src/app/platform/dev-harness-portal-api.test.ts src/app/platform/harness-stability.contract.test.ts src/app/components/portal/PortalProjectSelectPage.shell.test.ts src/app/components/portal/PortalOnboarding.shell.test.ts src/app/lib/platform-bff-client.test.ts src/app/components/portal/PortalDashboard.layout.test.ts src/app/platform/check-patch-notes-guard.test.ts',
+  },
+  {
+    name: 'phase1 platform smoke and release gate e2e',
+    command:
+      'CI=1 npx playwright test tests/e2e/platform-smoke.spec.ts tests/e2e/product-release-gates.spec.ts --config playwright.harness.config.mjs',
+  },
+  {
+    name: 'phase1 production build',
+    command: 'npm run build',
+  },
+];
+
+function parseExitCode(exitCode: number | null, signal: NodeJS.Signals | null): number {
+  if (typeof exitCode === 'number') return exitCode;
+  return signal ? 1 : 1;
+}
+
+async function defaultRunCommand(command: string): Promise<{ exitCode: number; durationMs: number }> {
+  const startedAt = process.hrtime.bigint();
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, {
+      shell: true,
+      stdio: 'inherit',
+      env: process.env,
+    });
+
+    child.once('error', (error) => {
+      reject(error);
+    });
+
+    child.once('close', (exitCode, signal) => {
+      const finishedAt = process.hrtime.bigint();
+      resolve({
+        exitCode: parseExitCode(exitCode, signal),
+        durationMs: Number((finishedAt - startedAt) / 1000000n),
+      });
+    });
+  });
+}
+
+function formatDuration(durationMs: number): string {
+  return `${durationMs}ms`;
+}
+
+export async function runPhase1PortalValidationGate(
+  options: Phase1PortalValidationGateOptions = {},
+): Promise<Phase1PortalValidationResult> {
+  const steps = options.steps || PHASE1_PORTAL_VALIDATION_STEPS;
+  const runCommand = options.runCommand || defaultRunCommand;
+  const writeJson = options.writeJson || writePhase1PortalValidationJson;
+  const now = options.now || (() => new Date());
+  const logger = options.logger || DEFAULT_LOGGER;
+
+  const results: Phase1PortalValidationStepResult[] = [];
+
+  for (const step of steps) {
+    logger.log(`[phase1] ${step.name}`);
+    logger.log(`[phase1] $ ${step.command}`);
+
+    const outcome = await runCommand(step.command);
+    const passed = outcome.exitCode === 0;
+
+    results.push({
+      ...step,
+      exitCode: outcome.exitCode,
+      durationMs: outcome.durationMs,
+      passed,
+    });
+
+    logger.log(
+      `[phase1] ${passed ? 'PASS' : 'FAIL'} ${step.name} (exit=${outcome.exitCode}, duration=${formatDuration(outcome.durationMs)})`,
+    );
+  }
+
+  const summary: Phase1PortalValidationSummary = {
+    suiteCount: results.length,
+    passedCount: results.filter((step) => step.passed).length,
+    failedCount: results.filter((step) => !step.passed).length,
+    totalDurationMs: results.reduce((total, step) => total + step.durationMs, 0),
+    generatedAt: now().toISOString(),
+  };
+
+  const payload: Phase1PortalValidationResult = {
+    steps: results,
+    summary,
+  };
+
+  if (options.jsonOutPath) {
+    await writeJson(options.jsonOutPath, payload);
+    logger.log(`[phase1] wrote JSON summary to ${options.jsonOutPath}`);
+  }
+
+  return payload;
+}
+
+export function formatPhase1PortalValidationSummary(result: Phase1PortalValidationResult): string {
+  const { summary, steps } = result;
+  const stepLines = steps.map(
+    (step, index) =>
+      `${index + 1}. ${step.passed ? 'PASS' : 'FAIL'} ${step.name} | exit=${step.exitCode} | duration=${formatDuration(step.durationMs)}`,
+  );
+
+  return [
+    `phase1 portal validation gate: ${summary.passedCount}/${summary.suiteCount} passed, failed=${summary.failedCount}, total=${formatDuration(summary.totalDurationMs)}`,
+    ...stepLines,
+    `generatedAt=${summary.generatedAt}`,
+  ].join('\n');
+}
+
+async function writePhase1PortalValidationJson(
+  filePath: string,
+  payload: Phase1PortalValidationResult,
+): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf-8');
+}
+
+function readFlag(argv: string[], flag: string): string {
+  const withEquals = argv.find((entry) => entry.startsWith(`${flag}=`));
+  if (withEquals) {
+    return withEquals.slice(flag.length + 1);
+  }
+
+  const index = argv.indexOf(flag);
+  if (index >= 0) {
+    return argv[index + 1] || '';
+  }
+
+  return '';
+}
+
+export function parsePhase1PortalValidationArgs(argv: string[]): Phase1PortalValidationGateOptions {
+  const jsonOutPath = readFlag(argv, '--json-out') || readFlag(argv, '-o');
+  return {
+    jsonOutPath: jsonOutPath ? path.resolve(jsonOutPath) : undefined,
+  };
+}
+
+async function main(): Promise<void> {
+  const options = parsePhase1PortalValidationArgs(process.argv.slice(2));
+  const result = await runPhase1PortalValidationGate(options);
+  DEFAULT_LOGGER.log(formatPhase1PortalValidationSummary(result));
+  process.exitCode = result.summary.failedCount > 0 ? 1 : 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('/phase1_portal_validation_gate.ts')) {
+  main().catch((error) => {
+    DEFAULT_LOGGER.error(error instanceof Error ? error.stack || error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -84,6 +84,7 @@ import { updateCounterpartyHistory, lookupCounterpartyHistory } from './counterp
 
 import { mountProjectRoutes } from './routes/projects.mjs';
 import { mountPortalEntryRoutes } from './routes/portal-entry.mjs';
+import { mountPortalReadModelRoutes } from './routes/portal-read-model.mjs';
 import { mountLedgerRoutes } from './routes/ledgers.mjs';
 import { mountTransactionRoutes } from './routes/transactions.mjs';
 import { mountAuditRoutes } from './routes/audit.mjs';
@@ -1351,6 +1352,7 @@ export function createBffApp(options = {}) {
     projectSheetSourceStorageService, projectRegistrationSlackService,
   });
   mountPortalEntryRoutes(app, { db, createMutatingRoute, idempotencyService });
+  mountPortalReadModelRoutes(app, { db });
   mountCashflowExportRoutes(app, { db, rbacPolicy });
   mountLedgerRoutes(app, { db, now, idempotencyService, auditChainService, piiProtector });
   mountTransactionRoutes(app, { db, now, idempotencyService, auditChainService, piiProtector, rbacPolicy, driveService });

--- a/server/bff/routes/portal-read-model.mjs
+++ b/server/bff/routes/portal-read-model.mjs
@@ -1,0 +1,823 @@
+import { asyncHandler, assertActorRoleAllowed, createHttpError, readOptionalText, ROUTE_ROLES } from '../bff-utils.mjs';
+import {
+  resolvePortalEntryMemberAccess,
+  resolvePortalEntryRegistrationState,
+  selectPortalEntryProjects,
+} from './portal-entry.mjs';
+import { addDays, getSeoulTodayIso } from '../payroll-worker.mjs';
+
+function pad2(value) {
+  return String(value).padStart(2, '0');
+}
+
+function parseYearMonth(value) {
+  const match = /^(\d{4})-(\d{2})$/.exec(String(value || '').trim());
+  if (!match) return null;
+  const year = Number.parseInt(match[1], 10);
+  const month = Number.parseInt(match[2], 10);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || month < 1 || month > 12) return null;
+  return { year, month };
+}
+
+function formatIsoDate(year, month, day) {
+  return `${String(year).padStart(4, '0')}-${pad2(month)}-${pad2(day)}`;
+}
+
+function addDaysUtc(isoDate, deltaDays) {
+  const [yRaw, mRaw, dRaw] = String(isoDate || '').split('-');
+  const year = Number.parseInt(yRaw, 10);
+  const month = Number.parseInt(mRaw, 10);
+  const day = Number.parseInt(dRaw, 10);
+  const base = Date.UTC(year, month - 1, day);
+  const next = new Date(base + Number(deltaDays) * 24 * 60 * 60 * 1000);
+  return formatIsoDate(next.getUTCFullYear(), next.getUTCMonth() + 1, next.getUTCDate());
+}
+
+function dayOfWeekUtc(year, month, day) {
+  return new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+}
+
+function daysInMonthUtc(year, month) {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+function startOfWeekWednesday(isoDate) {
+  const [yRaw, mRaw, dRaw] = String(isoDate || '').split('-');
+  const year = Number.parseInt(yRaw, 10);
+  const month = Number.parseInt(mRaw, 10);
+  const day = Number.parseInt(dRaw, 10);
+  const dow = dayOfWeekUtc(year, month, day);
+  const delta = -((dow - 3 + 7) % 7);
+  return addDaysUtc(isoDate, delta);
+}
+
+function countDaysInMonthForWeek(weekStart, year, month) {
+  let count = 0;
+  for (let i = 0; i < 7; i += 1) {
+    const date = addDaysUtc(weekStart, i);
+    const [yy, mm] = date.split('-');
+    if (Number.parseInt(yy, 10) === year && Number.parseInt(mm, 10) === month) count += 1;
+  }
+  return count;
+}
+
+function getMonthMondayWeeks(yearMonth) {
+  const parsed = parseYearMonth(yearMonth);
+  if (!parsed) return [];
+
+  const { year, month } = parsed;
+  const firstDay = formatIsoDate(year, month, 1);
+  const lastDay = formatIsoDate(year, month, daysInMonthUtc(year, month));
+  let weekStart = startOfWeekWednesday(firstDay);
+  const weeks = [];
+  const yy = year % 100;
+  let weekNo = 0;
+
+  while (weekStart <= lastDay) {
+    const daysInMonth = countDaysInMonthForWeek(weekStart, year, month);
+    if (daysInMonth >= 4) {
+      weekNo += 1;
+      const weekEnd = addDaysUtc(weekStart, 6);
+      const label = `${yy}-${month}-${weekNo}`;
+      weeks.push({ yearMonth, weekNo, weekStart, weekEnd, label });
+    }
+    weekStart = addDaysUtc(weekStart, 7);
+  }
+
+  return weeks;
+}
+
+function resolveCurrentCashflowWeek(todayIso) {
+  const yearMonth = typeof todayIso === 'string' ? todayIso.slice(0, 7) : '';
+  if (!/^\d{4}-\d{2}$/.test(yearMonth)) return undefined;
+  return getMonthMondayWeeks(yearMonth).find((week) => todayIso >= week.weekStart && todayIso <= week.weekEnd);
+}
+
+function normalizeProjectSummary(project) {
+  const value = project && typeof project === 'object' ? project : {};
+  const id = readOptionalText(value.id);
+  return {
+    id,
+    name: readOptionalText(value.name) || id,
+    shortName: readOptionalText(value.shortName) || undefined,
+    managerName: readOptionalText(value.managerName) || undefined,
+    clientOrg: readOptionalText(value.clientOrg) || undefined,
+    department: readOptionalText(value.department) || undefined,
+    status: readOptionalText(value.status) || undefined,
+    type: readOptionalText(value.type) || undefined,
+  };
+}
+
+function normalizeWeeklySubmissionStatus(status) {
+  const value = status && typeof status === 'object' ? status : {};
+  return {
+    projectId: readOptionalText(value.projectId),
+    yearMonth: readOptionalText(value.yearMonth),
+    weekNo: Number.isFinite(Number(value.weekNo)) ? Number(value.weekNo) : 0,
+    projectionEdited: Boolean(value.projectionEdited),
+    projectionUpdated: Boolean(value.projectionUpdated),
+    expenseEdited: Boolean(value.expenseEdited),
+    expenseUpdated: Boolean(value.expenseUpdated),
+    expenseReviewPendingCount: Number.isFinite(Number(value.expenseReviewPendingCount))
+      ? Math.max(0, Number(value.expenseReviewPendingCount))
+      : 0,
+    updatedAt: readOptionalText(value.updatedAt) || undefined,
+  };
+}
+
+function buildWeeklyAccountingSnapshot(status) {
+  return {
+    projectionEdited: Boolean(status?.projectionEdited),
+    projectionDone: Boolean(status?.projectionUpdated),
+    expenseEdited: Boolean(status?.expenseEdited),
+    expenseDone: Boolean(status?.expenseUpdated),
+    expenseSyncState: status?.expenseReviewPendingCount > 0 ? 'review_required' : (status?.expenseUpdated ? 'synced' : 'pending'),
+    expenseReviewPendingCount: Number.isFinite(status?.expenseReviewPendingCount) ? status.expenseReviewPendingCount : 0,
+    pmSubmitted: Boolean(status?.projectionUpdated && status?.expenseUpdated),
+    adminClosed: Boolean(status?.expenseUpdated),
+  };
+}
+
+function resolveWeeklyAccountingProductStatus(snapshot) {
+  const reviewCount = Math.max(0, Number(snapshot?.expenseReviewPendingCount) || 0);
+  const syncState = snapshot?.expenseSyncState || 'idle';
+  const saveState = snapshot?.expenseDone ? 'saved' : 'dirty';
+  const expenseDone = Boolean(snapshot?.expenseDone) || saveState === 'saved' || syncState === 'synced' || syncState === 'review_required' || syncState === 'sync_failed';
+
+  if (saveState === 'dirty' || saveState === 'saving' || (!expenseDone && saveState !== 'saved')) {
+    return {
+      kind: 'save_pending',
+      label: '저장 전 초안',
+      description: '현재 편집 내용은 아직 주간 정산 기준본으로 확정되지 않았습니다.',
+      tone: 'warning',
+      auditTitle: '최종 저장 대기 반영',
+    };
+  }
+
+  if (syncState === 'review_required') {
+    return {
+      kind: 'review_required',
+      label: reviewCount > 0 ? `사람 확인 ${reviewCount}건` : '사람 확인 필요',
+      description: '일부 행은 자동 분류가 끝나지 않았습니다. 증빙을 확인한 뒤 사람 확인을 마쳐야 최종 반영됩니다.',
+      tone: 'warning',
+      auditTitle: '최종 사람 확인 상태 반영',
+    };
+  }
+
+  if (syncState === 'synced') {
+    return {
+      kind: 'save_synced',
+      label: '동기화 완료',
+      description: '주간 정산 기준본이 실제값 반영까지 끝났습니다.',
+      tone: 'success',
+      auditTitle: '최종 동기화 반영',
+    };
+  }
+
+  if (syncState === 'sync_failed') {
+    return {
+      kind: 'sync_failed',
+      label: '동기화 실패',
+      description: '정산대장은 저장되었지만 실제값 반영이 끝나지 않았습니다.',
+      tone: 'danger',
+      auditTitle: '최종 동기화 실패 반영',
+    };
+  }
+
+  return {
+    kind: 'save_pending',
+    label: '저장 전 초안',
+    description: '현재 편집 내용은 아직 주간 정산 기준본으로 확정되지 않았습니다.',
+    tone: 'warning',
+    auditTitle: '최종 저장 대기 반영',
+  };
+}
+
+function resolvePortalAccountingStatus(status, currentWeek) {
+  const snapshot = buildWeeklyAccountingSnapshot(status);
+  const productStatus = resolveWeeklyAccountingProductStatus(snapshot);
+  return {
+    currentWeekLabel: currentWeek ? `${currentWeek.weekNo}주차` : '-',
+    projection: {
+      label: snapshot.projectionEdited ? '작성됨' : '미작성',
+      detail: currentWeek
+        ? `${currentWeek.weekNo}주차 · ${snapshot.projectionDone ? '제출 완료' : '미제출'}`
+        : '이번 주 주차를 찾지 못했습니다.',
+      latestUpdatedAt: status?.updatedAt || status?.projectionUpdatedAt || undefined,
+    },
+    expense: {
+      label: productStatus.label,
+      detail: currentWeek
+        ? `${currentWeek.weekNo}주차 · ${productStatus.description}`
+        : productStatus.description,
+      tone: productStatus.tone,
+    },
+  };
+}
+
+function resolvePayrollLiquidityStatus({
+  today,
+  activeRun,
+  expectedPayrollAmount,
+  dayBalances,
+}) {
+  const knownBalances = dayBalances
+    .map((entry) => entry.balance)
+    .filter((value) => typeof value === 'number');
+  const currentBalance = findBalanceForDay(dayBalances, today);
+  const worstBalance = knownBalances.length ? Math.min(...knownBalances) : null;
+  const insufficient = expectedPayrollAmount !== null
+    && knownBalances.some((balance) => balance < expectedPayrollAmount);
+  const paymentUnconfirmed = today >= activeRun.plannedPayDate && activeRun.paidStatus !== 'CONFIRMED';
+
+  if (insufficient) {
+    return {
+      status: 'insufficient_balance',
+      statusReason: 'D-3~D+3 구간에 예상 인건비보다 잔액이 낮습니다.',
+      worstBalance,
+      currentBalance,
+    };
+  }
+  if (paymentUnconfirmed) {
+    return {
+      status: 'payment_unconfirmed',
+      statusReason: '지급일이 지났지만 아직 지급 확정이 기록되지 않았습니다.',
+      worstBalance,
+      currentBalance,
+    };
+  }
+  if (expectedPayrollAmount === null) {
+    return {
+      status: 'baseline_missing',
+      statusReason: '직전 확정 지급액이 없어 예상 인건비 기준선을 만들 수 없습니다.',
+      worstBalance,
+      currentBalance,
+    };
+  }
+  if (knownBalances.length === 0) {
+    return {
+      status: 'balance_unknown',
+      statusReason: '잔액 데이터가 없어 지급 여력을 계산할 수 없습니다.',
+      worstBalance,
+      currentBalance,
+    };
+  }
+  return {
+    status: 'clear',
+    statusReason: '지급 창에서 잔액과 지급 상태가 안정적입니다.',
+    worstBalance,
+    currentBalance,
+  };
+}
+
+function findBalanceForDay(dayBalances, today) {
+  const sameDay = dayBalances.find((entry) => entry.date === today);
+  if (sameDay) return sameDay.balance;
+  const eligible = dayBalances
+    .filter((entry) => entry.date <= today && typeof entry.balance === 'number')
+    .sort((a, b) => b.date.localeCompare(a.date));
+  return eligible[0]?.balance ?? null;
+}
+
+function txAmount(tx) {
+  const expense = Number.isFinite(tx.amounts?.expenseAmount) ? tx.amounts.expenseAmount : 0;
+  const bank = Number.isFinite(tx.amounts?.bankAmount) ? tx.amounts.bankAmount : 0;
+  return Math.max(expense, bank, 0);
+}
+
+function findLatestBalanceOnOrBefore(transactions, day) {
+  let latest = null;
+  for (const tx of transactions) {
+    const txDay = String(tx.dateTime || '').slice(0, 10);
+    if (txDay > day) continue;
+    if (!latest || tx.dateTime > latest.dateTime) latest = tx;
+  }
+  return latest ? latest.amounts.balanceAfter : null;
+}
+
+function buildDayWindow(plannedPayDate) {
+  return Array.from({ length: 7 }, (_, index) => addDays(plannedPayDate, index - 3));
+}
+
+function findBaselineRun(projectRuns, activeRun) {
+  const confirmed = projectRuns
+    .filter((run) => run.id !== activeRun.id && run.paidStatus === 'CONFIRMED' && run.plannedPayDate < activeRun.plannedPayDate)
+    .sort((a, b) => b.plannedPayDate.localeCompare(a.plannedPayDate));
+  return confirmed[0] || null;
+}
+
+function computeExpectedPayrollAmount(baselineRun, transactions) {
+  if (!baselineRun?.matchedTxIds?.length) return null;
+  const matchedIds = new Set(baselineRun.matchedTxIds);
+  const amount = transactions
+    .filter((tx) => matchedIds.has(tx.id))
+    .reduce((sum, tx) => sum + txAmount(tx), 0);
+  return amount > 0 ? amount : null;
+}
+
+function resolveProjectPayrollLiquidity({ project, runs, transactions, today }) {
+  const projectRuns = runs
+    .filter((run) => run.projectId === project.id)
+    .sort((a, b) => a.plannedPayDate.localeCompare(b.plannedPayDate));
+  const activeRuns = projectRuns.filter((run) => {
+    const windowStart = addDays(run.plannedPayDate, -3);
+    const windowEnd = addDays(run.plannedPayDate, 3);
+    return today >= windowStart && today <= windowEnd;
+  });
+  const approvedTransactions = transactions
+    .filter((tx) => tx.projectId === project.id && tx.state === 'APPROVED' && typeof tx.amounts?.balanceAfter === 'number')
+    .sort((a, b) => a.dateTime.localeCompare(b.dateTime));
+
+  return activeRuns
+    .map((activeRun) => {
+      const baselineRun = findBaselineRun(projectRuns, activeRun);
+      const expectedPayrollAmount = computeExpectedPayrollAmount(baselineRun, approvedTransactions);
+      const dayBalances = buildDayWindow(activeRun.plannedPayDate).map((day) => ({
+        date: day,
+        balance: findLatestBalanceOnOrBefore(approvedTransactions, day),
+      }));
+      const { status, statusReason, worstBalance, currentBalance } = resolvePayrollLiquidityStatus({
+        today,
+        activeRun,
+        expectedPayrollAmount,
+        dayBalances,
+      });
+      return {
+        projectId: project.id,
+        projectName: project.name,
+        projectShortName: project.shortName || project.id,
+        runId: activeRun.id,
+        yearMonth: activeRun.yearMonth,
+        plannedPayDate: activeRun.plannedPayDate,
+        windowStart: dayBalances[0]?.date || addDays(activeRun.plannedPayDate, -3),
+        windowEnd: dayBalances[dayBalances.length - 1]?.date || addDays(activeRun.plannedPayDate, 3),
+        expectedPayrollAmount,
+        baselineRunId: baselineRun?.id || null,
+        status,
+        statusReason,
+        dayBalances,
+        worstBalance,
+        currentBalance,
+        paidStatus: activeRun.paidStatus,
+        acknowledged: activeRun.acknowledged,
+      };
+    })
+    .sort((a, b) => {
+      const priority = {
+        insufficient_balance: 0,
+        payment_unconfirmed: 1,
+        baseline_missing: 2,
+        balance_unknown: 3,
+        clear: 4,
+      };
+      const delta = priority[a.status] - priority[b.status];
+      if (delta !== 0) return delta;
+      return a.plannedPayDate.localeCompare(b.plannedPayDate);
+    });
+}
+
+function normalizeBankStatementProfile(columns, fileName = '') {
+  const joined = [...columns.map((col) => String(col || '').toLowerCase()), String(fileName || '').toLowerCase()].join(' ');
+  if (joined.includes('hana') || joined.includes('하나') || joined.includes('keb')) return 'hana';
+  if (joined.includes('kb') || joined.includes('국민')) return 'kb';
+  if (joined.includes('shinhan') || joined.includes('신한')) return 'shinhan';
+  return 'general';
+}
+
+function normalizeBankStatementRows(sheet) {
+  const value = sheet && typeof sheet === 'object' ? sheet : {};
+  const columns = Array.isArray(value.columns) ? value.columns.map((cell) => String(cell || '')) : [];
+  const rows = Array.isArray(value.rows) ? value.rows : [];
+  return {
+    columns,
+    rows,
+  };
+}
+
+function normalizeExpenseSheet(sheet) {
+  const value = sheet && typeof sheet === 'object' ? sheet : {};
+  return {
+    id: readOptionalText(value.id),
+    name: readOptionalText(value.name) || readOptionalText(value.id) || '기본 탭',
+    order: Number.isFinite(Number(value.order)) ? Number(value.order) : 0,
+    rows: Array.isArray(value.rows) ? value.rows : [],
+    createdAt: readOptionalText(value.createdAt) || undefined,
+    updatedAt: readOptionalText(value.updatedAt) || undefined,
+  };
+}
+
+function chooseActiveExpenseSheet(expenseSheets) {
+  if (!Array.isArray(expenseSheets) || expenseSheets.length === 0) {
+    return {
+      id: 'default',
+      name: '기본 탭',
+      rows: [],
+    };
+  }
+  return expenseSheets.find((sheet) => sheet.id === 'default') || expenseSheets[0];
+}
+
+export function buildPortalDashboardSummary(input) {
+  const project = normalizeProjectSummary(input.project);
+  const currentWeek = resolveCurrentCashflowWeek(input.todayIso || getSeoulTodayIso());
+  const weeklyStatuses = Array.isArray(input.weeklySubmissionStatuses)
+    ? input.weeklySubmissionStatuses.map((status) => normalizeWeeklySubmissionStatus(status))
+    : [];
+  const projectStatuses = weeklyStatuses.filter((status) => status.projectId === project.id);
+  const currentStatus = currentWeek
+    ? projectStatuses.find((status) => status.yearMonth === currentWeek.yearMonth && status.weekNo === currentWeek.weekNo)
+    : undefined;
+  const payrollRiskCount = Math.max(0, Number(input.payrollRiskCount) || 0);
+  const hrAlertCount = Math.max(0, Number(input.hrAlertCount) || 0);
+  const visibleProjects = Math.max(0, Number(input.visibleProjects) || 0);
+  const visibleIssues = [
+    {
+      label: '미확인 공지',
+      count: hrAlertCount,
+      tone: 'warn',
+      to: '/portal/change-requests',
+    },
+    {
+      label: '인건비 Queue',
+      count: payrollRiskCount,
+      tone: 'danger',
+      to: '/portal/payroll',
+    },
+  ].filter((item) => item.count > 0);
+
+  return {
+    project,
+    summary: {
+      payrollRiskCount,
+      visibleProjects,
+      hrAlertCount,
+      currentWeekLabel: currentWeek ? `${currentWeek.weekNo}주차` : '-',
+    },
+    surface: {
+      ...resolvePortalAccountingStatus(currentStatus, currentWeek),
+      visibleIssues,
+    },
+  };
+}
+
+export function buildPortalPayrollSummary(input) {
+  const project = normalizeProjectSummary(input.project);
+  const schedule = input.payrollSchedule && typeof input.payrollSchedule === 'object'
+    ? {
+        id: readOptionalText(input.payrollSchedule.id) || project.id,
+        projectId: readOptionalText(input.payrollSchedule.projectId) || project.id,
+        dayOfMonth: Number.isFinite(Number(input.payrollSchedule.dayOfMonth)) ? Number(input.payrollSchedule.dayOfMonth) : 0,
+        timezone: readOptionalText(input.payrollSchedule.timezone) || 'Asia/Seoul',
+        noticeLeadBusinessDays: Number.isFinite(Number(input.payrollSchedule.noticeLeadBusinessDays))
+          ? Number(input.payrollSchedule.noticeLeadBusinessDays)
+          : 3,
+        active: input.payrollSchedule.active !== false,
+      }
+    : {
+        id: project.id,
+        projectId: project.id,
+        dayOfMonth: 25,
+        timezone: 'Asia/Seoul',
+        noticeLeadBusinessDays: 3,
+        active: false,
+      };
+  const today = input.todayIso || getSeoulTodayIso();
+  const runs = Array.isArray(input.payrollRuns) ? input.payrollRuns : [];
+  const transactions = Array.isArray(input.transactions) ? input.transactions : [];
+  const queue = resolveProjectPayrollLiquidity({ project, runs, transactions, today });
+  const currentRun = queue[0] || null;
+
+  return {
+    project,
+    schedule,
+    currentRun,
+    summary: {
+      queueCount: queue.length,
+      riskCount: queue.filter((item) => item.status === 'insufficient_balance' || item.status === 'payment_unconfirmed').length,
+      status: currentRun?.status || 'clear',
+      statusReason: currentRun?.statusReason || '지급 창에서 잔액과 지급 상태가 안정적입니다.',
+    },
+    queue,
+  };
+}
+
+export function buildPortalWeeklyExpensesSummary(input) {
+  const project = normalizeProjectSummary(input.project);
+  const todayIso = input.todayIso || getSeoulTodayIso();
+  const currentWeek = resolveCurrentCashflowWeek(todayIso);
+  const weeklyStatuses = Array.isArray(input.weeklySubmissionStatuses)
+    ? input.weeklySubmissionStatuses.map((status) => normalizeWeeklySubmissionStatus(status))
+    : [];
+  const projectStatuses = weeklyStatuses.filter((status) => status.projectId === project.id);
+  const currentStatus = currentWeek
+    ? projectStatuses.find((status) => status.yearMonth === currentWeek.yearMonth && status.weekNo === currentWeek.weekNo)
+    : undefined;
+  const expenseSheets = Array.isArray(input.expenseSheets) ? input.expenseSheets.map((sheet) => normalizeExpenseSheet(sheet)) : [];
+  const activeExpenseSheet = chooseActiveExpenseSheet(expenseSheets);
+  const bankStatementRows = normalizeBankStatementRows(input.bankStatementRows);
+  const sheetSources = Array.isArray(input.sheetSources) ? input.sheetSources : [];
+  const bankStatementProfile = normalizeBankStatementProfile(bankStatementRows.columns, input.bankStatementFileName || '');
+
+  return {
+    project,
+    summary: {
+      currentWeekLabel: currentWeek ? `${currentWeek.weekNo}주차` : '-',
+      expenseReviewPendingCount: Number(currentStatus?.expenseReviewPendingCount) || 0,
+    },
+    expenseSheet: {
+      activeSheetId: activeExpenseSheet.id,
+      activeSheetName: activeExpenseSheet.name,
+      sheetCount: expenseSheets.length || (activeExpenseSheet.rows ? 1 : 0),
+      rowCount: Array.isArray(activeExpenseSheet.rows) ? activeExpenseSheet.rows.length : 0,
+    },
+    bankStatement: {
+      rowCount: bankStatementRows.rows.length,
+      columnCount: bankStatementRows.columns.length,
+      profile: bankStatementProfile,
+      lastSavedAt: readOptionalText(input.bankStatementLastSavedAt) || undefined,
+    },
+    sheetSources: sheetSources.map((source) => ({
+      sourceType: readOptionalText(source?.sourceType) || 'unknown',
+      sheetName: readOptionalText(source?.sheetName) || '',
+      fileName: readOptionalText(source?.fileName) || '',
+      rowCount: Number.isFinite(Number(source?.rowCount)) ? Number(source.rowCount) : 0,
+      columnCount: Number.isFinite(Number(source?.columnCount)) ? Number(source.columnCount) : 0,
+      uploadedAt: readOptionalText(source?.uploadedAt) || undefined,
+    })),
+    handoff: {
+      canOpenWeeklyExpenses: Boolean(project.id) && (expenseSheets.length > 0 || bankStatementRows.rows.length > 0),
+      canUseEvidenceWorkflow: sheetSources.some((source) => readOptionalText(source?.sourceType) === 'evidence_rules'),
+      nextPath: '/portal/bank-statements',
+    },
+  };
+}
+
+export function buildPortalBankStatementsSummary(input) {
+  const project = normalizeProjectSummary(input.project);
+  const expenseSheets = Array.isArray(input.expenseSheets) ? input.expenseSheets.map((sheet) => normalizeExpenseSheet(sheet)) : [];
+  const activeExpenseSheetId = readOptionalText(input.activeExpenseSheetId) || chooseActiveExpenseSheet(expenseSheets).id;
+  const activeExpenseSheet = expenseSheets.find((sheet) => sheet.id === activeExpenseSheetId) || chooseActiveExpenseSheet(expenseSheets);
+  const bankStatementRows = normalizeBankStatementRows(input.bankStatementRows);
+  const bankStatementProfile = normalizeBankStatementProfile(bankStatementRows.columns, input.bankStatementFileName || '');
+  const ready = bankStatementRows.rows.length > 0 || bankStatementRows.columns.length > 0;
+
+  return {
+    project,
+    bankStatement: {
+      rowCount: bankStatementRows.rows.length,
+      columnCount: bankStatementRows.columns.length,
+      profile: bankStatementProfile,
+      lastSavedAt: readOptionalText(input.bankStatementLastSavedAt) || undefined,
+    },
+    handoffContext: {
+      ready,
+      reason: ready
+        ? '저장된 통장내역이 있습니다.'
+        : '통장내역을 먼저 저장하면 주간 사업비 화면으로 이어갈 수 있습니다.',
+      nextPath: '/portal/weekly-expenses',
+      activeExpenseSheetId,
+      activeExpenseSheetName: activeExpenseSheet.name,
+      sheetCount: expenseSheets.length || (activeExpenseSheet.rows ? 1 : 0),
+    },
+  };
+}
+
+async function fetchVisibleProjects(db, tenantId, role, actorId, memberProjectIds) {
+  const snapshot = await db.collection(`orgs/${tenantId}/projects`).get();
+  const projects = snapshot.docs.map((doc) => ({ id: doc.id, ...(doc.data() || {}) }));
+  return selectPortalEntryProjects({
+    role,
+    actorId,
+    memberProjectIds,
+    projects,
+  });
+}
+
+async function resolvePortalReadModelContext(db, tenantId, actorId, actorRole) {
+  const memberSnapshot = await db.doc(`orgs/${tenantId}/members/${actorId}`).get();
+  const member = memberSnapshot.exists ? (memberSnapshot.data() || {}) : null;
+  const memberAccess = resolvePortalEntryMemberAccess(member);
+  const role = readOptionalText(member?.role) || actorRole || 'pm';
+  const selectedProjects = await fetchVisibleProjects(db, tenantId, role, actorId, memberAccess.projectIds);
+  const projectMap = new Map(selectedProjects.projects.map((project) => [project.id, project]));
+  const activeProjectId = projectMap.has(memberAccess.activeProjectId)
+    ? memberAccess.activeProjectId
+    : selectedProjects.projects[0]?.id || '';
+  const activeProject = activeProjectId ? projectMap.get(activeProjectId) || null : null;
+
+  return {
+    memberSnapshot,
+    member,
+    memberAccess,
+    role,
+    selectedProjects,
+    activeProjectId,
+    activeProject,
+  };
+}
+
+async function loadWeeklySubmissionStatuses(db, tenantId, projectId) {
+  const snap = await db.collection(`orgs/${tenantId}/weekly_submission_status`).where('projectId', '==', projectId).get();
+  return snap.docs.map((doc) => ({ id: doc.id, ...(doc.data() || {}) }));
+}
+
+async function loadPayrollData(db, tenantId, projectId) {
+  const [scheduleSnap, runsSnap, txSnap] = await Promise.all([
+    db.doc(`orgs/${tenantId}/payroll_schedules/${projectId}`).get(),
+    db.collection(`orgs/${tenantId}/payroll_runs`).where('projectId', '==', projectId).get(),
+    db.collection(`orgs/${tenantId}/transactions`).where('projectId', '==', projectId).get(),
+  ]);
+
+  return {
+    payrollSchedule: scheduleSnap.exists ? { id: scheduleSnap.id, ...(scheduleSnap.data() || {}) } : null,
+    payrollRuns: runsSnap.docs.map((doc) => ({ id: doc.id, ...(doc.data() || {}) })),
+    transactions: txSnap.docs.map((doc) => ({ id: doc.id, ...(doc.data() || {}) })),
+  };
+}
+
+async function loadWeeklyExpenseData(db, tenantId, projectId) {
+  const [statuses, expenseSheetSnap, bankStatementSnap, sheetSourcesSnap] = await Promise.all([
+    loadWeeklySubmissionStatuses(db, tenantId, projectId),
+    db.collection(`orgs/${tenantId}/projects/${projectId}/expense_sheets`).get(),
+    db.doc(`orgs/${tenantId}/projects/${projectId}/bank_statements/default`).get(),
+    db.collection(`orgs/${tenantId}/projects/${projectId}/sheet_sources`).get(),
+  ]);
+
+  return {
+    weeklySubmissionStatuses: statuses,
+    expenseSheets: expenseSheetSnap.docs.map((doc) => ({ id: doc.id, ...(doc.data() || {}) })),
+    bankStatementRows: bankStatementSnap.exists ? { id: bankStatementSnap.id, ...(bankStatementSnap.data() || {}) } : null,
+    sheetSources: sheetSourcesSnap.docs.map((doc) => ({ id: doc.id, ...(doc.data() || {}) })),
+    bankStatementLastSavedAt: bankStatementSnap.exists ? bankStatementSnap.data()?.updatedAt : undefined,
+  };
+}
+
+function readHrAnnouncementCount(announcements) {
+  return announcements.filter((announcement) => !Boolean(announcement.resolved)).length;
+}
+
+export function mountPortalReadModelRoutes(app, { db }) {
+  app.get('/api/v1/portal/dashboard-summary', asyncHandler(async (req, res) => {
+    assertActorRoleAllowed(req, ROUTE_ROLES.readCore, 'read portal dashboard summary');
+    const { tenantId, actorId, actorRole } = req.context;
+    const { memberSnapshot, member, memberAccess, role, selectedProjects, activeProjectId, activeProject } = await resolvePortalReadModelContext(
+      db,
+      tenantId,
+      actorId,
+      actorRole,
+    );
+    const activeProjectDoc = activeProjectId
+      ? await db.doc(`orgs/${tenantId}/projects/${activeProjectId}`).get()
+      : null;
+    const currentProject = activeProjectDoc?.exists
+      ? { id: activeProjectDoc.id, ...(activeProjectDoc.data() || {}) }
+      : activeProject || null;
+    if (!currentProject) {
+      throw createHttpError(404, '활성 사업을 찾을 수 없습니다.', 'project_not_found');
+    }
+
+    const todayIso = getSeoulTodayIso();
+    const weeklyStatuses = await loadWeeklySubmissionStatuses(db, tenantId, currentProject.id);
+    const payrollData = await loadPayrollData(db, tenantId, currentProject.id);
+    const hrAnnouncementsSnap = await db.collection(`orgs/${tenantId}/hr_announcements`).get();
+    const hrAlertCount = readHrAnnouncementCount(hrAnnouncementsSnap.docs.map((doc) => ({ id: doc.id, ...(doc.data() || {}) })));
+    const dashboard = buildPortalDashboardSummary({
+      project: currentProject,
+      todayIso,
+      weeklySubmissionStatuses: weeklyStatuses,
+      payrollRiskCount: resolveProjectPayrollLiquidity({
+        project: normalizeProjectSummary(currentProject),
+        runs: payrollData.payrollRuns,
+        transactions: payrollData.transactions,
+        today: todayIso,
+      }).filter((item) => item.status === 'insufficient_balance' || item.status === 'payment_unconfirmed').length,
+      visibleProjects: selectedProjects.projects.length,
+      hrAlertCount,
+    });
+
+    res.status(200).json({
+      ...dashboard,
+      registrationState: resolvePortalEntryRegistrationState({
+        role,
+        memberExists: memberSnapshot.exists,
+        projectIds: memberAccess.projectIds,
+      }),
+    });
+  }));
+
+  app.get('/api/v1/portal/payroll-summary', asyncHandler(async (req, res) => {
+    assertActorRoleAllowed(req, ROUTE_ROLES.readCore, 'read portal payroll summary');
+    const { tenantId, actorId, actorRole } = req.context;
+    const { memberSnapshot, member, memberAccess, role, activeProjectId, activeProject } = await resolvePortalReadModelContext(
+      db,
+      tenantId,
+      actorId,
+      actorRole,
+    );
+    const activeProjectDoc = activeProjectId
+      ? await db.doc(`orgs/${tenantId}/projects/${activeProjectId}`).get()
+      : null;
+    const currentProject = activeProjectDoc?.exists
+      ? { id: activeProjectDoc.id, ...(activeProjectDoc.data() || {}) }
+      : activeProject || null;
+    if (!currentProject) {
+      throw createHttpError(404, '활성 사업을 찾을 수 없습니다.', 'project_not_found');
+    }
+
+    const payrollData = await loadPayrollData(db, tenantId, currentProject.id);
+    const summary = buildPortalPayrollSummary({
+      project: currentProject,
+      payrollSchedule: payrollData.payrollSchedule,
+      payrollRuns: payrollData.payrollRuns,
+      transactions: payrollData.transactions,
+      todayIso: getSeoulTodayIso(),
+    });
+
+    res.status(200).json({
+      ...summary,
+      registrationState: resolvePortalEntryRegistrationState({
+        role,
+        memberExists: memberSnapshot.exists,
+        projectIds: memberAccess.projectIds,
+      }),
+    });
+  }));
+
+  app.get('/api/v1/portal/weekly-expenses-summary', asyncHandler(async (req, res) => {
+    assertActorRoleAllowed(req, ROUTE_ROLES.readCore, 'read portal weekly expenses summary');
+    const { tenantId, actorId, actorRole } = req.context;
+    const { memberSnapshot, member, memberAccess, role, activeProjectId, activeProject } = await resolvePortalReadModelContext(
+      db,
+      tenantId,
+      actorId,
+      actorRole,
+    );
+    const activeProjectDoc = activeProjectId
+      ? await db.doc(`orgs/${tenantId}/projects/${activeProjectId}`).get()
+      : null;
+    const currentProject = activeProjectDoc?.exists
+      ? { id: activeProjectDoc.id, ...(activeProjectDoc.data() || {}) }
+      : activeProject || null;
+    if (!currentProject) {
+      throw createHttpError(404, '활성 사업을 찾을 수 없습니다.', 'project_not_found');
+    }
+
+    const weeklyData = await loadWeeklyExpenseData(db, tenantId, currentProject.id);
+    const summary = buildPortalWeeklyExpensesSummary({
+      project: currentProject,
+      todayIso: getSeoulTodayIso(),
+      weeklySubmissionStatuses: weeklyData.weeklySubmissionStatuses,
+      expenseSheets: weeklyData.expenseSheets,
+      bankStatementRows: weeklyData.bankStatementRows,
+      sheetSources: weeklyData.sheetSources,
+      bankStatementLastSavedAt: weeklyData.bankStatementLastSavedAt,
+    });
+
+    res.status(200).json({
+      ...summary,
+      registrationState: resolvePortalEntryRegistrationState({
+        role,
+        memberExists: memberSnapshot.exists,
+        projectIds: memberAccess.projectIds,
+      }),
+    });
+  }));
+
+  app.get('/api/v1/portal/bank-statements-summary', asyncHandler(async (req, res) => {
+    assertActorRoleAllowed(req, ROUTE_ROLES.readCore, 'read portal bank statements summary');
+    const { tenantId, actorId, actorRole } = req.context;
+    const { memberSnapshot, member, memberAccess, role, activeProjectId, activeProject } = await resolvePortalReadModelContext(
+      db,
+      tenantId,
+      actorId,
+      actorRole,
+    );
+    const activeProjectDoc = activeProjectId
+      ? await db.doc(`orgs/${tenantId}/projects/${activeProjectId}`).get()
+      : null;
+    const currentProject = activeProjectDoc?.exists
+      ? { id: activeProjectDoc.id, ...(activeProjectDoc.data() || {}) }
+      : activeProject || null;
+    if (!currentProject) {
+      throw createHttpError(404, '활성 사업을 찾을 수 없습니다.', 'project_not_found');
+    }
+
+    const weeklyData = await loadWeeklyExpenseData(db, tenantId, currentProject.id);
+    const summary = buildPortalBankStatementsSummary({
+      project: currentProject,
+      activeExpenseSheetId: weeklyData.expenseSheets.find((sheet) => sheet.id === 'default')?.id || weeklyData.expenseSheets[0]?.id || 'default',
+      expenseSheets: weeklyData.expenseSheets,
+      bankStatementRows: weeklyData.bankStatementRows,
+      bankStatementLastSavedAt: weeklyData.bankStatementLastSavedAt,
+    });
+
+    res.status(200).json({
+      ...summary,
+      registrationState: resolvePortalEntryRegistrationState({
+        role,
+        memberExists: memberSnapshot.exists,
+        projectIds: memberAccess.projectIds,
+      }),
+    });
+  }));
+}

--- a/server/bff/routes/portal-read-model.test.mjs
+++ b/server/bff/routes/portal-read-model.test.mjs
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildPortalBankStatementsSummary,
+  buildPortalDashboardSummary,
+  buildPortalPayrollSummary,
+  buildPortalWeeklyExpensesSummary,
+  mountPortalReadModelRoutes,
+} from './portal-read-model.mjs';
+
+function createExpenseSheet(id, name, rows = []) {
+  return {
+    id,
+    name,
+    rows,
+    order: 0,
+  };
+}
+
+describe('portal read-model helpers', () => {
+  it('builds a dashboard summary from compact portal state', () => {
+    const result = buildPortalDashboardSummary({
+      project: {
+        id: 'p001',
+        name: '알파 프로젝트',
+        shortName: '알파',
+        managerName: '보람',
+        status: 'IN_PROGRESS',
+      },
+      todayIso: '2026-04-16',
+      payrollRiskCount: 2,
+      weeklySubmissionStatuses: [
+        {
+          id: 'p001-2026-04-w3',
+          projectId: 'p001',
+          yearMonth: '2026-04',
+          weekNo: 3,
+          projectionEdited: true,
+          projectionUpdated: true,
+          expenseEdited: false,
+          expenseUpdated: false,
+          expenseReviewPendingCount: 1,
+        },
+      ],
+      visibleProjects: 3,
+      hrAlertCount: 1,
+    });
+
+    expect(result.project.id).toBe('p001');
+    expect(result.surface.currentWeekLabel).toBe('3주차');
+    expect(result.surface.visibleIssues.map((issue) => issue.label)).toContain('미확인 공지');
+    expect(result.summary.payrollRiskCount).toBe(2);
+    expect(result.summary.visibleProjects).toBe(3);
+  });
+
+  it('builds a payroll summary that exposes the current liquidity queue item', () => {
+    const result = buildPortalPayrollSummary({
+      project: {
+        id: 'p001',
+        name: '알파 프로젝트',
+        shortName: '알파',
+      },
+      payrollSchedule: {
+        id: 'p001',
+        projectId: 'p001',
+        dayOfMonth: 25,
+        timezone: 'Asia/Seoul',
+        noticeLeadBusinessDays: 3,
+        active: true,
+      },
+      payrollRuns: [
+        {
+          id: 'p001-2026-03',
+          projectId: 'p001',
+          yearMonth: '2026-03',
+          plannedPayDate: '2026-03-25',
+          noticeDate: '2026-03-20',
+          noticeLeadBusinessDays: 3,
+          acknowledged: true,
+          paidStatus: 'CONFIRMED',
+          matchedTxIds: ['tx001'],
+          createdAt: '2026-03-01T00:00:00.000Z',
+          updatedAt: '2026-03-01T00:00:00.000Z',
+        },
+        {
+          id: 'p001-2026-04',
+          projectId: 'p001',
+          yearMonth: '2026-04',
+          plannedPayDate: '2026-04-25',
+          noticeDate: '2026-04-22',
+          noticeLeadBusinessDays: 3,
+          acknowledged: false,
+          paidStatus: 'MISSING',
+          createdAt: '2026-04-01T00:00:00.000Z',
+          updatedAt: '2026-04-01T00:00:00.000Z',
+        },
+      ],
+      transactions: [
+        {
+          id: 'tx001',
+          projectId: 'p001',
+          state: 'APPROVED',
+          dateTime: '2026-04-24T09:00:00.000Z',
+          amounts: { bankAmount: 1200000, depositAmount: 0, expenseAmount: 1200000, vatIn: 0, vatOut: 0, vatRefund: 0, balanceAfter: 3400000 },
+        },
+      ],
+      todayIso: '2026-04-26',
+    });
+
+    expect(result.schedule.dayOfMonth).toBe(25);
+    expect(result.currentRun.plannedPayDate).toBe('2026-04-25');
+    expect(result.summary.queueCount).toBe(1);
+    expect(result.summary.status).toBe('payment_unconfirmed');
+  });
+
+  it('builds weekly expense and bank statement summaries with handoff metadata', () => {
+    const weekly = buildPortalWeeklyExpensesSummary({
+      project: {
+        id: 'p001',
+        name: '알파 프로젝트',
+        shortName: '알파',
+      },
+      todayIso: '2026-04-16',
+      weeklySubmissionStatuses: [
+        {
+          id: 'p001-2026-04-w3',
+          projectId: 'p001',
+          yearMonth: '2026-04',
+          weekNo: 3,
+          projectionEdited: true,
+          projectionUpdated: true,
+          expenseEdited: true,
+          expenseUpdated: false,
+          expenseReviewPendingCount: 2,
+        },
+      ],
+      expenseSheets: [
+        createExpenseSheet('default', '기본 탭', [{ tempId: 'r1', cells: ['a'] }]),
+        createExpenseSheet('sheet-2', '보조 탭', []),
+      ],
+      activeExpenseSheetId: 'default',
+      bankStatementRows: {
+        columns: ['통장번호', '거래일시'],
+        rows: [{ tempId: 'b1', cells: ['001', '2026-04-16'] }],
+      },
+      sheetSources: [
+        { sourceType: 'bank_statement', sheetName: '통장내역', fileName: 'bank.xls', rowCount: 1, columnCount: 2, uploadedAt: '2026-04-16T09:00:00.000Z' },
+      ],
+    });
+
+    expect(weekly.expenseSheet.sheetCount).toBe(2);
+    expect(weekly.bankStatement.rowCount).toBe(1);
+    expect(weekly.handoff.canOpenWeeklyExpenses).toBe(true);
+    expect(weekly.summary.expenseReviewPendingCount).toBe(2);
+
+    const bank = buildPortalBankStatementsSummary({
+      project: {
+        id: 'p001',
+        name: '알파 프로젝트',
+        shortName: '알파',
+      },
+      activeExpenseSheetId: 'default',
+      expenseSheets: [
+        createExpenseSheet('default', '기본 탭', [{ tempId: 'r1', cells: ['a'] }]),
+      ],
+      bankStatementRows: {
+        columns: ['통장번호', '거래일시'],
+        rows: [{ tempId: 'b1', cells: ['001', '2026-04-16'] }],
+      },
+    });
+
+    expect(bank.bankStatement.profile).toBe('general');
+    expect(bank.handoffContext.ready).toBe(true);
+    expect(bank.handoffContext.nextPath).toBe('/portal/weekly-expenses');
+  });
+
+  it('registers the four portal read-model endpoints', () => {
+    const routes = [];
+    const app = {
+      get(path, handler) {
+        routes.push({ path, handler });
+      },
+    };
+
+    mountPortalReadModelRoutes(app, {
+      db: {},
+    });
+
+    expect(routes.map((route) => route.path)).toEqual([
+      '/api/v1/portal/dashboard-summary',
+      '/api/v1/portal/payroll-summary',
+      '/api/v1/portal/weekly-expenses-summary',
+      '/api/v1/portal/bank-statements-summary',
+    ]);
+  });
+});

--- a/src/app/components/portal/PortalBankStatementPage.tsx
+++ b/src/app/components/portal/PortalBankStatementPage.tsx
@@ -6,6 +6,13 @@ import { Button } from '../ui/button';
 import { Card, CardContent } from '../ui/card';
 import { Badge } from '../ui/badge';
 import { usePortalStore } from '../../data/portal-store';
+import { useAuth } from '../../data/auth-store';
+import { useFirebase } from '../../lib/firebase-context';
+import {
+  createPlatformApiClient,
+  fetchPortalBankStatementsSummaryViaBff,
+  type PortalBankStatementsSummaryResult,
+} from '../../lib/platform-bff-client';
 import {
   detectBankStatementProfile,
   getBankStatementProfileLabel,
@@ -17,6 +24,7 @@ import {
 } from '../../platform/bank-statement';
 import { normalizeKey, parseCsv, parseNumber } from '../../platform/csv-utils';
 import { loadXlsx, warmXlsx } from '../../platform/lazy-heavy-modules';
+import { resolvePortalProjectReadModel } from './portal-read-model';
 
 function getAmountColumnIndexes(columns: string[]): Set<number> {
   return new Set(
@@ -43,6 +51,9 @@ function formatBankStatementRows(
 
 export function PortalBankStatementPage() {
   const navigate = useNavigate();
+  const { user: authUser } = useAuth();
+  const { orgId } = useFirebase();
+  const apiClient = useMemo(() => createPlatformApiClient(import.meta.env), []);
   const {
     activeProjectId,
     portalUser,
@@ -56,11 +67,17 @@ export function PortalBankStatementPage() {
   const [saving, setSaving] = useState(false);
   const [lastUploadedName, setLastUploadedName] = useState('');
   const [lastSavedAt, setLastSavedAt] = useState('');
+  const [bankStatementsSummary, setBankStatementsSummary] = useState<PortalBankStatementsSummaryResult | null>(null);
   const [dragActive, setDragActive] = useState(false);
   const [uploadPreparing, setUploadPreparing] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  const projectName = myProject?.name || '내 사업';
+  const projectReadModel = useMemo(() => resolvePortalProjectReadModel({
+    summaryProject: bankStatementsSummary?.project,
+    fallbackProject: myProject,
+    activeProjectId,
+  }), [activeProjectId, bankStatementsSummary?.project, myProject]);
+  const projectName = projectReadModel.projectName;
   const ready = useMemo(() => Boolean(activeProjectId || myProject?.id), [activeProjectId, myProject?.id]);
   const bankProfile = useMemo(() => detectBankStatementProfile(columns, lastUploadedName), [columns, lastUploadedName]);
   const amountColIdxs = useMemo(() => getAmountColumnIndexes(columns), [columns]);
@@ -85,6 +102,29 @@ export function PortalBankStatementPage() {
     setColumns([]);
     setRows([]);
   }, [bankStatementRows, dirty, formatAmount]);
+
+  useEffect(() => {
+    if (!authUser?.uid || !orgId) return;
+    let cancelled = false;
+
+    void fetchPortalBankStatementsSummaryViaBff({
+      tenantId: orgId,
+      actor: authUser,
+      client: apiClient,
+    })
+      .then((summary) => {
+        if (!cancelled) setBankStatementsSummary(summary);
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.warn('[PortalBankStatementPage] bank-statements-summary fetch failed; using store fallback:', error);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [apiClient, authUser, orgId]);
 
   const parseExcelToMatrix = useCallback(async (file: File): Promise<string[][]> => {
     // KB 등 HTML-as-XLS 감지: 파일 앞부분이 HTML 태그로 시작하면 HTML 파서 사용
@@ -290,6 +330,11 @@ export function PortalBankStatementPage() {
         <div className="space-y-1">
           <div className="flex items-center gap-2 flex-wrap">
             <h1 className="text-[18px]" style={{ fontWeight: 700 }}>통장내역</h1>
+            {projectReadModel.statusLabel && (
+              <Badge variant="outline" className="text-[10px]">
+                {projectReadModel.statusLabel}
+              </Badge>
+            )}
             <Badge variant={hasUploadedSheet ? 'secondary' : 'outline'} className="text-[10px]">
               {hasUploadedSheet ? `${rows.length}건 불러옴` : '업로드 전'}
             </Badge>
@@ -301,6 +346,9 @@ export function PortalBankStatementPage() {
             </Badge>
           </div>
           <p className="text-[12px] text-muted-foreground">{projectName} · 카드/통장 내역 업로드</p>
+          {projectReadModel.ready && projectReadModel.projectMetaLabel && (
+            <p className="text-[11px] text-muted-foreground">{projectReadModel.projectMetaLabel}</p>
+          )}
         </div>
         <div className="flex items-center justify-end gap-2 flex-wrap">
           <Button variant="outline" size="sm" onClick={() => navigate('/portal/weekly-expenses')}>

--- a/src/app/components/portal/PortalDashboard.layout.test.ts
+++ b/src/app/components/portal/PortalDashboard.layout.test.ts
@@ -37,4 +37,10 @@ describe('PortalDashboard layout compaction', () => {
     expect(portalDashboardSource).not.toContain('인력변경 신청');
     expect(portalDashboardSource).not.toContain('사업비 입력(주간) 작성/제출');
   });
+
+  it('reads project detail labels through the read-model fallback instead of dereferencing summary project blindly', () => {
+    expect(portalDashboardSource).toContain('projectReadModel.clientOrg || myProject.clientOrg || \'-\'');
+    expect(portalDashboardSource).toContain('projectReadModel.managerName || portalUser.name');
+    expect(portalDashboardSource).not.toContain('dashboardSummary?.project.clientOrg');
+  });
 });

--- a/src/app/components/portal/PortalDashboard.tsx
+++ b/src/app/components/portal/PortalDashboard.tsx
@@ -6,30 +6,26 @@ import {
   BarChart3,
   Loader2,
 } from 'lucide-react';
-import {
-  collection,
-  getDocs,
-  query,
-  where,
-} from 'firebase/firestore';
 import { toast } from 'sonner';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import { usePortalStore } from '../../data/portal-store';
+import { useAuth } from '../../data/auth-store';
 import { useHrAnnouncements, HR_EVENT_LABELS, HR_EVENT_COLORS } from '../../data/hr-announcements-store';
 import { usePayroll } from '../../data/payroll-store';
-import { TRANSACTIONS } from '../../data/mock-data';
 import { fmtShort } from '../../data/budget-data';
 import {
   PROJECT_STATUS_LABELS, SETTLEMENT_TYPE_SHORT, BASIS_LABELS,
-  type Transaction,
 } from '../../data/types';
 import { addMonthsToYearMonth, getSeoulTodayIso } from '../../platform/business-days';
 import { resolveCurrentCashflowWeek } from '../../platform/cashflow-export-surface';
 import { useFirebase } from '../../lib/firebase-context';
-import { featureFlags } from '../../config/feature-flags';
-import { getOrgCollectionPath } from '../../lib/firebase';
+import {
+  createPlatformApiClient,
+  fetchPortalDashboardSummaryViaBff,
+  type PortalDashboardSummaryResult,
+} from '../../lib/platform-bff-client';
 import {
   isPayrollLiquidityRiskStatus,
   resolveProjectPayrollLiquidity,
@@ -40,6 +36,7 @@ import {
   resolveWeeklyAccountingProductStatus,
   resolveWeeklyAccountingSnapshot,
 } from '../../platform/weekly-accounting-state';
+import { resolvePortalProjectReadModel } from './portal-read-model';
 
 // ═══════════════════════════════════════════════════════════════
 // PortalDashboard — 내 사업 현황
@@ -84,13 +81,42 @@ function submissionBadgeClassName(tone: 'neutral' | 'warning' | 'danger' | 'succ
 
 export function PortalDashboard() {
   const navigate = useNavigate();
-  const { isLoading, portalUser, myProject, weeklySubmissionStatuses, projects } = usePortalStore();
+  const { user: authUser } = useAuth();
+  const { isLoading, portalUser, myProject, weeklySubmissionStatuses, projects, transactions } = usePortalStore();
   const { getProjectAlerts } = useHrAnnouncements();
   const { runs, monthlyCloses, acknowledgePayrollRun, acknowledgeMonthlyClose } = usePayroll();
-  const { db, isOnline, orgId } = useFirebase();
-  const firestoreEnabled = featureFlags.firestoreCoreEnabled && isOnline && !!db;
+  const { orgId } = useFirebase();
+  const apiClient = useMemo(() => createPlatformApiClient(import.meta.env), []);
+  const [dashboardSummary, setDashboardSummary] = useState<PortalDashboardSummaryResult | null>(null);
 
-  const [liveTransactions, setLiveTransactions] = useState<Transaction[] | null>(null);
+  useEffect(() => {
+    if (!authUser?.uid || !orgId) return;
+    let cancelled = false;
+
+    void fetchPortalDashboardSummaryViaBff({
+      tenantId: orgId,
+      actor: authUser,
+      client: apiClient,
+    })
+      .then((summary) => {
+        if (!cancelled) setDashboardSummary(summary);
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.warn('[PortalDashboard] dashboard-summary fetch failed; using store fallback:', error);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [apiClient, authUser, orgId]);
+
+  const projectReadModel = useMemo(() => resolvePortalProjectReadModel({
+    summaryProject: dashboardSummary?.project,
+    fallbackProject: myProject,
+    activeProjectId: myProject?.id,
+  }), [dashboardSummary?.project, myProject]);
 
   if (isLoading) {
     return (
@@ -133,37 +159,7 @@ export function PortalDashboard() {
     );
   }
 
-  useEffect(() => {
-    if (!firestoreEnabled || !db) {
-      setLiveTransactions(null);
-      return;
-    }
-
-    let isCancelled = false;
-
-    const txQuery = query(
-      collection(db, getOrgCollectionPath(orgId, 'transactions')),
-      where('projectId', '==', myProject.id),
-    );
-
-    void getDocs(txQuery)
-      .then((snap) => {
-        if (isCancelled) return;
-        setLiveTransactions(snap.docs.map((d) => d.data() as Transaction));
-      })
-      .catch((err) => {
-        if (isCancelled) return;
-        console.error('[PortalDashboard] transactions fetch error:', err);
-        toast.error('거래 데이터를 불러오지 못했습니다');
-        setLiveTransactions(null);
-      });
-
-    return () => {
-      isCancelled = true;
-    };
-  }, [db, firestoreEnabled, orgId, myProject.id]);
-
-  const myTx = (liveTransactions ?? TRANSACTIONS).filter(t => t.projectId === myProject.id);
+  const myTx = transactions.filter((t) => t.projectId === myProject.id);
 
   const today = getSeoulTodayIso();
   const yearMonth = today.slice(0, 7);
@@ -252,13 +248,13 @@ export function PortalDashboard() {
       };
     });
   }, [assignedProjects, currentWeek, weeklyStatusMap]);
-  const dashboardSurface = useMemo(() => buildPortalDashboardSurface({
+  const dashboardSurface = useMemo(() => dashboardSummary?.surface ?? buildPortalDashboardSurface({
     projectId: myProject.id,
     weeklySubmissionStatuses,
     todayIso: today,
     hrAlertCount: hrAlerts.length,
     payrollRiskCount: payrollRiskItems.length,
-  }), [hrAlerts.length, myProject.id, payrollRiskItems.length, today, weeklySubmissionStatuses]);
+  }), [dashboardSummary?.surface, hrAlerts.length, myProject.id, payrollRiskItems.length, today, weeklySubmissionStatuses]);
   const shouldShowPayrollQueue = Boolean(payrollDetail && payrollDetail.status !== 'clear');
   const financeSummaryItems = [
     { label: '총 입금', value: fmtShort(totalIn) },
@@ -275,7 +271,7 @@ export function PortalDashboard() {
             <div className="space-y-3">
               <div className="flex flex-wrap items-center gap-2">
                 <Badge className="h-5 rounded-full bg-[#e8f0fb] px-2 text-[10px] font-semibold text-[#1b4f8f]">
-                  {PROJECT_STATUS_LABELS[myProject.status]}
+                  {projectReadModel.statusLabel || PROJECT_STATUS_LABELS[myProject.status]}
                 </Badge>
                 <Badge variant="outline" className="h-5 rounded-full border-slate-300 px-2 text-[10px] font-semibold text-slate-600">
                   {SETTLEMENT_TYPE_SHORT[myProject.settlementType]}
@@ -285,7 +281,7 @@ export function PortalDashboard() {
                 </Badge>
               </div>
               <h2 className="text-[30px] font-semibold tracking-[-0.04em] text-slate-950">
-                {myProject.name}
+                {projectReadModel.projectName}
               </h2>
             </div>
 
@@ -314,11 +310,15 @@ export function PortalDashboard() {
                 <div className="space-y-2">
                   <div className="rounded-xl border border-slate-300 bg-white px-4 py-3">
                     <div className="text-[11px] font-medium text-slate-600">발주기관</div>
-                    <div className="mt-1 text-[14px] font-semibold text-slate-900">{myProject.clientOrg || '-'}</div>
+                    <div className="mt-1 text-[14px] font-semibold text-slate-900">
+                      {projectReadModel.clientOrg || myProject.clientOrg || '-'}
+                    </div>
                   </div>
                   <div className="rounded-xl border border-slate-300 bg-white px-4 py-3">
                     <div className="text-[11px] font-medium text-slate-600">담당자</div>
-                    <div className="mt-1 text-[14px] font-semibold text-slate-900">{portalUser.name}</div>
+                    <div className="mt-1 text-[14px] font-semibold text-slate-900">
+                      {projectReadModel.managerName || portalUser.name}
+                    </div>
                   </div>
                   <div className="rounded-xl border border-slate-300 bg-white px-4 py-3">
                     <div className="text-[11px] font-medium text-slate-600">사업비 총액</div>

--- a/src/app/components/portal/PortalEntryReadBoundary.shell.test.ts
+++ b/src/app/components/portal/PortalEntryReadBoundary.shell.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readPortalSource(fileName: string) {
+  return readFileSync(resolve(import.meta.dirname, fileName), 'utf8');
+}
+
+const dashboardSource = readPortalSource('PortalDashboard.tsx');
+const payrollSource = readPortalSource('PortalPayrollPage.tsx');
+const weeklyExpenseSource = readPortalSource('PortalWeeklyExpensePage.tsx');
+const bankStatementSource = readPortalSource('PortalBankStatementPage.tsx');
+
+describe('portal entry read boundary', () => {
+  it('hydrates dashboard surface from the portal dashboard summary BFF contract', () => {
+    expect(dashboardSource).toContain('createPlatformApiClient(import.meta.env)');
+    expect(dashboardSource).toContain('fetchPortalDashboardSummaryViaBff');
+    expect(dashboardSource).toContain('dashboardSummary');
+  });
+
+  it('hydrates payroll surface from the portal payroll summary BFF contract', () => {
+    expect(payrollSource).toContain('createPlatformApiClient(import.meta.env)');
+    expect(payrollSource).toContain('fetchPortalPayrollSummaryViaBff');
+    expect(payrollSource).toContain('payrollSummary');
+  });
+
+  it('hydrates weekly expense project summary and handoff context from the portal weekly summary BFF contract', () => {
+    expect(weeklyExpenseSource).toContain('createPlatformApiClient(import.meta.env)');
+    expect(weeklyExpenseSource).toContain('fetchPortalWeeklyExpensesSummaryViaBff');
+    expect(weeklyExpenseSource).not.toContain('fetchPortalEntryContextViaBff');
+    expect(weeklyExpenseSource).toContain('weeklySummary');
+  });
+
+  it('hydrates bank statement project summary and readiness context from the portal bank summary BFF contract', () => {
+    expect(bankStatementSource).toContain('createPlatformApiClient(import.meta.env)');
+    expect(bankStatementSource).toContain('fetchPortalBankStatementsSummaryViaBff');
+    expect(bankStatementSource).not.toContain('fetchPortalEntryContextViaBff');
+    expect(bankStatementSource).toContain('bankStatementsSummary');
+  });
+});

--- a/src/app/components/portal/PortalPayrollPage.tsx
+++ b/src/app/components/portal/PortalPayrollPage.tsx
@@ -1,12 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { CalendarDays, CheckCircle2, CircleDollarSign, Info, AlertTriangle, ArrowRight } from 'lucide-react';
-import {
-  collection,
-  getDocs,
-  query,
-  where,
-} from 'firebase/firestore';
 import { toast } from 'sonner';
 import { PageHeader } from '../layout/PageHeader';
 import { Card, CardContent } from '../ui/card';
@@ -14,20 +8,25 @@ import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
+import { useAuth } from '../../data/auth-store';
 import { usePortalStore } from '../../data/portal-store';
 import { usePayroll } from '../../data/payroll-store';
-import { TRANSACTIONS } from '../../data/mock-data';
+import { useFirebase } from '../../lib/firebase-context';
+import {
+  createPlatformApiClient,
+  fetchPortalPayrollSummaryViaBff,
+  type PortalPayrollSummaryResult,
+} from '../../lib/platform-bff-client';
 import { addMonthsToYearMonth, computePlannedPayDate, getSeoulTodayIso, subtractBusinessDays } from '../../platform/business-days';
 import { fmtShort } from '../../data/budget-data';
-import { featureFlags } from '../../config/feature-flags';
-import { useFirebase } from '../../lib/firebase-context';
-import { getOrgCollectionPath } from '../../lib/firebase';
-import type { Transaction } from '../../data/types';
 import { resolveProjectPayrollLiquidity, type PayrollLiquidityQueueItem } from '../../platform/payroll-liquidity';
+import { resolvePortalProjectReadModel } from './portal-read-model';
 
 export function PortalPayrollPage() {
   const navigate = useNavigate();
-  const { activeProjectId, myProject } = usePortalStore();
+  const { user: authUser } = useAuth();
+  const { activeProjectId, myProject, transactions } = usePortalStore();
+  const { orgId } = useFirebase();
   const {
     schedules,
     runs,
@@ -36,22 +35,31 @@ export function PortalPayrollPage() {
     acknowledgePayrollRun,
     acknowledgeMonthlyClose,
   } = usePayroll();
-  const { db, isOnline, orgId } = useFirebase();
-  const firestoreEnabled = featureFlags.firestoreCoreEnabled && isOnline && !!db;
-  const [liveTransactions, setLiveTransactions] = useState<Transaction[] | null>(null);
+  const apiClient = useMemo(() => createPlatformApiClient(import.meta.env), []);
+  const [payrollSummary, setPayrollSummary] = useState<PortalPayrollSummaryResult | null>(null);
 
   const today = getSeoulTodayIso();
   const yearMonth = today.slice(0, 7);
   const prevYearMonth = addMonthsToYearMonth(yearMonth, -1);
 
   const projectId = activeProjectId || myProject?.id || '';
-  const schedule = useMemo(() => schedules.find((s) => s.projectId === projectId) || null, [projectId, schedules]);
-  const run = useMemo(() => runs.find((r) => r.projectId === projectId && r.yearMonth === yearMonth) || null, [projectId, runs, yearMonth]);
+  const projectReadModel = useMemo(() => resolvePortalProjectReadModel({
+    summaryProject: payrollSummary?.project,
+    fallbackProject: myProject,
+    activeProjectId: projectId,
+  }), [myProject, payrollSummary?.project, projectId]);
+  const schedule = useMemo(
+    () => payrollSummary?.schedule ?? (schedules.find((s) => s.projectId === projectId) || null),
+    [payrollSummary?.schedule, projectId, schedules],
+  );
+  const run = useMemo(
+    () => payrollSummary?.currentRun ?? (runs.find((r) => r.projectId === projectId && r.yearMonth === yearMonth) || null),
+    [payrollSummary?.currentRun, projectId, runs, yearMonth],
+  );
   const monthlyClosePrev = useMemo(() => monthlyCloses.find((c) => c.projectId === projectId && c.yearMonth === prevYearMonth) || null, [monthlyCloses, prevYearMonth, projectId]);
   const projectTransactions = useMemo(() => {
-    const source = liveTransactions ?? TRANSACTIONS;
-    return source.filter((tx) => tx.projectId === projectId);
-  }, [liveTransactions, projectId]);
+    return transactions.filter((tx) => tx.projectId === projectId);
+  }, [projectId, transactions]);
 
   const [dayInput, setDayInput] = useState<string>(schedule ? String(schedule.dayOfMonth) : '');
   const day = Math.max(1, Math.min(31, Number.parseInt(dayInput || '0', 10) || 0));
@@ -75,36 +83,42 @@ export function PortalPayrollPage() {
         })
       : []
   ), [myProject, projectTransactions, runs, today]);
-  const activeQueueItem = queueItems[0] || null;
+  const activeQueueItem = useMemo(() => {
+    const summaryQueueItem = payrollSummary?.queue?.[0];
+    if (summaryQueueItem) return {
+      ...summaryQueueItem,
+      projectShortName: summaryQueueItem.projectShortName || summaryQueueItem.projectId,
+    } satisfies PayrollLiquidityQueueItem;
+    return queueItems[0] || null;
+  }, [payrollSummary?.queue, queueItems]);
 
   useEffect(() => {
-    if (!projectId || !firestoreEnabled || !db) {
-      setLiveTransactions(null);
-      return;
-    }
+    if (!authUser?.uid || !orgId) return;
+    let cancelled = false;
 
-    let isCancelled = false;
-    const txQuery = query(
-      collection(db, getOrgCollectionPath(orgId, 'transactions')),
-      where('projectId', '==', projectId),
-    );
-
-    void getDocs(txQuery)
-      .then((snap) => {
-        if (isCancelled) return;
-        setLiveTransactions(snap.docs.map((doc) => doc.data() as Transaction));
+    void fetchPortalPayrollSummaryViaBff({
+      tenantId: orgId,
+      actor: authUser,
+      client: apiClient,
+    })
+      .then((summary) => {
+        if (!cancelled) setPayrollSummary(summary);
       })
-      .catch((err) => {
-        if (isCancelled) return;
-        console.error('[PortalPayrollPage] transactions fetch error:', err);
-        toast.error('인건비 지급용 거래 내역을 불러오지 못했습니다');
-        setLiveTransactions(null);
+      .catch((error) => {
+        if (!cancelled) {
+          console.warn('[PortalPayrollPage] payroll-summary fetch failed; using store fallback:', error);
+        }
       });
 
     return () => {
-      isCancelled = true;
+      cancelled = true;
     };
-  }, [db, firestoreEnabled, orgId, projectId]);
+  }, [apiClient, authUser, orgId]);
+
+  useEffect(() => {
+    if (!schedule || dayInput) return;
+    setDayInput(String(schedule.dayOfMonth));
+  }, [dayInput, schedule]);
 
   async function onSave() {
     if (!projectId) return;
@@ -150,7 +164,7 @@ export function PortalPayrollPage() {
         iconGradient="linear-gradient(135deg, #0d9488 0%, #059669 100%)"
         title="인건비 지급 준비"
         description="지급일을 등록해 두면 지급 창 D-3부터 D+3까지 잔액 여력과 지급 확정 상태를 함께 점검할 수 있습니다."
-        badge={myProject?.shortName || myProject?.id || ''}
+        badge={payrollSummary?.project.shortName || myProject?.shortName || myProject?.id || ''}
       />
 
       {(needsPayrollAck || needsMonthlyCloseAck) && (
@@ -213,15 +227,23 @@ export function PortalPayrollPage() {
 
       <Card>
         <CardContent className="p-4 space-y-4">
-          <div className="flex items-center gap-2">
-            <CalendarDays className="w-4 h-4 text-teal-600" />
-            <p className="text-[13px]" style={{ fontWeight: 700 }}>인건비 지급일 등록</p>
-            {schedule ? (
-              <Badge className="text-[10px] bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">설정됨</Badge>
-            ) : (
-              <Badge variant="outline" className="text-[10px]">미설정</Badge>
-            )}
-          </div>
+            <div className="flex items-center gap-2">
+              <CalendarDays className="w-4 h-4 text-teal-600" />
+              <p className="text-[13px]" style={{ fontWeight: 700 }}>인건비 지급일 등록</p>
+              {projectReadModel.statusLabel && (
+                <Badge variant="outline" className="text-[10px]">
+                  {projectReadModel.statusLabel}
+                </Badge>
+              )}
+              {schedule ? (
+                <Badge className="text-[10px] bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">설정됨</Badge>
+              ) : (
+                <Badge variant="outline" className="text-[10px]">미설정</Badge>
+              )}
+            </div>
+          {projectReadModel.projectMetaLabel && (
+            <p className="text-[11px] text-muted-foreground">{projectReadModel.projectName} · {projectReadModel.projectMetaLabel}</p>
+          )}
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
             <div className="md:col-span-1">

--- a/src/app/components/portal/PortalRealtimeSafety.test.ts
+++ b/src/app/components/portal/PortalRealtimeSafety.test.ts
@@ -13,13 +13,23 @@ const portalPayrollSource = readFileSync(
 );
 
 describe('portal realtime safety', () => {
-  it('uses fetch-based transaction loading on the portal dashboard', () => {
-    expect(portalDashboardSource).toContain('getDocs(');
-    expect(portalDashboardSource).not.toContain('onSnapshot(txQuery');
+  it('does not fan out raw transaction reads from the portal dashboard page', () => {
+    expect(portalDashboardSource).not.toContain('firebase/firestore');
+    expect(portalDashboardSource).not.toContain('collection(');
+    expect(portalDashboardSource).not.toContain('getDocs(');
+    expect(portalDashboardSource).not.toContain('query(');
+    expect(portalDashboardSource).not.toContain('where(');
+    expect(portalDashboardSource).not.toContain('onSnapshot(');
+    expect(portalDashboardSource).toContain('transactions');
   });
 
-  it('uses fetch-based transaction loading on the portal payroll page', () => {
-    expect(portalPayrollSource).toContain('getDocs(');
-    expect(portalPayrollSource).not.toContain('onSnapshot(txQuery');
+  it('does not fan out raw transaction reads from the portal payroll page', () => {
+    expect(portalPayrollSource).not.toContain('firebase/firestore');
+    expect(portalPayrollSource).not.toContain('collection(');
+    expect(portalPayrollSource).not.toContain('getDocs(');
+    expect(portalPayrollSource).not.toContain('query(');
+    expect(portalPayrollSource).not.toContain('where(');
+    expect(portalPayrollSource).not.toContain('onSnapshot(');
+    expect(portalPayrollSource).toContain('transactions');
   });
 });

--- a/src/app/components/portal/PortalWeeklyExpensePage.tsx
+++ b/src/app/components/portal/PortalWeeklyExpensePage.tsx
@@ -30,6 +30,9 @@ import {
 import { toast } from 'sonner';
 import { useFirebase } from '../../lib/firebase-context';
 import {
+  createPlatformApiClient,
+  fetchPortalWeeklyExpensesSummaryViaBff,
+  type PortalWeeklyExpensesSummaryResult,
   type ProvisionTransactionEvidenceDriveResult,
   type SyncTransactionEvidenceDriveResult,
   type UploadTransactionEvidenceDriveResult,
@@ -72,6 +75,7 @@ import {
 import { resolvePortalHappyPath } from '../../platform/portal-happy-path';
 import { resolveWeeklyExpenseSavePolicy } from '../../platform/weekly-expense-save-policy';
 import { usePortalNavigationGuard } from './PortalLayout';
+import { resolvePortalProjectReadModel } from './portal-read-model';
 const GoogleSheetMigrationWizard = lazy(
   () => import('./GoogleSheetMigrationWizard').then((module) => ({ default: module.GoogleSheetMigrationWizard })),
 );
@@ -85,6 +89,7 @@ export function PortalWeeklyExpensePage() {
   const weeklyExpenseSavePolicy = resolveWeeklyExpenseSavePolicy();
   const { user: authUser, ensureGoogleWorkspaceAccess } = useAuth();
   const { orgId } = useFirebase();
+  const apiClient = useMemo(() => createPlatformApiClient(import.meta.env), []);
   const {
     activeProjectId,
     portalUser,
@@ -121,6 +126,7 @@ export function PortalWeeklyExpensePage() {
   const devHarnessConfig = readDevAuthHarnessConfig(import.meta.env, typeof window !== 'undefined' ? window.location : undefined);
   const [projectDriveProvisioning, setProjectDriveProvisioning] = useState(false);
   const [googleSheetImportOpen, setGoogleSheetImportOpen] = useState(false);
+  const [weeklySummary, setWeeklySummary] = useState<PortalWeeklyExpensesSummaryResult | null>(null);
   const [pendingQuickInsert, setPendingQuickInsert] = useState<PendingQuickInsert | null>(null);
   const [hasUnsavedSettlementChanges, setHasUnsavedSettlementChanges] = useState(false);
   const [pendingNavigationAttempt, setPendingNavigationAttempt] = useState<{ path: string; label: string } | null>(null);
@@ -132,7 +138,6 @@ export function PortalWeeklyExpensePage() {
   } | null>(null);
 
   const projectId = activeProjectId || myProject?.id || '';
-  const projectName = myProject?.name || '내 사업';
   const ledgerUserRole = portalUser?.role === 'pm' ? 'pm' : 'admin';
   const visibleExpenseSheets = useMemo(() => (
     expenseSheets.length > 0
@@ -143,11 +148,39 @@ export function PortalWeeklyExpensePage() {
     return visibleExpenseSheets.find((sheet) => sheet.id === activeExpenseSheetId)?.name || visibleExpenseSheets[0]?.name || '기본 탭';
   }, [visibleExpenseSheets, activeExpenseSheetId]);
   const bankStatementCount = bankStatementRows?.rows?.length || 0;
+  const projectReadModel = useMemo(() => resolvePortalProjectReadModel({
+    summaryProject: weeklySummary?.project,
+    fallbackProject: myProject,
+    activeProjectId,
+  }), [activeProjectId, myProject, weeklySummary?.project]);
+  const projectName = projectReadModel.projectName;
 
   const defaultLedgerId = useMemo(() => {
     const ledger = ledgers.find((l) => l.projectId === projectId);
     return ledger?.id || `l-${projectId}`;
   }, [projectId, ledgers]);
+  useEffect(() => {
+    if (!authUser?.uid || !orgId) return;
+    let cancelled = false;
+
+    void fetchPortalWeeklyExpensesSummaryViaBff({
+      tenantId: orgId,
+      actor: authUser,
+      client: apiClient,
+    })
+      .then((summary) => {
+        if (!cancelled) setWeeklySummary(summary);
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.warn('[PortalWeeklyExpensePage] weekly-expenses-summary fetch failed; using store fallback:', error);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [apiClient, authUser, orgId]);
   const happyPath = useMemo(() => resolvePortalHappyPath({
     authUser,
     portalUser,
@@ -744,6 +777,11 @@ export function PortalWeeklyExpensePage() {
           <div className="space-y-1">
           <div className="flex items-center gap-2 flex-wrap">
             <h2 className="text-base font-bold">사업비 입력(주간)</h2>
+            {projectReadModel.statusLabel && (
+              <Badge variant="outline" className="text-[10px]">
+                {projectReadModel.statusLabel}
+              </Badge>
+            )}
             <Badge variant="secondary" className="text-[10px]">
               현재 탭: {activeSheetName}
             </Badge>
@@ -768,6 +806,9 @@ export function PortalWeeklyExpensePage() {
                 ? '통장내역 기준본에서 이어서 작업합니다. 이 화면에서 분류 확인, 행 입력, 저장까지 바로 마무리하세요.'
                 : '통장내역 기준본을 먼저 만들면 이 화면에서 바로 입력과 저장을 이어갈 수 있습니다.'}
           </p>
+          {projectReadModel.projectMetaLabel && (
+            <p className="text-[11px] text-muted-foreground">{projectReadModel.projectName} · {projectReadModel.projectMetaLabel}</p>
+          )}
           </div>
           <div className="flex items-center gap-2 flex-wrap">
           {isDirectEntryMode ? (

--- a/src/app/components/portal/portal-read-model.test.ts
+++ b/src/app/components/portal/portal-read-model.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { resolvePortalProjectReadModel } from './portal-read-model';
+
+describe('resolvePortalProjectReadModel', () => {
+  it('prefers the BFF summary project for read surfaces', () => {
+    const model = resolvePortalProjectReadModel({
+      activeProjectId: 'project-bff',
+      summaryProject: {
+        id: 'project-bff',
+        name: 'BFF 사업',
+        status: 'IN_PROGRESS',
+        clientOrg: 'MYSC',
+        managerName: '보람',
+        department: 'AXR',
+      },
+      fallbackProject: {
+        id: 'project-store',
+        name: '스토어 사업',
+        status: 'CONTRACT_PENDING',
+        clientOrg: 'Fallback Org',
+        managerName: '다른 담당자',
+        department: 'Ops',
+        type: 'CONSULTING',
+      },
+    });
+
+    expect(model).toMatchObject({
+      projectId: 'project-bff',
+      projectName: 'BFF 사업',
+      statusLabel: '사업진행중',
+      projectMetaLabel: 'MYSC · 보람 · AXR',
+      ready: true,
+      source: 'bff',
+    });
+  });
+
+  it('falls back to the store-backed project shape when the summary project is unavailable', () => {
+    const model = resolvePortalProjectReadModel({
+      activeProjectId: 'project-store',
+      summaryProject: null,
+      fallbackProject: {
+        id: 'project-store',
+        name: '스토어 사업',
+        status: 'CONTRACT_PENDING',
+        clientOrg: 'Fallback Org',
+        managerName: '담당자',
+        department: 'Ops',
+        type: 'CONSULTING',
+      },
+    });
+
+    expect(model).toMatchObject({
+      projectId: 'project-store',
+      projectName: '스토어 사업',
+      statusLabel: '계약전',
+      projectMetaLabel: 'Fallback Org · 담당자 · Ops',
+      ready: true,
+      source: 'store',
+    });
+  });
+});

--- a/src/app/components/portal/portal-read-model.ts
+++ b/src/app/components/portal/portal-read-model.ts
@@ -1,0 +1,70 @@
+import { PROJECT_STATUS_LABELS, type Project } from '../../data/types';
+import type { PortalReadModelProjectSummary } from '../../lib/platform-bff-client';
+
+type PortalFallbackProject = Pick<
+  Project,
+  'id' | 'name' | 'status' | 'clientOrg' | 'managerName' | 'department' | 'type'
+>;
+
+export interface PortalProjectReadModel {
+  projectId: string;
+  projectName: string;
+  statusLabel: string;
+  projectMetaLabel: string;
+  ready: boolean;
+  source: 'bff' | 'store' | 'empty';
+}
+
+function normalizeProject(project: PortalReadModelProjectSummary | PortalFallbackProject | null | undefined) {
+  if (!project) return null;
+
+  const projectId = String(project.id || '').trim();
+  const projectName = String(project.name || '').trim();
+  const status = String(project.status || '').trim();
+  const statusLabel = status
+    ? PROJECT_STATUS_LABELS[status as keyof typeof PROJECT_STATUS_LABELS] || status
+    : '';
+  const projectMetaLabel = [
+    String(project.clientOrg || '').trim(),
+    String(project.managerName || '').trim(),
+    String(project.department || '').trim(),
+  ].filter(Boolean).join(' · ');
+
+  return {
+    projectId,
+    projectName,
+    statusLabel,
+    projectMetaLabel,
+  };
+}
+
+export function resolvePortalProjectReadModel(params: {
+  summaryProject?: PortalReadModelProjectSummary | null;
+  fallbackProject?: PortalFallbackProject | null;
+  activeProjectId?: string | null;
+}): PortalProjectReadModel {
+  const activeProjectId = String(params.activeProjectId || '').trim();
+  const preferred = normalizeProject(params.summaryProject);
+  const fallback = normalizeProject(params.fallbackProject);
+  const selected = preferred || fallback;
+
+  if (!selected) {
+    return {
+      projectId: activeProjectId,
+      projectName: '내 사업',
+      statusLabel: '',
+      projectMetaLabel: '',
+      ready: Boolean(activeProjectId),
+      source: 'empty',
+    };
+  }
+
+  return {
+    projectId: selected.projectId || activeProjectId,
+    projectName: selected.projectName || '내 사업',
+    statusLabel: selected.statusLabel,
+    projectMetaLabel: selected.projectMetaLabel,
+    ready: Boolean(selected.projectId || activeProjectId),
+    source: preferred ? 'bff' : 'store',
+  };
+}

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -8,6 +8,10 @@ import {
   deepSyncAuthGovernanceUserViaBff,
   fetchPortalEntryContextViaBff,
   fetchPortalOnboardingContextViaBff,
+  fetchPortalDashboardSummaryViaBff,
+  fetchPortalPayrollSummaryViaBff,
+  fetchPortalWeeklyExpensesSummaryViaBff,
+  fetchPortalBankStatementsSummaryViaBff,
   fetchAuthGovernanceUsersViaBff,
   linkProjectEvidenceDriveRootViaBff,
   notifyProjectRequestRegistrationViaBff,
@@ -53,12 +57,37 @@ describe('platform-bff-client', () => {
     vi.stubGlobal('window', {
       location: {
         origin: 'https://inner-platform.vercel.app',
+        hostname: 'inner-platform.vercel.app',
       },
     });
 
     expect(readPlatformApiRuntimeConfig({})).toEqual({
       enabled: false,
       baseUrl: 'https://inner-platform.vercel.app',
+    });
+
+    if (previousWindow === undefined) {
+      delete (globalThis as { window?: unknown }).window;
+    } else {
+      vi.stubGlobal('window', previousWindow);
+    }
+  });
+
+  it('prefers the current browser origin when the dev auth harness is enabled on localhost', () => {
+    const previousWindow = globalThis.window;
+    vi.stubGlobal('window', {
+      location: {
+        origin: 'http://localhost:4173',
+        hostname: 'localhost',
+      },
+    });
+
+    expect(readPlatformApiRuntimeConfig({
+      VITE_DEV_AUTH_HARNESS_ENABLED: 'true',
+      VITE_PLATFORM_API_BASE_URL: 'http://127.0.0.1:8787',
+    })).toEqual({
+      enabled: false,
+      baseUrl: 'http://localhost:4173',
     });
 
     if (previousWindow === undefined) {
@@ -138,6 +167,138 @@ describe('platform-bff-client', () => {
     }));
     expect(result.activeProjectId).toBe('p001');
     expect(result.projects).toHaveLength(1);
+  });
+
+  it('calls portal dashboard summary endpoint', async () => {
+    const client = asMockClient({
+      post: vi.fn(),
+      get: vi.fn(async () => ({
+        data: {
+          project: { id: 'p001', name: 'Project 1', managerName: '보람' },
+          summary: {
+            payrollRiskCount: 1,
+            visibleProjects: 3,
+          },
+          surface: {
+            currentWeekLabel: '3주차',
+            projection: { label: '작성됨', detail: '3주차 · 제출 완료', latestUpdatedAt: '2026-04-16T09:00:00.000Z' },
+            expense: { label: '지급 여력 양호', detail: '3주차 · 지급 여력 양호', tone: 'success' },
+            visibleIssues: [],
+          },
+        },
+      })),
+      request: vi.fn(),
+    });
+
+    const result = await fetchPortalDashboardSummaryViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'u001', role: 'pm', idToken: 'token-abc' },
+      client,
+    });
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/portal/dashboard-summary', expect.objectContaining({
+      tenantId: 'mysc',
+    }));
+    expect(result.summary.payrollRiskCount).toBe(1);
+  });
+
+  it('calls portal payroll summary endpoint', async () => {
+    const client = asMockClient({
+      post: vi.fn(),
+      get: vi.fn(async () => ({
+        data: {
+          project: { id: 'p001', name: 'Project 1', managerName: '보람' },
+          summary: {
+            queueCount: 1,
+            riskCount: 1,
+            status: 'payment_unconfirmed',
+          },
+          schedule: { id: 'p001', dayOfMonth: 25, timezone: 'Asia/Seoul', noticeLeadBusinessDays: 3, active: true },
+          currentRun: {
+            id: 'p001-2026-04',
+            projectId: 'p001',
+            yearMonth: '2026-04',
+            plannedPayDate: '2026-04-25',
+            noticeDate: '2026-04-22',
+            noticeLeadBusinessDays: 3,
+            acknowledged: false,
+            paidStatus: 'MISSING',
+            currentBalance: null,
+            worstBalance: null,
+            status: 'payment_unconfirmed',
+            statusReason: '지급일이 지났지만 아직 지급 확정이 기록되지 않았습니다.',
+            dayBalances: [],
+          },
+        },
+      })),
+      request: vi.fn(),
+    });
+
+    const result = await fetchPortalPayrollSummaryViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'u001', role: 'pm', idToken: 'token-abc' },
+      client,
+    });
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/portal/payroll-summary', expect.objectContaining({
+      tenantId: 'mysc',
+    }));
+    expect(result.summary.queueCount).toBe(1);
+  });
+
+  it('calls portal weekly-expenses summary endpoint', async () => {
+    const client = asMockClient({
+      post: vi.fn(),
+      get: vi.fn(async () => ({
+        data: {
+          project: { id: 'p001', name: 'Project 1', managerName: '보람' },
+          summary: {
+            currentWeekLabel: '3주차',
+            expenseReviewPendingCount: 2,
+          },
+          expenseSheet: { activeSheetId: 'default', activeSheetName: '기본 탭', sheetCount: 2, rowCount: 10 },
+          bankStatement: { rowCount: 4, columnCount: 8, profile: 'general' },
+          handoff: { canOpenWeeklyExpenses: true, canUseEvidenceWorkflow: false, nextPath: '/portal/bank-statements' },
+        },
+      })),
+      request: vi.fn(),
+    });
+
+    const result = await fetchPortalWeeklyExpensesSummaryViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'u001', role: 'pm', idToken: 'token-abc' },
+      client,
+    });
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/portal/weekly-expenses-summary', expect.objectContaining({
+      tenantId: 'mysc',
+    }));
+    expect(result.handoff.canOpenWeeklyExpenses).toBe(true);
+  });
+
+  it('calls portal bank-statements summary endpoint', async () => {
+    const client = asMockClient({
+      post: vi.fn(),
+      get: vi.fn(async () => ({
+        data: {
+          project: { id: 'p001', name: 'Project 1', managerName: '보람' },
+          bankStatement: { rowCount: 4, columnCount: 8, profile: 'general', lastSavedAt: '2026-04-16T09:00:00.000Z' },
+          handoffContext: { ready: true, reason: '저장된 통장내역이 있습니다.', nextPath: '/portal/weekly-expenses' },
+        },
+      })),
+      request: vi.fn(),
+    });
+
+    const result = await fetchPortalBankStatementsSummaryViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'u001', role: 'pm', idToken: 'token-abc' },
+      client,
+    });
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/portal/bank-statements-summary', expect.objectContaining({
+      tenantId: 'mysc',
+    }));
+    expect(result.handoffContext.ready).toBe(true);
   });
 
   it('calls portal session project switch endpoint', async () => {

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -7,6 +7,7 @@ import type {
   TransactionState,
 } from '../data/types';
 import { PlatformApiClient } from '../platform/api-client';
+import { readDevAuthHarnessConfig } from '../platform/dev-harness';
 import { buildStandardHeaders, type RequestActor } from '../platform/request-context';
 
 export interface PlatformApiRuntimeConfig {
@@ -127,6 +128,155 @@ export interface PortalOnboardingContextResult {
 export interface PortalSessionProjectResult {
   ok: boolean;
   activeProjectId: string;
+}
+
+export interface PortalReadModelProjectSummary {
+  id: string;
+  name: string;
+  shortName?: string;
+  managerName?: string;
+  clientOrg?: string;
+  department?: string;
+  status?: string;
+  type?: string;
+}
+
+export interface PortalDashboardSummaryResult {
+  project: PortalReadModelProjectSummary;
+  summary: {
+    payrollRiskCount: number;
+    visibleProjects: number;
+    hrAlertCount: number;
+    currentWeekLabel: string;
+  };
+  surface: {
+    currentWeekLabel: string;
+    projection: {
+      label: string;
+      detail: string;
+      latestUpdatedAt?: string;
+    };
+    expense: {
+      label: string;
+      detail: string;
+      tone: 'muted' | 'warning' | 'danger' | 'success';
+    };
+    visibleIssues: Array<{
+      label: string;
+      count: number;
+      tone: 'neutral' | 'warn' | 'danger';
+      to: string;
+    }>;
+  };
+  registrationState?: 'registered' | 'unregistered';
+}
+
+export interface PortalPayrollSummaryResult {
+  project: PortalReadModelProjectSummary;
+  schedule: {
+    id: string;
+    projectId: string;
+    dayOfMonth: number;
+    timezone: string;
+    noticeLeadBusinessDays: number;
+    active: boolean;
+  };
+  currentRun: {
+    id: string;
+    projectId: string;
+    yearMonth: string;
+    plannedPayDate: string;
+    noticeDate: string;
+    noticeLeadBusinessDays: number;
+    acknowledged: boolean;
+    paidStatus: string;
+    expectedPayrollAmount: number | null;
+    baselineRunId: string | null;
+    status: string;
+    statusReason: string;
+    dayBalances: Array<{ date: string; balance: number | null }>;
+    worstBalance: number | null;
+    currentBalance: number | null;
+  } | null;
+  summary: {
+    queueCount: number;
+    riskCount: number;
+    status: string;
+    statusReason: string;
+  };
+  queue: Array<{
+    projectId: string;
+    projectName: string;
+    projectShortName: string;
+    runId: string;
+    yearMonth: string;
+    plannedPayDate: string;
+    windowStart: string;
+    windowEnd: string;
+    expectedPayrollAmount: number | null;
+    baselineRunId: string | null;
+    status: string;
+    statusReason: string;
+    dayBalances: Array<{ date: string; balance: number | null }>;
+    worstBalance: number | null;
+    currentBalance: number | null;
+    paidStatus: string;
+    acknowledged: boolean;
+  }>;
+  registrationState?: 'registered' | 'unregistered';
+}
+
+export interface PortalWeeklyExpensesSummaryResult {
+  project: PortalReadModelProjectSummary;
+  summary: {
+    currentWeekLabel: string;
+    expenseReviewPendingCount: number;
+  };
+  expenseSheet: {
+    activeSheetId: string;
+    activeSheetName: string;
+    sheetCount: number;
+    rowCount: number;
+  };
+  bankStatement: {
+    rowCount: number;
+    columnCount: number;
+    profile: string;
+    lastSavedAt?: string;
+  };
+  sheetSources: Array<{
+    sourceType: string;
+    sheetName: string;
+    fileName: string;
+    rowCount: number;
+    columnCount: number;
+    uploadedAt?: string;
+  }>;
+  handoff: {
+    canOpenWeeklyExpenses: boolean;
+    canUseEvidenceWorkflow: boolean;
+    nextPath: string;
+  };
+  registrationState?: 'registered' | 'unregistered';
+}
+
+export interface PortalBankStatementsSummaryResult {
+  project: PortalReadModelProjectSummary;
+  bankStatement: {
+    rowCount: number;
+    columnCount: number;
+    profile: string;
+    lastSavedAt?: string;
+  };
+  handoffContext: {
+    ready: boolean;
+    reason: string;
+    nextPath: string;
+    activeExpenseSheetId: string;
+    activeExpenseSheetName: string;
+    sheetCount: number;
+  };
+  registrationState?: 'registered' | 'unregistered';
 }
 
 export interface PortalRegistrationResult {
@@ -455,9 +605,14 @@ function normalizeBaseUrl(value: unknown): string {
 export function readPlatformApiRuntimeConfig(
   env: Record<string, unknown> = import.meta.env,
 ): PlatformApiRuntimeConfig {
+  const devHarnessConfig = readDevAuthHarnessConfig(env);
+  const baseUrl = devHarnessConfig.enabled
+    ? resolveRuntimeBaseUrl()
+    : normalizeBaseUrl(env.VITE_PLATFORM_API_BASE_URL);
+
   return {
     enabled: parseFeatureFlag(env.VITE_PLATFORM_API_ENABLED, false),
-    baseUrl: normalizeBaseUrl(env.VITE_PLATFORM_API_BASE_URL),
+    baseUrl,
   };
 }
 
@@ -1023,6 +1178,74 @@ export async function fetchPortalOnboardingContextViaBff(params: {
   const apiClient = resolveClient(params.client);
   const response = await apiClient.get<PortalOnboardingContextResult>(
     '/api/v1/portal/onboarding-context',
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      timeoutMs: 8000,
+    },
+  );
+  return response.data;
+}
+
+export async function fetchPortalDashboardSummaryViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  client?: PlatformApiClientLike;
+}): Promise<PortalDashboardSummaryResult> {
+  const apiClient = resolveClient(params.client);
+  const response = await apiClient.get<PortalDashboardSummaryResult>(
+    '/api/v1/portal/dashboard-summary',
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      timeoutMs: 8000,
+    },
+  );
+  return response.data;
+}
+
+export async function fetchPortalPayrollSummaryViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  client?: PlatformApiClientLike;
+}): Promise<PortalPayrollSummaryResult> {
+  const apiClient = resolveClient(params.client);
+  const response = await apiClient.get<PortalPayrollSummaryResult>(
+    '/api/v1/portal/payroll-summary',
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      timeoutMs: 8000,
+    },
+  );
+  return response.data;
+}
+
+export async function fetchPortalWeeklyExpensesSummaryViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  client?: PlatformApiClientLike;
+}): Promise<PortalWeeklyExpensesSummaryResult> {
+  const apiClient = resolveClient(params.client);
+  const response = await apiClient.get<PortalWeeklyExpensesSummaryResult>(
+    '/api/v1/portal/weekly-expenses-summary',
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      timeoutMs: 8000,
+    },
+  );
+  return response.data;
+}
+
+export async function fetchPortalBankStatementsSummaryViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  client?: PlatformApiClientLike;
+}): Promise<PortalBankStatementsSummaryResult> {
+  const apiClient = resolveClient(params.client);
+  const response = await apiClient.get<PortalBankStatementsSummaryResult>(
+    '/api/v1/portal/bank-statements-summary',
     {
       tenantId: params.tenantId,
       actor: toRequestActor(params.actor),

--- a/src/app/platform/dev-harness-portal-api.test.ts
+++ b/src/app/platform/dev-harness-portal-api.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildDevHarnessPortalEntryContext,
+  buildDevHarnessPortalOnboardingContext,
+  buildDevHarnessPortalRegistrationResult,
+  buildDevHarnessPortalSessionProjectResult,
+} from './dev-harness-portal-api';
+
+describe('dev harness portal api helpers', () => {
+  it('builds a registered PM entry context with a visible start project', () => {
+    const context = buildDevHarnessPortalEntryContext({ actorId: 'u002', actorRole: 'pm' });
+
+    expect(context.registrationState).toBe('registered');
+    expect(context.activeProjectId).toBeTruthy();
+    expect(context.priorityProjectIds).toContain(context.activeProjectId);
+    expect(context.projects.some((project) => project.id === context.activeProjectId)).toBe(true);
+  });
+
+  it('builds an admin entry context with multiple visible projects', () => {
+    const context = buildDevHarnessPortalEntryContext({ actorId: 'u001', actorRole: 'admin' });
+
+    expect(context.registrationState).toBe('registered');
+    expect(context.projects.length).toBeGreaterThan(1);
+  });
+
+  it('builds onboarding context with visible projects', () => {
+    const context = buildDevHarnessPortalOnboardingContext({ actorRole: 'pm' });
+
+    expect(context.projects.length).toBeGreaterThan(0);
+    expect(context.registrationState).toBe('registered');
+  });
+
+  it('normalizes registration payloads into a stable active project', () => {
+    const result = buildDevHarnessPortalRegistrationResult({
+      projectId: 'p001',
+      projectIds: ['p001', 'p002', 'p001'],
+    });
+
+    expect(result).toEqual({
+      ok: true,
+      registrationState: 'registered',
+      activeProjectId: 'p001',
+      projectIds: ['p001', 'p002'],
+    });
+  });
+
+  it('rejects session project switches for unknown projects', () => {
+    expect(() => buildDevHarnessPortalSessionProjectResult('missing-project')).toThrow('project_not_found');
+  });
+});

--- a/src/app/platform/dev-harness-portal-api.ts
+++ b/src/app/platform/dev-harness-portal-api.ts
@@ -1,0 +1,184 @@
+import { ORG_MEMBERS, PROJECTS } from '../data/mock-data';
+
+type PortalEntryProjectSummary = {
+  id: string;
+  name: string;
+  status: string;
+  clientOrg: string;
+  managerName: string;
+  department: string;
+  type?: string;
+};
+
+type PortalEntryContextResult = {
+  registrationState: 'registered' | 'unregistered';
+  activeProjectId: string;
+  priorityProjectIds: string[];
+  projects: PortalEntryProjectSummary[];
+};
+
+type PortalOnboardingContextResult = {
+  registrationState: 'registered' | 'unregistered';
+  activeProjectId: string;
+  projects: PortalEntryProjectSummary[];
+};
+
+type PortalRegistrationResult = {
+  ok: boolean;
+  registrationState: 'registered';
+  activeProjectId: string;
+  projectIds: string[];
+};
+
+type PortalSessionProjectResult = {
+  ok: boolean;
+  activeProjectId: string;
+};
+
+const PRIVILEGED_ROLES = new Set(['admin', 'finance']);
+
+function normalizeText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeRole(value: unknown): string {
+  const normalized = normalizeText(value).toLowerCase();
+  return normalized === 'viewer' ? 'pm' : normalized;
+}
+
+function normalizeProjectIds(values: unknown[]): string[] {
+  return Array.from(
+    new Set(
+      values
+        .map((value) => normalizeText(value))
+        .filter(Boolean),
+    ),
+  );
+}
+
+function resolvePrimaryProjectId(projectIds: string[], preferredProjectId?: string): string {
+  const preferred = normalizeText(preferredProjectId);
+  if (preferred && projectIds.includes(preferred)) return preferred;
+  return projectIds[0] || '';
+}
+
+function resolveDefaultPmProjectId(): string {
+  return PROJECTS.find((project) => project.status === 'CONTRACT_PENDING')?.id
+    || PROJECTS[0]?.id
+    || '';
+}
+
+function normalizeProject(project: Record<string, unknown>): PortalEntryProjectSummary {
+  const id = normalizeText(project.id);
+  return {
+    id,
+    name: normalizeText(project.name) || id,
+    status: normalizeText(project.status) || 'CONTRACT_PENDING',
+    clientOrg: normalizeText(project.clientOrg),
+    managerName: normalizeText(project.managerName),
+    department: normalizeText(project.department),
+    type: normalizeText(project.type) || undefined,
+  };
+}
+
+function listVisibleProjects(actorId: string, actorRole: string): {
+  projects: PortalEntryProjectSummary[];
+  priorityProjectIds: string[];
+} {
+  const activeProjects = PROJECTS.filter((project) => !normalizeText((project as Record<string, unknown>).trashedAt));
+  if (PRIVILEGED_ROLES.has(actorRole)) {
+    return {
+      projects: activeProjects
+        .map((project) => normalizeProject(project as unknown as Record<string, unknown>))
+        .sort((left, right) => left.name.localeCompare(right.name, 'ko')),
+      priorityProjectIds: [],
+    };
+  }
+
+  const assignedProjectIds = normalizeProjectIds([resolveDefaultPmProjectId()]);
+  const projects = activeProjects
+    .filter((project) => assignedProjectIds.includes(project.id) || normalizeText(project.managerId) === actorId)
+    .map((project) => normalizeProject(project as unknown as Record<string, unknown>))
+    .sort((left, right) => left.name.localeCompare(right.name, 'ko'));
+
+  const priorityProjectIds = normalizeProjectIds([
+    ...assignedProjectIds,
+    ...projects
+      .filter((project) => normalizeText(project.id))
+      .map((project) => project.id),
+  ]);
+
+  return { projects, priorityProjectIds };
+}
+
+function resolveRegistrationState(actorRole: string, projectIds: string[]): 'registered' | 'unregistered' {
+  if (PRIVILEGED_ROLES.has(actorRole)) return 'registered';
+  return projectIds.length > 0 ? 'registered' : 'unregistered';
+}
+
+export function buildDevHarnessPortalEntryContext(params: {
+  actorId?: string;
+  actorRole?: string;
+}): PortalEntryContextResult {
+  const actorId = normalizeText(params.actorId) || ORG_MEMBERS.find((member) => member.role === 'pm')?.uid || 'u002';
+  const actorRole = normalizeRole(params.actorRole) || 'pm';
+  const { projects, priorityProjectIds } = listVisibleProjects(actorId, actorRole);
+  const activeProjectId = resolvePrimaryProjectId(priorityProjectIds, priorityProjectIds[0]);
+
+  return {
+    registrationState: resolveRegistrationState(actorRole, priorityProjectIds),
+    activeProjectId,
+    priorityProjectIds,
+    projects,
+  };
+}
+
+export function buildDevHarnessPortalOnboardingContext(params: {
+  actorRole?: string;
+}): PortalOnboardingContextResult {
+  const actorRole = normalizeRole(params.actorRole) || 'pm';
+  const projects = PROJECTS
+    .filter((project) => !normalizeText((project as Record<string, unknown>).trashedAt))
+    .map((project) => normalizeProject(project as unknown as Record<string, unknown>))
+    .sort((left, right) => left.name.localeCompare(right.name, 'ko'));
+  const defaultProjectIds = PRIVILEGED_ROLES.has(actorRole) ? [] : normalizeProjectIds([resolveDefaultPmProjectId()]);
+
+  return {
+    registrationState: resolveRegistrationState(actorRole, defaultProjectIds),
+    activeProjectId: resolvePrimaryProjectId(defaultProjectIds, defaultProjectIds[0]),
+    projects,
+  };
+}
+
+export function buildDevHarnessPortalSessionProjectResult(projectId: string): PortalSessionProjectResult {
+  const normalizedProjectId = normalizeText(projectId);
+  const exists = PROJECTS.some((project) => project.id === normalizedProjectId);
+  if (!exists) {
+    throw new Error('project_not_found');
+  }
+  return {
+    ok: true,
+    activeProjectId: normalizedProjectId,
+  };
+}
+
+export function buildDevHarnessPortalRegistrationResult(params: {
+  projectId?: string;
+  projectIds?: string[];
+}): PortalRegistrationResult {
+  const normalizedProjectIds = normalizeProjectIds([
+    ...(Array.isArray(params.projectIds) ? params.projectIds : []),
+    params.projectId,
+  ]);
+  const activeProjectId = resolvePrimaryProjectId(normalizedProjectIds, params.projectId || normalizedProjectIds[0]);
+  if (!activeProjectId) {
+    throw new Error('project_required');
+  }
+
+  return {
+    ok: true,
+    registrationState: 'registered',
+    activeProjectId,
+    projectIds: normalizedProjectIds,
+  };
+}

--- a/src/app/platform/harness-stability.contract.test.ts
+++ b/src/app/platform/harness-stability.contract.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const playwrightHarnessConfigSource = readFileSync(
+  resolve(import.meta.dirname, '../../../playwright.harness.config.mjs'),
+  'utf8',
+);
+
+const viteConfigSource = readFileSync(
+  resolve(import.meta.dirname, '../../../vite.config.ts'),
+  'utf8',
+);
+
+describe('phase1 harness stability contracts', () => {
+  it('runs the local harness serially to avoid dev-server churn false negatives', () => {
+    expect(playwrightHarnessConfigSource).toContain('workers: 1');
+    expect(playwrightHarnessConfigSource).toContain("fullyParallel: false");
+    expect(playwrightHarnessConfigSource).toContain('VITE_PLATFORM_API_BASE_URL=http://localhost:4173');
+  });
+
+  it('exposes dev-harness portal entry endpoints from the vite server', () => {
+    expect(viteConfigSource).toContain('devHarnessPortalApiPlugin()');
+    expect(viteConfigSource).toContain("/api/v1/portal/entry-context");
+    expect(viteConfigSource).toContain("/api/v1/portal/onboarding-context");
+    expect(viteConfigSource).toContain("/api/v1/portal/session-project");
+    expect(viteConfigSource).toContain("/api/v1/portal/registration");
+    expect(viteConfigSource).not.toContain('hasAuthHeader');
+  });
+});

--- a/src/app/platform/phase1-portal-validation-gate.test.ts
+++ b/src/app/platform/phase1-portal-validation-gate.test.ts
@@ -1,0 +1,112 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  PHASE1_PORTAL_VALIDATION_STEPS,
+  formatPhase1PortalValidationSummary,
+  runPhase1PortalValidationGate,
+} from '../../../scripts/phase1_portal_validation_gate';
+
+describe('phase1 portal validation gate', () => {
+  it('runs steps sequentially, captures metrics, and writes the JSON payload', async () => {
+    const seenCommands: string[] = [];
+    const writes: Array<{ filePath: string; payload: unknown }> = [];
+
+    const result = await runPhase1PortalValidationGate({
+      steps: PHASE1_PORTAL_VALIDATION_STEPS.slice(0, 3),
+      runCommand: async (command) => {
+        seenCommands.push(command);
+        const index = seenCommands.length;
+        return {
+          exitCode: index === 2 ? 1 : 0,
+          durationMs: index * 10,
+        };
+      },
+      now: () => new Date('2026-04-16T09:10:11.000Z'),
+      writeJson: async (filePath, payload) => {
+        writes.push({ filePath, payload });
+      },
+      jsonOutPath: '/tmp/phase1-portal-validation-gate.json',
+    });
+
+    expect(seenCommands).toEqual(PHASE1_PORTAL_VALIDATION_STEPS.slice(0, 3).map((step) => step.command));
+    expect(result.steps).toEqual([
+      {
+        name: PHASE1_PORTAL_VALIDATION_STEPS[0].name,
+        command: PHASE1_PORTAL_VALIDATION_STEPS[0].command,
+        exitCode: 0,
+        durationMs: 10,
+        passed: true,
+      },
+      {
+        name: PHASE1_PORTAL_VALIDATION_STEPS[1].name,
+        command: PHASE1_PORTAL_VALIDATION_STEPS[1].command,
+        exitCode: 1,
+        durationMs: 20,
+        passed: false,
+      },
+      {
+        name: PHASE1_PORTAL_VALIDATION_STEPS[2].name,
+        command: PHASE1_PORTAL_VALIDATION_STEPS[2].command,
+        exitCode: 0,
+        durationMs: 30,
+        passed: true,
+      },
+    ]);
+    expect(result.summary).toEqual({
+      suiteCount: 3,
+      passedCount: 2,
+      failedCount: 1,
+      totalDurationMs: 60,
+      generatedAt: '2026-04-16T09:10:11.000Z',
+    });
+    expect(writes).toEqual([
+      {
+        filePath: '/tmp/phase1-portal-validation-gate.json',
+        payload: {
+          steps: result.steps,
+          summary: result.summary,
+        },
+      },
+    ]);
+    expect(formatPhase1PortalValidationSummary(result)).toContain('phase1 portal validation gate: 2/3 passed');
+    expect(formatPhase1PortalValidationSummary(result)).toContain('failed=1');
+  });
+
+  it('serializes JSON payloads to disk when requested', async () => {
+    const jsonPath = path.join(process.cwd(), 'tmp-phase1-portal-validation-gate.json');
+
+    await runPhase1PortalValidationGate({
+      steps: PHASE1_PORTAL_VALIDATION_STEPS.slice(0, 1),
+      runCommand: async () => ({ exitCode: 0, durationMs: 7 }),
+      now: () => new Date('2026-04-16T09:10:11.000Z'),
+      jsonOutPath: jsonPath,
+    });
+
+    const written = JSON.parse(await fs.readFile(jsonPath, 'utf-8')) as {
+      summary: { suiteCount: number; passedCount: number; failedCount: number; totalDurationMs: number; generatedAt: string };
+      steps: Array<{ name: string; command: string; exitCode: number; durationMs: number; passed: boolean }>;
+    };
+
+    expect(written.summary).toEqual({
+      suiteCount: 1,
+      passedCount: 1,
+      failedCount: 0,
+      totalDurationMs: 7,
+      generatedAt: '2026-04-16T09:10:11.000Z',
+    });
+    expect(written.steps).toEqual([
+      {
+        name: PHASE1_PORTAL_VALIDATION_STEPS[0].name,
+        command: PHASE1_PORTAL_VALIDATION_STEPS[0].command,
+        exitCode: 0,
+        durationMs: 7,
+        passed: true,
+      },
+    ]);
+
+    await fs.unlink(jsonPath);
+  });
+});

--- a/tests/e2e/platform-smoke.spec.ts
+++ b/tests/e2e/platform-smoke.spec.ts
@@ -23,7 +23,7 @@ test('1. PM can login via dev auth harness', async ({ page }) => {
   await loginAsPm(page);
   await expect(page.locator('body')).toBeVisible();
   await expect(page.getByRole('heading', { name: '오늘 작업할 사업 선택' })).toBeVisible();
-  await expect(page.getByRole('button', { name: '이 사업으로 시작' })).toBeVisible();
+  await expect(page.locator('[data-testid^="portal-project-start-"]').first()).toBeVisible();
 });
 
 test('2. Admin can login via dev auth harness', async ({ page }) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,14 @@
-import { defineConfig } from 'vite'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { defineConfig, type PluginOption } from 'vite'
 import path from 'path'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
+import {
+  buildDevHarnessPortalEntryContext,
+  buildDevHarnessPortalOnboardingContext,
+  buildDevHarnessPortalRegistrationResult,
+  buildDevHarnessPortalSessionProjectResult,
+} from './src/app/platform/dev-harness-portal-api'
 
 function getVendorChunkName(id: string): string | undefined {
   if (!id.includes('node_modules')) return undefined
@@ -56,10 +63,91 @@ function getVendorChunkName(id: string): string | undefined {
   return undefined
 }
 
+function readRequestBody(req: IncomingMessage): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    req.on('data', (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)))
+    req.on('end', () => {
+      const text = Buffer.concat(chunks).toString('utf8').trim()
+      if (!text) {
+        resolve({})
+        return
+      }
+      try {
+        resolve(JSON.parse(text))
+      } catch (error) {
+        reject(error)
+      }
+    })
+    req.on('error', reject)
+  })
+}
+
+function writeJson(res: ServerResponse, statusCode: number, payload: unknown) {
+  res.statusCode = statusCode
+  res.setHeader('Content-Type', 'application/json')
+  res.end(JSON.stringify(payload))
+}
+
+function devHarnessPortalApiPlugin(): PluginOption {
+  return {
+    name: 'dev-harness-portal-api',
+    configureServer(server) {
+      server.middlewares.use(async (req, res, next) => {
+        const enabled = String(process.env.VITE_DEV_AUTH_HARNESS_ENABLED || '').trim().toLowerCase() === 'true'
+        const method = String(req.method || 'GET').toUpperCase()
+        const pathName = String(req.url || '').split('?')[0]
+
+        if (!enabled || !pathName.startsWith('/api/v1/portal/')) {
+          next()
+          return
+        }
+
+        const actorId = typeof req.headers['x-actor-id'] === 'string' ? req.headers['x-actor-id'] : ''
+        const actorRole = typeof req.headers['x-actor-role'] === 'string' ? req.headers['x-actor-role'] : ''
+
+        try {
+          if (method === 'GET' && pathName === '/api/v1/portal/entry-context') {
+            writeJson(res, 200, buildDevHarnessPortalEntryContext({ actorId, actorRole }))
+            return
+          }
+
+          if (method === 'GET' && pathName === '/api/v1/portal/onboarding-context') {
+            writeJson(res, 200, buildDevHarnessPortalOnboardingContext({ actorRole }))
+            return
+          }
+
+          if (method === 'POST' && pathName === '/api/v1/portal/session-project') {
+            const body = await readRequestBody(req) as { projectId?: string }
+            writeJson(res, 200, buildDevHarnessPortalSessionProjectResult(body.projectId || ''))
+            return
+          }
+
+          if (method === 'POST' && pathName === '/api/v1/portal/registration') {
+            const body = await readRequestBody(req) as { projectId?: string; projectIds?: string[] }
+            writeJson(res, 200, buildDevHarnessPortalRegistrationResult(body))
+            return
+          }
+        } catch (error) {
+          const code = error instanceof Error ? error.message : 'dev_harness_portal_api_error'
+          writeJson(res, 400, {
+            error: code,
+            message: code,
+          })
+          return
+        }
+
+        next()
+      })
+    },
+  }
+}
+
 export default defineConfig({
   plugins: [
     // The React and Tailwind plugins are both required for Make, even if
     // Tailwind is not being actively used – do not remove them
+    devHarnessPortalApiPlugin(),
     react(),
     tailwindcss(),
   ],


### PR DESCRIPTION
## Summary
- move portal dashboard, payroll, weekly-expenses, and bank-statements summary reads behind BFF read-model endpoints
- close the remaining phase1 smoke blockers by hardening the local dev harness API base, serializing the Playwright harness, and fixing the dashboard summary fallback regression
- add a canonical `phase1:portal:validation-gate` command plus orchestration/runbook docs so the main agent can own integration while subagents own bounded implementation slices

## Context
- stacked on top of #215
- related #214

## Verification
- `npm test -- src/app/platform/phase1-portal-validation-gate.test.ts`
- `npm run phase1:portal:validation-gate -- --json-out /tmp/phase1-portal-validation-gate.json`
