### PR TITLE
PM이 포털에서 프로젝트 진행 상태를 직접 바꿀 수 있게 개선

### DIFF
--- a/src/app/components/portal/PortalDashboard.layout.test.ts
+++ b/src/app/components/portal/PortalDashboard.layout.test.ts
@@ -31,6 +31,13 @@ describe('PortalDashboard layout compaction', () => {
     expect(portalDashboardSource).not.toContain('CardTitle className="text-[13px] text-slate-900">자금 요약');
   });
 
+  it('lets PMs update the current project status from the dashboard hero', () => {
+    expect(portalDashboardSource).toContain('updateProjectStatus');
+    expect(portalDashboardSource).toContain('PROJECT_STATUS_OPTIONS');
+    expect(portalDashboardSource).toContain('aria-label="사업 상태 변경"');
+    expect(portalDashboardSource).toContain('사업 상태를');
+  });
+
   it('absorbs submissions into the dashboard and drops duplicate submission blocks', () => {
     expect(portalDashboardSource).toContain('내 제출 현황');
     expect(portalDashboardSource).toContain('제출 상태를 한 번에 확인합니다.');

--- a/src/app/components/portal/PortalDashboard.tsx
+++ b/src/app/components/portal/PortalDashboard.tsx
@@ -17,6 +17,7 @@ import { toast } from 'sonner';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { usePortalStore } from '../../data/portal-store';
 import { useHrAnnouncements, HR_EVENT_LABELS, HR_EVENT_COLORS } from '../../data/hr-announcements-store';
 import { usePayroll } from '../../data/payroll-store';
@@ -25,6 +26,7 @@ import { TRANSACTIONS } from '../../data/mock-data';
 import { fmtShort } from '../../data/budget-data';
 import {
   PROJECT_STATUS_LABELS, SETTLEMENT_TYPE_SHORT, BASIS_LABELS,
+  type ProjectStatus,
   type Transaction,
 } from '../../data/types';
 import { addMonthsToYearMonth, getSeoulTodayIso } from '../../platform/business-days';
@@ -54,6 +56,13 @@ import { resolvePayrollCashflowAlignment } from '../../platform/payroll-cashflow
 // ═══════════════════════════════════════════════════════════════
 // PortalDashboard — 내 사업 현황
 // ═══════════════════════════════════════════════════════════════
+
+const PROJECT_STATUS_OPTIONS: ProjectStatus[] = [
+  'CONTRACT_PENDING',
+  'IN_PROGRESS',
+  'COMPLETED',
+  'COMPLETED_PENDING_PAYMENT',
+];
 
 function formatKstDateTime(value: string | undefined): string {
   if (!value) return '아직 수정 없음';
@@ -94,7 +103,7 @@ function submissionBadgeClassName(tone: 'neutral' | 'warning' | 'danger' | 'succ
 
 export function PortalDashboard() {
   const navigate = useNavigate();
-  const { isLoading, portalUser, myProject, weeklySubmissionStatuses, projects } = usePortalStore();
+  const { isLoading, portalUser, myProject, weeklySubmissionStatuses, projects, updateProjectStatus } = usePortalStore();
   const { getProjectAlerts } = useHrAnnouncements();
   const { schedules, runs, monthlyCloses, acknowledgePayrollRun, acknowledgeMonthlyClose } = usePayroll();
   const { weeks: cashflowWeeks } = useCashflowWeeks();
@@ -103,6 +112,7 @@ export function PortalDashboard() {
 
   const [liveTransactions, setLiveTransactions] = useState<Transaction[] | null>(null);
   const [transactionsFetchState, setTransactionsFetchState] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
+  const [statusSaving, setStatusSaving] = useState(false);
   const projectId = myProject?.id || '';
 
   useEffect(() => {
@@ -170,6 +180,22 @@ export function PortalDashboard() {
     } catch (err: any) {
       console.error(err);
       toast.error(err?.message || '확인 처리에 실패했습니다');
+    }
+  }
+
+  async function handleProjectStatusChange(nextStatus: string) {
+    if (!myProject || statusSaving) return;
+    const typedStatus = nextStatus as ProjectStatus;
+    if (typedStatus === myProject.status) return;
+
+    setStatusSaving(true);
+    try {
+      const ok = await updateProjectStatus(myProject.id, typedStatus);
+      if (ok) {
+        toast.success(`사업 상태를 '${PROJECT_STATUS_LABELS[typedStatus]}'로 변경했습니다.`);
+      }
+    } finally {
+      setStatusSaving(false);
     }
   }
 
@@ -445,9 +471,30 @@ export function PortalDashboard() {
           <div className="space-y-5">
             <div className="space-y-3">
               <div className="flex flex-wrap items-center gap-2">
-                <Badge className="h-5 rounded-full bg-[#e8f0fb] px-2 text-[10px] font-semibold text-[#1b4f8f]">
-                  {PROJECT_STATUS_LABELS[myProject.status]}
-                </Badge>
+                <div className="flex items-center gap-2 rounded-full border border-[#1b4f8f]/20 bg-[#e8f0fb] px-2 py-1 text-[#1b4f8f]">
+                  <span className="text-[10px] font-semibold">사업 상태</span>
+                  <Select
+                    value={myProject.status}
+                    disabled={statusSaving}
+                    onValueChange={(value) => void handleProjectStatusChange(value)}
+                  >
+                    <SelectTrigger
+                      aria-label="사업 상태 변경"
+                      size="sm"
+                      className="h-6 w-[132px] rounded-full border-[#1b4f8f]/20 bg-white px-2 text-[11px] font-semibold text-[#1b4f8f] shadow-none"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PROJECT_STATUS_OPTIONS.map((status) => (
+                        <SelectItem key={status} value={status}>
+                          {PROJECT_STATUS_LABELS[status]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  {statusSaving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+                </div>
                 <Badge variant="outline" className="h-5 rounded-full border-slate-300 px-2 text-[10px] font-semibold text-slate-600">
                   {SETTLEMENT_TYPE_SHORT[myProject.settlementType]}
                 </Badge>

--- a/src/app/data/portal-project-status.shell.test.ts
+++ b/src/app/data/portal-project-status.shell.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const portalStoreSource = readFileSync(
+  resolve(import.meta.dirname, 'portal-store.tsx'),
+  'utf8',
+);
+
+const typesSource = readFileSync(
+  resolve(import.meta.dirname, 'types.ts'),
+  'utf8',
+);
+const projectStatusLabelsSource = typesSource.slice(
+  typesSource.indexOf('export const PROJECT_STATUS_LABELS'),
+  typesSource.indexOf('export function normalizeProjectStatus'),
+);
+
+describe('portal project status editing contract', () => {
+  it('exposes a portal action that writes the project status field directly', () => {
+    expect(portalStoreSource).toContain('updateProjectStatus: (projectId: string, status: ProjectStatus) => Promise<boolean>');
+    expect(portalStoreSource).toContain('const updateProjectStatus = useCallback');
+    expect(portalStoreSource).toContain("doc(db, getOrgDocumentPath(orgId, 'projects', targetProjectId))");
+    expect(portalStoreSource).toContain('status: normalizedStatus');
+    expect(portalStoreSource).toContain('updateProjectStatus,');
+  });
+
+  it('uses PM-facing project status labels', () => {
+    expect(projectStatusLabelsSource).toContain("CONTRACT_PENDING: '계약 전'");
+    expect(projectStatusLabelsSource).toContain("IN_PROGRESS: '진행 중'");
+    expect(projectStatusLabelsSource).toContain("COMPLETED: '완료'");
+    expect(projectStatusLabelsSource).toContain("COMPLETED_PENDING_PAYMENT: '완료(잔금 대기)'");
+    expect(projectStatusLabelsSource).not.toContain("COMPLETED: '종료'");
+  });
+
+  it('uses PM-facing settlement labels instead of X-style wording', () => {
+    expect(typesSource).toContain("NONE: '정산 없음'");
+    expect(typesSource).toContain("NONE: '정산 기준 없음'");
+    expect(typesSource).not.toContain("NONE: '해당없음(정산대상 아님)'");
+    expect(typesSource).not.toContain('정산 X');
+  });
+});

--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -27,6 +27,7 @@ import type {
   ProjectSheetSourceSnapshot,
   ProjectSheetSourceType,
   Project,
+  ProjectStatus,
   ParticipationEntry,
   Transaction,
   TransactionState,
@@ -449,6 +450,7 @@ interface PortalActions {
     },
   ) => Promise<boolean>;
   setSessionActiveProject: (projectId: string) => Promise<boolean>;
+  updateProjectStatus: (projectId: string, status: ProjectStatus) => Promise<boolean>;
   logout: () => void;
   addExpenseSet: (set: ExpenseSet) => void;
   updateExpenseSet: (id: string, updates: Partial<ExpenseSet>) => void;
@@ -2903,6 +2905,82 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     return true;
   }, [scopedProjectIds]);
 
+  const updateProjectStatus = useCallback(async (projectId: string, status: ProjectStatus): Promise<boolean> => {
+    const targetProjectId = projectId.trim();
+    if (!targetProjectId || !includesProject(scopedProjectIds, targetProjectId)) {
+      toast.error('선택 가능한 사업이 아닙니다.');
+      return false;
+    }
+
+    const normalizedStatus = normalizeProjectStatus(status);
+    const existingProject = projectsRef.current.find((project) => project.id === targetProjectId);
+    if (!existingProject) {
+      toast.error('사업 정보를 찾지 못했습니다.');
+      return false;
+    }
+    if (existingProject.status === normalizedStatus) return true;
+
+    const now = new Date().toISOString();
+    const patch: Partial<Project> = {
+      status: normalizedStatus,
+      updatedAt: now,
+    };
+    const previousProjects = projectsRef.current;
+    const nextProjects = previousProjects.map((project) => (
+      project.id === targetProjectId ? { ...project, ...patch } : project
+    ));
+    projectsRef.current = nextProjects;
+    setProjects(nextProjects);
+
+    if (isDevHarnessUser || !firestoreEnabled || !db) return true;
+
+    try {
+      if (isPlatformApiEnabled()) {
+        const idToken = authUser?.idToken || await getAuthInstance()?.currentUser?.getIdToken() || undefined;
+        await upsertProjectViaBff({
+          tenantId: orgId,
+          actor: {
+            uid: authUser?.uid || portalUser?.id || 'portal-user',
+            email: authUser?.email || portalUser?.email || '',
+            role: authUser?.role || portalUser?.role || 'pm',
+            idToken,
+          },
+          project: {
+            ...existingProject,
+            ...patch,
+            expectedVersion: existingProject.version ?? 1,
+          } as UpsertProjectPayload,
+        });
+      } else {
+        await setDoc(
+          doc(db, getOrgDocumentPath(orgId, 'projects', targetProjectId)),
+          withTenantScope(orgId, patch),
+          { merge: true },
+        );
+      }
+      return true;
+    } catch (err) {
+      console.error('[PortalStore] updateProjectStatus error:', err);
+      projectsRef.current = previousProjects;
+      setProjects(previousProjects);
+      toast.error('사업 상태 저장에 실패했습니다.');
+      return false;
+    }
+  }, [
+    authUser?.email,
+    authUser?.idToken,
+    authUser?.role,
+    authUser?.uid,
+    db,
+    firestoreEnabled,
+    isDevHarnessUser,
+    orgId,
+    portalUser?.email,
+    portalUser?.id,
+    portalUser?.role,
+    scopedProjectIds,
+  ]);
+
   const logout = useCallback(() => {
     setActiveProjectIdState('');
     setPortalUser(null);
@@ -3222,6 +3300,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     weeklySubmissionStatuses,
     register,
     setSessionActiveProject,
+    updateProjectStatus,
     logout,
     addExpenseSet,
     updateExpenseSet,

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -75,8 +75,8 @@ export const CASHFLOW_CATEGORY_LABELS: Record<CashflowCategory, string> = Object
 export const PROJECT_STATUS_LABELS: Record<ProjectStatus, string> = {
   CONTRACT_PENDING: '계약 전',
   IN_PROGRESS: '진행 중',
-  COMPLETED: '종료',
-  COMPLETED_PENDING_PAYMENT: '종료(잔금 대기)',
+  COMPLETED: '완료',
+  COMPLETED_PENDING_PAYMENT: '완료(잔금 대기)',
 };
 
 export function normalizeProjectStatus(raw: unknown): ProjectStatus {
@@ -143,7 +143,7 @@ export const SETTLEMENT_TYPE_LABELS: Record<SettlementType, string> = {
   TYPE3: 'Type3. 공급가액+세금계산서 미발행',
   TYPE4: 'Type4. 세금계산서미발행+공급대가',
   TYPE5: 'Type5. 이나라도움+공급가액',
-  NONE: '해당없음(정산대상 아님)',
+  NONE: '정산 없음',
 };
 
 export const SETTLEMENT_TYPE_SHORT: Record<SettlementType, string> = {
@@ -152,13 +152,13 @@ export const SETTLEMENT_TYPE_SHORT: Record<SettlementType, string> = {
   TYPE3: 'Type3',
   TYPE4: 'Type4',
   TYPE5: 'Type5',
-  NONE: '해당없음(정산대상 아님)',
+  NONE: '정산 없음',
 };
 
 export const BASIS_LABELS: Record<Basis, string> = {
   '공급가액': '공급가액 기준',
   '공급대가': '공급대가 기준',
-  NONE: '해당없음(정산대상 아님)',
+  NONE: '정산 기준 없음',
 };
 
 export function normalizeSettlementType(raw: unknown): SettlementType {

--- a/src/app/platform/project-migration-review-dossier.test.ts
+++ b/src/app/platform/project-migration-review-dossier.test.ts
@@ -184,7 +184,7 @@ describe('buildMigrationReviewDossier', () => {
     }, null);
 
     expect(dossier.contract.projectTypeLabel).toBe('D-1 개발협력사업 - AVPN 포함');
-    expect(dossier.contract.settlementTypeLabel).toBe('해당없음(정산대상 아님)');
+    expect(dossier.contract.settlementTypeLabel).toBe('정산 없음');
     expect(dossier.contract.basisLabel).toBe('공급가액 기준');
     expect(dossier.contract.accountTypeLabel).toBe('일반 사업');
     expect(dossier.contract.fundInputModeLabel).toBe('통장내역 업로드');

--- a/src/app/platform/project-request-review.test.ts
+++ b/src/app/platform/project-request-review.test.ts
@@ -143,7 +143,7 @@ describe('project-request-review', () => {
     }));
 
     const items = model.checklistGroups.flatMap((group) => group.items);
-    expect(items.find((item) => item.key === 'settlementType')?.value).toBe('해당없음(정산대상 아님)');
+    expect(items.find((item) => item.key === 'settlementType')?.value).toBe('정산 없음');
     expect(items.find((item) => item.key === 'basis')?.value).toBe('공급가액 기준');
     expect(items.find((item) => item.key === 'accountType')?.value).toBe('일반 사업');
     expect(items.find((item) => item.key === 'fundInputMode')?.value).toBe('통장내역 업로드');


### PR DESCRIPTION
## 한눈에 보기
- PM 포털에서 현재 프로젝트의 진행 상태를 바로 수정할 수 있게 했습니다.
- 포털 대시보드 상단에 간단한 상태 선택 기능을 추가했습니다.
- PM에게 보이는 완료 프로젝트 문구를 `종료`에서 `완료`로 바꿔 더 자연스럽게 정리했습니다.

## 사용자가 체감하는 변화
- 관리 화면으로 이동하지 않아도 PM이 담당 프로젝트 상태를 빠르게 업데이트할 수 있습니다.
- 프로젝트 상태 표현이 운영자가 이해하기 쉬운 말로 바뀝니다.

## 확인한 것
- npx vitest run src/app/data/portal-project-status.shell.test.ts src/app/components/portal/PortalDashboard.layout.test.ts
- npm run build