### PR TITLE
정산 코멘트와 검토 문구를 더 이해하기 쉽게 정리

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1255,7 +1255,7 @@ export function CashflowProjectSheet({
               {closeDialog?.kind === 'prerequisite'
                 ? '내 제출현황에서 Projection 업데이트와 사업비 입력을 체크해주세요.'
                 : closeDialog?.kind === 'warning'
-                  ? '사업비 입력은 저장되었지만 일부 주차는 사람 확인 또는 동기화 확인이 더 필요합니다. 그래도 결산은 진행할 수 있습니다.'
+                  ? '사업비 입력은 저장되었지만 일부 주차는 검토 루프 또는 동기화 확인이 더 필요합니다. 그래도 결산은 진행할 수 있습니다.'
                 : 'Projection 업데이트와 사업비 입력 체크가 완료된 주차입니다. 결산완료 후에도 Projection은 계속 수정할 수 있습니다.'}
             </AlertDialogDescription>
           </AlertDialogHeader>

--- a/src/app/components/cashflow/CellCommentButton.tsx
+++ b/src/app/components/cashflow/CellCommentButton.tsx
@@ -12,12 +12,12 @@ export function CellCommentButton({
   return (
     <button
       type="button"
-      title={disabled ? '저장 후 메모를 남길 수 있습니다' : '셀 메모 열기'}
-      aria-label="셀 메모 열기"
+      title={disabled ? '저장 후 주석을 남길 수 있습니다' : '셀 주석 열기'}
+      aria-label="셀 주석 열기"
       disabled={disabled}
       className={`absolute top-1 right-1 inline-flex h-5 w-5 items-center justify-center rounded-md border text-[10px] transition ${
         count > 0
-          ? 'border-amber-300 bg-amber-50 text-amber-700 opacity-100'
+          ? 'border-[#26415f]/30 bg-[#26415f]/5 text-[#26415f] opacity-100'
           : 'border-transparent bg-background/90 text-muted-foreground opacity-0 group-hover:opacity-100'
       } ${disabled ? 'cursor-not-allowed opacity-40' : 'hover:border-border hover:text-foreground'}`}
       onClick={(event) => {
@@ -27,7 +27,7 @@ export function CellCommentButton({
     >
       <MessageSquare className="h-3.5 w-3.5" />
       {count > 0 && (
-        <span className="absolute -top-1 -right-1 inline-flex min-w-4 items-center justify-center rounded-full bg-amber-500 px-1 text-[9px] font-bold leading-none text-white">
+        <span className="absolute -top-1 -right-1 inline-flex min-w-4 items-center justify-center rounded-full bg-[#26415f] px-1 text-[9px] font-bold leading-none text-white">
           {count}
         </span>
       )}

--- a/src/app/components/cashflow/ImportEditor.tsx
+++ b/src/app/components/cashflow/ImportEditor.tsx
@@ -250,6 +250,10 @@ export function ImportEditor({
     () => countConfirmedImportRowReviews(meaningfulRows),
     [meaningfulRows],
   );
+  const cellCommentCount = useMemo(
+    () => comments.filter((comment) => comment.transactionId && comment.fieldKey).length,
+    [comments],
+  );
   const noIdx = useMemo(
     () => SETTLEMENT_COLUMNS.findIndex((c) => c.csvHeader === 'No.'),
     [],
@@ -1578,13 +1582,18 @@ export function ImportEditor({
                 <Badge variant="secondary" className="text-[10px] text-red-600">{missingCount}건 미입력</Badge>
               )}
               {reviewRequiredRowCount > 0 && (
-                <Badge variant="outline" className="text-[10px] border-amber-200 bg-amber-50 text-amber-700">
-                  사람 확인 {reviewRequiredRowCount}건
+                <Badge variant="outline" className="border-[#26415f]/25 bg-[#26415f]/5 text-[10px] text-[#26415f]">
+                  검토 루프 {reviewRequiredRowCount}건
                 </Badge>
               )}
               {reviewConfirmedRowCount > 0 && (
-                <Badge variant="outline" className="text-[10px] border-emerald-200 bg-emerald-50 text-emerald-700">
+                <Badge variant="outline" className="border-slate-200 bg-slate-50 text-[10px] text-slate-700">
                   확인 완료 {reviewConfirmedRowCount}건
+                </Badge>
+              )}
+              {cellCommentCount > 0 && (
+                <Badge variant="outline" className="border-slate-200 bg-slate-50 text-[10px] text-slate-700">
+                  셀 주석 {cellCommentCount}건
                 </Badge>
               )}
             </div>
@@ -1789,9 +1798,9 @@ export function ImportEditor({
         <div className="rounded-lg border bg-slate-50/70 px-3 py-2 text-[10px] text-muted-foreground">
           <div className="flex flex-wrap items-center gap-2">
             <span className="inline-flex rounded-full bg-slate-100 px-2 py-0.5 text-slate-700">원본: 통장내역 또는 기존 저장값</span>
-            <span className="inline-flex rounded-full bg-teal-100 px-2 py-0.5 text-teal-700">수정: 사용자가 직접 덮어쓴 값</span>
+            <span className="inline-flex rounded-full bg-white px-2 py-0.5 text-slate-700 ring-1 ring-inset ring-slate-200">수정: 사용자가 직접 덮어쓴 값</span>
             <span className="inline-flex rounded-full bg-slate-200 px-2 py-0.5 text-slate-700">계산: 정책에 따라 자동 계산되고 잠긴 값</span>
-            <span className="inline-flex rounded-full bg-amber-100 px-2 py-0.5 text-amber-700">검토/확인: 수식 후보값 확인 필요</span>
+            <span className="inline-flex rounded-full bg-[#26415f]/10 px-2 py-0.5 text-[#26415f]">검토 루프: 후보값 또는 주석 확인 필요</span>
           </div>
         </div>
         {/* Scrollable table */}

--- a/src/app/components/cashflow/ImportEditorRow.tsx
+++ b/src/app/components/cashflow/ImportEditorRow.tsx
@@ -380,13 +380,13 @@ function ImportEditorRow({
       return { label: '검토 필요', className: 'border-rose-200 bg-rose-50 text-rose-700' };
     }
     if (isReviewPending) {
-      return { label: '사람 확인', className: 'border-amber-200 bg-amber-50 text-amber-700' };
+      return { label: '검토 루프', className: 'border-[#26415f]/25 bg-[#26415f]/5 text-[#26415f]' };
     }
     if (isReviewConfirmed) {
-      return { label: '확인 완료', className: 'border-emerald-200 bg-emerald-50 text-emerald-700' };
+      return { label: '확인 완료', className: 'border-slate-200 bg-slate-50 text-slate-700' };
     }
     if ((row.userEditedCells?.size || 0) > 0) {
-      return { label: '수정됨', className: 'border-teal-200 bg-teal-50 text-teal-700' };
+      return { label: '수정됨', className: 'border-slate-200 bg-white text-slate-700' };
     }
     if (hasMissingCell) {
       return { label: '미입력', className: 'border-orange-200 bg-orange-50 text-orange-700' };
@@ -429,8 +429,8 @@ function ImportEditorRow({
     }
     if (row.reviewRequiredCellIndexes?.includes(colIdx)) {
       return isReviewConfirmed
-        ? { label: '확인', className: 'bg-emerald-100 text-emerald-700' }
-        : { label: '검토', className: 'bg-amber-100 text-amber-700' };
+        ? { label: '확인', className: 'bg-slate-100 text-slate-700' }
+        : { label: '검토', className: 'bg-[#26415f]/10 text-[#26415f]' };
     }
     const cellValue = String(row.cells[colIdx] || '').trim();
     if (
@@ -582,7 +582,7 @@ function ImportEditorRow({
                     }}
                   >
                     <Check className="h-3.5 w-3.5" />
-                    {isReviewConfirmed ? '사람 확인 해제' : '사람 확인 완료'}
+                    {isReviewConfirmed ? '검토 완료 해제' : '검토 완료'}
                   </DropdownMenuItem>
                 </>
               )}
@@ -592,7 +592,7 @@ function ImportEditorRow({
         {(hasError || hasMissingCell || isReviewPending) && (
           <span
             className={`absolute right-1 top-1 h-1 w-1 rounded-full ${
-              hasError || hasMissingCell ? 'bg-rose-500' : 'bg-amber-500'
+              hasError || hasMissingCell ? 'bg-rose-500' : 'bg-[#26415f]'
             }`}
             title={hasError ? (row.error || '행 오류') : hasMissingCell ? '미입력 셀 있음' : reviewHintLabel}
           />

--- a/src/app/components/cashflow/SettlementCommentThreadSheet.tsx
+++ b/src/app/components/cashflow/SettlementCommentThreadSheet.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { CheckCircle2, Clock3, MessageSquareText, Send, Tag } from 'lucide-react';
 import { toast } from 'sonner';
 import type { Comment } from '../../data/types';
 import { Badge } from '../ui/badge';
@@ -16,6 +17,12 @@ export interface ActiveCommentAnchor {
 function formatCommentTime(value: string): string {
   return value ? value.slice(0, 16).replace('T', ' ') : '';
 }
+
+const QUICK_COMMENT_TEMPLATES = [
+  { label: '확인 필요', text: '확인 필요: ' },
+  { label: '수정 완료', text: '수정 완료: ' },
+  { label: '근거 보강', text: '근거 보강: ' },
+] as const;
 
 export function SettlementCommentThreadSheet({
   anchor,
@@ -38,10 +45,26 @@ export function SettlementCommentThreadSheet({
 }) {
   const [draft, setDraft] = useState('');
   const [saving, setSaving] = useState(false);
+  const orderedComments = useMemo(
+    () => [...comments].sort((a, b) => String(a.createdAt || '').localeCompare(String(b.createdAt || ''))),
+    [comments],
+  );
+  const latestComment = orderedComments.length > 0 ? orderedComments[orderedComments.length - 1] : undefined;
+  const loopState = orderedComments.length === 0
+    ? { label: '기록 전', className: 'border-slate-200 bg-slate-50 text-slate-600' }
+    : { label: '논의 중', className: 'border-[#26415f]/25 bg-[#26415f]/5 text-[#26415f]' };
 
   useEffect(() => {
     if (!open) setDraft('');
   }, [open]);
+
+  const appendTemplate = useCallback((text: string) => {
+    setDraft((prev) => {
+      const current = prev.trimStart();
+      if (current.startsWith(text.trim())) return prev;
+      return current ? `${text}${current}` : text;
+    });
+  }, []);
 
   const handleSubmit = useCallback(async () => {
     if (!anchor || !onAddComment) return;
@@ -65,10 +88,10 @@ export function SettlementCommentThreadSheet({
         createdAt: new Date().toISOString(),
       });
       setDraft('');
-      toast.success('메모를 남겼습니다.');
+      toast.success('주석을 남겼습니다.');
     } catch (error) {
       console.error('[SettlementLedger] add comment failed:', error);
-      toast.error('메모 저장에 실패했습니다.');
+      toast.error('주석 저장에 실패했습니다.');
     } finally {
       setSaving(false);
     }
@@ -76,40 +99,99 @@ export function SettlementCommentThreadSheet({
 
   return (
     <Sheet modal={false} open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>
-      <SheetContent side="right" className="w-[420px] sm:max-w-[420px] gap-0">
-        <SheetHeader className="border-b">
-          <SheetTitle className="text-[14px]">셀 메모</SheetTitle>
-          <SheetDescription className="text-[11px]">
-            {anchor ? `${anchor.rowLabel} · ${anchor.fieldLabel}` : '메모를 남길 셀을 선택하세요.'}
-          </SheetDescription>
+      <SheetContent side="right" className="w-[calc(100vw-24px)] gap-0 p-0 sm:w-[460px] sm:max-w-[460px]">
+        <SheetHeader className="border-b bg-slate-50/70 px-5 py-4">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <SheetTitle className="flex items-center gap-2 text-[15px]">
+                <MessageSquareText className="h-4 w-4 text-[#26415f]" />
+                셀 주석
+              </SheetTitle>
+              <SheetDescription className="mt-1 text-[11px]">
+                {anchor ? `${anchor.rowLabel} · ${anchor.fieldLabel}` : '선택한 셀의 검토 기록'}
+              </SheetDescription>
+            </div>
+            <Badge variant="outline" className={`h-6 rounded-md px-2 text-[10px] ${loopState.className}`}>
+              {loopState.label}
+            </Badge>
+          </div>
+
+          <div className="mt-3 grid grid-cols-2 gap-2">
+            <div className="rounded-md border bg-white px-3 py-2">
+              <div className="flex items-center gap-1.5 text-[10px] text-slate-500">
+                <MessageSquareText className="h-3 w-3" />
+                주석
+              </div>
+              <p className="mt-1 text-[13px] font-semibold text-slate-950">{orderedComments.length}건</p>
+            </div>
+            <div className="rounded-md border bg-white px-3 py-2">
+              <div className="flex items-center gap-1.5 text-[10px] text-slate-500">
+                <Clock3 className="h-3 w-3" />
+                최근 기록
+              </div>
+              <p className="mt-1 truncate text-[13px] font-semibold text-slate-950">
+                {latestComment ? formatCommentTime(latestComment.createdAt) : '-'}
+              </p>
+            </div>
+          </div>
+
+          {anchor && (
+            <div className="mt-3 flex flex-wrap items-center gap-1.5">
+              <Badge variant="secondary" className="rounded-md text-[10px]">{anchor.rowLabel}</Badge>
+              <Badge variant="outline" className="rounded-md text-[10px]">{anchor.fieldLabel}</Badge>
+            </div>
+          )}
         </SheetHeader>
-        <div className="flex-1 overflow-y-auto px-4 py-4">
-          {comments.length === 0 ? (
-            <div className="rounded-lg border border-dashed px-4 py-6 text-[12px] text-muted-foreground">
-              아직 메모가 없습니다. 아래 입력창에 첫 메모를 남겨보세요.
+
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          {orderedComments.length === 0 ? (
+            <div className="rounded-md border border-dashed bg-slate-50 px-4 py-6 text-[12px] text-slate-500">
+              아직 주석이 없습니다.
             </div>
           ) : (
-            <div className="space-y-3">
-              {comments.map((comment) => (
-                <div key={comment.id} className="rounded-2xl border bg-background px-3 py-2.5 shadow-sm">
+            <div className="space-y-0 border-l border-slate-200 pl-4">
+              {orderedComments.map((comment) => (
+                <div key={comment.id} className="relative pb-4 last:pb-0">
+                  <span className="absolute -left-[21px] top-1 flex h-3 w-3 items-center justify-center rounded-full border border-[#26415f]/30 bg-white">
+                    <span className="h-1.5 w-1.5 rounded-full bg-[#26415f]" />
+                  </span>
                   <div className="flex items-center justify-between gap-2">
-                    <span className="text-[11px] font-semibold">{comment.authorName}</span>
-                    <span className="text-[10px] text-muted-foreground">{formatCommentTime(comment.createdAt)}</span>
+                    <span className="text-[11px] font-semibold text-slate-950">{comment.authorName}</span>
+                    <span className="text-[10px] text-slate-500">{formatCommentTime(comment.createdAt)}</span>
                   </div>
                   {comment.fieldLabel && (
-                    <Badge variant="secondary" className="mt-2 text-[9px]">{comment.fieldLabel}</Badge>
+                    <Badge variant="secondary" className="mt-2 rounded-md text-[9px]">{comment.fieldLabel}</Badge>
                   )}
-                  <p className="mt-2 whitespace-pre-wrap text-[12px] leading-5">{comment.content}</p>
+                  <p className="mt-2 whitespace-pre-wrap rounded-md border bg-white px-3 py-2 text-[12px] leading-5 text-slate-800">
+                    {comment.content}
+                  </p>
                 </div>
               ))}
             </div>
           )}
         </div>
-        <div className="border-t px-4 py-4 space-y-2">
+
+        <div className="space-y-3 border-t bg-white px-5 py-4">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="inline-flex items-center gap-1 text-[10px] font-semibold text-slate-500">
+              <Tag className="h-3 w-3" />
+              빠른 태그
+            </span>
+            {QUICK_COMMENT_TEMPLATES.map((item) => (
+              <button
+                key={item.label}
+                type="button"
+                className="h-6 rounded-md border border-slate-200 bg-slate-50 px-2 text-[10px] text-slate-700 hover:border-[#26415f]/30 hover:bg-[#26415f]/5"
+                onClick={() => appendTemplate(item.text)}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
           <Textarea
             value={draft}
-            placeholder="이 셀에 남길 메모를 적어주세요"
-            className="min-h-24 text-[12px]"
+            placeholder="검토 내용, 수정 근거, 확인 결과를 남겨주세요"
+            className="min-h-24 rounded-md text-[12px]"
             onChange={(event) => setDraft(event.target.value)}
             onKeyDown={(event) => {
               if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
@@ -119,9 +201,17 @@ export function SettlementCommentThreadSheet({
             }}
           />
           <div className="flex items-center justify-between gap-2">
-            <span className="text-[10px] text-muted-foreground">Cmd/Ctrl + Enter로 저장</span>
-            <Button size="sm" className="h-8 text-[11px]" disabled={!draft.trim() || saving || !anchor || !onAddComment} onClick={() => void handleSubmit()}>
-              {saving ? '저장중...' : '메모 남기기'}
+            <span className="inline-flex items-center gap-1 text-[10px] text-slate-500">
+              <CheckCircle2 className="h-3 w-3" />
+              같은 셀의 검토 기록에 누적됩니다.
+            </span>
+            <Button size="sm" className="h-8 gap-1.5 rounded-md text-[11px]" disabled={!draft.trim() || saving || !anchor || !onAddComment} onClick={() => void handleSubmit()}>
+              {saving ? '저장 중...' : (
+                <>
+                  <Send className="h-3.5 w-3.5" />
+                  주석 등록
+                </>
+              )}
             </Button>
           </div>
         </div>

--- a/src/app/components/cashflow/settlement-comment-loop-ui.shell.test.ts
+++ b/src/app/components/cashflow/settlement-comment-loop-ui.shell.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const componentDir = import.meta.dirname;
+
+const commentSheetSource = readFileSync(
+  resolve(componentDir, 'SettlementCommentThreadSheet.tsx'),
+  'utf8',
+);
+
+const commentButtonSource = readFileSync(
+  resolve(componentDir, 'CellCommentButton.tsx'),
+  'utf8',
+);
+
+const importEditorSource = readFileSync(
+  resolve(componentDir, 'ImportEditor.tsx'),
+  'utf8',
+);
+
+const importEditorRowSource = readFileSync(
+  resolve(componentDir, 'ImportEditorRow.tsx'),
+  'utf8',
+);
+
+const cashflowProjectSheetSource = readFileSync(
+  resolve(componentDir, 'CashflowProjectSheet.tsx'),
+  'utf8',
+);
+
+describe('settlement comment and review loop UI copy', () => {
+  it('uses comment language and quick loop helpers for cell notes', () => {
+    expect(commentSheetSource).toContain('셀 주석');
+    expect(commentSheetSource).toContain('QUICK_COMMENT_TEMPLATES');
+    expect(commentSheetSource).toContain('논의 중');
+    expect(commentSheetSource).toContain('주석 등록');
+    expect(commentSheetSource).toContain('검토 내용, 수정 근거, 확인 결과를 남겨주세요');
+    expect(commentButtonSource).toContain('셀 주석 열기');
+    expect(commentButtonSource).not.toContain('셀 메모');
+  });
+
+  it('labels pending review work as a review loop, not a person check', () => {
+    expect(importEditorSource).toContain('검토 루프');
+    expect(importEditorSource).toContain('셀 주석');
+    expect(importEditorSource).toContain('후보값 또는 주석 확인 필요');
+    expect(importEditorRowSource).toContain('검토 루프');
+    expect(importEditorRowSource).toContain('검토 완료');
+    expect(cashflowProjectSheetSource).toContain('검토 루프 또는 동기화 확인');
+    expect(importEditorSource).not.toContain('사람 확인');
+    expect(importEditorRowSource).not.toContain('사람 확인');
+    expect(cashflowProjectSheetSource).not.toContain('사람 확인');
+  });
+});


### PR DESCRIPTION
## 한눈에 보기
- 정산 셀에 남기는 코멘트 화면을 시간순 검토 기록처럼 읽히게 정리했습니다.
- `사람 확인`처럼 딱딱한 표현을 실제 검토 흐름에 맞는 문구로 바꿨습니다.
- 같은 문구가 다시 어색하게 바뀌지 않도록 화면 테스트를 추가했습니다.

## 사용자가 체감하는 변화
- 정산 중 어떤 셀에 왜 코멘트가 남았는지 더 쉽게 확인할 수 있습니다.
- 검토가 필요한 상태를 운영자가 더 자연스럽게 이해할 수 있습니다.

## 확인한 것
- npx vitest run src/app/components/cashflow/settlement-comment-loop-ui.shell.test.ts
- npm run build