### PR TITLE
모바일에서 명함 촬영 화면으로 바로 시작하도록 개선

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,8 +91,10 @@ CLIENT_ERROR_SLACK_MIN_LEVEL=fatal
 # Claude API (server-side, for Guide Q&A chatbot)
 ANTHROPIC_API_KEY=
 
-# Vertex AI Gemini for LAB business-card DB
-# Set GOOGLE_GENAI_USE_VERTEXAI=true and provide ADC/service account in the BFF runtime.
+# Gemini for LAB business-card DB.
+# Fast path: set GEMINI_API_KEY from Google AI Studio. Do not expose it with a VITE_ prefix.
+GEMINI_API_KEY=
+# Vertex AI path: set GOOGLE_GENAI_USE_VERTEXAI=true and provide ADC/service account in the BFF runtime.
 GOOGLE_GENAI_USE_VERTEXAI=true
 GOOGLE_CLOUD_PROJECT=
 GOOGLE_CLOUD_LOCATION=global

--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ VITE_SENTRY_TRACES_SAMPLE_RATE=0
 # Optional fixed login/testing hosts for Firebase Auth on Vercel previews.
 # Use exact hosts or full URLs, comma-separated. Random commit preview URLs should not be listed here.
 VITE_FIREBASE_AUTH_ALLOWED_HOSTS=
+# When true, allowed fixed hosts use the current app host as Firebase authDomain.
+# Vercel then proxies /__/auth/* to Firebase so mobile/PWA browsers keep auth state same-origin.
+VITE_FIREBASE_AUTH_PROXY_HELPER_ON_ALLOWED_HOSTS=true
+# Optional override list for auth helper proxy hosts. Defaults to VITE_FIREBASE_AUTH_ALLOWED_HOSTS plus fallback host.
+VITE_FIREBASE_AUTH_PROXY_HOSTS=
 # Optional fixed preview URL to open when login is blocked on a random Vercel preview.
 VITE_FIREBASE_AUTH_FALLBACK_URL=
 VITE_DEV_AUTH_HARNESS_ENABLED=false

--- a/.env.example
+++ b/.env.example
@@ -31,10 +31,10 @@ VITE_SENTRY_TRACES_SAMPLE_RATE=0
 # Optional fixed login/testing hosts for Firebase Auth on Vercel previews.
 # Use exact hosts or full URLs, comma-separated. Random commit preview URLs should not be listed here.
 VITE_FIREBASE_AUTH_ALLOWED_HOSTS=
-# When true, allowed fixed hosts use the current app host as Firebase authDomain.
-# Vercel then proxies /__/auth/* to Firebase so mobile/PWA browsers keep auth state same-origin.
-VITE_FIREBASE_AUTH_PROXY_HELPER_ON_ALLOWED_HOSTS=true
-# Optional override list for auth helper proxy hosts. Defaults to VITE_FIREBASE_AUTH_ALLOWED_HOSTS plus fallback host.
+# Optional auth helper proxy. Keep false unless the Google OAuth client also has
+# https://<host>/__/auth/handler registered as an authorized redirect URI.
+VITE_FIREBASE_AUTH_PROXY_HELPER_ON_ALLOWED_HOSTS=false
+# Optional exact hosts that may use the same-origin auth helper proxy.
 VITE_FIREBASE_AUTH_PROXY_HOSTS=
 # Optional fixed preview URL to open when login is blocked on a random Vercel preview.
 VITE_FIREBASE_AUTH_FALLBACK_URL=

--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,7 @@ GOOGLE_GENAI_USE_VERTEXAI=true
 GOOGLE_CLOUD_PROJECT=
 GOOGLE_CLOUD_LOCATION=global
 BUSINESS_CARD_GEMINI_MODEL=gemini-2.5-flash
+BUSINESS_CARD_GEMINI_FALLBACK_MODELS=gemini-2.5-flash-lite
 
 # Optional relation/pipeline tuning (server-side)
 # RELATION_RULES_PATH=policies/relation-rules.json

--- a/docs/superpowers/plans/2026-05-27-business-card-crop-gemini-stability-autoplan.md
+++ b/docs/superpowers/plans/2026-05-27-business-card-crop-gemini-stability-autoplan.md
@@ -1,0 +1,122 @@
+# Business Card Crop + Gemini Stability Autoplan
+
+Date: 2026-05-27
+Branch: `feat/business-card-gemini-api-key`
+Stage URL: `https://inner-platform-git-dev-merryai-devs-projects.vercel.app`
+
+## Understand Baseline
+
+`/understand` graph exists, but it is stale for this feature.
+
+- Graph commit: `74978f3936ebd15080c66044ffde6b3db9a2cbad`
+- Last analyzed: `2026-05-26T01:39:27.159Z`
+- Business-card nodes in graph: `0`
+
+Decision: use the graph only as platform dependency background and treat current source inspection as the source of truth for 명함 DB.
+
+Current dependency chain:
+
+```text
+BusinessCardLabPage.tsx
+  -> prepareBusinessCardImage(file)
+     -> readFileAsDataUrl
+     -> loadImage
+     -> canvas resize/compress to JPEG
+  -> processBusinessCardViaBff(...)
+     -> POST /api/v1/business-card-imports/process
+        -> routes/business-cards.mjs
+           -> uploadBusinessCard(...)
+           -> analyzeBusinessCard(...)
+              -> @google/genai GoogleGenAI.models.generateContent
+```
+
+## Immediate Fix: Gemini Cannot Be Used
+
+Observed root causes:
+
+- Vercel `GEMINI_API_KEY` contained surrounding console text, not only the raw API key.
+- `gemini-2.5-flash` can return transient `503 UNAVAILABLE` / high-demand failures.
+
+Applied stabilization:
+
+- Preview and Production `GEMINI_API_KEY` are now clean `AIza...` values.
+- Preview and Production now have `BUSINESS_CARD_GEMINI_FALLBACK_MODELS=gemini-2.5-flash-lite`.
+- BFF now retries retryable Gemini capacity failures with the fallback model list.
+- API key reachability was verified with a non-image Gemini call without printing the key.
+
+## Crop Strategy
+
+Goal: improve extraction accuracy by sending Gemini the card area, not the whole desk/background image.
+
+Principles:
+
+- Do not add OpenCV or a heavy WASM dependency in v1.
+- Keep crop client-side before upload so Storage and Gemini both receive a smaller, cleaner image.
+- Never silently destroy user intent: show crop confidence and allow original image fallback.
+- Prefer deterministic image processing over model-dependent pre-processing.
+
+Phase A: deterministic axis-aligned crop
+
+- Add a pure crop detector near `business-card-image.ts`.
+- Downsample image to an analysis canvas, max 512-768px.
+- Estimate background from border pixels.
+- Detect the largest rectangular area by contrast from surrounding background, favoring bright low-saturation card surfaces.
+- Validate confidence with area ratio, aspect ratio, and edge strength.
+- If confidence is high enough, crop with 3-6% padding before JPEG compression.
+- If confidence is low, keep the original image and mark crop as skipped.
+
+Phase B: UX guardrails
+
+- Add image metadata to `BusinessCardPreparedImage`:
+  - `crop.applied`
+  - `crop.confidence`
+  - `crop.bounds`
+  - `crop.reason`
+- In `BusinessCardLabPage`, show a compact status near the preview:
+  - `명함 영역 자동 정리됨`
+  - `원본 이미지 사용 중`
+- Add `원본 사용` when automatic crop looks wrong.
+
+Phase C: perspective correction only after QA
+
+- If mobile photos often show rotated/perspective cards, add four-corner detection and perspective correction.
+- Do not start with this because it has higher math and QA cost than axis-aligned crop.
+
+## QA Hypotheses
+
+High-risk cases to test before landing crop:
+
+- White card on white desk: detector should skip or keep original, not crop random whitespace.
+- Multiple cards in one photo: detector should choose largest/frontmost and Gemini prompt already warns about multi-card images.
+- Receipt/document mistaken as business card: detector may crop it, but review screen still prevents blind save.
+- Dark mode UI and image preview: crop badge must not create confusing green/yellow/red decoration.
+- iOS camera images: browser image decode usually honors orientation, but mobile QA must confirm portrait captures.
+
+## Implementation Plan
+
+1. Stabilize Gemini runtime first.
+   - Done in this branch: clean env, fallback env, retryable model fallback, tests.
+
+2. Add crop detector as isolated image utility.
+   - Create tests around synthetic `ImageData` so the algorithm can be QAed without browser flakiness.
+   - Keep `prepareBusinessCardImage` as the only integration point.
+
+3. Add reviewable crop UI.
+   - Keep current upload flow.
+   - Add crop status and original fallback control.
+   - Do not change the BFF contract unless crop metadata becomes operationally useful.
+
+4. Run QA loop.
+   - Unit: crop detector fixtures.
+   - Integration: `BusinessCardLabPage.shell.test.tsx` and image prep tests.
+   - Browser: mobile viewport upload UI, preview rendering, process button state.
+   - Stage: upload a real card photo and confirm Gemini fields are populated.
+
+5. Release gate.
+   - Stage alias only: `inner-platform-git-dev-merryai-devs-projects.vercel.app`.
+   - No random preview URL for auth testing.
+   - Production deploy only after mobile capture, extraction, review-save, and search are confirmed.
+
+## Decision
+
+Proceed with Gemini stability hotfix now. Start crop as a separate small implementation after this commit so the production-risky AI runtime fix and the image-processing UX change are not tangled.

