### PR TITLE
캐시플로 저장 기준을 서버 중심으로 통일

### DIFF
--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -1375,7 +1375,7 @@ export function createBffApp(options = {}) {
     projectRequestContractAiService, projectRequestContractStorageService,
     projectSheetSourceStorageService, projectRegistrationSlackService,
   });
-  mountCashflowExportRoutes(app, { db, rbacPolicy });
+  mountCashflowExportRoutes(app, { db, rbacPolicy, idempotencyService, now });
   mountLedgerRoutes(app, { db, now, idempotencyService, auditChainService, piiProtector });
   mountTransactionRoutes(app, { db, now, idempotencyService, auditChainService, piiProtector, rbacPolicy, driveService });
   mountAuditRoutes(app, { db, auditChainService });

--- a/server/bff/cashflow-canonical-store.mjs
+++ b/server/bff/cashflow-canonical-store.mjs
@@ -1,0 +1,527 @@
+import cashflowPolicyData from '../../src/app/policies/cashflow-policy.json' with { type: 'json' };
+import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES } from './cashflow-policy.mjs';
+
+const SETTLEMENT_COLUMN_HEADERS = [
+  '작성자',
+  'No.',
+  '거래일시',
+  '해당 주차',
+  '지출구분',
+  '비목',
+  '세목',
+  '세세목',
+  'cashflow항목',
+  '통장잔액',
+  '통장에 찍힌 입/출금액',
+  '입금액(사업비,공급가액,은행이자)',
+  '매입부가세 반환',
+  '사업비 사용액',
+  '매입부가세',
+];
+
+const COLUMN_INDEX = Object.fromEntries(SETTLEMENT_COLUMN_HEADERS.map((header, index) => [header, index]));
+const CASHFLOW_IN_LINE_IDS = new Set(CASHFLOW_IN_LINES);
+const LINE_BY_LABEL = new Map();
+
+function normalizePolicyLabel(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+for (const entry of cashflowPolicyData.lineEntries || []) {
+  LINE_BY_LABEL.set(normalizePolicyLabel(entry.lineId), entry.lineId);
+  LINE_BY_LABEL.set(normalizePolicyLabel(entry.label), entry.lineId);
+  LINE_BY_LABEL.set(normalizePolicyLabel(entry.label).replace(/\s+/g, ''), entry.lineId);
+  for (const alias of entry.aliases || []) {
+    LINE_BY_LABEL.set(normalizePolicyLabel(alias), entry.lineId);
+    LINE_BY_LABEL.set(normalizePolicyLabel(alias).replace(/\s+/g, ''), entry.lineId);
+  }
+}
+
+function pad2(value) {
+  return String(value).padStart(2, '0');
+}
+
+function parseYearMonth(value) {
+  const match = /^(\d{4})-(\d{2})$/.exec(String(value || '').trim());
+  if (!match) return null;
+  const year = Number.parseInt(match[1], 10);
+  const month = Number.parseInt(match[2], 10);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || month < 1 || month > 12) return null;
+  return { year, month, yearMonth: `${String(year).padStart(4, '0')}-${pad2(month)}` };
+}
+
+function formatIsoDate(year, month, day) {
+  return `${String(year)}-${pad2(month)}-${pad2(day)}`;
+}
+
+function addDaysUtc(isoDate, deltaDays) {
+  const [yRaw, mRaw, dRaw] = String(isoDate || '').split('-');
+  const year = Number.parseInt(yRaw, 10);
+  const month = Number.parseInt(mRaw, 10);
+  const day = Number.parseInt(dRaw, 10);
+  const base = Date.UTC(year, month - 1, day);
+  const next = new Date(base + deltaDays * 24 * 60 * 60 * 1000);
+  return formatIsoDate(next.getUTCFullYear(), next.getUTCMonth() + 1, next.getUTCDate());
+}
+
+function dayOfWeekUtc(year, month, day) {
+  return new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+}
+
+function daysInMonthUtc(year, month) {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+function startOfWeekWednesday(isoDate) {
+  const [yRaw, mRaw, dRaw] = String(isoDate || '').split('-');
+  const year = Number.parseInt(yRaw, 10);
+  const month = Number.parseInt(mRaw, 10);
+  const day = Number.parseInt(dRaw, 10);
+  const dow = dayOfWeekUtc(year, month, day);
+  const delta = -((dow - 3 + 7) % 7);
+  return addDaysUtc(isoDate, delta);
+}
+
+function countDaysInMonthForWeek(weekStart, year, month) {
+  let count = 0;
+  for (let i = 0; i < 7; i += 1) {
+    const date = addDaysUtc(weekStart, i);
+    const [yy, mm] = date.split('-');
+    if (Number.parseInt(yy, 10) === year && Number.parseInt(mm, 10) === month) count += 1;
+  }
+  return count;
+}
+
+export function getMonthCashflowWeeks(yearMonth) {
+  const parsed = parseYearMonth(yearMonth);
+  if (!parsed) return [];
+
+  const { year, month } = parsed;
+  const firstDay = formatIsoDate(year, month, 1);
+  const lastDay = formatIsoDate(year, month, daysInMonthUtc(year, month));
+  let weekStart = startOfWeekWednesday(firstDay);
+  const weeks = [];
+  const yy = year % 100;
+  let weekNo = 0;
+
+  while (weekStart <= lastDay) {
+    const daysInMonth = countDaysInMonthForWeek(weekStart, year, month);
+    if (daysInMonth >= 4) {
+      weekNo += 1;
+      weeks.push({
+        yearMonth: parsed.yearMonth,
+        weekNo,
+        weekStart,
+        weekEnd: addDaysUtc(weekStart, 6),
+        label: `${yy}-${month}-${weekNo}`,
+      });
+    }
+    weekStart = addDaysUtc(weekStart, 7);
+  }
+
+  return weeks;
+}
+
+function getYearCashflowWeeks(year) {
+  const all = [];
+  for (let month = 1; month <= 12; month += 1) {
+    all.push(...getMonthCashflowWeeks(`${year}-${pad2(month)}`));
+  }
+  return all;
+}
+
+function findWeekForDate(dateStr, weeks) {
+  if (!dateStr) return undefined;
+  const direct = weeks.find((week) => dateStr >= week.weekStart && dateStr <= week.weekEnd);
+  if (direct) return direct;
+
+  const [yRaw, mRaw] = dateStr.split('-');
+  const year = Number.parseInt(yRaw, 10);
+  const month = Number.parseInt(mRaw, 10);
+  if (!Number.isFinite(year) || !Number.isFinite(month)) return undefined;
+
+  const current = getMonthCashflowWeeks(`${year}-${pad2(month)}`);
+  const inCurrent = current.find((week) => dateStr >= week.weekStart && dateStr <= week.weekEnd);
+  if (inCurrent) return inCurrent;
+
+  const prevMonth = month === 1 ? 12 : month - 1;
+  const prevYear = month === 1 ? year - 1 : year;
+  const prev = getMonthCashflowWeeks(`${prevYear}-${pad2(prevMonth)}`);
+  const inPrev = prev.find((week) => dateStr >= week.weekStart && dateStr <= week.weekEnd);
+  if (inPrev) return inPrev;
+
+  const nextMonth = month === 12 ? 1 : month + 1;
+  const nextYear = month === 12 ? year + 1 : year;
+  return getMonthCashflowWeeks(`${nextYear}-${pad2(nextMonth)}`)
+    .find((week) => dateStr >= week.weekStart && dateStr <= week.weekEnd);
+}
+
+function resolveWeekFromLabel(label, anchorWeeks) {
+  const normalized = String(label || '').trim();
+  if (!normalized) return undefined;
+  const direct = anchorWeeks.find((week) => week.label === normalized);
+  if (direct) return direct;
+
+  const match = /^(\d{2})-(\d{1,2})-(\d{1,2})$/.exec(normalized);
+  if (!match) return undefined;
+  const year = 2000 + Number.parseInt(match[1], 10);
+  const month = Number.parseInt(match[2], 10);
+  const weekNo = Number.parseInt(match[3], 10);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(weekNo)) return undefined;
+  return getMonthCashflowWeeks(`${year}-${pad2(month)}`).find((week) => week.weekNo === weekNo);
+}
+
+function parseDateIso(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+  const compact = raw.match(/^(\d{4})[./-](\d{1,2})[./-](\d{1,2})/);
+  if (compact) {
+    return `${compact[1]}-${pad2(Number.parseInt(compact[2], 10))}-${pad2(Number.parseInt(compact[3], 10))}`;
+  }
+  const date = new Date(raw);
+  if (Number.isNaN(date.getTime())) return '';
+  return formatIsoDate(date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate());
+}
+
+function resolveWeekFromRow(row, anchorWeeks) {
+  const cells = Array.isArray(row?.cells) ? row.cells : [];
+  const explicitLabel = String(cells[COLUMN_INDEX['해당 주차']] || '').trim();
+  const fromLabel = resolveWeekFromLabel(explicitLabel, anchorWeeks);
+  if (fromLabel) return fromLabel;
+
+  const dateOnly = parseDateIso(cells[COLUMN_INDEX['거래일시']]);
+  if (!dateOnly) return undefined;
+  const dateYear = Number.parseInt(dateOnly.slice(0, 4), 10);
+  const anchorYear = Number.parseInt(anchorWeeks[0]?.yearMonth?.slice(0, 4) || '', 10);
+  return findWeekForDate(dateOnly, dateYear === anchorYear ? anchorWeeks : getYearCashflowWeeks(dateYear));
+}
+
+export function parseCashflowLineLabel(raw) {
+  const normalized = normalizePolicyLabel(raw);
+  if (!normalized) return undefined;
+  return LINE_BY_LABEL.get(normalized) || LINE_BY_LABEL.get(normalized.replace(/\s+/g, ''));
+}
+
+function parseAmount(value) {
+  if (typeof value === 'number') return Number.isFinite(value) ? Math.trunc(value) : 0;
+  const raw = String(value ?? '').trim();
+  if (!raw) return 0;
+  const negativeByParens = /^\(.+\)$/.test(raw);
+  const sanitized = raw.replace(/[,\s원₩$]/g, '').replace(/[()]/g, '');
+  const parsed = Number.parseFloat(sanitized.replace(/[^0-9.-]/g, ''));
+  if (!Number.isFinite(parsed)) return 0;
+  const amount = Math.trunc(parsed);
+  return negativeByParens ? -Math.abs(amount) : amount;
+}
+
+function rowAmount(row, header) {
+  const cells = Array.isArray(row?.cells) ? row.cells : [];
+  return parseAmount(cells[COLUMN_INDEX[header]]);
+}
+
+function isBankImportedExpenseRow(row) {
+  return String(row?.sourceTxId || '').startsWith('bank:') && row?.entryKind === 'EXPENSE';
+}
+
+function resolveActualLineAmounts(row) {
+  const cells = Array.isArray(row?.cells) ? row.cells : [];
+  const lineId = parseCashflowLineLabel(cells[COLUMN_INDEX['cashflow항목']]);
+  if (!lineId) return {};
+
+  const bankAmount = rowAmount(row, '통장에 찍힌 입/출금액');
+  const expenseAmount = rowAmount(row, '사업비 사용액');
+  const vatIn = rowAmount(row, '매입부가세');
+  const depositAmount = rowAmount(row, '입금액(사업비,공급가액,은행이자)');
+  const refundAmount = rowAmount(row, '매입부가세 반환');
+  const isInflowLine = CASHFLOW_IN_LINE_IDS.has(lineId);
+  const manualOutflowPending = isBankImportedExpenseRow(row) && (
+    !lineId
+    || (
+      lineId === 'INPUT_VAT_OUT'
+        ? vatIn <= 0
+        : !isInflowLine && expenseAmount <= 0
+    )
+  );
+
+  if (manualOutflowPending) return {};
+
+  if (isInflowLine) {
+    const outflowAdjustmentAmount = expenseAmount < 0
+      ? expenseAmount
+      : row?.entryKind === 'EXPENSE' && depositAmount <= 0 && refundAmount <= 0 && bankAmount > 0
+        ? -bankAmount
+        : 0;
+    const inflowAmount = depositAmount > 0 ? depositAmount : refundAmount > 0 ? refundAmount : bankAmount;
+    if (outflowAdjustmentAmount < 0) return { [lineId]: outflowAdjustmentAmount };
+    return inflowAmount > 0 ? { [lineId]: inflowAmount } : {};
+  }
+
+  if (lineId === 'INPUT_VAT_OUT') {
+    return vatIn > 0 ? { INPUT_VAT_OUT: vatIn } : {};
+  }
+
+  const amounts = {};
+  const primaryOutAmount = expenseAmount > 0
+    ? expenseAmount
+    : depositAmount > 0 || refundAmount > 0
+      ? 0
+      : bankAmount;
+  if (primaryOutAmount > 0) amounts[lineId] = primaryOutAmount;
+  if (vatIn > 0) amounts.INPUT_VAT_OUT = (amounts.INPUT_VAT_OUT || 0) + vatIn;
+  return amounts;
+}
+
+function normalizeAmounts(amounts) {
+  const normalized = {};
+  for (const lineId of CASHFLOW_ALL_LINES) {
+    if (Object.prototype.hasOwnProperty.call(amounts || {}, lineId)) {
+      normalized[lineId] = parseAmount(amounts[lineId]);
+    }
+  }
+  return normalized;
+}
+
+function clearedAmounts() {
+  return Object.fromEntries(CASHFLOW_ALL_LINES.map((lineId) => [lineId, 0]));
+}
+
+function weekKey(week) {
+  return `${week.yearMonth}:w${week.weekNo}`;
+}
+
+function parseWeekKey(key) {
+  const match = /^(\d{4}-\d{2}):w(\d+)$/.exec(String(key || ''));
+  if (!match) return undefined;
+  const weekNo = Number.parseInt(match[2], 10);
+  return getMonthCashflowWeeks(match[1]).find((week) => week.weekNo === weekNo);
+}
+
+export function buildCashflowActualSyncPlan({ rows, previousWeekKeys = [], anchorYear }) {
+  const fallbackYear = Number.isFinite(anchorYear) ? anchorYear : new Date().getFullYear();
+  const anchorWeeks = getYearCashflowWeeks(fallbackYear);
+  const weekLabels = new Set();
+  const byWeek = new Map();
+
+  for (const row of rows || []) {
+    const week = resolveWeekFromRow(row, anchorWeeks);
+    if (!week) continue;
+    const key = weekKey(week);
+    weekLabels.add(key);
+    const target = byWeek.get(key) || {};
+    for (const [lineId, amount] of Object.entries(resolveActualLineAmounts(row))) {
+      if (!amount) continue;
+      target[lineId] = (target[lineId] || 0) + amount;
+    }
+    byWeek.set(key, target);
+  }
+
+  const payload = Array.from(weekLabels)
+    .map((key) => {
+      const week = parseWeekKey(key);
+      return week ? { ...week, key, amounts: { ...clearedAmounts(), ...(byWeek.get(key) || {}) } } : null;
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.yearMonth.localeCompare(b.yearMonth) || a.weekNo - b.weekNo);
+
+  const currentKeys = new Set(payload.map((week) => week.key));
+  const clearedWeeks = Array.from(new Set(previousWeekKeys || []))
+    .filter((key) => !currentKeys.has(key))
+    .map((key) => parseWeekKey(key))
+    .filter(Boolean)
+    .map((week) => ({ ...week, key: weekKey(week), amounts: clearedAmounts() }));
+
+  return {
+    weeks: payload,
+    clearedWeeks,
+    weekKeys: payload.map((week) => week.key),
+  };
+}
+
+function resolveWeekDocId(projectId, yearMonth, weekNo) {
+  return `${projectId}-${yearMonth}-w${weekNo}`;
+}
+
+async function commitInChunks(db, mutations) {
+  for (let offset = 0; offset < mutations.length; offset += 450) {
+    const batch = db.batch();
+    for (const mutation of mutations.slice(offset, offset + 450)) {
+      mutation(batch);
+    }
+    await batch.commit();
+  }
+}
+
+function buildWeekPatch({ tenantId, actorId, actorName, projectId, mode, week, amounts, now }) {
+  const patch = {
+    id: resolveWeekDocId(projectId, week.yearMonth, week.weekNo),
+    tenantId,
+    projectId,
+    yearMonth: week.yearMonth,
+    weekNo: week.weekNo,
+    weekStart: week.weekStart,
+    weekEnd: week.weekEnd,
+    [`${mode}Source`]: mode === 'actual' ? 'expense_sheets_bff' : 'cashflow_input_bff',
+    [`${mode}SyncedAt`]: now,
+    updatedAt: now,
+    updatedByUid: actorId,
+    updatedByName: actorName,
+  };
+  patch[mode] = normalizeAmounts(amounts);
+  return patch;
+}
+
+function buildStatusPatch({ tenantId, actorId, actorName, projectId, week, mode, now, syncState }) {
+  const id = resolveWeekDocId(projectId, week.yearMonth, week.weekNo);
+  return {
+    id,
+    tenantId,
+    projectId,
+    yearMonth: week.yearMonth,
+    weekNo: week.weekNo,
+    ...(mode === 'projection'
+      ? {
+        projectionEdited: true,
+        projectionUpdated: true,
+        projectionUpdatedAt: now,
+        projectionUpdatedByName: actorName,
+      }
+      : {
+        expenseUpdated: true,
+        expenseSyncState: syncState || 'synced',
+        expenseReviewPendingCount: 0,
+        expenseUpdatedAt: now,
+        expenseUpdatedByName: actorName,
+      }),
+    updatedAt: now,
+    updatedByUid: actorId,
+    updatedByName: actorName,
+  };
+}
+
+export async function upsertCashflowWeekAmounts({ db, tenantId, actorId, actorName, projectId, mode, yearMonth, weekNo, amounts, now }) {
+  const parsed = parseYearMonth(yearMonth);
+  if (!parsed) {
+    const error = new Error('Invalid yearMonth');
+    error.statusCode = 400;
+    throw error;
+  }
+  const targetWeek = getMonthCashflowWeeks(parsed.yearMonth).find((week) => week.weekNo === weekNo);
+  if (!targetWeek) {
+    const error = new Error('Invalid cashflow week');
+    error.statusCode = 400;
+    throw error;
+  }
+
+  const weekRef = db.doc(`orgs/${tenantId}/cashflow_weeks/${resolveWeekDocId(projectId, targetWeek.yearMonth, targetWeek.weekNo)}`);
+  const statusRef = db.doc(`orgs/${tenantId}/weekly_submission_status/${resolveWeekDocId(projectId, targetWeek.yearMonth, targetWeek.weekNo)}`);
+  const patch = buildWeekPatch({ tenantId, actorId, actorName, projectId, mode, week: targetWeek, amounts, now });
+  const statusPatch = buildStatusPatch({ tenantId, actorId, actorName, projectId, week: targetWeek, mode, now });
+
+  await db.runTransaction(async (tx) => {
+    const snap = await tx.get(weekRef);
+    tx.set(weekRef, {
+      ...(snap.exists ? {} : { createdAt: now, pmSubmitted: false, adminClosed: false }),
+      ...patch,
+    }, { merge: true });
+    tx.set(statusRef, statusPatch, { merge: true });
+  });
+
+  return {
+    projectId,
+    yearMonth: targetWeek.yearMonth,
+    weekNo: targetWeek.weekNo,
+    weekStart: targetWeek.weekStart,
+    weekEnd: targetWeek.weekEnd,
+    mode,
+    updatedAt: now,
+  };
+}
+
+export async function syncProjectCashflowActualsFromExpenseSheets({ db, tenantId, actorId, actorName, projectId, now }) {
+  const sheetsSnap = await db.collection(`orgs/${tenantId}/projects/${projectId}/expense_sheets`).get();
+  const sheets = sheetsSnap.docs
+    .map((doc) => ({ id: doc.id, ...doc.data() }))
+    .filter((sheet) => !sheet.deletedAt && !sheet.trashedAt);
+  const rows = sheets.flatMap((sheet) => Array.isArray(sheet.rows) ? sheet.rows : []);
+  const stateRef = db.doc(`orgs/${tenantId}/cashflow_actual_sync_state/${projectId}`);
+  const stateSnap = await stateRef.get().catch(() => null);
+  const stateWeekKeys = Array.isArray(stateSnap?.data()?.weekKeys) ? stateSnap.data().weekKeys : [];
+  const existingWeeksSnap = await db.collection(`orgs/${tenantId}/cashflow_weeks`)
+    .where('projectId', '==', projectId)
+    .get();
+  const existingActualWeekKeys = existingWeeksSnap.docs
+    .map((doc) => doc.data() || {})
+    .filter((week) => {
+      const actual = week.actual && typeof week.actual === 'object' ? week.actual : {};
+      return Object.values(actual).some((amount) => Number(amount) !== 0);
+    })
+    .map((week) => `${week.yearMonth}:w${week.weekNo}`)
+    .filter((key) => /^\d{4}-\d{2}:w\d+$/.test(key));
+  const previousWeekKeys = Array.from(new Set([...stateWeekKeys, ...existingActualWeekKeys]));
+  const plan = buildCashflowActualSyncPlan({
+    rows,
+    previousWeekKeys,
+    anchorYear: new Date(now).getUTCFullYear(),
+  });
+  const writeWeeks = [...plan.weeks, ...plan.clearedWeeks];
+
+  const mutations = [];
+  for (const week of writeWeeks) {
+    const weekRef = db.doc(`orgs/${tenantId}/cashflow_weeks/${resolveWeekDocId(projectId, week.yearMonth, week.weekNo)}`);
+    const statusRef = db.doc(`orgs/${tenantId}/weekly_submission_status/${resolveWeekDocId(projectId, week.yearMonth, week.weekNo)}`);
+    const patch = buildWeekPatch({
+      tenantId,
+      actorId,
+      actorName,
+      projectId,
+      mode: 'actual',
+      week,
+      amounts: week.amounts,
+      now,
+    });
+    const statusPatch = buildStatusPatch({
+      tenantId,
+      actorId,
+      actorName,
+      projectId,
+      week,
+      mode: 'actual',
+      now,
+      syncState: plan.clearedWeeks.some((cleared) => cleared.key === week.key) ? 'synced' : 'synced',
+    });
+    mutations.push((batch) => {
+      batch.set(weekRef, {
+        ...patch,
+      }, { merge: true });
+      batch.set(statusRef, statusPatch, { merge: true });
+    });
+  }
+  mutations.push((batch) => {
+    batch.set(stateRef, {
+      id: projectId,
+      tenantId,
+      projectId,
+      source: 'expense_sheets_bff',
+      weekKeys: plan.weekKeys,
+      rowCount: rows.length,
+      sheetCount: sheets.length,
+      updatedAt: now,
+      updatedByUid: actorId,
+      updatedByName: actorName,
+    }, { merge: true });
+  });
+
+  await commitInChunks(db, mutations);
+
+  return {
+    ok: true,
+    projectId,
+    sourceRows: rows.length,
+    sheetCount: sheets.length,
+    upsertedWeeks: plan.weeks.length,
+    clearedWeeks: plan.clearedWeeks.length,
+    weeks: plan.weeks.map((week) => ({ yearMonth: week.yearMonth, weekNo: week.weekNo })),
+    cleared: plan.clearedWeeks.map((week) => ({ yearMonth: week.yearMonth, weekNo: week.weekNo })),
+    updatedAt: now,
+  };
+}

--- a/server/bff/cashflow-canonical-store.test.mjs
+++ b/server/bff/cashflow-canonical-store.test.mjs
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCashflowActualSyncPlan,
+  getMonthCashflowWeeks,
+  parseCashflowLineLabel,
+} from './cashflow-canonical-store.mjs';
+
+function row(cells, extra = {}) {
+  return {
+    tempId: extra.tempId || `row-${Math.random()}`,
+    cells: [
+      '', '', '', '', '', '', '', '', '', '', '', '', '', '', '',
+      ...[],
+    ].map((value, index) => cells[index] ?? value),
+    ...extra,
+  };
+}
+
+describe('cashflow canonical BFF helpers', () => {
+  it('uses the same Wednesday-based week buckets as the app cashflow sheet', () => {
+    expect(getMonthCashflowWeeks('2027-01').map((week) => week.label)).toEqual([
+      '27-1-1',
+      '27-1-2',
+      '27-1-3',
+      '27-1-4',
+      '27-1-5',
+    ]);
+    expect(getMonthCashflowWeeks('2027-01')[0]).toMatchObject({
+      yearMonth: '2027-01',
+      weekNo: 1,
+      weekStart: '2026-12-30',
+      weekEnd: '2027-01-05',
+    });
+  });
+
+  it('parses cashflow labels and aliases without relying on frontend code', () => {
+    expect(parseCashflowLineLabel('직접사업비(공급가액)')).toBe('DIRECT_COST_OUT');
+    expect(parseCashflowLineLabel('MYSC인건비')).toBe('MYSC_LABOR_OUT');
+  });
+
+  it('aggregates actuals from persisted expense rows and clears stale managed weeks', () => {
+    const plan = buildCashflowActualSyncPlan({
+      anchorYear: 2026,
+      previousWeekKeys: ['2026-05:w1', '2026-05:w2'],
+      rows: [
+        row({
+          2: '2026-05-01',
+          8: 'MYSC 인건비',
+          10: '48,064,130',
+          13: '48,064,130',
+        }, { tempId: 'labor' }),
+        row({
+          3: '26-5-1',
+          8: '직접사업비',
+          10: '3,637,422',
+          13: '3,620,183',
+          14: '17,239',
+        }, { tempId: 'direct' }),
+      ],
+    });
+
+    expect(plan.weeks).toHaveLength(1);
+    expect(plan.weeks[0].yearMonth).toBe('2026-05');
+    expect(plan.weeks[0].amounts.MYSC_LABOR_OUT).toBe(48064130);
+    expect(plan.weeks[0].amounts.DIRECT_COST_OUT).toBe(3620183);
+    expect(plan.weeks[0].amounts.INPUT_VAT_OUT).toBe(17239);
+    expect(plan.clearedWeeks).toHaveLength(1);
+    expect(plan.clearedWeeks[0]).toMatchObject({ yearMonth: '2026-05', weekNo: 2 });
+    expect(plan.clearedWeeks[0].amounts.MYSC_LABOR_OUT).toBe(0);
+  });
+
+  it('treats bank-imported expense rows on inflow lines as negative adjustments', () => {
+    const plan = buildCashflowActualSyncPlan({
+      anchorYear: 2026,
+      rows: [
+        row({
+          3: '26-5-1',
+          8: 'MYSC 선입금(잔금 등 입금 필요 시)',
+          10: '8,615,904',
+        }, { tempId: 'prepay-out', sourceTxId: 'bank:abc', entryKind: 'EXPENSE' }),
+      ],
+    });
+
+    expect(plan.weeks[0].amounts.MYSC_PREPAY_IN).toBe(-8615904);
+  });
+});

