### PR TITLE
refactor: close portal dashboard read-boundary slice

### DIFF
--- a/playwright.harness.config.mjs
+++ b/playwright.harness.config.mjs
@@ -3,8 +3,12 @@ import { defineConfig } from '@playwright/test';
 
 process.env.PORTAL_NETWORK_ARTIFACT_DIR ||= path.resolve('test-results/portal-network-artifacts');
 
-const PORTAL_ORIGIN = 'http://localhost:4173';
-const PORTAL_HOST = 'localhost';
+const DEFAULT_PORTAL_HOST = 'localhost';
+const DEFAULT_PORTAL_PORT = '4173';
+const DEFAULT_PORTAL_ORIGIN = `http://${DEFAULT_PORTAL_HOST}:${DEFAULT_PORTAL_PORT}`;
+const PORTAL_HOST = process.env.PORTAL_HARNESS_HOST || DEFAULT_PORTAL_HOST;
+const PORTAL_PORT = process.env.PORTAL_HARNESS_PORT || DEFAULT_PORTAL_PORT;
+const PORTAL_ORIGIN = process.env.PORTAL_HARNESS_ORIGIN || `http://${PORTAL_HOST}:${PORTAL_PORT}`;
 
 export default defineConfig({
   testDir: './tests/e2e',
@@ -21,7 +25,7 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
   webServer: {
-    command: `VITE_DEV_AUTH_HARNESS_ENABLED=true VITE_PLATFORM_API_BASE_URL=${PORTAL_ORIGIN} npm run dev -- --host ${PORTAL_HOST} --port 4173`,
+    command: `VITE_DEV_AUTH_HARNESS_ENABLED=true VITE_PLATFORM_API_BASE_URL=${PORTAL_ORIGIN} npm run dev -- --host ${PORTAL_HOST} --port ${PORTAL_PORT}`,
     url: `${PORTAL_ORIGIN}/login`,
     timeout: 120_000,
     reuseExistingServer: !process.env.CI,

--- a/scripts/phase1_portal_validation_gate.ts
+++ b/scripts/phase1_portal_validation_gate.ts
@@ -46,7 +46,7 @@ export const PHASE1_PORTAL_VALIDATION_STEPS: Phase1PortalValidationStep[] = [
   {
     name: 'phase1 platform smoke and release gate e2e',
     command:
-      'CI=1 npx playwright test tests/e2e/platform-smoke.spec.ts tests/e2e/product-release-gates.spec.ts --config playwright.harness.config.mjs',
+      'CI=1 PORTAL_HARNESS_PORT=4273 npx playwright test tests/e2e/platform-smoke.spec.ts tests/e2e/product-release-gates.spec.ts --config playwright.harness.config.mjs',
   },
   {
     name: 'phase1 production build',

--- a/scripts/portal_network_gate.ts
+++ b/scripts/portal_network_gate.ts
@@ -43,7 +43,7 @@ export const PORTAL_NETWORK_GATE_UNIT_CONTRACT_FILES = [
 export const PORTAL_NETWORK_GATE_COMMANDS = {
   unitContract: `npm test -- ${PORTAL_NETWORK_GATE_UNIT_CONTRACT_FILES.join(' ')}`,
   smoke:
-    'CI=1 npx playwright test tests/e2e/platform-smoke.spec.ts tests/e2e/product-release-gates.spec.ts --config playwright.harness.config.mjs',
+    'CI=1 PORTAL_HARNESS_PORT=4273 npx playwright test tests/e2e/platform-smoke.spec.ts tests/e2e/product-release-gates.spec.ts --config playwright.harness.config.mjs',
   build: 'npm run build',
 } as const;
 

--- a/server/bff/routes/portal-read-model.mjs
+++ b/server/bff/routes/portal-read-model.mjs
@@ -4,7 +4,7 @@ import {
   resolvePortalEntryRegistrationState,
   selectPortalEntryProjects,
 } from './portal-entry.mjs';
-import { addDays, getSeoulTodayIso } from '../payroll-worker.mjs';
+import { addDays, addMonthsToYearMonth, getSeoulTodayIso } from '../payroll-worker.mjs';
 
 function pad2(value) {
   return String(value).padStart(2, '0');
@@ -105,6 +105,9 @@ function normalizeProjectSummary(project) {
     department: readOptionalText(value.department) || undefined,
     status: readOptionalText(value.status) || undefined,
     type: readOptionalText(value.type) || undefined,
+    settlementType: readOptionalText(value.settlementType) || undefined,
+    basis: readOptionalText(value.basis) || undefined,
+    contractAmount: Number.isFinite(Number(value.contractAmount)) ? Number(value.contractAmount) : undefined,
   };
 }
 
@@ -121,6 +124,9 @@ function normalizeWeeklySubmissionStatus(status) {
     expenseReviewPendingCount: Number.isFinite(Number(value.expenseReviewPendingCount))
       ? Math.max(0, Number(value.expenseReviewPendingCount))
       : 0,
+    projectionEditedAt: readOptionalText(value.projectionEditedAt) || undefined,
+    projectionUpdatedAt: readOptionalText(value.projectionUpdatedAt) || undefined,
+    expenseUpdatedAt: readOptionalText(value.expenseUpdatedAt) || undefined,
     updatedAt: readOptionalText(value.updatedAt) || undefined,
   };
 }
@@ -193,7 +199,7 @@ function resolveWeeklyAccountingProductStatus(snapshot) {
   };
 }
 
-function resolvePortalAccountingStatus(status, currentWeek) {
+function resolvePortalAccountingStatus(status, currentWeek, latestProjectionUpdatedAt) {
   const snapshot = buildWeeklyAccountingSnapshot(status);
   const productStatus = resolveWeeklyAccountingProductStatus(snapshot);
   return {
@@ -203,7 +209,7 @@ function resolvePortalAccountingStatus(status, currentWeek) {
       detail: currentWeek
         ? `${currentWeek.weekNo}주차 · ${snapshot.projectionDone ? '제출 완료' : '미제출'}`
         : '이번 주 주차를 찾지 못했습니다.',
-      latestUpdatedAt: status?.updatedAt || status?.projectionUpdatedAt || undefined,
+      latestUpdatedAt: latestProjectionUpdatedAt,
     },
     expense: {
       label: productStatus.label,
@@ -213,6 +219,13 @@ function resolvePortalAccountingStatus(status, currentWeek) {
       tone: productStatus.tone,
     },
   };
+}
+
+function findLatestProjectionUpdatedAt(statuses) {
+  return (Array.isArray(statuses) ? statuses : [])
+    .map((status) => normalizeWeeklySubmissionStatus(status).projectionUpdatedAt)
+    .filter(Boolean)
+    .sort((left, right) => String(right).localeCompare(String(left)))[0];
 }
 
 function resolvePayrollLiquidityStatus({
@@ -417,6 +430,123 @@ function chooseActiveExpenseSheet(expenseSheets) {
   return expenseSheets.find((sheet) => sheet.id === 'default') || expenseSheets[0];
 }
 
+function formatShortAmount(value) {
+  const amount = Number.isFinite(Number(value)) ? Number(value) : 0;
+  const abs = Math.abs(amount);
+  if (abs >= 1e9) return `${(amount / 1e8).toFixed(0)}억`;
+  if (abs >= 1e8) return `${(amount / 1e8).toFixed(2)}억`;
+  if (abs >= 1e4) return `${Math.round(amount / 1e4).toLocaleString('ko-KR')}만`;
+  return amount.toLocaleString('ko-KR');
+}
+
+function sumProjectBankAmounts(transactions, projectId, direction) {
+  return (Array.isArray(transactions) ? transactions : [])
+    .filter((tx) => readOptionalText(tx?.projectId) === projectId && readOptionalText(tx?.direction) === direction)
+    .reduce((sum, tx) => {
+      const bankAmount = Number.isFinite(Number(tx?.amounts?.bankAmount)) ? Number(tx.amounts.bankAmount) : 0;
+      return sum + bankAmount;
+    }, 0);
+}
+
+function buildDashboardFinanceSummaryItems({ project, transactions }) {
+  const totalIn = sumProjectBankAmounts(transactions, project.id, 'IN');
+  const totalOut = sumProjectBankAmounts(transactions, project.id, 'OUT');
+  const balance = totalIn - totalOut;
+  const contractAmount = Number.isFinite(Number(project?.contractAmount)) ? Number(project.contractAmount) : 0;
+  const burnRate = contractAmount > 0 ? totalOut / contractAmount : 0;
+
+  return [
+    { label: '총 입금', value: formatShortAmount(totalIn) },
+    { label: '총 출금', value: formatShortAmount(totalOut) },
+    { label: '잔액', value: formatShortAmount(balance) },
+    { label: '소진율', value: `${(burnRate * 100).toFixed(1)}%` },
+  ];
+}
+
+function buildDashboardSubmissionRows({ projects, weeklyStatuses, currentWeek }) {
+  if (!currentWeek) return [];
+
+  const statusMap = new Map(
+    (Array.isArray(weeklyStatuses) ? weeklyStatuses : []).map((status) => [
+      `${status.projectId}-${status.yearMonth}-w${status.weekNo}`,
+      status,
+    ]),
+  );
+
+  return (Array.isArray(projects) ? projects : []).map((project) => {
+    const normalizedProject = normalizeProjectSummary(project);
+    const status = statusMap.get(`${normalizedProject.id}-${currentWeek.yearMonth}-w${currentWeek.weekNo}`);
+    const snapshot = buildWeeklyAccountingSnapshot(status);
+    const expenseStatus = resolveWeeklyAccountingProductStatus(snapshot);
+
+    return {
+      id: normalizedProject.id,
+      name: normalizedProject.name,
+      shortName: normalizedProject.shortName || normalizedProject.id,
+      projectionInputLabel: snapshot.projectionEdited ? '입력됨' : '미입력',
+      projectionDoneLabel: snapshot.projectionDone ? '제출 완료' : '미완료',
+      expenseLabel: expenseStatus.label,
+      expenseTone: expenseStatus.tone === 'muted' ? 'neutral' : expenseStatus.tone,
+      latestProjectionUpdatedAt: status?.projectionUpdatedAt || status?.projectionEditedAt || status?.updatedAt,
+    };
+  });
+}
+
+function buildDashboardHrAlertPreview({ alerts, projectId }) {
+  const visibleAlerts = (Array.isArray(alerts) ? alerts : [])
+    .filter((alert) => readOptionalText(alert?.projectId) === projectId && !Boolean(alert?.acknowledged))
+    .sort((a, b) => String(b?.createdAt || '').localeCompare(String(a?.createdAt || '')));
+
+  return {
+    count: visibleAlerts.length,
+    items: visibleAlerts.slice(0, 3).map((alert) => ({
+      id: readOptionalText(alert?.id),
+      employeeName: readOptionalText(alert?.employeeName) || '-',
+      eventType: readOptionalText(alert?.eventType) || 'UNKNOWN',
+      effectiveDate: readOptionalText(alert?.effectiveDate) || '',
+      projectId,
+    })),
+    overflowCount: Math.max(0, visibleAlerts.length - 3),
+  };
+}
+
+function buildDashboardNoticeSummary({ projectId, todayIso, payrollRuns, monthlyCloses, hrAlerts }) {
+  const yearMonth = typeof todayIso === 'string' ? todayIso.slice(0, 7) : '';
+  const previousYearMonth = /^\d{4}-\d{2}$/.test(yearMonth)
+    ? addMonthsToYearMonth(yearMonth, -1)
+    : '';
+  const payrollRun = (Array.isArray(payrollRuns) ? payrollRuns : []).find((run) => (
+    readOptionalText(run?.projectId) === projectId
+    && readOptionalText(run?.yearMonth) === yearMonth
+  )) || null;
+  const monthlyClose = (Array.isArray(monthlyCloses) ? monthlyCloses : []).find((close) => (
+    readOptionalText(close?.projectId) === projectId
+    && readOptionalText(close?.yearMonth) === previousYearMonth
+  )) || null;
+  const hrAlertPreview = buildDashboardHrAlertPreview({
+    alerts: hrAlerts,
+    projectId,
+  });
+
+  return {
+    payrollAck: payrollRun && todayIso >= readOptionalText(payrollRun.noticeDate) && !Boolean(payrollRun.acknowledged)
+      ? {
+          runId: readOptionalText(payrollRun.id),
+          plannedPayDate: readOptionalText(payrollRun.plannedPayDate),
+          noticeDate: readOptionalText(payrollRun.noticeDate),
+        }
+      : null,
+    monthlyCloseAck: monthlyClose && readOptionalText(monthlyClose.status) === 'DONE' && !Boolean(monthlyClose.acknowledged)
+      ? {
+          closeId: readOptionalText(monthlyClose.id),
+          yearMonth: readOptionalText(monthlyClose.yearMonth),
+          doneAt: readOptionalText(monthlyClose.doneAt) || undefined,
+        }
+      : null,
+    hrAlerts: hrAlertPreview,
+  };
+}
+
 export function buildPortalDashboardSummary(input) {
   const project = normalizeProjectSummary(input.project);
   const currentWeek = resolveCurrentCashflowWeek(input.todayIso || getSeoulTodayIso());
@@ -427,9 +557,19 @@ export function buildPortalDashboardSummary(input) {
   const currentStatus = currentWeek
     ? projectStatuses.find((status) => status.yearMonth === currentWeek.yearMonth && status.weekNo === currentWeek.weekNo)
     : undefined;
+  const latestProjectionUpdatedAt = readOptionalText(input.projectionLatestUpdatedAt)
+    || findLatestProjectionUpdatedAt(input.projectWeeklySubmissionStatuses)
+    || findLatestProjectionUpdatedAt(projectStatuses);
+  const accountingStatus = resolvePortalAccountingStatus(currentStatus, currentWeek, latestProjectionUpdatedAt);
   const payrollRiskCount = Math.max(0, Number(input.payrollRiskCount) || 0);
   const hrAlertCount = Math.max(0, Number(input.hrAlertCount) || 0);
   const visibleProjects = Math.max(0, Number(input.visibleProjects) || 0);
+  const orderedProjects = [
+    project,
+    ...(Array.isArray(input.projects) ? input.projects : [])
+      .map((entry) => normalizeProjectSummary(entry))
+      .filter((entry) => entry.id && entry.id !== project.id),
+  ];
   const visibleIssues = [
     {
       label: '미확인 공지',
@@ -444,6 +584,12 @@ export function buildPortalDashboardSummary(input) {
       to: '/portal/payroll',
     },
   ].filter((item) => item.count > 0);
+  const payrollQueue = resolveProjectPayrollLiquidity({
+    project,
+    runs: Array.isArray(input.payrollRuns) ? input.payrollRuns : [],
+    transactions: Array.isArray(input.transactions) ? input.transactions : [],
+    today: input.todayIso || getSeoulTodayIso(),
+  });
 
   return {
     project,
@@ -453,9 +599,40 @@ export function buildPortalDashboardSummary(input) {
       hrAlertCount,
       currentWeekLabel: currentWeek ? `${currentWeek.weekNo}주차` : '-',
     },
+    currentWeek: currentWeek
+      ? {
+          label: currentWeek.label,
+          weekStart: currentWeek.weekStart,
+          weekEnd: currentWeek.weekEnd,
+          yearMonth: currentWeek.yearMonth,
+          weekNo: currentWeek.weekNo,
+        }
+      : null,
     surface: {
-      ...resolvePortalAccountingStatus(currentStatus, currentWeek),
+      ...accountingStatus,
       visibleIssues,
+    },
+    financeSummaryItems: buildDashboardFinanceSummaryItems({
+      project: input.project && typeof input.project === 'object'
+        ? { ...(input.project || {}), id: project.id }
+        : project,
+      transactions: input.transactions,
+    }),
+    submissionRows: buildDashboardSubmissionRows({
+      projects: orderedProjects,
+      weeklyStatuses,
+      currentWeek,
+    }),
+    notices: buildDashboardNoticeSummary({
+      projectId: project.id,
+      todayIso: input.todayIso || getSeoulTodayIso(),
+      payrollRuns: input.payrollRuns,
+      monthlyCloses: input.monthlyCloses,
+      hrAlerts: input.hrAlerts,
+    }),
+    payrollQueue: {
+      item: payrollQueue[0] || null,
+      riskItems: payrollQueue.filter((item) => item.status === 'insufficient_balance' || item.status === 'payment_unconfirmed'),
     },
   };
 }
@@ -622,16 +799,18 @@ async function loadWeeklySubmissionStatuses(db, tenantId, projectId) {
 }
 
 async function loadPayrollData(db, tenantId, projectId) {
-  const [scheduleSnap, runsSnap, txSnap] = await Promise.all([
+  const [scheduleSnap, runsSnap, txSnap, closeSnap] = await Promise.all([
     db.doc(`orgs/${tenantId}/payroll_schedules/${projectId}`).get(),
     db.collection(`orgs/${tenantId}/payroll_runs`).where('projectId', '==', projectId).get(),
     db.collection(`orgs/${tenantId}/transactions`).where('projectId', '==', projectId).get(),
+    db.collection(`orgs/${tenantId}/monthly_closes`).where('projectId', '==', projectId).get(),
   ]);
 
   return {
     payrollSchedule: scheduleSnap.exists ? { id: scheduleSnap.id, ...(scheduleSnap.data() || {}) } : null,
     payrollRuns: runsSnap.docs.map((doc) => ({ id: doc.id, ...(doc.data() || {}) })),
     transactions: txSnap.docs.map((doc) => ({ id: doc.id, ...(doc.data() || {}) })),
+    monthlyCloses: closeSnap.docs.map((doc) => ({ id: doc.id, ...(doc.data() || {}) })),
   };
 }
 
@@ -652,8 +831,18 @@ async function loadWeeklyExpenseData(db, tenantId, projectId) {
   };
 }
 
-function readHrAnnouncementCount(announcements) {
-  return announcements.filter((announcement) => !Boolean(announcement.resolved)).length;
+async function loadWeeklySubmissionStatusesForProjects(db, tenantId, projectIds, currentWeek) {
+  const uniqueProjectIds = Array.from(new Set((Array.isArray(projectIds) ? projectIds : []).filter(Boolean)));
+  if (!uniqueProjectIds.length || !currentWeek) return [];
+
+  const statusSnap = await db.collection(`orgs/${tenantId}/weekly_submission_status`)
+    .where('yearMonth', '==', currentWeek.yearMonth)
+    .where('weekNo', '==', currentWeek.weekNo)
+    .get();
+  const visibleProjectIds = new Set(uniqueProjectIds);
+  return statusSnap.docs
+    .map((doc) => ({ id: doc.id, ...(doc.data() || {}) }))
+    .filter((status) => visibleProjectIds.has(readOptionalText(status?.projectId)));
 }
 
 export function mountPortalReadModelRoutes(app, { db }) {
@@ -666,24 +855,55 @@ export function mountPortalReadModelRoutes(app, { db }) {
       actorId,
       actorRole,
     );
-    const activeProjectDoc = activeProjectId
-      ? await db.doc(`orgs/${tenantId}/projects/${activeProjectId}`).get()
+    const requestedProjectId = readOptionalText(req.query?.projectId);
+    const visibleProjectMap = new Map(selectedProjects.projects.map((project) => [project.id, project]));
+    if (requestedProjectId && !visibleProjectMap.has(requestedProjectId)) {
+      throw createHttpError(403, '선택 가능한 사업이 아닙니다.', 'project_forbidden');
+    }
+
+    const targetProjectId = requestedProjectId || activeProjectId;
+    const targetProjectFallback = (targetProjectId ? visibleProjectMap.get(targetProjectId) : null) || activeProject || null;
+    const activeProjectDoc = targetProjectId
+      ? await db.doc(`orgs/${tenantId}/projects/${targetProjectId}`).get()
       : null;
     const currentProject = activeProjectDoc?.exists
       ? { id: activeProjectDoc.id, ...(activeProjectDoc.data() || {}) }
-      : activeProject || null;
+      : targetProjectFallback;
     if (!currentProject) {
-      throw createHttpError(404, '활성 사업을 찾을 수 없습니다.', 'project_not_found');
+      throw createHttpError(
+        404,
+        requestedProjectId ? '선택한 사업을 찾을 수 없습니다.' : '활성 사업을 찾을 수 없습니다.',
+        'project_not_found',
+      );
     }
 
     const todayIso = getSeoulTodayIso();
-    const weeklyStatuses = await loadWeeklySubmissionStatuses(db, tenantId, currentProject.id);
-    const payrollData = await loadPayrollData(db, tenantId, currentProject.id);
-    const hrAnnouncementsSnap = await db.collection(`orgs/${tenantId}/hr_announcements`).get();
-    const hrAlertCount = readHrAnnouncementCount(hrAnnouncementsSnap.docs.map((doc) => ({ id: doc.id, ...(doc.data() || {}) })));
+    const dashboardProjectIds = Array.from(new Set([
+      currentProject.id,
+      ...selectedProjects.projects.map((project) => project.id).filter(Boolean),
+    ]));
+    const currentWeek = resolveCurrentCashflowWeek(todayIso);
+    const [weeklyStatuses, currentProjectWeeklyStatuses, payrollData, hrAlertsSnap] = await Promise.all([
+      loadWeeklySubmissionStatusesForProjects(db, tenantId, dashboardProjectIds, currentWeek),
+      loadWeeklySubmissionStatuses(db, tenantId, currentProject.id),
+      loadPayrollData(db, tenantId, currentProject.id),
+      db.collection(`orgs/${tenantId}/project_change_alerts`).where('projectId', '==', currentProject.id).get(),
+    ]);
+    const hrAlerts = hrAlertsSnap.docs.map((doc) => ({ id: doc.id, ...(doc.data() || {}) }));
+    const hrAlertCount = buildDashboardHrAlertPreview({
+      alerts: hrAlerts,
+      projectId: currentProject.id,
+    }).count;
     const dashboard = buildPortalDashboardSummary({
       project: currentProject,
+      projects: selectedProjects.projects,
       todayIso,
+      transactions: payrollData.transactions,
+      payrollRuns: payrollData.payrollRuns,
+      monthlyCloses: payrollData.monthlyCloses,
+      hrAlerts,
+      projectWeeklySubmissionStatuses: currentProjectWeeklyStatuses,
+      projectionLatestUpdatedAt: findLatestProjectionUpdatedAt(currentProjectWeeklyStatuses),
       weeklySubmissionStatuses: weeklyStatuses,
       payrollRiskCount: resolveProjectPayrollLiquidity({
         project: normalizeProjectSummary(currentProject),

--- a/server/bff/routes/portal-read-model.test.mjs
+++ b/server/bff/routes/portal-read-model.test.mjs
@@ -1,3 +1,5 @@
+import express from 'express';
+import request from 'supertest';
 import { describe, expect, it } from 'vitest';
 import {
   buildPortalBankStatementsSummary,
@@ -16,6 +18,80 @@ function createExpenseSheet(id, name, rows = []) {
   };
 }
 
+function createDocSnapshot(path, value) {
+  const id = String(path).split('/').pop();
+  return {
+    id,
+    exists: value !== undefined,
+    data() {
+      return value;
+    },
+  };
+}
+
+function createQuerySnapshot(path, docs) {
+  return {
+    path,
+    docs: (Array.isArray(docs) ? docs : []).map((entry) => ({
+      id: entry.id,
+      data() {
+        return entry.data;
+      },
+    })),
+  };
+}
+
+function createFakeDb({ docs = {}, collections = {} } = {}) {
+  const collectionReads = [];
+  const queryReads = [];
+
+  function applyFilters(entries, filters) {
+    return filters.reduce((current, filter) => current.filter((entry) => {
+      if (filter.op !== '==') return false;
+      return entry.data?.[filter.field] === filter.expectedValue;
+    }), Array.isArray(entries) ? entries : []);
+  }
+
+  function createQuery(path, baseDocs, filters = []) {
+    return {
+      doc(id) {
+        return {
+          async get() {
+            return createDocSnapshot(`${path}/${id}`, docs[`${path}/${id}`]);
+          },
+        };
+      },
+      where(field, op, expectedValue) {
+        return createQuery(path, baseDocs, [...filters, { field, op, expectedValue }]);
+      },
+      async get() {
+        queryReads.push({
+          path,
+          filters: filters.map((filter) => ({ ...filter })),
+        });
+        return createQuerySnapshot(path, applyFilters(baseDocs, filters));
+      },
+    };
+  }
+
+  return {
+    collectionReads,
+    queryReads,
+    doc(path) {
+      return {
+        async get() {
+          return createDocSnapshot(path, docs[path]);
+        },
+      };
+    },
+    collection(path) {
+      collectionReads.push(path);
+      const baseDocs = collections[path] || [];
+      return createQuery(path, baseDocs);
+    },
+  };
+}
+
 describe('portal read-model helpers', () => {
   it('builds a dashboard summary from compact portal state', () => {
     const result = buildPortalDashboardSummary({
@@ -24,10 +100,41 @@ describe('portal read-model helpers', () => {
         name: '알파 프로젝트',
         shortName: '알파',
         managerName: '보람',
+        clientOrg: 'MYSC',
         status: 'IN_PROGRESS',
+        settlementType: 'TYPE1',
+        basis: '공급가액',
+        contractAmount: 3000000,
       },
+      projects: [
+        {
+          id: 'p001',
+          name: '알파 프로젝트',
+          shortName: '알파',
+          contractAmount: 3000000,
+        },
+        {
+          id: 'p002',
+          name: '베타 프로젝트',
+          shortName: '베타',
+        },
+      ],
       todayIso: '2026-04-16',
       payrollRiskCount: 2,
+      transactions: [
+        {
+          id: 'tx-in',
+          projectId: 'p001',
+          direction: 'IN',
+          amounts: { bankAmount: 3000000 },
+        },
+        {
+          id: 'tx-out',
+          projectId: 'p001',
+          direction: 'OUT',
+          amounts: { bankAmount: 1250000 },
+        },
+      ],
       weeklySubmissionStatuses: [
         {
           id: 'p001-2026-04-w3',
@@ -39,17 +146,95 @@ describe('portal read-model helpers', () => {
           expenseEdited: false,
           expenseUpdated: false,
           expenseReviewPendingCount: 1,
+          projectionUpdatedAt: '2026-04-16T02:00:00.000Z',
+        },
+        {
+          id: 'p002-2026-04-w3',
+          projectId: 'p002',
+          yearMonth: '2026-04',
+          weekNo: 3,
+          projectionEdited: false,
+          projectionUpdated: false,
+          expenseEdited: true,
+          expenseUpdated: true,
+          expenseReviewPendingCount: 0,
+          projectionUpdatedAt: '2026-04-15T02:00:00.000Z',
         },
       ],
       visibleProjects: 3,
       hrAlertCount: 1,
+      hrAlerts: [
+        {
+          id: 'alert-1',
+          projectId: 'p001',
+          employeeName: '보람',
+          eventType: 'RESIGNATION',
+          effectiveDate: '2026-04-20',
+          acknowledged: false,
+          createdAt: '2026-04-16T09:00:00.000Z',
+        },
+        {
+          id: 'alert-2',
+          projectId: 'p001',
+          employeeName: '하모니',
+          eventType: 'TRANSFER',
+          effectiveDate: '2026-04-21',
+          acknowledged: true,
+          createdAt: '2026-04-16T08:00:00.000Z',
+        },
+      ],
     });
 
     expect(result.project.id).toBe('p001');
+    expect(result.project).toMatchObject({
+      settlementType: 'TYPE1',
+      basis: '공급가액',
+      contractAmount: 3000000,
+      clientOrg: 'MYSC',
+      managerName: '보람',
+    });
     expect(result.surface.currentWeekLabel).toBe('3주차');
     expect(result.surface.visibleIssues.map((issue) => issue.label)).toContain('미확인 공지');
     expect(result.summary.payrollRiskCount).toBe(2);
     expect(result.summary.visibleProjects).toBe(3);
+    expect(result.financeSummaryItems).toEqual([
+      { label: '총 입금', value: '300만' },
+      { label: '총 출금', value: '125만' },
+      { label: '잔액', value: '175만' },
+      { label: '소진율', value: '41.7%' },
+    ]);
+    expect(result.submissionRows).toEqual([
+      {
+        id: 'p001',
+        name: '알파 프로젝트',
+        shortName: '알파',
+        projectionInputLabel: '입력됨',
+        projectionDoneLabel: '제출 완료',
+        expenseLabel: '저장 전 초안',
+        expenseTone: 'warning',
+        latestProjectionUpdatedAt: '2026-04-16T02:00:00.000Z',
+      },
+      {
+        id: 'p002',
+        name: '베타 프로젝트',
+        shortName: '베타',
+        projectionInputLabel: '미입력',
+        projectionDoneLabel: '미완료',
+        expenseLabel: '동기화 완료',
+        expenseTone: 'success',
+        latestProjectionUpdatedAt: '2026-04-15T02:00:00.000Z',
+      },
+    ]);
+    expect(result.notices.hrAlerts.count).toBe(1);
+    expect(result.notices.hrAlerts.items).toEqual([
+      {
+        id: 'alert-1',
+        employeeName: '보람',
+        eventType: 'RESIGNATION',
+        effectiveDate: '2026-04-20',
+        projectId: 'p001',
+      },
+    ]);
   });
 
   it('builds a payroll summary that exposes the current liquidity queue item', () => {
@@ -191,5 +376,494 @@ describe('portal read-model helpers', () => {
       '/api/v1/portal/weekly-expenses-summary',
       '/api/v1/portal/bank-statements-summary',
     ]);
+  });
+
+  it('serves dashboard summary through the mounted handler using the physical HR alert collection path', async () => {
+    const db = createFakeDb({
+      docs: {
+        'orgs/test-tenant/members/user-1': {
+          role: 'pm',
+          projectId: 'p001',
+          projectIds: ['p001'],
+          portalProfile: { projectId: 'p001', projectIds: ['p001'] },
+        },
+        'orgs/test-tenant/projects/p001': {
+          name: '알파 프로젝트',
+          shortName: '알파',
+          contractAmount: 3000000,
+          managerId: 'user-1',
+        },
+        'orgs/test-tenant/payroll_schedules/p001': {
+          projectId: 'p001',
+          dayOfMonth: 25,
+          timezone: 'Asia/Seoul',
+        },
+      },
+      collections: {
+        'orgs/test-tenant/projects': [
+          {
+            id: 'p001',
+            data: {
+              name: '알파 프로젝트',
+              shortName: '알파',
+              contractAmount: 3000000,
+              managerId: 'user-1',
+            },
+          },
+        ],
+        'orgs/test-tenant/weekly_submission_status': [
+          {
+            id: 'p001-2026-04-w3',
+            data: {
+              projectId: 'p001',
+              yearMonth: '2026-04',
+              weekNo: 3,
+              projectionEdited: true,
+              projectionUpdated: true,
+              expenseEdited: false,
+              expenseUpdated: false,
+              expenseReviewPendingCount: 0,
+              projectionUpdatedAt: '2026-04-16T02:00:00.000Z',
+            },
+          },
+        ],
+        'orgs/test-tenant/payroll_runs': [],
+        'orgs/test-tenant/transactions': [
+          {
+            id: 'tx-in',
+            data: {
+              projectId: 'p001',
+              direction: 'IN',
+              amounts: { bankAmount: 3000000 },
+            },
+          },
+        ],
+        'orgs/test-tenant/monthly_closes': [],
+        'orgs/test-tenant/project_change_alerts': [
+          {
+            id: 'alert-1',
+            data: {
+              projectId: 'p001',
+              employeeName: '보람',
+              eventType: 'RESIGNATION',
+              effectiveDate: '2026-04-20',
+              acknowledged: false,
+              createdAt: '2026-04-16T09:00:00.000Z',
+            },
+          },
+          {
+            id: 'alert-2',
+            data: {
+              projectId: 'p001',
+              employeeName: '하모니',
+              eventType: 'TRANSFER',
+              effectiveDate: '2026-04-21',
+              acknowledged: true,
+              createdAt: '2026-04-16T08:00:00.000Z',
+            },
+          },
+        ],
+      },
+    });
+    const app = express();
+    app.use((req, _res, next) => {
+      req.context = {
+        tenantId: 'test-tenant',
+        actorId: 'user-1',
+        actorRole: 'pm',
+      };
+      next();
+    });
+    mountPortalReadModelRoutes(app, { db });
+    app.use((error, _req, res, _next) => {
+      res.status(error?.statusCode || 500).json({
+        error: error?.code || 'internal_error',
+        message: error?.message || 'Unexpected error',
+      });
+    });
+
+    const response = await request(app).get('/api/v1/portal/dashboard-summary');
+
+    expect(response.status).toBe(200);
+    expect(db.collectionReads).toContain('orgs/test-tenant/project_change_alerts');
+    expect(response.body.notices.hrAlerts).toEqual({
+      count: 1,
+      items: [
+        {
+          id: 'alert-1',
+          employeeName: '보람',
+          eventType: 'RESIGNATION',
+          effectiveDate: '2026-04-20',
+          projectId: 'p001',
+        },
+      ],
+      overflowCount: 0,
+    });
+  });
+
+  it('serves dashboard summary for an explicit visible project without depending on member active project state', async () => {
+    const db = createFakeDb({
+      docs: {
+        'orgs/test-tenant/members/user-1': {
+          role: 'pm',
+          projectId: 'p001',
+          projectIds: ['p001', 'p002'],
+          portalProfile: { projectId: 'p001', projectIds: ['p001', 'p002'] },
+        },
+        'orgs/test-tenant/projects/p002': {
+          name: '베타 프로젝트',
+          shortName: '베타',
+          contractAmount: 1200000,
+          managerId: 'user-2',
+        },
+      },
+      collections: {
+        'orgs/test-tenant/projects': [
+          {
+            id: 'p001',
+            data: {
+              name: '알파 프로젝트',
+              shortName: '알파',
+              contractAmount: 3000000,
+              managerId: 'user-1',
+            },
+          },
+          {
+            id: 'p002',
+            data: {
+              name: '베타 프로젝트',
+              shortName: '베타',
+              contractAmount: 1200000,
+              managerId: 'user-2',
+            },
+          },
+        ],
+        'orgs/test-tenant/weekly_submission_status': [
+          {
+            id: 'p002-2026-04-w3',
+            data: {
+              projectId: 'p002',
+              yearMonth: '2026-04',
+              weekNo: 3,
+              projectionEdited: true,
+              projectionUpdated: true,
+              expenseEdited: true,
+              expenseUpdated: true,
+              expenseReviewPendingCount: 0,
+              projectionUpdatedAt: '2026-04-16T02:00:00.000Z',
+            },
+          },
+        ],
+        'orgs/test-tenant/payroll_runs': [],
+        'orgs/test-tenant/transactions': [],
+        'orgs/test-tenant/monthly_closes': [],
+        'orgs/test-tenant/project_change_alerts': [],
+      },
+    });
+    const app = express();
+    app.use((req, _res, next) => {
+      req.context = {
+        tenantId: 'test-tenant',
+        actorId: 'user-1',
+        actorRole: 'pm',
+      };
+      next();
+    });
+    mountPortalReadModelRoutes(app, { db });
+    app.use((error, _req, res, _next) => {
+      res.status(error?.statusCode || 500).json({
+        error: error?.code || 'internal_error',
+        message: error?.message || 'Unexpected error',
+      });
+    });
+
+    const response = await request(app).get('/api/v1/portal/dashboard-summary?projectId=p002');
+
+    expect(response.status).toBe(200);
+    expect(response.body.project.id).toBe('p002');
+  });
+
+  it('uses the latest historical projectionUpdatedAt for the dashboard projection timestamp while keeping current-week rows scoped', async () => {
+    const db = createFakeDb({
+      docs: {
+        'orgs/test-tenant/members/user-1': {
+          role: 'pm',
+          projectId: 'p001',
+          projectIds: ['p001', 'p002'],
+          portalProfile: { projectId: 'p001', projectIds: ['p001', 'p002'] },
+        },
+        'orgs/test-tenant/projects/p001': {
+          name: '알파 프로젝트',
+          shortName: '알파',
+          contractAmount: 3000000,
+          managerId: 'user-1',
+        },
+      },
+      collections: {
+        'orgs/test-tenant/projects': [
+          {
+            id: 'p001',
+            data: {
+              name: '알파 프로젝트',
+              shortName: '알파',
+              contractAmount: 3000000,
+              managerId: 'user-1',
+            },
+          },
+          {
+            id: 'p002',
+            data: {
+              name: '베타 프로젝트',
+              shortName: '베타',
+              contractAmount: 1200000,
+              managerId: 'user-2',
+            },
+          },
+        ],
+        'orgs/test-tenant/weekly_submission_status': [
+          {
+            id: 'p001-2026-04-w3',
+            data: {
+              projectId: 'p001',
+              yearMonth: '2026-04',
+              weekNo: 3,
+              projectionEdited: true,
+              projectionUpdated: true,
+              projectionUpdatedAt: '2026-04-12T01:00:00.000Z',
+              updatedAt: '2026-04-17T09:00:00.000Z',
+            },
+          },
+          {
+            id: 'p001-2026-04-w2',
+            data: {
+              projectId: 'p001',
+              yearMonth: '2026-04',
+              weekNo: 2,
+              projectionEdited: true,
+              projectionUpdated: true,
+              projectionUpdatedAt: '2026-04-16T08:00:00.000Z',
+              updatedAt: '2026-04-16T08:30:00.000Z',
+            },
+          },
+          {
+            id: 'p002-2026-04-w3',
+            data: {
+              projectId: 'p002',
+              yearMonth: '2026-04',
+              weekNo: 3,
+              projectionEdited: true,
+              projectionUpdated: true,
+              projectionUpdatedAt: '2026-04-15T02:00:00.000Z',
+            },
+          },
+        ],
+        'orgs/test-tenant/payroll_runs': [],
+        'orgs/test-tenant/transactions': [],
+        'orgs/test-tenant/monthly_closes': [],
+        'orgs/test-tenant/project_change_alerts': [],
+      },
+    });
+    const app = express();
+    app.use((req, _res, next) => {
+      req.context = {
+        tenantId: 'test-tenant',
+        actorId: 'user-1',
+        actorRole: 'pm',
+      };
+      next();
+    });
+    mountPortalReadModelRoutes(app, { db });
+    app.use((error, _req, res, _next) => {
+      res.status(error?.statusCode || 500).json({
+        error: error?.code || 'internal_error',
+        message: error?.message || 'Unexpected error',
+      });
+    });
+
+    const response = await request(app).get('/api/v1/portal/dashboard-summary');
+
+    expect(response.status).toBe(200);
+    expect(response.body.surface.projection.latestUpdatedAt).toBe('2026-04-16T08:00:00.000Z');
+
+    const weeklyStatusReads = db.queryReads.filter((entry) => entry.path === 'orgs/test-tenant/weekly_submission_status');
+    expect(weeklyStatusReads).toHaveLength(2);
+    expect(weeklyStatusReads).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        filters: [
+          { field: 'yearMonth', op: '==', expectedValue: '2026-04' },
+          { field: 'weekNo', op: '==', expectedValue: 3 },
+        ],
+      }),
+      expect.objectContaining({
+        filters: [
+          { field: 'projectId', op: '==', expectedValue: 'p001' },
+        ],
+      }),
+    ]));
+  });
+
+  it('rejects dashboard summary requests for projects outside the visible project set', async () => {
+    const db = createFakeDb({
+      docs: {
+        'orgs/test-tenant/members/user-1': {
+          role: 'pm',
+          projectId: 'p001',
+          projectIds: ['p001'],
+          portalProfile: { projectId: 'p001', projectIds: ['p001'] },
+        },
+      },
+      collections: {
+        'orgs/test-tenant/projects': [
+          {
+            id: 'p001',
+            data: {
+              name: '알파 프로젝트',
+              shortName: '알파',
+              contractAmount: 3000000,
+              managerId: 'user-1',
+            },
+          },
+          {
+            id: 'p002',
+            data: {
+              name: '베타 프로젝트',
+              shortName: '베타',
+              contractAmount: 1200000,
+              managerId: 'user-2',
+            },
+          },
+        ],
+        'orgs/test-tenant/weekly_submission_status': [],
+        'orgs/test-tenant/payroll_runs': [],
+        'orgs/test-tenant/transactions': [],
+        'orgs/test-tenant/monthly_closes': [],
+        'orgs/test-tenant/project_change_alerts': [],
+      },
+    });
+    const app = express();
+    app.use((req, _res, next) => {
+      req.context = {
+        tenantId: 'test-tenant',
+        actorId: 'user-1',
+        actorRole: 'pm',
+      };
+      next();
+    });
+    mountPortalReadModelRoutes(app, { db });
+    app.use((error, _req, res, _next) => {
+      res.status(error?.statusCode || 500).json({
+        error: error?.code || 'internal_error',
+        message: error?.message || 'Unexpected error',
+      });
+    });
+
+    const response = await request(app).get('/api/v1/portal/dashboard-summary?projectId=p002');
+
+    expect(response.status).toBe(403);
+    expect(response.body).toMatchObject({
+      error: 'project_forbidden',
+    });
+  });
+
+  it('loads dashboard weekly submission status through one current-week constrained query instead of per-project history scans', async () => {
+    const db = createFakeDb({
+      docs: {
+        'orgs/test-tenant/members/user-1': {
+          role: 'pm',
+          projectId: 'p001',
+          projectIds: ['p001', 'p002'],
+          portalProfile: { projectId: 'p001', projectIds: ['p001', 'p002'] },
+        },
+        'orgs/test-tenant/projects/p001': {
+          name: '알파 프로젝트',
+          shortName: '알파',
+          contractAmount: 3000000,
+          managerId: 'user-1',
+        },
+      },
+      collections: {
+        'orgs/test-tenant/projects': [
+          {
+            id: 'p001',
+            data: {
+              name: '알파 프로젝트',
+              shortName: '알파',
+              contractAmount: 3000000,
+              managerId: 'user-1',
+            },
+          },
+          {
+            id: 'p002',
+            data: {
+              name: '베타 프로젝트',
+              shortName: '베타',
+              contractAmount: 1200000,
+              managerId: 'user-2',
+            },
+          },
+        ],
+        'orgs/test-tenant/weekly_submission_status': [
+          {
+            id: 'p001-history',
+            data: {
+              projectId: 'p001',
+              yearMonth: '2025-01',
+              weekNo: 1,
+              projectionEdited: true,
+            },
+          },
+          {
+            id: 'p002-history',
+            data: {
+              projectId: 'p002',
+              yearMonth: '2025-01',
+              weekNo: 1,
+              projectionEdited: false,
+            },
+          },
+        ],
+        'orgs/test-tenant/payroll_runs': [],
+        'orgs/test-tenant/transactions': [],
+        'orgs/test-tenant/monthly_closes': [],
+        'orgs/test-tenant/project_change_alerts': [],
+      },
+    });
+    const app = express();
+    app.use((req, _res, next) => {
+      req.context = {
+        tenantId: 'test-tenant',
+        actorId: 'user-1',
+        actorRole: 'pm',
+      };
+      next();
+    });
+    mountPortalReadModelRoutes(app, { db });
+    app.use((error, _req, res, _next) => {
+      res.status(error?.statusCode || 500).json({
+        error: error?.code || 'internal_error',
+        message: error?.message || 'Unexpected error',
+      });
+    });
+
+    const response = await request(app).get('/api/v1/portal/dashboard-summary');
+
+    expect(response.status).toBe(200);
+    expect(response.body.submissionRows).toHaveLength(2);
+
+    const weeklyStatusReads = db.queryReads.filter((entry) => entry.path === 'orgs/test-tenant/weekly_submission_status');
+    expect(weeklyStatusReads).toHaveLength(2);
+    expect(weeklyStatusReads).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        filters: [
+          { field: 'yearMonth', op: '==', expectedValue: '2026-04' },
+          { field: 'weekNo', op: '==', expectedValue: 3 },
+        ],
+      }),
+      expect.objectContaining({
+        filters: [
+          { field: 'projectId', op: '==', expectedValue: 'p001' },
+        ],
+      }),
+    ]));
   });
 });

--- a/src/app/components/portal/PortalDashboard.layout.test.ts
+++ b/src/app/components/portal/PortalDashboard.layout.test.ts
@@ -7,6 +7,10 @@ const portalDashboardSource = readFileSync(
   'utf8',
 );
 
+function expectSourceToMatchAny(...patterns: RegExp[]) {
+  expect(patterns.some((pattern) => pattern.test(portalDashboardSource))).toBe(true);
+}
+
 describe('PortalDashboard layout compaction', () => {
   it('keeps project detail and weekly status inside one unified slab', () => {
     expect(portalDashboardSource).toContain('프로젝트 상세');
@@ -38,9 +42,44 @@ describe('PortalDashboard layout compaction', () => {
     expect(portalDashboardSource).not.toContain('사업비 입력(주간) 작성/제출');
   });
 
-  it('reads project detail labels through the read-model fallback instead of dereferencing summary project blindly', () => {
-    expect(portalDashboardSource).toContain('projectReadModel.clientOrg || myProject.clientOrg || \'-\'');
-    expect(portalDashboardSource).toContain('projectReadModel.managerName || portalUser.name');
-    expect(portalDashboardSource).not.toContain('dashboardSummary?.project.clientOrg');
+  it('reads hero and project detail fields from the BFF summary project instead of store fallbacks', () => {
+    expect(portalDashboardSource).toContain("const activeDashboardSummary = dashboardSummary?.project?.id === currentProjectId");
+    expectSourceToMatchAny(
+      /const\s+\w+\s*=\s*activeDashboardSummary\?\.project;/,
+      /activeDashboardSummary\?\.project\?\.clientOrg/,
+    );
+    expectSourceToMatchAny(
+      /summaryProject\?\.clientOrg\s*\|\|\s*'-'/,
+      /activeDashboardSummary\?\.project\?\.clientOrg\s*\|\|\s*'-'/,
+    );
+    expectSourceToMatchAny(
+      /summaryProject\?\.managerName\s*\|\|\s*'-'/,
+      /activeDashboardSummary\?\.project\?\.managerName\s*\|\|\s*'-'/,
+    );
+    expectSourceToMatchAny(/summaryProject\?\.contractAmount/, /activeDashboardSummary\?\.project\?\.contractAmount/);
+    expectSourceToMatchAny(/summaryProject\?\.settlementType/, /activeDashboardSummary\?\.project\?\.settlementType/);
+    expectSourceToMatchAny(/summaryProject\?\.basis/, /activeDashboardSummary\?\.project\?\.basis/);
+    expectSourceToMatchAny(/summaryProject\?\.status/, /activeDashboardSummary\?\.project\?\.status/);
+    expect(portalDashboardSource).not.toContain('projectReadModel.clientOrg || myProject.clientOrg || \'-\'');
+    expect(portalDashboardSource).not.toContain('projectReadModel.managerName || portalUser.name');
+    expect(portalDashboardSource).not.toContain('myProject.contractAmount');
+    expect(portalDashboardSource).not.toContain('myProject.settlementType');
+    expect(portalDashboardSource).not.toContain('myProject.basis');
+    expect(portalDashboardSource).not.toContain('PROJECT_STATUS_LABELS[myProject.status]');
+  });
+
+  it('reads dashboard status blocks from the summary contract instead of rebuilding local dashboard surfaces', () => {
+    expectSourceToMatchAny(
+      /const\s+\w+\s*=\s*activeDashboardSummary\?\.surface;/,
+      /activeDashboardSummary\?\.surface\?\.projection\?\.label/,
+    );
+    expectSourceToMatchAny(/dashboardSurface\?\.projection/, /activeDashboardSummary\?\.surface\?\.projection/);
+    expectSourceToMatchAny(/dashboardSurface\?\.expense/, /activeDashboardSummary\?\.surface\?\.expense/);
+    expectSourceToMatchAny(/dashboardSurface\?\.currentWeekLabel/, /activeDashboardSummary\?\.surface\?\.currentWeekLabel/);
+    expect(portalDashboardSource).not.toContain('buildPortalDashboardSurface(');
+    expect(portalDashboardSource).not.toContain('resolveProjectPayrollLiquidity(');
+    expect(portalDashboardSource).not.toContain('resolveCurrentCashflowWeek(');
+    expect(portalDashboardSource).not.toContain('resolveWeeklyAccountingSnapshot(');
+    expect(portalDashboardSource).not.toContain('resolveWeeklyAccountingProductStatus(');
   });
 });

--- a/src/app/components/portal/PortalDashboard.regression.test.ts
+++ b/src/app/components/portal/PortalDashboard.regression.test.ts
@@ -1,0 +1,1178 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type DashboardSummary = {
+  project: {
+    id: string;
+    name: string;
+    status: string;
+    clientOrg: string;
+    managerName: string;
+    settlementType: string;
+    basis: string;
+    contractAmount: number;
+  };
+  summary: {
+    payrollRiskCount: number;
+    visibleProjects: number;
+    hrAlertCount: number;
+    currentWeekLabel: string;
+  };
+  currentWeek: {
+    label: string;
+    weekStart: string;
+    weekEnd: string;
+    yearMonth: string;
+    weekNo: number;
+  } | null;
+  surface: {
+    currentWeekLabel: string;
+    projection: {
+      label: string;
+      detail: string;
+      latestUpdatedAt?: string;
+    };
+    expense: {
+      label: string;
+      detail: string;
+      tone: 'muted' | 'warning' | 'danger' | 'success';
+    };
+    visibleIssues: Array<{
+      label: string;
+      count: number;
+      tone: 'neutral' | 'warn' | 'danger';
+      to: string;
+    }>;
+  };
+  financeSummaryItems: Array<{ label: string; value: string }>;
+  submissionRows: Array<{
+    id: string;
+    name: string;
+    shortName: string;
+    projectionInputLabel: string;
+    projectionDoneLabel: string;
+    expenseLabel: string;
+    expenseTone: 'neutral' | 'warning' | 'danger' | 'success';
+    latestProjectionUpdatedAt?: string;
+  }>;
+  notices: {
+    payrollAck: {
+      runId: string;
+      plannedPayDate: string;
+      noticeDate: string;
+    } | null;
+    monthlyCloseAck: {
+      closeId: string;
+      yearMonth: string;
+      doneAt?: string;
+    } | null;
+    hrAlerts: {
+      count: number;
+      items: Array<{
+        id: string;
+        employeeName: string;
+        eventType: string;
+        effectiveDate: string;
+        projectId: string;
+      }>;
+      overflowCount: number;
+    };
+  };
+  payrollQueue: {
+    item: null;
+    riskItems: [];
+  };
+};
+
+type ExpandedNode =
+  | string
+  | number
+  | null
+  | undefined
+  | { type: unknown; props: Record<string, unknown> & { children?: ExpandedNode[] } }
+  | ExpandedNode[];
+
+type RenderedElement = {
+  type: unknown;
+  props: Record<string, unknown> & { children?: import('react').ReactNode };
+};
+
+function toRenderedElement(node: unknown): RenderedElement {
+  return node as RenderedElement;
+}
+
+function depsChanged(nextDeps: unknown[] | undefined, prevDeps: unknown[] | undefined) {
+  if (!nextDeps || !prevDeps) return true;
+  if (nextDeps.length !== prevDeps.length) return true;
+  return nextDeps.some((value, index) => !Object.is(value, prevDeps[index]));
+}
+
+function createReactHookHarness() {
+  let stateIndex = 0;
+  let effectIndex = 0;
+  let memoIndex = 0;
+  let refIndex = 0;
+
+  const states: unknown[] = [];
+  const effectDeps: Array<unknown[] | undefined> = [];
+  const effectCleanups: Array<(() => void) | undefined> = [];
+  const memoValues: unknown[] = [];
+  const memoDeps: Array<unknown[] | undefined> = [];
+  const refs: Array<{ current: unknown }> = [];
+
+  function beginRender() {
+    stateIndex = 0;
+    effectIndex = 0;
+    memoIndex = 0;
+    refIndex = 0;
+  }
+
+  async function moduleFactory() {
+    const React = await vi.importActual<typeof import('react')>('react');
+    return {
+      ...React,
+      useState: <T,>(initialValue: T | (() => T)) => {
+        const index = stateIndex++;
+        if (!(index in states)) {
+          states[index] = typeof initialValue === 'function'
+            ? (initialValue as () => T)()
+            : initialValue;
+        }
+        const setState = (nextValue: T | ((prevValue: T) => T)) => {
+          const previousValue = states[index] as T;
+          states[index] = typeof nextValue === 'function'
+            ? (nextValue as (prevValue: T) => T)(previousValue)
+            : nextValue;
+        };
+        return [states[index] as T, setState] as const;
+      },
+      useEffect: (effect: () => void | (() => void), deps?: unknown[]) => {
+        const index = effectIndex++;
+        const previousDeps = effectDeps[index];
+        if (!depsChanged(deps, previousDeps)) return;
+        effectCleanups[index]?.();
+        effectDeps[index] = deps ? [...deps] : undefined;
+        effectCleanups[index] = effect() || undefined;
+      },
+      useMemo: <T,>(factory: () => T, deps?: unknown[]) => {
+        const index = memoIndex++;
+        const previousDeps = memoDeps[index];
+        if (depsChanged(deps, previousDeps)) {
+          memoValues[index] = factory();
+          memoDeps[index] = deps ? [...deps] : undefined;
+        }
+        return memoValues[index] as T;
+      },
+      useRef: <T,>(initialValue: T) => {
+        const index = refIndex++;
+        if (!refs[index]) refs[index] = { current: initialValue };
+        return refs[index] as { current: T };
+      },
+    };
+  }
+
+  return { beginRender, moduleFactory };
+}
+
+function createSummary(overrides?: Partial<DashboardSummary['notices']> & { projectId?: string; projectName?: string }): DashboardSummary {
+  return {
+    project: {
+      id: overrides?.projectId || 'project-1',
+      name: overrides?.projectName || '프로젝트 1',
+      status: 'active',
+      clientOrg: '기관 A',
+      managerName: '담당자 A',
+      settlementType: 'monthly',
+      basis: 'cost',
+      contractAmount: 1000000,
+    },
+    summary: {
+      payrollRiskCount: 0,
+      visibleProjects: 1,
+      hrAlertCount: 0,
+      currentWeekLabel: '2026-04 3주차',
+    },
+    currentWeek: {
+      label: '2026-04 3주차',
+      weekStart: '2026-04-13',
+      weekEnd: '2026-04-19',
+      yearMonth: '2026-04',
+      weekNo: 3,
+    },
+    surface: {
+      currentWeekLabel: '2026-04 3주차',
+      projection: {
+        label: '입력됨',
+        detail: '정상 제출',
+        latestUpdatedAt: '2026-04-16T01:00:00.000Z',
+      },
+      expense: {
+        label: '정상',
+        detail: '문제 없음',
+        tone: 'success',
+      },
+      visibleIssues: [],
+    },
+    financeSummaryItems: [
+      { label: '총 입금', value: '10,000원' },
+      { label: '총 출금', value: '5,000원' },
+      { label: '잔액', value: '5,000원' },
+      { label: '소진율', value: '50%' },
+    ],
+    submissionRows: [],
+    notices: {
+      payrollAck: overrides?.payrollAck ?? null,
+      monthlyCloseAck: overrides?.monthlyCloseAck ?? null,
+      hrAlerts: overrides?.hrAlerts ?? {
+        count: 0,
+        items: [],
+        overflowCount: 0,
+      },
+    },
+    payrollQueue: {
+      item: null,
+      riskItems: [],
+    },
+  };
+}
+
+function flattenText(node: ExpandedNode): string {
+  if (node == null) return '';
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(flattenText).join('');
+  return flattenText(node.props.children || []);
+}
+
+function findNode(node: ExpandedNode, predicate: (candidate: Exclude<ExpandedNode, string | number | null | undefined | ExpandedNode[]>) => boolean):
+  Exclude<ExpandedNode, string | number | null | undefined | ExpandedNode[]> | null {
+  if (node == null || typeof node === 'string' || typeof node === 'number') return null;
+  if (Array.isArray(node)) {
+    for (const child of node) {
+      const found = findNode(child, predicate);
+      if (found) return found;
+    }
+    return null;
+  }
+  if (predicate(node)) return node;
+  return findNode(node.props.children || [], predicate);
+}
+
+async function flushAsyncWork() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('PortalDashboard regression', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('refetches dashboard summary after payroll acknowledgement so the stale notice disappears', async () => {
+    const hookHarness = createReactHookHarness();
+    const navigateSpy = vi.fn();
+    const toastSuccessSpy = vi.fn();
+    const acknowledgePayrollRun = vi.fn().mockResolvedValue(undefined);
+    const portalState = {
+      isLoading: false,
+      portalUser: { id: 'portal-user-1' },
+      myProject: { id: 'project-1' },
+    };
+    const authState = { user: { uid: 'user-1' } };
+    const firebaseState = { orgId: 'org-1' };
+    const fetchDashboardSummary = vi.fn()
+      .mockResolvedValueOnce(createSummary({
+        payrollAck: {
+          runId: 'run-1',
+          plannedPayDate: '2026-04-25',
+          noticeDate: '2026-04-22',
+        },
+      }))
+      .mockResolvedValueOnce(createSummary());
+
+    vi.doMock('react', hookHarness.moduleFactory);
+    vi.doMock('react-router', () => ({ useNavigate: () => navigateSpy }));
+    vi.doMock('sonner', () => ({
+      toast: {
+        success: toastSuccessSpy,
+        error: vi.fn(),
+      },
+    }));
+    vi.doMock('../ui/card', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      return {
+        Card: ({ children, ...props }: any) => React.createElement('div', props, children),
+        CardContent: ({ children, ...props }: any) => React.createElement('div', props, children),
+        CardHeader: ({ children, ...props }: any) => React.createElement('div', props, children),
+      };
+    });
+    vi.doMock('../ui/badge', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      return {
+        Badge: ({ children, ...props }: any) => React.createElement('span', props, children),
+      };
+    });
+    vi.doMock('../ui/button', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      return {
+        Button: ({ children, ...props }: any) => React.createElement('button', props, children),
+      };
+    });
+    vi.doMock('../../data/portal-store', () => ({
+      usePortalStore: () => portalState,
+    }));
+    vi.doMock('../../data/auth-store', () => ({
+      useAuth: () => authState,
+    }));
+    vi.doMock('../../data/payroll-store', () => ({
+      usePayroll: () => ({
+        acknowledgePayrollRun,
+        acknowledgeMonthlyClose: vi.fn(),
+      }),
+    }));
+    vi.doMock('../../data/budget-data', () => ({
+      fmtShort: (value: number) => String(value),
+    }));
+    vi.doMock('../../data/hr-announcements-store', () => ({
+      HR_EVENT_COLORS: {},
+      HR_EVENT_LABELS: {},
+    }));
+    vi.doMock('../../data/types', () => ({
+      PROJECT_STATUS_LABELS: { active: '진행 중' },
+      SETTLEMENT_TYPE_SHORT: { monthly: '월 정산' },
+      BASIS_LABELS: { cost: '원가' },
+    }));
+    vi.doMock('../../lib/firebase-context', () => ({
+      useFirebase: () => firebaseState,
+    }));
+    vi.doMock('../../lib/platform-bff-client', () => ({
+      createPlatformApiClient: vi.fn(() => ({ name: 'api-client' })),
+      fetchPortalDashboardSummaryViaBff: fetchDashboardSummary,
+    }));
+    vi.doMock('lucide-react', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      const Icon = () => React.createElement('span');
+      return {
+        AlertTriangle: Icon,
+        CheckCircle2: Icon,
+        CircleDollarSign: Icon,
+        Loader2: Icon,
+        ShieldCheck: Icon,
+      };
+    });
+
+    const React = await vi.importActual<typeof import('react')>('react');
+    const { PortalDashboard } = await import('./PortalDashboard');
+
+    const expandNode = (node: unknown): ExpandedNode => {
+      if (node == null || typeof node === 'string' || typeof node === 'number') return node;
+      if (Array.isArray(node)) return node.map(expandNode);
+      if (!React.isValidElement(node)) return null;
+      const element = toRenderedElement(node);
+      if (typeof element.type === 'function') {
+        const Component = element.type as (props: typeof element.props) => unknown;
+        return expandNode(Component(element.props));
+      }
+      return {
+        type: element.type,
+        props: {
+          ...element.props,
+          children: React.Children.toArray(element.props.children).map(expandNode),
+        },
+      };
+    };
+
+    const renderTree = () => {
+      hookHarness.beginRender();
+      return expandNode(PortalDashboard());
+    };
+
+    renderTree();
+    await flushAsyncWork();
+    let tree = renderTree();
+
+    expect(fetchDashboardSummary).toHaveBeenCalledTimes(1);
+    expect(flattenText(tree)).toContain('인건비 지급 예정: 2026-04-25');
+
+    const acknowledgeButton = findNode(
+      tree,
+      (candidate) => candidate.type === 'button' && flattenText(candidate).includes('확인했습니다'),
+    );
+
+    expect(acknowledgeButton).not.toBeNull();
+
+    await (acknowledgeButton?.props.onClick as () => Promise<void>)();
+    await flushAsyncWork();
+    tree = renderTree();
+
+    expect(acknowledgePayrollRun).toHaveBeenCalledWith('run-1');
+    expect(fetchDashboardSummary).toHaveBeenCalledTimes(2);
+    expect(flattenText(tree)).not.toContain('인건비 지급 예정: 2026-04-25');
+    expect(toastSuccessSpy).toHaveBeenCalled();
+  });
+
+  it('refetches dashboard summary after monthly close acknowledgement so the stale notice disappears', async () => {
+    const hookHarness = createReactHookHarness();
+    const acknowledgeMonthlyClose = vi.fn().mockResolvedValue(undefined);
+    const portalState = {
+      isLoading: false,
+      portalUser: { id: 'portal-user-1' },
+      myProject: { id: 'project-1' },
+    };
+    const authState = { user: { uid: 'user-1' } };
+    const firebaseState = { orgId: 'org-1' };
+    const fetchDashboardSummary = vi.fn()
+      .mockResolvedValueOnce(createSummary({
+        monthlyCloseAck: {
+          closeId: 'close-1',
+          yearMonth: '2026-03',
+          doneAt: '2026-04-01T00:00:00.000Z',
+        },
+      }))
+      .mockResolvedValueOnce(createSummary());
+
+    vi.doMock('react', hookHarness.moduleFactory);
+    vi.doMock('react-router', () => ({ useNavigate: () => vi.fn() }));
+    vi.doMock('sonner', () => ({
+      toast: {
+        success: vi.fn(),
+        error: vi.fn(),
+      },
+    }));
+    vi.doMock('../ui/card', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      return {
+        Card: ({ children, ...props }: any) => React.createElement('div', props, children),
+        CardContent: ({ children, ...props }: any) => React.createElement('div', props, children),
+        CardHeader: ({ children, ...props }: any) => React.createElement('div', props, children),
+      };
+    });
+    vi.doMock('../ui/badge', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      return {
+        Badge: ({ children, ...props }: any) => React.createElement('span', props, children),
+      };
+    });
+    vi.doMock('../ui/button', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      return {
+        Button: ({ children, ...props }: any) => React.createElement('button', props, children),
+      };
+    });
+    vi.doMock('../../data/portal-store', () => ({
+      usePortalStore: () => portalState,
+    }));
+    vi.doMock('../../data/auth-store', () => ({
+      useAuth: () => authState,
+    }));
+    vi.doMock('../../data/payroll-store', () => ({
+      usePayroll: () => ({
+        acknowledgePayrollRun: vi.fn(),
+        acknowledgeMonthlyClose,
+      }),
+    }));
+    vi.doMock('../../data/budget-data', () => ({
+      fmtShort: (value: number) => String(value),
+    }));
+    vi.doMock('../../data/hr-announcements-store', () => ({
+      HR_EVENT_COLORS: {},
+      HR_EVENT_LABELS: {},
+    }));
+    vi.doMock('../../data/types', () => ({
+      PROJECT_STATUS_LABELS: { active: '진행 중' },
+      SETTLEMENT_TYPE_SHORT: { monthly: '월 정산' },
+      BASIS_LABELS: { cost: '원가' },
+    }));
+    vi.doMock('../../lib/firebase-context', () => ({
+      useFirebase: () => firebaseState,
+    }));
+    vi.doMock('../../lib/platform-bff-client', () => ({
+      createPlatformApiClient: vi.fn(() => ({ name: 'api-client' })),
+      fetchPortalDashboardSummaryViaBff: fetchDashboardSummary,
+    }));
+    vi.doMock('lucide-react', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      const Icon = () => React.createElement('span');
+      return {
+        AlertTriangle: Icon,
+        CheckCircle2: Icon,
+        CircleDollarSign: Icon,
+        Loader2: Icon,
+        ShieldCheck: Icon,
+      };
+    });
+
+    const React = await vi.importActual<typeof import('react')>('react');
+    const { PortalDashboard } = await import('./PortalDashboard');
+
+    const expandNode = (node: unknown): ExpandedNode => {
+      if (node == null || typeof node === 'string' || typeof node === 'number') return node;
+      if (Array.isArray(node)) return node.map(expandNode);
+      if (!React.isValidElement(node)) return null;
+      const element = toRenderedElement(node);
+      if (typeof element.type === 'function') {
+        const Component = element.type as (props: typeof element.props) => unknown;
+        return expandNode(Component(element.props));
+      }
+      return {
+        type: element.type,
+        props: {
+          ...element.props,
+          children: React.Children.toArray(element.props.children).map(expandNode),
+        },
+      };
+    };
+
+    const renderTree = () => {
+      hookHarness.beginRender();
+      return expandNode(PortalDashboard());
+    };
+
+    renderTree();
+    await flushAsyncWork();
+    let tree = renderTree();
+
+    expect(fetchDashboardSummary).toHaveBeenCalledTimes(1);
+    expect(flattenText(tree)).toContain('월간 정산 완료 확인: 2026-03');
+
+    const acknowledgeButton = findNode(
+      tree,
+      (candidate) => candidate.type === 'button' && flattenText(candidate).includes('확인했습니다'),
+    );
+
+    expect(acknowledgeButton).not.toBeNull();
+
+    await (acknowledgeButton?.props.onClick as () => Promise<void>)();
+    await flushAsyncWork();
+    tree = renderTree();
+
+    expect(acknowledgeMonthlyClose).toHaveBeenCalledWith('close-1');
+    expect(fetchDashboardSummary).toHaveBeenCalledTimes(2);
+    expect(flattenText(tree)).not.toContain('월간 정산 완료 확인: 2026-03');
+  });
+
+  it('shows explicit loading and unavailable states while the active project summary is pending or failed', async () => {
+    const hookHarness = createReactHookHarness();
+    const portalState = {
+      isLoading: false,
+      portalUser: { id: 'portal-user-1' },
+      myProject: { id: 'project-1' },
+    };
+    const authState = { user: { uid: 'user-1' } };
+    const firebaseState = { orgId: 'org-1' };
+    const deferredProject2Summary = createDeferred<DashboardSummary>();
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchDashboardSummary = vi.fn()
+      .mockResolvedValueOnce(createSummary({
+        projectId: 'project-1',
+        projectName: '프로젝트 1',
+      }))
+      .mockImplementationOnce(() => deferredProject2Summary.promise);
+
+    vi.doMock('react', hookHarness.moduleFactory);
+    vi.doMock('react-router', () => ({ useNavigate: () => vi.fn() }));
+    vi.doMock('sonner', () => ({
+      toast: {
+        success: vi.fn(),
+        error: vi.fn(),
+      },
+    }));
+    vi.doMock('../ui/card', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      return {
+        Card: ({ children, ...props }: any) => React.createElement('div', props, children),
+        CardContent: ({ children, ...props }: any) => React.createElement('div', props, children),
+        CardHeader: ({ children, ...props }: any) => React.createElement('div', props, children),
+      };
+    });
+    vi.doMock('../ui/badge', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      return {
+        Badge: ({ children, ...props }: any) => React.createElement('span', props, children),
+      };
+    });
+    vi.doMock('../ui/button', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      return {
+        Button: ({ children, ...props }: any) => React.createElement('button', props, children),
+      };
+    });
+    vi.doMock('../../data/portal-store', () => ({
+      usePortalStore: () => portalState,
+    }));
+    vi.doMock('../../data/auth-store', () => ({
+      useAuth: () => authState,
+    }));
+    vi.doMock('../../data/payroll-store', () => ({
+      usePayroll: () => ({
+        acknowledgePayrollRun: vi.fn(),
+        acknowledgeMonthlyClose: vi.fn(),
+      }),
+    }));
+    vi.doMock('../../data/budget-data', () => ({
+      fmtShort: (value: number) => String(value),
+    }));
+    vi.doMock('../../data/hr-announcements-store', () => ({
+      HR_EVENT_COLORS: {},
+      HR_EVENT_LABELS: {},
+    }));
+    vi.doMock('../../data/types', () => ({
+      PROJECT_STATUS_LABELS: { active: '진행 중' },
+      SETTLEMENT_TYPE_SHORT: { monthly: '월 정산' },
+      BASIS_LABELS: { cost: '원가' },
+    }));
+    vi.doMock('../../lib/firebase-context', () => ({
+      useFirebase: () => firebaseState,
+    }));
+    vi.doMock('../../lib/platform-bff-client', () => ({
+      createPlatformApiClient: vi.fn(() => ({ name: 'api-client' })),
+      fetchPortalDashboardSummaryViaBff: fetchDashboardSummary,
+    }));
+    vi.doMock('lucide-react', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      const Icon = () => React.createElement('span');
+      return {
+        AlertTriangle: Icon,
+        CheckCircle2: Icon,
+        CircleDollarSign: Icon,
+        Loader2: Icon,
+        ShieldCheck: Icon,
+      };
+    });
+
+    const React = await vi.importActual<typeof import('react')>('react');
+    const { PortalDashboard } = await import('./PortalDashboard');
+
+    const expandNode = (node: unknown): ExpandedNode => {
+      if (node == null || typeof node === 'string' || typeof node === 'number') return node;
+      if (Array.isArray(node)) return node.map(expandNode);
+      if (!React.isValidElement(node)) return null;
+      const element = toRenderedElement(node);
+      if (typeof element.type === 'function') {
+        const Component = element.type as (props: typeof element.props) => unknown;
+        return expandNode(Component(element.props));
+      }
+      return {
+        type: element.type,
+        props: {
+          ...element.props,
+          children: React.Children.toArray(element.props.children).map(expandNode),
+        },
+      };
+    };
+
+    const renderDashboard = () => {
+      hookHarness.beginRender();
+      return expandNode(PortalDashboard());
+    };
+
+    renderDashboard();
+    await flushAsyncWork();
+    let tree = renderDashboard();
+
+    expect(flattenText(tree)).toContain('프로젝트 1');
+    expect(fetchDashboardSummary).toHaveBeenCalledTimes(1);
+    expect(fetchDashboardSummary).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      projectId: 'project-1',
+    }));
+
+    portalState.myProject = { id: 'project-2' };
+
+    renderDashboard();
+    tree = renderDashboard();
+
+    expect(fetchDashboardSummary).toHaveBeenCalledTimes(2);
+    expect(fetchDashboardSummary).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      projectId: 'project-2',
+    }));
+    expect(flattenText(tree)).toContain('대시보드 요약을 불러오는 중입니다.');
+    expect(flattenText(tree)).not.toContain('프로젝트 1');
+    expect(flattenText(tree)).not.toContain('내 제출 현황');
+
+    deferredProject2Summary.reject(new Error('project-2 summary failed'));
+    await flushAsyncWork();
+    tree = renderDashboard();
+
+    expect(flattenText(tree)).toContain('대시보드 요약을 지금 불러올 수 없습니다.');
+    expect(flattenText(tree)).not.toContain('내 제출 현황');
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('keeps the dashboard in a loading state before the first summary resolves for the current project', async () => {
+    const hookHarness = createReactHookHarness();
+    const portalState = {
+      isLoading: false,
+      portalUser: { id: 'portal-user-1' },
+      myProject: { id: 'project-2' },
+    };
+    const authState = { user: { uid: 'user-1' } };
+    const firebaseState = { orgId: 'org-1' };
+    const deferredSummary = createDeferred<DashboardSummary>();
+    const fetchDashboardSummary = vi.fn().mockImplementation(() => deferredSummary.promise);
+
+    vi.doMock('react', hookHarness.moduleFactory);
+    vi.doMock('react-router', () => ({ useNavigate: () => vi.fn() }));
+    vi.doMock('sonner', () => ({
+      toast: {
+        success: vi.fn(),
+        error: vi.fn(),
+      },
+    }));
+    vi.doMock('../ui/card', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      return {
+        Card: ({ children, ...props }: any) => React.createElement('div', props, children),
+        CardContent: ({ children, ...props }: any) => React.createElement('div', props, children),
+        CardHeader: ({ children, ...props }: any) => React.createElement('div', props, children),
+      };
+    });
+    vi.doMock('../ui/badge', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      return {
+        Badge: ({ children, ...props }: any) => React.createElement('span', props, children),
+      };
+    });
+    vi.doMock('../ui/button', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      return {
+        Button: ({ children, ...props }: any) => React.createElement('button', props, children),
+      };
+    });
+    vi.doMock('../../data/portal-store', () => ({
+      usePortalStore: () => portalState,
+    }));
+    vi.doMock('../../data/auth-store', () => ({
+      useAuth: () => authState,
+    }));
+    vi.doMock('../../data/payroll-store', () => ({
+      usePayroll: () => ({
+        acknowledgePayrollRun: vi.fn(),
+        acknowledgeMonthlyClose: vi.fn(),
+      }),
+    }));
+    vi.doMock('../../data/budget-data', () => ({
+      fmtShort: (value: number) => String(value),
+    }));
+    vi.doMock('../../data/hr-announcements-store', () => ({
+      HR_EVENT_COLORS: {},
+      HR_EVENT_LABELS: {},
+    }));
+    vi.doMock('../../data/types', () => ({
+      PROJECT_STATUS_LABELS: { active: '진행 중' },
+      SETTLEMENT_TYPE_SHORT: { monthly: '월 정산' },
+      BASIS_LABELS: { cost: '원가' },
+    }));
+    vi.doMock('../../lib/firebase-context', () => ({
+      useFirebase: () => firebaseState,
+    }));
+    vi.doMock('../../lib/platform-bff-client', () => ({
+      createPlatformApiClient: vi.fn(() => ({ name: 'api-client' })),
+      fetchPortalDashboardSummaryViaBff: fetchDashboardSummary,
+    }));
+    vi.doMock('lucide-react', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      const Icon = () => React.createElement('span');
+      return {
+        AlertTriangle: Icon,
+        CheckCircle2: Icon,
+        CircleDollarSign: Icon,
+        Loader2: Icon,
+        ShieldCheck: Icon,
+      };
+    });
+
+    const React = await vi.importActual<typeof import('react')>('react');
+    const { PortalDashboard } = await import('./PortalDashboard');
+
+    const expandNode = (node: unknown): ExpandedNode => {
+      if (node == null || typeof node === 'string' || typeof node === 'number') return node;
+      if (Array.isArray(node)) return node.map(expandNode);
+      if (!React.isValidElement(node)) return null;
+      const element = toRenderedElement(node);
+      if (typeof element.type === 'function') {
+        const Component = element.type as (props: typeof element.props) => unknown;
+        return expandNode(Component(element.props));
+      }
+      return {
+        type: element.type,
+        props: {
+          ...element.props,
+          children: React.Children.toArray(element.props.children).map(expandNode),
+        },
+      };
+    };
+
+    const renderDashboard = () => {
+      hookHarness.beginRender();
+      return expandNode(PortalDashboard());
+    };
+
+    let tree = renderDashboard();
+
+    expect(fetchDashboardSummary).toHaveBeenCalledTimes(1);
+    expect(fetchDashboardSummary).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      projectId: 'project-2',
+    }));
+    expect(flattenText(tree)).toContain('대시보드 요약을 불러오는 중입니다.');
+    expect(flattenText(tree)).not.toContain('내 사업');
+    expect(flattenText(tree)).not.toContain('내 제출 현황');
+
+    deferredSummary.resolve(createSummary({
+      projectId: 'project-2',
+      projectName: '프로젝트 2',
+    }));
+    await flushAsyncWork();
+    tree = renderDashboard();
+
+    expect(flattenText(tree)).toContain('프로젝트 2');
+  });
+
+  it('does not clear project B payroll notice when project A acknowledgement resolves after a switch', async () => {
+    const hookHarness = createReactHookHarness();
+    const acknowledgePayrollRun = vi.fn();
+    const deferredAcknowledge = createDeferred<void>();
+    const deferredRefreshAfterAck = createDeferred<DashboardSummary>();
+    const portalState = {
+      isLoading: false,
+      portalUser: { id: 'portal-user-1' },
+      myProject: { id: 'project-1' },
+    };
+    const authState = { user: { uid: 'user-1' } };
+    const firebaseState = { orgId: 'org-1' };
+    const fetchDashboardSummary = vi.fn()
+      .mockResolvedValueOnce(createSummary({
+        projectId: 'project-1',
+        projectName: '프로젝트 1',
+        payrollAck: {
+          runId: 'run-1',
+          plannedPayDate: '2026-04-25',
+          noticeDate: '2026-04-22',
+        },
+      }))
+      .mockResolvedValueOnce(createSummary({
+        projectId: 'project-2',
+        projectName: '프로젝트 2',
+        payrollAck: {
+          runId: 'run-2',
+          plannedPayDate: '2026-04-30',
+          noticeDate: '2026-04-27',
+        },
+      }))
+      .mockImplementationOnce(() => deferredRefreshAfterAck.promise);
+
+    acknowledgePayrollRun.mockImplementation(() => deferredAcknowledge.promise);
+
+    vi.doMock('react', hookHarness.moduleFactory);
+    vi.doMock('react-router', () => ({ useNavigate: () => vi.fn() }));
+    vi.doMock('sonner', () => ({
+      toast: {
+        success: vi.fn(),
+        error: vi.fn(),
+      },
+    }));
+    vi.doMock('../ui/card', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      return {
+        Card: ({ children, ...props }: any) => React.createElement('div', props, children),
+        CardContent: ({ children, ...props }: any) => React.createElement('div', props, children),
+        CardHeader: ({ children, ...props }: any) => React.createElement('div', props, children),
+      };
+    });
+    vi.doMock('../ui/badge', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      return {
+        Badge: ({ children, ...props }: any) => React.createElement('span', props, children),
+      };
+    });
+    vi.doMock('../ui/button', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      return {
+        Button: ({ children, ...props }: any) => React.createElement('button', props, children),
+      };
+    });
+    vi.doMock('../../data/portal-store', () => ({
+      usePortalStore: () => portalState,
+    }));
+    vi.doMock('../../data/auth-store', () => ({
+      useAuth: () => authState,
+    }));
+    vi.doMock('../../data/payroll-store', () => ({
+      usePayroll: () => ({
+        acknowledgePayrollRun,
+        acknowledgeMonthlyClose: vi.fn(),
+      }),
+    }));
+    vi.doMock('../../data/budget-data', () => ({
+      fmtShort: (value: number) => String(value),
+    }));
+    vi.doMock('../../data/hr-announcements-store', () => ({
+      HR_EVENT_COLORS: {},
+      HR_EVENT_LABELS: {},
+    }));
+    vi.doMock('../../data/types', () => ({
+      PROJECT_STATUS_LABELS: { active: '진행 중' },
+      SETTLEMENT_TYPE_SHORT: { monthly: '월 정산' },
+      BASIS_LABELS: { cost: '원가' },
+    }));
+    vi.doMock('../../lib/firebase-context', () => ({
+      useFirebase: () => firebaseState,
+    }));
+    vi.doMock('../../lib/platform-bff-client', () => ({
+      createPlatformApiClient: vi.fn(() => ({ name: 'api-client' })),
+      fetchPortalDashboardSummaryViaBff: fetchDashboardSummary,
+    }));
+    vi.doMock('lucide-react', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      const Icon = () => React.createElement('span');
+      return {
+        AlertTriangle: Icon,
+        CheckCircle2: Icon,
+        CircleDollarSign: Icon,
+        Loader2: Icon,
+        ShieldCheck: Icon,
+      };
+    });
+
+    const React = await vi.importActual<typeof import('react')>('react');
+    const { PortalDashboard } = await import('./PortalDashboard');
+
+    const expandNode = (node: unknown): ExpandedNode => {
+      if (node == null || typeof node === 'string' || typeof node === 'number') return node;
+      if (Array.isArray(node)) return node.map(expandNode);
+      if (!React.isValidElement(node)) return null;
+      const element = toRenderedElement(node);
+      if (typeof element.type === 'function') {
+        const Component = element.type as (props: typeof element.props) => unknown;
+        return expandNode(Component(element.props));
+      }
+      return {
+        type: element.type,
+        props: {
+          ...element.props,
+          children: React.Children.toArray(element.props.children).map(expandNode),
+        },
+      };
+    };
+
+    const renderDashboard = () => {
+      hookHarness.beginRender();
+      return expandNode(PortalDashboard());
+    };
+
+    renderDashboard();
+    await flushAsyncWork();
+    let tree = renderDashboard();
+
+    expect(flattenText(tree)).toContain('인건비 지급 예정: 2026-04-25');
+
+    const acknowledgeButton = findNode(
+      tree,
+      (candidate) => candidate.type === 'button' && flattenText(candidate).includes('확인했습니다'),
+    );
+
+    expect(acknowledgeButton).not.toBeNull();
+
+    const acknowledgePromise = (acknowledgeButton?.props.onClick as () => Promise<void>)();
+
+    portalState.myProject = { id: 'project-2' };
+
+    renderDashboard();
+    await flushAsyncWork();
+    tree = renderDashboard();
+
+    expect(fetchDashboardSummary).toHaveBeenCalledTimes(2);
+    expect(fetchDashboardSummary).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      projectId: 'project-2',
+    }));
+    expect(flattenText(tree)).toContain('인건비 지급 예정: 2026-04-30');
+    expect(flattenText(tree)).not.toContain('인건비 지급 예정: 2026-04-25');
+
+    deferredAcknowledge.resolve(undefined);
+    await flushAsyncWork();
+    tree = renderDashboard();
+
+    expect(acknowledgePayrollRun).toHaveBeenCalledWith('run-1');
+    expect(fetchDashboardSummary).toHaveBeenCalledTimes(3);
+    expect(fetchDashboardSummary).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      projectId: 'project-2',
+    }));
+    expect(flattenText(tree)).toContain('인건비 지급 예정: 2026-04-30');
+
+    deferredRefreshAfterAck.resolve(createSummary({
+      projectId: 'project-2',
+      projectName: '프로젝트 2',
+      payrollAck: {
+        runId: 'run-2',
+        plannedPayDate: '2026-04-30',
+        noticeDate: '2026-04-27',
+      },
+    }));
+    await acknowledgePromise;
+  });
+
+  it('suppresses stale project summary and actions immediately when the current project changes, even if refetch fails', async () => {
+    const hookHarness = createReactHookHarness();
+    const portalState = {
+      isLoading: false,
+      portalUser: { id: 'portal-user-1' },
+      myProject: { id: 'project-1' },
+    };
+    const authState = { user: { uid: 'user-1' } };
+    const firebaseState = { orgId: 'org-1' };
+    const deferredProject2Summary = createDeferred<DashboardSummary>();
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const fetchDashboardSummary = vi.fn()
+      .mockResolvedValueOnce(createSummary({
+        projectId: 'project-1',
+        projectName: '프로젝트 1',
+        payrollAck: {
+          runId: 'run-1',
+          plannedPayDate: '2026-04-25',
+          noticeDate: '2026-04-22',
+        },
+      }))
+      .mockImplementationOnce(() => deferredProject2Summary.promise);
+
+    vi.doMock('react', hookHarness.moduleFactory);
+    vi.doMock('react-router', () => ({ useNavigate: () => vi.fn() }));
+    vi.doMock('sonner', () => ({
+      toast: {
+        success: vi.fn(),
+        error: vi.fn(),
+      },
+    }));
+    vi.doMock('../ui/card', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      return {
+        Card: ({ children, ...props }: any) => React.createElement('div', props, children),
+        CardContent: ({ children, ...props }: any) => React.createElement('div', props, children),
+        CardHeader: ({ children, ...props }: any) => React.createElement('div', props, children),
+      };
+    });
+    vi.doMock('../ui/badge', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      return {
+        Badge: ({ children, ...props }: any) => React.createElement('span', props, children),
+      };
+    });
+    vi.doMock('../ui/button', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      return {
+        Button: ({ children, ...props }: any) => React.createElement('button', props, children),
+      };
+    });
+    vi.doMock('../../data/portal-store', () => ({
+      usePortalStore: () => portalState,
+    }));
+    vi.doMock('../../data/auth-store', () => ({
+      useAuth: () => authState,
+    }));
+    vi.doMock('../../data/payroll-store', () => ({
+      usePayroll: () => ({
+        acknowledgePayrollRun: vi.fn(),
+        acknowledgeMonthlyClose: vi.fn(),
+      }),
+    }));
+    vi.doMock('../../data/budget-data', () => ({
+      fmtShort: (value: number) => String(value),
+    }));
+    vi.doMock('../../data/hr-announcements-store', () => ({
+      HR_EVENT_COLORS: {},
+      HR_EVENT_LABELS: {},
+    }));
+    vi.doMock('../../data/types', () => ({
+      PROJECT_STATUS_LABELS: { active: '진행 중' },
+      SETTLEMENT_TYPE_SHORT: { monthly: '월 정산' },
+      BASIS_LABELS: { cost: '원가' },
+    }));
+    vi.doMock('../../lib/firebase-context', () => ({
+      useFirebase: () => firebaseState,
+    }));
+    vi.doMock('../../lib/platform-bff-client', () => ({
+      createPlatformApiClient: vi.fn(() => ({ name: 'api-client' })),
+      fetchPortalDashboardSummaryViaBff: fetchDashboardSummary,
+    }));
+    vi.doMock('lucide-react', async () => {
+      const React = await vi.importActual<typeof import('react')>('react');
+      const Icon = () => React.createElement('span');
+      return {
+        AlertTriangle: Icon,
+        CheckCircle2: Icon,
+        CircleDollarSign: Icon,
+        Loader2: Icon,
+        ShieldCheck: Icon,
+      };
+    });
+
+    const React = await vi.importActual<typeof import('react')>('react');
+    const { PortalDashboard } = await import('./PortalDashboard');
+
+    const expandNode = (node: unknown): ExpandedNode => {
+      if (node == null || typeof node === 'string' || typeof node === 'number') return node;
+      if (Array.isArray(node)) return node.map(expandNode);
+      if (!React.isValidElement(node)) return null;
+      const element = toRenderedElement(node);
+      if (typeof element.type === 'function') {
+        const Component = element.type as (props: typeof element.props) => unknown;
+        return expandNode(Component(element.props));
+      }
+      return {
+        type: element.type,
+        props: {
+          ...element.props,
+          children: React.Children.toArray(element.props.children).map(expandNode),
+        },
+      };
+    };
+
+    const renderDashboard = () => {
+      hookHarness.beginRender();
+      return expandNode(PortalDashboard());
+    };
+
+    renderDashboard();
+    await flushAsyncWork();
+    let tree = renderDashboard();
+    expect(fetchDashboardSummary).toHaveBeenCalledTimes(1);
+    expect(fetchDashboardSummary).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      projectId: 'project-1',
+    }));
+    expect(flattenText(tree)).toContain('프로젝트 1');
+    expect(flattenText(tree)).toContain('인건비 지급 예정: 2026-04-25');
+
+    renderDashboard();
+    await flushAsyncWork();
+    expect(fetchDashboardSummary).toHaveBeenCalledTimes(1);
+
+    portalState.myProject = { id: 'project-2' };
+
+    tree = renderDashboard();
+    expect(flattenText(tree)).not.toContain('프로젝트 1');
+    expect(flattenText(tree)).not.toContain('인건비 지급 예정: 2026-04-25');
+
+    await flushAsyncWork();
+    expect(fetchDashboardSummary).toHaveBeenCalledTimes(2);
+    expect(fetchDashboardSummary).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      projectId: 'project-2',
+    }));
+
+    deferredProject2Summary.reject(new Error('project-2 summary failed'));
+    await flushAsyncWork();
+
+    tree = renderDashboard();
+    expect(flattenText(tree)).not.toContain('프로젝트 1');
+    expect(flattenText(tree)).not.toContain('인건비 지급 예정: 2026-04-25');
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    consoleWarnSpy.mockRestore();
+  });
+});