--- a/docs/wiki/business-card-db/03-vertex-gemini-extraction.md
+++ b/docs/wiki/business-card-db/03-vertex-gemini-extraction.md
@@ -7,13 +7,20 @@ unblocks:
   - business-card-db-review-save-search
 ---
 
-# 03 Vertex Gemini Extraction
+# 03 Gemini Extraction
 
 ## Runtime
 
-Use Vertex AI through the Google Gen AI SDK on the BFF server.
+Use the Google Gen AI SDK on the BFF server. The fast setup path uses a Google AI Studio API key. The enterprise setup path uses Vertex AI.
 
 Environment:
+
+```text
+GEMINI_API_KEY=<Google AI Studio API key>
+BUSINESS_CARD_GEMINI_MODEL=gemini-2.5-flash
+```
+
+Vertex AI environment:
 
 ```text
 GOOGLE_GENAI_USE_VERTEXAI=true
@@ -21,6 +28,8 @@ GOOGLE_CLOUD_PROJECT=inner-platform-live-20260316
 GOOGLE_CLOUD_LOCATION=global
 BUSINESS_CARD_GEMINI_MODEL=gemini-2.5-flash
 ```
+
+If `GEMINI_API_KEY` is present, the BFF uses the API key path first. If it is absent, the BFF falls back to Vertex AI when `GOOGLE_GENAI_USE_VERTEXAI=true`.
 
 ## Input
 

--- a/docs/wiki/business-card-db/03-vertex-gemini-extraction.md
+++ b/docs/wiki/business-card-db/03-vertex-gemini-extraction.md
@@ -18,6 +18,7 @@ Environment:
 ```text
 GEMINI_API_KEY=<Google AI Studio API key>
 BUSINESS_CARD_GEMINI_MODEL=gemini-2.5-flash
+BUSINESS_CARD_GEMINI_FALLBACK_MODELS=gemini-2.5-flash-lite
 ```
 
 Vertex AI environment:
@@ -27,9 +28,11 @@ GOOGLE_GENAI_USE_VERTEXAI=true
 GOOGLE_CLOUD_PROJECT=inner-platform-live-20260316
 GOOGLE_CLOUD_LOCATION=global
 BUSINESS_CARD_GEMINI_MODEL=gemini-2.5-flash
+BUSINESS_CARD_GEMINI_FALLBACK_MODELS=gemini-2.5-flash-lite
 ```
 
 If `GEMINI_API_KEY` is present, the BFF uses the API key path first. If it is absent, the BFF falls back to Vertex AI when `GOOGLE_GENAI_USE_VERTEXAI=true`.
+If the primary Gemini model returns a transient capacity error, the BFF retries with the fallback model list before marking the import as failed.
 
 ## Input
 

--- a/docs/wiki/business-card-db/04-pwa-mobile-capture.md
+++ b/docs/wiki/business-card-db/04-pwa-mobile-capture.md
@@ -12,11 +12,12 @@ unblocks:
 ## Routes
 
 ```text
