### PR TITLE
포털 프로젝트 설정 화면 로딩 실패를 안전하게 처리

### DIFF
--- a/src/app/platform/lazy-route.test.ts
+++ b/src/app/platform/lazy-route.test.ts
@@ -38,4 +38,14 @@ describe('loadLazyRouteModule', () => {
     expect(spy).toHaveBeenCalledWith('[routes] failed to load PortalSubmissionsPage:', error);
     spy.mockRestore();
   });
+
+  it('falls back cleanly when a route module resolves to undefined', async () => {
+    const result = await loadLazyRouteModule(
+      async () => undefined as never,
+      'PortalProjectSettings',
+      Fallback,
+    );
+
+    expect(result.default).toBe(Fallback as ComponentType);
+  });
 });

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -44,7 +44,6 @@ const NotFoundPage = lazy(() => import('./components/layout/NotFoundPage').then(
 // Portal pages
 const PortalOnboarding = lazy(() => import('./components/portal/PortalOnboarding').then(m => ({ default: m.PortalOnboarding })));
 const PortalProjectSelectPage = lazy(() => import('./components/portal/PortalProjectSelectPage').then(m => ({ default: m.PortalProjectSelectPage })));
-const PortalProjectSettings = lazy(() => import('./components/portal/PortalProjectSettings').then(m => ({ default: m.PortalProjectSettings })));
 const PortalDashboard = lazy(() => import('./components/portal/PortalDashboard').then(m => ({ default: m.PortalDashboard })));
 const PortalBudget = lazy(() => import('./components/portal/PortalBudget').then(m => ({ default: m.PortalBudget })));
 const PortalPersonnel = lazy(() => import('./components/portal/PortalPersonnel').then(m => ({ default: m.PortalPersonnel })));
@@ -68,6 +67,12 @@ const PortalWeeklyExpensePage = lazy(() => loadLazyRouteModule(
   'PortalWeeklyExpensePage',
   RouteChunkFallback,
   '[routes] failed to load PortalWeeklyExpensePage:',
+));
+const PortalProjectSettings = lazy(() => loadLazyRouteModule(
+  () => import('./components/portal/PortalProjectSettings'),
+  'PortalProjectSettings',
+  RouteChunkFallback,
+  '[routes] failed to load PortalProjectSettings:',
 ));
 const PortalBankStatementPage = lazy(() => import('./components/portal/PortalBankStatementPage').then(m => ({ default: m.PortalBankStatementPage })));
 const GuideChatPage = lazy(() => import('./components/guide-chat/GuideChatPage').then(m => ({ default: m.GuideChatPage })));


### PR DESCRIPTION
## 한눈에 보기
- 포털 프로젝트 설정 화면을 불러올 때 문제가 생겨도 앱 전체가 깨지지 않도록 안전한 로딩 방식을 적용했습니다.
- 잘못된 lazy route 모듈이 들어와도 다시 안내 화면을 보여주는 회귀 테스트를 추가했습니다.
- Firestore나 실제 데이터 저장 흐름은 건드리지 않고 화면 로딩 보호에만 범위를 제한했습니다.

## 사용자가 체감하는 변화
- 프로젝트 설정 화면 진입 중 일부 파일 로딩 문제가 생겨도 전체 화면이 멈추는 일을 줄입니다.
- 사용자는 새로고침 또는 홈 이동 안내를 받을 수 있습니다.

## 확인한 것
- npx vitest run src/app/platform/lazy-route.test.ts src/app/routes.provider-scope.test.ts src/app/components/portal/PortalProjectSettings.shell.test.ts
- git diff --check
- npm run build
- npm run policy:verify
- npm test