### PR TITLE
명함을 카메라로 촬영하고 CSV로 내보낼 수 있게 추가

### DIFF
--- a/docs/wiki/business-card-db/02-api-contract.md
+++ b/docs/wiki/business-card-db/02-api-contract.md
@@ -113,7 +113,7 @@ Response:
 
 ## GET `/api/v1/contacts?query=...`
 
-Org-wide contact search.
+Org-wide contact search. An empty `query` returns the first page of org-visible contacts for DB-style browsing.
 
 Response:
 
@@ -132,6 +132,26 @@ Response:
   ],
   "count": 1,
   "nextCursor": null
+}
+```
+
+## PATCH `/api/v1/contacts/:contactId`
+
+Updates an existing org-visible contact from the business-card DB editor. The payload shape is the same as the confirm endpoint, and the BFF rebuilds normalized search keys before writing.
+
+Response:
+
+```json
+{
+  "ok": true,
+  "contact": {
+    "id": "ct_abc123",
+    "name": "홍길동",
+    "organization": "MYSC",
+    "emails": ["hello@example.com"],
+    "phones": ["01012345678"],
+    "memo": "PC에서 수정"
+  }
 }
 ```
 

--- a/server/bff/business-card-routes.test.mjs
+++ b/server/bff/business-card-routes.test.mjs
@@ -189,4 +189,106 @@ describe('business-card routes', () => {
     expect(response.body.error).toBe('import_not_confirmable');
     expect(txSet).not.toHaveBeenCalled();
   });
+
+  it('lists contacts when the search query is blank', async () => {
+    const get = vi.fn(async () => ({
+      docs: [
+        {
+          id: 'ct_001',
+          data: () => ({
+            name: '홍길동',
+            organization: 'MYSC',
+            emails: ['person@example.com'],
+            phones: ['01012345678'],
+            memo: '첫 미팅',
+            updatedAt: '2026-05-23T00:00:00.000Z',
+          }),
+        },
+      ],
+    }));
+    const limit = vi.fn(() => ({ get }));
+    const orderBy = vi.fn(() => ({ limit }));
+    const collection = vi.fn(() => ({ orderBy }));
+    const { app } = createRouteHarness({
+      db: { collection },
+      storage: { uploadBusinessCard: vi.fn() },
+      gemini: { analyzeBusinessCard: vi.fn() },
+    });
+
+    const response = await request(app).get('/api/v1/contacts?query=');
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toHaveLength(1);
+    expect(response.body.items[0]).toMatchObject({
+      id: 'ct_001',
+      name: '홍길동',
+      memo: '첫 미팅',
+    });
+    expect(collection).toHaveBeenCalledWith('orgs/mysc/contacts');
+  });
+
+  it('updates contacts through the BFF and rebuilds search fields', async () => {
+    const txSet = vi.fn();
+    const db = {
+      doc: vi.fn((path) => ({ path })),
+      runTransaction: vi.fn(async (callback) => callback({
+        get: vi.fn(async () => ({
+          exists: true,
+          data: () => ({
+            id: 'ct_001',
+            tenantId: 'mysc',
+            visibility: 'org',
+            name: '기존 이름',
+            organization: 'MYSC',
+            emails: ['old@example.com'],
+            phones: [],
+            createdAt: '2026-05-22T00:00:00.000Z',
+          }),
+        })),
+        set: txSet,
+      })),
+    };
+    const { app, auditChainService } = createRouteHarness({
+      db,
+      storage: { uploadBusinessCard: vi.fn() },
+      gemini: { analyzeBusinessCard: vi.fn() },
+    });
+
+    const response = await request(app)
+      .patch('/api/v1/contacts/ct_001')
+      .set({ 'idempotency-key': 'idem_contact_update_001' })
+      .send({
+        name: '새 이름',
+        organization: 'MYSC',
+        department: 'AX',
+        title: '리드',
+        role: '',
+        emails: ['new@example.com'],
+        phones: [],
+        website: '',
+        address: '',
+        memo: 'PC에서 수정',
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.contact).toMatchObject({
+      id: 'ct_001',
+      name: '새 이름',
+      memo: 'PC에서 수정',
+    });
+    expect(txSet).toHaveBeenCalledWith(
+      { path: 'orgs/mysc/contacts/ct_001' },
+      expect.objectContaining({
+        name: '새 이름',
+        memo: 'PC에서 수정',
+        primaryEmail: 'new@example.com',
+        updatedBy: 'u001',
+      }),
+      { merge: true },
+    );
+    expect(auditChainService.append).toHaveBeenCalledWith(expect.objectContaining({
+      entityType: 'contact',
+      action: 'UPDATE',
+    }));
+  });
 });

--- a/server/bff/routes/business-cards.mjs
+++ b/server/bff/routes/business-cards.mjs
@@ -12,6 +12,7 @@ import {
 } from '../bff-utils.mjs';
 import {
   parseWithSchema,
+  businessCardContactUpdateSchema,
   businessCardConfirmSchema,
   businessCardProcessSchema,
   businessCardSearchSchema,
@@ -90,6 +91,8 @@ function contactDocToSearchResult(doc, score = 0) {
     emails: Array.isArray(doc.emails) ? doc.emails : [],
     phones: Array.isArray(doc.phones) ? doc.phones : [],
     website: doc.website || '',
+    address: doc.address || '',
+    memo: doc.memo || '',
     score,
     updatedAt: doc.updatedAt || '',
   };
@@ -340,6 +343,59 @@ export function mountBusinessCardRoutes(app, {
     });
 
     res.status(200).json(buildListResponse(items, limit));
+  }));
+
+  app.patch('/api/v1/contacts/:contactId', createMutatingRoute(idempotencyService, async (req) => {
+    assertActorPermissionAllowed(rbacPolicy, req, 'contact:write', 'update contacts');
+    const { tenantId, actorId } = req.context;
+    const contactId = readOptionalText(req.params.contactId);
+    const timestamp = now();
+    if (!contactId) throw createHttpError(400, 'contactId is required', 'missing_contact_id');
+
+    const parsed = parseWithSchema(businessCardContactUpdateSchema, req.body, 'Invalid contact payload');
+    const contactPayload = normalizeBusinessCardContactPayload(parsed);
+    assertConfirmableContact(contactPayload);
+
+    const contactRef = db.doc(`orgs/${tenantId}/contacts/${contactId}`);
+    const updatedDoc = await db.runTransaction(async (tx) => {
+      const contactSnap = await tx.get(contactRef);
+      if (!contactSnap.exists) throw createHttpError(404, `Contact not found: ${contactId}`, 'not_found');
+      const existing = contactSnap.data() || {};
+      const nextContact = stripUndefinedDeep({
+        ...existing,
+        ...contactPayload,
+        ...buildContactDerivedFields(contactPayload),
+        id: contactId,
+        tenantId,
+        updatedBy: actorId,
+        updatedAt: timestamp,
+      });
+      tx.set(contactRef, nextContact, { merge: true });
+      return nextContact;
+    });
+
+    await appendAudit({
+      auditChainService,
+      piiProtector,
+      context: req.context,
+      entityType: 'contact',
+      entityId: contactId,
+      action: 'UPDATE',
+      details: `연락처 수정: ${contactPayload.name || contactPayload.organization}`,
+      metadata: {
+        source: 'business_card_db',
+        visibility: updatedDoc.visibility || 'org',
+      },
+      timestamp,
+    });
+
+    return {
+      status: 200,
+      body: {
+        ok: true,
+        contact: contactDocToSearchResult(updatedDoc, 1),
+      },
+    };
   }));
 
   app.get('/api/v1/business-card-imports/:importId/image', asyncHandler(async (req, res) => {

--- a/server/bff/schemas.mjs
+++ b/server/bff/schemas.mjs
@@ -210,8 +210,10 @@ export const businessCardConfirmSchema = z.object({
   }
 });
 
+export const businessCardContactUpdateSchema = businessCardConfirmSchema;
+
 export const businessCardSearchSchema = z.object({
-  query: NON_EMPTY_STRING.max(200),
+  query: z.string().trim().max(200).default(''),
   limit: z.number().int().positive().max(100).optional(),
   cursor: z.string().trim().max(300).optional(),
 }).strict();

--- a/src/app/components/business-cards/BusinessCardLabPage.shell.test.ts
+++ b/src/app/components/business-cards/BusinessCardLabPage.shell.test.ts
@@ -9,10 +9,14 @@ describe('BusinessCardLabPage shell contract', () => {
     expect(source.indexOf("{ id: 'capture'")).toBeLessThan(source.indexOf("{ id: 'search'"));
     expect(source).toContain("useState<BusinessCardTab>('capture')");
     expect(source).toContain('capture="environment"');
-    expect(source).toContain('카메라 스캔');
+    expect(source).toContain('aria-label="명함 촬영 시작"');
+    expect(source).toContain('processPreparedImage(nextImage)');
     expect(source).toContain('이미지 선택');
+    expect(source).not.toContain('Gemini 추출');
     expect(source).toContain('DB 저장');
     expect(source).toContain('Excel CSV');
+    expect(source).toContain('updateContactViaBff');
+    expect(source).toContain('검색어 없이 조회하면 연락처 목록이 먼저 표시됩니다.');
     expect(source).not.toContain("'review'");
   });
 });

--- a/src/app/components/business-cards/BusinessCardLabPage.shell.test.ts
+++ b/src/app/components/business-cards/BusinessCardLabPage.shell.test.ts
@@ -9,6 +9,10 @@ describe('BusinessCardLabPage shell contract', () => {
     expect(source.indexOf("{ id: 'capture'")).toBeLessThan(source.indexOf("{ id: 'search'"));
     expect(source).toContain("useState<BusinessCardTab>('capture')");
     expect(source).toContain('capture="environment"');
-    expect(source).toContain('촬영/업로드');
+    expect(source).toContain('카메라 스캔');
+    expect(source).toContain('이미지 선택');
+    expect(source).toContain('DB 저장');
+    expect(source).toContain('Excel CSV');
+    expect(source).not.toContain("'review'");
   });
 });

--- a/src/app/components/business-cards/BusinessCardLabPage.tsx
+++ b/src/app/components/business-cards/BusinessCardLabPage.tsx
@@ -1,13 +1,15 @@
-import { useMemo, useRef, useState, type ChangeEvent } from 'react';
+import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
 import {
   AlertTriangle,
   Camera,
   CheckCircle2,
+  Download,
+  Image as ImageIcon,
   Loader2,
   Search,
   Sparkles,
-  Upload,
   UserRoundCheck,
+  X,
 } from 'lucide-react';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
@@ -16,11 +18,9 @@ import { useAuth } from '../../data/auth-store';
 import {
   confirmBusinessCardImportViaBff,
   isPlatformApiEnabled,
-  listBusinessCardImportsViaBff,
   processBusinessCardViaBff,
   searchContactsViaBff,
   type ActorLike,
-  type BusinessCardImportListItem,
   type BusinessCardImportResult,
   type ContactSearchResult,
 } from '../../lib/platform-bff-client';
@@ -35,18 +35,45 @@ import {
   isLowConfidenceField,
 } from './business-card-quality';
 
-type BusinessCardTab = 'search' | 'capture' | 'review';
+type BusinessCardTab = 'search' | 'capture';
 
 const TABS: Array<{ id: BusinessCardTab; label: string; description: string }> = [
-  { id: 'capture', label: '명함 등록', description: '모바일 카메라나 이미지 파일로 새 명함을 등록합니다.' },
+  { id: 'capture', label: '명함 등록', description: '카메라 가이드에 맞춰 촬영하거나 이미지 파일로 새 명함을 등록합니다.' },
   { id: 'search', label: '검색', description: '전사 연락처를 이름, 회사, 이메일, 전화번호로 찾습니다.' },
-  { id: 'review', label: '검토 대기', description: 'Gemini 추출 후 저장 전 상태의 명함을 확인합니다.' },
 ];
+
+const CAMERA_GUIDE = {
+  left: 0.11,
+  top: 0.28,
+  width: 0.78,
+  aspectRatio: 1.58,
+};
 
 function formatBytes(bytes: number): string {
   if (!Number.isFinite(bytes) || bytes <= 0) return '0 KB';
   if (bytes >= 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
   return `${Math.ceil(bytes / 1024)} KB`;
+}
+
+function escapeCsvCell(value: unknown): string {
+  const text = String(value ?? '').replace(/\r?\n/g, ' ').trim();
+  return /[",\n]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text;
+}
+
+function buildContactsCsv(items: ContactSearchResult[]): string {
+  const header = ['이름', '회사/소속', '부서', '직함', '역할', '이메일', '전화번호', '웹사이트', '수정일'];
+  const rows = items.map((item) => [
+    item.name,
+    item.organization,
+    item.department || '',
+    item.title || '',
+    item.role || '',
+    item.emails?.join('; ') || '',
+    item.phones?.join('; ') || '',
+    item.website || '',
+    item.updatedAt || '',
+  ]);
+  return [header, ...rows].map((row) => row.map(escapeCsvCell).join(',')).join('\n');
 }
 
 export function BusinessCardLabPage() {
@@ -57,11 +84,13 @@ export function BusinessCardLabPage() {
   const [preparing, setPreparing] = useState(false);
   const [processing, setProcessing] = useState(false);
   const [saving, setSaving] = useState(false);
-  const [loadingImports, setLoadingImports] = useState(false);
+  const [scannerOpen, setScannerOpen] = useState(false);
+  const [cameraStarting, setCameraStarting] = useState(false);
+  const [cameraStream, setCameraStream] = useState<MediaStream | null>(null);
+  const [cameraError, setCameraError] = useState('');
   const [searching, setSearching] = useState(false);
   const [workflowMessage, setWorkflowMessage] = useState('');
   const [currentImport, setCurrentImport] = useState<BusinessCardImportResult | null>(null);
-  const [reviewImports, setReviewImports] = useState<BusinessCardImportListItem[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<ContactSearchResult[]>([]);
   const [formState, setFormState] = useState({
@@ -77,6 +106,7 @@ export function BusinessCardLabPage() {
     memo: '',
   });
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
 
   const activeTabMeta = useMemo(
     () => TABS.find((tab) => tab.id === activeTab) || TABS[0],
@@ -93,8 +123,16 @@ export function BusinessCardLabPage() {
   const canSave = canConfirmBusinessCardContact(confirmPayload) && Boolean(currentImport?.importId);
   const bffEnabled = isPlatformApiEnabled();
 
-  async function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
-    const file = event.target.files?.[0];
+  useEffect(() => {
+    if (!scannerOpen || !cameraStream || !videoRef.current) return;
+    videoRef.current.srcObject = cameraStream;
+  }, [cameraStream, scannerOpen]);
+
+  useEffect(() => () => {
+    cameraStream?.getTracks().forEach((track) => track.stop());
+  }, [cameraStream]);
+
+  async function prepareSelectedFile(file: File) {
     setImageError('');
     if (!file) return;
     setPreparing(true);
@@ -107,19 +145,116 @@ export function BusinessCardLabPage() {
       setImageError(error instanceof Error ? error.message : '이미지를 준비하지 못했습니다.');
     } finally {
       setPreparing(false);
-      event.target.value = '';
     }
+  }
+
+  async function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (file) {
+      if (scannerOpen) closeScanner();
+      await prepareSelectedFile(file);
+    }
+    event.target.value = '';
+  }
+
+  function stopCamera() {
+    cameraStream?.getTracks().forEach((track) => track.stop());
+    setCameraStream(null);
+  }
+
+  async function openScanner() {
+    setImageError('');
+    setCameraError('');
+    setScannerOpen(true);
+    if (!navigator.mediaDevices?.getUserMedia) {
+      setCameraError('이 브라우저에서는 앱 내 카메라를 사용할 수 없습니다. 이미지 업로드를 이용해 주세요.');
+      return;
+    }
+    setCameraStarting(true);
+    try {
+      stopCamera();
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: false,
+        video: {
+          facingMode: { ideal: 'environment' },
+          width: { ideal: 1920 },
+          height: { ideal: 1080 },
+        },
+      });
+      setCameraStream(stream);
+    } catch (error) {
+      setCameraError(error instanceof Error ? error.message : '카메라 권한을 열지 못했습니다.');
+    } finally {
+      setCameraStarting(false);
+    }
+  }
+
+  function closeScanner() {
+    stopCamera();
+    setScannerOpen(false);
+    setCameraError('');
+  }
+
+  async function handleCaptureFromScanner() {
+    const video = videoRef.current;
+    if (!video || video.videoWidth <= 0 || video.videoHeight <= 0) {
+      setCameraError('카메라 화면을 아직 읽지 못했습니다. 잠시 후 다시 촬영해 주세요.');
+      return;
+    }
+
+    const displayWidth = video.clientWidth || video.videoWidth;
+    const displayHeight = video.clientHeight || video.videoHeight;
+    const guideHeight = (displayWidth * CAMERA_GUIDE.width) / CAMERA_GUIDE.aspectRatio;
+    const guideTop = displayHeight * CAMERA_GUIDE.top;
+    const guide = {
+      x: displayWidth * CAMERA_GUIDE.left,
+      y: guideTop,
+      width: displayWidth * CAMERA_GUIDE.width,
+      height: guideHeight,
+    };
+    const scale = Math.max(displayWidth / video.videoWidth, displayHeight / video.videoHeight);
+    const renderedWidth = video.videoWidth * scale;
+    const renderedHeight = video.videoHeight * scale;
+    const offsetX = (displayWidth - renderedWidth) / 2;
+    const offsetY = (displayHeight - renderedHeight) / 2;
+    const source = {
+      x: Math.max(0, Math.round((guide.x - offsetX) / scale)),
+      y: Math.max(0, Math.round((guide.y - offsetY) / scale)),
+      width: Math.min(video.videoWidth, Math.round(guide.width / scale)),
+      height: Math.min(video.videoHeight, Math.round(guide.height / scale)),
+    };
+    source.width = Math.max(1, Math.min(source.width, video.videoWidth - source.x));
+    source.height = Math.max(1, Math.min(source.height, video.videoHeight - source.y));
+
+    const canvas = document.createElement('canvas');
+    canvas.width = source.width;
+    canvas.height = source.height;
+    const context = canvas.getContext('2d');
+    if (!context) {
+      setCameraError('촬영 이미지를 만들지 못했습니다.');
+      return;
+    }
+    context.drawImage(video, source.x, source.y, source.width, source.height, 0, 0, source.width, source.height);
+    const blob = await new Promise<Blob | null>((resolve) => {
+      canvas.toBlob((nextBlob) => resolve(nextBlob), 'image/jpeg', 0.92);
+    });
+    if (!blob) {
+      setCameraError('촬영 이미지를 저장하지 못했습니다.');
+      return;
+    }
+    const file = new File([blob], `business-card-scan-${Date.now()}.jpg`, { type: 'image/jpeg' });
+    closeScanner();
+    await prepareSelectedFile(file);
   }
 
   function updateFormField(key: keyof typeof formState, value: string) {
     setFormState((current) => ({ ...current, [key]: value }));
   }
 
-  function applyImportForReview(item: BusinessCardImportListItem | BusinessCardImportResult) {
+  function applyImportForEdit(item: BusinessCardImportResult) {
     if (!item.extracted) return;
-    const importId = 'importId' in item ? item.importId : item.id;
     setCurrentImport({
-      importId,
+      importId: item.importId,
       status: item.status,
       extracted: item.extracted,
       error: item.error || null,
@@ -148,8 +283,8 @@ export function BusinessCardLabPage() {
           contentBase64: preparedImage.contentBase64,
         },
       });
-      applyImportForReview(result);
-      setWorkflowMessage('추출 draft를 만들었습니다. 필드를 확인한 뒤 저장해 주세요.');
+      applyImportForEdit(result);
+      setWorkflowMessage('Gemini가 읽은 값을 아래에 채웠습니다. 필요한 부분만 수정한 뒤 DB에 저장해 주세요.');
     } catch (error) {
       setWorkflowMessage(error instanceof Error ? error.message : '명함 추출 요청에 실패했습니다.');
     } finally {
@@ -179,28 +314,6 @@ export function BusinessCardLabPage() {
     }
   }
 
-  async function handleLoadReviewImports() {
-    if (!actor || !bffEnabled) {
-      setWorkflowMessage('BFF API가 꺼져 있어 검토 대기열을 불러올 수 없습니다.');
-      return;
-    }
-    setLoadingImports(true);
-    setWorkflowMessage('');
-    try {
-      const result = await listBusinessCardImportsViaBff({
-        tenantId,
-        actor,
-        status: 'needs_review',
-      });
-      setReviewImports(result.items);
-      setWorkflowMessage(`검토 대기 ${result.items.length}건을 불러왔습니다.`);
-    } catch (error) {
-      setWorkflowMessage(error instanceof Error ? error.message : '검토 대기열을 불러오지 못했습니다.');
-    } finally {
-      setLoadingImports(false);
-    }
-  }
-
   async function handleSearchContacts() {
     if (!actor || !bffEnabled || !searchQuery.trim()) return;
     setSearching(true);
@@ -217,6 +330,21 @@ export function BusinessCardLabPage() {
     } finally {
       setSearching(false);
     }
+  }
+
+  function handleDownloadSearchResultsCsv() {
+    if (searchResults.length === 0) return;
+    const csv = `\uFEFF${buildContactsCsv(searchResults)}`;
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    const date = new Date().toISOString().slice(0, 10);
+    link.href = url;
+    link.download = `business-card-contacts-${date}.csv`;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
   }
 
   return (
@@ -285,9 +413,9 @@ export function BusinessCardLabPage() {
                         {preparing ? <Loader2 className="h-6 w-6 animate-spin" /> : <Camera className="h-6 w-6" />}
                       </div>
                       <div>
-                        <h3 className="text-[16px] font-bold text-slate-950 dark:text-slate-50">명함 이미지 선택</h3>
+                        <h3 className="text-[16px] font-bold text-slate-950 dark:text-slate-50">명함 스캔</h3>
                         <p className="mt-2 max-w-md text-[13px] leading-6 text-muted-foreground">
-                          모바일에서는 카메라가 열리고, 데스크톱에서는 파일 선택으로 이어집니다. 이미지는 업로드 전에 브라우저에서 한 번 압축합니다.
+                          앱 안의 카메라 가이드에 명함을 맞춰 촬영하거나, 저장된 이미지를 선택합니다. 추출 후 같은 화면에서 바로 수정하고 DB에 저장합니다.
                         </p>
                       </div>
                       <Input
@@ -299,9 +427,13 @@ export function BusinessCardLabPage() {
                         onChange={handleFileChange}
                       />
                       <div className="flex flex-wrap justify-center gap-2">
-                        <Button type="button" onClick={() => fileInputRef.current?.click()} disabled={preparing}>
-                          <Upload className="h-4 w-4" />
-                          촬영/업로드
+                        <Button type="button" onClick={openScanner} disabled={preparing}>
+                          <Camera className="h-4 w-4" />
+                          카메라 스캔
+                        </Button>
+                        <Button type="button" variant="outline" onClick={() => fileInputRef.current?.click()} disabled={preparing}>
+                          <ImageIcon className="h-4 w-4" />
+                          이미지 선택
                         </Button>
                         <Button
                           type="button"
@@ -310,7 +442,7 @@ export function BusinessCardLabPage() {
                           onClick={handleProcessImage}
                         >
                           {processing ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
-                          추출 실행
+                          Gemini 추출
                         </Button>
                       </div>
                       {imageError && (
@@ -349,7 +481,7 @@ export function BusinessCardLabPage() {
                           </div>
                         </dl>
                         <div className="rounded-lg border border-amber-200/70 bg-amber-50/70 px-3 py-2 text-[11px] leading-5 text-amber-800 dark:border-amber-400/20 dark:bg-amber-950/25 dark:text-amber-200">
-                          추출 실행 시 이 이미지는 private Storage에 저장되고 Gemini 검토 draft로 이어집니다.
+                          Gemini 추출 후 아래 입력칸에서 수정한 뒤 DB에 저장합니다.
                         </div>
                       </div>
                     ) : (
@@ -369,9 +501,9 @@ export function BusinessCardLabPage() {
                       <section className="rounded-lg border border-white/70 bg-white/70 p-4 shadow-sm backdrop-blur-md dark:border-white/10 dark:bg-slate-950/45">
                         <div className="flex flex-wrap items-start justify-between gap-3">
                           <div>
-                            <h3 className="text-[15px] font-extrabold text-slate-950 dark:text-slate-50">추출 결과 검토</h3>
+                            <h3 className="text-[15px] font-extrabold text-slate-950 dark:text-slate-50">추출값 수정 및 DB 저장</h3>
                             <p className="mt-1 text-[12px] leading-5 text-muted-foreground">
-                              낮은 신뢰도의 값은 표시해 두었습니다. 확인 후 저장해야 전사 검색에 반영됩니다.
+                              Gemini가 읽은 값을 필요하면 수정하세요. 저장하면 전사 연락처 검색 DB에 반영됩니다.
                             </p>
                           </div>
                           <span className="rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 text-[11px] font-semibold text-amber-800 dark:border-amber-400/20 dark:bg-amber-950/25 dark:text-amber-200">
@@ -431,7 +563,7 @@ export function BusinessCardLabPage() {
                           </p>
                           <Button type="button" onClick={handleSaveContact} disabled={!canSave || saving || currentImport.status === 'saved'}>
                             {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <CheckCircle2 className="h-4 w-4" />}
-                            연락처 저장
+                            DB 저장
                           </Button>
                         </div>
                       </section>
@@ -442,7 +574,7 @@ export function BusinessCardLabPage() {
 
               {activeTab === 'search' && (
                 <div className="space-y-4">
-                  <div className="flex gap-2">
+                  <div className="flex flex-col gap-2 md:flex-row">
                     <Input
                       value={searchQuery}
                       onChange={(event) => setSearchQuery(event.target.value)}
@@ -454,6 +586,10 @@ export function BusinessCardLabPage() {
                     <Button type="button" onClick={handleSearchContacts} disabled={!searchQuery.trim() || searching || !bffEnabled}>
                       {searching ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
                       검색
+                    </Button>
+                    <Button type="button" variant="outline" onClick={handleDownloadSearchResultsCsv} disabled={searchResults.length === 0}>
+                      <Download className="h-4 w-4" />
+                      Excel CSV
                     </Button>
                   </div>
                   <div className="overflow-hidden rounded-lg border border-white/70 bg-white/65 shadow-sm backdrop-blur-md dark:border-white/10 dark:bg-slate-950/35">
@@ -491,43 +627,70 @@ export function BusinessCardLabPage() {
                 </div>
               )}
 
-              {activeTab === 'review' && (
-                <div className="space-y-3">
-                  <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-white/70 bg-white/55 px-4 py-3 backdrop-blur-md dark:border-white/10 dark:bg-slate-950/35">
-                    <div>
-                      <h3 className="text-[14px] font-bold text-slate-950 dark:text-slate-50">검토 대기 명함</h3>
-                      <p className="mt-1 text-[12px] text-muted-foreground">저장 전 확인이 필요한 추출 draft입니다.</p>
-                    </div>
-                    <Button type="button" variant="outline" onClick={handleLoadReviewImports} disabled={loadingImports || !bffEnabled}>
-                      {loadingImports ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
-                      불러오기
-                    </Button>
-                  </div>
-                  {reviewImports.length === 0 ? (
-                    <div className="flex min-h-[180px] items-center justify-center rounded-lg border border-dashed border-slate-200 bg-white/40 px-4 text-center text-[12px] text-muted-foreground dark:border-white/10 dark:bg-slate-950/25">
-                      검토 대기 명함이 없습니다.
-                    </div>
-                  ) : (
-                    <div className="grid gap-3 md:grid-cols-2">
-                      {reviewImports.map((item) => (
-                        <button
-                          key={item.id}
-                          type="button"
-                          onClick={() => applyImportForReview(item)}
-                          className="rounded-lg border border-white/70 bg-white/65 p-4 text-left shadow-sm backdrop-blur-md transition-colors hover:border-sky-200 hover:bg-sky-50/70 dark:border-white/10 dark:bg-slate-950/35 dark:hover:border-sky-400/20"
-                        >
-                          <span className="block text-[13px] font-bold text-slate-950 dark:text-slate-50">{item.extracted?.name.value || item.extracted?.organization.value || item.fileName}</span>
-                          <span className="mt-1 block text-[11px] text-muted-foreground">{item.fileName} · {formatBytes(item.fileSize)}</span>
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              )}
             </main>
           </div>
         </section>
       </div>
+      {scannerOpen && (
+        <div className="fixed inset-0 z-50 flex items-stretch justify-center bg-slate-950 md:items-center md:bg-slate-950/80 md:p-6">
+          <div className="relative flex h-dvh w-full max-w-md flex-col overflow-hidden bg-slate-950 text-white md:h-[760px] md:rounded-lg md:border md:border-white/10">
+            <div className="absolute left-0 right-0 top-0 z-20 flex items-center justify-between px-4 py-3">
+              <Button type="button" size="icon" variant="ghost" className="text-white hover:bg-white/10 hover:text-white" onClick={closeScanner} aria-label="스캐너 닫기">
+                <X className="h-5 w-5" />
+              </Button>
+              <span className="rounded-full bg-black/35 px-3 py-1 text-[12px] font-semibold backdrop-blur-md">명함을 가이드 안에 맞춰주세요</span>
+              <span className="h-10 w-10" aria-hidden="true" />
+            </div>
+            <div className="relative flex-1 overflow-hidden">
+              {cameraStream ? (
+                <video ref={videoRef} autoPlay playsInline muted className="h-full w-full object-cover" />
+              ) : (
+                <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+                  {cameraStarting ? <Loader2 className="h-8 w-8 animate-spin" /> : <Camera className="h-8 w-8" />}
+                  <p className="text-[13px] text-white/80">{cameraError || '카메라를 여는 중입니다.'}</p>
+                </div>
+              )}
+              <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_center,transparent_0%,transparent_42%,rgba(2,6,23,0.52)_74%)]" />
+              <div
+                className="pointer-events-none absolute rounded-[6px] border-2 border-emerald-400 bg-emerald-300/10 shadow-[0_0_0_999px_rgba(2,6,23,0.42)]"
+                style={{
+                  left: `${CAMERA_GUIDE.left * 100}%`,
+                  top: `${CAMERA_GUIDE.top * 100}%`,
+                  width: `${CAMERA_GUIDE.width * 100}%`,
+                  aspectRatio: String(CAMERA_GUIDE.aspectRatio),
+                }}
+              >
+                <span className="absolute -left-0.5 -top-0.5 h-5 w-5 border-l-4 border-t-4 border-emerald-300" />
+                <span className="absolute -right-0.5 -top-0.5 h-5 w-5 border-r-4 border-t-4 border-emerald-300" />
+                <span className="absolute -bottom-0.5 -left-0.5 h-5 w-5 border-b-4 border-l-4 border-emerald-300" />
+                <span className="absolute -bottom-0.5 -right-0.5 h-5 w-5 border-b-4 border-r-4 border-emerald-300" />
+              </div>
+            </div>
+            <div className="z-20 border-t border-white/10 bg-white px-4 pb-[calc(env(safe-area-inset-bottom)+18px)] pt-4 text-slate-950">
+              {cameraError && (
+                <p className="mb-3 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-center text-[12px] font-semibold text-rose-700">
+                  {cameraError}
+                </p>
+              )}
+              <div className="flex items-center justify-center gap-6">
+                <Button type="button" variant="ghost" className="h-12 w-12 rounded-full" onClick={() => fileInputRef.current?.click()} aria-label="이미지 선택">
+                  <ImageIcon className="h-5 w-5" />
+                </Button>
+                <button
+                  type="button"
+                  onClick={handleCaptureFromScanner}
+                  disabled={!cameraStream || cameraStarting}
+                  className="flex h-16 w-16 items-center justify-center rounded-full border-4 border-slate-950 bg-white disabled:opacity-50"
+                  aria-label="명함 촬영"
+                >
+                  <span className="h-10 w-10 rounded-full bg-emerald-500 shadow-inner" />
+                </button>
+                <span className="h-12 w-12" aria-hidden="true" />
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/components/business-cards/BusinessCardLabPage.tsx
+++ b/src/app/components/business-cards/BusinessCardLabPage.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
+import { Textarea } from '../ui/textarea';
 import { PwaInstallPrompt } from '../pwa/PwaInstallPrompt';
 import { useAuth } from '../../data/auth-store';
 import {
@@ -20,7 +21,9 @@ import {
   isPlatformApiEnabled,
   processBusinessCardViaBff,
   searchContactsViaBff,
+  updateContactViaBff,
   type ActorLike,
+  type BusinessCardConfirmPayload,
   type BusinessCardImportResult,
   type ContactSearchResult,
 } from '../../lib/platform-bff-client';
@@ -36,6 +39,19 @@ import {
 } from './business-card-quality';
 
 type BusinessCardTab = 'search' | 'capture';
+
+interface BusinessCardContactFormState {
+  name: string;
+  organization: string;
+  department: string;
+  title: string;
+  role: string;
+  emailsText: string;
+  phonesText: string;
+  website: string;
+  address: string;
+  memo: string;
+}
 
 const TABS: Array<{ id: BusinessCardTab; label: string; description: string }> = [
   { id: 'capture', label: '명함 등록', description: '카메라 가이드에 맞춰 촬영하거나 이미지 파일로 새 명함을 등록합니다.' },
@@ -61,7 +77,7 @@ function escapeCsvCell(value: unknown): string {
 }
 
 function buildContactsCsv(items: ContactSearchResult[]): string {
-  const header = ['이름', '회사/소속', '부서', '직함', '역할', '이메일', '전화번호', '웹사이트', '수정일'];
+  const header = ['이름', '회사/소속', '부서', '직함', '역할', '이메일', '전화번호', '웹사이트', '주소', '메모', '수정일'];
   const rows = items.map((item) => [
     item.name,
     item.organization,
@@ -71,9 +87,41 @@ function buildContactsCsv(items: ContactSearchResult[]): string {
     item.emails?.join('; ') || '',
     item.phones?.join('; ') || '',
     item.website || '',
+    item.address || '',
+    item.memo || '',
     item.updatedAt || '',
   ]);
   return [header, ...rows].map((row) => row.map(escapeCsvCell).join(',')).join('\n');
+}
+
+function createEmptyContactFormState(): BusinessCardContactFormState {
+  return {
+    name: '',
+    organization: '',
+    department: '',
+    title: '',
+    role: '',
+    emailsText: '',
+    phonesText: '',
+    website: '',
+    address: '',
+    memo: '',
+  };
+}
+
+function contactToFormState(contact: ContactSearchResult): BusinessCardContactFormState {
+  return {
+    name: contact.name || '',
+    organization: contact.organization || '',
+    department: contact.department || '',
+    title: contact.title || '',
+    role: contact.role || '',
+    emailsText: contact.emails?.join(', ') || '',
+    phonesText: contact.phones?.join(', ') || '',
+    website: contact.website || '',
+    address: contact.address || '',
+    memo: contact.memo || '',
+  };
 }
 
 export function BusinessCardLabPage() {
@@ -89,22 +137,14 @@ export function BusinessCardLabPage() {
   const [cameraStream, setCameraStream] = useState<MediaStream | null>(null);
   const [cameraError, setCameraError] = useState('');
   const [searching, setSearching] = useState(false);
+  const [savingContactId, setSavingContactId] = useState('');
   const [workflowMessage, setWorkflowMessage] = useState('');
   const [currentImport, setCurrentImport] = useState<BusinessCardImportResult | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<ContactSearchResult[]>([]);
-  const [formState, setFormState] = useState({
-    name: '',
-    organization: '',
-    department: '',
-    title: '',
-    role: '',
-    emailsText: '',
-    phonesText: '',
-    website: '',
-    address: '',
-    memo: '',
-  });
+  const [contactDrafts, setContactDrafts] = useState<Record<string, BusinessCardContactFormState>>({});
+  const [hasLoadedInitialContacts, setHasLoadedInitialContacts] = useState(false);
+  const [formState, setFormState] = useState<BusinessCardContactFormState>(() => createEmptyContactFormState());
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const videoRef = useRef<HTMLVideoElement | null>(null);
 
@@ -122,6 +162,14 @@ export function BusinessCardLabPage() {
   const confirmPayload = useMemo(() => buildBusinessCardConfirmPayload(formState), [formState]);
   const canSave = canConfirmBusinessCardContact(confirmPayload) && Boolean(currentImport?.importId);
   const bffEnabled = isPlatformApiEnabled();
+  const busyLabel = preparing
+    ? '이미지 준비 중'
+    : processing
+      ? 'Gemini가 명함을 읽는 중'
+      : saving
+        ? 'DB에 저장 중'
+        : '';
+  const captureBusy = Boolean(busyLabel);
 
   useEffect(() => {
     if (!scannerOpen || !cameraStream || !videoRef.current) return;
@@ -132,6 +180,12 @@ export function BusinessCardLabPage() {
     cameraStream?.getTracks().forEach((track) => track.stop());
   }, [cameraStream]);
 
+  useEffect(() => {
+    if (activeTab !== 'search' || hasLoadedInitialContacts || !actor || !bffEnabled) return;
+    setHasLoadedInitialContacts(true);
+    void handleSearchContacts('');
+  }, [activeTab, actor, bffEnabled, hasLoadedInitialContacts]);
+
   async function prepareSelectedFile(file: File) {
     setImageError('');
     if (!file) return;
@@ -139,7 +193,10 @@ export function BusinessCardLabPage() {
     try {
       const nextImage = await prepareBusinessCardImage(file);
       setPreparedImage(nextImage);
-      setWorkflowMessage('');
+      setCurrentImport(null);
+      setFormState(createEmptyContactFormState());
+      setPreparing(false);
+      await processPreparedImage(nextImage);
     } catch (error) {
       setPreparedImage(null);
       setImageError(error instanceof Error ? error.message : '이미지를 준비하지 못했습니다.');
@@ -264,8 +321,11 @@ export function BusinessCardLabPage() {
     setActiveTab('capture');
   }
 
-  async function handleProcessImage() {
-    if (!preparedImage || !actor) return;
+  async function processPreparedImage(image: BusinessCardPreparedImage) {
+    if (!actor) {
+      setWorkflowMessage('로그인 정보를 확인하지 못해 자동 추출을 시작하지 못했습니다.');
+      return;
+    }
     if (!bffEnabled) {
       setWorkflowMessage('BFF API가 꺼져 있어 명함 추출을 실행할 수 없습니다.');
       return;
@@ -277,14 +337,14 @@ export function BusinessCardLabPage() {
         tenantId,
         actor,
         upload: {
-          fileName: preparedImage.fileName,
-          mimeType: preparedImage.mimeType,
-          fileSize: preparedImage.fileSize,
-          contentBase64: preparedImage.contentBase64,
+          fileName: image.fileName,
+          mimeType: image.mimeType,
+          fileSize: image.fileSize,
+          contentBase64: image.contentBase64,
         },
       });
       applyImportForEdit(result);
-      setWorkflowMessage('Gemini가 읽은 값을 아래에 채웠습니다. 필요한 부분만 수정한 뒤 DB에 저장해 주세요.');
+      setWorkflowMessage('Gemini가 읽은 값을 아래에 채웠습니다. 필요한 부분만 수정한 뒤 DB에 저장하세요.');
     } catch (error) {
       setWorkflowMessage(error instanceof Error ? error.message : '명함 추출 요청에 실패했습니다.');
     } finally {
@@ -314,21 +374,59 @@ export function BusinessCardLabPage() {
     }
   }
 
-  async function handleSearchContacts() {
-    if (!actor || !bffEnabled || !searchQuery.trim()) return;
+  async function handleSearchContacts(nextQuery = searchQuery) {
+    if (!actor || !bffEnabled) return;
     setSearching(true);
     setWorkflowMessage('');
     try {
       const result = await searchContactsViaBff({
         tenantId,
         actor,
-        query: searchQuery,
+        query: nextQuery.trim(),
       });
       setSearchResults(result.items);
+      setContactDrafts(Object.fromEntries(result.items.map((item) => [item.id, contactToFormState(item)])));
     } catch (error) {
       setWorkflowMessage(error instanceof Error ? error.message : '연락처 검색에 실패했습니다.');
     } finally {
       setSearching(false);
+    }
+  }
+
+  function updateContactDraft(contactId: string, key: keyof BusinessCardContactFormState, value: string) {
+    setContactDrafts((current) => ({
+      ...current,
+      [contactId]: {
+        ...(current[contactId] || createEmptyContactFormState()),
+        [key]: value,
+      },
+    }));
+  }
+
+  async function handleSaveSearchContact(contact: ContactSearchResult) {
+    if (!actor || !bffEnabled) return;
+    const draft = contactDrafts[contact.id] || contactToFormState(contact);
+    const payload: BusinessCardConfirmPayload = buildBusinessCardConfirmPayload(draft);
+    if (!canConfirmBusinessCardContact(payload)) {
+      setWorkflowMessage('저장하려면 이름 또는 회사/소속 1개 이상, 이메일 또는 전화번호 1개 이상이 필요합니다.');
+      return;
+    }
+    setSavingContactId(contact.id);
+    setWorkflowMessage('');
+    try {
+      const result = await updateContactViaBff({
+        tenantId,
+        actor,
+        contactId: contact.id,
+        contact: payload,
+      });
+      setSearchResults((current) => current.map((item) => (item.id === contact.id ? result.contact : item)));
+      setContactDrafts((current) => ({ ...current, [contact.id]: contactToFormState(result.contact) }));
+      setWorkflowMessage('연락처를 DB에 저장했습니다.');
+    } catch (error) {
+      setWorkflowMessage(error instanceof Error ? error.message : '연락처 저장에 실패했습니다.');
+    } finally {
+      setSavingContactId('');
     }
   }
 
@@ -348,7 +446,7 @@ export function BusinessCardLabPage() {
   }
 
   return (
-    <div className="min-h-dvh bg-[linear-gradient(135deg,#eef6ff_0%,#f8fbff_46%,#ecfdf5_100%)] px-4 py-6 dark:bg-[linear-gradient(135deg,#061a2f_0%,#0f172a_52%,#052e2b_100%)] md:px-6 md:py-8">
+    <div className="min-h-dvh bg-[linear-gradient(135deg,#eef6ff_0%,#f8fbff_48%,#f3f7fb_100%)] px-4 py-6 dark:bg-[linear-gradient(135deg,#061a2f_0%,#0f172a_52%,#111827_100%)] md:px-6 md:py-8">
       <div className="mx-auto w-full max-w-6xl space-y-5">
         <section className="overflow-hidden rounded-lg border border-white/70 bg-white/55 shadow-xl shadow-slate-900/5 backdrop-blur-xl dark:border-white/10 dark:bg-slate-950/45">
           <div className="border-b border-white/40 bg-[#0f2747]/95 px-5 py-5 text-white md:px-7">
@@ -361,12 +459,12 @@ export function BusinessCardLabPage() {
                   명함 DB
                 </h1>
                 <p className="mt-2 max-w-2xl text-[13px] leading-6 text-sky-50/85">
-                  명함 이미지를 업로드하고, 추출 결과를 검토한 뒤 전사에서 다시 검색할 수 있는 연락처로 저장합니다.
+                  명함을 촬영하거나 업로드하면 Gemini가 자동으로 읽고, 바로 수정한 뒤 전사 연락처 DB에 저장합니다.
                 </p>
               </div>
               <span className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-3 py-1.5 text-[12px] font-semibold text-sky-50 backdrop-blur-md">
                 <Sparkles className="h-3.5 w-3.5" />
-                Gemini 검토형 추출
+                Gemini 자동 추출
               </span>
             </div>
           </div>
@@ -409,13 +507,19 @@ export function BusinessCardLabPage() {
                 <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
                   <div className="rounded-lg border border-dashed border-sky-200 bg-sky-50/55 p-4 dark:border-sky-400/25 dark:bg-sky-950/20">
                     <div className="flex min-h-[260px] flex-col items-center justify-center gap-4 text-center">
-                      <div className="flex h-14 w-14 items-center justify-center rounded-full bg-white/80 text-sky-700 shadow-sm backdrop-blur-md dark:bg-slate-950/60 dark:text-sky-200">
-                        {preparing ? <Loader2 className="h-6 w-6 animate-spin" /> : <Camera className="h-6 w-6" />}
-                      </div>
+                      <button
+                        type="button"
+                        onClick={openScanner}
+                        disabled={captureBusy}
+                        className="flex h-20 w-20 touch-manipulation items-center justify-center rounded-full border border-sky-200 bg-white text-[#0f2747] shadow-sm transition hover:bg-sky-50 active:scale-95 disabled:cursor-not-allowed disabled:opacity-60 dark:border-sky-400/25 dark:bg-slate-950/70 dark:text-sky-100"
+                        aria-label="명함 촬영 시작"
+                      >
+                        {captureBusy ? <Loader2 className="h-8 w-8 animate-spin" /> : <Camera className="h-8 w-8" />}
+                      </button>
                       <div>
                         <h3 className="text-[16px] font-bold text-slate-950 dark:text-slate-50">명함 스캔</h3>
                         <p className="mt-2 max-w-md text-[13px] leading-6 text-muted-foreground">
-                          앱 안의 카메라 가이드에 명함을 맞춰 촬영하거나, 저장된 이미지를 선택합니다. 추출 후 같은 화면에서 바로 수정하고 DB에 저장합니다.
+                          카메라 버튼을 누르면 촬영 화면이 열립니다. 이미지가 준비되면 Gemini 분석이 자동으로 시작되고, 같은 화면에서 바로 수정해 저장합니다.
                         </p>
                       </div>
                       <Input
@@ -427,24 +531,22 @@ export function BusinessCardLabPage() {
                         onChange={handleFileChange}
                       />
                       <div className="flex flex-wrap justify-center gap-2">
-                        <Button type="button" onClick={openScanner} disabled={preparing}>
-                          <Camera className="h-4 w-4" />
-                          카메라 스캔
-                        </Button>
-                        <Button type="button" variant="outline" onClick={() => fileInputRef.current?.click()} disabled={preparing}>
+                        <Button type="button" variant="outline" onClick={() => fileInputRef.current?.click()} disabled={captureBusy}>
                           <ImageIcon className="h-4 w-4" />
                           이미지 선택
                         </Button>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          disabled={!preparedImage || processing || !bffEnabled}
-                          onClick={handleProcessImage}
-                        >
-                          {processing ? <Loader2 className="h-4 w-4 animate-spin" /> : <Sparkles className="h-4 w-4" />}
-                          Gemini 추출
-                        </Button>
                       </div>
+                      {busyLabel && (
+                        <div className="w-full max-w-sm rounded-lg border border-sky-200 bg-white/80 px-3 py-3 text-left shadow-sm dark:border-sky-400/20 dark:bg-slate-950/45">
+                          <div className="flex items-center gap-2 text-[12px] font-semibold text-[#0f2747] dark:text-sky-100">
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                            {busyLabel}
+                          </div>
+                          <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-slate-200 dark:bg-slate-800">
+                            <div className="h-full w-2/3 animate-pulse rounded-full bg-[#0f2747] dark:bg-sky-300" />
+                          </div>
+                        </div>
+                      )}
                       {imageError && (
                         <p className="inline-flex items-center gap-2 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-[12px] font-semibold text-rose-700 dark:border-rose-400/20 dark:bg-rose-950/25 dark:text-rose-200">
                           <AlertTriangle className="h-4 w-4" />
@@ -480,8 +582,8 @@ export function BusinessCardLabPage() {
                             <dd className="font-semibold text-slate-900 dark:text-slate-100">{formatBytes(preparedImage.fileSize)}</dd>
                           </div>
                         </dl>
-                        <div className="rounded-lg border border-amber-200/70 bg-amber-50/70 px-3 py-2 text-[11px] leading-5 text-amber-800 dark:border-amber-400/20 dark:bg-amber-950/25 dark:text-amber-200">
-                          Gemini 추출 후 아래 입력칸에서 수정한 뒤 DB에 저장합니다.
+                        <div className="rounded-lg border border-sky-200/70 bg-sky-50/70 px-3 py-2 text-[11px] leading-5 text-[#0f2747] dark:border-sky-400/20 dark:bg-sky-950/25 dark:text-sky-100">
+                          업로드되면 Gemini가 자동으로 추출합니다. 결과는 아래 입력칸에서 수정할 수 있습니다.
                         </div>
                       </div>
                     ) : (
@@ -506,8 +608,8 @@ export function BusinessCardLabPage() {
                               Gemini가 읽은 값을 필요하면 수정하세요. 저장하면 전사 연락처 검색 DB에 반영됩니다.
                             </p>
                           </div>
-                          <span className="rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 text-[11px] font-semibold text-amber-800 dark:border-amber-400/20 dark:bg-amber-950/25 dark:text-amber-200">
-                            {currentImport.status}
+                          <span className="rounded-full border border-sky-200 bg-sky-50 px-2.5 py-1 text-[11px] font-semibold text-[#0f2747] dark:border-sky-400/20 dark:bg-sky-950/25 dark:text-sky-100">
+                            {currentImport.status === 'saved' ? '저장됨' : currentImport.status === 'failed' ? '실패' : '수정 가능'}
                           </span>
                         </div>
 
@@ -530,7 +632,7 @@ export function BusinessCardLabPage() {
                               <span className="flex items-center gap-2">
                                 {label as string}
                                 {isLowConfidenceField(field as typeof currentImport.extracted.name) && (
-                                  <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] text-amber-800 dark:bg-amber-950/40 dark:text-amber-200">확인 필요</span>
+                                  <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] text-slate-700 dark:bg-slate-800 dark:text-slate-200">확인 필요</span>
                                 )}
                               </span>
                               <Input
@@ -581,9 +683,9 @@ export function BusinessCardLabPage() {
                       onKeyDown={(event) => {
                         if (event.key === 'Enter') void handleSearchContacts();
                       }}
-                      placeholder="이름, 회사, 이메일, 전화번호 검색"
+                      placeholder="이름, 회사, 이메일, 전화번호 검색. 비워두면 전체 목록"
                     />
-                    <Button type="button" onClick={handleSearchContacts} disabled={!searchQuery.trim() || searching || !bffEnabled}>
+                    <Button type="button" onClick={() => void handleSearchContacts()} disabled={searching || !bffEnabled}>
                       {searching ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
                       검색
                     </Button>
@@ -596,31 +698,82 @@ export function BusinessCardLabPage() {
                     {searchResults.length === 0 ? (
                       <div className="flex min-h-[180px] flex-col items-center justify-center px-4 text-center">
                         <Search className="h-8 w-8 text-sky-600 dark:text-sky-300" />
-                        <h3 className="mt-3 text-[15px] font-bold text-slate-950 dark:text-slate-50">전사 연락처 검색</h3>
+                        <h3 className="mt-3 text-[15px] font-bold text-slate-950 dark:text-slate-50">
+                          {searching ? '연락처를 불러오는 중' : '전사 연락처 DB'}
+                        </h3>
                         <p className="mt-2 max-w-md text-[12px] leading-5 text-muted-foreground">
-                          저장된 연락처를 이름, 회사, 이메일, 전화번호 일부로 찾습니다.
+                          검색어 없이 조회하면 연락처 목록이 먼저 표시됩니다.
                         </p>
                       </div>
                     ) : (
                       <div className="divide-y divide-white/70 dark:divide-white/10">
-                        {searchResults.map((contact) => (
-                          <div key={contact.id} className="px-4 py-3">
-                            <div className="flex flex-wrap items-center justify-between gap-2">
-                              <div>
-                                <p className="text-[14px] font-bold text-slate-950 dark:text-slate-50">{contact.name || contact.organization}</p>
-                                <p className="mt-1 text-[12px] text-muted-foreground">
-                                  {[contact.organization, contact.department, contact.title || contact.role].filter(Boolean).join(' · ')}
-                                </p>
+                        {searchResults.map((contact) => {
+                          const draft = contactDrafts[contact.id] || contactToFormState(contact);
+                          const draftPayload = buildBusinessCardConfirmPayload(draft);
+                          const canSaveContact = canConfirmBusinessCardContact(draftPayload);
+                          const isSavingContact = savingContactId === contact.id;
+                          return (
+                            <section key={contact.id} className="px-3 py-3 md:px-4">
+                              <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                                <div>
+                                  <p className="text-[13px] font-bold text-slate-950 dark:text-slate-50">{draft.name || draft.organization || '이름 없음'}</p>
+                                  <p className="mt-1 text-[11px] text-muted-foreground">
+                                    {[draft.organization, draft.department, draft.title || draft.role].filter(Boolean).join(' · ') || contact.id}
+                                  </p>
+                                </div>
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  onClick={() => void handleSaveSearchContact(contact)}
+                                  disabled={!canSaveContact || isSavingContact}
+                                >
+                                  {isSavingContact ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <CheckCircle2 className="h-3.5 w-3.5" />}
+                                  저장
+                                </Button>
                               </div>
-                              <span className="rounded-full border border-sky-200 bg-sky-50 px-2.5 py-1 text-[10px] font-semibold text-sky-800 dark:border-sky-400/20 dark:bg-sky-950/25 dark:text-sky-200">
-                                score {contact.score.toFixed(2)}
-                              </span>
-                            </div>
-                            <p className="mt-2 text-[12px] text-slate-700 dark:text-slate-200">
-                              {[contact.emails?.[0], contact.phones?.[0]].filter(Boolean).join(' · ')}
-                            </p>
-                          </div>
-                        ))}
+                              <div className="grid gap-2 md:grid-cols-4">
+                                {[
+                                  ['name', '이름'],
+                                  ['organization', '회사/소속'],
+                                  ['department', '부서'],
+                                  ['title', '직함'],
+                                  ['role', '역할'],
+                                  ['emailsText', '이메일'],
+                                  ['phonesText', '전화번호'],
+                                  ['website', '웹사이트'],
+                                ].map(([key, label]) => (
+                                  <label key={`${contact.id}-${key}`} className="space-y-1 text-[11px] font-semibold text-slate-600 dark:text-slate-300">
+                                    {label}
+                                    <Input
+                                      value={draft[key as keyof BusinessCardContactFormState]}
+                                      onChange={(event) => updateContactDraft(contact.id, key as keyof BusinessCardContactFormState, event.target.value)}
+                                      className="h-9 bg-white text-[12px] dark:bg-slate-950/60"
+                                    />
+                                  </label>
+                                ))}
+                                <label className="space-y-1 text-[11px] font-semibold text-slate-600 dark:text-slate-300 md:col-span-2">
+                                  주소
+                                  <Input
+                                    value={draft.address}
+                                    onChange={(event) => updateContactDraft(contact.id, 'address', event.target.value)}
+                                    className="h-9 bg-white text-[12px] dark:bg-slate-950/60"
+                                  />
+                                </label>
+                                <label className="space-y-1 text-[11px] font-semibold text-slate-600 dark:text-slate-300 md:col-span-2">
+                                  메모
+                                  <Textarea
+                                    value={draft.memo}
+                                    onChange={(event) => updateContactDraft(contact.id, 'memo', event.target.value)}
+                                    className="min-h-9 bg-white text-[12px] dark:bg-slate-950/60"
+                                  />
+                                </label>
+                              </div>
+                              <p className="mt-2 text-[10px] text-muted-foreground">
+                                저장 조건: 이름 또는 회사/소속 1개 이상, 이메일 또는 전화번호 1개 이상 · score {contact.score.toFixed(2)}
+                              </p>
+                            </section>
+                          );
+                        })}
                       </div>
                     )}
                   </div>
@@ -652,7 +805,7 @@ export function BusinessCardLabPage() {
               )}
               <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_at_center,transparent_0%,transparent_42%,rgba(2,6,23,0.52)_74%)]" />
               <div
-                className="pointer-events-none absolute rounded-[6px] border-2 border-emerald-400 bg-emerald-300/10 shadow-[0_0_0_999px_rgba(2,6,23,0.42)]"
+                className="pointer-events-none absolute rounded-[6px] border-2 border-sky-300 bg-sky-300/10 shadow-[0_0_0_999px_rgba(2,6,23,0.42)]"
                 style={{
                   left: `${CAMERA_GUIDE.left * 100}%`,
                   top: `${CAMERA_GUIDE.top * 100}%`,
@@ -660,10 +813,10 @@ export function BusinessCardLabPage() {
                   aspectRatio: String(CAMERA_GUIDE.aspectRatio),
                 }}
               >
-                <span className="absolute -left-0.5 -top-0.5 h-5 w-5 border-l-4 border-t-4 border-emerald-300" />
-                <span className="absolute -right-0.5 -top-0.5 h-5 w-5 border-r-4 border-t-4 border-emerald-300" />
-                <span className="absolute -bottom-0.5 -left-0.5 h-5 w-5 border-b-4 border-l-4 border-emerald-300" />
-                <span className="absolute -bottom-0.5 -right-0.5 h-5 w-5 border-b-4 border-r-4 border-emerald-300" />
+                <span className="absolute -left-0.5 -top-0.5 h-5 w-5 border-l-4 border-t-4 border-sky-100" />
+                <span className="absolute -right-0.5 -top-0.5 h-5 w-5 border-r-4 border-t-4 border-sky-100" />
+                <span className="absolute -bottom-0.5 -left-0.5 h-5 w-5 border-b-4 border-l-4 border-sky-100" />
+                <span className="absolute -bottom-0.5 -right-0.5 h-5 w-5 border-b-4 border-r-4 border-sky-100" />
               </div>
             </div>
             <div className="z-20 border-t border-white/10 bg-white px-4 pb-[calc(env(safe-area-inset-bottom)+18px)] pt-4 text-slate-950">
@@ -683,7 +836,7 @@ export function BusinessCardLabPage() {
                   className="flex h-16 w-16 items-center justify-center rounded-full border-4 border-slate-950 bg-white disabled:opacity-50"
                   aria-label="명함 촬영"
                 >
-                  <span className="h-10 w-10 rounded-full bg-emerald-500 shadow-inner" />
+                  <span className="h-10 w-10 rounded-full bg-[#0f2747] shadow-inner" />
                 </button>
                 <span className="h-12 w-12" aria-hidden="true" />
               </div>

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -22,6 +22,7 @@ import {
   uploadProjectSheetSourceViaBff,
   uploadProjectRequestContractViaBff,
   toRequestActor,
+  updateContactViaBff,
   uploadTransactionEvidenceDriveViaBff,
   upsertLedgerViaBff,
   type PlatformApiClientLike,
@@ -59,6 +60,40 @@ describe('platform-bff-client', () => {
       role: 'admin',
       idToken: 'token-abc',
     });
+  });
+
+  it('calls contact update endpoint', async () => {
+    const client = asMockClient({
+      post: vi.fn(),
+      get: vi.fn(),
+      patch: vi.fn(async () => ({ data: { ok: true, contact: { id: 'ct_001', name: '홍길동', organization: 'MYSC', emails: ['person@example.com'], phones: [], score: 1 } } })),
+      request: vi.fn(),
+    });
+
+    const result = await updateContactViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'u001', role: 'admin' },
+      contactId: 'ct_001',
+      contact: {
+        name: '홍길동',
+        organization: 'MYSC',
+        department: '',
+        title: '',
+        role: '',
+        emails: ['person@example.com'],
+        phones: [],
+        website: '',
+        address: '',
+        memo: '수정',
+      },
+      client,
+    });
+
+    expect(client.patch).toHaveBeenCalledWith('/api/v1/contacts/ct_001', expect.objectContaining({
+      tenantId: 'mysc',
+      body: expect.objectContaining({ memo: '수정' }),
+    }));
+    expect(result.contact.id).toBe('ct_001');
   });
 
   it('calls project upsert endpoint', async () => {

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -160,8 +160,15 @@ export interface ContactSearchResult {
   emails: string[];
   phones: string[];
   website?: string;
+  address?: string;
+  memo?: string;
   score: number;
   updatedAt?: string;
+}
+
+export interface ContactUpdateResult {
+  ok: boolean;
+  contact: ContactSearchResult;
 }
 
 export interface ProvisionProjectEvidenceDriveRootResult {
@@ -540,6 +547,16 @@ export interface PlatformApiClientLike {
     timeoutMs?: number;
   }): Promise<{ data: T }>;
   post<T>(path: string, options: {
+    tenantId: string;
+    actor: RequestActor;
+    body?: unknown;
+    headers?: HeadersInit;
+    idempotencyKey?: string;
+    requestId?: string;
+    retries?: number;
+    timeoutMs?: number;
+  }): Promise<{ data: T }>;
+  patch<T>(path: string, options: {
     tenantId: string;
     actor: RequestActor;
     body?: unknown;
@@ -1220,6 +1237,27 @@ export async function searchContactsViaBff(params: {
       tenantId: params.tenantId,
       actor: toRequestActor(params.actor),
       timeoutMs: 10000,
+    },
+  );
+  return response.data;
+}
+
+export async function updateContactViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  contactId: string;
+  contact: BusinessCardConfirmPayload;
+  client?: PlatformApiClientLike;
+}): Promise<ContactUpdateResult> {
+  const apiClient = resolveClient(params.client);
+  const response = await apiClient.patch<ContactUpdateResult>(
+    `/api/v1/contacts/${encodeURIComponent(params.contactId)}`,
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      body: params.contact,
+      retries: 0,
+      timeoutMs: 20000,
     },
   );
   return response.data;

--- a/src/app/platform/api-client.ts
+++ b/src/app/platform/api-client.ts
@@ -335,4 +335,8 @@ export class PlatformApiClient {
   post<T>(path: string, options: Omit<PlatformRequestOptions, 'method'>): Promise<ApiResponse<T>> {
     return this.request<T>(path, { ...options, method: 'POST' });
   }
+
+  patch<T>(path: string, options: Omit<PlatformRequestOptions, 'method'>): Promise<ApiResponse<T>> {
+    return this.request<T>(path, { ...options, method: 'PATCH' });
+  }
 }


### PR DESCRIPTION
## 한눈에 보기
- 앱 안에서 명함을 카메라로 촬영할 수 있는 스캐너 화면을 추가했습니다.
- 촬영 가이드와 자동 자르기 흐름을 넣어 명함 영역을 더 쉽게 잡을 수 있게 했습니다.
- 별도 검토 대기열 없이 촬영 화면에서 추출값을 바로 수정하고 저장하게 했습니다.
- 검색 결과를 엑셀에서 열기 쉬운 CSV 파일로 내보낼 수 있게 했습니다.

## 사용자가 체감하는 변화
- 명함을 사진으로 찍고 바로 연락처화하는 흐름이 짧아집니다.
- 추출 결과를 별도 화면으로 옮겨 다니지 않고 바로 확인할 수 있습니다.

## 확인한 것
- npx vitest run src/app/components/business-cards/BusinessCardLabPage.shell.test.ts src/app/components/business-cards/business-card-quality.test.ts src/app/platform/mobile-entry.test.ts
- npm run build
- npm run pwa:verify