--- a/src/app/components/portal/PortalDashboard.tsx
+++ b/src/app/components/portal/PortalDashboard.tsx
@@ -1,46 +1,24 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
-import {
-  TrendingUp, AlertTriangle,
-  CheckCircle2, CircleDollarSign, ShieldCheck,
-  BarChart3,
-  Loader2,
-} from 'lucide-react';
+import { AlertTriangle, CheckCircle2, CircleDollarSign, Loader2, ShieldCheck } from 'lucide-react';
 import { toast } from 'sonner';
-import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
+import { Card, CardContent, CardHeader } from '../ui/card';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import { usePortalStore } from '../../data/portal-store';
 import { useAuth } from '../../data/auth-store';
-import { useHrAnnouncements, HR_EVENT_LABELS, HR_EVENT_COLORS } from '../../data/hr-announcements-store';
-import { usePayroll } from '../../data/payroll-store';
 import { fmtShort } from '../../data/budget-data';
+import { HR_EVENT_COLORS, HR_EVENT_LABELS } from '../../data/hr-announcements-store';
+import { usePayroll } from '../../data/payroll-store';
 import {
   PROJECT_STATUS_LABELS, SETTLEMENT_TYPE_SHORT, BASIS_LABELS,
 } from '../../data/types';
-import { addMonthsToYearMonth, getSeoulTodayIso } from '../../platform/business-days';
-import { resolveCurrentCashflowWeek } from '../../platform/cashflow-export-surface';
 import { useFirebase } from '../../lib/firebase-context';
 import {
   createPlatformApiClient,
   fetchPortalDashboardSummaryViaBff,
   type PortalDashboardSummaryResult,
 } from '../../lib/platform-bff-client';
