### PR TITLE
Fix project owner assignment consistency

### DIFF
--- a/scripts/audit-project-owner-consistency.mjs
+++ b/scripts/audit-project-owner-consistency.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+import { createFirestoreDb, resolveProjectId } from '../server/bff/firestore.mjs';
+
+function readFlag(name, fallback = '') {
+  const index = process.argv.indexOf(name);
+  if (index === -1) return fallback;
+  return process.argv[index + 1] || fallback;
+}
+
+function hasFlag(name) {
+  return process.argv.includes(name);
+}
+
+function normalizeText(value) {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function compactText(value) {
+  return normalizeText(value).replace(/\s+/g, '');
+}
+
+function includesProject(member, projectId) {
+  const rootIds = Array.isArray(member?.projectIds) ? member.projectIds : [];
+  const profileIds = Array.isArray(member?.portalProfile?.projectIds) ? member.portalProfile.projectIds : [];
+  return rootIds.includes(projectId) || profileIds.includes(projectId)
+    || member?.projectId === projectId || member?.portalProfile?.projectId === projectId;
+}
+
+async function readCollection(db, path) {
+  const snap = await db.collection(path).get();
+  return snap.docs.map((doc) => ({ docId: doc.id, ...doc.data() }));
+}
+
+function buildRows({ projects, requests, legacyRequests, members }) {
+  const activeProjects = projects.filter((project) => !project.trashedAt);
+  const membersByUid = new Map();
+  members.forEach((member) => {
+    if (member.uid) membersByUid.set(member.uid, member);
+    membersByUid.set(member.docId, member);
+  });
+
+  const allRequests = [...requests, ...legacyRequests.map((request) => ({ ...request, legacyCollection: true }))];
+  const requestByProject = new Map();
+  allRequests.forEach((request) => {
+    if (!request.approvedProjectId) return;
+    const current = requestByProject.get(request.approvedProjectId);
+    if (!current || String(request.requestedAt || '').localeCompare(String(current.requestedAt || '')) > 0) {
+      requestByProject.set(request.approvedProjectId, request);
+    }
+  });
+  const projectById = new Map(activeProjects.map((project) => [project.id || project.docId, project]));
+
+  const hiddenPending = [];
+  allRequests
+    .filter((request) => request.status === 'PENDING' && request.approvedProjectId)
+    .forEach((request) => {
+      const project = projectById.get(request.approvedProjectId);
+      const hidden = !project
+        || project.trashedAt
+        || project.registrationSource !== 'pm_portal'
+        || project.executiveReviewStatus !== 'PENDING';
+      if (!hidden) return;
+      hiddenPending.push({
+        check: 'hidden-pending',
+        projectId: request.approvedProjectId,
+        projectName: project?.name || request.payload?.name || '',
+        requestId: request.id || request.docId,
+        requestStatus: request.status,
+        registrationSource: project?.registrationSource || '',
+        executiveReviewStatus: project?.executiveReviewStatus || '',
+        reason: !project ? 'linked project missing' : 'pending request is hidden by project fields',
+      });
+    });
+
+  const missingRegisteredBy = [];
+  const assignmentMismatch = [];
+  const legacyManagerMismatch = [];
+
+  activeProjects.forEach((project) => {
+    const projectId = project.id || project.docId;
+    const request = requestByProject.get(projectId);
+    const registeredById = normalizeText(project.registeredById);
+    const registeredByName = normalizeText(project.registeredByName);
+    const registeredByEmail = normalizeText(project.registeredByEmail);
+    const managerId = normalizeText(project.managerId);
+    const managerName = normalizeText(project.managerName);
+
+    if (project.registrationSource === 'pm_portal' && (!registeredById || !registeredByName || !registeredByEmail)) {
+      missingRegisteredBy.push({
+        check: 'missing-registered-by',
+        projectId,
+        projectName: project.name || '',
+        requestId: request?.id || request?.docId || '',
+        requestStatus: request?.status || '',
+        registeredById,
+        registeredByName,
+        registeredByEmail,
+        managerId,
+        managerName,
+      });
+    }
+
+    if (registeredById) {
+      const member = membersByUid.get(registeredById);
+      if (!member || !includesProject(member, projectId) || (registeredByName && compactText(member.name) !== compactText(registeredByName))) {
+        assignmentMismatch.push({
+          check: 'assignment-mismatch',
+          projectId,
+          projectName: project.name || '',
+          registeredById,
+          registeredByName,
+          memberName: member?.name || '',
+          memberEmail: member?.email || '',
+          memberHasProject: member ? includesProject(member, projectId) : false,
+        });
+      }
+    }
+
+    if (!registeredById && managerId) {
+      const member = membersByUid.get(managerId);
+      if (member && managerName && compactText(member.name) !== compactText(managerName)) {
+        legacyManagerMismatch.push({
+          check: 'legacy-manager-mismatch',
+          projectId,
+          projectName: project.name || '',
+          managerId,
+          managerName,
+          memberName: member.name || '',
+          memberEmail: member.email || '',
+          requestId: request?.id || request?.docId || '',
+          requestStatus: request?.status || '',
+        });
+      }
+    }
+  });
+
+  return {
+    hiddenPending,
+    missingRegisteredBy,
+    assignmentMismatch,
+    legacyManagerMismatch,
+  };
+}
+
+function filterRows(groups, only) {
+  if (!only) return groups;
+  return Object.fromEntries(Object.entries(groups).map(([key, rows]) => [
+    key,
+    rows.filter((row) => row.check === only),
+  ]));
+}
+
+function printTable(groups) {
+  Object.entries(groups).forEach(([key, rows]) => {
+    console.log(`\n## ${key} (${rows.length})`);
+    if (rows.length === 0) return;
+    console.table(rows);
+  });
+}
+
+const orgId = readFlag('--org', process.env.BFF_TENANT_ID || process.env.VITE_DEFAULT_ORG_ID || 'mysc');
+const firebaseProjectId = readFlag('--firebase-project', readFlag('--project', resolveProjectId()));
+const format = readFlag('--format', 'table');
+const only = readFlag('--only', '');
+const failOnIssues = hasFlag('--fail-on-issues');
+
+const db = createFirestoreDb({ projectId: firebaseProjectId });
+const [projects, requests, legacyRequests, members] = await Promise.all([
+  readCollection(db, `orgs/${orgId}/projects`),
+  readCollection(db, `orgs/${orgId}/project_requests`),
+  readCollection(db, `orgs/${orgId}/projectRequests`).catch(() => []),
+  readCollection(db, `orgs/${orgId}/members`),
+]);
+
+const groups = filterRows(buildRows({ projects, requests, legacyRequests, members }), only);
+const issueCount = Object.values(groups).reduce((sum, rows) => sum + rows.length, 0);
+
+if (format === 'json') {
+  console.log(JSON.stringify({ orgId, firebaseProjectId, issueCount, groups }, null, 2));
+} else if (format === 'ndjson') {
+  Object.values(groups).flat().forEach((row) => console.log(JSON.stringify(row)));
+} else {
+  console.log(`Project owner consistency audit: org=${orgId}, firebaseProject=${firebaseProjectId}, issues=${issueCount}`);
+  printTable(groups);
+}
+
+if (failOnIssues && issueCount > 0) {
+  process.exitCode = 1;
+}

--- a/src/app/components/portal/PortalDashboard.tsx
+++ b/src/app/components/portal/PortalDashboard.tsx
@@ -246,7 +246,11 @@ export function PortalDashboard() {
     const ordered = projectIds
       .map((projectId) => projectMap.get(projectId))
       .filter((project): project is NonNullable<typeof project> => Boolean(project));
-    if (ordered.length > 0) return ordered;
+    const seen = new Set(ordered.map((project) => project.id));
+    const owned = projects.filter((project) => (
+      project.registeredById === portalUser.id && !seen.has(project.id)
+    ));
+    if (ordered.length > 0 || owned.length > 0) return [...ordered, ...owned];
     return myProject ? [myProject] : [];
   }, [myProject, portalUser, projects]);
   const currentWeek = useMemo(() => resolveCurrentCashflowWeek(today), [today]);

