### PR TITLE
캐시플로 잔액이 해를 넘어가도 이어지도록 수정

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -29,7 +29,7 @@ import {
   type WeeklySubmissionStatus,
 } from '../../data/types';
 import { getSeoulTodayIso } from '../../platform/business-days';
-import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES, computeOpeningCashflowTotals } from '../../platform/cashflow-sheet';
+import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES, computeCashflowDerivedTotals, computeOpeningCashflowTotals } from '../../platform/cashflow-sheet';
 import { getMonthMondayWeeks } from '../../platform/cashflow-weeks';
 import { resolveWeeklyAccountingState } from '../../platform/weekly-accounting-state';
 import { useAuth } from '../../data/auth-store';
@@ -250,32 +250,19 @@ export function CashflowProjectSheet({
 
   const derivedByMode = useMemo(() => {
     function compute(mode: 'projection' | 'actual') {
-      const rowTotals: Record<CashflowSheetLineId, number> = Object.fromEntries(CASHFLOW_ALL_LINES.map((id) => [id, 0])) as any;
       const openingIn = mode === 'projection' ? openingTotalsByMode.projectionIn : openingTotalsByMode.actualIn;
       const openingOut = mode === 'projection' ? openingTotalsByMode.projectionOut : openingTotalsByMode.actualOut;
-      let runningIn = openingIn;
-      let runningOut = openingOut;
-      const weekTotals = monthWeeks.map((def) => {
-        const weekIn = CASHFLOW_IN_LINES.reduce((acc, id) => acc + getEffectiveAmount({ yearMonth, mode, weekNo: def.weekNo, lineId: id }), 0);
-        const weekOut = CASHFLOW_OUT_LINES.reduce((acc, id) => acc + getEffectiveAmount({ yearMonth, mode, weekNo: def.weekNo, lineId: id }), 0);
-        runningIn += weekIn;
-        runningOut += weekOut;
-        return { weekNo: def.weekNo, totalIn: runningIn, totalOut: runningOut, net: runningIn - runningOut, weekIn, weekOut };
+      return computeCashflowDerivedTotals({
+        openingIn,
+        openingOut,
+        weeks: monthWeeks.map((def) => ({
+          weekNo: def.weekNo,
+          amounts: Object.fromEntries(CASHFLOW_ALL_LINES.map((lineId) => [
+            lineId,
+            getEffectiveAmount({ yearMonth, mode, weekNo: def.weekNo, lineId }),
+          ])) as Partial<Record<CashflowSheetLineId, number>>,
+        })),
       });
-
-      for (const lineId of CASHFLOW_ALL_LINES) {
-        for (const def of monthWeeks) {
-          rowTotals[lineId] += getEffectiveAmount({ yearMonth, mode, weekNo: def.weekNo, lineId });
-        }
-      }
-
-      const totalIn = weekTotals.length ? weekTotals[weekTotals.length - 1].totalIn : openingIn;
-      const totalOut = weekTotals.length ? weekTotals[weekTotals.length - 1].totalOut : openingOut;
-      return {
-        rowTotals,
-        weekTotals,
-        monthTotals: { totalIn, totalOut, net: totalIn - totalOut },
-      };
     }
 
     return {

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -29,7 +29,7 @@ import {
   type WeeklySubmissionStatus,
 } from '../../data/types';
 import { getSeoulTodayIso } from '../../platform/business-days';
-import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES, computeCashflowTotals } from '../../platform/cashflow-sheet';
+import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES, computeOpeningCashflowTotals } from '../../platform/cashflow-sheet';
 import { getMonthMondayWeeks } from '../../platform/cashflow-weeks';
 import { resolveWeeklyAccountingState } from '../../platform/weekly-accounting-state';
 import { useAuth } from '../../data/auth-store';
@@ -126,37 +126,11 @@ export function CashflowProjectSheet({
   }, [projectWeeks]);
 
   const openingTotalsByMode = useMemo(() => {
-    function ymToNumber(value: string): number | null {
-      const [y, m] = value.split('-');
-      const yy = Number.parseInt(y, 10);
-      const mm = Number.parseInt(m, 10);
-      if (!Number.isFinite(yy) || !Number.isFinite(mm)) return null;
-      return yy * 100 + mm;
-    }
-
-    const currentYmNum = ymToNumber(normalizedYearMonth);
-    const currentYear = currentYmNum ? Math.trunc(currentYmNum / 100) : null;
-    let projectionIn = 0;
-    let projectionOut = 0;
-    let actualIn = 0;
-    let actualOut = 0;
-
-    for (const w of weeks) {
-      if (w.projectId !== projectId) continue;
-      const ymRaw = typeof w.yearMonth === 'string' ? w.yearMonth : '';
-      const ymNum = ymToNumber(ymRaw);
-      if (!ymNum || !currentYear || !currentYmNum) continue;
-      if (Math.trunc(ymNum / 100) !== currentYear) continue;
-      if (ymNum >= currentYmNum) continue;
-      const p = computeCashflowTotals(w.projection);
-      const a = computeCashflowTotals(w.actual);
-      projectionIn += p.totalIn;
-      projectionOut += p.totalOut;
-      actualIn += a.totalIn;
-      actualOut += a.totalOut;
-    }
-
-    return { projectionIn, projectionOut, actualIn, actualOut };
+    return computeOpeningCashflowTotals({
+      weeks,
+      projectId,
+      yearMonth: normalizedYearMonth,
+    });
   }, [normalizedYearMonth, projectId, weeks]);
 
 

--- a/src/app/components/cashflow/ImportEditor.tsx
+++ b/src/app/components/cashflow/ImportEditor.tsx
@@ -1601,7 +1601,7 @@ export function ImportEditor({
           </div>
           <div className="shrink-0 text-right text-[11px] text-muted-foreground">
             <div>행 왼쪽 배지에서 출처를 확인할 수 있습니다.</div>
-            <div>사람 확인이 필요한 후보값은 확인 완료 전까지 캐시플로 반영이 보류됩니다.</div>
+            <div>입력한 값은 저장 시 캐시플로 actual에 바로 반영됩니다.</div>
             {onToggleFullscreen && (
               <Button
                 variant="outline"

--- a/src/app/components/cashflow/SettlementLedgerPage.shell.test.ts
+++ b/src/app/components/cashflow/SettlementLedgerPage.shell.test.ts
@@ -26,7 +26,7 @@ describe('SettlementLedgerPage direct-entry workbook flow', () => {
   });
 
   it('emits a separate saving-state signal while the sheet save request is in flight', () => {
-    expect(settlementLedgerSource).toContain("onSavingStateChange?.(sheetSaveState === 'saving')");
+    expect(settlementLedgerSource).toContain("onSavingStateChange?.(sheetSaveState === 'saving' || cashflowSyncing)");
   });
 
   it('does not keep a human-review queue between expense saves and cashflow actual sync', () => {
@@ -34,5 +34,12 @@ describe('SettlementLedgerPage direct-entry workbook flow', () => {
     expect(settlementLedgerSource).not.toContain('const syncableWeeks = payload.filter((week) => !blockedWeeks.includes(week));');
     expect(settlementLedgerSource).not.toContain("expenseSyncState: 'review_required'");
     expect(settlementLedgerSource).toContain("expenseSyncState: 'synced'");
+  });
+
+  it('uses persisted weekly sync status to resume pending cashflow updates after returning to the page', () => {
+    expect(settlementLedgerSource).toContain('weeklySubmissionStatuses?: WeeklySubmissionStatus[]');
+    expect(settlementLedgerSource).toContain('resolveCashflowSyncStateFromStatuses');
+    expect(settlementLedgerSource).toContain("cashflowSyncState !== 'pending' && cashflowSyncState !== 'sync_failed'");
+    expect(settlementLedgerSource).toContain("void syncImportRowsToCashflow(importRows, { silent: true });");
   });
 });

--- a/src/app/components/cashflow/SettlementLedgerPage.shell.test.ts
+++ b/src/app/components/cashflow/SettlementLedgerPage.shell.test.ts
@@ -28,4 +28,11 @@ describe('SettlementLedgerPage direct-entry workbook flow', () => {
   it('emits a separate saving-state signal while the sheet save request is in flight', () => {
     expect(settlementLedgerSource).toContain("onSavingStateChange?.(sheetSaveState === 'saving')");
   });
+
+  it('does not keep a human-review queue between expense saves and cashflow actual sync', () => {
+    expect(settlementLedgerSource).toContain('const syncableWeeks = payload;');
+    expect(settlementLedgerSource).not.toContain('const syncableWeeks = payload.filter((week) => !blockedWeeks.includes(week));');
+    expect(settlementLedgerSource).not.toContain("expenseSyncState: 'review_required'");
+    expect(settlementLedgerSource).toContain("expenseSyncState: 'synced'");
+  });
 });

--- a/src/app/components/cashflow/SettlementLedgerPage.tsx
+++ b/src/app/components/cashflow/SettlementLedgerPage.tsx
@@ -62,7 +62,6 @@ import {
   writeImportDraftCache,
   clearImportDraftCache,
 } from '../../platform/settlement-draft-cache';
-import { countPendingImportRowReviews } from '../../platform/settlement-review';
 import { loadExcelJs, warmExcelJs } from '../../platform/lazy-heavy-modules';
 
 // ── Types ──
@@ -204,7 +203,7 @@ export function SettlementLedgerPage({
   const [lastCashflowSyncedAt, setLastCashflowSyncedAt] = useState('');
   const [editorFullscreen, setEditorFullscreen] = useState(false);
   const [sheetSaveState, setSheetSaveState] = useState<'idle' | 'dirty' | 'saving' | 'saved' | 'save_failed'>('idle');
-  const [cashflowSyncState, setCashflowSyncState] = useState<'idle' | 'pending' | 'syncing' | 'synced' | 'sync_failed' | 'review_required'>('idle');
+  const [cashflowSyncState, setCashflowSyncState] = useState<'idle' | 'pending' | 'syncing' | 'synced' | 'sync_failed'>('idle');
   const [downloadFrom, setDownloadFrom] = useState('');
   const [downloadTo, setDownloadTo] = useState('');
   const [downloadPreparing, setDownloadPreparing] = useState(false);
@@ -236,8 +235,6 @@ export function SettlementLedgerPage({
     () => `settlement-import-draft:${projectId}:${defaultLedgerId}:${year}`,
     [projectId, defaultLedgerId, year],
   );
-  const weekIdx = useMemo(() => SETTLEMENT_COLUMNS.findIndex((column) => column.csvHeader === '해당 주차'), []);
-  const dateIdx = useMemo(() => SETTLEMENT_COLUMNS.findIndex((column) => column.csvHeader === '거래일시'), []);
   const budgetCodeIdx = useMemo(() => SETTLEMENT_COLUMNS.findIndex((column) => column.csvHeader === '비목'), []);
   const subCodeIdx = useMemo(() => SETTLEMENT_COLUMNS.findIndex((column) => column.csvHeader === '세목'), []);
   const subSubCodeIdx = useMemo(() => SETTLEMENT_COLUMNS.findIndex((column) => column.csvHeader === '세세목'), []);
@@ -573,35 +570,6 @@ export function SettlementLedgerPage({
     }
   }, [buildExportMatrix, projectName, year]);
 
-  const resolveWeekLabelForImportRow = useCallback((row: ImportRow): string => {
-    const explicitLabel = weekIdx >= 0 ? String(row.cells[weekIdx] || '').trim() : '';
-    if (explicitLabel) return explicitLabel;
-    if (dateIdx < 0) return '';
-    const parsedDate = parseDate(String(row.cells[dateIdx] || '').trim());
-    if (!parsedDate) return '';
-    const dateOnly = parsedDate.slice(0, 10);
-    const dateYear = Number.parseInt(dateOnly.slice(0, 4), 10);
-    if (!Number.isFinite(dateYear)) return '';
-    const anchorYear = Number.parseInt(yearWeeks[0]?.yearMonth.slice(0, 4) || '', 10);
-    const matchedWeek = findWeekForDate(
-      dateOnly,
-      dateYear === anchorYear ? yearWeeks : getYearMondayWeeks(dateYear),
-    );
-    return matchedWeek?.label || '';
-  }, [dateIdx, weekIdx, yearWeeks]);
-
-  const buildPendingReviewCountsByWeek = useCallback((rows: ImportRow[]) => {
-    const counts = new Map<string, number>();
-    for (const row of rows) {
-      const isPending = (row.reviewHints?.length || 0) > 0 && row.reviewStatus !== 'confirmed';
-      if (!isPending) continue;
-      const weekLabel = resolveWeekLabelForImportRow(row);
-      if (!weekLabel) continue;
-      counts.set(weekLabel, (counts.get(weekLabel) || 0) + 1);
-    }
-    return counts;
-  }, [resolveWeekLabelForImportRow]);
-
   const buildPayloadWeekLabelMap = useCallback(() => {
     const labelMap = new Map<string, string>();
     for (const week of yearWeeks) {
@@ -678,18 +646,12 @@ export function SettlementLedgerPage({
     options?: { silent?: boolean },
   ) => {
     const silent = options?.silent ?? false;
-    const pendingReviewCount = countPendingImportRowReviews(rows);
-    const reviewCountsByWeekLabel = buildPendingReviewCountsByWeek(rows);
     const payload = onPreviewActualSyncPayload
       ? await onPreviewActualSyncPayload(rows, yearWeeks, sheetRows || null)
       : buildSettlementActualSyncPayloadLocally(rows, yearWeeks, sheetRows || null);
-    const weekLabelMap = buildPayloadWeekLabelMap();
-    const blockedWeeks = payload.filter((week) => (
-      reviewCountsByWeekLabel.get(weekLabelMap.get(`${week.yearMonth}:${week.weekNo}`) || '') || 0
-    ) > 0);
-    const syncableWeeks = payload.filter((week) => !blockedWeeks.includes(week));
+    const syncableWeeks = payload;
     setCashflowSyncing(true);
-    setCashflowSyncState(blockedWeeks.length > 0 ? 'review_required' : 'syncing');
+    setCashflowSyncState('syncing');
     try {
       let syncFailed = false;
       await Promise.all(
@@ -708,18 +670,10 @@ export function SettlementLedgerPage({
           }
         }),
       );
-      if (blockedWeeks.length > 0) {
-        await updateWeeklyStatusesForPayload(blockedWeeks, {
-          expenseUpdated: true,
-          expenseSyncState: 'review_required',
-          reviewCountsByWeekLabel,
-        });
-      }
       if (syncFailed) {
         await updateWeeklyStatusesForPayload(syncableWeeks, {
           expenseUpdated: true,
           expenseSyncState: 'sync_failed',
-          reviewCountsByWeekLabel,
         });
         setCashflowSyncState('sync_failed');
         if (!silent) toast.message('정산대장은 저장되었지만 캐시플로 업데이트에 실패했습니다.');
@@ -729,25 +683,18 @@ export function SettlementLedgerPage({
         await updateWeeklyStatusesForPayload(syncableWeeks, {
           expenseUpdated: true,
           expenseSyncState: 'synced',
-          reviewCountsByWeekLabel,
         });
       }
-      setCashflowSyncState(blockedWeeks.length > 0 ? 'review_required' : 'synced');
+      setCashflowSyncState('synced');
       setLastCashflowSyncedAt(new Date().toISOString());
       if (!silent) {
-        if (blockedWeeks.length > 0 && syncableWeeks.length > 0) {
-          toast.success(`검토가 끝난 ${syncableWeeks.length}개 주차는 캐시플로에 반영했고, ${blockedWeeks.length}개 주차는 사람 확인 상태로 남겼습니다.`);
-        } else if (blockedWeeks.length > 0) {
-          toast.message(`정산대장은 저장했고, 사람 확인 ${pendingReviewCount}건이 있는 주차는 검토 후 캐시플로에 반영됩니다.`);
-        } else {
-          toast.success('캐시플로 실제값까지 동기화했습니다.');
-        }
+        toast.success('캐시플로 실제값까지 동기화했습니다.');
       }
-      return blockedWeeks.length > 0 ? ('review_required' as const) : ('synced' as const);
+      return 'synced' as const;
     } finally {
       setCashflowSyncing(false);
     }
-  }, [buildPayloadWeekLabelMap, buildPendingReviewCountsByWeek, onPreviewActualSyncPayload, projectId, sheetRows, updateWeeklyStatusesForPayload, upsertWeekAmounts, yearWeeks]);
+  }, [onPreviewActualSyncPayload, projectId, sheetRows, updateWeeklyStatusesForPayload, upsertWeekAmounts, yearWeeks]);
 
   const handleImportSave = useCallback(async (options?: { silent?: boolean; syncCashflow?: boolean }) => {
     if (!importRows) return;
@@ -773,10 +720,6 @@ export function SettlementLedgerPage({
     const syncOutcome = await syncImportRowsToCashflow(persistedRows, { silent: true });
     if (syncOutcome === 'synced') {
       toast.success(`작성본 ${persistedRows.length}건을 저장하고 캐시플로 actual까지 반영했습니다.`);
-      return;
-    }
-    if (syncOutcome === 'review_required') {
-      toast.message(`작성본 ${persistedRows.length}건을 저장했고, 사람 확인이 필요한 주차는 검토 후 actual에 반영됩니다.`);
       return;
     }
     toast.error(`작성본 ${persistedRows.length}건은 저장했지만 캐시플로 actual 반영은 다시 확인이 필요합니다.`);
@@ -855,7 +798,6 @@ export function SettlementLedgerPage({
     if (sheetSaveState === 'saving') return '시트 저장 중...';
     if (sheetSaveState === 'save_failed') return '시트 저장 실패';
     if (importDirty || sheetSaveState === 'dirty') return '저장 전 초안';
-    if (cashflowSyncState === 'review_required') return '저장 완료 · 사람 확인 필요';
     if (cashflowSyncState === 'syncing') return '저장 완료 · actual 반영 중';
     if (cashflowSyncState === 'sync_failed') return '저장 완료 · actual 반영 실패';
     if (cashflowSyncState === 'pending') {
@@ -872,25 +814,23 @@ export function SettlementLedgerPage({
     return saveMode === 'manual' ? '수동 저장만 사용' : '자동 저장 대기';
   }, [cashflowSyncState, importDirty, lastAutoSavedAt, lastCashflowSyncedAt, saveMode, sheetSaveState]);
 
-  const pendingReviewCount = useMemo(() => countPendingImportRowReviews(importRows || []), [importRows]);
-
   const weeklyAccountingStatus = useMemo(() => resolveWeeklyAccountingProductStatus({
     snapshot: {
       projectionEdited: importDirty,
       projectionDone: true,
       expenseEdited: importDirty,
-      expenseDone: sheetSaveState === 'saved' || cashflowSyncState === 'pending' || cashflowSyncState === 'syncing' || cashflowSyncState === 'synced' || cashflowSyncState === 'review_required' || cashflowSyncState === 'sync_failed',
-      expenseSyncState: cashflowSyncState === 'review_required' || cashflowSyncState === 'sync_failed' || cashflowSyncState === 'synced'
+      expenseDone: sheetSaveState === 'saved' || cashflowSyncState === 'pending' || cashflowSyncState === 'syncing' || cashflowSyncState === 'synced' || cashflowSyncState === 'sync_failed',
+      expenseSyncState: cashflowSyncState === 'sync_failed' || cashflowSyncState === 'synced'
         ? cashflowSyncState
         : 'pending',
-      expenseReviewPendingCount: pendingReviewCount,
+      expenseReviewPendingCount: 0,
       pmSubmitted: false,
       adminClosed: false,
     },
     saveState: sheetSaveState,
     syncState: cashflowSyncState,
-    reviewCount: pendingReviewCount,
-  }), [cashflowSyncState, importDirty, pendingReviewCount, sheetSaveState]);
+    reviewCount: 0,
+  }), [cashflowSyncState, importDirty, sheetSaveState]);
   const weeklyAccountingStatusHooks = useMemo(
     () => resolveWeeklyAccountingProductStatusDomHooks(weeklyAccountingStatus),
     [weeklyAccountingStatus],

--- a/src/app/components/cashflow/SettlementLedgerPage.tsx
+++ b/src/app/components/cashflow/SettlementLedgerPage.tsx
@@ -11,6 +11,7 @@ import type {
   SettlementSheetPolicy,
   Transaction,
   TransactionState,
+  WeeklySubmissionStatus,
 } from '../../data/types';
 import { resolveApiErrorMessage } from '../../platform/api-error-message';
 import { findWeekForDate, getYearMondayWeeks, type MonthMondayWeek } from '../../platform/cashflow-weeks';
@@ -70,6 +71,24 @@ interface WeekBucket {
   week: MonthMondayWeek;
   transactions: Transaction[];
   collapsed: boolean;
+}
+
+type CashflowExpenseSyncState = 'idle' | 'pending' | 'syncing' | 'synced' | 'sync_failed';
+
+function resolveCashflowSyncStateFromStatuses(
+  payload: Array<{ yearMonth: string; weekNo: number }>,
+  statusMap: Map<string, WeeklySubmissionStatus>,
+): Exclude<CashflowExpenseSyncState, 'syncing'> | null {
+  if (payload.length === 0) return null;
+  let hasSynced = false;
+  for (const week of payload) {
+    const status = statusMap.get(`${week.yearMonth}:${week.weekNo}`);
+    const state = status?.expenseSyncState;
+    if (state === 'sync_failed') return 'sync_failed';
+    if (state === 'pending' || state === 'review_required' || !state) return 'pending';
+    if (state === 'synced') hasSynced = true;
+  }
+  return hasSynced ? 'synced' : null;
 }
 
 export interface SettlementLedgerProps {
@@ -139,6 +158,7 @@ export interface SettlementLedgerProps {
   ) => Promise<SettlementActualSyncWeekPayload[]>;
   onDirtyStateChange?: (dirty: boolean) => void;
   onSavingStateChange?: (saving: boolean) => void;
+  weeklySubmissionStatuses?: WeeklySubmissionStatus[];
   discardChangesRequestToken?: number;
   autoSaveIdleMs?: number;
   autoSaveSyncCashflow?: boolean;
@@ -187,6 +207,7 @@ export function SettlementLedgerPage({
   onPreviewActualSyncPayload,
   onDirtyStateChange,
   onSavingStateChange,
+  weeklySubmissionStatuses = [],
   discardChangesRequestToken = 0,
   autoSaveIdleMs = 60_000,
   autoSaveSyncCashflow = true,
@@ -203,7 +224,7 @@ export function SettlementLedgerPage({
   const [lastCashflowSyncedAt, setLastCashflowSyncedAt] = useState('');
   const [editorFullscreen, setEditorFullscreen] = useState(false);
   const [sheetSaveState, setSheetSaveState] = useState<'idle' | 'dirty' | 'saving' | 'saved' | 'save_failed'>('idle');
-  const [cashflowSyncState, setCashflowSyncState] = useState<'idle' | 'pending' | 'syncing' | 'synced' | 'sync_failed'>('idle');
+  const [cashflowSyncState, setCashflowSyncState] = useState<CashflowExpenseSyncState>('idle');
   const [downloadFrom, setDownloadFrom] = useState('');
   const [downloadTo, setDownloadTo] = useState('');
   const [downloadPreparing, setDownloadPreparing] = useState(false);
@@ -213,6 +234,7 @@ export function SettlementLedgerPage({
   const restoredDraftCacheKeyRef = useRef('');
   const hasAppliedSheetRowsRef = useRef(false);
   const lastDiscardChangesRequestTokenRef = useRef(0);
+  const pendingCashflowSyncRetryKeyRef = useRef('');
   const pendingSheetRowsEchoSignatureRef = useRef<string | null>(null);
   const pendingSheetRowsSyncRef = useRef<{ rows: ImportRow[] | null; reason: WeeklyAccountingSheetRowsHydrationReason } | null>(null);
   const cloneImportRows = useCallback((input: ImportRow[]) => (
@@ -235,6 +257,14 @@ export function SettlementLedgerPage({
     () => `settlement-import-draft:${projectId}:${defaultLedgerId}:${year}`,
     [projectId, defaultLedgerId, year],
   );
+  const weeklySubmissionStatusMap = useMemo(() => {
+    const map = new Map<string, WeeklySubmissionStatus>();
+    for (const status of weeklySubmissionStatuses) {
+      if (status.projectId !== projectId) continue;
+      map.set(`${status.yearMonth}:${status.weekNo}`, status);
+    }
+    return map;
+  }, [projectId, weeklySubmissionStatuses]);
   const budgetCodeIdx = useMemo(() => SETTLEMENT_COLUMNS.findIndex((column) => column.csvHeader === '비목'), []);
   const subCodeIdx = useMemo(() => SETTLEMENT_COLUMNS.findIndex((column) => column.csvHeader === '세목'), []);
   const subSubCodeIdx = useMemo(() => SETTLEMENT_COLUMNS.findIndex((column) => column.csvHeader === '세세목'), []);
@@ -317,16 +347,22 @@ export function SettlementLedgerPage({
     if (hydration.shouldReplaceRows) {
       setImportRows(cloneImportRows(incomingRows || []));
     }
+    const persistedSyncState = incomingRowsOrigin === 'persisted'
+      ? resolveCashflowSyncStateFromStatuses(
+        buildSettlementActualSyncPayloadLocally(incomingRows || [], yearWeeks, null),
+        weeklySubmissionStatusMap,
+      )
+      : null;
     setImportDirty(false);
     setSheetSaveState(hydration.nextSaveState);
-    setCashflowSyncState(hydration.nextSyncState);
+    setCashflowSyncState(persistedSyncState || hydration.nextSyncState);
     if (reason !== 'persistence_echo') {
       clearImportDraftCache(draftCacheKey);
     } else {
       pendingSheetRowsEchoSignatureRef.current = null;
     }
     hasAppliedSheetRowsRef.current = true;
-  }, [cashflowSyncState, cloneImportRows, draftCacheKey, importRows, projectTxs, sheetSaveState, yearWeeks]);
+  }, [cashflowSyncState, cloneImportRows, draftCacheKey, importRows, projectTxs, sheetSaveState, weeklySubmissionStatusMap, yearWeeks]);
 
   useEffect(() => {
     const nextSignature = serializeWeeklyAccountingImportRowsMaterially(sheetRows);
@@ -725,6 +761,17 @@ export function SettlementLedgerPage({
     toast.error(`작성본 ${persistedRows.length}건은 저장했지만 캐시플로 actual 반영은 다시 확인이 필요합니다.`);
   }, [cloneImportRows, persistImportRowsSnapshot, syncImportRowsToCashflow]);
 
+  useEffect(() => {
+    if (sheetSaveState !== 'saved') return;
+    if (importDirty || !importRows || importRows.length === 0) return;
+    if (cashflowSyncState !== 'pending' && cashflowSyncState !== 'sync_failed') return;
+    const signature = serializeWeeklyAccountingImportRowsMaterially(importRows);
+    const retryKey = `${draftCacheKey}:${cashflowSyncState}:${signature}`;
+    if (pendingCashflowSyncRetryKeyRef.current === retryKey) return;
+    pendingCashflowSyncRetryKeyRef.current = retryKey;
+    void syncImportRowsToCashflow(importRows, { silent: true });
+  }, [cashflowSyncState, draftCacheKey, importDirty, importRows, sheetSaveState, syncImportRowsToCashflow]);
+
   const handleDirectEntryWorkbookFile = useCallback(async (file: File) => {
     setDirectEntryUploading(true);
     try {
@@ -769,22 +816,22 @@ export function SettlementLedgerPage({
   }, [autosavePlan, handleImportSave]);
 
   useEffect(() => {
-    if (!importDirty) return;
+    if (!importDirty && !cashflowSyncing) return;
     const handleBeforeUnload = (event: BeforeUnloadEvent) => {
       event.preventDefault();
       event.returnValue = '';
     };
     window.addEventListener('beforeunload', handleBeforeUnload);
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
-  }, [importDirty]);
+  }, [cashflowSyncing, importDirty]);
 
   useEffect(() => {
     onDirtyStateChange?.(importDirty || sheetSaveState === 'dirty');
   }, [importDirty, onDirtyStateChange, sheetSaveState]);
 
   useEffect(() => {
-    onSavingStateChange?.(sheetSaveState === 'saving');
-  }, [onSavingStateChange, sheetSaveState]);
+    onSavingStateChange?.(sheetSaveState === 'saving' || cashflowSyncing);
+  }, [cashflowSyncing, onSavingStateChange, sheetSaveState]);
 
   useEffect(() => () => {
     onDirtyStateChange?.(false);

--- a/src/app/components/portal/PortalWeeklyExpensePage.tsx
+++ b/src/app/components/portal/PortalWeeklyExpensePage.tsx
@@ -110,6 +110,7 @@ export function PortalWeeklyExpensePage() {
     saveBudgetPlanRows,
     saveBudgetCodeBook,
     markSheetSourceApplied,
+    weeklySubmissionStatuses,
     upsertWeeklySubmissionStatus,
   } = usePortalStore();
   const { submitWeekAsPm, upsertWeekAmounts } = useCashflowWeeks();
@@ -974,6 +975,7 @@ export function PortalWeeklyExpensePage() {
           onPreviewActualSyncPayload={previewActualSyncWithLocalKernel}
           onDirtyStateChange={setHasUnsavedSettlementChanges}
           onSavingStateChange={setIsSettlementSaving}
+          weeklySubmissionStatuses={weeklySubmissionStatuses}
           discardChangesRequestToken={0}
         />
       </Suspense>

--- a/src/app/data/cashflow-weeks-store.tsx
+++ b/src/app/data/cashflow-weeks-store.tsx
@@ -23,7 +23,7 @@ import {
 } from 'firebase/firestore';
 import { useAuth } from './auth-store';
 import type { CashflowSheetLineId, CashflowWeekSheet, VarianceFlag, VarianceFlagEvent } from './types';
-import { filterCashflowWeeksForYear, shouldCreateDocOnUpdateError } from './cashflow-weeks.helpers';
+import { filterCashflowWeeksThroughSelectedYear, shouldCreateDocOnUpdateError } from './cashflow-weeks.helpers';
 import {
   buildCashflowWeekUpdatePatch,
   buildInitialCashflowWeekDoc,
@@ -135,12 +135,15 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
     setIsLoading(true);
 
     const base = collection(db, getOrgCollectionPath(orgId, 'cashflowWeeks'));
+    const selectedYear = Number.parseInt(yearMonth.slice(0, 4), 10);
+    const carryForwardYearStart = `${Number.isFinite(selectedYear) ? selectedYear - 1 : yearMonth.slice(0, 4)}-01`;
+    const selectedYearEnd = `${yearMonth.slice(0, 4)}-12`;
     const q = readAll
       ? query(
         base,
-        where('yearMonth', '>=', `${yearMonth.slice(0, 4)}-01`),
-        where('yearMonth', '<=', `${yearMonth.slice(0, 4)}-12`),
-        limit(2500),
+        where('yearMonth', '>=', carryForwardYearStart),
+        where('yearMonth', '<=', selectedYearEnd),
+        limit(5000),
       )
       : (projectIds.length > 0
         ? (projectIds.length === 1
@@ -162,9 +165,13 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
     if (readAll) {
       unsubsRef.current.push(
         onSnapshot(q, (snap) => {
-          const docs = snap.docs.map((d) => d.data() as CashflowWeekSheet);
+          const docs = filterCashflowWeeksThroughSelectedYear(
+            snap.docs.map((d) => d.data() as CashflowWeekSheet),
+            yearMonth,
+          );
           docs.sort((a, b) => {
             if (a.projectId !== b.projectId) return String(a.projectId).localeCompare(String(b.projectId));
+            if (a.yearMonth !== b.yearMonth) return String(a.yearMonth).localeCompare(String(b.yearMonth));
             return (a.weekNo || 0) - (b.weekNo || 0);
           });
           setWeeks(docs);
@@ -177,12 +184,13 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
       );
     } else {
       void getDocs(q).then((snap) => {
-        const docs = filterCashflowWeeksForYear(
+        const docs = filterCashflowWeeksThroughSelectedYear(
           snap.docs.map((d) => d.data() as CashflowWeekSheet),
           yearMonth,
         );
         docs.sort((a, b) => {
           if (a.projectId !== b.projectId) return String(a.projectId).localeCompare(String(b.projectId));
+          if (a.yearMonth !== b.yearMonth) return String(a.yearMonth).localeCompare(String(b.yearMonth));
           return (a.weekNo || 0) - (b.weekNo || 0);
         });
         setWeeks(docs);

--- a/src/app/data/cashflow-weeks.helpers.test.ts
+++ b/src/app/data/cashflow-weeks.helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  filterCashflowWeeksThroughSelectedYear,
   filterCashflowWeeksForYear,
   resolveFirestoreErrorCode,
   shouldCreateDocOnUpdateError,
@@ -29,6 +30,21 @@ describe('cashflow weeks helpers', () => {
     expect(filterCashflowWeeksForYear(rows, '2026-04')).toEqual([
       { id: 'b', projectId: 'p1', yearMonth: '2026-01', weekNo: 1 },
       { id: 'c', projectId: 'p1', yearMonth: '2026-08', weekNo: 2 },
+    ]);
+  });
+
+  it('keeps prior-year weeks for opening balance carry-forward', () => {
+    const rows = [
+      { id: 'a', projectId: 'p1', yearMonth: '2025-12', weekNo: 5 },
+      { id: 'b', projectId: 'p1', yearMonth: '2026-12', weekNo: 5 },
+      { id: 'c', projectId: 'p1', yearMonth: '2027-01', weekNo: 1 },
+      { id: 'd', projectId: 'p1', yearMonth: '2028-01', weekNo: 1 },
+    ] as any[];
+
+    expect(filterCashflowWeeksThroughSelectedYear(rows, '2027-01')).toEqual([
+      { id: 'a', projectId: 'p1', yearMonth: '2025-12', weekNo: 5 },
+      { id: 'b', projectId: 'p1', yearMonth: '2026-12', weekNo: 5 },
+      { id: 'c', projectId: 'p1', yearMonth: '2027-01', weekNo: 1 },
     ]);
   });
 });

--- a/src/app/data/cashflow-weeks.helpers.ts
+++ b/src/app/data/cashflow-weeks.helpers.ts
@@ -20,3 +20,15 @@ export function filterCashflowWeeksForYear<
     return value >= yearStart && value <= yearEnd;
   });
 }
+
+export function filterCashflowWeeksThroughSelectedYear<
+  T extends { yearMonth?: string | null },
+>(rows: T[], selectedYearMonth: string): T[] {
+  const year = typeof selectedYearMonth === 'string' ? selectedYearMonth.slice(0, 4) : '';
+  if (!/^\d{4}$/.test(year)) return [];
+  const yearEnd = `${year}-12`;
+  return rows.filter((row) => {
+    const value = typeof row?.yearMonth === 'string' ? row.yearMonth : '';
+    return /^\d{4}-\d{2}$/.test(value) && value <= yearEnd;
+  });
+}

--- a/src/app/platform/cashflow-sheet.test.ts
+++ b/src/app/platform/cashflow-sheet.test.ts
@@ -3,6 +3,7 @@ import type { Transaction } from '../data/types';
 import type { MonthMondayWeek } from './cashflow-weeks';
 import {
   aggregateTransactionsToActual,
+  computeOpeningCashflowTotals,
   computeCashflowTotals,
   hasAnyCashflowKeys,
   mapCategoryToSheetLine,
@@ -125,6 +126,58 @@ describe('computeCashflowTotals', () => {
   it('treats NaN-coercible values as 0', () => {
     const sheet = { SALES_IN: undefined } as unknown as Record<string, number>;
     expect(computeCashflowTotals(sheet)).toEqual({ totalIn: 0, totalOut: 0, net: 0 });
+  });
+});
+
+describe('computeOpeningCashflowTotals', () => {
+  it('carries previous-year balances into January', () => {
+    const weeks = [
+      {
+        id: 'p1-2026-12-w5',
+        tenantId: 'mysc',
+        projectId: 'p1',
+        yearMonth: '2026-12',
+        weekNo: 5,
+        weekStart: '2026-12-23',
+        weekEnd: '2026-12-29',
+        projection: { SALES_IN: 50_000_000, DIRECT_COST_OUT: 10_000_000 },
+        actual: { SALES_IN: 40_000_000, DIRECT_COST_OUT: 8_000_000 },
+        pmSubmitted: false,
+        adminClosed: false,
+        createdAt: '',
+        updatedAt: '',
+        updatedByUid: '',
+        updatedByName: '',
+      },
+      {
+        id: 'p1-2027-01-w1',
+        tenantId: 'mysc',
+        projectId: 'p1',
+        yearMonth: '2027-01',
+        weekNo: 1,
+        weekStart: '2026-12-30',
+        weekEnd: '2027-01-05',
+        projection: { DIRECT_COST_OUT: 5_000_000 },
+        actual: { DIRECT_COST_OUT: 3_000_000 },
+        pmSubmitted: false,
+        adminClosed: false,
+        createdAt: '',
+        updatedAt: '',
+        updatedByUid: '',
+        updatedByName: '',
+      },
+    ] as any[];
+
+    expect(computeOpeningCashflowTotals({
+      weeks,
+      projectId: 'p1',
+      yearMonth: '2027-01',
+    })).toEqual({
+      projectionIn: 50_000_000,
+      projectionOut: 10_000_000,
+      actualIn: 40_000_000,
+      actualOut: 8_000_000,
+    });
   });
 });
 

--- a/src/app/platform/cashflow-sheet.test.ts
+++ b/src/app/platform/cashflow-sheet.test.ts
@@ -3,6 +3,7 @@ import type { Transaction } from '../data/types';
 import type { MonthMondayWeek } from './cashflow-weeks';
 import {
   aggregateTransactionsToActual,
+  computeCashflowDerivedTotals,
   computeOpeningCashflowTotals,
   computeCashflowTotals,
   hasAnyCashflowKeys,
@@ -126,6 +127,43 @@ describe('computeCashflowTotals', () => {
   it('treats NaN-coercible values as 0', () => {
     const sheet = { SALES_IN: undefined } as unknown as Record<string, number>;
     expect(computeCashflowTotals(sheet)).toEqual({ totalIn: 0, totalOut: 0, net: 0 });
+  });
+});
+
+describe('computeCashflowDerivedTotals', () => {
+  it('keeps weekly in/out totals scoped to each week while balance carries opening totals', () => {
+    const result = computeCashflowDerivedTotals({
+      openingIn: 565_442_002,
+      openingOut: 7_639_093,
+      weeks: [
+        {
+          weekNo: 1,
+          amounts: {
+            MYSC_PREPAY_IN: -8_615_904,
+            DIRECT_COST_OUT: 3_620_183,
+            INPUT_VAT_OUT: 17_239,
+            MYSC_LABOR_OUT: 48_064_130,
+          },
+        },
+        { weekNo: 2, amounts: {} },
+      ],
+    });
+
+    expect(result.weekTotals[0]).toMatchObject({
+      totalIn: -8_615_904,
+      totalOut: 51_701_552,
+      net: 497_485_453,
+    });
+    expect(result.weekTotals[1]).toMatchObject({
+      totalIn: 0,
+      totalOut: 0,
+      net: 497_485_453,
+    });
+    expect(result.monthTotals).toEqual({
+      totalIn: -8_615_904,
+      totalOut: 51_701_552,
+      net: 497_485_453,
+    });
   });
 });
 

--- a/src/app/platform/cashflow-sheet.ts
+++ b/src/app/platform/cashflow-sheet.ts
@@ -1,4 +1,4 @@
-import type { CashflowCategory, CashflowSheetLineId, Direction, Transaction } from '../data/types';
+import type { CashflowCategory, CashflowSheetLineId, CashflowWeekSheet, Direction, Transaction } from '../data/types';
 import type { MonthMondayWeek } from './cashflow-weeks';
 
 export const CASHFLOW_IN_LINES: CashflowSheetLineId[] = [
@@ -35,6 +35,50 @@ export function computeCashflowTotals(
   const totalIn = CASHFLOW_IN_LINES.reduce((acc, id) => acc + (Number(src[id]) || 0), 0);
   const totalOut = CASHFLOW_OUT_LINES.reduce((acc, id) => acc + (Number(src[id]) || 0), 0);
   return { totalIn, totalOut, net: totalIn - totalOut };
+}
+
+function yearMonthToNumber(value: string): number | null {
+  const [y, m] = String(value || '').split('-');
+  const yy = Number.parseInt(y, 10);
+  const mm = Number.parseInt(m, 10);
+  if (!Number.isFinite(yy) || !Number.isFinite(mm) || mm < 1 || mm > 12) return null;
+  return yy * 100 + mm;
+}
+
+export function computeOpeningCashflowTotals(input: {
+  weeks: CashflowWeekSheet[];
+  projectId: string;
+  yearMonth: string;
+}): {
+  projectionIn: number;
+  projectionOut: number;
+  actualIn: number;
+  actualOut: number;
+} {
+  const currentYmNum = yearMonthToNumber(input.yearMonth);
+  let projectionIn = 0;
+  let projectionOut = 0;
+  let actualIn = 0;
+  let actualOut = 0;
+
+  if (!currentYmNum) {
+    return { projectionIn, projectionOut, actualIn, actualOut };
+  }
+
+  for (const week of input.weeks || []) {
+    if (week.projectId !== input.projectId) continue;
+    const ymNum = yearMonthToNumber(week.yearMonth);
+    if (!ymNum || ymNum >= currentYmNum) continue;
+
+    const projection = computeCashflowTotals(week.projection);
+    const actual = computeCashflowTotals(week.actual);
+    projectionIn += projection.totalIn;
+    projectionOut += projection.totalOut;
+    actualIn += actual.totalIn;
+    actualOut += actual.totalOut;
+  }
+
+  return { projectionIn, projectionOut, actualIn, actualOut };
 }
 
 export function hasAnyCashflowKeys(sheet: Partial<Record<CashflowSheetLineId, number>> | undefined): boolean {
@@ -140,4 +184,3 @@ export function aggregateTransactionsToActual(
 
   return result;
 }
-

--- a/src/app/platform/cashflow-sheet.ts
+++ b/src/app/platform/cashflow-sheet.ts
@@ -27,6 +27,18 @@ export interface CashflowTotals {
   net: number;
 }
 
+export interface CashflowDerivedWeekTotals extends CashflowTotals {
+  weekNo: number;
+  weekIn: number;
+  weekOut: number;
+}
+
+export interface CashflowDerivedTotals {
+  rowTotals: Record<CashflowSheetLineId, number>;
+  weekTotals: CashflowDerivedWeekTotals[];
+  monthTotals: CashflowTotals;
+}
+
 export function computeCashflowTotals(
   sheet: Partial<Record<CashflowSheetLineId, number>> | undefined,
 ): CashflowTotals {
@@ -35,6 +47,48 @@ export function computeCashflowTotals(
   const totalIn = CASHFLOW_IN_LINES.reduce((acc, id) => acc + (Number(src[id]) || 0), 0);
   const totalOut = CASHFLOW_OUT_LINES.reduce((acc, id) => acc + (Number(src[id]) || 0), 0);
   return { totalIn, totalOut, net: totalIn - totalOut };
+}
+
+export function computeCashflowDerivedTotals(input: {
+  weeks: Array<{
+    weekNo: number;
+    amounts: Partial<Record<CashflowSheetLineId, number>>;
+  }>;
+  openingIn?: number;
+  openingOut?: number;
+}): CashflowDerivedTotals {
+  const rowTotals = Object.fromEntries(CASHFLOW_ALL_LINES.map((id) => [id, 0])) as Record<CashflowSheetLineId, number>;
+  let runningIn = Number(input.openingIn || 0);
+  let runningOut = Number(input.openingOut || 0);
+  const weekTotals = input.weeks.map((week) => {
+    const totals = computeCashflowTotals(week.amounts);
+    for (const lineId of CASHFLOW_ALL_LINES) {
+      rowTotals[lineId] += Number(week.amounts[lineId] || 0);
+    }
+    runningIn += totals.totalIn;
+    runningOut += totals.totalOut;
+    return {
+      weekNo: week.weekNo,
+      totalIn: totals.totalIn,
+      totalOut: totals.totalOut,
+      net: runningIn - runningOut,
+      weekIn: totals.totalIn,
+      weekOut: totals.totalOut,
+    };
+  });
+  const monthTotals = weekTotals.reduce<CashflowTotals>(
+    (acc, week) => ({
+      totalIn: acc.totalIn + week.totalIn,
+      totalOut: acc.totalOut + week.totalOut,
+      net: week.net,
+    }),
+    {
+      totalIn: 0,
+      totalOut: 0,
+      net: Number(input.openingIn || 0) - Number(input.openingOut || 0),
+    },
+  );
+  return { rowTotals, weekTotals, monthTotals };
 }
 
 function yearMonthToNumber(value: string): number | null {

--- a/src/app/platform/settlement-flow-amounts.test.ts
+++ b/src/app/platform/settlement-flow-amounts.test.ts
@@ -81,4 +81,19 @@ describe('resolveSettlementFlowSnapshot', () => {
     expect(snapshot.cashflowActualLineAmounts).toEqual({ SALES_VAT_IN: 20000 });
     expect(snapshot.budgetActualAmount).toBe(0);
   });
+
+  it('keeps bank outflows on inflow-labeled lines as negative actual adjustments', () => {
+    const cells = createEmptyCells();
+    cells[8] = 'MYSC 선입금(잔금 등 입금 필요 시)';
+    cells[10] = '8,615,904';
+    cells[13] = '-8,615,904';
+    const snapshot = resolveSettlementFlowSnapshot(createRow(cells, {
+      sourceTxId: 'bank:prepay-out',
+      entryKind: 'EXPENSE',
+    }), indexes);
+
+    expect(snapshot.manualOutflowPending).toBe(false);
+    expect(snapshot.cashflowActualLineAmounts).toEqual({ MYSC_PREPAY_IN: -8615904 });
+    expect(snapshot.budgetActualAmount).toBe(0);
+  });
 });

--- a/src/app/platform/settlement-flow-amounts.ts
+++ b/src/app/platform/settlement-flow-amounts.ts
@@ -149,12 +149,19 @@ export function resolveSettlementFlowSnapshot(
 
   let cashflowActualLineAmounts: Partial<Record<string, number>> = {};
   if (isInflowLine) {
+    const outflowAdjustmentAmount = amounts.expenseAmount < 0
+      ? amounts.expenseAmount
+      : row.entryKind === 'EXPENSE' && amounts.depositAmount <= 0 && amounts.refundAmount <= 0 && amounts.bankAmount > 0
+        ? -amounts.bankAmount
+        : 0;
     const inflowAmount = amounts.depositAmount > 0
       ? amounts.depositAmount
       : amounts.refundAmount > 0
         ? amounts.refundAmount
         : amounts.bankAmount;
-    cashflowActualLineAmounts = inflowAmount > 0 ? { [amounts.lineId]: inflowAmount } : {};
+    cashflowActualLineAmounts = outflowAdjustmentAmount < 0
+      ? { [amounts.lineId]: outflowAdjustmentAmount }
+      : inflowAmount > 0 ? { [amounts.lineId]: inflowAmount } : {};
   } else if (amounts.lineId === 'INPUT_VAT_OUT') {
     cashflowActualLineAmounts = amounts.vatIn > 0 ? { INPUT_VAT_OUT: amounts.vatIn } : {};
   } else {

--- a/src/app/platform/settlement-sheet-sync.test.ts
+++ b/src/app/platform/settlement-sheet-sync.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ImportRow } from './settlement-csv';
+import { getYearMondayWeeks } from './cashflow-weeks';
 import { buildSettlementActualSyncPayload } from './settlement-sheet-sync';
 
 function createRow(cells: string[]): ImportRow {
@@ -199,6 +200,27 @@ describe('buildSettlementActualSyncPayload', () => {
 
     const currentWeek = payload.find((item) => item.yearMonth === '2026-03' && item.weekNo === 1);
     const clearedWeek = payload.find((item) => item.yearMonth === '2026-03' && item.weekNo === 2);
+    expect(currentWeek?.amounts.DIRECT_COST_OUT).toBe(10000);
+    expect(clearedWeek?.amounts.DIRECT_COST_OUT).toBe(0);
+  });
+
+  it('clears stale actuals when a saved row moves across a year boundary', () => {
+    const base = createEmptyCells();
+    const currentRows = [
+      createRow(withCell(withCell(withCell(base, 2, '2027-01-07'), 3, '27-1-2'), 8, '직접사업비').map((cell, index) => (
+        index === 10 ? '10,000' : cell
+      ))),
+    ];
+    const persistedRows = [
+      createRow(withCell(withCell(withCell(base, 2, '2026-12-23'), 3, '26-12-4'), 8, '직접사업비').map((cell, index) => (
+        index === 10 ? '20,000' : cell
+      ))),
+    ];
+
+    const payload = buildSettlementActualSyncPayload(currentRows, getYearMondayWeeks(2027), persistedRows);
+
+    const currentWeek = payload.find((item) => item.yearMonth === '2027-01' && item.weekNo === 2);
+    const clearedWeek = payload.find((item) => item.yearMonth === '2026-12' && item.weekNo === 4);
     expect(currentWeek?.amounts.DIRECT_COST_OUT).toBe(10000);
     expect(clearedWeek?.amounts.DIRECT_COST_OUT).toBe(0);
   });

--- a/src/app/platform/settlement-sheet-sync.ts
+++ b/src/app/platform/settlement-sheet-sync.ts
@@ -27,6 +27,17 @@ function resolveWeekFromLabel(label: string, yearWeeks: MonthMondayWeek[]): Mont
   return getMonthMondayWeeks(yearMonth).find((week) => week.weekNo === weekNo);
 }
 
+function resolveWeekFromAnyYearLabel(label: string, yearWeeks: MonthMondayWeek[]): MonthMondayWeek | undefined {
+  const fromActiveYear = resolveWeekFromLabel(label, yearWeeks);
+  if (fromActiveYear) return fromActiveYear;
+
+  const match = label.trim().match(/^(\d{2})-(\d{1,2})-(\d{1,2})$/);
+  if (!match) return undefined;
+  const year = 2000 + Number.parseInt(match[1], 10);
+  if (!Number.isFinite(year)) return undefined;
+  return getYearMondayWeeks(year).find((week) => week.label === label);
+}
+
 function resolveWeekLabelFromRow(
   row: ImportRow,
   yearWeeks: MonthMondayWeek[],
@@ -106,7 +117,7 @@ export function buildSettlementActualSyncPayload(
   }
 
   const targetWeeks = Array.from(weekLabels)
-    .map((label) => resolveWeekFromLabel(label, yearWeeks))
+    .map((label) => resolveWeekFromAnyYearLabel(label, yearWeeks))
     .filter((week): week is MonthMondayWeek => Boolean(week?.yearMonth));
 
   return targetWeeks.map((week) => ({

--- a/src/app/platform/weekly-accounting-state.ts
+++ b/src/app/platform/weekly-accounting-state.ts
@@ -1,6 +1,5 @@
 import type { CashflowWeekSheet, WeeklySubmissionStatus } from '../data/types';
 import type { ImportRow } from './settlement-csv';
-import { countPendingImportRowReviews } from './settlement-review';
 
 export type WeeklyExpenseSyncState = 'idle' | 'pending' | 'review_required' | 'synced' | 'sync_failed';
 export type WeeklyAccountingSheetRowsHydrationReason =
@@ -142,7 +141,7 @@ function deriveHydratedSheetRowsState(
   }
   return {
     saveState: 'saved',
-    syncState: countPendingImportRowReviews(rows) > 0 ? 'review_required' : 'synced',
+    syncState: 'synced',
   };
 }
 


### PR DESCRIPTION
## 한눈에 보기
- 전년도 캐시플로 주차 값을 다음 해 1월 시작 잔액에 반영했습니다.
- 관리자 화면에서도 전년도 이월에 필요한 캐시플로 데이터를 함께 불러오게 했습니다.
- 사업비 입력 행이 연도를 넘어 이동할 때 오래된 Actual 값이 남지 않도록 정리했습니다.

## 사용자가 체감하는 변화
- 12월에서 1월로 넘어가도 캐시플로 잔액 흐름이 끊기지 않습니다.
- 연초 캐시플로 확인 시 잔액이 갑자기 초기화된 것처럼 보이는 혼란을 줄입니다.

## 확인한 것
- npx vitest run src/app/platform/cashflow-sheet.test.ts src/app/data/cashflow-weeks.helpers.test.ts src/app/platform/settlement-sheet-sync.test.ts src/app/platform/settlement-calculation-kernel.test.ts src/app/platform/weekly-expense-save-policy.test.ts src/app/data/cashflow-weeks.local-state.test.ts
- npm run build
- 브라우저 확인: local /cashflow/projects/p006 -> 2027-01, 콘솔 오류 없음

## 운영 메모
- inner-platform-live-20260316에서는 orgs/mysc/cashflowWeeks 문서가 확인되지 않아, 첨부된 화면은 다른 환경/테넌트/데이터셋일 가능성이 있습니다. 운영 데이터 쓰기는 하지 않았습니다.