### PR TITLE
main 병합이 자동으로 운영 배포되지 않도록 차단

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,11 @@
   "framework": "vite",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  },
   "functions": {
     "api/bff.js": {
       "maxDuration": 60


### PR DESCRIPTION
## 한눈에 보기
- Vercel의 main 브랜치 자동 운영 배포를 껐습니다.
- main이 아닌 브랜치는 계속 preview/stage 확인용으로 배포될 수 있게 유지했습니다.

## 왜 필요한가
기존에는 main에 병합되면 Vercel Git 연동이 바로 Production으로 올릴 수 있었습니다. 우리는 production-deploy.yml을 통한 명시적 운영 배포만 허용하려고 하므로, main 병합만으로 라이브가 바뀌는 상태는 위험했습니다.

## 사용자가 체감하는 변화
- main에 병합해도 운영 사이트가 자동으로 바뀌지 않습니다.
- Stage/Preview에서 확인한 뒤 정해진 절차로만 운영 반영할 수 있습니다.

## 확인한 것
- Node로 vercel.json 파싱 확인
- git diff --check
- submit-mysc.com alias가 현재 rollback 배포를 가리키는 것 확인