### PR TITLE
캐시플로 동기화가 기존 Actual 값을 0으로 지우지 않도록 방지

### DIFF
--- a/server/bff/cashflow-canonical-store.mjs
+++ b/server/bff/cashflow-canonical-store.mjs
@@ -445,19 +445,22 @@ export async function syncProjectCashflowActualsFromExpenseSheets({ db, tenantId
   const rows = sheets.flatMap((sheet) => Array.isArray(sheet.rows) ? sheet.rows : []);
   const stateRef = db.doc(`orgs/${tenantId}/cashflow_actual_sync_state/${projectId}`);
   const stateSnap = await stateRef.get().catch(() => null);
-  const stateWeekKeys = Array.isArray(stateSnap?.data()?.weekKeys) ? stateSnap.data().weekKeys : [];
-  const existingWeeksSnap = await db.collection(`orgs/${tenantId}/cashflow_weeks`)
-    .where('projectId', '==', projectId)
-    .get();
-  const existingActualWeekKeys = existingWeeksSnap.docs
-    .map((doc) => doc.data() || {})
-    .filter((week) => {
-      const actual = week.actual && typeof week.actual === 'object' ? week.actual : {};
-      return Object.values(actual).some((amount) => Number(amount) !== 0);
-    })
-    .map((week) => `${week.yearMonth}:w${week.weekNo}`)
-    .filter((key) => /^\d{4}-\d{2}:w\d+$/.test(key));
-  const previousWeekKeys = Array.from(new Set([...stateWeekKeys, ...existingActualWeekKeys]));
+  const previousWeekKeys = Array.isArray(stateSnap?.data()?.weekKeys) ? stateSnap.data().weekKeys : [];
+  if (rows.length === 0) {
+    return {
+      ok: true,
+      skipped: true,
+      reason: 'no_expense_sheet_rows',
+      projectId,
+      sourceRows: 0,
+      sheetCount: sheets.length,
+      upsertedWeeks: 0,
+      clearedWeeks: 0,
+      weeks: [],
+      cleared: [],
+      updatedAt: now,
+    };
+  }
   const plan = buildCashflowActualSyncPlan({
     rows,
     previousWeekKeys,

--- a/server/bff/cashflow-canonical-store.test.mjs
+++ b/server/bff/cashflow-canonical-store.test.mjs
@@ -3,6 +3,7 @@ import {
   buildCashflowActualSyncPlan,
   getMonthCashflowWeeks,
   parseCashflowLineLabel,
+  syncProjectCashflowActualsFromExpenseSheets,
 } from './cashflow-canonical-store.mjs';
 
 function row(cells, extra = {}) {
@@ -82,5 +83,48 @@ describe('cashflow canonical BFF helpers', () => {
     });
 
     expect(plan.weeks[0].amounts.MYSC_PREPAY_IN).toBe(-8615904);
+  });
+
+  it('does not clear existing actuals when a project has no persisted expense rows', async () => {
+    const writes = [];
+    const db = {
+      collection(path) {
+        if (path.endsWith('/expense_sheets')) {
+          return { async get() { return { docs: [{ id: 'default', data: () => ({ rows: [] }) }] }; } };
+        }
+        throw new Error(`unexpected collection path ${path}`);
+      },
+      doc(path) {
+        return {
+          path,
+          async get() {
+            return { exists: true, data: () => ({ weekKeys: ['2026-05:w1'] }) };
+          },
+        };
+      },
+      batch() {
+        return {
+          set(...args) { writes.push(args); },
+          async commit() {},
+        };
+      },
+    };
+
+    const result = await syncProjectCashflowActualsFromExpenseSheets({
+      db,
+      tenantId: 'mysc',
+      actorId: 'u1',
+      actorName: 'PM',
+      projectId: 'p1',
+      now: '2026-05-27T09:40:00.000Z',
+    });
+
+    expect(result).toMatchObject({
+      skipped: true,
+      reason: 'no_expense_sheet_rows',
+      upsertedWeeks: 0,
+      clearedWeeks: 0,
+    });
+    expect(writes).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## 한눈에 보기
- 서버 동기화가 기존 Actual 주차를 모두 오래된 값으로 오해하지 않도록 수정했습니다.
- 서버가 이전에 관리한 동기화 값만 정리 대상으로 삼게 했습니다.
- 저장된 사업비 입력 행이 비어 있으면 Actual 동기화 쓰기를 아예 건너뛰게 했습니다.

## 왜 필요한가
이전 수정에서는 동기화할 원본 행이 없는 달을 열었을 때, 이미 저장되어 있던 Actual 값까지 0으로 덮어쓸 수 있었습니다. 이 PR은 사용자가 입력해 둔 기존 Actual 값을 보호합니다.

## 확인한 것
- npx vitest run server/bff/cashflow-canonical-store.test.mjs server/bff/cashflow-export.test.mjs server/bff/app.test.ts src/app/components/cashflow/SettlementLedgerPage.shell.test.ts src/app/components/portal/PortalWeeklyExpensePage.flow-layout.test.ts
- npm run build