### PR TITLE
Actual 동기화 후 화면 값이 바로 유지되도록 수정

### DIFF
--- a/server/bff/cashflow-canonical-store.mjs
+++ b/server/bff/cashflow-canonical-store.mjs
@@ -523,8 +523,20 @@ export async function syncProjectCashflowActualsFromExpenseSheets({ db, tenantId
     sheetCount: sheets.length,
     upsertedWeeks: plan.weeks.length,
     clearedWeeks: plan.clearedWeeks.length,
-    weeks: plan.weeks.map((week) => ({ yearMonth: week.yearMonth, weekNo: week.weekNo })),
-    cleared: plan.clearedWeeks.map((week) => ({ yearMonth: week.yearMonth, weekNo: week.weekNo })),
+    weeks: plan.weeks.map((week) => ({
+      yearMonth: week.yearMonth,
+      weekNo: week.weekNo,
+      weekStart: week.weekStart,
+      weekEnd: week.weekEnd,
+      amounts: week.amounts,
+    })),
+    cleared: plan.clearedWeeks.map((week) => ({
+      yearMonth: week.yearMonth,
+      weekNo: week.weekNo,
+      weekStart: week.weekStart,
+      weekEnd: week.weekEnd,
+      amounts: week.amounts,
+    })),
     updatedAt: now,
   };
 }

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -6,11 +6,17 @@ const cashflowProjectSheetSource = readFileSync(
   resolve(import.meta.dirname, 'CashflowProjectSheet.tsx'),
   'utf8',
 );