-import {
-  isPayrollLiquidityRiskStatus,
-  resolveProjectPayrollLiquidity,
-  type PayrollLiquidityQueueItem,
-} from '../../platform/payroll-liquidity';
-import { buildPortalDashboardSurface } from '../../platform/portal-dashboard-surface';
-import {
-  resolveWeeklyAccountingProductStatus,
-  resolveWeeklyAccountingSnapshot,
-} from '../../platform/weekly-accounting-state';
-import { resolvePortalProjectReadModel } from './portal-read-model';
-
-// ═══════════════════════════════════════════════════════════════
-// PortalDashboard — 내 사업 현황
-// ═══════════════════════════════════════════════════════════════
 
 function formatKstDateTime(value: string | undefined): string {
   if (!value) return '아직 수정 없음';
@@ -79,44 +57,142 @@ function submissionBadgeClassName(tone: 'neutral' | 'warning' | 'danger' | 'succ
   return 'border-slate-200 bg-slate-50 text-slate-700';
 }
 
+type DashboardPayrollQueueItem = NonNullable<PortalDashboardSummaryResult['payrollQueue']['item']>;
+type DashboardSummaryRequestState = {
+  projectId: string;
+  status: 'idle' | 'loading' | 'ready' | 'error';
+};
+
+const PORTAL_PAYROLL_BADGE_STYLES: Record<string, string> = {
+  insufficient_balance: 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300',
+  payment_unconfirmed: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+  baseline_missing: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
+  balance_unknown: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
+  clear: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+};
+
+function portalPayrollLabel(status: string) {
+  if (status === 'insufficient_balance') return '잔액 부족 위험';
+  if (status === 'payment_unconfirmed') return '지급 확인 필요';
+  if (status === 'baseline_missing') return '기준 지급액 없음';
+  if (status === 'balance_unknown') return '잔액 데이터 없음';
+  return '이번 지급 창 안정';
+}
+
+function PortalDashboardSummaryStateCard({
+  description,
+  loading,
+  title,
+}: {
+  description: string;
+  loading: boolean;
+  title: string;
+}) {
+  return (
+    <Card className="border-slate-200 bg-white shadow-sm">
+      <CardContent className="p-6">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+          <div className={`flex h-11 w-11 items-center justify-center rounded-2xl ${loading ? 'bg-slate-100 text-slate-600' : 'bg-rose-50 text-rose-600'}`}>
+            {loading ? <Loader2 className="h-5 w-5 animate-spin" /> : <AlertTriangle className="h-5 w-5" />}
+          </div>
+          <div className="space-y-1.5">
+            <h2 className="text-[18px] font-semibold tracking-[-0.03em] text-slate-950">{title}</h2>
+            <p className="text-[12px] leading-6 text-slate-600">{description}</p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
 export function PortalDashboard() {
   const navigate = useNavigate();
+  const { isLoading, portalUser, myProject } = usePortalStore();
   const { user: authUser } = useAuth();
-  const { isLoading, portalUser, myProject, weeklySubmissionStatuses, projects, transactions } = usePortalStore();
-  const { getProjectAlerts } = useHrAnnouncements();
-  const { runs, monthlyCloses, acknowledgePayrollRun, acknowledgeMonthlyClose } = usePayroll();
+  const { acknowledgePayrollRun, acknowledgeMonthlyClose } = usePayroll();
   const { orgId } = useFirebase();
   const apiClient = useMemo(() => createPlatformApiClient(import.meta.env), []);
   const [dashboardSummary, setDashboardSummary] = useState<PortalDashboardSummaryResult | null>(null);
+  const [dashboardSummaryRequestState, setDashboardSummaryRequestState] = useState<DashboardSummaryRequestState>({
+    projectId: '',
+    status: 'idle',
+  });
+  const currentProjectId = myProject?.id || '';
+  const currentProjectIdRef = useRef(currentProjectId);
+  const latestDashboardSummaryRequestIdRef = useRef(0);
+  const activeDashboardSummary = dashboardSummary?.project?.id === currentProjectId
+    ? dashboardSummary
+    : null;
+  currentProjectIdRef.current = currentProjectId;
+
+  async function refreshDashboardSummary(options?: {
+    mode?: 'blocking' | 'background';
+    projectId?: string;
+  }) {
+    const targetProjectId = options?.projectId ?? currentProjectId;
+    if (!authUser?.uid || !orgId || !targetProjectId) return null;
+    const requestId = latestDashboardSummaryRequestIdRef.current + 1;
+    latestDashboardSummaryRequestIdRef.current = requestId;
+    if ((options?.mode ?? 'background') === 'blocking') {
+      setDashboardSummaryRequestState({
+        projectId: targetProjectId,
+        status: 'loading',
+      });
+    }
+
+    try {
+      const summary = await fetchPortalDashboardSummaryViaBff({
+        tenantId: orgId,
+        actor: authUser,
+        projectId: targetProjectId,
+        client: apiClient,
+      });
+      if (latestDashboardSummaryRequestIdRef.current === requestId) {
+        setDashboardSummary(summary);
+        setDashboardSummaryRequestState({
+          projectId: targetProjectId,
+          status: summary.project?.id === targetProjectId ? 'ready' : 'error',
+        });
+        if (summary.project?.id !== targetProjectId) {
+          console.warn('[PortalDashboard] dashboard-summary project mismatch:', {
+            expectedProjectId: targetProjectId,
+            receivedProjectId: summary.project?.id,
+          });
+        }
+      }
+      return summary;
+    } catch (error) {
+      if (latestDashboardSummaryRequestIdRef.current === requestId) {
+        console.warn('[PortalDashboard] dashboard-summary fetch failed:', error);
+        setDashboardSummaryRequestState({
+          projectId: targetProjectId,
+          status: 'error',
+        });
+      }
+      return null;
+    }
+  }
 
   useEffect(() => {
-    if (!authUser?.uid || !orgId) return;
-    let cancelled = false;
-
-    void fetchPortalDashboardSummaryViaBff({
-      tenantId: orgId,
-      actor: authUser,
-      client: apiClient,
-    })
-      .then((summary) => {
-        if (!cancelled) setDashboardSummary(summary);
-      })
-      .catch((error) => {
-        if (!cancelled) {
-          console.warn('[PortalDashboard] dashboard-summary fetch failed; using store fallback:', error);
-        }
+    if (!authUser?.uid || !orgId || !currentProjectId) {
+      setDashboardSummary(null);
+      setDashboardSummaryRequestState({
+        projectId: '',
+        status: 'idle',
       });
+      return undefined;
+    }
+
+    setDashboardSummary((current) => (current?.project?.id === currentProjectId ? current : null));
+    void refreshDashboardSummary({
+      mode: 'blocking',
+      projectId: currentProjectId,
+    });
 
     return () => {
-      cancelled = true;
+      latestDashboardSummaryRequestIdRef.current += 1;
     };
-  }, [apiClient, authUser, orgId]);
-
-  const projectReadModel = useMemo(() => resolvePortalProjectReadModel({
-    summaryProject: dashboardSummary?.project,
-    fallbackProject: myProject,
-    activeProjectId: myProject?.id,
-  }), [dashboardSummary?.project, myProject]);
+  }, [apiClient, authUser, currentProjectId, orgId]);
 
   if (isLoading) {
     return (
@@ -159,109 +235,125 @@ export function PortalDashboard() {
     );
   }
 
-  const myTx = transactions.filter((t) => t.projectId === myProject.id);
+  const activeSummaryRequestStatus = dashboardSummaryRequestState.projectId === currentProjectId
+    ? dashboardSummaryRequestState.status
+    : (!activeDashboardSummary && Boolean(currentProjectId) ? 'loading' : 'idle');
 
-  const today = getSeoulTodayIso();
-  const yearMonth = today.slice(0, 7);
-  const prevYearMonth = addMonthsToYearMonth(yearMonth, -1);
-  const payrollRun = runs.find((r) => r.projectId === myProject.id && r.yearMonth === yearMonth) || null;
-  const monthlyClosePrev = monthlyCloses.find((c) => c.projectId === myProject.id && c.yearMonth === prevYearMonth) || null;
-  const hrAlerts = getProjectAlerts(myProject.id).filter((a) => !a.acknowledged);
-  const needsPayrollAck = !!(payrollRun && today >= payrollRun.noticeDate && !payrollRun.acknowledged);
-  const needsMonthlyCloseAck = !!(monthlyClosePrev && monthlyClosePrev.status === 'DONE' && !monthlyClosePrev.acknowledged);
+  if (!activeDashboardSummary && activeSummaryRequestStatus === 'loading') {
+    return (
+      <PortalDashboardSummaryStateCard
+        loading
+        title="대시보드 요약을 불러오는 중입니다."
+        description="선택한 사업의 최신 운영 요약을 확인한 뒤 대시보드를 표시합니다."
+      />
+    );
+  }
+
+  if (!activeDashboardSummary && activeSummaryRequestStatus === 'error') {
+    return (
+      <PortalDashboardSummaryStateCard
+        loading={false}
+        title="대시보드 요약을 지금 불러올 수 없습니다."
+        description="요약 데이터가 준비되지 않아 현재 상태를 추정해서 보여주지 않습니다. 잠시 후 다시 확인해주세요."
+      />
+    );
+  }
+
+  const summaryProject = activeDashboardSummary?.project;
+  const projectStatusLabel = summaryProject?.status
+    ? PROJECT_STATUS_LABELS[summaryProject.status as keyof typeof PROJECT_STATUS_LABELS] || summaryProject.status
+    : '-';
+  const projectSettlementLabel = summaryProject?.settlementType
+    ? SETTLEMENT_TYPE_SHORT[summaryProject.settlementType as keyof typeof SETTLEMENT_TYPE_SHORT] || summaryProject.settlementType
+    : '-';
+  const projectBasisLabel = summaryProject?.basis
+    ? BASIS_LABELS[summaryProject.basis as keyof typeof BASIS_LABELS] || summaryProject.basis
+    : '-';
+  const projectContractAmount = typeof summaryProject?.contractAmount === 'number' && summaryProject.contractAmount > 0
+    ? `${fmtShort(summaryProject.contractAmount)}원`
+    : '-';
+  const dashboardSurface = activeDashboardSummary?.surface;
+  const financeSummaryItems = activeDashboardSummary?.financeSummaryItems ?? [
+    { label: '총 입금', value: '-' },
+    { label: '총 출금', value: '-' },
+    { label: '잔액', value: '-' },
+    { label: '소진율', value: '-' },
+  ];
+  const dashboardSubmissionRows = activeDashboardSummary?.submissionRows ?? [];
+  const currentWeek = activeDashboardSummary?.currentWeek;
+  const issueItems = activeDashboardSummary?.surface?.visibleIssues ?? [];
+  const notices = activeDashboardSummary?.notices ?? {
+    payrollAck: null,
+    monthlyCloseAck: null,
+    hrAlerts: {
+      count: 0,
+      items: [],
+      overflowCount: 0,
+    },
+  };
+  const payrollQueue = activeDashboardSummary?.payrollQueue ?? {
+    item: null,
+    riskItems: [],
+  };
+  const shouldShowPayrollQueue = Boolean(payrollQueue.item && payrollQueue.item.status !== 'clear');
 
   async function onAckPayroll() {
-    if (!payrollRun) return;
+    const targetProjectId = currentProjectId;
+    const targetRunId = notices.payrollAck?.runId;
+    if (!targetRunId) return;
     try {
-      await acknowledgePayrollRun(payrollRun.id);
+      await acknowledgePayrollRun(targetRunId);
+      setDashboardSummary((current) => {
+        if (!current) return current;
+        if (current.project?.id !== targetProjectId) return current;
+        if (current.notices.payrollAck?.runId !== targetRunId) return current;
+        return {
+          ...current,
+          notices: {
+            ...current.notices,
+            payrollAck: null,
+          },
+        };
+      });
+      await refreshDashboardSummary({
+        mode: 'background',
+        projectId: currentProjectIdRef.current || targetProjectId,
+      });
       toast.success('공지 확인이 기록되었습니다');
-    } catch (err: any) {
-      console.error(err);
-      toast.error(err?.message || '확인 처리에 실패했습니다');
+    } catch (error: any) {
+      console.error(error);
+      toast.error(error?.message || '확인 처리에 실패했습니다');
     }
   }
 
   async function onAckMonthlyClose() {
-    if (!monthlyClosePrev) return;
+    const targetProjectId = currentProjectId;
+    const targetCloseId = notices.monthlyCloseAck?.closeId;
+    if (!targetCloseId) return;
     try {
-      await acknowledgeMonthlyClose(monthlyClosePrev.id);
+      await acknowledgeMonthlyClose(targetCloseId);
+      setDashboardSummary((current) => {
+        if (!current) return current;
+        if (current.project?.id !== targetProjectId) return current;
+        if (current.notices.monthlyCloseAck?.closeId !== targetCloseId) return current;
+        return {
+          ...current,
+          notices: {
+            ...current.notices,
+            monthlyCloseAck: null,
+          },
+        };
+      });
+      await refreshDashboardSummary({
+        mode: 'background',
+        projectId: currentProjectIdRef.current || targetProjectId,
+      });
       toast.success('월간 정산 확인이 기록되었습니다');
-    } catch (err: any) {
-      console.error(err);
-      toast.error(err?.message || '확인 처리에 실패했습니다');
+    } catch (error: any) {
+      console.error(error);
+      toast.error(error?.message || '확인 처리에 실패했습니다');
     }
   }
-
-  // 재무 KPI
-  const totalIn = myTx.filter(t => t.direction === 'IN').reduce((s, t) => s + t.amounts.bankAmount, 0);
-  const totalOut = myTx.filter(t => t.direction === 'OUT').reduce((s, t) => s + t.amounts.bankAmount, 0);
-  const balance = totalIn - totalOut;
-  const burnRate = myProject.contractAmount > 0 ? totalOut / myProject.contractAmount : 0;
-  const payrollQueueItems = useMemo(() => resolveProjectPayrollLiquidity({
-    project: myProject,
-    runs,
-    transactions: myTx,
-    today,
-  }), [myProject, myTx, runs, today]);
-  const payrollRiskItems = useMemo(
-    () => payrollQueueItems.filter((item) => isPayrollLiquidityRiskStatus(item.status)),
-    [payrollQueueItems],
-  );
-  const payrollDetail = payrollQueueItems[0] || null;
-  const assignedProjects = useMemo(() => {
-    if (!portalUser) return myProject ? [myProject] : [];
-    const projectIds = Array.isArray(portalUser.projectIds) && portalUser.projectIds.length > 0
-      ? portalUser.projectIds
-      : portalUser.projectId ? [portalUser.projectId] : [];
-    const projectMap = new Map(projects.map((project) => [project.id, project]));
-    const ordered = projectIds
-      .map((projectId) => projectMap.get(projectId))
-      .filter((project): project is NonNullable<typeof project> => Boolean(project));
-    if (ordered.length > 0) return ordered;
-    return myProject ? [myProject] : [];
-  }, [myProject, portalUser, projects]);
-  const currentWeek = useMemo(() => resolveCurrentCashflowWeek(today), [today]);
-  const weeklyStatusMap = useMemo(() => {
-    const map = new Map<string, typeof weeklySubmissionStatuses[number]>();
-    weeklySubmissionStatuses.forEach((status) => {
-      map.set(`${status.projectId}-${status.yearMonth}-w${status.weekNo}`, status);
-    });
-    return map;
-  }, [weeklySubmissionStatuses]);
-  const dashboardSubmissionRows = useMemo(() => {
-    if (!currentWeek) return [];
-    return assignedProjects.map((project) => {
-      const status = weeklyStatusMap.get(`${project.id}-${currentWeek.yearMonth}-w${currentWeek.weekNo}`);
-      const snapshot = resolveWeeklyAccountingSnapshot(status);
-      const expenseStatus = resolveWeeklyAccountingProductStatus({ snapshot });
-      return {
-        id: project.id,
-        name: project.name,
-        shortName: project.shortName || project.id,
-        projectionInputLabel: snapshot.projectionEdited ? '입력됨' : '미입력',
-        projectionDoneLabel: snapshot.projectionDone ? '제출 완료' : '미완료',
-        expenseLabel: expenseStatus.label,
-        expenseTone: expenseStatus.tone === 'muted'
-          ? 'neutral'
-          : expenseStatus.tone,
-        latestProjectionUpdatedAt: status?.projectionUpdatedAt || status?.projectionEditedAt,
-      };
-    });
-  }, [assignedProjects, currentWeek, weeklyStatusMap]);
-  const dashboardSurface = useMemo(() => dashboardSummary?.surface ?? buildPortalDashboardSurface({
-    projectId: myProject.id,
-    weeklySubmissionStatuses,
-    todayIso: today,
-    hrAlertCount: hrAlerts.length,
-    payrollRiskCount: payrollRiskItems.length,
-  }), [dashboardSummary?.surface, hrAlerts.length, myProject.id, payrollRiskItems.length, today, weeklySubmissionStatuses]);
-  const shouldShowPayrollQueue = Boolean(payrollDetail && payrollDetail.status !== 'clear');
-  const financeSummaryItems = [
-    { label: '총 입금', value: fmtShort(totalIn) },
-    { label: '총 출금', value: fmtShort(totalOut) },
-    { label: '잔액', value: fmtShort(balance) },
-    { label: '소진율', value: `${(burnRate * 100).toFixed(1)}%` },
-  ];
 
   return (
     <div className="space-y-6">
@@ -271,17 +363,17 @@ export function PortalDashboard() {
             <div className="space-y-3">
               <div className="flex flex-wrap items-center gap-2">
                 <Badge className="h-5 rounded-full bg-[#e8f0fb] px-2 text-[10px] font-semibold text-[#1b4f8f]">
-                  {projectReadModel.statusLabel || PROJECT_STATUS_LABELS[myProject.status]}
+                  {projectStatusLabel}
                 </Badge>
                 <Badge variant="outline" className="h-5 rounded-full border-slate-300 px-2 text-[10px] font-semibold text-slate-600">
-                  {SETTLEMENT_TYPE_SHORT[myProject.settlementType]}
+                  {projectSettlementLabel}
                 </Badge>
                 <Badge variant="outline" className="h-5 rounded-full border-slate-300 px-2 text-[10px] font-semibold text-slate-600">
-                  {BASIS_LABELS[myProject.basis]}
+                  {projectBasisLabel}
                 </Badge>
               </div>
               <h2 className="text-[30px] font-semibold tracking-[-0.04em] text-slate-950">
-                {projectReadModel.projectName}
+                {summaryProject?.name || '내 사업'}
               </h2>
             </div>
 
@@ -311,25 +403,25 @@ export function PortalDashboard() {
                   <div className="rounded-xl border border-slate-300 bg-white px-4 py-3">
                     <div className="text-[11px] font-medium text-slate-600">발주기관</div>
                     <div className="mt-1 text-[14px] font-semibold text-slate-900">
-                      {projectReadModel.clientOrg || myProject.clientOrg || '-'}
+                      {summaryProject?.clientOrg || '-'}
                     </div>
                   </div>
                   <div className="rounded-xl border border-slate-300 bg-white px-4 py-3">
                     <div className="text-[11px] font-medium text-slate-600">담당자</div>
                     <div className="mt-1 text-[14px] font-semibold text-slate-900">
-                      {projectReadModel.managerName || portalUser.name}
+                      {summaryProject?.managerName || '-'}
                     </div>
                   </div>
                   <div className="rounded-xl border border-slate-300 bg-white px-4 py-3">
                     <div className="text-[11px] font-medium text-slate-600">사업비 총액</div>
                     <div className="mt-1 text-[14px] font-semibold text-slate-900">
-                      {myProject.contractAmount > 0 ? `${fmtShort(myProject.contractAmount)}원` : '-'}
+                      {projectContractAmount}
                     </div>
                   </div>
                   <div className="rounded-xl border border-slate-300 bg-white px-4 py-3">
                     <div className="text-[11px] font-medium text-slate-600">이번 주 Projection</div>
                     <div className="mt-1 text-[14px] font-semibold text-slate-900">
-                      {dashboardSurface.currentWeekLabel} · {dashboardSurface.projection.label}
+                      {dashboardSurface?.currentWeekLabel || '-'} · {dashboardSurface?.projection?.label || '미작성'}
                     </div>
                   </div>
                 </div>
@@ -342,35 +434,35 @@ export function PortalDashboard() {
                     <div className="flex items-start justify-between gap-3">
                       <div>
                         <div className="text-[11px] font-medium text-slate-600">Projection</div>
-                        <div className="mt-1 text-[14px] font-semibold text-slate-900">{dashboardSurface.projection.label}</div>
-                        <div className="mt-1 text-[11px] text-slate-500">{dashboardSurface.projection.detail}</div>
+                        <div className="mt-1 text-[14px] font-semibold text-slate-900">{dashboardSurface?.projection?.label || '미작성'}</div>
+                        <div className="mt-1 text-[11px] text-slate-500">{dashboardSurface?.projection?.detail || '이번 주 제출 상태를 확인하지 못했습니다.'}</div>
                       </div>
-                      <Badge variant="outline" className={`rounded-full ${dashboardSurface.projection.label === '미작성' ? 'border-amber-200 bg-amber-50 text-amber-700' : 'border-emerald-200 bg-emerald-50 text-emerald-700'}`}>
-                        {dashboardSurface.projection.label}
+                      <Badge variant="outline" className={`rounded-full ${(dashboardSurface?.projection?.label || '미작성') === '미작성' ? 'border-amber-200 bg-amber-50 text-amber-700' : 'border-emerald-200 bg-emerald-50 text-emerald-700'}`}>
+                        {dashboardSurface?.projection?.label || '미작성'}
                       </Badge>
                     </div>
                   </div>
                   <div className="rounded-xl border border-slate-300 bg-white px-4 py-3">
                     <div className="text-[11px] font-medium text-slate-600">최근 Projection 수정</div>
                     <div className="mt-1 text-[14px] font-semibold text-slate-900">
-                      {formatKstDateTime(dashboardSurface.projection.latestUpdatedAt)}
+                      {formatKstDateTime(dashboardSurface?.projection?.latestUpdatedAt)}
                     </div>
                   </div>
                   <div className="rounded-xl border border-slate-300 bg-white px-4 py-3">
                     <div className="flex items-start justify-between gap-3">
                       <div>
                         <div className="text-[11px] font-medium text-slate-600">사업비 입력</div>
-                        <div className="mt-1 text-[14px] font-semibold text-slate-900">{dashboardSurface.expense.label}</div>
-                        <div className="mt-1 text-[11px] text-slate-500">{dashboardSurface.expense.detail}</div>
+                        <div className="mt-1 text-[14px] font-semibold text-slate-900">{dashboardSurface?.expense?.label || '확인 필요'}</div>
+                        <div className="mt-1 text-[11px] text-slate-500">{dashboardSurface?.expense?.detail || '사업비 입력 상태를 확인하지 못했습니다.'}</div>
                       </div>
-                      <Badge variant="outline" className={`rounded-full ${accountingToneBadgeClassName(dashboardSurface.expense.tone)}`}>
-                        {dashboardSurface.expense.label}
+                      <Badge variant="outline" className={`rounded-full ${accountingToneBadgeClassName(dashboardSurface?.expense?.tone || 'muted')}`}>
+                        {dashboardSurface?.expense?.label || '확인 필요'}
                       </Badge>
                     </div>
                   </div>
-                  {dashboardSurface.visibleIssues.length > 0 && (
+                  {issueItems.length > 0 && (
                     <div className="flex flex-wrap gap-2 pt-2">
-                      {dashboardSurface.visibleIssues.map((item) => (
+                      {issueItems.map((item) => (
                         <button
                           key={item.label}
                           className={`inline-flex items-center gap-2 rounded-full border px-3 py-2 text-[11px] font-semibold transition-colors ${issueToneClassName(item.tone)}`}
@@ -393,18 +485,16 @@ export function PortalDashboard() {
         <CardHeader className="border-b border-slate-200/80 pb-3">
           <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
             <div className="space-y-1">
-              <CardTitle className="text-[15px] font-semibold tracking-[-0.02em] text-slate-950">
+              <h2 className="text-[15px] font-semibold tracking-[-0.02em] text-slate-950">
                 내 제출 현황
-              </CardTitle>
+              </h2>
               <p className="text-[11px] text-slate-500">
                 제출 상태를 한 번에 확인합니다.
               </p>
             </div>
-            {currentWeek && (
-              <div className="text-[11px] font-medium text-slate-500">
-                {currentWeek.label} · {currentWeek.weekStart} ~ {currentWeek.weekEnd}
-              </div>
-            )}
+            <div className="text-[11px] font-medium text-slate-500">
+              {currentWeek ? `${currentWeek.label} · ${currentWeek.weekStart} ~ ${currentWeek.weekEnd}` : '-'}
+            </div>
           </div>
         </CardHeader>
         <CardContent className="pt-4">
@@ -466,8 +556,7 @@ export function PortalDashboard() {
         </CardContent>
       </Card>
 
-      {/* 중요 공지 (인건비 / 월간정산 / 퇴사·전배) */}
-      {(needsPayrollAck || needsMonthlyCloseAck || hrAlerts.length > 0) && (
+      {(notices.payrollAck || notices.monthlyCloseAck || notices.hrAlerts.items.length > 0) && (
         <Card className="border-slate-200 bg-white shadow-sm">
           <CardContent className="p-4 space-y-3">
             <div className="flex items-start gap-2.5">
@@ -480,68 +569,60 @@ export function PortalDashboard() {
               </div>
             </div>
 
-            {needsPayrollAck && payrollRun && (
+            {notices.payrollAck && (
               <div className="flex items-center justify-between gap-3 rounded-xl border border-slate-200 bg-slate-50 p-3">
                 <div className="min-w-0">
                   <p className="text-[12px]" style={{ fontWeight: 700 }}>
-                    인건비 지급 예정: {payrollRun.plannedPayDate}
+                    인건비 지급 예정: {notices.payrollAck.plannedPayDate}
                   </p>
                   <p className="text-[10px] text-muted-foreground">
-                    공지일: {payrollRun.noticeDate} (지급일 3영업일 전)
+                    공지일: {notices.payrollAck.noticeDate} (지급일 3영업일 전)
                   </p>
                 </div>
-                <Button
-                  size="sm"
-                  className="h-8 text-[12px] gap-1.5 shrink-0"
-                  onClick={onAckPayroll}
-                >
+                <Button size="sm" className="h-8 text-[12px] gap-1.5 shrink-0" onClick={onAckPayroll}>
                   <CheckCircle2 className="w-3.5 h-3.5" /> 확인했습니다
                 </Button>
               </div>
             )}
 
-            {needsMonthlyCloseAck && monthlyClosePrev && (
+            {notices.monthlyCloseAck && (
               <div className="flex items-center justify-between gap-3 rounded-xl border border-slate-200 bg-slate-50 p-3">
                 <div className="min-w-0">
                   <p className="text-[12px]" style={{ fontWeight: 700 }}>
-                    월간 정산 완료 확인: {monthlyClosePrev.yearMonth}
+                    월간 정산 완료 확인: {notices.monthlyCloseAck.yearMonth}
                   </p>
                   <p className="text-[10px] text-muted-foreground">
-                    완료일: {monthlyClosePrev.doneAt ? new Date(monthlyClosePrev.doneAt).toLocaleDateString('ko-KR') : '-'}
+                    완료일: {notices.monthlyCloseAck.doneAt ? new Date(notices.monthlyCloseAck.doneAt).toLocaleDateString('ko-KR') : '-'}
                   </p>
                 </div>
-                <Button
-                  size="sm"
-                  className="h-8 text-[12px] gap-1.5 shrink-0"
-                  onClick={onAckMonthlyClose}
-                >
+                <Button size="sm" className="h-8 text-[12px] gap-1.5 shrink-0" onClick={onAckMonthlyClose}>
                   <CheckCircle2 className="w-3.5 h-3.5" /> 확인했습니다
                 </Button>
               </div>
             )}
 
-            {hrAlerts.length > 0 && (
+            {notices.hrAlerts.items.length > 0 && (
               <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
-                <div className="flex items-center justify-between gap-3 mb-2">
+                <div className="mb-2 flex items-center justify-between gap-3">
                   <p className="text-[12px]" style={{ fontWeight: 700 }}>인사 공지 (미확인)</p>
                   <Button variant="outline" size="sm" className="h-7 text-[11px]" onClick={() => navigate('/portal/change-requests')}>
                     확인하러 가기
                   </Button>
                 </div>
                 <div className="space-y-1.5">
-                  {hrAlerts.slice(0, 3).map((a) => (
-                    <div key={a.id} className="flex items-center justify-between gap-2 text-[11px]">
+                  {notices.hrAlerts.items.map((item) => (
+                    <div key={item.id} className="flex items-center justify-between gap-2 text-[11px]">
                       <div className="min-w-0">
-                        <span className={`text-[9px] h-4 px-1.5 inline-flex items-center rounded ${HR_EVENT_COLORS[a.eventType]}`}>
-                          {HR_EVENT_LABELS[a.eventType]}
+                        <span className={`inline-flex h-4 items-center rounded px-1.5 text-[9px] ${HR_EVENT_COLORS[item.eventType as keyof typeof HR_EVENT_COLORS] || 'bg-slate-100 text-slate-700'}`}>
+                          {HR_EVENT_LABELS[item.eventType as keyof typeof HR_EVENT_LABELS] || item.eventType}
                         </span>
-                        <span className="ml-2 truncate">{a.employeeName} · {a.effectiveDate}</span>
+                        <span className="ml-2 truncate">{item.employeeName} · {item.effectiveDate}</span>
                       </div>
-                      <Badge variant="outline" className="text-[10px] shrink-0">{a.projectId}</Badge>
+                      <Badge variant="outline" className="shrink-0 text-[10px]">{item.projectId}</Badge>
                     </div>
                   ))}
-                  {hrAlerts.length > 3 && (
-                    <p className="text-[10px] text-muted-foreground">외 {hrAlerts.length - 3}건</p>
+                  {notices.hrAlerts.overflowCount > 0 && (
+                    <p className="text-[10px] text-muted-foreground">외 {notices.hrAlerts.overflowCount}건</p>
                   )}
                 </div>
               </div>
@@ -552,31 +633,14 @@ export function PortalDashboard() {
 
       {shouldShowPayrollQueue && (
         <PortalPayrollQueueCard
-          item={payrollDetail}
-          riskItems={payrollRiskItems}
+          item={payrollQueue.item}
+          riskItems={payrollQueue.riskItems}
           onOpenDetail={() => navigate('/portal/payroll')}
           onOpenBankStatements={() => navigate('/portal/bank-statements')}
         />
       )}
-
     </div>
   );
-}
-
-const PORTAL_PAYROLL_BADGE_STYLES: Record<PayrollLiquidityQueueItem['status'], string> = {
-  insufficient_balance: 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300',
-  payment_unconfirmed: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
-  baseline_missing: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
-  balance_unknown: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
-  clear: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
-};
-
-function portalPayrollLabel(status: PayrollLiquidityQueueItem['status']) {
-  if (status === 'insufficient_balance') return '잔액 부족 위험';
-  if (status === 'payment_unconfirmed') return '지급 확인 필요';
-  if (status === 'baseline_missing') return '기준 지급액 없음';
-  if (status === 'balance_unknown') return '잔액 데이터 없음';
-  return '이번 지급 창 안정';
 }
 
 function PortalPayrollQueueCard({
@@ -585,15 +649,15 @@ function PortalPayrollQueueCard({
   onOpenDetail,
   onOpenBankStatements,
 }: {
-  item: PayrollLiquidityQueueItem | null;
-  riskItems: PayrollLiquidityQueueItem[];
+  item: DashboardPayrollQueueItem | null;
+  riskItems: DashboardPayrollQueueItem[];
   onOpenDetail: () => void;
   onOpenBankStatements: () => void;
 }) {
   return (
     <Card data-testid="portal-payroll-liquidity-card" className="border-border/60 shadow-sm">
       <CardHeader className="pb-2">
-        <CardTitle className="flex items-center justify-between gap-2 text-[13px]">
+        <h2 className="flex items-center justify-between gap-2 text-[13px]" style={{ fontWeight: 700 }}>
           <span className="flex items-center gap-2">
             <div className="flex h-7 w-7 items-center justify-center rounded-xl bg-emerald-50 text-emerald-600 dark:bg-emerald-950/40 dark:text-emerald-300">
               <CircleDollarSign className="h-4 w-4" />
@@ -603,7 +667,7 @@ function PortalPayrollQueueCard({
           <Button variant="outline" size="sm" className="h-7 text-[11px]" onClick={onOpenDetail}>
             상세 보기
           </Button>
-        </CardTitle>
+        </h2>
       </CardHeader>
       <CardContent className="space-y-3 pt-0">
         {!item ? (
@@ -616,12 +680,10 @@ function PortalPayrollQueueCard({
               <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
                 <div className="min-w-0 space-y-1">
                   <div className="flex items-center gap-2">
-                    <Badge className={`text-[10px] ${PORTAL_PAYROLL_BADGE_STYLES[risk.status]}`}>
+                    <Badge className={`text-[10px] ${PORTAL_PAYROLL_BADGE_STYLES[risk.status] || PORTAL_PAYROLL_BADGE_STYLES.clear}`}>
                       {portalPayrollLabel(risk.status)}
                     </Badge>
-                    <span className="text-[11px] text-muted-foreground">
-                      지급일 {risk.plannedPayDate}
-                    </span>
+                    <span className="text-[11px] text-muted-foreground">지급일 {risk.plannedPayDate}</span>
                   </div>
                   <p className="text-[13px] text-foreground" style={{ fontWeight: 700 }}>
                     예상 인건비 {risk.expectedPayrollAmount !== null ? `${fmtShort(risk.expectedPayrollAmount)}원` : '-'} · 최저 잔액 {risk.worstBalance !== null ? `${fmtShort(risk.worstBalance)}원` : '-'}

--- a/src/app/components/portal/PortalEntryReadBoundary.shell.test.ts
+++ b/src/app/components/portal/PortalEntryReadBoundary.shell.test.ts
@@ -16,6 +16,18 @@ describe('portal entry read boundary', () => {
     expect(dashboardSource).toContain('createPlatformApiClient(import.meta.env)');
     expect(dashboardSource).toContain('fetchPortalDashboardSummaryViaBff');
     expect(dashboardSource).toContain('dashboardSummary');
+    const portalStoreDestructure = dashboardSource.match(
+      /const\s*\{([\s\S]*?)\}\s*=\s*usePortalStore\(\);/,
+    );
+
+    expect(portalStoreDestructure?.[1]).toBeDefined();
+    const destructuredPortalStoreFields = portalStoreDestructure?.[1]
+      ?.split(',')
+      .map((field) => field.trim())
+      .filter(Boolean)
+      .sort();
+
+    expect(destructuredPortalStoreFields).toEqual(['isLoading', 'myProject', 'portalUser']);
   });
 
   it('hydrates payroll surface from the portal payroll summary BFF contract', () => {

--- a/src/app/components/portal/PortalRealtimeSafety.test.ts
+++ b/src/app/components/portal/PortalRealtimeSafety.test.ts
@@ -20,7 +20,15 @@ describe('portal realtime safety', () => {
     expect(portalDashboardSource).not.toContain('query(');
     expect(portalDashboardSource).not.toContain('where(');
     expect(portalDashboardSource).not.toContain('onSnapshot(');
-    expect(portalDashboardSource).toContain('transactions');
+  });
+
+  it('keeps the portal dashboard summary-first and raw-surface free', () => {
+    expect(portalDashboardSource).not.toMatch(/\bweeklySubmissionStatuses\b/);
+    expect(portalDashboardSource).not.toMatch(/\bprojects\b/);
+    expect(portalDashboardSource).not.toMatch(/\btransactions\b/);
+    expect(portalDashboardSource).not.toMatch(/\bgetProjectAlerts\b/);
+    expect(portalDashboardSource).not.toMatch(/\bruns\b/);
+    expect(portalDashboardSource).not.toMatch(/\bmonthlyCloses\b/);
   });
 
   it('does not fan out raw transaction reads from the portal payroll page', () => {

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -174,7 +174,15 @@ describe('platform-bff-client', () => {
       post: vi.fn(),
       get: vi.fn(async () => ({
         data: {
-          project: { id: 'p001', name: 'Project 1', managerName: '보람' },
+          project: {
+            id: 'p001',
+            name: 'Project 1',
+            managerName: '보람',
+            clientOrg: 'MYSC',
+            settlementType: 'TYPE1',
+            basis: '공급가액',
+            contractAmount: 3000000,
+          },
           summary: {
             payrollRiskCount: 1,
             visibleProjects: 3,
@@ -185,6 +193,24 @@ describe('platform-bff-client', () => {
             expense: { label: '지급 여력 양호', detail: '3주차 · 지급 여력 양호', tone: 'success' },
             visibleIssues: [],
           },
+          financeSummaryItems: [
+            { label: '총 입금', value: '300만' },
+            { label: '총 출금', value: '125만' },
+            { label: '잔액', value: '175만' },
+            { label: '소진율', value: '41.7%' },
+          ],
+          submissionRows: [
+            {
+              id: 'p001',
+              name: 'Project 1',
+              shortName: 'P1',
+              projectionInputLabel: '입력됨',
+              projectionDoneLabel: '제출 완료',
+              expenseLabel: '동기화 완료',
+              expenseTone: 'success',
+              latestProjectionUpdatedAt: '2026-04-16T09:00:00.000Z',
+            },
+          ],
         },
       })),
       request: vi.fn(),
@@ -193,13 +219,23 @@ describe('platform-bff-client', () => {
     const result = await fetchPortalDashboardSummaryViaBff({
       tenantId: 'mysc',
       actor: { uid: 'u001', role: 'pm', idToken: 'token-abc' },
+      projectId: 'p001',
       client,
     });
 
-    expect(client.get).toHaveBeenCalledWith('/api/v1/portal/dashboard-summary', expect.objectContaining({
+    expect(client.get).toHaveBeenCalledWith('/api/v1/portal/dashboard-summary?projectId=p001', expect.objectContaining({
       tenantId: 'mysc',
     }));
     expect(result.summary.payrollRiskCount).toBe(1);
+    expect(result.project).toMatchObject({
+      clientOrg: 'MYSC',
+      managerName: '보람',
+      settlementType: 'TYPE1',
+      basis: '공급가액',
+      contractAmount: 3000000,
+    });
+    expect(result.financeSummaryItems[0]).toEqual({ label: '총 입금', value: '300만' });
+    expect(result.submissionRows[0]?.expenseTone).toBe('success');
   });
 
   it('calls portal payroll summary endpoint', async () => {

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -1,9 +1,11 @@
 import { featureFlags, parseFeatureFlag } from '../config/feature-flags';
 import type {
   AccountType,
+  Basis,
   ProjectSheetSourceSnapshot,
   ProjectSheetSourceType,
   ProjectRequestContractAnalysis,
+  SettlementType,
   TransactionState,
 } from '../data/types';
 import { PlatformApiClient } from '../platform/api-client';
@@ -139,6 +141,9 @@ export interface PortalReadModelProjectSummary {
   department?: string;
   status?: string;
   type?: string;
+  settlementType?: SettlementType;
+  basis?: Basis;
+  contractAmount?: number;
 }
 
 export interface PortalDashboardSummaryResult {
@@ -149,6 +154,13 @@ export interface PortalDashboardSummaryResult {
     hrAlertCount: number;
     currentWeekLabel: string;
   };
+  currentWeek: {
+    label: string;
+    weekStart: string;
+    weekEnd: string;
+    yearMonth: string;
+    weekNo: number;
+  } | null;
   surface: {
     currentWeekLabel: string;
     projection: {
@@ -166,6 +178,83 @@ export interface PortalDashboardSummaryResult {
       count: number;
       tone: 'neutral' | 'warn' | 'danger';
       to: string;
+    }>;
+  };
+  financeSummaryItems: Array<{
+    label: string;
+    value: string;
+  }>;
+  submissionRows: Array<{
+    id: string;
+    name: string;
+    shortName: string;
+    projectionInputLabel: string;
+    projectionDoneLabel: string;
+    expenseLabel: string;
+    expenseTone: 'neutral' | 'warning' | 'danger' | 'success';
+    latestProjectionUpdatedAt?: string;
+  }>;
+  notices: {
+    payrollAck: {
+      runId: string;
+      plannedPayDate: string;
+      noticeDate: string;
+    } | null;
+    monthlyCloseAck: {
+      closeId: string;
+      yearMonth: string;
+      doneAt?: string;
+    } | null;
+    hrAlerts: {
+      count: number;
+      items: Array<{
+        id: string;
+        employeeName: string;
+        eventType: string;
+        effectiveDate: string;
+        projectId: string;
+      }>;
+      overflowCount: number;
+    };
+  };
+  payrollQueue: {
+    item: {
+      projectId: string;
+      projectName: string;
+      projectShortName: string;
+      runId: string;
+      yearMonth: string;
+      plannedPayDate: string;
+      windowStart: string;
+      windowEnd: string;
+      expectedPayrollAmount: number | null;
+      baselineRunId: string | null;
+      status: string;
+      statusReason: string;
+      dayBalances: Array<{ date: string; balance: number | null }>;
+      worstBalance: number | null;
+      currentBalance: number | null;
+      paidStatus: string;
+      acknowledged: boolean;
+    } | null;
+    riskItems: Array<{
+      projectId: string;
+      projectName: string;
+      projectShortName: string;
+      runId: string;
+      yearMonth: string;
+      plannedPayDate: string;
+      windowStart: string;
+      windowEnd: string;
+      expectedPayrollAmount: number | null;
+      baselineRunId: string | null;
+      status: string;
+      statusReason: string;
+      dayBalances: Array<{ date: string; balance: number | null }>;
+      worstBalance: number | null;
+      currentBalance: number | null;
+      paidStatus: string;
+      acknowledged: boolean;
     }>;
   };
   registrationState?: 'registered' | 'unregistered';
@@ -1190,11 +1279,12 @@ export async function fetchPortalOnboardingContextViaBff(params: {
 export async function fetchPortalDashboardSummaryViaBff(params: {
   tenantId: string;
   actor: ActorLike;
+  projectId: string;
   client?: PlatformApiClientLike;
 }): Promise<PortalDashboardSummaryResult> {
   const apiClient = resolveClient(params.client);
   const response = await apiClient.get<PortalDashboardSummaryResult>(
-    '/api/v1/portal/dashboard-summary',
+    `/api/v1/portal/dashboard-summary?projectId=${encodeURIComponent(params.projectId)}`,
     {
       tenantId: params.tenantId,
       actor: toRequestActor(params.actor),

--- a/src/app/platform/dev-harness-portal-api.test.ts
+++ b/src/app/platform/dev-harness-portal-api.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import { resolveDevHarnessPortalApiResponse } from '../../../vite.config';
 import {
+  buildDevHarnessPortalBankStatementsSummary,
+  buildDevHarnessPortalDashboardSummary,
   buildDevHarnessPortalEntryContext,
   buildDevHarnessPortalOnboardingContext,
+  buildDevHarnessPortalPayrollSummary,
   buildDevHarnessPortalRegistrationResult,
   buildDevHarnessPortalSessionProjectResult,
+  buildDevHarnessPortalWeeklyExpensesSummary,
 } from './dev-harness-portal-api';
 
 describe('dev harness portal api helpers', () => {
@@ -46,5 +51,108 @@ describe('dev harness portal api helpers', () => {
 
   it('rejects session project switches for unknown projects', () => {
     expect(() => buildDevHarnessPortalSessionProjectResult('missing-project')).toThrow('project_not_found');
+  });
+
+  it('builds dashboard summary for a visible PM project', () => {
+    const entry = buildDevHarnessPortalEntryContext({ actorId: 'u002', actorRole: 'pm' });
+    const summary = buildDevHarnessPortalDashboardSummary({
+      actorId: 'u002',
+      actorRole: 'pm',
+      projectId: entry.activeProjectId,
+    });
+
+    expect(summary.project.id).toBe(entry.activeProjectId);
+    expect(summary.currentWeek?.label).toBeTruthy();
+    expect(summary.financeSummaryItems).toHaveLength(4);
+    expect(summary.submissionRows.length).toBeGreaterThan(0);
+    expect(summary.surface.currentWeekLabel).toMatch(/주차$/);
+  });
+
+  it('rejects dashboard summary requests for unknown projects', () => {
+    expect(() => buildDevHarnessPortalDashboardSummary({
+      actorId: 'u002',
+      actorRole: 'pm',
+      projectId: 'missing-project',
+    })).toThrow('project_not_found');
+  });
+
+  it('handles dashboard summary requests through the vite dev harness router', async () => {
+    const response = await resolveDevHarnessPortalApiResponse({
+      enabled: true,
+      method: 'GET',
+      url: '/api/v1/portal/dashboard-summary?projectId=p001',
+      actorId: 'u002',
+      actorRole: 'pm',
+      readBody: async () => ({}),
+    });
+
+    expect(response.handled).toBe(true);
+    expect(response.statusCode).toBe(200);
+    expect(response.payload).toMatchObject({
+      project: { id: 'p001' },
+      summary: { currentWeekLabel: expect.stringMatching(/주차$/) },
+    });
+  });
+
+  it('builds payroll, weekly expenses, and bank statement summaries for a visible PM project', () => {
+    const payroll = buildDevHarnessPortalPayrollSummary({ actorId: 'u002', actorRole: 'pm' });
+    const weeklyExpenses = buildDevHarnessPortalWeeklyExpensesSummary({ actorId: 'u002', actorRole: 'pm' });
+    const bankStatements = buildDevHarnessPortalBankStatementsSummary({ actorId: 'u002', actorRole: 'pm' });
+
+    expect(payroll.currentRun?.projectId).toBe(payroll.project.id);
+    expect(payroll.queue.length).toBeGreaterThan(0);
+
+    expect(weeklyExpenses.expenseSheet.activeSheetName).toBe('기본 탭');
+    expect(weeklyExpenses.bankStatement.rowCount).toBeGreaterThan(0);
+    expect(weeklyExpenses.handoff.canOpenWeeklyExpenses).toBe(true);
+
+    expect(bankStatements.bankStatement.profile).toBe('generic');
+    expect(bankStatements.handoffContext.ready).toBe(true);
+    expect(bankStatements.handoffContext.nextPath).toBe('/portal/weekly-expenses');
+  });
+
+  it('handles phase1 read-model summary routes through the vite dev harness router', async () => {
+    const [payroll, weeklyExpenses, bankStatements] = await Promise.all([
+      resolveDevHarnessPortalApiResponse({
+        enabled: true,
+        method: 'GET',
+        url: '/api/v1/portal/payroll-summary',
+        actorId: 'u002',
+        actorRole: 'pm',
+        readBody: async () => ({}),
+      }),
+      resolveDevHarnessPortalApiResponse({
+        enabled: true,
+        method: 'GET',
+        url: '/api/v1/portal/weekly-expenses-summary',
+        actorId: 'u002',
+        actorRole: 'pm',
+        readBody: async () => ({}),
+      }),
+      resolveDevHarnessPortalApiResponse({
+        enabled: true,
+        method: 'GET',
+        url: '/api/v1/portal/bank-statements-summary',
+        actorId: 'u002',
+        actorRole: 'pm',
+        readBody: async () => ({}),
+      }),
+    ]);
+
+    expect(payroll).toMatchObject({
+      handled: true,
+      statusCode: 200,
+      payload: { project: { id: expect.any(String) }, summary: { queueCount: expect.any(Number) } },
+    });
+    expect(weeklyExpenses).toMatchObject({
+      handled: true,
+      statusCode: 200,
+      payload: { expenseSheet: { activeSheetName: '기본 탭' } },
+    });
+    expect(bankStatements).toMatchObject({
+      handled: true,
+      statusCode: 200,
+      payload: { handoffContext: { ready: true, nextPath: '/portal/weekly-expenses' } },
+    });
   });
 });

--- a/src/app/platform/dev-harness-portal-api.ts
+++ b/src/app/platform/dev-harness-portal-api.ts
@@ -1,4 +1,7 @@
 import { ORG_MEMBERS, PROJECTS } from '../data/mock-data';
+import { resolveCurrentCashflowWeek } from './cashflow-export-surface';
+import { buildPortalDashboardSurface } from './portal-dashboard-surface';
+import type { WeeklySubmissionStatus } from '../data/types';
 
 type PortalEntryProjectSummary = {
   id: string;
@@ -35,7 +38,151 @@ type PortalSessionProjectResult = {
   activeProjectId: string;
 };
 
+type PortalDashboardSummaryResult = {
+  project: PortalEntryProjectSummary & {
+    settlementType?: string;
+    basis?: string;
+    contractAmount?: number;
+  };
+  summary: {
+    payrollRiskCount: number;
+    visibleProjects: number;
+    hrAlertCount: number;
+    currentWeekLabel: string;
+  };
+  currentWeek: {
+    label: string;
+    weekStart: string;
+    weekEnd: string;
+    yearMonth: string;
+    weekNo: number;
+  } | null;
+  surface: ReturnType<typeof buildPortalDashboardSurface>;
+  financeSummaryItems: Array<{ label: string; value: string }>;
+  submissionRows: Array<{
+    id: string;
+    name: string;
+    shortName: string;
+    projectionInputLabel: string;
+    projectionDoneLabel: string;
+    expenseLabel: string;
+    expenseTone: 'neutral' | 'warning' | 'danger' | 'success';
+    latestProjectionUpdatedAt?: string;
+  }>;
+  notices: {
+    payrollAck: null;
+    monthlyCloseAck: null;
+    hrAlerts: {
+      count: number;
+      items: [];
+      overflowCount: number;
+    };
+  };
+  payrollQueue: {
+    item: null;
+    riskItems: [];
+  };
+  registrationState: 'registered' | 'unregistered';
+};
+
+type PortalPayrollSummaryResult = {
+  project: PortalDashboardSummaryResult['project'];
+  schedule: {
+    id: string;
+    projectId: string;
+    dayOfMonth: number;
+    timezone: string;
+    noticeLeadBusinessDays: number;
+    active: boolean;
+  };
+  currentRun: {
+    id: string;
+    projectId: string;
+    yearMonth: string;
+    plannedPayDate: string;
+    noticeDate: string;
+    noticeLeadBusinessDays: number;
+    acknowledged: boolean;
+    paidStatus: string;
+    expectedPayrollAmount: number | null;
+    baselineRunId: string | null;
+    status: string;
+    statusReason: string;
+    dayBalances: Array<{ date: string; balance: number | null }>;
+    worstBalance: number | null;
+    currentBalance: number | null;
+  } | null;
+  summary: {
+    queueCount: number;
+    riskCount: number;
+    status: string;
+    statusReason: string;
+  };
+  queue: Array<NonNullable<PortalPayrollSummaryResult['currentRun']> & {
+    projectName: string;
+    projectShortName: string;
+    runId: string;
+    windowStart: string;
+    windowEnd: string;
+  }>;
+  registrationState: 'registered' | 'unregistered';
+};
+
+type PortalWeeklyExpensesSummaryResult = {
+  project: PortalDashboardSummaryResult['project'];
+  summary: {
+    currentWeekLabel: string;
+    expenseReviewPendingCount: number;
+  };
+  expenseSheet: {
+    activeSheetId: string;
+    activeSheetName: string;
+    sheetCount: number;
+    rowCount: number;
+  };
+  bankStatement: {
+    rowCount: number;
+    columnCount: number;
+    profile: string;
+    lastSavedAt?: string;
+  };
+  sheetSources: Array<{
+    sourceType: string;
+    sheetName: string;
+    fileName: string;
+    rowCount: number;
+    columnCount: number;
+    uploadedAt?: string;
+  }>;
+  handoff: {
+    canOpenWeeklyExpenses: boolean;
+    canUseEvidenceWorkflow: boolean;
+    nextPath: string;
+  };
+  registrationState: 'registered' | 'unregistered';
+};
+
+type PortalBankStatementsSummaryResult = {
+  project: PortalDashboardSummaryResult['project'];
+  bankStatement: {
+    rowCount: number;
+    columnCount: number;
+    profile: string;
+    lastSavedAt?: string;
+  };
+  handoffContext: {
+    ready: boolean;
+    reason: string;
+    nextPath: string;
+    activeExpenseSheetId: string;
+    activeExpenseSheetName: string;
+    sheetCount: number;
+  };
+  registrationState: 'registered' | 'unregistered';
+};
+
 const PRIVILEGED_ROLES = new Set(['admin', 'finance']);
+const DEV_HARNESS_TODAY_ISO = '2026-04-16';
 
 function normalizeText(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
@@ -81,11 +228,76 @@ function normalizeProject(project: Record<string, unknown>): PortalEntryProjectS
   };
 }
 
+function fmtWon(value: number): string {
+  return `${new Intl.NumberFormat('ko-KR').format(value)}원`;
+}
+
+function buildHarnessWeeklyStatuses(projectIds: string[]): WeeklySubmissionStatus[] {
+  const currentWeek = resolveCurrentCashflowWeek(DEV_HARNESS_TODAY_ISO);
+  if (!currentWeek) return [];
+  return projectIds.map((projectId, index) => {
+    const edited = index === 0;
+    const submitted = index === 0;
+    const reviewRequired = index === 1;
+    return {
+      id: `${projectId}-${currentWeek.yearMonth}-w${currentWeek.weekNo}`,
+      projectId,
+      yearMonth: currentWeek.yearMonth,
+      weekNo: currentWeek.weekNo,
+      projectionEdited: edited,
+      projectionUpdated: submitted,
+      projectionUpdatedAt: edited ? '2026-04-15T02:30:00.000Z' : undefined,
+      expenseEdited: true,
+      expenseUpdated: !reviewRequired,
+      expenseSyncState: reviewRequired ? 'review_required' : 'synced',
+      expenseReviewPendingCount: reviewRequired ? 2 : 0,
+      expenseUpdatedAt: !reviewRequired ? '2026-04-15T04:30:00.000Z' : undefined,
+      updatedAt: '2026-04-15T04:30:00.000Z',
+    };
+  });
+}
+
+function resolveHarnessProjectContext(params: {
+  actorId?: string;
+  actorRole?: string;
+  projectId?: string;
+}) {
+  const actorId = normalizeText(params.actorId) || ORG_MEMBERS.find((member) => member.role === 'pm')?.uid || 'u002';
+  const actorRole = normalizeRole(params.actorRole) || 'pm';
+  const context = buildDevHarnessPortalEntryContext({ actorId, actorRole });
+  const requestedProjectId = normalizeText(params.projectId);
+  const targetProjectId = requestedProjectId || context.activeProjectId;
+  const currentProject = context.projects.find((project) => project.id === targetProjectId);
+  if (!currentProject) {
+    throw new Error('project_not_found');
+  }
+  const projectRecord = PROJECTS.find((project) => project.id === currentProject.id);
+  return {
+    actorId,
+    actorRole,
+    context,
+    currentProject,
+    projectRecord,
+  };
+}
+
+function buildHarnessProjectReadModel(
+  project: PortalEntryProjectSummary,
+  projectRecord?: Record<string, unknown>,
+): PortalDashboardSummaryResult['project'] {
+  return {
+    ...project,
+    settlementType: normalizeText(projectRecord?.settlementType) || undefined,
+    basis: normalizeText(projectRecord?.basis) || undefined,
+    contractAmount: typeof projectRecord?.contractAmount === 'number' ? projectRecord.contractAmount : undefined,
+  };
+}
+
 function listVisibleProjects(actorId: string, actorRole: string): {
   projects: PortalEntryProjectSummary[];
   priorityProjectIds: string[];
 } {
-  const activeProjects = PROJECTS.filter((project) => !normalizeText((project as Record<string, unknown>).trashedAt));
+  const activeProjects = PROJECTS.filter((project) => !normalizeText((project as unknown as Record<string, unknown>).trashedAt));
   if (PRIVILEGED_ROLES.has(actorRole)) {
     return {
       projects: activeProjects
@@ -138,7 +350,7 @@ export function buildDevHarnessPortalOnboardingContext(params: {
 }): PortalOnboardingContextResult {
   const actorRole = normalizeRole(params.actorRole) || 'pm';
   const projects = PROJECTS
-    .filter((project) => !normalizeText((project as Record<string, unknown>).trashedAt))
+    .filter((project) => !normalizeText((project as unknown as Record<string, unknown>).trashedAt))
     .map((project) => normalizeProject(project as unknown as Record<string, unknown>))
     .sort((left, right) => left.name.localeCompare(right.name, 'ko'));
   const defaultProjectIds = PRIVILEGED_ROLES.has(actorRole) ? [] : normalizeProjectIds([resolveDefaultPmProjectId()]);
@@ -159,6 +371,218 @@ export function buildDevHarnessPortalSessionProjectResult(projectId: string): Po
   return {
     ok: true,
     activeProjectId: normalizedProjectId,
+  };
+}
+
+export function buildDevHarnessPortalDashboardSummary(params: {
+  actorId?: string;
+  actorRole?: string;
+  projectId?: string;
+}): PortalDashboardSummaryResult {
+  const { context, currentProject, projectRecord } = resolveHarnessProjectContext(params);
+  const currentWeek = resolveCurrentCashflowWeek(DEV_HARNESS_TODAY_ISO);
+  const weeklyStatuses = buildHarnessWeeklyStatuses(context.projects.map((project) => project.id));
+  const surface = buildPortalDashboardSurface({
+    projectId: currentProject.id,
+    weeklySubmissionStatuses: weeklyStatuses,
+    todayIso: DEV_HARNESS_TODAY_ISO,
+    hrAlertCount: 0,
+    payrollRiskCount: 0,
+  });
+
+  return {
+    project: buildHarnessProjectReadModel(currentProject, projectRecord),
+    summary: {
+      payrollRiskCount: 0,
+      visibleProjects: context.projects.length,
+      hrAlertCount: 0,
+      currentWeekLabel: surface.currentWeekLabel,
+    },
+    currentWeek: currentWeek
+      ? {
+        label: `${currentWeek.weekNo}주차`,
+        weekStart: currentWeek.weekStart,
+        weekEnd: currentWeek.weekEnd,
+        yearMonth: currentWeek.yearMonth,
+        weekNo: currentWeek.weekNo,
+      }
+      : null,
+    surface,
+    financeSummaryItems: [
+      { label: '총 입금', value: fmtWon(Number(projectRecord?.contractAmount || 0)) },
+      { label: '총 출금', value: fmtWon(Math.floor(Number(projectRecord?.budgetCurrentYear || 0) * 0.6)) },
+      { label: '잔액', value: fmtWon(Math.floor(Number(projectRecord?.budgetCurrentYear || 0) * 0.4)) },
+      { label: '소진율', value: projectRecord?.budgetCurrentYear ? '60%' : '-' },
+    ],
+    submissionRows: context.projects.map((project, index) => {
+      const status = weeklyStatuses.find((row) => row.projectId === project.id);
+      const surfaceForProject = buildPortalDashboardSurface({
+        projectId: project.id,
+        weeklySubmissionStatuses: weeklyStatuses,
+        todayIso: DEV_HARNESS_TODAY_ISO,
+        hrAlertCount: 0,
+        payrollRiskCount: 0,
+      });
+      return {
+        id: project.id,
+        name: project.name,
+        shortName: project.name,
+        projectionInputLabel: status?.projectionEdited ? '입력됨' : '미입력',
+        projectionDoneLabel: status?.projectionUpdated ? '제출 완료' : '미제출',
+        expenseLabel: surfaceForProject.expense.label,
+        expenseTone: surfaceForProject.expense.tone === 'muted' ? 'neutral' : surfaceForProject.expense.tone,
+        latestProjectionUpdatedAt: status?.projectionUpdatedAt,
+      };
+    }),
+    notices: {
+      payrollAck: null,
+      monthlyCloseAck: null,
+      hrAlerts: {
+        count: 0,
+        items: [],
+        overflowCount: 0,
+      },
+    },
+    payrollQueue: {
+      item: null,
+      riskItems: [],
+    },
+    registrationState: context.registrationState,
+  };
+}
+
+export function buildDevHarnessPortalPayrollSummary(params: {
+  actorId?: string;
+  actorRole?: string;
+  projectId?: string;
+}): PortalPayrollSummaryResult {
+  const { context, currentProject, projectRecord } = resolveHarnessProjectContext(params);
+  const schedule = {
+    id: `${currentProject.id}-schedule`,
+    projectId: currentProject.id,
+    dayOfMonth: 25,
+    timezone: 'Asia/Seoul',
+    noticeLeadBusinessDays: 3,
+    active: true,
+  };
+  const currentRun = {
+    id: `${currentProject.id}-run-2026-04`,
+    projectId: currentProject.id,
+    yearMonth: '2026-04',
+    plannedPayDate: '2026-04-25',
+    noticeDate: '2026-04-22',
+    noticeLeadBusinessDays: 3,
+    acknowledged: false,
+    paidStatus: 'PENDING',
+    expectedPayrollAmount: Math.max(1_200_000, Math.floor(Number(projectRecord?.budgetCurrentYear || 0) * 0.08)),
+    baselineRunId: `${currentProject.id}-run-2026-03`,
+    status: 'payment_unconfirmed',
+    statusReason: '지급일이 다가와 잔액과 지급 상태를 함께 점검해야 합니다.',
+    dayBalances: [
+      { date: '2026-04-22', balance: Math.max(2_400_000, Math.floor(Number(projectRecord?.budgetCurrentYear || 0) * 0.15)) },
+      { date: '2026-04-25', balance: Math.max(1_900_000, Math.floor(Number(projectRecord?.budgetCurrentYear || 0) * 0.12)) },
+      { date: '2026-04-28', balance: Math.max(1_600_000, Math.floor(Number(projectRecord?.budgetCurrentYear || 0) * 0.1)) },
+    ],
+    worstBalance: Math.max(1_600_000, Math.floor(Number(projectRecord?.budgetCurrentYear || 0) * 0.1)),
+    currentBalance: Math.max(1_900_000, Math.floor(Number(projectRecord?.budgetCurrentYear || 0) * 0.12)),
+  };
+  return {
+    project: buildHarnessProjectReadModel(currentProject, projectRecord),
+    schedule,
+    currentRun,
+    summary: {
+      queueCount: 1,
+      riskCount: 1,
+      status: currentRun.status,
+      statusReason: currentRun.statusReason,
+    },
+    queue: [{
+      ...currentRun,
+      projectName: currentProject.name,
+      projectShortName: currentProject.name,
+      runId: currentRun.id,
+      windowStart: '2026-04-22',
+      windowEnd: '2026-04-28',
+    }],
+    registrationState: context.registrationState,
+  };
+}
+
+export function buildDevHarnessPortalWeeklyExpensesSummary(params: {
+  actorId?: string;
+  actorRole?: string;
+  projectId?: string;
+}): PortalWeeklyExpensesSummaryResult {
+  const { context, currentProject, projectRecord } = resolveHarnessProjectContext(params);
+  const currentWeek = resolveCurrentCashflowWeek(DEV_HARNESS_TODAY_ISO);
+  return {
+    project: buildHarnessProjectReadModel(currentProject, projectRecord),
+    summary: {
+      currentWeekLabel: currentWeek ? `${currentWeek.weekNo}주차` : '-',
+      expenseReviewPendingCount: 2,
+    },
+    expenseSheet: {
+      activeSheetId: 'default',
+      activeSheetName: '기본 탭',
+      sheetCount: 1,
+      rowCount: 6,
+    },
+    bankStatement: {
+      rowCount: 12,
+      columnCount: 6,
+      profile: 'generic',
+      lastSavedAt: '2026-04-15T04:30:00.000Z',
+    },
+    sheetSources: [
+      {
+        sourceType: 'bank_statement',
+        sheetName: '원본 업로드',
+        fileName: 'bank-statement-apr.xlsx',
+        rowCount: 12,
+        columnCount: 6,
+        uploadedAt: '2026-04-15T04:00:00.000Z',
+      },
+      {
+        sourceType: 'evidence_rules',
+        sheetName: '증빙 규칙',
+        fileName: 'evidence-rules.xlsx',
+        rowCount: 4,
+        columnCount: 3,
+        uploadedAt: '2026-04-15T04:05:00.000Z',
+      },
+    ],
+    handoff: {
+      canOpenWeeklyExpenses: true,
+      canUseEvidenceWorkflow: true,
+      nextPath: '/portal/bank-statements',
+    },
+    registrationState: context.registrationState,
+  };
+}
+
+export function buildDevHarnessPortalBankStatementsSummary(params: {
+  actorId?: string;
+  actorRole?: string;
+  projectId?: string;
+}): PortalBankStatementsSummaryResult {
+  const { context, currentProject, projectRecord } = resolveHarnessProjectContext(params);
+  return {
+    project: buildHarnessProjectReadModel(currentProject, projectRecord),
+    bankStatement: {
+      rowCount: 12,
+      columnCount: 6,
+      profile: 'generic',
+      lastSavedAt: '2026-04-15T04:30:00.000Z',
+    },
+    handoffContext: {
+      ready: true,
+      reason: '저장된 통장내역이 있습니다.',
+      nextPath: '/portal/weekly-expenses',
+      activeExpenseSheetId: 'default',
+      activeExpenseSheetName: '기본 탭',
+      sheetCount: 1,
+    },
+    registrationState: context.registrationState,
   };
 }
 

--- a/src/app/platform/harness-stability.contract.test.ts
+++ b/src/app/platform/harness-stability.contract.test.ts
@@ -16,10 +16,13 @@ describe('phase1 harness stability contracts', () => {
   it('runs the local harness serially to avoid dev-server churn false negatives', () => {
     expect(playwrightHarnessConfigSource).toContain('workers: 1');
     expect(playwrightHarnessConfigSource).toContain("fullyParallel: false");
-    expect(playwrightHarnessConfigSource).toContain("const PORTAL_ORIGIN = 'http://localhost:4173';");
+    expect(playwrightHarnessConfigSource).toContain("const DEFAULT_PORTAL_HOST = 'localhost';");
+    expect(playwrightHarnessConfigSource).toContain("const DEFAULT_PORTAL_PORT = '4173';");
+    expect(playwrightHarnessConfigSource).toContain('const PORTAL_HOST = process.env.PORTAL_HARNESS_HOST || DEFAULT_PORTAL_HOST;');
+    expect(playwrightHarnessConfigSource).toContain('const PORTAL_PORT = process.env.PORTAL_HARNESS_PORT || DEFAULT_PORTAL_PORT;');
     expect(playwrightHarnessConfigSource).toMatch(/baseURL:\s*PORTAL_ORIGIN/);
     expect(playwrightHarnessConfigSource).toMatch(
-      /VITE_PLATFORM_API_BASE_URL=\$\{PORTAL_ORIGIN\}\s+npm run dev -- --host \$\{PORTAL_HOST\} --port 4173/,
+      /VITE_PLATFORM_API_BASE_URL=\$\{PORTAL_ORIGIN\}\s+npm run dev -- --host \$\{PORTAL_HOST\} --port \$\{PORTAL_PORT\}/,
     );
     expect(playwrightHarnessConfigSource).toContain('url: `${PORTAL_ORIGIN}/login`,');
   });
@@ -28,6 +31,10 @@ describe('phase1 harness stability contracts', () => {
     expect(viteConfigSource).toContain('devHarnessPortalApiPlugin()');
     expect(viteConfigSource).toContain("/api/v1/portal/entry-context");
     expect(viteConfigSource).toContain("/api/v1/portal/onboarding-context");
+    expect(viteConfigSource).toContain("/api/v1/portal/dashboard-summary");
+    expect(viteConfigSource).toContain("/api/v1/portal/payroll-summary");
+    expect(viteConfigSource).toContain("/api/v1/portal/weekly-expenses-summary");
+    expect(viteConfigSource).toContain("/api/v1/portal/bank-statements-summary");
     expect(viteConfigSource).toContain("/api/v1/portal/session-project");
     expect(viteConfigSource).toContain("/api/v1/portal/registration");
     expect(viteConfigSource).not.toContain('hasAuthHeader');

--- a/tests/e2e/support/portal-network-artifact.test.ts
+++ b/tests/e2e/support/portal-network-artifact.test.ts
@@ -37,8 +37,10 @@ describe('portal network artifact file output', () => {
   it('keeps the Playwright harness on localhost origin and preserves artifact dir support', () => {
     const configSource = readFileSync(new URL('../../../playwright.harness.config.mjs', import.meta.url), 'utf8');
 
-    expect(configSource).toContain("const PORTAL_ORIGIN = 'http://localhost:4173'");
-    expect(configSource).toContain("const PORTAL_HOST = 'localhost'");
+    expect(configSource).toContain("const DEFAULT_PORTAL_HOST = 'localhost';");
+    expect(configSource).toContain("const DEFAULT_PORTAL_PORT = '4173';");
+    expect(configSource).toContain('const PORTAL_HOST = process.env.PORTAL_HARNESS_HOST || DEFAULT_PORTAL_HOST;');
+    expect(configSource).toContain('const PORTAL_PORT = process.env.PORTAL_HARNESS_PORT || DEFAULT_PORTAL_PORT;');
     expect(configSource).toContain('process.env.PORTAL_NETWORK_ARTIFACT_DIR ||= path.resolve');
     expect(configSource).not.toContain('127.0.0.1');
   });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,10 +4,14 @@ import path from 'path'
 import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import {
+  buildDevHarnessPortalBankStatementsSummary,
+  buildDevHarnessPortalDashboardSummary,
   buildDevHarnessPortalEntryContext,
   buildDevHarnessPortalOnboardingContext,
+  buildDevHarnessPortalPayrollSummary,
   buildDevHarnessPortalRegistrationResult,
   buildDevHarnessPortalSessionProjectResult,
+  buildDevHarnessPortalWeeklyExpensesSummary,
 } from './src/app/platform/dev-harness-portal-api'
 
 function getVendorChunkName(id: string): string | undefined {
@@ -89,6 +93,120 @@ function writeJson(res: ServerResponse, statusCode: number, payload: unknown) {
   res.end(JSON.stringify(payload))
 }
 
+export async function resolveDevHarnessPortalApiResponse(params: {
+  enabled: boolean
+  method: string
+  url: string
+  actorId: string
+  actorRole: string
+  readBody: () => Promise<unknown>
+}): Promise<{
+  handled: boolean
+  statusCode?: number
+  payload?: unknown
+}> {
+  const method = String(params.method || 'GET').toUpperCase()
+  const requestUrl = new URL(params.url || '/', 'http://localhost')
+  const pathName = requestUrl.pathname
+
+  if (!params.enabled || !pathName.startsWith('/api/v1/portal/')) {
+    return { handled: false }
+  }
+
+  try {
+    if (method === 'GET' && pathName === '/api/v1/portal/entry-context') {
+      return {
+        handled: true,
+        statusCode: 200,
+        payload: buildDevHarnessPortalEntryContext({ actorId: params.actorId, actorRole: params.actorRole }),
+      }
+    }
+
+    if (method === 'GET' && pathName === '/api/v1/portal/onboarding-context') {
+      return {
+        handled: true,
+        statusCode: 200,
+        payload: buildDevHarnessPortalOnboardingContext({ actorRole: params.actorRole }),
+      }
+    }
+
+    if (method === 'GET' && pathName === '/api/v1/portal/dashboard-summary') {
+      return {
+        handled: true,
+        statusCode: 200,
+        payload: buildDevHarnessPortalDashboardSummary({
+          actorId: params.actorId,
+          actorRole: params.actorRole,
+          projectId: requestUrl.searchParams.get('projectId') || '',
+        }),
+      }
+    }
+
+    if (method === 'GET' && pathName === '/api/v1/portal/payroll-summary') {
+      return {
+        handled: true,
+        statusCode: 200,
+        payload: buildDevHarnessPortalPayrollSummary({
+          actorId: params.actorId,
+          actorRole: params.actorRole,
+        }),
+      }
+    }
+
+    if (method === 'GET' && pathName === '/api/v1/portal/weekly-expenses-summary') {
+      return {
+        handled: true,
+        statusCode: 200,
+        payload: buildDevHarnessPortalWeeklyExpensesSummary({
+          actorId: params.actorId,
+          actorRole: params.actorRole,
+        }),
+      }
+    }
+
+    if (method === 'GET' && pathName === '/api/v1/portal/bank-statements-summary') {
+      return {
+        handled: true,
+        statusCode: 200,
+        payload: buildDevHarnessPortalBankStatementsSummary({
+          actorId: params.actorId,
+          actorRole: params.actorRole,
+        }),
+      }
+    }
+
+    if (method === 'POST' && pathName === '/api/v1/portal/session-project') {
+      const body = await params.readBody() as { projectId?: string }
+      return {
+        handled: true,
+        statusCode: 200,
+        payload: buildDevHarnessPortalSessionProjectResult(body.projectId || ''),
+      }
+    }
+
+    if (method === 'POST' && pathName === '/api/v1/portal/registration') {
+      const body = await params.readBody() as { projectId?: string; projectIds?: string[] }
+      return {
+        handled: true,
+        statusCode: 200,
+        payload: buildDevHarnessPortalRegistrationResult(body),
+      }
+    }
+  } catch (error) {
+    const code = error instanceof Error ? error.message : 'dev_harness_portal_api_error'
+    return {
+      handled: true,
+      statusCode: 400,
+      payload: {
+        error: code,
+        message: code,
+      },
+    }
+  }
+
+  return { handled: false }
+}
+
 function devHarnessPortalApiPlugin(): PluginOption {
   return {
     name: 'dev-harness-portal-api',
@@ -96,48 +214,24 @@ function devHarnessPortalApiPlugin(): PluginOption {
       server.middlewares.use(async (req, res, next) => {
         const enabled = String(process.env.VITE_DEV_AUTH_HARNESS_ENABLED || '').trim().toLowerCase() === 'true'
         const method = String(req.method || 'GET').toUpperCase()
-        const pathName = String(req.url || '').split('?')[0]
 
-        if (!enabled || !pathName.startsWith('/api/v1/portal/')) {
+        const actorId = typeof req.headers['x-actor-id'] === 'string' ? req.headers['x-actor-id'] : ''
+        const actorRole = typeof req.headers['x-actor-role'] === 'string' ? req.headers['x-actor-role'] : ''
+        const response = await resolveDevHarnessPortalApiResponse({
+          enabled,
+          method,
+          url: req.url || '/',
+          actorId,
+          actorRole,
+          readBody: async () => readRequestBody(req),
+        })
+
+        if (!response.handled) {
           next()
           return
         }
 
-        const actorId = typeof req.headers['x-actor-id'] === 'string' ? req.headers['x-actor-id'] : ''
-        const actorRole = typeof req.headers['x-actor-role'] === 'string' ? req.headers['x-actor-role'] : ''
-
-        try {
-          if (method === 'GET' && pathName === '/api/v1/portal/entry-context') {
-            writeJson(res, 200, buildDevHarnessPortalEntryContext({ actorId, actorRole }))
-            return
-          }
-
-          if (method === 'GET' && pathName === '/api/v1/portal/onboarding-context') {
-            writeJson(res, 200, buildDevHarnessPortalOnboardingContext({ actorRole }))
-            return
-          }
-
-          if (method === 'POST' && pathName === '/api/v1/portal/session-project') {
-            const body = await readRequestBody(req) as { projectId?: string }
-            writeJson(res, 200, buildDevHarnessPortalSessionProjectResult(body.projectId || ''))
-            return
-          }
-
-          if (method === 'POST' && pathName === '/api/v1/portal/registration') {
-            const body = await readRequestBody(req) as { projectId?: string; projectIds?: string[] }
-            writeJson(res, 200, buildDevHarnessPortalRegistrationResult(body))
-            return
-          }
-        } catch (error) {
-          const code = error instanceof Error ? error.message : 'dev_harness_portal_api_error'
-          writeJson(res, 400, {
-            error: code,
-            message: code,
-          })
-          return
-        }
-
-        next()
+        writeJson(res, response.statusCode || 200, response.payload)
       })
     },
   }


### PR DESCRIPTION
## Summary
- close the portal dashboard read-boundary slice on top of the network gate foundation
- make dashboard summaries project-explicit and suppress stale cross-project dashboard state
- add dev-harness support for portal dashboard summary routes so Playwright and the canonical gate exercise the same BFF boot path

## Verification
- npx vitest run src/app/lib/platform-bff-client.test.ts server/bff/routes/portal-read-model.test.mjs src/app/components/portal/PortalDashboard.regression.test.ts src/app/components/portal/PortalDashboard.layout.test.ts src/app/components/portal/PortalEntryReadBoundary.shell.test.ts src/app/components/portal/PortalRealtimeSafety.test.ts src/app/platform/dev-harness-portal-api.test.ts
- npm run phase0:portal:network-gate -- --json-out /tmp/portal-network-gate-dashboard-final-clean.json