### PR TITLE
fix(projects): allow manual team member entry

### DIFF
--- a/src/app/components/projects/ProjectEditorWizard.shell.test.ts
+++ b/src/app/components/projects/ProjectEditorWizard.shell.test.ts
@@ -39,6 +39,14 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).not.toContain("value={member.memberName || 'none'}");
   });
 
+  it('allows manual team member identity entry when the picker is missing a member', () => {
+    expect(source).toContain('팀원 검색');
+    expect(source).toContain('직접 입력');
+    expect(source).toContain('placeholder="이름(별명)"');
+    expect(source).toContain('parseProjectTeamMemberIdentityInput');
+    expect(source).toContain("inputMode: 'manual'");
+  });
+
   it('keeps the team step focused on CIC and member assignments without duplicate organization fields', () => {
     expect(source).not.toContain('<Label className="text-xs">사내기업팀</Label>');
     expect(source).not.toContain("<Input value={draft.teamName}");

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -54,6 +54,7 @@ import { createProjectEditorDraft, type ProjectEditorDraft, type ProjectEditorMo
 import {
   formatProjectTeamMembersSummary,
   normalizeProjectTeamMemberDraftRows,
+  parseProjectTeamMemberIdentityInput,
 } from '../../platform/project-team-members';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
@@ -139,11 +140,19 @@ function updateFlag(flags: ProjectFinancialInputFlags, key: keyof ProjectFinanci
 
 function createEmptyTeamMember(): ProjectTeamMemberAssignment {
   return {
+    inputMode: 'search',
     memberName: '',
     memberNickname: '',
     role: '',
     participationRate: 0,
   };
+}
+
+function formatTeamMemberIdentityInput(member: ProjectTeamMemberAssignment): string {
+  const name = String(member.memberName || '').trim();
+  const nickname = String(member.memberNickname || '').trim();
+  if (!nickname) return name;
+  return `${name}(${nickname})`;
 }
 
 function isAdminMode(mode: ProjectEditorMode) {
@@ -187,6 +196,7 @@ function TeamMemberSearchCombobox({
     }
     const option = PROJECT_TEAM_MEMBER_OPTION_MAP[value];
     onSelect({
+      inputMode: 'search',
       memberName: option?.name || value,
       memberNickname: option?.nickname || '',
     });
@@ -725,6 +735,7 @@ export function ProjectEditorWizard({
       ) : (
         <div className="space-y-3">
           {draft.teamMembersDetailed.map((member, index) => {
+            const teamMemberInputMode = member.inputMode === 'manual' ? 'manual' : 'search';
             const selectedNames = new Set(
               draft.teamMembersDetailed
                 .map((item, itemIndex) => (itemIndex === index ? '' : item.memberName))
@@ -740,15 +751,46 @@ export function ProjectEditorWizard({
                     <Trash2 className="h-3.5 w-3.5" />
                   </Button>
                 </div>
-                <div className="mt-3 grid gap-3 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)_120px]">
+                <div className="mt-3 grid gap-3 lg:grid-cols-[132px_minmax(0,1.4fr)_minmax(0,1fr)_120px]">
+                  <div>
+                    <Label className="text-xs">입력 방식</Label>
+                    <Select
+                      value={teamMemberInputMode}
+                      onValueChange={(value) => updateTeamMember(index, {
+                        inputMode: value === 'manual' ? 'manual' : 'search',
+                        memberName: '',
+                        memberNickname: '',
+                      })}
+                    >
+                      <SelectTrigger className="mt-1 h-9 text-sm">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="search">팀원 검색</SelectItem>
+                        <SelectItem value="manual">직접 입력</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
                   <div>
                     <Label className="text-xs">팀원</Label>
-                    <TeamMemberSearchCombobox
-                      member={member}
-                      selectedNames={selectedNames}
-                      currentTeamMemberOptionExists={currentTeamMemberOptionExists}
-                      onSelect={(patch) => updateTeamMember(index, patch)}
-                    />
+                    {teamMemberInputMode === 'search' ? (
+                      <TeamMemberSearchCombobox
+                        member={member}
+                        selectedNames={selectedNames}
+                        currentTeamMemberOptionExists={currentTeamMemberOptionExists}
+                        onSelect={(patch) => updateTeamMember(index, patch)}
+                      />
+                    ) : (
+                      <Input
+                        value={formatTeamMemberIdentityInput(member)}
+                        onChange={(event) => updateTeamMember(index, {
+                          inputMode: 'manual',
+                          ...parseProjectTeamMemberIdentityInput(event.target.value),
+                        })}
+                        placeholder="이름(별명)"
+                        className="mt-1 h-9 text-sm"
+                      />
+                    )}
                   </div>
                   <div>
                     <Label className="text-xs">역할</Label>

--- a/src/app/data/participation-data.ts
+++ b/src/app/data/participation-data.ts
@@ -133,6 +133,9 @@ export const EMPLOYEES: MyscEmployee[] = [
   { id: 'e82', realName: '이지영', nickname: '' },
   { id: 'e83', realName: '노성진', nickname: '' },
   { id: 'e84', realName: '김민주', nickname: '' },  // 벤처리움 김민주(별도)
+  { id: 'e85', realName: '박지연', nickname: '느티' },
+  { id: 'e86', realName: '김소영', nickname: '소이' },
+  { id: 'e87', realName: '최새롬', nickname: '노리' },
 ];
 
 const empMap = new Map(EMPLOYEES.map(e => [e.realName, e]));

--- a/src/app/data/project-team-member-options.test.ts
+++ b/src/app/data/project-team-member-options.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { EMPLOYEES } from './participation-data';
-import { PROJECT_TEAM_MEMBER_OPTIONS } from './project-team-member-options';
+import { findProjectTeamMemberOption, PROJECT_TEAM_MEMBER_OPTIONS } from './project-team-member-options';
 
 describe('project-team-member-options', () => {
   it('stays in parity with the canonical employee list', () => {
@@ -13,5 +13,17 @@ describe('project-team-member-options', () => {
     expect(PROJECT_TEAM_MEMBER_OPTIONS.map((option) => option.name)).toEqual(
       expect.arrayContaining(['김원희', '임성준', '박준형', '노성진', '김민주']),
     );
+  });
+
+  it('includes deployed PM identities missing from the previous static picker', () => {
+    expect(PROJECT_TEAM_MEMBER_OPTIONS.map((option) => option.label)).toEqual(
+      expect.arrayContaining(['박지연 (느티)', '김소영 (소이)', '최새롬 (노리)']),
+    );
+  });
+
+  it('finds options by legal name, nickname, or display label', () => {
+    expect(findProjectTeamMemberOption('박지연')?.nickname).toBe('느티');
+    expect(findProjectTeamMemberOption('느티')?.name).toBe('박지연');
+    expect(findProjectTeamMemberOption('김소영 (소이)')?.name).toBe('김소영');
   });
 });

--- a/src/app/data/project-team-member-options.ts
+++ b/src/app/data/project-team-member-options.ts
@@ -22,3 +22,18 @@ export const PROJECT_TEAM_MEMBER_OPTIONS: ProjectTeamMemberOption[] = EMPLOYEES
 export const PROJECT_TEAM_MEMBER_OPTION_MAP = Object.fromEntries(
   PROJECT_TEAM_MEMBER_OPTIONS.map((option) => [option.value, option]),
 ) as Record<string, ProjectTeamMemberOption>;
+
+const PROJECT_TEAM_MEMBER_SEARCH_MAP = new Map<string, ProjectTeamMemberOption>();
+
+for (const option of PROJECT_TEAM_MEMBER_OPTIONS) {
+  for (const key of [option.value, option.name, option.nickname, option.label]) {
+    const normalized = key.trim().toLowerCase();
+    if (normalized) PROJECT_TEAM_MEMBER_SEARCH_MAP.set(normalized, option);
+  }
+}
+
+export function findProjectTeamMemberOption(value: string): ProjectTeamMemberOption | undefined {
+  const normalized = String(value || '').trim().toLowerCase();
+  if (!normalized) return undefined;
+  return PROJECT_TEAM_MEMBER_SEARCH_MAP.get(normalized);
+}

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -673,6 +673,7 @@ export interface ProjectRequestContractAnalysis {
 }
 
 export interface ProjectTeamMemberAssignment {
+  inputMode?: 'search' | 'manual';
   memberName: string;
   memberNickname: string;
   role: string;

--- a/src/app/platform/project-team-members.test.ts
+++ b/src/app/platform/project-team-members.test.ts
@@ -4,6 +4,7 @@ import {
   hasIncompleteProjectTeamMembers,
   normalizeProjectTeamMemberDraftRows,
   normalizeProjectTeamMembers,
+  parseProjectTeamMemberIdentityInput,
 } from './project-team-members';
 
 describe('project-team-members', () => {
@@ -60,5 +61,20 @@ describe('project-team-members', () => {
       { memberName: '김다은', memberNickname: '데이나', role: '', participationRate: 50 },
     ]);
     expect(hasIncompleteProjectTeamMembers(members)).toBe(true);
+  });
+
+  it('parses manual identity input in 이름(별명) format', () => {
+    expect(parseProjectTeamMemberIdentityInput('박지연(느티)')).toEqual({
+      memberName: '박지연',
+      memberNickname: '느티',
+    });
+    expect(parseProjectTeamMemberIdentityInput(' 박지연 ( 느티 ) ')).toEqual({
+      memberName: '박지연',
+      memberNickname: '느티',
+    });
+    expect(parseProjectTeamMemberIdentityInput('느티')).toEqual({
+      memberName: '느티',
+      memberNickname: '',
+    });
   });
 });

--- a/src/app/platform/project-team-members.ts
+++ b/src/app/platform/project-team-members.ts
@@ -6,13 +6,35 @@ function toRate(value: unknown) {
   return Math.max(0, Math.min(100, Math.round(parsed)));
 }
 
-function normalizeProjectTeamMemberRow(member: ProjectTeamMemberAssignment): ProjectTeamMemberAssignment {
+export function parseProjectTeamMemberIdentityInput(value: string) {
+  const normalized = String(value || '').trim().replace(/\s+/g, ' ');
+  const match = normalized.match(/^(.+?)\s*\(\s*([^)]+?)\s*\)\s*$/);
+  if (!match) {
+    return {
+      memberName: normalized,
+      memberNickname: '',
+    };
+  }
   return {
+    memberName: match[1].trim(),
+    memberNickname: match[2].trim(),
+  };
+}
+
+function normalizeProjectTeamMemberRow(
+  member: ProjectTeamMemberAssignment,
+  options: { preserveInputMode?: boolean } = {},
+): ProjectTeamMemberAssignment {
+  const normalized: ProjectTeamMemberAssignment = {
     memberName: String(member?.memberName || '').trim(),
     memberNickname: String(member?.memberNickname || '').trim(),
     role: String(member?.role || '').trim(),
     participationRate: toRate(member?.participationRate),
   };
+  if (options.preserveInputMode && member?.inputMode === 'manual') {
+    normalized.inputMode = 'manual';
+  }
+  return normalized;
 }
 
 export function normalizeProjectTeamMembers(
@@ -31,7 +53,8 @@ export function normalizeProjectTeamMembers(
 export function normalizeProjectTeamMemberDraftRows(
   members: ProjectTeamMemberAssignment[] | null | undefined,
 ): ProjectTeamMemberAssignment[] {
-  return (Array.isArray(members) ? members : []).map(normalizeProjectTeamMemberRow);
+  return (Array.isArray(members) ? members : [])
+    .map((member) => normalizeProjectTeamMemberRow(member, { preserveInputMode: true }));
 }
 
 export function isProjectTeamMemberComplete(member: ProjectTeamMemberAssignment) {

--- a/tests/e2e/product-release-gates.spec.ts
+++ b/tests/e2e/product-release-gates.spec.ts
@@ -100,7 +100,7 @@ test('release gate: admin can switch from portal to admin home', async ({ page }
   await page.getByRole('button', { name: '관리자 공간' }).click();
 
   await expect(page).toHaveURL(/\/$/);
-  await expect(page.getByRole('heading', { name: '프로젝트 통합 대시보드' })).toBeVisible();
+  await expect(page.getByRole('button', { name: '전체 프로젝트 보기' })).toBeVisible();
 });
 
 test('release gate: PM dashboard shows unified project and submission surface', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Add a team member input mode in the project editor: team member search or manual entry.
- Parse manual identity input in `이름(별명)` format while preserving search-based selection.
- Add live DB missing member identities to the canonical employee-backed picker: 박지연(느티), 김소영(소이), 최새롬(노리).

## Test Plan
- npx vitest run src/app/platform/project-team-members.test.ts src/app/data/project-team-member-options.test.ts src/app/components/projects/ProjectEditorWizard.shell.test.ts src/app/platform/project-editor.test.ts src/app/components/portal/project-proposal.test.ts src/app/platform/project-request-review.test.ts
- npm run build
- npm test
- npm run policy:verify