+const cashflowWeeksStoreSource = readFileSync(
+  resolve(import.meta.dirname, '../../data/cashflow-weeks-store.tsx'),
+  'utf8',
+);
 
 describe('CashflowProjectSheet actual sync flow', () => {
   it('keeps actual sync separate from manual actual save', () => {
     expect(cashflowProjectSheetSource).toContain('Actual 동기화');
-    expect(cashflowProjectSheetSource).toContain('syncProjectCashflowActualsViaBff');
+    expect(cashflowProjectSheetSource).toContain('syncProjectActualsFromExpenseSheets');
+    expect(cashflowWeeksStoreSource).toContain('syncProjectCashflowActualsViaBff');
+    expect(cashflowWeeksStoreSource).toContain('applyWeekAmountsToLocalWeeks');
     expect(cashflowProjectSheetSource).toContain('Actual 저장');
     expect(cashflowProjectSheetSource).toContain("toast.message('저장할 변경사항이 없습니다.')");
   });

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -39,7 +39,7 @@ import { useFirebase } from '../../lib/firebase-context';
 import { getOrgDocumentPath } from '../../lib/firebase';
 import { loadExcelJs, warmExcelJs } from '../../platform/lazy-heavy-modules';
 import { buildCashflowExportWorkbookSpec } from '../../platform/cashflow-export';
-import { exportCashflowWorkbookViaBff, isPlatformApiEnabled, syncProjectCashflowActualsViaBff } from '../../lib/platform-bff-client';
+import { exportCashflowWorkbookViaBff, isPlatformApiEnabled } from '../../lib/platform-bff-client';
 
 function fmt(n: number): string {
   return n.toLocaleString('ko-KR');
@@ -101,6 +101,7 @@ export function CashflowProjectSheet({
     upsertWeekAmounts,
     submitWeekAsPm,
     closeWeekAsAdmin,
+    syncProjectActualsFromExpenseSheets,
   } = useCashflowWeeks();
 
   const monthWeeks = useMemo(() => getMonthMondayWeeks(yearMonth), [yearMonth]);
@@ -489,27 +490,27 @@ export function CashflowProjectSheet({
   }, [drafts, flushWeek, monthWeeks, yearMonth]);
 
   const syncActualsFromExpenseSheet = useCallback(() => {
-    if (!isPlatformApiEnabled() || !user) {
-      toast.error('Actual 동기화 API가 연결되어 있지 않습니다.');
-      return;
-    }
     void (async () => {
       setActualSyncing(true);
-      const result = await syncProjectCashflowActualsViaBff({
-        tenantId: orgId,
-        actor: {
-          uid: user.uid,
-          email: user.email,
-          role: user.role,
-          idToken: user.idToken,
-          googleAccessToken: user.googleAccessToken,
-        },
-        projectId,
-      });
+      const result = await syncProjectActualsFromExpenseSheets({ projectId });
       if (result.skipped) {
         toast.message('동기화할 정산대장 행이 없습니다.');
         return;
       }
+      setDrafts((prev) => {
+        const next = { ...prev };
+        for (const key of Object.keys(next)) {
+          if (key.startsWith(`${yearMonth}:actual:`)) delete next[key];
+        }
+        return next;
+      });
+      setWeekSaveState((prev) => {
+        const next = { ...prev };
+        for (const week of monthWeeks) {
+          delete next[resolveWeekKey({ yearMonth, mode: 'actual', weekNo: week.weekNo })];
+        }
+        return next;
+      });
       toast.success(`Actual ${result.upsertedWeeks}개 주차를 동기화했습니다.`);
     })().catch((error) => {
       console.error('[Cashflow] actual sync failed:', error);
@@ -517,7 +518,7 @@ export function CashflowProjectSheet({
     }).finally(() => {
       setActualSyncing(false);
     });
-  }, [orgId, projectId, user]);
+  }, [monthWeeks, projectId, resolveWeekKey, syncProjectActualsFromExpenseSheets, yearMonth]);
 
   const copyMonthValues = useCallback((sourceMode: 'projection' | 'actual', targetMode: 'projection' | 'actual') => {
     if (sourceMode === targetMode) return;

--- a/src/app/data/cashflow-weeks-store.tsx
+++ b/src/app/data/cashflow-weeks-store.tsx
@@ -31,7 +31,12 @@ import {
 import { applyWeekAmountsToLocalWeeks } from './cashflow-weeks.local-state';
 import { useFirebase } from '../lib/firebase-context';
 import { getOrgCollectionPath, getOrgDocumentPath } from '../lib/firebase';
-import { isPlatformApiEnabled, upsertCashflowWeekAmountsViaBff } from '../lib/platform-bff-client';
+import {
+  isPlatformApiEnabled,
+  syncProjectCashflowActualsViaBff,
+  upsertCashflowWeekAmountsViaBff,
+  type ProjectCashflowActualSyncResult,
+} from '../lib/platform-bff-client';
 import { addMonthsToYearMonth, getSeoulTodayIso } from '../platform/business-days';
 import { getMonthMondayWeeks } from '../platform/cashflow-weeks';
 import { normalizeProjectIds } from './project-assignment';
@@ -64,6 +69,7 @@ interface CashflowWeekActions {
   }) => Promise<void>;
   submitWeekAsPm: (input: { projectId: string; yearMonth: string; weekNo: number }) => Promise<void>;
   closeWeekAsAdmin: (input: { projectId: string; yearMonth: string; weekNo: number }) => Promise<void>;
+  syncProjectActualsFromExpenseSheets: (input: { projectId: string }) => Promise<ProjectCashflowActualSyncResult>;
   updateVarianceFlag: (input: {
     sheetId: string;
     varianceFlag: VarianceFlag | undefined;
@@ -347,6 +353,59 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
     });
   }, [upsertWeekAmounts]);
 
+  const syncProjectActualsFromExpenseSheets = useCallback(async (input: {
+    projectId: string;
+  }): Promise<ProjectCashflowActualSyncResult> => {
+    const actor = user;
+    const projectId = input.projectId.trim();
+    if (!actor || !projectId) throw new Error('Actual 동기화 권한 정보가 없습니다.');
+    if (!isPlatformApiEnabled() || actor.source === 'dev_harness') {
+      throw new Error('Actual 동기화 API가 연결되어 있지 않습니다.');
+    }
+
+    const result = await syncProjectCashflowActualsViaBff({
+      tenantId: orgId,
+      actor: {
+        uid: actor.uid,
+        email: actor.email,
+        role: actor.role,
+        idToken: (actor as any).idToken,
+        googleAccessToken: (actor as any).googleAccessToken,
+      },
+      projectId,
+    });
+
+    if (!result.skipped) {
+      setWeeks((prev) => [...result.weeks, ...result.cleared].reduce((nextWeeks, week) => {
+        const fallback = getMonthMondayWeeks(week.yearMonth).find((candidate) => candidate.weekNo === week.weekNo);
+        return applyWeekAmountsToLocalWeeks({
+          weeks: nextWeeks,
+          orgId,
+          actorUid: actor.uid,
+          actorName: actor.name,
+          projectId,
+          yearMonth: week.yearMonth,
+          weekNo: week.weekNo,
+          weekStart: week.weekStart || fallback?.weekStart || '',
+          weekEnd: week.weekEnd || fallback?.weekEnd || '',
+          mode: 'actual',
+          amounts: (week.amounts || {}) as Partial<Record<CashflowSheetLineId, number>>,
+          now: result.updatedAt,
+        });
+      }, prev));
+    }
+
+    console.groupCollapsed(`[CashflowActualSync] project=${projectId}`);
+    console.log('response', result);
+    console.table(result.weeks.map((week) => ({
+      week: `${week.yearMonth}:w${week.weekNo}`,
+      nonZero: Object.fromEntries(Object.entries(week.amounts || {}).filter(([, amount]) => Number(amount) !== 0)),
+    })));
+    console.groupEnd();
+
+    return result;
+  }, [orgId, user]);
+
   const submitWeekAsPm = useCallback(async (input: {
     projectId: string;
     yearMonth: string;
@@ -502,6 +561,7 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
     upsertLineAmount,
     submitWeekAsPm,
     closeWeekAsAdmin,
+    syncProjectActualsFromExpenseSheets,
     updateVarianceFlag,
     getWeeksForProject,
   }), [
@@ -515,6 +575,7 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
     upsertLineAmount,
     submitWeekAsPm,
     closeWeekAsAdmin,
+    syncProjectActualsFromExpenseSheets,
     updateVarianceFlag,
     getWeeksForProject,
   ]);

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -562,8 +562,20 @@ export interface ProjectCashflowActualSyncResult {
   sheetCount: number;
   upsertedWeeks: number;
   clearedWeeks: number;
-  weeks: Array<{ yearMonth: string; weekNo: number }>;
-  cleared: Array<{ yearMonth: string; weekNo: number }>;
+  weeks: Array<{
+    yearMonth: string;
+    weekNo: number;
+    weekStart?: string;
+    weekEnd?: string;
+    amounts?: Record<string, number>;
+  }>;
+  cleared: Array<{
+    yearMonth: string;
+    weekNo: number;
+    weekStart?: string;
+    weekEnd?: string;
+    amounts?: Record<string, number>;
+  }>;
   updatedAt: string;
 }
 


### PR DESCRIPTION
## 한눈에 보기
- 서버가 Actual 동기화 결과 금액을 다시 내려주도록 했습니다.
- 동기화 직후 화면의 캐시플로 값도 즉시 갱신되도록 저장 흐름을 정리했습니다.
- 오래된 Actual 임시 입력값이 화면에 남아 혼란을 주지 않도록 정리했습니다.
- 문제가 생겼을 때 확인할 수 있도록 개발자 도구 로그를 작게 추가했습니다.

## 사용자가 체감하는 변화
- 사업비 입력에서 Actual로 동기화한 값이 저장 후 바로 화면에 남습니다.
- 새로고침 전까지 값이 사라진 것처럼 보이는 문제가 줄어듭니다.

## 확인한 것
- npx vitest run src/app/components/cashflow/CashflowProjectSheet.shell.test.ts server/bff/cashflow-canonical-store.test.mjs
- npm run build