### PR TITLE
BFF 서버를 로컬 Kubernetes에서 미리 점검하는 리허설 추가

### DIFF
--- a/infra/k8s/base/bff-deployment.yaml
+++ b/infra/k8s/base/bff-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysc-bff
+  labels:
+    app.kubernetes.io/name: mysc-bff
+    app.kubernetes.io/part-of: inner-platform
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mysc-bff
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mysc-bff
+        app.kubernetes.io/part-of: inner-platform
+    spec:
+      containers:
+        - name: bff
+          image: inner-platform-bff:local
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: mysc-bff-env
+          livenessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /api/v1/health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 192Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/infra/k8s/base/bff-service.yaml
+++ b/infra/k8s/base/bff-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysc-bff
+  labels:
+    app.kubernetes.io/name: mysc-bff
+    app.kubernetes.io/part-of: inner-platform
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: mysc-bff
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/infra/k8s/base/kustomization.yaml
+++ b/infra/k8s/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - bff-deployment.yaml
+  - bff-service.yaml

--- a/infra/k8s/local/kind-config.yaml
+++ b/infra/k8s/local/kind-config.yaml
@@ -1,0 +1,4 @@
+apiVersion: kind.x-k8s.io/v1alpha4
+kind: Cluster
+nodes:
+  - role: control-plane

--- a/infra/k8s/overlays/local/README.md
+++ b/infra/k8s/overlays/local/README.md
@@ -1,0 +1,25 @@
+# Local Kubernetes Rehearsal
+
+This overlay is for local BFF operations rehearsal only.
+
+Safety constraints:
+
+- `BFF_DEPLOY_ENV=local`
+- no live Firebase project ID
+- no live Firebase Admin credentials
+- no Kubernetes CronJobs
+- no public ingress
+- access by `kubectl port-forward` only
+
+Run:
+
+```bash
+bash scripts/k8s_local_rehearsal.sh
+```
+
+After the script completes:
+
+```bash
+kubectl -n inner-platform-local port-forward svc/mysc-bff 18787:8080
+curl http://127.0.0.1:18787/api/v1/health
+```

--- a/infra/k8s/overlays/local/bff-env-configmap.yaml
+++ b/infra/k8s/overlays/local/bff-env-configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mysc-bff-env
+data:
+  NODE_ENV: production
+  BFF_DEPLOY_ENV: local
+  FIREBASE_PROJECT_ID: demo-inner-platform-local
+  BFF_AUTH_MODE: headers
+  BFF_HOST: 0.0.0.0
+  BFF_PORT: "8080"
+  BFF_ALLOWED_ORIGINS: http://127.0.0.1:5173,http://localhost:5173
+  BFF_WORKERS_ENABLED: "false"
+  BFF_SCHEDULER_OWNER: disabled
+  FIRESTORE_EMULATOR_HOST: host.docker.internal:8080
+  FIREBASE_AUTH_EMULATOR_HOST: host.docker.internal:9099

--- a/infra/k8s/overlays/local/kustomization.yaml
+++ b/infra/k8s/overlays/local/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: inner-platform-local
+resources:
+  - namespace.yaml
+  - ../../base
+  - bff-env-configmap.yaml
+patches:
+  - target:
+      kind: Deployment
+      name: mysc-bff
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/imagePullPolicy
+        value: Never

--- a/infra/k8s/overlays/local/namespace.yaml
+++ b/infra/k8s/overlays/local/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: inner-platform-local
+  labels:
+    app.kubernetes.io/part-of: inner-platform
+    inner-platform.mysc.co.kr/environment: local

--- a/scripts/k8s_local_rehearsal.sh
+++ b/scripts/k8s_local_rehearsal.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLUSTER_NAME="${CLUSTER_NAME:-inner-platform-local}"
+NAMESPACE="${NAMESPACE:-inner-platform-local}"
+IMAGE="${IMAGE:-inner-platform-bff:local}"
+LOCAL_PORT="${LOCAL_PORT:-18787}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+KIND_CONFIG="${ROOT_DIR}/infra/k8s/local/kind-config.yaml"
+KUSTOMIZE_DIR="${ROOT_DIR}/infra/k8s/overlays/local"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd docker
+require_cmd kind
+require_cmd kubectl
+require_cmd curl
+
+cd "$ROOT_DIR"
+
+if ! docker info >/dev/null 2>&1; then
+  echo "Docker is not running. Start Docker Desktop, then retry." >&2
+  exit 1
+fi
+
+if ! kind get clusters | grep -Fxq "$CLUSTER_NAME"; then
+  kind create cluster --name "$CLUSTER_NAME" --config "$KIND_CONFIG"
+fi
+
+for attempt in 1 2 3; do
+  if docker build --pull=false -f server/bff/Dockerfile -t "$IMAGE" .; then
+    break
+  fi
+  if [ "$attempt" = "3" ]; then
+    echo "Docker image build failed after ${attempt} attempts." >&2
+    exit 1
+  fi
+  echo "Docker image build failed; retrying (${attempt}/3)..." >&2
+  sleep 10
+done
+kind load docker-image "$IMAGE" --name "$CLUSTER_NAME"
+
+kubectl config use-context "kind-${CLUSTER_NAME}" >/dev/null
+kubectl apply -k "$KUSTOMIZE_DIR"
+kubectl -n "$NAMESPACE" rollout restart deployment/mysc-bff
+kubectl -n "$NAMESPACE" rollout status deployment/mysc-bff --timeout=180s
+
+PF_LOG="$(mktemp -t inner-platform-bff-port-forward.XXXXXX.log)"
+kubectl -n "$NAMESPACE" port-forward svc/mysc-bff "${LOCAL_PORT}:8080" >"$PF_LOG" 2>&1 &
+PF_PID="$!"
+cleanup() {
+  kill "$PF_PID" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 30); do
+  if curl -fsS "http://127.0.0.1:${LOCAL_PORT}/api/v1/health" >/tmp/inner-platform-bff-health.json; then
+    cat /tmp/inner-platform-bff-health.json
+    echo
+    echo "Local BFF is reachable at http://127.0.0.1:${LOCAL_PORT}/api/v1/health"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "Port-forward health check failed. Port-forward log:" >&2
+cat "$PF_LOG" >&2
+exit 1

