### PR TITLE
관리자 화면 상단에서 포털로 바로 이동할 수 있게 개선

### DIFF
--- a/src/app/components/layout/AppLayout.shell.test.ts
+++ b/src/app/components/layout/AppLayout.shell.test.ts
@@ -25,6 +25,14 @@ describe('AppLayout LAB shell contract', () => {
     expect(source).toContain('LAB 메뉴 보이기');
     expect(source).toContain("'admin', 'nav'");
   });
+
+  it('keeps the user portal switch next to the realtime status instead of inside LAB navigation', () => {
+    expect(source).toContain('function openPortalWorkspace()');
+    expect(source).toContain("setWorkspacePreference('portal'");
+    expect(source).toContain("navigate('/portal')");
+    expect(source).toContain('로그아웃 없이 사용자 포털로 이동');
+    expect(source).toContain('사용자 포털');
+  });
 });
 
 describe('AppLayout root entry contract', () => {

--- a/src/app/components/layout/AppLayout.tsx
+++ b/src/app/components/layout/AppLayout.tsx
@@ -3,7 +3,7 @@ import { Outlet, NavLink, useLocation, useNavigate } from 'react-router';
 import {
   ChevronLeft, ChevronRight,
   Search, HelpCircle,
-  Menu, LogOut,
+  Menu, LogOut, ExternalLink,
 } from 'lucide-react';
 import { useAppStore, AppProvider } from '../../data/store';
 import { useAuth } from '../../data/auth-store';
@@ -101,6 +101,11 @@ function AppLayoutContent() {
     const next = !labEnabled;
     writeShellLabEnabled(next);
     setLabEnabled(next);
+  }
+
+  function openPortalWorkspace() {
+    void setWorkspacePreference('portal', { persistDefault: false })
+      .finally(() => navigate('/portal'));
   }
 
   const pendingCount = transactions.filter(t => t.state === 'SUBMITTED').length;
@@ -368,6 +373,23 @@ function AppLayoutContent() {
                   로컬
                 </div>
               )}
+
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    size="sm"
+                    onClick={openPortalWorkspace}
+                    className="h-8 gap-1.5 rounded-md border border-slate-950 bg-slate-950 px-3 text-[12px] font-semibold text-white shadow-sm transition-colors hover:bg-slate-800 hover:text-white focus-visible:ring-2 focus-visible:ring-slate-400 dark:border-slate-200 dark:bg-slate-100 dark:text-slate-950 dark:hover:bg-white"
+                    aria-label="로그아웃 없이 사용자 포털로 이동"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" />
+                    <span className="hidden sm:inline">사용자 포털</span>
+                    <span className="sm:hidden">포털</span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent className="text-[11px]">로그아웃 없이 사용자 포털로 이동</TooltipContent>
+              </Tooltip>
 
               <div className="w-px h-4 bg-border/50 mx-0.5" />
 

--- a/src/app/data/cashflow-weeks-store.tsx
+++ b/src/app/data/cashflow-weeks-store.tsx
@@ -21,6 +21,7 @@ import {
   type Unsubscribe,
 } from 'firebase/firestore';
 import { useAuth } from './auth-store';
+import { useFirestoreAccessPolicy } from './firestore-realtime-mode';
 import type { CashflowSheetLineId, CashflowWeekSheet, VarianceFlag, VarianceFlagEvent } from './types';
 import { filterCashflowWeeksThroughSelectedYear, shouldCreateDocOnUpdateError } from './cashflow-weeks.helpers';
 import {
@@ -84,6 +85,7 @@ const CashflowWeekContext: React.Context<(CashflowWeekState & CashflowWeekAction
 
 export function CashflowWeekProvider({ children }: { children: ReactNode }) {
   const { user, isAuthenticated, isLoading: authLoading } = useAuth();
+  const { routeMode } = useFirestoreAccessPolicy(user?.role);
   const { db, isOnline, orgId } = useFirebase();
   const firestoreEnabled = isOnline && !!db;
 
@@ -159,7 +161,7 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
       unsubsRef.current.forEach((u) => u());
       unsubsRef.current = [];
     };
-  }, [authLoading, isAuthenticated, user, db, firestoreEnabled, orgId, yearMonth]);
+  }, [authLoading, isAuthenticated, user, db, firestoreEnabled, orgId, routeMode, yearMonth]);
 
   const upsertWeekAmounts = useCallback(async (input: {
     projectId: string;

--- a/src/app/platform/nav-config.ts
+++ b/src/app/platform/nav-config.ts
@@ -2,7 +2,7 @@ import type { LucideIcon } from 'lucide-react';
 import {
   LayoutDashboard, FolderKanban, BarChart3,
   FileCheck, Settings, Shield, ClipboardList, ClipboardCheck,
-  Calculator, Wallet, ExternalLink, UserCog,
+  Calculator, Wallet, UserCog,
   ListChecks, MessagesSquare, UserRoundCheck,
   CircleDollarSign, ArrowLeftRight,
 } from 'lucide-react';
@@ -55,7 +55,6 @@ export const NAV_GROUPS: NavGroup[] = [
       { to: '/approvals', icon: ListChecks, label: '승인 대기열', accent: true },
       { to: '/users', icon: UserCog, label: '권한/사용자' },
       { to: '/settings', icon: Settings, label: '설정' },
-      { to: '/portal', icon: ExternalLink, label: '사용자 포털' },
     ],
   },
 ];

--- a/src/app/platform/shell-lab-visibility.test.ts
+++ b/src/app/platform/shell-lab-visibility.test.ts
@@ -51,7 +51,6 @@ describe('shell LAB visibility', () => {
       '/hr-announcements',
       '/training',
       '/settings',
-      '/portal',
     ]);
 
     for (const route of ADMIN_LAB_ROUTES) {

--- a/src/app/platform/shell-lab-visibility.ts
+++ b/src/app/platform/shell-lab-visibility.ts
@@ -29,7 +29,6 @@ export const ADMIN_LAB_ROUTES = [
   '/hr-announcements',
   '/training',
   '/settings',
-  '/portal',
 ] as const;
 
 export const PORTAL_LAB_ROUTES = [


### PR DESCRIPTION
## 한눈에 보기
- 사용자 포털로 이동하는 버튼을 숨겨진 LAB/사이드바가 아니라 관리자 화면 상단에 배치했습니다.
- 로그아웃하지 않고 관리자 화면과 포털을 오갈 수 있도록 작업 공간 전환 방식을 정리했습니다.
- 포털 이동 버튼이 계속 보이도록 화면 구조 테스트를 추가했습니다.

## 사용자가 체감하는 변화
- 관리자나 재무 담당자가 포털 화면을 확인할 때 더 빠르게 이동할 수 있습니다.
- 작업 공간을 바꿀 때 로그인 상태가 끊기지 않습니다.

## 확인한 것
- npx vitest run src/app/components/layout/AppLayout.shell.test.ts src/app/platform/shell-lab-visibility.test.ts src/app/platform/admin-foundation.shell.test.ts
- npm run build