### PR TITLE
Projection 값을 Actual로 한 번에 복사하는 버튼 제거

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -859,15 +859,6 @@ export function CashflowProjectSheet({
               variant="outline"
               size="sm"
               className="h-8 text-[12px] gap-1.5"
-              onClick={() => copyMonthValues('projection', 'actual')}
-              disabled={!canEdit}
-            >
-              <ArrowLeftRight className="w-3.5 h-3.5" /> Projection → Actual
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-8 text-[12px] gap-1.5"
               onClick={() => copyMonthValues('actual', 'projection')}
             >
               <ArrowLeftRight className="w-3.5 h-3.5" /> Actual → Projection


### PR DESCRIPTION
## 한눈에 보기
- 프로젝트 캐시플로 화면에서 `Projection → Actual` 월 단위 복사 버튼을 제거했습니다.
- `Actual → Projection`, 엑셀 다운로드, 월 저장 기능은 그대로 유지했습니다.

## 왜 필요한가
Projection은 계획값이고 Actual은 실제 사업비 입력/정산 결과여야 합니다. 계획값을 Actual로 쉽게 복사할 수 있으면 실제값이 아닌 숫자가 실적으로 남을 위험이 있습니다.

## 사용자가 체감하는 변화
- Actual은 실제 입력과 동기화 흐름을 통해 관리하게 되어 숫자의 의미가 더 명확해집니다.

## 확인한 것
- npx vitest run src/app/platform/cashflow-export-surface.test.ts src/app/platform/weekly-accounting-state.test.ts src/app/platform/settlement-sheet-sync.test.ts
- npm run build