--- a/server/bff/routes/cashflow-exports.mjs
+++ b/server/bff/routes/cashflow-exports.mjs
@@ -1,6 +1,18 @@
-import { asyncHandler, assertActorPermissionAllowed, createHttpError, readOptionalText } from '../bff-utils.mjs';
-import { parseWithSchema, cashflowExportSchema } from '../schemas.mjs';
+import {
+  asyncHandler,
+  assertActorPermissionAllowed,
+  assertActorRoleAllowed,
+  createHttpError,
+  createMutatingRoute,
+  readOptionalText,
+  ROUTE_ROLES,
+} from '../bff-utils.mjs';
+import { parseWithSchema, cashflowActualSyncSchema, cashflowExportSchema, cashflowWeekAmountsSchema } from '../schemas.mjs';
 import { buildCashflowExportFileName, buildCashflowExportWorkbookBuffer, expandCashflowYearMonthRange } from '../cashflow-export.mjs';
+import {
+  syncProjectCashflowActualsFromExpenseSheets,
+  upsertCashflowWeekAmounts,
+} from '../cashflow-canonical-store.mjs';
 
 function encodeContentDisposition(fileName) {
   const fallback = 'cashflow-export.xlsx';
@@ -18,7 +30,53 @@ function nextYearMonth(yearMonth) {
   return `${String(nextYear).padStart(4, '0')}-${String(nextMonth).padStart(2, '0')}`;
 }
 
-export function mountCashflowExportRoutes(app, { db, rbacPolicy }) {
+export function mountCashflowExportRoutes(app, { db, rbacPolicy, idempotencyService, now }) {
+  app.post('/api/v1/projects/:projectId/cashflow-weeks/upsert', createMutatingRoute(idempotencyService, async (req) => {
+    const { tenantId, actorId, actorEmail } = req.context;
+    assertActorRoleAllowed(req, ROUTE_ROLES.writeCore, 'write cashflow week amounts');
+    const projectId = readOptionalText(req.params.projectId);
+    const projectSnap = await db.doc(`orgs/${tenantId}/projects/${projectId}`).get();
+    if (!projectSnap.exists) {
+      throw createHttpError(404, '프로젝트를 찾을 수 없습니다.', 'not_found');
+    }
+
+    const payload = parseWithSchema(cashflowWeekAmountsSchema, req.body, 'Invalid cashflow week request');
+    const result = await upsertCashflowWeekAmounts({
+      db,
+      tenantId,
+      actorId,
+      actorName: actorEmail || actorId,
+      projectId,
+      mode: payload.mode,
+      yearMonth: payload.yearMonth,
+      weekNo: payload.weekNo,
+      amounts: payload.amounts,
+      now: now(),
+    });
+    return { status: 200, body: { ok: true, ...result } };
+  }));
+
+  app.post('/api/v1/projects/:projectId/cashflow-actuals/sync', createMutatingRoute(idempotencyService, async (req) => {
+    const { tenantId, actorId, actorEmail } = req.context;
+    assertActorRoleAllowed(req, ROUTE_ROLES.writeCore, 'sync cashflow actuals');
+    parseWithSchema(cashflowActualSyncSchema, req.body || {}, 'Invalid cashflow actual sync request');
+    const projectId = readOptionalText(req.params.projectId);
+    const projectSnap = await db.doc(`orgs/${tenantId}/projects/${projectId}`).get();
+    if (!projectSnap.exists) {
+      throw createHttpError(404, '프로젝트를 찾을 수 없습니다.', 'not_found');
+    }
+
+    const result = await syncProjectCashflowActualsFromExpenseSheets({
+      db,
+      tenantId,
+      actorId,
+      actorName: actorEmail || actorId,
+      projectId,
+      now: now(),
+    });
+    return { status: 200, body: result };
+  }));
+
   app.post('/api/v1/cashflow-exports', asyncHandler(async (req, res) => {
     const { tenantId } = req.context;
     assertActorPermissionAllowed(rbacPolicy, req, 'cashflow:export', 'export cashflow workbooks');

--- a/server/bff/schemas.mjs
+++ b/server/bff/schemas.mjs
@@ -278,6 +278,17 @@ export const cashflowExportSchema = z.object({
   }
 });
 
+export const cashflowWeekAmountsSchema = z.object({
+  yearMonth: z.string().trim().regex(/^\d{4}-\d{2}$/),
+  weekNo: z.number().int().min(1).max(6),
+  mode: z.enum(['projection', 'actual']),
+  amounts: z.record(z.string().trim().min(1), z.number().finite()),
+}).strict();
+
+export const cashflowActualSyncSchema = z.object({
+  reason: z.string().trim().max(300).optional(),
+}).strict();
+
 export const genericWriteSchema = z.object({
   entityType: NON_EMPTY_STRING,
   entityId: NON_EMPTY_STRING.optional(),

--- a/src/app/components/cashflow/SettlementLedgerPage.tsx
+++ b/src/app/components/cashflow/SettlementLedgerPage.tsx
@@ -156,6 +156,7 @@ export interface SettlementLedgerProps {
     yearWeeks: MonthMondayWeek[],
     persistedRows?: ImportRow[] | null,
   ) => Promise<SettlementActualSyncWeekPayload[]>;
+  onSyncCashflowActuals?: () => Promise<Array<{ yearMonth: string; weekNo: number }>>;
   onDirtyStateChange?: (dirty: boolean) => void;
   onSavingStateChange?: (saving: boolean) => void;
   weeklySubmissionStatuses?: WeeklySubmissionStatus[];
@@ -205,6 +206,7 @@ export function SettlementLedgerPage({
   onPendingQuickInsertHandled,
   onDeriveRows,
   onPreviewActualSyncPayload,
+  onSyncCashflowActuals,
   onDirtyStateChange,
   onSavingStateChange,
   weeklySubmissionStatuses = [],
@@ -689,6 +691,35 @@ export function SettlementLedgerPage({
     setCashflowSyncing(true);
     setCashflowSyncState('syncing');
     try {
+      if (onSyncCashflowActuals) {
+        try {
+          const syncedWeeks = await onSyncCashflowActuals();
+          if (syncedWeeks.length > 0) {
+            await updateWeeklyStatusesForPayload(syncedWeeks, {
+              expenseUpdated: true,
+              expenseSyncState: 'synced',
+            });
+          }
+          setCashflowSyncState('synced');
+          setLastCashflowSyncedAt(new Date().toISOString());
+          if (!silent) {
+            toast.success('캐시플로 실제값까지 동기화했습니다.');
+          }
+          return 'synced' as const;
+        } catch (err) {
+          console.error('[SettlementLedger] BFF cashflow actual sync failed:', err);
+          if (syncableWeeks.length > 0) {
+            await updateWeeklyStatusesForPayload(syncableWeeks, {
+              expenseUpdated: true,
+              expenseSyncState: 'sync_failed',
+            });
+          }
+          setCashflowSyncState('sync_failed');
+          if (!silent) toast.message('정산대장은 저장되었지만 캐시플로 업데이트에 실패했습니다.');
+          return 'sync_failed' as const;
+        }
+      }
+
       let syncFailed = false;
       await Promise.all(
         syncableWeeks.map(async (week) => {
@@ -717,8 +748,8 @@ export function SettlementLedgerPage({
       }
       if (syncableWeeks.length > 0) {
         await updateWeeklyStatusesForPayload(syncableWeeks, {
-          expenseUpdated: true,
-          expenseSyncState: 'synced',
+            expenseUpdated: true,
+            expenseSyncState: 'synced',
         });
       }
       setCashflowSyncState('synced');
@@ -730,7 +761,15 @@ export function SettlementLedgerPage({
     } finally {
       setCashflowSyncing(false);
     }
-  }, [onPreviewActualSyncPayload, projectId, sheetRows, updateWeeklyStatusesForPayload, upsertWeekAmounts, yearWeeks]);
+  }, [
+    onPreviewActualSyncPayload,
+    onSyncCashflowActuals,
+    projectId,
+    sheetRows,
+    updateWeeklyStatusesForPayload,
+    upsertWeekAmounts,
+    yearWeeks,
+  ]);
 
   const handleImportSave = useCallback(async (options?: { silent?: boolean; syncCashflow?: boolean }) => {
     if (!importRows) return;

--- a/src/app/components/portal/PortalWeeklyExpensePage.tsx
+++ b/src/app/components/portal/PortalWeeklyExpensePage.tsx
@@ -37,6 +37,7 @@ import {
   uploadTransactionEvidenceDriveViaBff,
   fetchBudgetSuggestionViaBff,
   isPlatformApiEnabled,
+  syncProjectCashflowActualsViaBff,
 } from '../../lib/platform-bff-client';
 import { PlatformApiError } from '../../platform/api-client';
 import {
@@ -85,6 +86,7 @@ export function PortalWeeklyExpensePage() {
   const { user: authUser, ensureGoogleWorkspaceAccess } = useAuth();
   const { orgId } = useFirebase();
   const {
+    isLoading: portalStoreLoading,
     activeProjectId,
     portalUser,
     myProject,
@@ -308,30 +310,69 @@ export function PortalWeeklyExpensePage() {
     return buildSettlementActualSyncPayloadLocally(rows, getYearMondayWeeks(currentYear), rows);
   }, [activeExpenseSheetId, expenseSheetRows, visibleExpenseSheets]);
 
+  const projectExpenseSourceSignature = useMemo(() => {
+    const rows = buildProjectExpenseRowsForActualSync({
+      sheets: visibleExpenseSheets,
+      activeSheetId: activeExpenseSheetId,
+      activeRows: expenseSheetRows ?? [],
+    });
+    return JSON.stringify({
+      projectId,
+      sheets: visibleExpenseSheets.map((sheet) => ({
+        id: sheet.id,
+        name: sheet.name,
+        rowCount: Array.isArray(sheet.rows) ? sheet.rows.length : 0,
+      })),
+      rows: rows.map((row) => ({
+        tempId: row.tempId,
+        sourceTxId: row.sourceTxId,
+        entryKind: row.entryKind,
+        cells: row.cells,
+      })),
+    });
+  }, [activeExpenseSheetId, expenseSheetRows, projectId, visibleExpenseSheets]);
+
+  const syncCashflowActualsFromCanonicalSource = useCallback(async () => {
+    if (!projectId) return [];
+    if (isPlatformApiEnabled()) {
+      const result = await syncProjectCashflowActualsViaBff({
+        tenantId: orgId,
+        actor: bffActor,
+        projectId,
+      });
+      return [...result.weeks, ...result.cleared];
+    }
+
+    await Promise.all(projectActualSyncPayload.map((week) => upsertWeekAmounts({
+      projectId,
+      yearMonth: week.yearMonth,
+      weekNo: week.weekNo,
+      mode: 'actual',
+      amounts: week.amounts as any,
+    })));
+    if (projectActualSyncPayload.length > 0) {
+      await Promise.all(projectActualSyncPayload.map((week) => upsertWeeklySubmissionStatus({
+        projectId,
+        yearMonth: week.yearMonth,
+        weekNo: week.weekNo,
+        expenseUpdated: true,
+        expenseSyncState: 'synced',
+        expenseReviewPendingCount: 0,
+      })));
+    }
+    return projectActualSyncPayload.map((week) => ({ yearMonth: week.yearMonth, weekNo: week.weekNo }));
+  }, [bffActor, orgId, projectActualSyncPayload, projectId, upsertWeekAmounts, upsertWeeklySubmissionStatus]);
+
   useEffect(() => {
-    if (!projectId || projectActualSyncPayload.length === 0) return;
-    const signature = JSON.stringify(projectActualSyncPayload);
+    if (!projectId || portalStoreLoading || hasUnsavedSettlementChanges || isSettlementSaving) return;
+    const signature = projectExpenseSourceSignature;
     if (actualSyncSignatureRef.current === signature) return;
     actualSyncSignatureRef.current = signature;
     let cancelled = false;
     void (async () => {
       try {
-        await Promise.all(projectActualSyncPayload.map((week) => upsertWeekAmounts({
-          projectId,
-          yearMonth: week.yearMonth,
-          weekNo: week.weekNo,
-          mode: 'actual',
-          amounts: week.amounts as any,
-        })));
+        await syncCashflowActualsFromCanonicalSource();
         if (cancelled) return;
-        await Promise.all(projectActualSyncPayload.map((week) => upsertWeeklySubmissionStatus({
-          projectId,
-          yearMonth: week.yearMonth,
-          weekNo: week.weekNo,
-          expenseUpdated: true,
-          expenseSyncState: 'synced',
-          expenseReviewPendingCount: 0,
-        })));
       } catch (error) {
         actualSyncSignatureRef.current = '';
         reportError(error, {
@@ -352,7 +393,14 @@ export function PortalWeeklyExpensePage() {
     return () => {
       cancelled = true;
     };
-  }, [projectActualSyncPayload, projectId, upsertWeekAmounts, upsertWeeklySubmissionStatus]);
+  }, [
+    hasUnsavedSettlementChanges,
+    isSettlementSaving,
+    portalStoreLoading,
+    projectExpenseSourceSignature,
+    projectId,
+    syncCashflowActualsFromCanonicalSource,
+  ]);
 
   const handleEvidenceDriveError = useCallback((error: unknown, actionLabel: string) => {
     reportError(error, {
@@ -1045,6 +1093,7 @@ export function PortalWeeklyExpensePage() {
           onPendingQuickInsertHandled={handlePendingQuickInsertHandled}
           onDeriveRows={deriveRowsWithLocalKernel}
           onPreviewActualSyncPayload={previewActualSyncWithLocalKernel}
+          onSyncCashflowActuals={syncCashflowActualsFromCanonicalSource}
           onDirtyStateChange={setHasUnsavedSettlementChanges}
           onSavingStateChange={setIsSettlementSaving}
           weeklySubmissionStatuses={weeklySubmissionStatuses}

--- a/src/app/data/cashflow-weeks-store.tsx
+++ b/src/app/data/cashflow-weeks-store.tsx
@@ -31,6 +31,7 @@ import {
 import { applyWeekAmountsToLocalWeeks } from './cashflow-weeks.local-state';
 import { useFirebase } from '../lib/firebase-context';
 import { getOrgCollectionPath, getOrgDocumentPath } from '../lib/firebase';
+import { isPlatformApiEnabled, upsertCashflowWeekAmountsViaBff } from '../lib/platform-bff-client';
 import { addMonthsToYearMonth, getSeoulTodayIso } from '../platform/business-days';
 import { getMonthMondayWeeks } from '../platform/cashflow-weeks';
 import { normalizeProjectIds } from './project-assignment';
@@ -205,6 +206,45 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
     const monthWeeks = getMonthMondayWeeks(ym);
     const def = monthWeeks.find((w) => w.weekNo === weekNo);
     if (!def) return;
+
+    if (isPlatformApiEnabled() && actor.source !== 'dev_harness') {
+      const normalizedAmounts = input.amounts || {};
+      await upsertCashflowWeekAmountsViaBff({
+        tenantId: orgId,
+        actor: {
+          uid: actor.uid,
+          email: actor.email,
+          role: actor.role,
+          idToken: (actor as any).idToken,
+          googleAccessToken: (actor as any).googleAccessToken,
+        },
+        projectId,
+        payload: {
+          yearMonth: ym,
+          weekNo,
+          mode: input.mode,
+          amounts: Object.fromEntries(
+            Object.entries(normalizedAmounts).map(([lineId, amount]) => [lineId, Number(amount) || 0]),
+          ),
+        },
+      });
+      const now = new Date().toISOString();
+      setWeeks((prev) => applyWeekAmountsToLocalWeeks({
+        weeks: prev,
+        orgId,
+        actorUid: actor.uid,
+        actorName: actor.name,
+        projectId,
+        yearMonth: ym,
+        weekNo,
+        weekStart: def.weekStart,
+        weekEnd: def.weekEnd,
+        mode: input.mode,
+        amounts: normalizedAmounts,
+        now,
+      }));
+      return;
+    }
 
     if (!db && actor.source === 'dev_harness') {
       const now = new Date().toISOString();

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -535,6 +535,36 @@ export interface OverrideTransactionEvidenceDriveCategoriesPayload {
   }>;
 }
 
+export interface CashflowWeekAmountsPayload {
+  yearMonth: string;
+  weekNo: number;
+  mode: 'projection' | 'actual';
+  amounts: Record<string, number>;
+}
+
+export interface CashflowWeekAmountsResult {
+  ok: boolean;
+  projectId: string;
+  yearMonth: string;
+  weekNo: number;
+  weekStart: string;
+  weekEnd: string;
+  mode: 'projection' | 'actual';
+  updatedAt: string;
+}
+
+export interface ProjectCashflowActualSyncResult {
+  ok: boolean;
+  projectId: string;
+  sourceRows: number;
+  sheetCount: number;
+  upsertedWeeks: number;
+  clearedWeeks: number;
+  weeks: Array<{ yearMonth: string; weekNo: number }>;
+  cleared: Array<{ yearMonth: string; weekNo: number }>;
+  updatedAt: string;
+}
+
 export interface PlatformApiClientLike {
   get<T>(path: string, options: {
     tenantId: string;
@@ -1280,6 +1310,47 @@ export async function overrideTransactionEvidenceDriveCategoriesViaBff(params: {
       body: params.overrides,
       retries: 0,
       timeoutMs: 15000,
+    },
+  );
+  return response.data;
+}
+
+export async function upsertCashflowWeekAmountsViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectId: string;
+  payload: CashflowWeekAmountsPayload;
+  client?: PlatformApiClientLike;
+}): Promise<CashflowWeekAmountsResult> {
+  const apiClient = resolveClient(params.client);
+  const response = await apiClient.post<CashflowWeekAmountsResult>(
+    `/api/v1/projects/${encodeURIComponent(params.projectId)}/cashflow-weeks/upsert`,
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      body: params.payload,
+      retries: 0,
+      timeoutMs: 12000,
+    },
+  );
+  return response.data;
+}
+
+export async function syncProjectCashflowActualsViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectId: string;
+  client?: PlatformApiClientLike;
+}): Promise<ProjectCashflowActualSyncResult> {
+  const apiClient = resolveClient(params.client);
+  const response = await apiClient.post<ProjectCashflowActualSyncResult>(
+    `/api/v1/projects/${encodeURIComponent(params.projectId)}/cashflow-actuals/sync`,
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      body: {},
+      retries: 0,
+      timeoutMs: 20000,
     },
   );
   return response.data;


### PR DESCRIPTION
## 한눈에 보기
- 캐시플로 Projection과 수동 입력 금액 저장을 브라우저 직접 저장이 아니라 서버 경유 저장으로 바꿨습니다.
- 서버가 저장된 사업비 입력 시트를 읽어 안정적인 Actual 값을 계산하고 저장하게 했습니다.
- 화면은 입력과 표시 역할에 집중하고, 공식 저장 기준은 서버가 맡도록 정리했습니다.

## 사용자가 체감하는 변화
- 같은 값을 여러 화면에서 볼 때 기준이 더 일관됩니다.
- 브라우저 상태에 따라 저장 결과가 달라지는 위험을 줄입니다.

## 확인한 것
- npx vitest run server/bff/cashflow-canonical-store.test.mjs server/bff/cashflow-export.test.mjs server/bff/app.test.ts src/app/components/cashflow/SettlementLedgerPage.shell.test.ts src/app/components/portal/PortalWeeklyExpensePage.flow-layout.test.ts
- npm run build