--- a/src/app/components/portal/PortalProjectEdit.tsx
+++ b/src/app/components/portal/PortalProjectEdit.tsx
@@ -25,6 +25,7 @@ import {
   buildPortalProjectEditSavePayload,
   isProjectVersionConflictError,
 } from '../../platform/project-edit-save';
+import { buildProjectOwnerAssignmentPatches } from '../../platform/project-owner-assignment';
 import { Button } from '../ui/button';
 import { Card, CardContent } from '../ui/card';
 import { Label } from '../ui/label';
@@ -134,6 +135,62 @@ export function PortalProjectEdit() {
     && project.executiveReviewStatus === 'APPROVED'
   );
 
+  const syncProjectOwnerAssignment = async (draft: ProjectEditorDraft) => {
+    if (!db || !myProject?.id || !draft.registeredById) return;
+    const previousOwnerId = myProject.registeredById || myProject.managerId || '';
+    const nextOwnerId = draft.registeredById;
+    const previousRef = previousOwnerId && previousOwnerId !== nextOwnerId
+      ? doc(db, getOrgDocumentPath(orgId, 'members', previousOwnerId))
+      : null;
+    const nextRef = doc(db, getOrgDocumentPath(orgId, 'members', nextOwnerId));
+    const [previousSnap, nextSnap] = await Promise.all([
+      previousRef ? getDoc(previousRef) : Promise.resolve(null),
+      getDoc(nextRef),
+    ]);
+    if (!nextSnap.exists()) {
+      throw new Error('선택한 사업 담당자 계정을 찾을 수 없습니다.');
+    }
+    const previousMember = previousSnap?.exists() ? previousSnap.data() : undefined;
+    const nextMember = nextSnap.data();
+    const patches = buildProjectOwnerAssignmentPatches({
+      projectId: myProject.id,
+      projectName: draft.name || myProject.name,
+      previousOwnerId,
+      nextOwner: {
+        uid: nextOwnerId,
+        name: draft.registeredByName,
+        email: draft.registeredByEmail,
+      },
+      previousMember,
+      nextMember,
+    });
+    const now = new Date().toISOString();
+    if (previousRef && patches.previous) {
+      await setDoc(previousRef, {
+        projectIds: patches.previous.projectIds,
+        projectNames: patches.previous.projectNames,
+        portalProfile: {
+          projectIds: patches.previous.projectIds,
+          projectNames: patches.previous.projectNames,
+        },
+        updatedAt: now,
+      }, { merge: true });
+    }
+    if (patches.next) {
+      await setDoc(nextRef, {
+        projectId: patches.next.projectId,
+        projectIds: patches.next.projectIds,
+        projectNames: patches.next.projectNames,
+        portalProfile: {
+          projectId: patches.next.projectId,
+          projectIds: patches.next.projectIds,
+          projectNames: patches.next.projectNames,
+        },
+        updatedAt: now,
+      }, { merge: true });
+    }
+  };
+
   const persistProject = async (
     draft: ProjectEditorDraft,
     options: { forcePendingReview?: boolean; reviewComment?: string | null } = {},
@@ -232,6 +289,8 @@ export function PortalProjectEdit() {
         );
       }
     }
+
+    await syncProjectOwnerAssignment(draft);
 
     return savedProject;
   };

