### PR TITLE
전체 사업비 입력 시트 기준으로 Actual을 동기화

### DIFF
--- a/src/app/components/portal/PortalWeeklyExpensePage.flow-layout.test.ts
+++ b/src/app/components/portal/PortalWeeklyExpensePage.flow-layout.test.ts
@@ -53,4 +53,10 @@ describe('PortalWeeklyExpensePage flow layout', () => {
   it('guards the setup panel so the page can render when no setup action is needed', () => {
     expect(weeklyExpenseSource).toMatch(/\{weeklySetupPanel \? \(\s*<Card data-testid="weekly-expense-setup-panel" className=\{weeklySetupPanel\.toneClass\}>/);
   });
+
+  it('keeps cashflow actual sync tied to the full project expense-sheet source, not only the active tab save button', () => {
+    expect(weeklyExpenseSource).toContain('buildProjectExpenseRowsForActualSync');
+    expect(weeklyExpenseSource).toContain('projectActualSyncPayload');
+    expect(weeklyExpenseSource).toContain('actual_realtime_sync');
+  });
 });

--- a/src/app/components/portal/PortalWeeklyExpensePage.tsx
+++ b/src/app/components/portal/PortalWeeklyExpensePage.tsx
@@ -56,6 +56,7 @@ import { buildOptimisticUploadedEvidencePatch } from '../../platform/evidence-up
 import { readDevAuthHarnessConfig } from '../../platform/dev-harness';
 import { detectParticipationRisk } from '../../platform/participation-risk-rules';
 import { normalizeBudgetLabel } from '../../platform/budget-labels';
+import { buildProjectExpenseRowsForActualSync } from '../../platform/expense-sheet-actual-sync';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -69,6 +70,7 @@ import {
 import { resolvePortalHappyPath } from '../../platform/portal-happy-path';
 import { resolveWeeklyExpenseSavePolicy } from '../../platform/weekly-expense-save-policy';
 import { usePortalNavigationGuard } from './PortalLayout';
+import { getYearMondayWeeks } from '../../platform/cashflow-weeks';
 const GoogleSheetMigrationWizard = lazy(
   () => import('./GoogleSheetMigrationWizard').then((module) => ({ default: module.GoogleSheetMigrationWizard })),
 );
@@ -121,6 +123,7 @@ export function PortalWeeklyExpensePage() {
   const [hasUnsavedSettlementChanges, setHasUnsavedSettlementChanges] = useState(false);
   const [isSettlementSaving, setIsSettlementSaving] = useState(false);
   const [pendingNavigationAttempt, setPendingNavigationAttempt] = useState<{ path: string; label: string } | null>(null);
+  const actualSyncSignatureRef = useRef('');
   const [participationRiskWarning, setParticipationRiskWarning] = useState<{
     yearMonth: string;
     weekNo: number;
@@ -280,7 +283,76 @@ export function PortalWeeklyExpensePage() {
     rows: ImportRow[],
     yearWeeks: Parameters<typeof buildSettlementActualSyncPayloadLocally>[1],
     persistedRows?: ImportRow[] | null,
-  ) => buildSettlementActualSyncPayloadLocally(rows, yearWeeks, persistedRows), []);
+  ) => {
+    const currentProjectRows = buildProjectExpenseRowsForActualSync({
+      sheets: visibleExpenseSheets,
+      activeSheetId: activeExpenseSheetId,
+      activeRows: rows,
+    });
+    const persistedProjectRows = buildProjectExpenseRowsForActualSync({
+      sheets: visibleExpenseSheets,
+      activeSheetId: activeExpenseSheetId,
+      activeRows: persistedRows ?? expenseSheetRows ?? [],
+    });
+    return buildSettlementActualSyncPayloadLocally(currentProjectRows, yearWeeks, persistedProjectRows);
+  }, [activeExpenseSheetId, expenseSheetRows, visibleExpenseSheets]);
+
+  const projectActualSyncPayload = useMemo(() => {
+    const rows = buildProjectExpenseRowsForActualSync({
+      sheets: visibleExpenseSheets,
+      activeSheetId: activeExpenseSheetId,
+      activeRows: expenseSheetRows ?? [],
+    });
+    if (rows.length === 0) return [];
+    const currentYear = new Date().getFullYear();
+    return buildSettlementActualSyncPayloadLocally(rows, getYearMondayWeeks(currentYear), rows);
+  }, [activeExpenseSheetId, expenseSheetRows, visibleExpenseSheets]);
+
+  useEffect(() => {
+    if (!projectId || projectActualSyncPayload.length === 0) return;
+    const signature = JSON.stringify(projectActualSyncPayload);
+    if (actualSyncSignatureRef.current === signature) return;
+    actualSyncSignatureRef.current = signature;
+    let cancelled = false;
+    void (async () => {
+      try {
+        await Promise.all(projectActualSyncPayload.map((week) => upsertWeekAmounts({
+          projectId,
+          yearMonth: week.yearMonth,
+          weekNo: week.weekNo,
+          mode: 'actual',
+          amounts: week.amounts as any,
+        })));
+        if (cancelled) return;
+        await Promise.all(projectActualSyncPayload.map((week) => upsertWeeklySubmissionStatus({
+          projectId,
+          yearMonth: week.yearMonth,
+          weekNo: week.weekNo,
+          expenseUpdated: true,
+          expenseSyncState: 'synced',
+          expenseReviewPendingCount: 0,
+        })));
+      } catch (error) {
+        actualSyncSignatureRef.current = '';
+        reportError(error, {
+          message: '[PortalWeeklyExpensePage] actual realtime sync failed:',
+          options: {
+            level: 'error',
+            tags: {
+              surface: 'portal_weekly_expense',
+              action: 'actual_realtime_sync',
+            },
+            extra: {
+              projectId,
+            },
+          },
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [projectActualSyncPayload, projectId, upsertWeekAmounts, upsertWeeklySubmissionStatus]);
 
   const handleEvidenceDriveError = useCallback((error: unknown, actionLabel: string) => {
     reportError(error, {

--- a/src/app/data/cashflow-weeks-store.tsx
+++ b/src/app/data/cashflow-weeks-store.tsx
@@ -12,7 +12,6 @@ import {
   collection,
   doc,
   getDoc,
-  getDocs,
   limit,
   onSnapshot,
   query,
@@ -162,28 +161,8 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
           limit(2500),
         ));
 
-    if (readAll) {
-      unsubsRef.current.push(
-        onSnapshot(q, (snap) => {
-          const docs = filterCashflowWeeksThroughSelectedYear(
-            snap.docs.map((d) => d.data() as CashflowWeekSheet),
-            yearMonth,
-          );
-          docs.sort((a, b) => {
-            if (a.projectId !== b.projectId) return String(a.projectId).localeCompare(String(b.projectId));
-            if (a.yearMonth !== b.yearMonth) return String(a.yearMonth).localeCompare(String(b.yearMonth));
-            return (a.weekNo || 0) - (b.weekNo || 0);
-          });
-          setWeeks(docs);
-          setIsLoading(false);
-        }, (err) => {
-          console.error('[CashflowWeeks] listen error:', err);
-          setWeeks([]);
-          setIsLoading(false);
-        }),
-      );
-    } else {
-      void getDocs(q).then((snap) => {
+    unsubsRef.current.push(
+      onSnapshot(q, (snap) => {
         const docs = filterCashflowWeeksThroughSelectedYear(
           snap.docs.map((d) => d.data() as CashflowWeekSheet),
           yearMonth,
@@ -195,12 +174,12 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
         });
         setWeeks(docs);
         setIsLoading(false);
-      }).catch((err) => {
-        console.error('[CashflowWeeks] fetch error:', err);
+      }, (err) => {
+        console.error('[CashflowWeeks] listen error:', err);
         setWeeks([]);
         setIsLoading(false);
-      });
-    }
+      }),
+    );
 
     return () => {
       unsubsRef.current.forEach((u) => u());

--- a/src/app/data/firestore-realtime-providers.test.ts
+++ b/src/app/data/firestore-realtime-providers.test.ts
@@ -21,4 +21,11 @@ describe('route-aware firestore realtime providers', () => {
       expect(source).not.toContain('canUseRealtimeListeners(');
     });
   }
+
+  it('keeps cashflow weeks realtime for project-scoped users so actual values do not go stale', () => {
+    const source = readFileSync(resolve(import.meta.dirname, 'cashflow-weeks-store.tsx'), 'utf8');
+
+    expect(source).toContain('onSnapshot(q,');
+    expect(source).not.toContain('getDocs(q)');
+  });
 });

--- a/src/app/platform/expense-sheet-actual-sync.test.ts
+++ b/src/app/platform/expense-sheet-actual-sync.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import type { ImportRow } from './settlement-csv';
+import { buildProjectExpenseRowsForActualSync } from './expense-sheet-actual-sync';
+import { buildSettlementActualSyncPayload } from './settlement-sheet-sync';
+
+function row(tempId: string): ImportRow {
+  return {
+    tempId,
+    cells: [],
+  };
+}
+
+function settlementRow(input: {
+  tempId: string;
+  date: string;
+  week: string;
+  cashflowLine: string;
+  amount: string;
+}): ImportRow {
+  const cells = Array.from({ length: 26 }, () => '');
+  cells[2] = input.date;
+  cells[3] = input.week;
+  cells[8] = input.cashflowLine;
+  cells[10] = input.amount;
+  return {
+    tempId: input.tempId,
+    cells,
+  };
+}
+
+describe('buildProjectExpenseRowsForActualSync', () => {
+  it('aggregates every expense sheet and replaces only the active sheet rows', () => {
+    const result = buildProjectExpenseRowsForActualSync({
+      activeSheetId: 'sheet-2',
+      activeRows: [row('sheet-2-edited')],
+      sheets: [
+        { id: 'default', rows: [row('default-1')] },
+        { id: 'sheet-2', rows: [row('sheet-2-old')] },
+        { id: 'sheet-3', rows: [row('sheet-3-1')] },
+      ],
+    });
+
+    expect(result.map((item) => item.tempId)).toEqual([
+      'default-1',
+      'sheet-2-edited',
+      'sheet-3-1',
+    ]);
+  });
+
+  it('keeps edited active rows even before the active sheet exists in the snapshot', () => {
+    const result = buildProjectExpenseRowsForActualSync({
+      activeSheetId: 'new-sheet',
+      activeRows: [row('new-sheet-edited')],
+      sheets: [
+        { id: 'default', rows: [row('default-1')] },
+      ],
+    });
+
+    expect(result.map((item) => item.tempId)).toEqual([
+      'default-1',
+      'new-sheet-edited',
+    ]);
+  });
+
+  it('builds actual payload from all sheets so saving one tab does not clear another tab actual', () => {
+    const activeRows = [
+      settlementRow({
+        tempId: 'active-edited',
+        date: '2026-05-05',
+        week: '26-05-01',
+        cashflowLine: '직접사업비',
+        amount: '10,000',
+      }),
+    ];
+    const projectRows = buildProjectExpenseRowsForActualSync({
+      activeSheetId: 'sheet-2',
+      activeRows,
+      sheets: [
+        {
+          id: 'default',
+          rows: [
+            settlementRow({
+              tempId: 'default-existing',
+              date: '2026-05-06',
+              week: '26-05-01',
+              cashflowLine: 'MYSC 인건비',
+              amount: '40,000',
+            }),
+          ],
+        },
+        {
+          id: 'sheet-2',
+          rows: [
+            settlementRow({
+              tempId: 'active-old',
+              date: '2026-05-05',
+              week: '26-05-01',
+              cashflowLine: '직접사업비',
+              amount: '5,000',
+            }),
+          ],
+        },
+      ],
+    });
+
+    const payload = buildSettlementActualSyncPayload(projectRows, [
+      { yearMonth: '2026-05', weekNo: 1, weekStart: '2026-05-04', weekEnd: '2026-05-10', label: '26-05-01' },
+    ]);
+
+    expect(payload).toHaveLength(1);
+    expect(payload[0]?.amounts.DIRECT_COST_OUT).toBe(10000);
+    expect(payload[0]?.amounts.MYSC_LABOR_OUT).toBe(40000);
+  });
+});

--- a/src/app/platform/expense-sheet-actual-sync.ts
+++ b/src/app/platform/expense-sheet-actual-sync.ts
@@ -1,0 +1,35 @@
+import type { ImportRow } from './settlement-csv';
+
+export interface ExpenseSheetRowsSource {
+  id: string;
+  rows: ImportRow[] | null;
+}
+
+export function buildProjectExpenseRowsForActualSync(params: {
+  sheets: ExpenseSheetRowsSource[];
+  activeSheetId: string;
+  activeRows: ImportRow[] | null | undefined;
+}): ImportRow[] {
+  const activeSheetId = String(params.activeSheetId || 'default').trim() || 'default';
+  const activeRows = Array.isArray(params.activeRows) ? params.activeRows : [];
+  const sheets = Array.isArray(params.sheets) ? params.sheets : [];
+  const rows: ImportRow[] = [];
+  let activeSheetFound = false;
+
+  for (const sheet of sheets) {
+    const sheetId = String(sheet?.id || '').trim();
+    if (!sheetId) continue;
+    if (sheetId === activeSheetId) {
+      rows.push(...activeRows);
+      activeSheetFound = true;
+      continue;
+    }
+    if (Array.isArray(sheet.rows)) rows.push(...sheet.rows);
+  }
+
+  if (!activeSheetFound) {
+    rows.push(...activeRows);
+  }
+
+  return rows;
+}

--- a/src/app/platform/weekly-expense-save-policy.test.ts
+++ b/src/app/platform/weekly-expense-save-policy.test.ts
@@ -6,10 +6,10 @@ import {
 } from './weekly-expense-save-policy';
 
 describe('resolveWeeklyExpenseSavePolicy', () => {
-  it('enables idle autosave with cashflow sync after 120 seconds', () => {
+  it('enables near-realtime autosave with cashflow sync', () => {
     expect(resolveWeeklyExpenseSavePolicy()).toEqual({
       mode: 'auto',
-      idleMs: 120_000,
+      idleMs: 1_500,
       syncCashflowOnAutoSave: true,
       showStatusButton: true,
       showInlineStatus: false,

--- a/src/app/platform/weekly-expense-save-policy.ts
+++ b/src/app/platform/weekly-expense-save-policy.ts
@@ -28,7 +28,7 @@ export interface WeeklyExpenseAutosavePlan {
 export function resolveWeeklyExpenseSavePolicy(): WeeklyExpenseSavePolicy {
   return {
     mode: 'auto',
-    idleMs: 120_000,
+    idleMs: 1_500,
     syncCashflowOnAutoSave: true,
     showStatusButton: true,
     showInlineStatus: false,


### PR DESCRIPTION
## 한눈에 보기
- 현재 열어둔 탭뿐 아니라 프로젝트의 모든 사업비 입력 탭을 기준으로 Actual 값을 계산하게 했습니다.
- PM이 보는 캐시플로 주차 값이 오래된 상태로 남지 않도록 읽기 방식을 보강했습니다.
- 자동 저장 대기 시간을 줄여 사업비 입력 변경이 Actual 동기화로 더 빨리 이어지게 했습니다.

## 사용자가 체감하는 변화
- 여러 탭에 나뉜 사업비 입력값도 캐시플로 Actual에 빠지지 않고 반영됩니다.
- 입력 후 Actual 반영까지 기다리는 시간이 줄어듭니다.

## 확인한 것
- npx vitest run src/app/platform/expense-sheet-actual-sync.test.ts src/app/platform/weekly-expense-save-policy.test.ts src/app/platform/settlement-sheet-sync.test.ts src/app/data/firestore-realtime-providers.test.ts src/app/components/portal/PortalWeeklyExpensePage.flow-layout.test.ts
- npm run build

## 추가 확인
- Actual 동기화 데이터 흐름 중심 QA
- 관련 화면과 저장 모듈 구조 점검