### PR TITLE
Loosen project approval schema and close PM dashboard

### DIFF
--- a/src/app/components/approval/AdminApprovalPage.shell.test.ts
+++ b/src/app/components/approval/AdminApprovalPage.shell.test.ts
@@ -9,6 +9,7 @@ describe('AdminApprovalPage shell contract', () => {
     expect(source).toContain('ProjectMigrationAuditPage');
     expect(source).toContain('<ProjectMigrationAuditPage embedded reviewScope="pending" />');
     expect(source).toContain('pendingProjectReviews');
+    expect(source).toContain('project.executiveReviewStatus');
     expect(source).toContain('프로젝트 등록 검토');
     expect(source).toContain('대표 검토');
     expect(source).toContain('프로젝트 등록 요청부터 먼저 정리합니다');

--- a/src/app/components/approval/AdminApprovalPage.tsx
+++ b/src/app/components/approval/AdminApprovalPage.tsx
@@ -108,8 +108,7 @@ export function AdminApprovalPage() {
   );
   const pendingProjectReviews = useMemo(
     () => projects.filter((project) => (
-      project.registrationSource === 'pm_portal'
-      && (project.executiveReviewStatus || 'PENDING') === 'PENDING'
+      (project.executiveReviewStatus || (project.registrationSource === 'pm_portal' ? 'PENDING' : 'APPROVED')) === 'PENDING'
     )),
     [projects],
   );

--- a/src/app/components/portal/PortalLayout.tsx
+++ b/src/app/components/portal/PortalLayout.tsx
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { Outlet, NavLink, useLocation, useNavigate } from 'react-router';
 import {
-  LayoutDashboard, Calculator,
+  Calculator,
   LogOut,
   FolderKanban, Menu,
   Plus, Pencil,
@@ -86,7 +86,6 @@ const NAV_SECTIONS = [
   {
     title: '마이메뉴',
     items: [
-      { to: '/portal', icon: LayoutDashboard, label: '내 프로젝트 현황', exact: true },
       { to: '/portal/business-cards', icon: UserRoundCheck, label: '명함 DB' },
       { to: '/portal/payroll', icon: CircleDollarSign, label: '인건비/공지', accent: true },
     ],
@@ -273,7 +272,7 @@ function PortalContent() {
   const topNavItems = useMemo(() => navSections.flatMap((section) => section.items), [navSections]);
   const currentSectionLabel = useMemo(() => {
     const current = topNavItems.find((item) => isActive(item.to, item.exact));
-    return current?.label || '내 프로젝트 현황';
+    return current?.label || '프로젝트 선택';
   }, [topNavItems, location.pathname]);
   const shellCommandItems = useMemo(() => buildPortalShellCommandItems({
     role: authUser?.role,

--- a/src/app/components/portal/PortalProjectSettings.shell.test.ts
+++ b/src/app/components/portal/PortalProjectSettings.shell.test.ts
@@ -11,7 +11,7 @@ describe('PortalProjectSettings shell contract', () => {
   it('keeps only assignment and primary-project editing while preserving save navigation', () => {
     expect(portalProjectSettingsSource).toContain('선택한 프로젝트와 주 프로젝트를 확인하세요.');
     expect(portalProjectSettingsSource).toContain('주 프로젝트 저장');
-    expect(portalProjectSettingsSource).toContain("navigate('/portal', { replace: true });");
+    expect(portalProjectSettingsSource).toContain("navigate('/portal/project-select', { replace: true });");
     expect(portalProjectSettingsSource).toContain('선택한 프로젝트만 보기');
     expect(portalProjectSettingsSource).toContain('주 프로젝트로 지정');
     expect(portalProjectSettingsSource).toContain('프로젝트명, 계약 대상, 담당자로 검색');

--- a/src/app/components/portal/PortalProjectSettings.tsx
+++ b/src/app/components/portal/PortalProjectSettings.tsx
@@ -229,7 +229,7 @@ export function PortalProjectSettings() {
       return;
     }
 
-    navigate('/portal', { replace: true });
+    navigate('/portal/project-select', { replace: true });
   };
 
   return (

--- a/src/app/components/projects/ProjectMigrationAuditPage.shell.test.ts
+++ b/src/app/components/projects/ProjectMigrationAuditPage.shell.test.ts
@@ -56,6 +56,12 @@ describe('ProjectMigrationAuditPage shell contract', () => {
     expect(pageSource).toContain('trashedReason: trashReason');
   });
 
+  it('listens to both canonical and legacy project request collections', () => {
+    expect(pageSource).toContain("const PROJECT_REQUEST_COLLECTIONS: ProjectRequestCollectionName[] = ['project_requests', 'projectRequests']");
+    expect(pageSource).toContain('__collectionName: collectionName');
+    expect(compositeSource).toContain('isMigrationAuditPmRegistration');
+  });
+
   it('shows the uploaded contract PDF next to analysis notes', () => {
     expect(detailSource).toContain('계약 분석 보조 정보');
     expect(detailSource).toContain('ContractDocumentPreview');

--- a/src/app/components/projects/ProjectMigrationAuditPage.tsx
+++ b/src/app/components/projects/ProjectMigrationAuditPage.tsx
@@ -16,7 +16,7 @@ import type {
   ProjectExecutiveReviewStatus,
   ProjectRequest,
 } from '../../data/types';
-import { getOrgCollectionPath, getOrgDocumentPath } from '../../lib/firebase';
+import { getOrgDocumentPath, getOrgRootPath } from '../../lib/firebase';
 import { useFirebase } from '../../lib/firebase-context';
 import { isPlatformApiEnabled, reviewProjectExecutiveStatusViaBff } from '../../lib/platform-bff-client';
 import {
@@ -45,6 +45,12 @@ import {
 import { Textarea } from '../ui/textarea';
 
 type ReviewActionMode = 'approve' | 'reject' | 'discard';
+type ProjectRequestCollectionName = 'project_requests' | 'projectRequests';
+type ProjectRequestWithSource = ProjectRequest & {
+  __collectionName?: ProjectRequestCollectionName;
+};
+
+const PROJECT_REQUEST_COLLECTIONS: ProjectRequestCollectionName[] = ['project_requests', 'projectRequests'];
 
 function getReviewDialogTitle(mode: ReviewActionMode): string {
   if (mode === 'approve') return '이 프로젝트를 승인할까요?';
@@ -140,26 +146,51 @@ export function ProjectMigrationAuditPage({
     }
 
     setLoadingRequests(true);
-    const requestQuery = query(
-      collection(db, getOrgCollectionPath(orgId, 'projectRequests')),
-      orderBy('requestedAt', 'desc'),
-    );
+    const sourceRows = new Map<ProjectRequestCollectionName, ProjectRequestWithSource[]>();
+    const initializedSources = new Set<ProjectRequestCollectionName>();
+    let disposed = false;
 
-    const unsubscribe = onSnapshot(
-      requestQuery,
-      (snapshot) => {
-        const next = snapshot.docs.map((docSnap) => docSnap.data() as ProjectRequest);
-        setRequests(next);
+    const publish = () => {
+      if (disposed) return;
+      setRequests(Array.from(sourceRows.values()).flat());
+      if (initializedSources.size === PROJECT_REQUEST_COLLECTIONS.length) {
         setLoadingRequests(false);
-      },
-      (error) => {
-        console.error('[ProjectMigrationAuditPage] project request listen error:', error);
-        setRequests([]);
-        setLoadingRequests(false);
-      },
-    );
+      }
+    };
 
-    return () => unsubscribe();
+    const unsubscribers = PROJECT_REQUEST_COLLECTIONS.map((collectionName) => {
+      const requestQuery = query(
+        collection(db, `${getOrgRootPath(orgId)}/${collectionName}`),
+        orderBy('requestedAt', 'desc'),
+      );
+
+      return onSnapshot(
+        requestQuery,
+        (snapshot) => {
+          sourceRows.set(
+            collectionName,
+            snapshot.docs.map((docSnap) => ({
+              ...(docSnap.data() as ProjectRequest),
+              id: String((docSnap.data() as ProjectRequest).id || docSnap.id),
+              __collectionName: collectionName,
+            })),
+          );
+          initializedSources.add(collectionName);
+          publish();
+        },
+        (error) => {
+          console.error(`[ProjectMigrationAuditPage] ${collectionName} listen error:`, error);
+          sourceRows.set(collectionName, []);
+          initializedSources.add(collectionName);
+          publish();
+        },
+      );
+    });
+
+    return () => {
+      disposed = true;
+      unsubscribers.forEach((unsubscribe) => unsubscribe());
+    };
   }, [db, isOnline, orgId]);
 
   const records = useMemo(
@@ -249,6 +280,7 @@ export function ProjectMigrationAuditPage({
           console.warn('[ProjectMigrationAuditPage] executive review slack not delivered:', response.slackReason);
         }
       } else {
+        const requestCollectionName = (activeRecord.request as ProjectRequestWithSource | null)?.__collectionName || 'project_requests';
         await updateProject(activeRecord.project.id, {
           executiveReviewStatus: nextExecutiveStatus,
           executiveReviewedAt: now,
@@ -276,7 +308,9 @@ export function ProjectMigrationAuditPage({
 
         if (db && activeRecord.request) {
           await setDoc(
-            doc(db, getOrgDocumentPath(orgId, 'projectRequests', activeRecord.request.id)),
+            requestCollectionName === 'project_requests'
+              ? doc(db, getOrgDocumentPath(orgId, 'projectRequests', activeRecord.request.id))
+              : doc(db, `${getOrgRootPath(orgId)}/${requestCollectionName}/${activeRecord.request.id}`),
             buildProjectRequestReviewPatch({
               projectId: activeRecord.project.id,
               reviewerId,

--- a/src/app/components/projects/migration-audit/MigrationAuditDetailPanel.tsx
+++ b/src/app/components/projects/migration-audit/MigrationAuditDetailPanel.tsx
@@ -12,6 +12,7 @@ import type { MigrationAuditConsoleRecord } from '../../../platform/project-migr
 import {
   describeMigrationAuditActionState,
   getMigrationAuditStatusLabel,
+  isMigrationAuditPmRegistration,
 } from '../../../platform/project-migration-console';
 import { buildMigrationReviewDossier } from '../../../platform/project-migration-review-dossier';
 import { Badge } from '../../ui/badge';
@@ -167,7 +168,7 @@ export function MigrationAuditDetailPanel({
 
   const dossier = buildMigrationReviewDossier(record.project, record.request);
   const actionState = describeMigrationAuditActionState(record);
-  const isPmPortalProject = record.project.registrationSource === 'pm_portal';
+  const isPmPortalProject = isMigrationAuditPmRegistration(record);
   const contractDocument = record.project.contractDocument || record.request?.payload.contractDocument || null;
 
   return (

--- a/src/app/components/projects/migration-audit/MigrationAuditQueueRail.tsx
+++ b/src/app/components/projects/migration-audit/MigrationAuditQueueRail.tsx
@@ -5,7 +5,10 @@ import type {
   MigrationAuditConsoleRecord,
   MigrationAuditConsoleStatus,
 } from '../../../platform/project-migration-console';
-import { getMigrationAuditStatusLabel } from '../../../platform/project-migration-console';
+import {
+  getMigrationAuditStatusLabel,
+  isMigrationAuditPmRegistration,
+} from '../../../platform/project-migration-console';
 
 interface MigrationAuditQueueRailProps {
   records: MigrationAuditConsoleRecord[];
@@ -25,7 +28,7 @@ function formatRequestedAt(value: string) {
 }
 
 function getSourceLabel(record: MigrationAuditConsoleRecord) {
-  return record.project.registrationSource === 'pm_portal' ? 'PM 등록' : '기존 등록';
+  return isMigrationAuditPmRegistration(record) ? 'PM 등록' : '기존 등록';
 }
 
 export function MigrationAuditQueueRail({

--- a/src/app/platform/admin-command-index.ts
+++ b/src/app/platform/admin-command-index.ts
@@ -327,19 +327,6 @@ const ADMIN_COMMAND_DEFINITIONS: AdminCommandItem[] = [
 
 const PM_COMMAND_DEFINITIONS: AdminCommandItem[] = [
   {
-    id: 'pm:dashboard',
-    label: 'PM 내 프로젝트 현황',
-    description: '담당 프로젝트의 예산, 사업비, 캐시플로 상태를 봅니다.',
-    category: 'PM',
-    scope: 'pm',
-    to: '/portal',
-    icon: 'dashboard',
-    kind: 'page',
-    priority: 110,
-    featured: true,
-    keywords: ['PM', '포털', '내 프로젝트', '내 사업', '사업 현황', '프로젝트 현황', '담당 프로젝트', '담당 사업', '홈', '대시보드', '상태'],
-  },
-  {
     id: 'pm:budget',
     label: 'PM 예산 편집',
     description: '예산 구조, 비목, 세목, 사업비 계획을 편집합니다.',

--- a/src/app/platform/project-migration-console.test.ts
+++ b/src/app/platform/project-migration-console.test.ts
@@ -6,6 +6,7 @@ import {
   describeMigrationAuditActionState,
   filterMigrationAuditConsoleRecords,
   findMigrationAuditRecord,
+  isMigrationAuditPmRegistration,
   normalizeCicLabel,
   summarizeMigrationAuditConsole,
 } from './project-migration-console';
@@ -135,6 +136,7 @@ describe('project-migration-console', () => {
     );
 
     expect(records[0]?.status).toBe('PENDING');
+    expect(isMigrationAuditPmRegistration(records[0])).toBe(true);
   });
 
   it('filters by cic and review status', () => {

--- a/src/app/platform/project-migration-console.ts
+++ b/src/app/platform/project-migration-console.ts
@@ -72,6 +72,10 @@ export function getMigrationAuditStatusLabel(status: MigrationAuditConsoleStatus
   return '검토 대기';
 }
 
+export function isMigrationAuditPmRegistration(record: MigrationAuditConsoleRecord): boolean {
+  return !!record.request || record.project.registrationSource === 'pm_portal';
+}
+
 export function buildMigrationAuditConsoleRecords(
   projects: Project[],
   requests: ProjectRequest[],

--- a/src/app/routes.lazy-route.shell.test.ts
+++ b/src/app/routes.lazy-route.shell.test.ts
@@ -20,4 +20,9 @@ describe('route lazy loading safety', () => {
     expect(routesSource).toContain('shouldUseBusinessCardMobileEntry');
     expect(routesSource).toContain('{ index: true, element: <MobileAwareAdminHome /> }');
   });
+
+  it('closes the PM portal project dashboard route by sending /portal to project selection', () => {
+    expect(routesSource).toContain('{ index: true, element: <Navigate to="/portal/project-select" replace /> }');
+    expect(routesSource).not.toContain('{ index: true, element: <S C={PortalDashboard} /> }');
+  });
 });

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -46,7 +46,6 @@ const NotFoundPage = lazy(() => import('./components/layout/NotFoundPage').then(
 // Portal pages
 const PortalOnboarding = lazy(() => import('./components/portal/PortalOnboarding').then(m => ({ default: m.PortalOnboarding })));
 const PortalProjectSelectPage = lazy(() => import('./components/portal/PortalProjectSelectPage').then(m => ({ default: m.PortalProjectSelectPage })));
-const PortalDashboard = lazy(() => import('./components/portal/PortalDashboard').then(m => ({ default: m.PortalDashboard })));
 const PortalBudget = lazy(() => import('./components/portal/PortalBudget').then(m => ({ default: m.PortalBudget })));
 const PortalPersonnel = lazy(() => import('./components/portal/PortalPersonnel').then(m => ({ default: m.PortalPersonnel })));
 const PortalChangeRequests = lazy(() => import('./components/portal/PortalChangeRequests').then(m => ({ default: m.PortalChangeRequests })));
@@ -167,7 +166,7 @@ export const router = createBrowserRouter([
     path: '/portal',
     element: <PortalRouteShell />,
     children: [
-      { index: true, element: <S C={PortalDashboard} /> },
+      { index: true, element: <Navigate to="/portal/project-select" replace /> },
       // ── Company Board (전사 게시판) ──
       {
         path: 'board',
@@ -179,7 +178,7 @@ export const router = createBrowserRouter([
       { path: 'onboarding', element: <S C={PortalOnboarding} /> },
       { path: 'project-select', element: <S C={PortalProjectSelectPage} /> },
       { path: 'project-settings', element: <S C={PortalProjectSettings} /> },
-      { path: 'submissions', element: <Navigate to="/portal" replace /> },
+      { path: 'submissions', element: <Navigate to="/portal/project-select" replace /> },
       { path: 'payroll', element: <S C={PortalPayrollPage} /> },
       { path: 'cashflow', element: <S C={PortalCashflowPage} /> },
       { path: 'budget', element: <S C={PortalBudget} /> },


### PR DESCRIPTION
## Summary\n- Read both canonical and legacy project request collections in the PM registration approval console\n- Treat linked project requests as PM registration records even when legacy project fields are incomplete\n- Close the PM portal project dashboard by redirecting /portal to project selection and removing its nav/search entry\n\n## Verification\n- npx vitest run src/app/platform/project-migration-console.test.ts src/app/components/projects/ProjectMigrationAuditPage.shell.test.ts src/app/components/approval/AdminApprovalPage.shell.test.ts src/app/routes.lazy-route.shell.test.ts src/app/components/portal/PortalLayout.shell.test.ts src/app/components/portal/PortalProjectSettings.shell.test.ts\n- npm run build