--- a/src/app/components/portal/PortalProjectRegister.tsx
+++ b/src/app/components/portal/PortalProjectRegister.tsx
@@ -30,10 +30,13 @@ export function PortalProjectRegister() {
 
   const initialDraft = useMemo(
     () => createProjectEditorDraft({
+      registeredById: authUser?.uid || '',
+      registeredByName: authUser?.name || portalUser?.name || '',
+      registeredByEmail: authUser?.email || portalUser?.email || '',
       managerId: authUser?.uid || '',
       managerName: authUser?.name || portalUser?.name || '',
     }),
-    [authUser?.name, authUser?.uid, portalUser?.name],
+    [authUser?.email, authUser?.name, authUser?.uid, portalUser?.email, portalUser?.name],
   );
 
   const handleSubmit = async (draft: ProjectEditorDraft) => {

--- a/src/app/components/projects/ProjectEditorWizard.shell.test.ts
+++ b/src/app/components/projects/ProjectEditorWizard.shell.test.ts
@@ -23,12 +23,19 @@ describe('ProjectEditorWizard dropdown contract', () => {
   });
 
   it('keeps select values representable in their option lists', () => {
-    expect(source).toContain('const managerOptions = useMemo');
-    expect(source).toContain('uid: draft.managerId');
+    expect(source).toContain('const ownerOptions = useMemo');
+    expect(source).toContain('uid: draft.registeredById');
     expect(source).toContain("if (value === 'none')");
     expect(source).toContain("onSelect({ memberName: '', memberNickname: '' })");
     expect(source).toContain('currentTeamMemberOptionExists');
     expect(source).toContain('member.memberNickname ? `${member.memberName} (${member.memberNickname})` : member.memberName');
+  });
+
+  it('uses a member select for project owner instead of free text manager input', () => {
+    expect(source).toContain('사업 담당자');
+    expect(source).toContain('registeredById');
+    expect(source).toContain('registeredByName: member?.name ||');
+    expect(source).not.toContain('<Input value={draft.managerName}');
   });
 
   it('uses a searchable team member picker for registration and edit flows', () => {

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -412,21 +412,40 @@ export function ProjectEditorWizard({
   const teamMembersSummary = formatProjectTeamMembersSummary(draft.teamMembersDetailed, '', '\n');
   const projectTypeOptions = getProjectTypeSelectableOptions(draft.type);
   const contractTypeOptions = getProjectContractTypeSelectableOptions(draft.contractType);
-  const managerOptions = useMemo(() => {
-    const pmMembers = members.filter((member) => member.role === 'pm');
-    if (!draft.managerId || pmMembers.some((member) => member.uid === draft.managerId)) {
-      return pmMembers;
+  const ownerOptions = useMemo(() => {
+    if (!draft.registeredById || members.some((member) => member.uid === draft.registeredById)) {
+      return members;
     }
     return [
-      ...pmMembers,
+      ...members,
       {
-        uid: draft.managerId,
-        name: draft.managerName || draft.managerId,
-        email: '',
+        uid: draft.registeredById,
+        name: draft.registeredByName || draft.registeredById,
+        email: draft.registeredByEmail || '',
         role: 'pm' as const,
       },
     ];
-  }, [draft.managerId, draft.managerName, members]);
+  }, [draft.registeredByEmail, draft.registeredById, draft.registeredByName, members]);
+
+  useEffect(() => {
+    if (!draft.registeredById) return;
+    const member = members.find((item) => item.uid === draft.registeredById);
+    if (!member) return;
+    if (
+      draft.registeredByName === member.name
+      && draft.registeredByEmail === (member.email || '')
+      && draft.managerId === member.uid
+      && draft.managerName === member.name
+    ) return;
+    setDraft((prev) => createProjectEditorDraft({
+      ...prev,
+      registeredById: member.uid,
+      registeredByName: member.name,
+      registeredByEmail: member.email || '',
+      managerId: member.uid,
+      managerName: member.name,
+    }));
+  }, [draft.managerId, draft.managerName, draft.registeredByEmail, draft.registeredById, draft.registeredByName, members]);
 
   const update = <K extends keyof ProjectEditorDraft>(key: K, value: ProjectEditorDraft[K]) => {
     setDraft((prev) => createProjectEditorWizardDraft({ ...prev, [key]: value }));
@@ -941,29 +960,31 @@ export function ProjectEditorWizard({
     <div className="space-y-4">
       <div className="grid gap-4 lg:grid-cols-2">
         <div>
-          <Label className="text-xs">PM *</Label>
-          <Input value={draft.managerName} onChange={(event) => update('managerName', event.target.value)} className="mt-1 h-9 text-sm" />
-        </div>
-        <div>
-          <Label className="text-xs">담당자 계정</Label>
-          <Select value={draft.managerId || 'none'} onValueChange={(value) => {
+          <Label className="text-xs">사업 담당자 *</Label>
+          <Select value={draft.registeredById || 'none'} onValueChange={(value) => {
             const member = members.find((item) => item.uid === value);
             setDraft((prev) => createProjectEditorDraft({
               ...prev,
+              registeredById: value === 'none' ? '' : value,
+              registeredByName: member?.name || '',
+              registeredByEmail: member?.email || '',
               managerId: value === 'none' ? '' : value,
-              managerName: member?.name || prev.managerName,
+              managerName: member?.name || '',
             }));
           }}>
-            <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue placeholder="선택" /></SelectTrigger>
+            <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue placeholder="조직원 선택" /></SelectTrigger>
             <SelectContent>
               <SelectItem value="none">선택 안 함</SelectItem>
-              {managerOptions.map((member) => (
+              {ownerOptions.map((member) => (
                 <SelectItem key={member.uid} value={member.uid}>
                   {member.email ? `${member.name} (${member.email})` : member.name}
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            프로젝트 현황과 PM 포털 노출은 이 조직원 계정 기준으로 연결됩니다.
+          </p>
         </div>
       </div>
       <div className="flex items-center justify-between gap-3">

--- a/src/app/components/projects/ProjectListPage.shell.test.ts
+++ b/src/app/components/projects/ProjectListPage.shell.test.ts
@@ -21,4 +21,9 @@ describe('ProjectListPage shell contract', () => {
     expect(source).toContain('SETTLEMENT_TYPE_SHORT[normalizeSettlementType(p.settlementType)]');
     expect(source).not.toContain('p.isSettled ?');
   });
+
+  it('shows the business owner from registeredBy fields', () => {
+    expect(source).toContain('사업 담당자');
+    expect(source).toContain('p.registeredByName || p.managerName');
+  });
 });

--- a/src/app/components/projects/ProjectListPage.tsx
+++ b/src/app/components/projects/ProjectListPage.tsx
@@ -227,7 +227,7 @@ export function ProjectListPage() {
                   </span>
                 </TableHead>
                 <TableHead className="min-w-[90px]">계약 기간</TableHead>
-                <TableHead className="min-w-[80px]">담당자</TableHead>
+                <TableHead className="min-w-[80px]">사업 담당자</TableHead>
                 <TableHead className="text-right min-w-[100px] cursor-pointer" onClick={() => handleSort('contractAmount')}>
                   <span className="flex items-center justify-end gap-1">
                     계약금액 <ArrowUpDown className="w-3 h-3" />
@@ -270,7 +270,7 @@ export function ProjectListPage() {
                     {p.contractEnd ? ` ~ ${p.contractEnd.replace(/-/g, '.')}` : ''}
                   </TableCell>
                   <TableCell className="text-[11px] whitespace-nowrap">
-                    {p.managerName || '-'}
+                    {p.registeredByName || p.managerName || '-'}
                   </TableCell>
                   <TableCell className="text-right text-sm whitespace-nowrap">
                     {p.contractAmount > 0 ? fmtFull(p.contractAmount) : '-'}

--- a/src/app/components/projects/ProjectMigrationAuditPage.tsx
+++ b/src/app/components/projects/ProjectMigrationAuditPage.tsx
@@ -170,8 +170,7 @@ export function ProjectMigrationAuditPage({
   const scopedRecords = useMemo(
     () => reviewScope === 'pending'
       ? records.filter((record) => (
-          record.project.registrationSource === 'pm_portal'
-          && record.status === 'PENDING'
+          record.status === 'PENDING'
         ))
       : records,
     [records, reviewScope],

--- a/src/app/components/projects/ProjectWizard.tsx
+++ b/src/app/components/projects/ProjectWizard.tsx
@@ -12,6 +12,7 @@ import {
   createProjectEditorDraft,
   type ProjectEditorDraft,
 } from '../../platform/project-editor';
+import { buildProjectOwnerAssignmentPatches } from '../../platform/project-owner-assignment';
 import { resolveProjectCic } from '../../platform/project-cic';
 import { ProjectEditorWizard } from './ProjectEditorWizard';
 
@@ -41,6 +42,10 @@ function createProjectFromDraft(
     name: draft.name,
     shortName: draft.name,
     officialContractName: draft.officialContractName,
+    registeredById: draft.registeredById,
+    registeredByName: draft.registeredByName,
+    registeredByEmail: draft.registeredByEmail,
+    registeredAt: now,
     status: draft.status,
     type: draft.type,
     phase: draft.phase,
@@ -71,8 +76,8 @@ function createProjectFromDraft(
     department: draft.department,
     cic: resolveProjectCic({ department: draft.department }),
     teamName: draft.teamName,
-    managerId: draft.managerId,
-    managerName: draft.managerName,
+    managerId: draft.registeredById,
+    managerName: draft.registeredByName,
     budgetCurrentYear: draft.budgetCurrentYear || draft.contractAmount,
     taxInvoiceAmount: draft.taxInvoiceAmount,
     profitRate: draft.profitRate,
@@ -91,7 +96,7 @@ function createProjectFromDraft(
 
 export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: ProjectWizardProps) {
   const navigate = useNavigate();
-  const { addProject, updateProject, members, currentUser } = useAppStore();
+  const { addProject, updateProject, upsertMember, members, currentUser } = useAppStore();
   const { orgId } = useFirebase();
   const [busyActionId, setBusyActionId] = useState<string | null>(null);
 
@@ -124,11 +129,13 @@ export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: Projec
 
       if (editProject) {
         await updateProject(editProject.id, patch);
+        syncProjectOwnerAssignment(editProject.id, draft.name || editProject.name, editProject.registeredById || editProject.managerId || '', draft);
         toast.success('프로젝트 수정 내용이 저장되었습니다.');
         navigate(`/projects/${editProject.id}`);
       } else {
         const project = createProjectFromDraft(draft, patch, now);
         await addProject(project);
+        syncProjectOwnerAssignment(project.id, project.name, '', draft);
         toast.success(draft.phase === 'PROSPECT' ? '예정 프로젝트로 저장했습니다.' : '프로젝트를 등록했습니다.');
         navigate(`/projects/${project.id}`);
       }
@@ -137,6 +144,56 @@ export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: Projec
       toast.error(error instanceof Error ? error.message : '프로젝트 저장에 실패했습니다.');
     } finally {
       setBusyActionId(null);
+    }
+  };
+
+  const syncProjectOwnerAssignment = (
+    projectId: string,
+    projectName: string,
+    previousOwnerId: string,
+    draft: ProjectEditorDraft,
+  ) => {
+    if (!draft.registeredById) return;
+    const previousMember = members.find((member) => member.uid === previousOwnerId) as (typeof members[number] & Record<string, unknown>) | undefined;
+    const nextMember = members.find((member) => member.uid === draft.registeredById) as (typeof members[number] & Record<string, unknown>) | undefined;
+    if (!nextMember) return;
+    const patches = buildProjectOwnerAssignmentPatches({
+      projectId,
+      projectName,
+      previousOwnerId,
+      nextOwner: {
+        uid: draft.registeredById,
+        name: draft.registeredByName,
+        email: draft.registeredByEmail,
+      },
+      previousMember,
+      nextMember,
+    });
+    if (previousMember && patches.previous) {
+      upsertMember({
+        ...previousMember,
+        projectIds: patches.previous.projectIds,
+        projectNames: patches.previous.projectNames,
+        portalProfile: {
+          ...(typeof previousMember.portalProfile === 'object' && previousMember.portalProfile ? previousMember.portalProfile : {}),
+          projectIds: patches.previous.projectIds,
+          projectNames: patches.previous.projectNames,
+        },
+      });
+    }
+    if (patches.next) {
+      upsertMember({
+        ...nextMember,
+        projectId: patches.next.projectId,
+        projectIds: patches.next.projectIds,
+        projectNames: patches.next.projectNames,
+        portalProfile: {
+          ...(typeof nextMember.portalProfile === 'object' && nextMember.portalProfile ? nextMember.portalProfile : {}),
+          projectId: patches.next.projectId,
+          projectIds: patches.next.projectIds,
+          projectNames: patches.next.projectNames,
+        },
+      });
     }
   };
 

--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -2302,38 +2302,50 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     }
     const now = new Date().toISOString();
     const id = `pr-${Date.now()}`;
+    const requesterName = authUser.name || portalUser?.name || '사용자';
+    const requesterEmail = authUser.email || portalUser?.email || '';
+    const ownerId = payload.registeredById || payload.managerId || authUser.uid;
+    const ownerName = payload.registeredByName || payload.managerName || requesterName;
+    const ownerEmail = payload.registeredByEmail || (ownerId === authUser.uid ? requesterEmail : '');
+    const requestPayload: ProjectRequestPayload = {
+      ...payload,
+      registeredById: ownerId,
+      registeredByName: ownerName,
+      registeredByEmail: ownerEmail,
+      managerId: ownerId,
+      managerName: ownerName,
+    };
     const request: ProjectRequest = {
       id,
       tenantId: orgId,
       status: 'PENDING',
-      payload,
+      payload: requestPayload,
       requestedBy: authUser.uid,
-      requestedByName: authUser.name || portalUser?.name || '사용자',
-      requestedByEmail: authUser.email || portalUser?.email || '',
+      requestedByName: requesterName,
+      requestedByEmail: requesterEmail,
       requestedAt: now,
       createdAt: now,
       updatedAt: now,
     };
     // Immediately create project (no admin approval flow)
     const projectId = `p${Date.now()}`;
-    const slug = String(payload.name || '')
+    const slug = String(requestPayload.name || '')
       .toLowerCase()
       .replace(/[^a-z0-9가-힣\s-]/g, '')
       .replace(/\s+/g, '-')
       .slice(0, 50);
     const revenueFinancials = resolveProjectRevenueFinancials({
-      contractAmount: payload.contractAmount,
-      totalRevenueAmount: payload.totalRevenueAmount,
+      contractAmount: requestPayload.contractAmount,
+      totalRevenueAmount: requestPayload.totalRevenueAmount,
       preferredSource: 'totalRevenueAmount',
     });
-    const financialInputFlags = normalizeProjectFinancialInputFlagsForAmounts(payload.financialInputFlags, {
-      contractAmount: payload.contractAmount,
-      salesVatAmount: payload.salesVatAmount,
+    const financialInputFlags = normalizeProjectFinancialInputFlagsForAmounts(requestPayload.financialInputFlags, {
+      contractAmount: requestPayload.contractAmount,
+      salesVatAmount: requestPayload.salesVatAmount,
       totalRevenueAmount: revenueFinancials.totalRevenueAmount,
-      supportAmount: payload.supportAmount,
+      supportAmount: requestPayload.supportAmount,
     });
-    const paymentPlan = payload.paymentPlan || { contract: 0, interim: 0, final: 0 };
-    const requesterName = authUser.name || portalUser?.name || '사용자';
+    const paymentPlan = requestPayload.paymentPlan || { contract: 0, interim: 0, final: 0 };
     const project: Project = {
       id: projectId,
       slug,
@@ -2348,48 +2360,52 @@ export function PortalProvider({ children }: { children: ReactNode }) {
         reviewedByName: requesterName,
         reviewComment: 'PM 신규 등록',
       }],
-      name: payload.name,
-      officialContractName: payload.officialContractName,
-      status: normalizeProjectStatus(payload.status),
-      type: normalizeProjectType(payload.type),
-      phase: normalizeProjectPhase(payload.phase),
-      contractAmount: payload.contractAmount,
-      contractStart: payload.contractStart,
-      contractEnd: payload.contractEnd,
-      settlementType: normalizeSettlementType(payload.settlementType),
-      basis: normalizeBasis(payload.basis),
-      accountType: normalizeAccountType(payload.accountType),
-      fundInputMode: normalizeProjectFundInputMode(payload.fundInputMode),
-      settlementSheetPolicy: normalizeSettlementSheetPolicy(payload.settlementSheetPolicy, normalizeProjectFundInputMode(payload.fundInputMode)),
+      registeredById: ownerId,
+      registeredByName: ownerName,
+      registeredByEmail: ownerEmail,
+      registeredAt: now,
+      name: requestPayload.name,
+      officialContractName: requestPayload.officialContractName,
+      status: normalizeProjectStatus(requestPayload.status),
+      type: normalizeProjectType(requestPayload.type),
+      phase: normalizeProjectPhase(requestPayload.phase),
+      contractAmount: requestPayload.contractAmount,
+      contractStart: requestPayload.contractStart,
+      contractEnd: requestPayload.contractEnd,
+      settlementType: normalizeSettlementType(requestPayload.settlementType),
+      basis: normalizeBasis(requestPayload.basis),
+      accountType: normalizeAccountType(requestPayload.accountType),
+      fundInputMode: normalizeProjectFundInputMode(requestPayload.fundInputMode),
+      settlementSheetPolicy: normalizeSettlementSheetPolicy(requestPayload.settlementSheetPolicy, normalizeProjectFundInputMode(requestPayload.fundInputMode)),
       paymentPlan,
-      paymentPlanDesc: payload.paymentPlanDesc,
-      clientOrg: payload.clientOrg,
-      groupwareName: payload.groupwareName || '',
-      participantCondition: payload.participantCondition,
-      teamMembersDetailed: payload.teamMembersDetailed || [],
-      contractType: normalizeProjectContractType(payload.contractType),
-      projectPurpose: payload.projectPurpose,
+      paymentPlanDesc: requestPayload.paymentPlanDesc,
+      clientOrg: requestPayload.clientOrg,
+      groupwareName: requestPayload.groupwareName || '',
+      participantCondition: requestPayload.participantCondition,
+      teamMembersDetailed: requestPayload.teamMembersDetailed || [],
+      contractType: normalizeProjectContractType(requestPayload.contractType),
+      projectPurpose: requestPayload.projectPurpose,
       totalRevenueAmount: revenueFinancials.totalRevenueAmount,
-      supportAmount: payload.supportAmount,
-      salesVatAmount: payload.salesVatAmount,
+      supportAmount: requestPayload.supportAmount,
+      salesVatAmount: requestPayload.salesVatAmount,
       financialInputFlags,
-      settlementGuide: payload.settlementGuide,
-      contractDocument: payload.contractDocument,
-      department: payload.department,
-      cic: resolveProjectCic({ department: payload.department }),
-      teamName: payload.teamName,
-      managerId: payload.managerId || authUser.uid,
-      managerName: payload.managerName || authUser.name || portalUser?.name || '',
-      budgetCurrentYear: payload.contractAmount || 0,
+      settlementGuide: requestPayload.settlementGuide,
+      contractDocument: requestPayload.contractDocument,
+      department: requestPayload.department,
+      cic: resolveProjectCic({ department: requestPayload.department }),
+      teamName: requestPayload.teamName,
+      managerId: ownerId,
+      managerName: ownerName,
+      budgetCurrentYear: requestPayload.contractAmount || 0,
       taxInvoiceAmount: 0,
       profitRate: revenueFinancials.profitRate,
       profitAmount: revenueFinancials.profitAmount,
       isSettled: false,
-      finalPaymentNote: payload.finalPaymentNote || '',
+      finalPaymentNote: requestPayload.finalPaymentNote || '',
       confirmerName: '',
       lastCheckedAt: '',
       cashflowDiffNote: '',
-      description: payload.description,
+      description: requestPayload.description,
       createdAt: now,
       updatedAt: now,
     };
@@ -2416,7 +2432,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     const nextPortalProjectId = resolvePrimaryProjectId(nextPortalProjectIds, projectId) || projectId;
     const nextPortalProjectNames = {
       ...(portalUser?.projectNames || {}),
-      [projectId]: payload.name,
+      [projectId]: requestPayload.name,
     };
     await setDoc(doc(db, getOrgDocumentPath(orgId, 'members', authUser.uid)), {
       uid: authUser.uid,

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -516,6 +516,10 @@ export interface Project {
   orgId: string;
   cic?: string;
   registrationSource?: string;
+  registeredById?: string;
+  registeredByName?: string;
+  registeredByEmail?: string;
+  registeredAt?: string;
   executiveReviewStatus?: ProjectExecutiveReviewStatus;
   executiveReviewedAt?: string;
   executiveReviewedById?: string;
@@ -723,6 +727,9 @@ export interface ProjectRequestPayload {
   settlementGuide: string;
   finalPaymentNote?: string;
   projectPurpose: string;
+  registeredById?: string;
+  registeredByName?: string;
+  registeredByEmail?: string;
   managerId?: string;
   managerName: string;
   teamName: string;

--- a/src/app/platform/portal-project-selection.test.ts
+++ b/src/app/platform/portal-project-selection.test.ts
@@ -38,6 +38,20 @@ describe('portal project selection helpers', () => {
     expect(result.searchProjects.map((project) => project.id)).toEqual(['p-assigned', 'p-managed']);
   });
 
+  it('prioritizes registeredById as PM portal owner over legacy managerId', () => {
+    const result = resolvePortalProjectCandidates({
+      role: 'pm',
+      authUid: 'owner-1',
+      assignedProjectIds: [],
+      projects: [
+        { id: 'p-owner', name: 'Owner Project', registeredById: 'owner-1', managerId: 'legacy-other' },
+        { id: 'p-legacy', name: 'Legacy Project', registeredById: 'other', managerId: 'owner-1' },
+      ] as unknown as Project[],
+    });
+
+    expect(result.searchProjects.map((project) => project.id)).toEqual(['p-owner']);
+  });
+
   it('lets admin and finance search the full project pool', () => {
     const adminResult = resolvePortalProjectCandidates({
       role: 'admin',

--- a/src/app/platform/portal-project-selection.ts
+++ b/src/app/platform/portal-project-selection.ts
@@ -66,7 +66,9 @@ export function resolvePortalProjectCandidates(input: {
   const assignedProjectIds = new Set(normalizeProjectIds(input.assignedProjectIds || []));
   const authUid = typeof input.authUid === 'string' ? input.authUid.trim() : '';
   const allowedProjects = projects.filter((project) => (
-    assignedProjectIds.has(project.id) || (authUid && project.managerId === authUid)
+    assignedProjectIds.has(project.id)
+    || (authUid && project.registeredById === authUid)
+    || (authUid && !project.registeredById && project.managerId === authUid)
   ));
 
   return {

--- a/src/app/platform/project-editor.test.ts
+++ b/src/app/platform/project-editor.test.ts
@@ -99,11 +99,47 @@ describe('project editor draft mapping', () => {
 
     expect(draft.totalRevenueAmount).toBe(91_000);
     expect(draft.currency).toBe('KRW');
+    expect(draft.registeredById).toBe('pm-1');
+    expect(draft.registeredByName).toBe('김다은');
     expect(draft.profitAmount).toBe(91_000);
     expect(draft.profitRate).toBe(0.91);
     expect(draft.teamMembersDetailed).toEqual([
       { memberName: '김다은', memberNickname: '데이나', role: 'PM', participationRate: 60 },
     ]);
+  });
+
+  it('uses selected registeredBy member as the project owner source of truth', () => {
+    const base = {
+      ...baseProject,
+      registeredById: 'writer-1',
+      registeredByName: '기존 작성자',
+      registeredByEmail: 'writer@mysc.co.kr',
+      managerId: 'writer-1',
+      managerName: '기존 작성자',
+    };
+    const draft = createProjectEditorDraft({
+      ...buildProjectEditorDraftFromProject(base),
+      registeredById: 'member-2',
+      registeredByName: '새 담당자',
+      registeredByEmail: 'member2@mysc.co.kr',
+    });
+
+    const patch = buildProjectEditorProjectPatch(draft, {
+      baseProject: base,
+      mode: 'admin',
+      actorId: 'admin-1',
+      actorName: '관리자',
+      now: '2026-05-28T00:00:00.000Z',
+    });
+    const payload = buildProjectRequestPayloadFromDraft(draft);
+
+    expect(patch.registeredById).toBe('member-2');
+    expect(patch.registeredByName).toBe('새 담당자');
+    expect(patch.registeredByEmail).toBe('member2@mysc.co.kr');
+    expect(patch.managerId).toBe('member-2');
+    expect(patch.managerName).toBe('새 담당자');
+    expect(payload.registeredById).toBe('member-2');
+    expect(payload.managerName).toBe('새 담당자');
   });
 
   it('treats an explicit empty project team list as the current edit value', () => {
@@ -239,7 +275,9 @@ describe('project editor draft mapping', () => {
       ...buildProjectEditorDraftFromProject(baseProject),
       name: '기후테크수정',
       totalRevenueAmount: 93_000,
-      managerName: '변민욱',
+      registeredById: 'pm-2',
+      registeredByName: '변민욱',
+      registeredByEmail: 'boram@mysc.co.kr',
     });
 
     const changes = buildProjectEditorReviewChanges(baseProject, draft);
@@ -258,8 +296,8 @@ describe('project editor draft mapping', () => {
         after: '93,000원',
       },
       {
-        key: 'managerName',
-        label: 'PM',
+        key: 'registeredByName',
+        label: '사업 담당자',
         before: '김다은',
         after: '변민욱',
       },

--- a/src/app/platform/project-editor.ts
+++ b/src/app/platform/project-editor.ts
@@ -74,6 +74,9 @@ export interface ProjectEditorDraft {
   settlementSheetPolicy: SettlementSheetPolicy;
   profitRate: number;
   profitAmount: number;
+  registeredById: string;
+  registeredByName: string;
+  registeredByEmail: string;
   managerId: string;
   managerName: string;
   teamName: string;
@@ -127,6 +130,9 @@ const DEFAULT_DRAFT: ProjectEditorDraft = {
   settlementSheetPolicy: createSettlementSheetPolicy('STANDARD'),
   profitRate: 0,
   profitAmount: 0,
+  registeredById: '',
+  registeredByName: '',
+  registeredByEmail: '',
   managerId: '',
   managerName: '',
   teamName: '',
@@ -215,7 +221,7 @@ const REVIEW_CHANGE_FIELDS: Array<{
   { key: 'basis', label: '정산 기준', before: (project) => BASIS_LABELS[normalizeBasis(project.basis)] || '-', after: (draft) => BASIS_LABELS[normalizeBasis(draft.basis)] || '-' },
   { key: 'accountType', label: '통장 유형', before: (project) => ACCOUNT_TYPE_LABELS[normalizeAccountType(project.accountType)] || '-', after: (draft) => ACCOUNT_TYPE_LABELS[normalizeAccountType(draft.accountType)] || '-' },
   { key: 'fundInputMode', label: '자금 입력 방식', before: (project) => PROJECT_FUND_INPUT_MODE_LABELS[normalizeProjectFundInputMode(project.fundInputMode)] || '-', after: (draft) => PROJECT_FUND_INPUT_MODE_LABELS[normalizeProjectFundInputMode(draft.fundInputMode)] || '-' },
-  { key: 'managerName', label: 'PM', before: (project) => normalizeChangeValue(project.managerName), after: (draft) => normalizeChangeValue(draft.managerName) },
+  { key: 'registeredByName', label: '사업 담당자', before: (project) => normalizeChangeValue(project.registeredByName || project.managerName), after: (draft) => normalizeChangeValue(draft.registeredByName || draft.managerName) },
   { key: 'teamName', label: '사내기업팀', before: (project) => normalizeChangeValue(project.teamName), after: (draft) => normalizeChangeValue(draft.teamName) },
   { key: 'teamMembersDetailed', label: '서류상 참여인력', before: (project) => formatTeamMembersForChange(project.teamMembersDetailed), after: (draft) => formatTeamMembersForChange(draft.teamMembersDetailed) },
   { key: 'paymentPlan', label: '입금 분할', before: (project) => formatPaymentPlanForChange(project.paymentPlan), after: (draft) => formatPaymentPlanForChange(draft.paymentPlan) },
@@ -252,6 +258,11 @@ export function createProjectEditorDraft(overrides: Partial<ProjectEditorDraft> 
     ),
     contractType: normalizeProjectContractType(overrides.contractType ?? DEFAULT_DRAFT.contractType),
     currency: normalizeProjectCurrency(overrides.currency ?? DEFAULT_DRAFT.currency),
+    registeredById: text(overrides.registeredById ?? overrides.managerId ?? DEFAULT_DRAFT.registeredById),
+    registeredByName: text(overrides.registeredByName ?? overrides.managerName ?? DEFAULT_DRAFT.registeredByName),
+    registeredByEmail: text(overrides.registeredByEmail ?? DEFAULT_DRAFT.registeredByEmail),
+    managerId: text(overrides.registeredById ?? overrides.managerId ?? DEFAULT_DRAFT.managerId),
+    managerName: text(overrides.registeredByName ?? overrides.managerName ?? DEFAULT_DRAFT.managerName),
     paymentPlan: normalizePaymentPlan(overrides.paymentPlan ?? DEFAULT_DRAFT.paymentPlan),
     teamMembersDetailed: normalizeProjectTeamMembers(overrides.teamMembersDetailed),
   };
@@ -307,8 +318,11 @@ export function buildProjectEditorDraftFromProject(
     ),
     profitRate: normalizedProject.profitRate,
     profitAmount: normalizedProject.profitAmount,
-    managerId: text(normalizedProject.managerId),
-    managerName: text(normalizedProject.managerName || payload?.managerName),
+    registeredById: text(normalizedProject.registeredById || payload?.registeredById || normalizedProject.managerId || payload?.managerId),
+    registeredByName: text(normalizedProject.registeredByName || payload?.registeredByName || normalizedProject.managerName || payload?.managerName),
+    registeredByEmail: text(normalizedProject.registeredByEmail || payload?.registeredByEmail),
+    managerId: text(normalizedProject.registeredById || payload?.registeredById || normalizedProject.managerId || payload?.managerId),
+    managerName: text(normalizedProject.registeredByName || payload?.registeredByName || normalizedProject.managerName || payload?.managerName),
     teamName: text(normalizedProject.teamName || payload?.teamName),
     teamMembersDetailed,
     participantCondition: text(normalizedProject.participantCondition || payload?.participantCondition),
@@ -357,8 +371,11 @@ export function buildProjectRequestPayloadFromDraft(draftInput: ProjectEditorDra
     settlementGuide: text(draft.settlementGuide),
     finalPaymentNote: text(draft.finalPaymentNote),
     projectPurpose: text(draft.projectPurpose),
-    managerId: text(draft.managerId),
-    managerName: text(draft.managerName),
+    registeredById: text(draft.registeredById),
+    registeredByName: text(draft.registeredByName),
+    registeredByEmail: text(draft.registeredByEmail),
+    managerId: text(draft.registeredById),
+    managerName: text(draft.registeredByName),
     teamName: text(draft.teamName),
     teamMembers: formatProjectTeamMembersSummary(teamMembersDetailed, '', ', '),
     teamMembersDetailed,
@@ -457,8 +474,11 @@ export function buildProjectEditorProjectPatch(
     department: text(draft.department),
     cic: resolveProjectCic({ department: draft.department }),
     teamName: text(draft.teamName),
-    managerId: text(draft.managerId),
-    managerName: text(draft.managerName),
+    registeredById: text(draft.registeredById),
+    registeredByName: text(draft.registeredByName),
+    registeredByEmail: text(draft.registeredByEmail),
+    managerId: text(draft.registeredById),
+    managerName: text(draft.registeredByName),
     budgetCurrentYear: nonNegativeAmount(draft.budgetCurrentYear || draft.contractAmount),
     taxInvoiceAmount: nonNegativeAmount(draft.taxInvoiceAmount),
     profitRate: draft.profitRate,

--- a/src/app/platform/project-migration-console.test.ts
+++ b/src/app/platform/project-migration-console.test.ts
@@ -114,9 +114,27 @@ describe('project-migration-console', () => {
 
     expect(records).toHaveLength(3);
     expect(records.map((record) => record.id)).toEqual(['p-1', 'p-2', 'p-3']);
-    expect(records[0].status).toBe('PENDING');
+    expect(records[0].status).toBe('APPROVED');
     expect(records[1].status).toBe('REVISION_REJECTED');
     expect(records[2].status).toBe('APPROVED');
+  });
+
+  it('treats linked pending project request as pending even when registrationSource is missing', () => {
+    const records = buildMigrationAuditConsoleRecords(
+      [makeProject({
+        id: 'p-cts2',
+        name: '2026 CTS2',
+        registrationSource: undefined,
+        executiveReviewStatus: 'PENDING',
+      })],
+      [makeRequest({
+        id: 'pr-cts2',
+        status: 'PENDING',
+        approvedProjectId: 'p-cts2',
+      })],
+    );
+
+    expect(records[0]?.status).toBe('PENDING');
   });
 
   it('filters by cic and review status', () => {

--- a/src/app/platform/project-migration-console.ts
+++ b/src/app/platform/project-migration-console.ts
@@ -54,9 +54,15 @@ function deriveProjectRequestMap(requests: ProjectRequest[]): Map<string, Projec
   return map;
 }
 
-export function deriveMigrationAuditStatus(project: Project): MigrationAuditConsoleStatus {
-  if (project.registrationSource !== 'pm_portal') return 'APPROVED';
-  return project.executiveReviewStatus || 'PENDING';
+export function deriveMigrationAuditStatus(
+  project: Project,
+  request?: ProjectRequest | null,
+): MigrationAuditConsoleStatus {
+  if (request?.status === 'PENDING') return 'PENDING';
+  if (project.executiveReviewStatus) return project.executiveReviewStatus;
+  if (request?.status === 'REJECTED') return 'REVISION_REJECTED';
+  if (request?.status === 'APPROVED') return 'APPROVED';
+  return project.registrationSource === 'pm_portal' ? 'PENDING' : 'APPROVED';
 }
 
 export function getMigrationAuditStatusLabel(status: MigrationAuditConsoleStatus): string {
@@ -84,11 +90,11 @@ export function buildMigrationAuditConsoleRecords(
         id: project.id,
         project,
         request,
-        status: deriveMigrationAuditStatus(project),
+        status: deriveMigrationAuditStatus(project, request),
         cic: normalizeCicLabel(project.cic || project.department),
         title: normalizeText(project.officialContractName || project.name) || '이름 없음',
         clientOrg: normalizeText(project.clientOrg),
-        managerName: normalizeText(project.managerName),
+        managerName: normalizeText(project.registeredByName || project.managerName),
         requestedAt: normalizeText(request?.requestedAt || project.createdAt),
       };
     })

--- a/src/app/platform/project-migration-review-dossier.ts
+++ b/src/app/platform/project-migration-review-dossier.ts
@@ -208,7 +208,7 @@ export function buildMigrationReviewDossier(
     identity: {
       clientOrg: readable(project.clientOrg || payload?.clientOrg),
       cic: readable(project.cic || project.department || payload?.department),
-      pmName: readable(project.managerName || payload?.managerName),
+      pmName: readable(project.registeredByName || payload?.registeredByName || project.managerName || payload?.managerName),
       department: readable(project.department || payload?.department),
       officialContractName: readable(project.officialContractName || payload?.officialContractName || project.name),
       groupwareName: readable(project.groupwareName || payload?.groupwareName),

--- a/src/app/platform/project-owner-assignment.test.ts
+++ b/src/app/platform/project-owner-assignment.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { buildProjectOwnerAssignmentPatches } from './project-owner-assignment';
+
+describe('project owner assignment patches', () => {
+  it('adds project to next registered owner and removes from previous owner', () => {
+    const patches = buildProjectOwnerAssignmentPatches({
+      projectId: 'p1',
+      projectName: '테스트 사업',
+      previousOwnerId: 'old',
+      nextOwner: { uid: 'new', name: '새 담당자', email: 'new@mysc.co.kr' },
+      previousMember: { projectIds: ['p1', 'p2'], projectNames: { p1: '테스트 사업' } },
+      nextMember: { projectIds: ['p3'], projectNames: {} },
+    });
+
+    expect(patches.project).toMatchObject({
+      registeredById: 'new',
+      registeredByName: '새 담당자',
+      registeredByEmail: 'new@mysc.co.kr',
+      managerId: 'new',
+      managerName: '새 담당자',
+    });
+    expect(patches.requestPayload).toMatchObject({
+      registeredById: 'new',
+      registeredByName: '새 담당자',
+      registeredByEmail: 'new@mysc.co.kr',
+      managerId: 'new',
+      managerName: '새 담당자',
+    });
+    expect(patches.previous?.projectIds).toEqual(['p2']);
+    expect(patches.next?.projectIds).toEqual(['p3', 'p1']);
+    expect(patches.next?.projectNames?.p1).toBe('테스트 사업');
+  });
+
+  it('does not remove ownership when the selected owner is unchanged', () => {
+    const patches = buildProjectOwnerAssignmentPatches({
+      projectId: 'p1',
+      projectName: '테스트 사업',
+      previousOwnerId: 'same',
+      nextOwner: { uid: 'same', name: '같은 담당자' },
+      previousMember: { projectIds: ['p1'], projectNames: { p1: '테스트 사업' } },
+      nextMember: { projectIds: ['p1'], projectNames: { p1: '테스트 사업' } },
+    });
+
+    expect(patches.previous).toBeNull();
+    expect(patches.next?.projectIds).toEqual(['p1']);
+  });
+});

--- a/src/app/platform/project-owner-assignment.ts
+++ b/src/app/platform/project-owner-assignment.ts
@@ -1,0 +1,50 @@
+export interface ProjectOwnerAssignmentMemberSnapshot {
+  projectIds?: string[];
+  projectNames?: Record<string, string>;
+}
+
+export interface ProjectOwnerAssignmentOwner {
+  uid: string;
+  name: string;
+  email?: string;
+}
+
+export function buildProjectOwnerAssignmentPatches(input: {
+  projectId: string;
+  projectName: string;
+  previousOwnerId?: string;
+  nextOwner?: ProjectOwnerAssignmentOwner;
+  previousMember?: ProjectOwnerAssignmentMemberSnapshot;
+  nextMember?: ProjectOwnerAssignmentMemberSnapshot;
+}) {
+  const projectId = input.projectId.trim();
+  const projectName = input.projectName.trim();
+  const nextOwnerId = input.nextOwner?.uid.trim() || '';
+  const nextOwnerName = input.nextOwner?.name.trim() || '';
+  const nextOwnerEmail = input.nextOwner?.email?.trim() || '';
+  const previousIds = (input.previousMember?.projectIds || []).filter((id) => id !== projectId);
+  const previousNames = { ...(input.previousMember?.projectNames || {}) };
+  delete previousNames[projectId];
+
+  const nextIds = Array.from(new Set([...(input.nextMember?.projectIds || []), projectId]));
+  const nextNames = { ...(input.nextMember?.projectNames || {}), [projectId]: projectName };
+
+  const ownerPatch = nextOwnerId ? {
+    registeredById: nextOwnerId,
+    registeredByName: nextOwnerName,
+    registeredByEmail: nextOwnerEmail,
+    managerId: nextOwnerId,
+    managerName: nextOwnerName,
+  } : null;
+
+  return {
+    project: ownerPatch,
+    requestPayload: ownerPatch,
+    previous: input.previousOwnerId && input.previousOwnerId !== nextOwnerId
+      ? { projectIds: previousIds, projectNames: previousNames }
+      : null,
+    next: nextOwnerId
+      ? { projectIds: nextIds, projectNames: nextNames, projectId }
+      : null,
+  };
+}


### PR DESCRIPTION
## Summary
- add registeredBy* as the project owner source of truth and mirror legacy manager fields
- make project owner selection member-ID based in project edit/register flows
- prioritize linked project request status in approval review queue
- add read-only owner consistency audit script

## Verification
- npx vitest run src/app/platform/project-migration-console.test.ts src/app/platform/project-editor.test.ts src/app/platform/portal-project-selection.test.ts src/app/platform/project-owner-assignment.test.ts src/app/components/projects/ProjectEditorWizard.shell.test.ts src/app/components/projects/ProjectListPage.shell.test.ts
- npm run build

## Data policy
- no live Firestore corrections are applied by this PR
- audit script is read-only