+/mobile-entry
 /business-cards
 /portal/business-cards
 ```
 
-Both routes point to the same LAB business card workspace with role-aware shell wrapping.
+`/mobile-entry` is the PWA start URL: mobile users land on the business-card DB first, while desktop users keep the existing workspace entry. The business-card routes point to the same LAB business card workspace with role-aware shell wrapping.
 
 ## Capture UI
 

--- a/docs/wiki/business-card-db/08-pwa-commercial-packaging.md
+++ b/docs/wiki/business-card-db/08-pwa-commercial-packaging.md
@@ -37,6 +37,7 @@ Commercial order:
 
 | Endpoint | Purpose |
 | --- | --- |
+| `/mobile-entry` | PWA start URL. Mobile opens business-card DB first; desktop falls back to the existing workspace entry. |
 | `/install` | Device-aware PWA install landing page |
 | `/install/ios` | iPhone Safari Add to Home Screen instructions |
 | `/install/android` | Android Chrome install instructions and TWA readiness notes |
@@ -46,7 +47,7 @@ Commercial order:
 
 ## PWA Package Contract
 
-- `public/manifest.webmanifest` provides app identity, start URL, scope, standalone display, Korean language metadata, square icons, maskable icon, and shortcuts.
+- `public/manifest.webmanifest` provides app identity, `/mobile-entry` start URL, scope, standalone display, Korean language metadata, square icons, maskable icon, and shortcuts.
 - `public/pwa/myscube-icon-192.png` and `public/pwa/myscube-icon-512.png` are generated from the approved MYSCube logo.
 - `public/pwa/myscube-icon-maskable-512.png` keeps safe-zone padding for Android launcher masks.
 - `public/sw.js` caches only shell assets and brand assets.
@@ -90,7 +91,7 @@ npm run pwa:verify
 - Korean HTML metadata
 - Apple touch icon
 - service worker private cache bypasses
-- `/install`, `/install/ios`, `/install/android`, and `/business-cards` route registration
+- `/install`, `/install/ios`, `/install/android`, `/mobile-entry`, and `/business-cards` route registration
 - same-origin camera permissions policy in `vercel.json`
 
 Live package check after deployment/alias:
@@ -103,7 +104,7 @@ npm run pwa:verify:live -- https://inner-platform.vercel.app
 
 `pwa:verify:live` checks:
 
-- `/install`, `/install/ios`, `/install/android`, and `/business-cards` return the app shell over HTTPS
+- `/install`, `/install/ios`, `/install/android`, `/mobile-entry`, and `/business-cards` return the app shell over HTTPS
 - live manifest fields and icon references
 - live PNG icon dimensions
 - service worker private cache bypasses

--- a/policies/nav-policy.json
+++ b/policies/nav-policy.json
@@ -7,6 +7,7 @@
       "/dashboard",
       "/projects",
       "/board",
+      "/business-cards",
       "/cashflow",
       "/evidence",
       "/payroll",
@@ -22,6 +23,7 @@
       "/projects",
       "/projects/new",
       "/board",
+      "/business-cards",
       "/evidence",
       "/expense-management",
       "/claude-sdk-help",
@@ -32,6 +34,7 @@
       "/dashboard",
       "/projects",
       "/board",
+      "/business-cards",
       "/claude-sdk-help",
       "/portal"
     ]

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -5,7 +5,7 @@
   "description": "MYSC 사내 프로젝트, 재무, 연락처 운영 플랫폼",
   "lang": "ko-KR",
   "dir": "ltr",
-  "start_url": "/",
+  "start_url": "/mobile-entry",
   "scope": "/",
   "display": "standalone",
   "orientation": "portrait-primary",

--- a/scripts/validate_pwa_live_package.mjs
+++ b/scripts/validate_pwa_live_package.mjs
@@ -95,6 +95,7 @@ async function verifyManifest(baseUrl) {
 
   if (manifest.display !== 'standalone') fail('manifest display must be standalone');
   if (manifest.lang !== 'ko-KR') fail('manifest lang must be ko-KR');
+  if (manifest.start_url !== '/mobile-entry') fail('manifest start_url must be /mobile-entry');
 
   const icons = Array.isArray(manifest.icons) ? manifest.icons : [];
   const requiredIcons = new Map([
@@ -162,6 +163,7 @@ async function main() {
     verifyHtmlEndpoint(baseUrl, '/install'),
     verifyHtmlEndpoint(baseUrl, '/install/ios'),
     verifyHtmlEndpoint(baseUrl, '/install/android'),
+    verifyHtmlEndpoint(baseUrl, '/mobile-entry'),
     verifyManifest(baseUrl),
     verifyIcon(baseUrl, '/pwa/myscube-icon-192.png', 192),
     verifyIcon(baseUrl, '/pwa/myscube-icon-512.png', 512),

--- a/scripts/validate_pwa_package.mjs
+++ b/scripts/validate_pwa_package.mjs
@@ -43,6 +43,7 @@ for (const field of ['id', 'name', 'short_name', 'start_url', 'scope', 'display'
 
 if (manifest.display !== 'standalone') fail('manifest display must be standalone');
 if (manifest.lang !== 'ko-KR') fail('manifest lang must be ko-KR');
+if (manifest.start_url !== '/mobile-entry') fail('manifest start_url must be /mobile-entry');
 if (!Array.isArray(manifest.icons) || manifest.icons.length < 3) fail('manifest must include any and maskable icons');
 
 const requiredIcons = new Map([
@@ -72,7 +73,7 @@ for (const privatePrefix of ['/api/', '/api/v1/', '/business-card-imports/']) {
   requireText('public/sw.js', privatePrefix, `service worker private cache bypass ${privatePrefix}`);
 }
 
-for (const route of ["'/install'", "'/install/ios'", "'/install/android'", "'business-cards'"]) {
+for (const route of ["'/install'", "'/install/ios'", "'/install/android'", "'/mobile-entry'", "'business-cards'"]) {
   requireText('src/app/routes.tsx', route, `PWA install route ${route}`);
 }
 

--- a/server/bff/business-card-gemini-ai.mjs
+++ b/server/bff/business-card-gemini-ai.mjs
@@ -5,9 +5,30 @@ import {
 } from './business-card-domain.mjs';
 
 const DEFAULT_MODEL = 'gemini-2.5-flash';
+const DEFAULT_FALLBACK_MODELS = ['gemini-2.5-flash-lite'];
 
 function resolveModel(env = process.env) {
   return readOptionalText(env.BUSINESS_CARD_GEMINI_MODEL) || DEFAULT_MODEL;
+}
+
+function parseModelList(value) {
+  return String(value || '')
+    .split(',')
+    .map((entry) => readOptionalText(entry))
+    .filter(Boolean);
+}
+
+function resolveModelCandidates(env = process.env, primaryModel = resolveModel(env)) {
+  const seen = new Set();
+  return [
+    primaryModel,
+    ...parseModelList(env.BUSINESS_CARD_GEMINI_FALLBACK_MODELS),
+    ...DEFAULT_FALLBACK_MODELS,
+  ].filter((candidate) => {
+    if (!candidate || seen.has(candidate)) return false;
+    seen.add(candidate);
+    return true;
+  });
 }
 
 function resolveApiKey(env = process.env) {
@@ -122,9 +143,15 @@ function readResponseText(response) {
   return readOptionalText(response?.candidates?.[0]?.content?.parts?.map((part) => part.text || '').join('\n'));
 }
 
+function isRetryableGeminiError(error) {
+  const text = error instanceof Error ? error.message : String(error || '');
+  return /(?:503|UNAVAILABLE|RESOURCE_EXHAUSTED|high demand|try again later|temporarily unavailable)/i.test(text);
+}
+
 export function createBusinessCardGeminiAiService(options = {}) {
   const env = options.env || process.env;
   const model = options.model || resolveModel(env);
+  const modelCandidates = options.modelCandidates || resolveModelCandidates(env, model);
   const client = options.client || null;
   const importSdk = options.importSdk || (() => import('@google/genai'));
   const configuredProvider = resolveApiKey(env) ? 'gemini-api' : 'vertex-ai';
@@ -179,65 +206,71 @@ export function createBusinessCardGeminiAiService(options = {}) {
         };
       }
 
-      try {
-        const response = await ai.models.generateContent({
-          model,
-          contents: [
-            {
-              role: 'user',
-              parts: [
-                { text: buildPrompt(input?.fileName) },
-                {
-                  inlineData: {
-                    mimeType: input?.mimeType || 'image/jpeg',
-                    data: input?.contentBase64,
+      let lastError = null;
+      for (const candidateModel of modelCandidates) {
+        try {
+          const response = await ai.models.generateContent({
+            model: candidateModel,
+            contents: [
+              {
+                role: 'user',
+                parts: [
+                  { text: buildPrompt(input?.fileName) },
+                  {
+                    inlineData: {
+                      mimeType: input?.mimeType || 'image/jpeg',
+                      data: input?.contentBase64,
+                    },
                   },
-                },
-              ],
+                ],
+              },
+            ],
+            config: {
+              responseMimeType: 'application/json',
+              responseSchema,
             },
-          ],
-          config: {
-            responseMimeType: 'application/json',
-            responseSchema,
-          },
-        });
-        const rawText = await readResponseText(response);
-        const parsed = extractJson(rawText);
-        if (!isStructuredExtractionCandidate(parsed)) {
+          });
+          const rawText = await readResponseText(response);
+          const parsed = extractJson(rawText);
+          if (!isStructuredExtractionCandidate(parsed)) {
+            return {
+              provider: configuredProvider,
+              model: candidateModel,
+              status: 'manual_review',
+              extracted: buildEmptyBusinessCardExtraction([
+                'Gemini 응답 형식이 맞지 않아 수동 검토가 필요합니다.',
+              ]),
+              rawResponseText: rawText,
+              error: {
+                code: 'gemini_malformed_response',
+                message: 'Gemini did not return the expected business-card JSON shape.',
+              },
+            };
+          }
+          const extracted = normalizeBusinessCardExtraction(parsed);
           return {
             provider: configuredProvider,
-            model,
-            status: 'manual_review',
-            extracted: buildEmptyBusinessCardExtraction([
-              'Gemini 응답 형식이 맞지 않아 수동 검토가 필요합니다.',
-            ]),
+            model: candidateModel,
+            status: 'ok',
+            extracted,
             rawResponseText: rawText,
-            error: {
-              code: 'gemini_malformed_response',
-              message: 'Gemini did not return the expected business-card JSON shape.',
-            },
           };
+        } catch (error) {
+          lastError = error;
+          if (!isRetryableGeminiError(error)) break;
         }
-        const extracted = normalizeBusinessCardExtraction(parsed);
-        return {
-          provider: configuredProvider,
-          model,
-          status: 'ok',
-          extracted,
-          rawResponseText: rawText,
-        };
-      } catch (error) {
-        return {
-          provider: configuredProvider,
-          model,
-          status: 'failed',
-          extracted: fallback,
-          error: {
-            code: 'gemini_extract_failed',
-            message: error instanceof Error ? error.message : String(error),
-          },
-        };
       }
+
+      return {
+        provider: configuredProvider,
+        model: modelCandidates.join(','),
+        status: 'failed',
+        extracted: fallback,
+        error: {
+          code: 'gemini_extract_failed',
+          message: lastError instanceof Error ? lastError.message : String(lastError),
+        },
+      };
     },
   };
 }
@@ -247,4 +280,5 @@ export {
   responseSchema as businessCardGeminiResponseSchema,
   resolveApiKey,
   resolveModel,
+  resolveModelCandidates,
 };

--- a/server/bff/business-card-gemini-ai.mjs
+++ b/server/bff/business-card-gemini-ai.mjs
@@ -10,6 +10,10 @@ function resolveModel(env = process.env) {
   return readOptionalText(env.BUSINESS_CARD_GEMINI_MODEL) || DEFAULT_MODEL;
 }
 
+function resolveApiKey(env = process.env) {
+  return readOptionalText(env.GEMINI_API_KEY || env.GOOGLE_API_KEY);
+}
+
 function buildPrompt(fileName) {
   return [
     'You extract contact details from a Korean or bilingual business card image.',
@@ -123,9 +127,15 @@ export function createBusinessCardGeminiAiService(options = {}) {
   const model = options.model || resolveModel(env);
   const client = options.client || null;
   const importSdk = options.importSdk || (() => import('@google/genai'));
+  const configuredProvider = resolveApiKey(env) ? 'gemini-api' : 'vertex-ai';
 
   async function getClient() {
     if (client) return client;
+    const apiKey = resolveApiKey(env);
+    if (apiKey) {
+      const { GoogleGenAI } = await importSdk();
+      return new GoogleGenAI({ apiKey });
+    }
     if (String(env.GOOGLE_GENAI_USE_VERTEXAI || '').toLowerCase() !== 'true') return null;
     const { GoogleGenAI } = await importSdk();
     return new GoogleGenAI({
@@ -145,7 +155,7 @@ export function createBusinessCardGeminiAiService(options = {}) {
         ai = await getClient();
       } catch (error) {
         return {
-          provider: 'vertex-ai',
+          provider: configuredProvider,
           model,
           status: 'manual_review',
           extracted: fallback,
@@ -158,7 +168,7 @@ export function createBusinessCardGeminiAiService(options = {}) {
 
       if (!ai?.models?.generateContent) {
         return {
-          provider: 'vertex-ai',
+          provider: configuredProvider,
           model,
           status: 'manual_review',
           extracted: fallback,
@@ -195,7 +205,7 @@ export function createBusinessCardGeminiAiService(options = {}) {
         const parsed = extractJson(rawText);
         if (!isStructuredExtractionCandidate(parsed)) {
           return {
-            provider: 'vertex-ai',
+            provider: configuredProvider,
             model,
             status: 'manual_review',
             extracted: buildEmptyBusinessCardExtraction([
@@ -210,7 +220,7 @@ export function createBusinessCardGeminiAiService(options = {}) {
         }
         const extracted = normalizeBusinessCardExtraction(parsed);
         return {
-          provider: 'vertex-ai',
+          provider: configuredProvider,
           model,
           status: 'ok',
           extracted,
@@ -218,7 +228,7 @@ export function createBusinessCardGeminiAiService(options = {}) {
         };
       } catch (error) {
         return {
-          provider: 'vertex-ai',
+          provider: configuredProvider,
           model,
           status: 'failed',
           extracted: fallback,
@@ -235,5 +245,6 @@ export function createBusinessCardGeminiAiService(options = {}) {
 export {
   buildPrompt,
   responseSchema as businessCardGeminiResponseSchema,
+  resolveApiKey,
   resolveModel,
 };

--- a/server/bff/business-card-gemini-ai.test.mjs
+++ b/server/bff/business-card-gemini-ai.test.mjs
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
-import { buildPrompt, createBusinessCardGeminiAiService, resolveApiKey } from './business-card-gemini-ai.mjs';
+import {
+  buildPrompt,
+  createBusinessCardGeminiAiService,
+  resolveApiKey,
+  resolveModelCandidates,
+} from './business-card-gemini-ai.mjs';
 
 describe('business-card-gemini-ai', () => {
   it('normalizes structured Gemini JSON responses', async () => {
@@ -124,6 +129,53 @@ describe('business-card-gemini-ai', () => {
   it('trims Gemini API keys from environment variables', () => {
     expect(resolveApiKey({ GEMINI_API_KEY: '  key\n' })).toBe('key');
     expect(resolveApiKey({ GOOGLE_API_KEY: '  fallback-key\n' })).toBe('fallback-key');
+  });
+
+  it('builds a deduped Gemini model fallback list', () => {
+    expect(resolveModelCandidates({
+      BUSINESS_CARD_GEMINI_MODEL: 'gemini-primary',
+      BUSINESS_CARD_GEMINI_FALLBACK_MODELS: ' gemini-lite, gemini-primary, gemini-extra ',
+    })).toEqual(['gemini-primary', 'gemini-lite', 'gemini-extra', 'gemini-2.5-flash-lite']);
+  });
+
+  it('retries transient Gemini capacity failures with a fallback model', async () => {
+    const generateContent = vi.fn(async ({ model }) => {
+      if (model === 'gemini-primary') {
+        throw new Error('503 UNAVAILABLE: model is currently experiencing high demand');
+      }
+      return {
+        text: JSON.stringify({
+          name: { value: '박명함', confidence: 'high', evidence: '박명함' },
+          organization: { value: 'MYSC', confidence: 'high', evidence: 'MYSC' },
+          department: { value: '', confidence: 'low', evidence: '' },
+          title: { value: '', confidence: 'low', evidence: '' },
+          role: { value: '', confidence: 'low', evidence: '' },
+          emails: [{ value: 'card@example.com', confidence: 'high', evidence: 'card@example.com' }],
+          phones: [],
+          website: { value: '', confidence: 'low', evidence: '' },
+          address: { value: '', confidence: 'low', evidence: '' },
+          memo: { value: '', confidence: 'low', evidence: '' },
+          rawText: '박명함 MYSC card@example.com',
+          warnings: [],
+        }),
+      };
+    });
+    const service = createBusinessCardGeminiAiService({
+      client: { models: { generateContent } },
+      modelCandidates: ['gemini-primary', 'gemini-lite'],
+    });
+
+    const result = await service.analyzeBusinessCard({
+      fileName: 'card.jpg',
+      mimeType: 'image/jpeg',
+      contentBase64: Buffer.from('fake-image', 'utf8').toString('base64'),
+    });
+
+    expect(generateContent).toHaveBeenCalledTimes(2);
+    expect(generateContent.mock.calls.map(([input]) => input.model)).toEqual(['gemini-primary', 'gemini-lite']);
+    expect(result.status).toBe('ok');
+    expect(result.model).toBe('gemini-lite');
+    expect(result.extracted.name.value).toBe('박명함');
   });
 
   it('marks malformed Gemini responses for manual review', async () => {

--- a/server/bff/business-card-gemini-ai.test.mjs
+++ b/server/bff/business-card-gemini-ai.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { buildPrompt, createBusinessCardGeminiAiService } from './business-card-gemini-ai.mjs';
+import { buildPrompt, createBusinessCardGeminiAiService, resolveApiKey } from './business-card-gemini-ai.mjs';
 
 describe('business-card-gemini-ai', () => {
   it('normalizes structured Gemini JSON responses', async () => {
@@ -74,6 +74,56 @@ describe('business-card-gemini-ai', () => {
     expect(result.status).toBe('manual_review');
     expect(result.error.code).toBe('gemini_not_configured');
     expect(result.extracted.warnings[0]).toContain('수동 검토');
+  });
+
+  it('uses Gemini API key configuration before Vertex AI', async () => {
+    const constructed = [];
+    const generateContent = vi.fn(async () => ({
+      text: JSON.stringify({
+        name: { value: '김명함', confidence: 'high', evidence: '김명함' },
+        organization: { value: 'MYSC', confidence: 'high', evidence: 'MYSC' },
+        department: { value: '', confidence: 'low', evidence: '' },
+        title: { value: '', confidence: 'low', evidence: '' },
+        role: { value: '', confidence: 'low', evidence: '' },
+        emails: [{ value: 'card@example.com', confidence: 'high', evidence: 'card@example.com' }],
+        phones: [],
+        website: { value: '', confidence: 'low', evidence: '' },
+        address: { value: '', confidence: 'low', evidence: '' },
+        memo: { value: '', confidence: 'low', evidence: '' },
+        rawText: '김명함 MYSC card@example.com',
+        warnings: [],
+      }),
+    }));
+    const service = createBusinessCardGeminiAiService({
+      env: {
+        GEMINI_API_KEY: '  ai-studio-key-with-newline\n',
+        GOOGLE_GENAI_USE_VERTEXAI: 'true',
+        GOOGLE_CLOUD_PROJECT: 'should-not-be-used',
+      },
+      importSdk: async () => ({
+        GoogleGenAI: class {
+          constructor(options) {
+            constructed.push(options);
+            this.models = { generateContent };
+          }
+        },
+      }),
+    });
+
+    const result = await service.analyzeBusinessCard({
+      fileName: 'card.jpg',
+      mimeType: 'image/jpeg',
+      contentBase64: 'abc',
+    });
+
+    expect(constructed).toEqual([{ apiKey: 'ai-studio-key-with-newline' }]);
+    expect(result.provider).toBe('gemini-api');
+    expect(result.status).toBe('ok');
+  });
+
+  it('trims Gemini API keys from environment variables', () => {
+    expect(resolveApiKey({ GEMINI_API_KEY: '  key\n' })).toBe('key');
+    expect(resolveApiKey({ GOOGLE_API_KEY: '  fallback-key\n' })).toBe('fallback-key');
   });
 
   it('marks malformed Gemini responses for manual review', async () => {

--- a/src/app/components/auth/LoginPage.shell.test.ts
+++ b/src/app/components/auth/LoginPage.shell.test.ts
@@ -9,7 +9,8 @@ describe('LoginPage post-login transition contract', () => {
     expect(source).toContain('resolveLoginSuccessPath');
     expect(source).toContain('POST_LOGIN_TRANSITION_MS');
     expect(source).toContain('PostLoginTransition');
-    expect(source).toContain('업무 검색 화면을 준비하고 있습니다');
+    expect(source).toContain('시작 화면을 준비하고 있습니다');
+    expect(source).toContain('viewportWidth');
     expect(source).toContain('animate-in fade-in-0 zoom-in-95');
     expect(source).not.toContain('if (isAuthenticated && user) return null;');
   });

--- a/src/app/components/auth/LoginPage.tsx
+++ b/src/app/components/auth/LoginPage.tsx
@@ -48,10 +48,10 @@ function PostLoginTransition({ displayName }: { displayName: string }) {
                 Login Complete
               </p>
               <h1 className="mt-2 text-[24px] font-extrabold leading-tight text-slate-950 dark:text-slate-50 md:text-[30px]">
-                {displayName}님, 업무 검색 화면을 준비하고 있습니다
+                {displayName}님, 시작 화면을 준비하고 있습니다
               </h1>
               <p className="mt-3 text-[13px] leading-6 text-slate-600 dark:text-slate-300">
-                필요한 기능을 바로 찾을 수 있도록 진입 화면을 여는 중입니다.
+                현재 기기와 요청한 링크에 맞는 진입 화면을 여는 중입니다.
               </p>
             </div>
             <div className="h-1.5 overflow-hidden rounded-full bg-slate-200/80 dark:bg-slate-800/80">
@@ -109,6 +109,10 @@ export function LoginPage() {
         user.role,
         activeWorkspace,
         redirectFrom,
+        {
+          userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : '',
+          viewportWidth: typeof window !== 'undefined' ? window.innerWidth : undefined,
+        },
       );
       const timer = window.setTimeout(() => {
         navigate(target, { replace: true });

--- a/src/app/components/business-cards/BusinessCardLabPage.shell.test.ts
+++ b/src/app/components/business-cards/BusinessCardLabPage.shell.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(import.meta.dirname, 'BusinessCardLabPage.tsx'), 'utf8');
+
+describe('BusinessCardLabPage shell contract', () => {
+  it('keeps capture as the first and default mobile workflow', () => {
+    expect(source.indexOf("{ id: 'capture'")).toBeLessThan(source.indexOf("{ id: 'search'"));
+    expect(source).toContain("useState<BusinessCardTab>('capture')");
+    expect(source).toContain('capture="environment"');
+    expect(source).toContain('촬영/업로드');
+  });
+});

--- a/src/app/components/business-cards/BusinessCardLabPage.tsx
+++ b/src/app/components/business-cards/BusinessCardLabPage.tsx
@@ -38,8 +38,8 @@ import {
 type BusinessCardTab = 'search' | 'capture' | 'review';
 
 const TABS: Array<{ id: BusinessCardTab; label: string; description: string }> = [
-  { id: 'search', label: '검색', description: '전사 연락처를 이름, 회사, 이메일, 전화번호로 찾습니다.' },
   { id: 'capture', label: '명함 등록', description: '모바일 카메라나 이미지 파일로 새 명함을 등록합니다.' },
+  { id: 'search', label: '검색', description: '전사 연락처를 이름, 회사, 이메일, 전화번호로 찾습니다.' },
   { id: 'review', label: '검토 대기', description: 'Gemini 추출 후 저장 전 상태의 명함을 확인합니다.' },
 ];
 

--- a/src/app/components/dashboard/FeatureSearchPage.shell.test.ts
+++ b/src/app/components/dashboard/FeatureSearchPage.shell.test.ts
@@ -9,7 +9,10 @@ const routesSource = readFileSync(resolve(import.meta.dirname, '../../routes.tsx
 describe('FeatureSearchPage shell contract', () => {
   it('makes feature search the full-screen admin landing page with admin and PM grouping', () => {
     expect(routesSource).toContain('const FeatureSearchPage');
-    expect(routesSource).toContain('{ index: true, element: <S C={FeatureSearchPage} /> }');
+    expect(routesSource).toContain('function MobileAwareAdminHome()');
+    expect(routesSource).toContain('shouldUseBusinessCardMobileEntry');
+    expect(routesSource).toContain(': <S C={FeatureSearchPage} />;');
+    expect(routesSource).toContain('{ index: true, element: <MobileAwareAdminHome /> }');
     expect(routesSource).toContain("{ path: 'dashboard', element: <S C={DashboardPage} /> }");
     expect(source).toContain('AdminCommandSearch');
     expect(source).toContain('displayName');

--- a/src/app/components/pwa/MobileEntryPage.shell.test.ts
+++ b/src/app/components/pwa/MobileEntryPage.shell.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(import.meta.dirname, 'MobileEntryPage.tsx'), 'utf8');
+
+describe('MobileEntryPage route contract', () => {
+  it('sends mobile PWA launches to business cards and desktop launches to the existing root', () => {
+    expect(source).toContain('shouldUseBusinessCardMobileEntry');
+    expect(source).toContain('BUSINESS_CARD_MOBILE_ENTRY_PATH');
+    expect(source).toContain("'/mobile-entry'");
+    expect(source).toContain("to={useBusinessCardEntry ? BUSINESS_CARD_MOBILE_ENTRY_PATH : '/'}");
+  });
+});

--- a/src/app/components/pwa/MobileEntryPage.tsx
+++ b/src/app/components/pwa/MobileEntryPage.tsx
@@ -1,0 +1,15 @@
+import { Navigate } from 'react-router';
+import {
+  BUSINESS_CARD_MOBILE_ENTRY_PATH,
+  shouldUseBusinessCardMobileEntry,
+} from '../../platform/mobile-entry';
+
+export function MobileEntryPage() {
+  const useBusinessCardEntry = shouldUseBusinessCardMobileEntry({
+    userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : '',
+    viewportWidth: typeof window !== 'undefined' ? window.innerWidth : undefined,
+    requestedPath: typeof window !== 'undefined' ? window.location.pathname : '/mobile-entry',
+  });
+
+  return <Navigate to={useBusinessCardEntry ? BUSINESS_CARD_MOBILE_ENTRY_PATH : '/'} replace />;
+}

--- a/src/app/lib/firebase.test.ts
+++ b/src/app/lib/firebase.test.ts
@@ -67,15 +67,26 @@ describe('Firebase auth domain proxy', () => {
     expect(resolveFirebaseAuthDomain(
       'mysc-bmp-14173451.firebaseapp.com',
       {
-        VITE_FIREBASE_AUTH_ALLOWED_HOSTS: 'inner-platform-git-dev-merryai-devs-projects.vercel.app',
+        VITE_FIREBASE_AUTH_PROXY_HOSTS: 'inner-platform-git-dev-merryai-devs-projects.vercel.app',
       },
       { hostname: 'localhost' },
     )).toBe('mysc-bmp-14173451.firebaseapp.com');
   });
 
-  it('uses the current app host as authDomain only for configured fixed auth hosts', () => {
+  it('keeps the configured Firebase auth domain on fixed auth hosts unless proxy is explicitly configured', () => {
+    expect(resolveFirebaseAuthDomain(
+      'mysc-bmp-14173451.firebaseapp.com',
+      {
+        VITE_FIREBASE_AUTH_ALLOWED_HOSTS: 'inner-platform-git-dev-merryai-devs-projects.vercel.app',
+      },
+      { hostname: 'inner-platform-git-dev-merryai-devs-projects.vercel.app' },
+    )).toBe('mysc-bmp-14173451.firebaseapp.com');
+  });
+
+  it('uses the current app host as authDomain only for explicit proxy hosts', () => {
     const env = {
       VITE_FIREBASE_AUTH_ALLOWED_HOSTS: 'inner-platform-git-dev-merryai-devs-projects.vercel.app',
+      VITE_FIREBASE_AUTH_PROXY_HOSTS: 'inner-platform-git-dev-merryai-devs-projects.vercel.app',
       VITE_FIREBASE_AUTH_PROXY_HELPER_ON_ALLOWED_HOSTS: 'true',
     };
 
@@ -101,6 +112,8 @@ describe('Firebase auth domain proxy', () => {
       VITE_FIREBASE_MESSAGING_SENDER_ID: 'env-msg',
       VITE_FIREBASE_APP_ID: 'env-app',
       VITE_FIREBASE_AUTH_ALLOWED_HOSTS: 'inner-platform-git-dev-merryai-devs-projects.vercel.app',
+      VITE_FIREBASE_AUTH_PROXY_HOSTS: 'inner-platform-git-dev-merryai-devs-projects.vercel.app',
+      VITE_FIREBASE_AUTH_PROXY_HELPER_ON_ALLOWED_HOSTS: 'true',
     }, {
       hostname: 'inner-platform-git-dev-merryai-devs-projects.vercel.app',
     });

--- a/src/app/lib/firebase.test.ts
+++ b/src/app/lib/firebase.test.ts
@@ -4,6 +4,8 @@ import {
   getOrgCollectionPath,
   getOrgDocumentPath,
   readFirebaseEmulatorConfig,
+  readFirebaseConfigFromEnv,
+  resolveFirebaseAuthDomain,
   selectFirebaseConfig,
   shouldEnableFirebaseEmulatorsForLocation,
   type FirebaseConfig,
@@ -57,6 +59,53 @@ describe('selectFirebaseConfig', () => {
   it('falls back to saved config when env config is disabled', () => {
     const selected = selectFirebaseConfig(savedConfig, {}, false);
     expect(selected?.projectId).toBe('saved-project');
+  });
+});
+
+describe('Firebase auth domain proxy', () => {
+  it('keeps the configured Firebase auth domain on local development hosts', () => {
+    expect(resolveFirebaseAuthDomain(
+      'mysc-bmp-14173451.firebaseapp.com',
+      {
+        VITE_FIREBASE_AUTH_ALLOWED_HOSTS: 'inner-platform-git-dev-merryai-devs-projects.vercel.app',
+      },
+      { hostname: 'localhost' },
+    )).toBe('mysc-bmp-14173451.firebaseapp.com');
+  });
+
+  it('uses the current app host as authDomain only for configured fixed auth hosts', () => {
+    const env = {
+      VITE_FIREBASE_AUTH_ALLOWED_HOSTS: 'inner-platform-git-dev-merryai-devs-projects.vercel.app',
+      VITE_FIREBASE_AUTH_PROXY_HELPER_ON_ALLOWED_HOSTS: 'true',
+    };
+
+    expect(resolveFirebaseAuthDomain(
+      'mysc-bmp-14173451.firebaseapp.com',
+      env,
+      { hostname: 'inner-platform-git-dev-merryai-devs-projects.vercel.app' },
+    )).toBe('inner-platform-git-dev-merryai-devs-projects.vercel.app');
+
+    expect(resolveFirebaseAuthDomain(
+      'mysc-bmp-14173451.firebaseapp.com',
+      env,
+      { hostname: 'inner-platform-random123-merryai-devs-projects.vercel.app' },
+    )).toBe('mysc-bmp-14173451.firebaseapp.com');
+  });
+
+  it('applies authDomain proxy selection when reading env config', () => {
+    const selected = readFirebaseConfigFromEnv({
+      VITE_FIREBASE_API_KEY: 'env-api-key',
+      VITE_FIREBASE_AUTH_DOMAIN: 'mysc-bmp-14173451.firebaseapp.com',
+      VITE_FIREBASE_PROJECT_ID: 'env-project',
+      VITE_FIREBASE_STORAGE_BUCKET: 'env-bucket',
+      VITE_FIREBASE_MESSAGING_SENDER_ID: 'env-msg',
+      VITE_FIREBASE_APP_ID: 'env-app',
+      VITE_FIREBASE_AUTH_ALLOWED_HOSTS: 'inner-platform-git-dev-merryai-devs-projects.vercel.app',
+    }, {
+      hostname: 'inner-platform-git-dev-merryai-devs-projects.vercel.app',
+    });
+
+    expect(selected?.authDomain).toBe('inner-platform-git-dev-merryai-devs-projects.vercel.app');
   });
 });
 

--- a/src/app/lib/firebase.ts
+++ b/src/app/lib/firebase.ts
@@ -35,6 +35,7 @@ export interface FirebaseEmulatorConfig {
 
 interface LocationLike {
   hostname?: string;
+  host?: string;
 }
 
 function normalizeString(value: unknown): string {
@@ -51,6 +52,20 @@ function getRuntimeLocation(): LocationLike | undefined {
   return window.location;
 }
 
+function normalizeHost(value: unknown): string {
+  const raw = typeof value === 'string' ? value.trim().toLowerCase() : '';
+  if (!raw) return '';
+  const withoutProtocol = raw.replace(/^https?:\/\//, '');
+  return withoutProtocol.replace(/[/?#].*$/, '').replace(/:\d+$/, '');
+}
+
+function parseHostList(value: unknown): string[] {
+  return String(value || '')
+    .split(',')
+    .map((entry) => normalizeHost(entry))
+    .filter(Boolean);
+}
+
 function isLoopbackDevHostname(hostname: string): boolean {
   const normalized = hostname.trim().toLowerCase();
   return normalized === 'localhost'
@@ -60,17 +75,46 @@ function isLoopbackDevHostname(hostname: string): boolean {
     || normalized.endsWith('.localhost');
 }
 
+function getLocationHostname(locationLike?: LocationLike): string {
+  return normalizeHost(locationLike?.hostname || locationLike?.host);
+}
+
 export function shouldEnableFirebaseEmulatorsForLocation(locationLike?: LocationLike): boolean {
-  if (!locationLike?.hostname) return true;
-  return isLoopbackDevHostname(locationLike.hostname);
+  const hostname = getLocationHostname(locationLike);
+  if (!hostname) return true;
+  return isLoopbackDevHostname(hostname);
+}
+
+function getFirebaseAuthProxyHosts(env: Record<string, unknown>): string[] {
+  const hosts = new Set([
+    ...parseHostList(env.VITE_FIREBASE_AUTH_ALLOWED_HOSTS),
+    ...parseHostList(env.VITE_FIREBASE_AUTH_PROXY_HOSTS),
+  ]);
+  const fallbackUrl = normalizeString(env.VITE_FIREBASE_AUTH_FALLBACK_URL);
+  if (fallbackUrl) hosts.add(normalizeHost(fallbackUrl));
+  return Array.from(hosts);
+}
+
+export function resolveFirebaseAuthDomain(
+  configuredAuthDomain: unknown,
+  env: Record<string, unknown> = import.meta.env,
+  locationLike: LocationLike | undefined = getRuntimeLocation(),
+): string {
+  const configured = normalizeString(configuredAuthDomain);
+  const currentHost = getLocationHostname(locationLike);
+  const proxyEnabled = parseFeatureFlag(env.VITE_FIREBASE_AUTH_PROXY_HELPER_ON_ALLOWED_HOSTS, true);
+  if (!proxyEnabled || !currentHost || isLoopbackDevHostname(currentHost)) return configured;
+  if (!getFirebaseAuthProxyHosts(env).includes(currentHost)) return configured;
+  return currentHost;
 }
 
 export function readFirebaseConfigFromEnv(
   env: Record<string, unknown> = import.meta.env,
+  locationLike: LocationLike | undefined = getRuntimeLocation(),
 ): FirebaseConfig | null {
   const cfg: FirebaseConfig = {
     apiKey: normalizeString(env.VITE_FIREBASE_API_KEY),
-    authDomain: normalizeString(env.VITE_FIREBASE_AUTH_DOMAIN),
+    authDomain: resolveFirebaseAuthDomain(env.VITE_FIREBASE_AUTH_DOMAIN, env, locationLike),
     projectId: normalizeString(env.VITE_FIREBASE_PROJECT_ID),
     storageBucket: normalizeString(env.VITE_FIREBASE_STORAGE_BUCKET),
     messagingSenderId: normalizeString(env.VITE_FIREBASE_MESSAGING_SENDER_ID),

--- a/src/app/lib/firebase.ts
+++ b/src/app/lib/firebase.ts
@@ -86,13 +86,7 @@ export function shouldEnableFirebaseEmulatorsForLocation(locationLike?: Location
 }
 
 function getFirebaseAuthProxyHosts(env: Record<string, unknown>): string[] {
-  const hosts = new Set([
-    ...parseHostList(env.VITE_FIREBASE_AUTH_ALLOWED_HOSTS),
-    ...parseHostList(env.VITE_FIREBASE_AUTH_PROXY_HOSTS),
-  ]);
-  const fallbackUrl = normalizeString(env.VITE_FIREBASE_AUTH_FALLBACK_URL);
-  if (fallbackUrl) hosts.add(normalizeHost(fallbackUrl));
-  return Array.from(hosts);
+  return parseHostList(env.VITE_FIREBASE_AUTH_PROXY_HOSTS);
 }
 
 export function resolveFirebaseAuthDomain(
@@ -102,7 +96,7 @@ export function resolveFirebaseAuthDomain(
 ): string {
   const configured = normalizeString(configuredAuthDomain);
   const currentHost = getLocationHostname(locationLike);
-  const proxyEnabled = parseFeatureFlag(env.VITE_FIREBASE_AUTH_PROXY_HELPER_ON_ALLOWED_HOSTS, true);
+  const proxyEnabled = parseFeatureFlag(env.VITE_FIREBASE_AUTH_PROXY_HELPER_ON_ALLOWED_HOSTS, false);
   if (!proxyEnabled || !currentHost || isLoopbackDevHostname(currentHost)) return configured;
   if (!getFirebaseAuthProxyHosts(env).includes(currentHost)) return configured;
   return currentHost;

--- a/src/app/platform/admin-foundation.shell.test.ts
+++ b/src/app/platform/admin-foundation.shell.test.ts
@@ -25,7 +25,10 @@ describe('admin monitoring foundation shell contract', () => {
   });
 
   it('registers a dedicated cashflow export route under the admin shell', () => {
-    expect(routesSource).toContain("{ index: true, element: <S C={FeatureSearchPage} /> }");
+    expect(routesSource).toContain("const FeatureSearchPage");
+    expect(routesSource).toContain("function MobileAwareAdminHome()");
+    expect(routesSource).toContain(": <S C={FeatureSearchPage} />;");
+    expect(routesSource).toContain("{ index: true, element: <MobileAwareAdminHome /> }");
     expect(routesSource).toContain("{ path: 'dashboard', element: <S C={DashboardPage} /> }");
     expect(routesSource).toContain("{ path: 'cashflow/export', element: <S C={CashflowExportPage} /> }");
     expect(routesSource).toContain("{ path: 'cashflow/weekly', element: <S C={CashflowWeeklyPage} /> }");

--- a/src/app/platform/admin-nav.test.ts
+++ b/src/app/platform/admin-nav.test.ts
@@ -39,6 +39,13 @@ describe('admin nav access control', () => {
     expect(canAccessAdminPath('viewer', '/approvals')).toBe(false);
   });
 
+  it('allows every signed-in role into the business card capture route', () => {
+    expect(canAccessAdminPath('admin', '/business-cards')).toBe(true);
+    expect(canAccessAdminPath('finance', '/business-cards')).toBe(true);
+    expect(canAccessAdminPath('pm', '/business-cards')).toBe(true);
+    expect(canAccessAdminPath('viewer', '/business-cards')).toBe(true);
+  });
+
   it('restores migration audit as an admin-only menu route', () => {
     expect(canShowAdminNavItem('admin', '/projects/migration-audit')).toBe(true);
     expect(canShowAdminNavItem('finance', '/projects/migration-audit')).toBe(false);

--- a/src/app/platform/admin-nav.ts
+++ b/src/app/platform/admin-nav.ts
@@ -61,6 +61,7 @@ function canonicalizeAdminPath(pathname: string): string | undefined {
     '/koica-personnel',
     '/personnel-changes',
     '/hr-announcements',
+    '/business-cards',
   ];
   for (const p of prefixes) {
     if (pathname === p || pathname.startsWith(p + '/')) return p;

--- a/src/app/platform/mobile-entry.test.ts
+++ b/src/app/platform/mobile-entry.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BUSINESS_CARD_MOBILE_ENTRY_PATH,
+  MOBILE_ENTRY_PATH,
+  isMobileUserAgent,
+  isMobileViewport,
+  shouldUseBusinessCardMobileEntry,
+} from './mobile-entry';
+
+describe('mobile-entry', () => {
+  it('uses business cards as the mobile default entry', () => {
+    expect(BUSINESS_CARD_MOBILE_ENTRY_PATH).toBe('/business-cards');
+    expect(MOBILE_ENTRY_PATH).toBe('/mobile-entry');
+    expect(shouldUseBusinessCardMobileEntry({
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) Mobile/15E148 Safari/604.1',
+      requestedPath: '/',
+    })).toBe(true);
+    expect(shouldUseBusinessCardMobileEntry({
+      userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Chrome/125.0 Mobile Safari/537.36',
+    })).toBe(true);
+  });
+
+  it('preserves explicit deep links on mobile', () => {
+    expect(shouldUseBusinessCardMobileEntry({
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) Mobile/15E148 Safari/604.1',
+      requestedPath: '/portal/cashflow',
+    })).toBe(false);
+    expect(shouldUseBusinessCardMobileEntry({
+      viewportWidth: 390,
+      requestedPath: '/business-cards',
+    })).toBe(false);
+  });
+
+  it('treats the dedicated mobile entry route as a default entry', () => {
+    expect(shouldUseBusinessCardMobileEntry({
+      viewportWidth: 390,
+      requestedPath: '/mobile-entry',
+    })).toBe(true);
+  });
+
+  it('falls back to viewport width when user agent is not specific', () => {
+    expect(isMobileUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5)')).toBe(false);
+    expect(isMobileViewport(390)).toBe(true);
+    expect(isMobileViewport(1024)).toBe(false);
+    expect(shouldUseBusinessCardMobileEntry({ viewportWidth: 390, requestedPath: '/' })).toBe(true);
+  });
+});

--- a/src/app/platform/mobile-entry.ts
+++ b/src/app/platform/mobile-entry.ts
@@ -1,0 +1,23 @@
+export const BUSINESS_CARD_MOBILE_ENTRY_PATH = '/business-cards';
+export const MOBILE_ENTRY_PATH = '/mobile-entry';
+
+export interface MobileEntryContext {
+  userAgent?: string;
+  viewportWidth?: number;
+  requestedPath?: string;
+}
+
+export function isMobileUserAgent(userAgent: unknown): boolean {
+  const ua = typeof userAgent === 'string' ? userAgent.toLowerCase() : '';
+  return /iphone|ipad|ipod|android|mobile/.test(ua);
+}
+
+export function isMobileViewport(width: unknown): boolean {
+  return typeof width === 'number' && Number.isFinite(width) && width > 0 && width < 768;
+}
+
+export function shouldUseBusinessCardMobileEntry(input: MobileEntryContext = {}): boolean {
+  const requestedPath = typeof input.requestedPath === 'string' ? input.requestedPath.trim() : '';
+  if (requestedPath && requestedPath !== '/' && requestedPath !== MOBILE_ENTRY_PATH) return false;
+  return isMobileUserAgent(input.userAgent) || isMobileViewport(input.viewportWidth);
+}

--- a/src/app/platform/navigation.test.ts
+++ b/src/app/platform/navigation.test.ts
@@ -224,10 +224,23 @@ describe('resolveLoginSuccessPath', () => {
     expect(resolveLoginSuccessPath('viewer', undefined, '/')).toBe('/');
   });
 
+  it('uses business cards as the mobile default post-login entry', () => {
+    const mobileContext = {
+      userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) Mobile/15E148 Safari/604.1',
+    };
+
+    expect(resolveLoginSuccessPath('admin', undefined, undefined, mobileContext)).toBe('/business-cards');
+    expect(resolveLoginSuccessPath('pm', undefined, '/', mobileContext)).toBe('/business-cards');
+    expect(resolveLoginSuccessPath('viewer', undefined, '/mobile-entry', mobileContext)).toBe('/business-cards');
+  });
+
   it('preserves explicit deep links after login when they are role-safe', () => {
     expect(resolveLoginSuccessPath('admin', 'admin', '/users')).toBe('/users');
     expect(resolveLoginSuccessPath('pm', undefined, '/portal/budget')).toBe('/portal/project-select?redirect=%2Fportal%2Fbudget');
     expect(resolveLoginSuccessPath('pm', undefined, '/users')).toBe('/portal/project-select?redirect=%2Fportal');
+    expect(resolveLoginSuccessPath('pm', undefined, '/portal/cashflow', {
+      viewportWidth: 390,
+    })).toBe('/portal/project-select?redirect=%2Fportal%2Fcashflow');
   });
 });
 

--- a/src/app/platform/navigation.ts
+++ b/src/app/platform/navigation.ts
@@ -1,5 +1,10 @@
 import { normalizeWorkspaceId, type WorkspaceId } from '../data/member-workspace';
 import { canAccessAdminPath } from './admin-nav';
+import {
+  BUSINESS_CARD_MOBILE_ENTRY_PATH,
+  shouldUseBusinessCardMobileEntry,
+  type MobileEntryContext,
+} from './mobile-entry';
 import { resolvePortalProjectSelectPath } from './portal-project-selection';
 
 export type HomePath = '/' | '/portal';
@@ -114,8 +119,15 @@ export function resolveLoginSuccessPath(
   role: unknown,
   preferredWorkspace: WorkspaceId | unknown,
   requestedPath?: unknown,
+  mobileEntryContext?: MobileEntryContext,
 ): string {
   const normalizedPath = normalizeRequestedPath(requestedPath);
+  if (shouldUseBusinessCardMobileEntry({
+    ...mobileEntryContext,
+    requestedPath: normalizedPath || '/',
+  })) {
+    return BUSINESS_CARD_MOBILE_ENTRY_PATH;
+  }
   if (!normalizedPath || normalizedPath === '/') return '/';
   return resolvePortalEntryPath(role, preferredWorkspace, normalizedPath);
 }

--- a/src/app/platform/pwa-install.test.ts
+++ b/src/app/platform/pwa-install.test.ts
@@ -36,7 +36,9 @@ describe('pwa-install', () => {
 
   it('returns platform-specific install copy', () => {
     expect(getPwaInstallTarget('ios').steps.join(' ')).toContain('홈 화면에 추가');
+    expect(getPwaInstallTarget('ios').steps.join(' ')).toContain('명함 DB가 먼저 열립니다');
     expect(getPwaInstallTarget('android').summary).toContain('TWA');
+    expect(getPwaInstallTarget('desktop').steps.join(' ')).toContain('모바일에서는 명함 DB가 먼저 열리고');
   });
 
   it('reads standalone display mode', () => {

--- a/src/app/platform/pwa-install.ts
+++ b/src/app/platform/pwa-install.ts
@@ -25,7 +25,7 @@ const TARGETS: Record<PwaInstallPlatform, PwaInstallTarget> = {
       'Safari에서 MYSCube 라이브 링크를 엽니다.',
       '공유 버튼을 누르고 홈 화면에 추가를 선택합니다.',
       'Open as Web App이 보이면 켠 상태로 추가합니다.',
-      '홈 화면의 MYSCube 아이콘으로 다시 실행합니다.',
+      '홈 화면의 MYSCube 아이콘으로 다시 실행하면 명함 DB가 먼저 열립니다.',
     ],
     checks: [
       '주소창 없이 standalone 화면으로 열리는지 확인',
@@ -44,7 +44,7 @@ const TARGETS: Record<PwaInstallPlatform, PwaInstallTarget> = {
     steps: [
       'Chrome에서 MYSCube 라이브 링크를 엽니다.',
       '주소창 또는 브라우저 메뉴의 앱 설치를 선택합니다.',
-      '설치된 MYSCube 아이콘으로 다시 실행합니다.',
+      '설치된 MYSCube 아이콘으로 다시 실행하면 명함 DB가 먼저 열립니다.',
       '명함 DB에서 촬영, 추출, 검토 저장 흐름을 확인합니다.',
     ],
     checks: [
@@ -64,7 +64,7 @@ const TARGETS: Record<PwaInstallPlatform, PwaInstallTarget> = {
     steps: [
       '현재 기기에 맞는 설치 안내를 선택합니다.',
       '설치 후 MYSCube 아이콘으로 앱을 실행합니다.',
-      '로그인 후 명함 DB 또는 필요한 업무 화면으로 이동합니다.',
+      '모바일에서는 명함 DB가 먼저 열리고, 데스크톱에서는 기존 업무 화면으로 이동합니다.',
     ],
     checks: [
       'manifest 아이콘이 192px, 512px, maskable 512px로 제공되는지 확인',

--- a/src/app/routes.lazy-route.shell.test.ts
+++ b/src/app/routes.lazy-route.shell.test.ts
@@ -12,4 +12,12 @@ describe('route lazy loading safety', () => {
       "const PortalProjectSettings = lazy(() => import('./components/portal/PortalProjectSettings').then(m => ({ default: m.PortalProjectSettings })));",
     );
   });
+
+  it('registers the mobile PWA entry route separately from the desktop root', () => {
+    expect(routesSource).toContain("const MobileEntryPage = lazy(() => import('./components/pwa/MobileEntryPage')");
+    expect(routesSource).toContain("{ path: '/mobile-entry', element: <S C={MobileEntryPage} /> }");
+    expect(routesSource).toContain('function MobileAwareAdminHome()');
+    expect(routesSource).toContain('shouldUseBusinessCardMobileEntry');
+    expect(routesSource).toContain('{ index: true, element: <MobileAwareAdminHome /> }');
+  });
 });

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -5,11 +5,13 @@ import { PortalLayout } from './components/portal/PortalLayout';
 import { AdminRouteProviders } from './data/admin-route-providers';
 import { PortalRouteProviders } from './data/portal-route-providers';
 import { loadLazyRouteModule } from './platform/lazy-route';
+import { BUSINESS_CARD_MOBILE_ENTRY_PATH, shouldUseBusinessCardMobileEntry } from './platform/mobile-entry';
 
 // Lazy-loaded pages — each becomes a separate chunk
 const LoginPage = lazy(() => import('./components/auth/LoginPage').then(m => ({ default: m.LoginPage })));
 const WorkspaceSelectPage = lazy(() => import('./components/auth/WorkspaceSelectPage').then(m => ({ default: m.WorkspaceSelectPage })));
 const PwaInstallPage = lazy(() => import('./components/pwa/PwaInstallPage').then(m => ({ default: m.PwaInstallPage })));
+const MobileEntryPage = lazy(() => import('./components/pwa/MobileEntryPage').then(m => ({ default: m.MobileEntryPage })));
 const FeatureSearchPage = lazy(() => import('./components/dashboard/FeatureSearchPage').then(m => ({ default: m.FeatureSearchPage })));
 const DashboardPage = lazy(() => import('./components/dashboard/DashboardPage').then(m => ({ default: m.DashboardPage })));
 const BoardFeedPage = lazy(() => import('./components/board/BoardFeedPage').then(m => ({ default: m.BoardFeedPage })));
@@ -95,6 +97,18 @@ function PortalRouteShell() {
   return <PortalRouteProviders><PortalLayout /></PortalRouteProviders>;
 }
 
+function MobileAwareAdminHome() {
+  const useBusinessCardEntry = shouldUseBusinessCardMobileEntry({
+    userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : '',
+    viewportWidth: typeof window !== 'undefined' ? window.innerWidth : undefined,
+    requestedPath: typeof window !== 'undefined' ? window.location.pathname : '/',
+  });
+
+  return useBusinessCardEntry
+    ? <Navigate to={BUSINESS_CARD_MOBILE_ENTRY_PATH} replace />
+    : <S C={FeatureSearchPage} />;
+}
+
 export const router = createBrowserRouter([
   // ── Login ──
   { path: '/login', element: <S C={LoginPage} /> },
@@ -102,12 +116,13 @@ export const router = createBrowserRouter([
   { path: '/install', element: <S C={PwaInstallPage} /> },
   { path: '/install/ios', element: <S C={PwaInstallPage} /> },
   { path: '/install/android', element: <S C={PwaInstallPage} /> },
+  { path: '/mobile-entry', element: <S C={MobileEntryPage} /> },
   // ── Admin (관리자) ──
   {
     path: '/',
     element: <AdminRouteShell />,
     children: [
-      { index: true, element: <S C={FeatureSearchPage} /> },
+      { index: true, element: <MobileAwareAdminHome /> },
       { path: 'dashboard', element: <S C={DashboardPage} /> },
       { path: 'business-cards', element: <S C={BusinessCardLabPage} /> },
       // ── Company Board (전사 게시판) ──

--- a/vercel.json
+++ b/vercel.json
@@ -33,7 +33,25 @@
   ],
   "headers": [
     {
-      "source": "/(.*)",
+      "source": "/__/auth/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin-allow-popups" }
+      ]
+    },
+    {
+      "source": "/__/firebase/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
+        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin-allow-popups" }
+      ]
+    },
+    {
+      "source": "/((?!(?:__/auth|__/firebase)/).*)",
       "headers": [
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },
@@ -45,6 +63,14 @@
     }
   ],
   "rewrites": [
+    {
+      "source": "/__/auth/:path*",
+      "destination": "https://mysc-bmp-14173451.firebaseapp.com/__/auth/:path*"
+    },
+    {
+      "source": "/__/firebase/:path*",
+      "destination": "https://mysc-bmp-14173451.firebaseapp.com/__/firebase/:path*"
+    },
     {
       "source": "/api/v1",
       "destination": "/api/bff?__path=/api/v1"


### PR DESCRIPTION
## 한눈에 보기
- 명함 정보 추출에 Gemini API 키 방식을 추가하고, 기존 Vertex 방식은 예비 경로로 유지했습니다.
- 모바일/PWA 기본 진입 화면을 명함 촬영 흐름으로 바꿨습니다.
- 포털 캐시플로처럼 직접 주소로 들어가는 기존 링크는 그대로 동작하게 했습니다.
- PWA 문서, 앱 설정 검증, 이동 정책 테스트를 함께 정리했습니다.

## 사용자가 체감하는 변화
- 모바일에서 앱을 열면 명함 촬영 업무를 바로 시작할 수 있습니다.
- 기존에 공유된 특정 화면 링크는 깨지지 않습니다.

## 확인한 것
- npm test
- npm run build
- npm run pwa:qa
- 모바일 브라우저 확인: /mobile-entry -> 로그인, 콘솔 오류 없음
- Playwright iPhone 13 확인: manifest start_url=/mobile-entry, 페이지 오류 없음

## 운영 메모
- 이 PR에는 라이브 배포가 포함되지 않습니다. 고정 preview/stage에서 확인한 뒤 수동으로 승격합니다.