### PR TITLE
프로젝트 등록/수정 화면에서 계약서 PDF를 올릴 수 있게 추가

### DIFF
--- a/src/app/components/portal/PortalMinimalSweep.layout.test.ts
+++ b/src/app/components/portal/PortalMinimalSweep.layout.test.ts
@@ -86,15 +86,15 @@ describe('portal minimal sweep', () => {
     expect(projectEditorWizardSource).toContain('정산 시트 또는 엑셀 템플릿으로 직접 입력합니다.');
   });
 
-  it('lets rejected pm projects recover from the shared edit screen without contract extraction', () => {
+  it('lets rejected pm projects recover from the shared edit screen with contract upload available', () => {
     expect(projectEditSource).toContain('수정 후 다시 제출');
     expect(projectEditSource).toContain('반려 사유');
     expect(projectEditSource).toContain('승인 완료');
     expect(projectEditSource).toContain('검토 대기');
     expect(projectEditSource).not.toContain('다시 제출할 검토 요청 정보를 찾지 못했습니다.');
     expect(projectEditSource).not.toContain("actionId === 'resubmit' && !requestDoc");
-    expect(projectEditSource).not.toContain('계약서 PDF');
-    expect(projectEditSource).not.toContain('processProjectRequestContractViaBff');
+    expect(projectEditSource).toContain('processProjectRequestContractViaBff');
+    expect(projectEditSource).toContain('onContractFileUpload={handleContractFileUpload}');
     expect(projectEditSource).not.toContain('임원 심사 큐');
     expect(projectEditSource).not.toContain('임원 검토 큐');
   });

--- a/src/app/components/portal/PortalProjectEdit.tsx
+++ b/src/app/components/portal/PortalProjectEdit.tsx
@@ -10,6 +10,7 @@ import { getAuthInstance, getOrgCollectionPath, getOrgDocumentPath } from '../..
 import { useFirebase } from '../../lib/firebase-context';
 import {
   isPlatformApiEnabled,
+  processProjectRequestContractViaBff,
   upsertProjectViaBff,
   type UpsertProjectPayload,
 } from '../../lib/platform-bff-client';
@@ -261,6 +262,30 @@ export function PortalProjectEdit() {
     }
   };
 
+  const handleContractFileUpload = async (file: File) => {
+    if (!authUser?.uid) {
+      throw new Error('로그인 정보를 확인할 수 없습니다.');
+    }
+    if (!isPlatformApiEnabled()) {
+      throw new Error('계약서 업로드는 플랫폼 API가 켜진 환경에서만 사용할 수 있습니다.');
+    }
+    const idToken = authUser.idToken || await getAuthInstance()?.currentUser?.getIdToken() || undefined;
+    const processed = await processProjectRequestContractViaBff({
+      tenantId: orgId,
+      actor: {
+        uid: authUser.uid,
+        email: authUser.email,
+        role: authUser.role,
+        idToken,
+      },
+      file,
+    });
+    return {
+      contractDocument: processed.contractDocument,
+      contractAnalysis: processed.analysis,
+    };
+  };
+
   if (!myProject) {
     return (
       <Card className="border-dashed border-slate-200 bg-slate-50">
@@ -284,6 +309,7 @@ export function PortalProjectEdit() {
         ...(canResubmit ? [{ id: 'resubmit', label: '수정 후 다시 제출', icon: SendHorizontal, variant: 'secondary' as const }] : []),
       ]}
       busyActionId={busyActionId}
+      onContractFileUpload={handleContractFileUpload}
       onCancel={() => navigate('/portal')}
       onSubmit={(draft, actionId) => void handleSubmit(draft, actionId)}
       topSlot={executiveBanner ? (

--- a/src/app/components/portal/PortalProjectRegister.tsx
+++ b/src/app/components/portal/PortalProjectRegister.tsx
@@ -9,6 +9,7 @@ import { useFirebase } from '../../lib/firebase-context';
 import {
   isPlatformApiEnabled,
   notifyProjectRequestRegistrationViaBff,
+  processProjectRequestContractViaBff,
 } from '../../lib/platform-bff-client';
 import {
   buildProjectRequestPayloadFromDraft,
@@ -78,6 +79,30 @@ export function PortalProjectRegister() {
     }
   };
 
+  const handleContractFileUpload = async (file: File) => {
+    if (!authUser?.uid) {
+      throw new Error('로그인 정보를 확인할 수 없습니다.');
+    }
+    if (!isPlatformApiEnabled()) {
+      throw new Error('계약서 업로드는 플랫폼 API가 켜진 환경에서만 사용할 수 있습니다.');
+    }
+    const idToken = authUser.idToken || await getAuthInstance()?.currentUser?.getIdToken() || undefined;
+    const processed = await processProjectRequestContractViaBff({
+      tenantId: orgId,
+      actor: {
+        uid: authUser.uid,
+        email: authUser.email,
+        role: authUser.role,
+        idToken,
+      },
+      file,
+    });
+    return {
+      contractDocument: processed.contractDocument,
+      contractAnalysis: processed.analysis,
+    };
+  };
+
   if (submitted) {
     return (
       <div className="mx-auto max-w-3xl py-10">
@@ -110,6 +135,7 @@ export function PortalProjectRegister() {
       draftKey={`portal-register-${authUser?.uid || 'anonymous'}`}
       actions={[{ id: 'submit', label: '등록 요청 저장', icon: Send }]}
       busyActionId={busyActionId}
+      onContractFileUpload={handleContractFileUpload}
       onCancel={() => navigate('/portal')}
       onSubmit={(draft) => void handleSubmit(draft)}
     />

--- a/src/app/components/projects/ProjectEditorWizard.shell.test.ts
+++ b/src/app/components/projects/ProjectEditorWizard.shell.test.ts
@@ -90,4 +90,14 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain('descriptionClassName="text-rose-600"');
     expect(source).not.toContain('업로드된 PDF를 마지막 확인 단계에서 바로 봅니다.');
   });
+
+  it('supports contract PDF upload before saving registration or edit drafts', () => {
+    expect(source).toContain('onContractFileUpload');
+    expect(source).toContain('handleContractDocumentSelect');
+    expect(source).toContain('MAX_CONTRACT_UPLOAD_SIZE_BYTES');
+    expect(source).toContain('mergeContractAnalysisIntoDraft');
+    expect(source).toContain('계약서 업로드');
+    expect(source).toContain('계약서 교체');
+    expect(source).toContain('첨부 제거');
+  });
 });

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -8,13 +8,18 @@ import {
   ChevronsUpDown,
   ClipboardList,
   CreditCard,
+  FileText,
+  Loader2,
   Plus,
   Save,
   Trash2,
+  Upload,
+  X,
   Users,
   Wallet,
 } from 'lucide-react';
-import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type ChangeEvent, type ReactNode } from 'react';
+import { toast } from 'sonner';
 import {
   ACCOUNT_TYPE_LABELS,
   BASIS_LABELS,
@@ -35,6 +40,7 @@ import {
   type ProjectFinancialInputFlags,
   type ProjectFundInputMode,
   type ProjectPhase,
+  type ProjectRequestContractAnalysis,
   type ProjectStatus,
   type ProjectTeamMemberAssignment,
   type ProjectType,
@@ -104,9 +110,18 @@ interface ProjectEditorWizardProps {
   topSlot?: ReactNode;
   actions: ProjectEditorAction[];
   busyActionId?: string | null;
+  onContractFileUpload?: (file: File) => Promise<{
+    contractDocument: ProjectEditorDraft['contractDocument'];
+    contractAnalysis: ProjectRequestContractAnalysis | null;
+  }>;
   onCancel?: () => void;
   onSubmit: (draft: ProjectEditorDraft, actionId: string) => void | Promise<void>;
 }
+
+const MAX_CONTRACT_UPLOAD_SIZE_BYTES = 4 * 1024 * 1024;
+const MAX_CONTRACT_UPLOAD_SIZE_LABEL = '4MB';
+
+type ContractUploadState = 'idle' | 'extracting' | 'ready' | 'error';
 
 const STEPS: Array<{
   id: ProjectEditorStep;
@@ -122,6 +137,43 @@ const STEPS: Array<{
 
 function fmtKRW(value: number) {
   return value ? value.toLocaleString('ko-KR') : '0';
+}
+
+function readText(value: unknown) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function readNumberSuggestion(value: ProjectRequestContractAnalysis['fields']['contractAmount'] | undefined) {
+  return typeof value?.value === 'number' && Number.isFinite(value.value) ? value.value : null;
+}
+
+function mergeContractAnalysisIntoDraft(
+  prev: ProjectEditorDraft,
+  analysis: ProjectRequestContractAnalysis | null,
+): ProjectEditorDraft {
+  if (!analysis) return prev;
+  const currentFlags = normalizeProjectFinancialInputFlags(prev.financialInputFlags);
+  const suggestedContractAmount = readNumberSuggestion(analysis.fields.contractAmount);
+  const suggestedSalesVatAmount = readNumberSuggestion(analysis.fields.salesVatAmount);
+  const shouldApplyContractAmount = !currentFlags.contractAmount && suggestedContractAmount != null;
+  const shouldApplySalesVatAmount = !currentFlags.salesVatAmount && suggestedSalesVatAmount != null;
+
+  return createProjectEditorDraft({
+    ...prev,
+    officialContractName: prev.officialContractName || readText(analysis.fields.officialContractName?.value),
+    clientOrg: prev.clientOrg || readText(analysis.fields.clientOrg?.value),
+    contractStart: prev.contractStart || readText(analysis.fields.contractStart?.value),
+    contractEnd: prev.contractEnd || readText(analysis.fields.contractEnd?.value),
+    projectPurpose: prev.projectPurpose || readText(analysis.fields.projectPurpose?.value),
+    description: prev.description || readText(analysis.fields.description?.value),
+    contractAmount: shouldApplyContractAmount ? suggestedContractAmount : prev.contractAmount,
+    salesVatAmount: shouldApplySalesVatAmount ? suggestedSalesVatAmount : prev.salesVatAmount,
+    financialInputFlags: {
+      ...currentFlags,
+      contractAmount: currentFlags.contractAmount || suggestedContractAmount != null,
+      salesVatAmount: currentFlags.salesVatAmount || suggestedSalesVatAmount != null,
+    },
+  });
 }
 
 function formatPaymentPlanAmount(amount: number, contractAmount: number) {
@@ -287,15 +339,21 @@ export function ProjectEditorWizard({
   topSlot,
   actions,
   busyActionId,
+  onContractFileUpload,
   onCancel,
   onSubmit,
 }: ProjectEditorWizardProps) {
   const [stepIndex, setStepIndex] = useState(0);
   const [draft, setDraft] = useState<ProjectEditorDraft>(() => createProjectEditorWizardDraft(initialDraft));
+  const [contractUploadState, setContractUploadState] = useState<ContractUploadState>('idle');
+  const [contractUploadError, setContractUploadError] = useState('');
+  const contractUploadInputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
     setDraft(createProjectEditorWizardDraft(initialDraft));
     setStepIndex(0);
+    setContractUploadState('idle');
+    setContractUploadError('');
   }, [draftKey]);
 
   const step = STEPS[stepIndex];
@@ -374,6 +432,61 @@ export function ProjectEditorWizard({
       ...prev,
       teamMembersDetailed: prev.teamMembersDetailed.filter((_, itemIndex) => itemIndex !== index),
     }));
+  };
+
+  const handleContractDocumentSelect = async (event: ChangeEvent<HTMLInputElement>) => {
+    const input = event.currentTarget;
+    const file = input.files?.[0];
+    if (!file) return;
+    if (!onContractFileUpload) {
+      toast.error('계약서 업로드를 사용할 수 없는 화면입니다.');
+      input.value = '';
+      return;
+    }
+    if (!/pdf$/i.test(file.name) && file.type !== 'application/pdf') {
+      toast.error('계약서 파일은 PDF로 업로드해 주세요.');
+      input.value = '';
+      return;
+    }
+    if (file.size > MAX_CONTRACT_UPLOAD_SIZE_BYTES) {
+      const message = `계약서 PDF는 ${MAX_CONTRACT_UPLOAD_SIZE_LABEL} 이하만 업로드할 수 있습니다. 파일을 압축하거나 필요한 페이지만 추려 다시 시도해 주세요.`;
+      setContractUploadState('error');
+      setContractUploadError(message);
+      toast.error(message);
+      input.value = '';
+      return;
+    }
+
+    setContractUploadState('extracting');
+    setContractUploadError('');
+    try {
+      const processed = await onContractFileUpload(file);
+      setDraft((prev) => mergeContractAnalysisIntoDraft(createProjectEditorWizardDraft({
+        ...prev,
+        contractDocument: processed.contractDocument,
+        contractAnalysis: processed.contractAnalysis,
+      }), processed.contractAnalysis));
+      setContractUploadState('ready');
+      toast.success(`계약서 PDF 업로드 및 분석 완료: ${file.name}`);
+    } catch (error) {
+      console.error('[ProjectEditorWizard] contract upload failed:', error);
+      const message = error instanceof Error ? error.message : '계약서 업로드에 실패했습니다.';
+      setContractUploadState('error');
+      setContractUploadError(message);
+      toast.error(message);
+    } finally {
+      input.value = '';
+    }
+  };
+
+  const removeContractDocument = () => {
+    setDraft((prev) => createProjectEditorWizardDraft({
+      ...prev,
+      contractDocument: null,
+      contractAnalysis: null,
+    }));
+    setContractUploadState('idle');
+    setContractUploadError('');
   };
 
   const submitIssues = useMemo(() => {
@@ -502,6 +615,65 @@ export function ProjectEditorWizard({
 
   const renderFinancialStep = () => (
     <div className="space-y-4">
+      {onContractFileUpload ? (
+        <div className="rounded-xl border border-slate-200 bg-slate-50/70 p-4">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <FileText className="h-4 w-4 text-slate-600" />
+                <Label className="text-xs font-semibold">계약서 PDF</Label>
+              </div>
+              <p className="mt-1 text-[11px] leading-5 text-muted-foreground">
+                PDF를 올리면 계약명, 계약기간, 계약금액, 계약 대상 후보를 읽어와 빈 항목만 채웁니다.
+              </p>
+              {draft.contractDocument ? (
+                <div className="mt-3 flex flex-wrap items-center gap-2 text-[12px]">
+                  <span className="max-w-full truncate font-medium text-slate-900">{draft.contractDocument.name}</span>
+                  <span className="text-muted-foreground">
+                    {(draft.contractDocument.size / 1024 / 1024).toFixed(2)} MB
+                  </span>
+                  <Button asChild type="button" variant="outline" size="sm" className="h-7 px-2 text-[11px]">
+                    <a href={draft.contractDocument.downloadURL} target="_blank" rel="noreferrer">원문 보기</a>
+                  </Button>
+                  <Button type="button" variant="ghost" size="sm" className="h-7 px-2 text-[11px] text-rose-600" onClick={removeContractDocument}>
+                    <X className="mr-1 h-3.5 w-3.5" />
+                    첨부 제거
+                  </Button>
+                </div>
+              ) : null}
+              {draft.contractAnalysis ? (
+                <div className="mt-3 rounded-lg border border-emerald-200 bg-white px-3 py-2 text-[12px] leading-5 text-slate-700">
+                  <span className="font-semibold text-emerald-700">분석 요약</span>
+                  <span className="ml-2">{draft.contractAnalysis.summary}</span>
+                </div>
+              ) : null}
+              {contractUploadError ? (
+                <p className="mt-2 text-[11px] text-rose-600">{contractUploadError}</p>
+              ) : null}
+            </div>
+            <div className="shrink-0">
+              <input
+                ref={contractUploadInputRef}
+                type="file"
+                accept="application/pdf,.pdf"
+                className="hidden"
+                onChange={handleContractDocumentSelect}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full gap-2 lg:w-auto"
+                disabled={contractUploadState === 'extracting'}
+                onClick={() => contractUploadInputRef.current?.click()}
+              >
+                {contractUploadState === 'extracting' ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
+                {draft.contractDocument ? '계약서 교체' : '계약서 업로드'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
       <div className="grid gap-4 lg:grid-cols-2">
         <div>
           <Label className="text-xs">계약 시작일 *</Label>


### PR DESCRIPTION
## 한눈에 보기
- 프로젝트 등록/수정 공통 화면에 계약서 PDF 업로드, 교체, 삭제 기능을 추가했습니다.
- 기존 서버의 계약서 분석 기능과 연결해 계약서 내용을 자동으로 읽어올 수 있게 했습니다.
- 자동 분석 결과는 비어 있는 입력칸에만 채우고, 사용자가 이미 입력한 값은 덮어쓰지 않게 했습니다.

## 사용자가 체감하는 변화
- 계약서를 따로 처리하지 않고 프로젝트 화면에서 바로 올릴 수 있습니다.
- 계약서에서 읽은 정보가 초안 입력을 도와주지만, 사람이 적어둔 값은 유지됩니다.

## 구조 확인
- 영향 경로: PortalProjectEdit / PortalProjectRegister / ProjectEditorWizard / platform-bff-client / server project-request-contract 서비스
- 서버의 계약서 처리 기능은 이미 있었고, 이번 PR은 화면 진입점을 복구한 작업입니다.
- 변경 영향 확인용 .understand-anything/diff-overlay.json 작성

## 확인한 것
- npx vitest run src/app/components/projects/ProjectEditorWizard.shell.test.ts src/app/components/portal/PortalMinimalSweep.layout.test.ts src/app/lib/platform-bff-client.test.ts src/app/platform/project-editor.test.ts
- npm run build