### PR TITLE
Fix project status edit and settlement type labels

### DIFF
--- a/src/app/components/portal/PortalMinimalSweep.layout.test.ts
+++ b/src/app/components/portal/PortalMinimalSweep.layout.test.ts
@@ -74,6 +74,12 @@ describe('portal minimal sweep', () => {
     expect(projectEditSource).not.toContain('현재 프로젝트:');
   });
 
+  it('allows PM project edit to change the project status through the shared editor', () => {
+    expect(projectEditorWizardSource).toContain("mode === 'admin' || mode === 'portal-edit'");
+    expect(projectEditorWizardSource).toContain('프로젝트 진행 상태');
+    expect(projectEditorWizardSource).toContain("update('status', value as ProjectStatus)");
+  });
+
   it('removes dash placeholders and review coaching from project register summaries', () => {
     expect(projectRegisterSource).not.toContain('제출 전 최종 확인');
     expect(projectRegisterSource).not.toContain("|| '-'");

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -240,6 +240,10 @@ function isAdminMode(mode: ProjectEditorMode) {
   return mode === 'admin';
 }
 
+function canEditProjectStatus(mode: ProjectEditorMode) {
+  return mode === 'admin' || mode === 'portal-edit';
+}
+
 function createProjectEditorWizardDraft(overrides: Partial<ProjectEditorDraft> = {}): ProjectEditorDraft {
   const draft = createProjectEditorDraft(overrides);
   if (!Array.isArray(overrides.teamMembersDetailed)) {
@@ -742,8 +746,8 @@ export function ProjectEditorWizard({
         </div>
       </div>
 
-      {isAdminMode(mode) ? (
-        <div className="grid gap-4 lg:grid-cols-3">
+      {canEditProjectStatus(mode) ? (
+        <div className={`grid gap-4 ${isAdminMode(mode) ? 'lg:grid-cols-3' : 'lg:grid-cols-2'}`}>
           <div>
             <Label className="text-xs">프로젝트 진행 상태</Label>
             <Select value={draft.status} onValueChange={(value) => update('status', value as ProjectStatus)}>
@@ -755,18 +759,20 @@ export function ProjectEditorWizard({
               </SelectContent>
             </Select>
           </div>
-          <div>
-            <Label className="text-xs">프로젝트 구분</Label>
-            <Select value={draft.phase} onValueChange={(value) => update('phase', value as ProjectPhase)}>
-              <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue /></SelectTrigger>
-              <SelectContent>
-                {(Object.keys(PROJECT_PHASE_LABELS) as ProjectPhase[]).map((phase) => (
-                  <SelectItem key={phase} value={phase}>{PROJECT_PHASE_LABELS[phase]}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          {renderContractTypeSelect()}
+          {isAdminMode(mode) ? (
+            <div>
+              <Label className="text-xs">프로젝트 구분</Label>
+              <Select value={draft.phase} onValueChange={(value) => update('phase', value as ProjectPhase)}>
+                <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {(Object.keys(PROJECT_PHASE_LABELS) as ProjectPhase[]).map((phase) => (
+                    <SelectItem key={phase} value={phase}>{PROJECT_PHASE_LABELS[phase]}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          ) : null}
+          {isAdminMode(mode) ? renderContractTypeSelect() : null}
         </div>
       ) : (
         <div className="grid gap-4 lg:grid-cols-3">
@@ -1152,10 +1158,10 @@ export function ProjectEditorWizard({
             <ReviewRow label="계약 대상" value={draft.clientOrg} />
             <ReviewRow label="그룹웨어 등록명" value={draft.groupwareName} />
             <ReviewRow label="프로젝트 목적" value={draft.projectPurpose} />
-            {isAdminMode(mode) ? (
+            {canEditProjectStatus(mode) ? (
               <>
                 <ReviewRow label="프로젝트 진행 상태" value={PROJECT_STATUS_LABELS[draft.status]} />
-                <ReviewRow label="프로젝트 구분" value={PROJECT_PHASE_LABELS[draft.phase]} />
+                {isAdminMode(mode) ? <ReviewRow label="프로젝트 구분" value={PROJECT_PHASE_LABELS[draft.phase]} /> : null}
               </>
             ) : null}
           </CardContent>

--- a/src/app/components/projects/ProjectListPage.shell.test.ts
+++ b/src/app/components/projects/ProjectListPage.shell.test.ts
@@ -14,4 +14,11 @@ describe('ProjectListPage shell contract', () => {
     expect(source).toContain('승인 대기');
     expect(source).toContain('증빙 미제출');
   });
+
+  it('shows settlement type labels instead of O/X settlement flags', () => {
+    expect(source).toContain('정산 유형');
+    expect(source).toContain('normalizeSettlementType(p.settlementType)');
+    expect(source).toContain('SETTLEMENT_TYPE_SHORT[normalizeSettlementType(p.settlementType)]');
+    expect(source).not.toContain('p.isSettled ?');
+  });
 });

--- a/src/app/components/projects/ProjectListPage.tsx
+++ b/src/app/components/projects/ProjectListPage.tsx
@@ -19,7 +19,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { useAppStore } from '../../data/store';
 import {
   PROJECT_STATUS_LABELS, PROJECT_TYPE_LABELS, PROJECT_TYPE_SHORT_LABELS,
-  SETTLEMENT_TYPE_SHORT,
+  SETTLEMENT_TYPE_LABELS, SETTLEMENT_TYPE_SHORT, normalizeSettlementType,
   type ProjectStatus, type ProjectType, type Project,
 } from '../../data/types';
 import { PageHeader } from '../layout/PageHeader';
@@ -233,7 +233,7 @@ export function ProjectListPage() {
                     계약금액 <ArrowUpDown className="w-3 h-3" />
                   </span>
                 </TableHead>
-                <TableHead className="min-w-[35px] text-center">정산</TableHead>
+                <TableHead className="min-w-[80px] text-center">정산 유형</TableHead>
                 {activeTab === 'trash' && (
                   <>
                     <TableHead className="min-w-[90px]">삭제일</TableHead>
@@ -276,11 +276,12 @@ export function ProjectListPage() {
                     {p.contractAmount > 0 ? fmtFull(p.contractAmount) : '-'}
                   </TableCell>
                   <TableCell className="text-center text-sm">
-                    {p.isSettled ? (
-                      <span className="text-green-600">O</span>
-                    ) : (
-                      <span className="text-muted-foreground">X</span>
-                    )}
+                    <span
+                      className="inline-flex items-center rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[10px] font-semibold text-slate-700"
+                      title={SETTLEMENT_TYPE_LABELS[normalizeSettlementType(p.settlementType)]}
+                    >
+                      {SETTLEMENT_TYPE_SHORT[normalizeSettlementType(p.settlementType)]}
+                    </span>
                   </TableCell>
                   {activeTab === 'trash' && (
                     <>


### PR DESCRIPTION
## Summary
- Show settlement type labels in admin project list instead of O/X settlement flags
- Allow PM project edit to update the project progress status through the shared editor
- Keep admin project list status rendering wired to Project.status

## Verification
- npx vitest run src/app/components/projects/ProjectListPage.shell.test.ts src/app/components/portal/PortalMinimalSweep.layout.test.ts src/app/data/portal-project-status.shell.test.ts src/app/components/portal/PortalDashboard.layout.test.ts
- npm run build