### PR TITLE
fix(projects): preserve manual member IME input

### DIFF
--- a/src/app/components/projects/ProjectEditorWizard.shell.test.ts
+++ b/src/app/components/projects/ProjectEditorWizard.shell.test.ts
@@ -47,6 +47,12 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain("inputMode: 'manual'");
   });
 
+  it('keeps manual team member input bound to the raw typed value instead of reparsing formatted text', () => {
+    expect(source).toContain('formatTeamMemberIdentityInput(member)');
+    expect(source).toContain('identityInput: event.target.value');
+    expect(source).toContain('value={member.identityInput ?? formatTeamMemberIdentityInput(member)}');
+  });
+
   it('keeps the team step focused on CIC and member assignments without duplicate organization fields', () => {
     expect(source).not.toContain('<Label className="text-xs">사내기업팀</Label>');
     expect(source).not.toContain("<Input value={draft.teamName}");

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -197,6 +197,7 @@ function TeamMemberSearchCombobox({
     const option = PROJECT_TEAM_MEMBER_OPTION_MAP[value];
     onSelect({
       inputMode: 'search',
+      identityInput: undefined,
       memberName: option?.name || value,
       memberNickname: option?.nickname || '',
     });
@@ -758,6 +759,7 @@ export function ProjectEditorWizard({
                       value={teamMemberInputMode}
                       onValueChange={(value) => updateTeamMember(index, {
                         inputMode: value === 'manual' ? 'manual' : 'search',
+                        identityInput: value === 'manual' ? '' : undefined,
                         memberName: '',
                         memberNickname: '',
                       })}
@@ -782,9 +784,10 @@ export function ProjectEditorWizard({
                       />
                     ) : (
                       <Input
-                        value={formatTeamMemberIdentityInput(member)}
+                        value={member.identityInput ?? formatTeamMemberIdentityInput(member)}
                         onChange={(event) => updateTeamMember(index, {
                           inputMode: 'manual',
+                          identityInput: event.target.value,
                           ...parseProjectTeamMemberIdentityInput(event.target.value),
                         })}
                         placeholder="이름(별명)"

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -674,6 +674,7 @@ export interface ProjectRequestContractAnalysis {
 
 export interface ProjectTeamMemberAssignment {
   inputMode?: 'search' | 'manual';
+  identityInput?: string;
   memberName: string;
   memberNickname: string;
   role: string;

--- a/src/app/platform/project-team-members.test.ts
+++ b/src/app/platform/project-team-members.test.ts
@@ -45,6 +45,28 @@ describe('project-team-members', () => {
     ])).toEqual([]);
   });
 
+  it('preserves raw manual identity input while editing so Korean IME composition is not reformatted', () => {
+    expect(normalizeProjectTeamMemberDraftRows([
+      {
+        inputMode: 'manual',
+        identityInput: ' 박지연 ( 느티',
+        memberName: '박지연 ( 느티',
+        memberNickname: '',
+        role: '',
+        participationRate: 0,
+      },
+    ])).toEqual([
+      {
+        inputMode: 'manual',
+        identityInput: ' 박지연 ( 느티',
+        memberName: '박지연 ( 느티',
+        memberNickname: '',
+        role: '',
+        participationRate: 0,
+      },
+    ]);
+  });
+
   it('treats member with name and role but no rate as complete', () => {
     expect(hasIncompleteProjectTeamMembers([
       { memberName: '김다은', memberNickname: '', role: 'PM', participationRate: 0 },

--- a/src/app/platform/project-team-members.ts
+++ b/src/app/platform/project-team-members.ts
@@ -33,6 +33,9 @@ function normalizeProjectTeamMemberRow(
   };
   if (options.preserveInputMode && member?.inputMode === 'manual') {
     normalized.inputMode = 'manual';
+    if (typeof member?.identityInput === 'string') {
+      normalized.identityInput = member.identityInput;
+    }
   }
   return normalized;
 }


### PR DESCRIPTION
## Summary
- Preserve the raw manual team member input string while editing so Korean IME composition is not reformatted on each keystroke.
- Keep parsing the manual `이름(별명)` value into member name/nickname, while leaving the controlled input bound to the raw typed value.
- Drop the raw UI-only field during save normalization by only preserving it in draft rows.

## Test Plan
- npx vitest run src/app/platform/project-team-members.test.ts src/app/components/projects/ProjectEditorWizard.shell.test.ts src/app/platform/project-editor.test.ts src/app/data/project-team-member-options.test.ts
- npm run build
- npm test