--- a/server/bff/Dockerfile
+++ b/server/bff/Dockerfile
@@ -3,9 +3,11 @@ FROM node:24-alpine
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev --ignore-scripts
 
 COPY server ./server
+COPY policies ./policies
+COPY src/app/policies ./src/app/policies
 
 ENV NODE_ENV=production
 ENV BFF_WORKERS_ENABLED=false

--- a/server/local-k8s-rehearsal.test.ts
+++ b/server/local-k8s-rehearsal.test.ts
@@ -1,0 +1,52 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(rootDir, relativePath), 'utf8');
+}
+
+describe('local Kubernetes rehearsal manifests', () => {
+  it('keeps the local overlay isolated from live data and schedulers', () => {
+    const configMap = read('infra/k8s/overlays/local/bff-env-configmap.yaml');
+    const overlay = read('infra/k8s/overlays/local/kustomization.yaml');
+    const namespace = read('infra/k8s/overlays/local/namespace.yaml');
+
+    expect(configMap).toContain('BFF_DEPLOY_ENV: local');
+    expect(configMap).toContain('FIREBASE_PROJECT_ID: demo-inner-platform-local');
+    expect(configMap).not.toContain('inner-platform-live-20260316');
+    expect(configMap).toContain('BFF_WORKERS_ENABLED: "false"');
+    expect(configMap).toContain('BFF_SCHEDULER_OWNER: disabled');
+    expect(configMap).toContain('FIRESTORE_EMULATOR_HOST: host.docker.internal:8080');
+    expect(overlay).toContain('value: Never');
+    expect(namespace).toContain('inner-platform.mysc.co.kr/environment: local');
+  });
+
+  it('does not define CronJobs or public ingress in the local overlay', () => {
+    const files = [
+      'infra/k8s/base/bff-deployment.yaml',
+      'infra/k8s/base/bff-service.yaml',
+      'infra/k8s/base/kustomization.yaml',
+      'infra/k8s/overlays/local/bff-env-configmap.yaml',
+      'infra/k8s/overlays/local/kustomization.yaml',
+      'infra/k8s/overlays/local/namespace.yaml',
+    ];
+    const combined = files.map(read).join('\n---\n');
+
+    expect(combined).not.toMatch(/\bkind:\s*CronJob\b/);
+    expect(combined).not.toMatch(/\bkind:\s*Ingress\b/);
+    expect(combined).not.toMatch(/\btype:\s*LoadBalancer\b/);
+    expect(combined).not.toMatch(/\btype:\s*NodePort\b/);
+  });
+
+  it('keeps the BFF container build compatible with production-only installs', () => {
+    const dockerfile = read('server/bff/Dockerfile');
+
+    expect(dockerfile).toContain('npm ci --omit=dev --ignore-scripts');
+    expect(dockerfile).toContain('COPY policies ./policies');
+    expect(dockerfile).toContain('COPY src/app/policies ./src/app/policies');
+  });
+});


### PR DESCRIPTION
## 한눈에 보기
- BFF 서버만 대상으로 로컬 Kubernetes 리허설 환경을 추가했습니다.
- Kustomize base/local 구성을 추가해 Deployment, 내부 Service, 로컬 전용 ConfigMap을 만들 수 있게 했습니다.
- 로컬 리허설이 실제 Firebase, CronJob, Ingress, LoadBalancer, NodePort와 섞이지 않도록 막았습니다.
- BFF Docker 이미지가 운영 설치 단계에서 정상 부팅되도록 prepare script와 정책 파일 복사를 정리했습니다.

## 왜 필요한가
운영 인프라에 올리기 전에 BFF 컨테이너가 Kubernetes 환경에서 제대로 뜨는지 로컬에서 먼저 확인하기 위한 안전장치입니다.

## 확인한 것
- bash scripts/k8s_local_rehearsal.sh
- kubectl -n inner-platform-local get deploy,svc,pods
- kubectl -n inner-platform-local get cronjobs,ingress
- /Users/boram/InnerPlatform/node_modules/.bin/vitest run server/local-k8s-rehearsal.test.ts
- git diff --check