### PR TITLE
fix: remove portal redirect loops

### DIFF
--- a/src/app/components/auth/WorkspaceSelectPage.tsx
+++ b/src/app/components/auth/WorkspaceSelectPage.tsx
@@ -26,7 +26,7 @@ const ADMIN_WORKSPACE_FEATURES = [
 ];
 
 const PM_WORKSPACE_FEATURES = [
-  '내 프로젝트 현황',
+  '프로젝트 선택',
   '예산 편집',
   '사업비 입력',
   '캐시플로',

--- a/src/app/components/dashboard/FeatureSearchPage.tsx
+++ b/src/app/components/dashboard/FeatureSearchPage.tsx
@@ -13,7 +13,7 @@ const ADMIN_ENTRY_POINTS = [
 ];
 
 const PM_ENTRY_POINTS = [
-  { label: '내 프로젝트 현황', to: '/portal' },
+  { label: '프로젝트 선택', to: '/portal/project-select' },
   { label: '예산 편집', to: '/portal/budget' },
   { label: '사업비 입력', to: '/portal/weekly-expenses' },
   { label: '프로젝트 등록 요청', to: '/portal/register-project' },

--- a/src/app/components/layout/AppLayout.shell.test.ts
+++ b/src/app/components/layout/AppLayout.shell.test.ts
@@ -29,7 +29,7 @@ describe('AppLayout LAB shell contract', () => {
   it('keeps the user portal switch next to the realtime status instead of inside LAB navigation', () => {
     expect(source).toContain('function openPortalWorkspace()');
     expect(source).toContain("setWorkspacePreference('portal'");
-    expect(source).toContain("navigate('/portal')");
+    expect(source).toContain("navigate('/portal/project-select')");
     expect(source).toContain('로그아웃 없이 사용자 포털로 이동');
     expect(source).toContain('사용자 포털');
   });

--- a/src/app/components/layout/AppLayout.tsx
+++ b/src/app/components/layout/AppLayout.tsx
@@ -60,7 +60,7 @@ function AppLayoutContent() {
         return;
       }
 
-      navigate('/portal', { replace: true });
+      navigate('/portal/project-select', { replace: true });
       return;
     }
 
@@ -105,7 +105,7 @@ function AppLayoutContent() {
 
   function openPortalWorkspace() {
     void setWorkspacePreference('portal', { persistDefault: false })
-      .finally(() => navigate('/portal'));
+      .finally(() => navigate('/portal/project-select'));
   }
 
   const pendingCount = transactions.filter(t => t.state === 'SUBMITTED').length;
@@ -194,12 +194,19 @@ function AppLayoutContent() {
         >
           {/* Brand */}
           <div className={`flex h-[48px] items-center px-3 ${collapsed ? 'justify-center overflow-hidden' : ''}`}>
-            <MyscWordmark
-              tone="onDark"
-              size={collapsed ? 'sm' : 'md'}
-              className={collapsed ? 'max-w-8 overflow-hidden' : ''}
-              imageClassName={collapsed ? 'max-w-none' : ''}
-            />
+            <button
+              type="button"
+              aria-label="홈으로 이동"
+              onClick={() => navigate('/')}
+              className="rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+            >
+              <MyscWordmark
+                tone="onDark"
+                size={collapsed ? 'sm' : 'md'}
+                className={collapsed ? 'max-w-8 overflow-hidden' : ''}
+                imageClassName={collapsed ? 'max-w-none' : ''}
+              />
+            </button>
           </div>
 
           {/* Quick search */}

--- a/src/app/components/portal/PortalDashboard.layout.test.ts
+++ b/src/app/components/portal/PortalDashboard.layout.test.ts
@@ -8,9 +8,9 @@ const portalDashboardSource = readFileSync(
 );
 
 describe('PortalDashboard closure', () => {
-  it('redirects the closed PM project status dashboard to project selection', () => {
-    expect(portalDashboardSource).toContain('Navigate');
-    expect(portalDashboardSource).toContain('to="/portal/project-select"');
+  it('keeps the closed PM project status dashboard off the route without redirecting', () => {
+    expect(portalDashboardSource).toContain('PortalProjectSelectPage');
+    expect(portalDashboardSource).not.toContain('Navigate');
     expect(portalDashboardSource).not.toContain('프로젝트 상세');
     expect(portalDashboardSource).not.toContain('내 제출 현황');
     expect(portalDashboardSource).not.toContain('사업 상태');

--- a/src/app/components/portal/PortalDashboard.tsx
+++ b/src/app/components/portal/PortalDashboard.tsx
@@ -1,5 +1,5 @@
-import { Navigate } from 'react-router';
+import { PortalProjectSelectPage } from './PortalProjectSelectPage';
 
 export function PortalDashboard() {
-  return <Navigate to="/portal/project-select" replace />;
+  return <PortalProjectSelectPage />;
 }

--- a/src/app/components/portal/PortalLayout.shell.test.ts
+++ b/src/app/components/portal/PortalLayout.shell.test.ts
@@ -68,11 +68,13 @@ describe('PortalLayout shell actions', () => {
     expect(portalLayoutSource).not.toContain("/portal/submissions");
   });
 
-  it('keeps onboarding bypass routes aligned with navigation policy', () => {
+  it('keeps portal navigation explicit without onboarding or project-select redirect effects', () => {
     expect(portalLayoutSource).toContain('isPortalStandaloneEntryPath');
     expect(portalLayoutSource).toContain("navigate('/portal/project-select')");
     expect(portalLayoutSource).toContain("navigate('/portal/weekly-expenses')");
     expect(portalLayoutSource).toContain("navigate('/portal/register-project')");
+    expect(portalLayoutSource).not.toContain('shouldForcePortalOnboarding');
+    expect(portalLayoutSource).not.toContain('resolvePortalProjectSelectPath(currentPath)');
   });
 
   it('exposes stable portal navigation test ids for release-gate flows', () => {

--- a/src/app/components/portal/PortalLayout.tsx
+++ b/src/app/components/portal/PortalLayout.tsx
@@ -65,17 +65,13 @@ import {
   canEnterPortalWorkspace,
   isPortalStandaloneEntryPath,
   isAdminSpaceRole,
-  shouldForcePortalOnboarding,
 } from '../../platform/navigation';
 import { addMonthsToYearMonth, getSeoulTodayIso } from '../../platform/business-days';
 import { normalizeProjectFundInputMode } from '../../data/types';
 import { rememberRecentPortalProject } from '../../platform/portal-recent-projects';
 import { buildPortalShellCommandItems, buildPortalShellNotificationItems } from '../../platform/portal-shell-actions';
 import { shouldShowShellRoute, useShellLabEnabled } from '../../platform/shell-lab-visibility';
-import {
-  resolvePortalProjectCandidates,
-  resolvePortalProjectSelectPath,
-} from '../../platform/portal-project-selection';
+import { resolvePortalProjectCandidates } from '../../platform/portal-project-selection';
 
 // ═══════════════════════════════════════════════════════════════
 // PortalLayout — 사용자(PM) 전용 레이아웃
@@ -155,7 +151,6 @@ export function usePortalNavigationGuard() {
 function PortalContent() {
   const {
     activeProjectId,
-    isRegistered,
     isLoading: portalLoading,
     portalUser,
     myProject,
@@ -325,39 +320,6 @@ function PortalContent() {
     if (authUser?.lastWorkspace === 'portal') return;
     void setWorkspacePreference('portal', { persistDefault: false });
   }, [authLoading, authUser?.lastWorkspace, authUser?.role, isAuthenticated, setWorkspacePreference]);
-
-  // 포털 미등록 시 온보딩으로 (인증은 되었지만 포털 프로젝트 미선택)
-  useEffect(() => {
-    if (authLoading || portalLoading) return;
-    if (shouldForcePortalOnboarding({
-      isAuthenticated,
-      role: authUser?.role,
-      isRegistered,
-      pathname: location.pathname,
-    })) {
-      navigate('/portal/onboarding', { replace: true });
-    }
-  }, [authLoading, portalLoading, isAuthenticated, authUser?.role, isRegistered, location.pathname, navigate]);
-
-  useEffect(() => {
-    if (authLoading || portalLoading) return;
-    if (!isAuthenticated || !canEnterPortalWorkspace(authUser?.role)) return;
-    if (location.pathname === '/portal/project-select') return;
-    if (location.pathname === '/portal/project-settings' || location.pathname === '/portal/register-project') return;
-    if (!isRegistered && (location.pathname === '/portal/onboarding' || location.pathname === '/portal/weekly-expenses')) return;
-    if (activeProjectId) return;
-    navigate(resolvePortalProjectSelectPath(currentPath), { replace: true });
-  }, [
-    activeProjectId,
-    authLoading,
-    authUser?.role,
-    currentPath,
-    isAuthenticated,
-    isRegistered,
-    location.pathname,
-    navigate,
-    portalLoading,
-  ]);
 
   // Close mobile sidebar on navigation
   useEffect(() => {
@@ -549,12 +511,19 @@ function PortalContent() {
         `}>
           {/* Brand */}
           <div className={`flex items-center gap-2.5 h-[48px] px-3 ${collapsed ? 'justify-center' : ''}`}>
-            <MyscWordmark
-              tone="onDark"
-              size={collapsed ? 'sm' : 'md'}
-              className={collapsed ? 'max-w-8 overflow-hidden' : ''}
-              imageClassName={collapsed ? 'max-w-none' : ''}
-            />
+            <button
+              type="button"
+              aria-label="포털 홈으로 이동"
+              onClick={() => navigate('/portal/project-select')}
+              className="rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+            >
+              <MyscWordmark
+                tone="onDark"
+                size={collapsed ? 'sm' : 'md'}
+                className={collapsed ? 'max-w-8 overflow-hidden' : ''}
+                imageClassName={collapsed ? 'max-w-none' : ''}
+              />
+            </button>
             {!collapsed && (
               <div className="flex-1" />
             )}
@@ -784,7 +753,14 @@ function PortalContent() {
                 <Menu className="h-4 w-4" />
               </button>
               <div className="flex min-w-0 items-center gap-2">
-                <MyscWordmark tone="onDark" size="md" className="shrink-0" />
+                <button
+                  type="button"
+                  aria-label="포털 홈으로 이동"
+                  onClick={() => navigate('/portal/project-select')}
+                  className="shrink-0 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+                >
+                  <MyscWordmark tone="onDark" size="md" />
+                </button>
               </div>
               <div className="hidden flex-1 items-center justify-center px-4 md:flex">
                 <button
@@ -968,7 +944,7 @@ function PortalContent() {
           <main className="flex-1 overflow-y-auto">
             <div className={useWidePortalCanvas ? 'w-full max-w-none px-3 py-4 md:px-5 md:py-6 xl:px-8' : 'mx-auto w-full max-w-[1480px] p-4 md:p-6'}>
               <PageTransition>
-                <ErrorBoundary homePath="/portal" resetKey={location.pathname}>
+                <ErrorBoundary homePath="/portal/project-select" resetKey={location.pathname}>
                   <Outlet />
                 </ErrorBoundary>
               </PageTransition>

--- a/src/app/components/portal/PortalOnboarding.tsx
+++ b/src/app/components/portal/PortalOnboarding.tsx
@@ -48,13 +48,6 @@ export function PortalOnboarding() {
   }, [authLoading, isAuthenticated, isAdminSpaceUser, navigate]);
 
   useEffect(() => {
-    if (authLoading || isLoading) return;
-    if (isRegistered) {
-      navigate('/portal', { replace: true });
-    }
-  }, [authLoading, isLoading, isRegistered, navigate]);
-
-  useEffect(() => {
     const merged = normalizeProjectIds([
       ...(Array.isArray(portalUser?.projectIds) ? portalUser.projectIds : []),
       portalUser?.projectId,
@@ -123,7 +116,7 @@ export function PortalOnboarding() {
       return;
     }
 
-    navigate('/portal', { replace: true });
+    navigate('/portal/project-select', { replace: true });
   };
 
   if (isLoading || authLoading) {

--- a/src/app/components/portal/PortalProjectEdit.tsx
+++ b/src/app/components/portal/PortalProjectEdit.tsx
@@ -334,7 +334,7 @@ export function PortalProjectEdit() {
       <Card className="border-dashed border-slate-200 bg-slate-50">
         <CardContent className="p-8 text-center">
           <p className="text-sm text-slate-600">수정할 프로젝트를 찾지 못했습니다.</p>
-          <Button className="mt-4" onClick={() => navigate('/portal')}>포털로 돌아가기</Button>
+          <Button className="mt-4" onClick={() => navigate('/portal/project-select')}>프로젝트 선택으로 돌아가기</Button>
         </CardContent>
       </Card>
     );
@@ -353,7 +353,7 @@ export function PortalProjectEdit() {
       ]}
       busyActionId={busyActionId}
       onContractFileUpload={handleContractFileUpload}
-      onCancel={() => navigate('/portal')}
+      onCancel={() => navigate('/portal/project-select')}
       onSubmit={(draft, actionId) => void handleSubmit(draft, actionId)}
       topSlot={executiveBanner ? (
         <div className={`rounded-2xl border px-4 py-4 ${bannerClassName(executiveBanner.tone)}`}>

--- a/src/app/components/portal/PortalProjectRegister.tsx
+++ b/src/app/components/portal/PortalProjectRegister.tsx
@@ -104,8 +104,8 @@ export function PortalProjectRegister() {
                 수정 화면과 승인 화면에서 같은 입력값을 기준으로 검토됩니다.
               </p>
             </div>
-            <Button onClick={() => navigate('/portal')} className="gap-2">
-              포털로 돌아가기
+            <Button onClick={() => navigate('/portal/project-select')} className="gap-2">
+              프로젝트 선택으로 돌아가기
             </Button>
           </CardContent>
         </Card>
@@ -123,7 +123,7 @@ export function PortalProjectRegister() {
       actions={[{ id: 'submit', label: '등록 요청 저장', icon: Send }]}
       busyActionId={busyActionId}
       onContractFileUpload={handleContractFileUpload}
-      onCancel={() => navigate('/portal')}
+      onCancel={() => navigate('/portal/project-select')}
       onSubmit={(draft) => void handleSubmit(draft)}
     />
   );

--- a/src/app/components/portal/PortalProjectSelectPage.shell.test.ts
+++ b/src/app/components/portal/PortalProjectSelectPage.shell.test.ts
@@ -9,6 +9,11 @@ describe('PortalProjectSelectPage shell', () => {
     expect(source).toContain('오늘 작업할 프로젝트 선택');
     expect(source).toContain('이 프로젝트로 시작');
     expect(source).toContain('data-testid="portal-project-select-page"');
+    expect(source).toContain('id="portal-project-search"');
+    expect(source).toContain('name="portalProjectSearch"');
+    expect(source).toContain("resolvePortalProjectSwitchPath('/portal/budget')");
+    expect(source).not.toContain('resolveRequestedRedirectPath');
+    expect(source).not.toContain("navigate('/portal/onboarding'");
     expect(source).not.toContain('주사업으로 지정');
     expect(source).not.toContain('증빙 드라이브 연결');
   });

--- a/src/app/components/portal/PortalProjectSelectPage.tsx
+++ b/src/app/components/portal/PortalProjectSelectPage.tsx
@@ -8,7 +8,6 @@ import { PROJECT_STATUS_LABELS, type Project } from '../../data/types';
 import {
   canEnterPortalWorkspace,
   isAdminSpaceRole,
-  resolveRequestedRedirectPath,
 } from '../../platform/navigation';
 import {
   resolvePortalProjectCandidates,
@@ -90,7 +89,6 @@ export function PortalProjectSelectPage() {
   const navigate = useNavigate();
   const { isAuthenticated, isLoading: authLoading, user: authUser } = useAuth();
   const {
-    isRegistered,
     isLoading: portalLoading,
     portalUser,
     activeProjectId,
@@ -101,9 +99,7 @@ export function PortalProjectSelectPage() {
   const [pendingProjectId, setPendingProjectId] = useState('');
 
   const currentPath = `${location.pathname}${location.search}${location.hash}`;
-  const redirectTarget = resolvePortalProjectSwitchPath(
-    resolveRequestedRedirectPath(undefined, location.search) || '/portal',
-  );
+  const redirectTarget = resolvePortalProjectSwitchPath('/portal/budget');
   const assignedProjectIds = useMemo(() => normalizeProjectIds([
     ...(Array.isArray(portalUser?.projectIds) ? portalUser.projectIds : []),
     portalUser?.projectId,
@@ -135,10 +131,7 @@ export function PortalProjectSelectPage() {
       navigate('/', { replace: true });
       return;
     }
-    if (!isRegistered && !isAdminSpaceRole(authUser?.role)) {
-      navigate('/portal/onboarding', { replace: true });
-    }
-  }, [authLoading, authUser?.role, currentPath, isAuthenticated, isRegistered, navigate, portalLoading]);
+  }, [authLoading, authUser?.role, currentPath, isAuthenticated, navigate, portalLoading]);
 
   const handleStart = async (projectId: string) => {
     setPendingProjectId(projectId);
@@ -182,6 +175,8 @@ export function PortalProjectSelectPage() {
             <div className="flex items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-3 py-2.5">
               <Search className="h-4 w-4 text-slate-400" />
               <Input
+                id="portal-project-search"
+                name="portalProjectSearch"
                 value={search}
                 onChange={(event) => setSearch(event.target.value)}
                 placeholder="프로젝트명, 계약 대상, 유형, PM으로 검색"

--- a/src/app/components/portal/PortalWeeklyExpensePage.tsx
+++ b/src/app/components/portal/PortalWeeklyExpensePage.tsx
@@ -855,7 +855,7 @@ export function PortalWeeklyExpensePage() {
           </p>
           <div className="flex flex-wrap gap-2">
             <Button size="sm" onClick={() => navigate('/portal/project-settings')}>사업 연결 확인하기</Button>
-            <Button variant="outline" size="sm" onClick={() => navigate('/portal')}>포털 홈으로 이동</Button>
+            <Button variant="outline" size="sm" onClick={() => navigate('/portal/project-select')}>프로젝트 선택으로 이동</Button>
           </div>
         </div>
       </div>

--- a/src/app/platform/navigation.test.ts
+++ b/src/app/platform/navigation.test.ts
@@ -14,7 +14,6 @@ import {
   resolvePostLoginPath,
   resolveWorkspaceSelectionPath,
   shouldPromptWorkspaceSelection,
-  shouldForcePortalOnboarding,
 } from './navigation';
 
 const ALL_ROLES = ['admin', 'finance', 'pm', 'viewer'] as const;
@@ -111,27 +110,27 @@ describe('resolveHomePath', () => {
     expect(resolveHomePath('admin', 'admin')).toBe('/');
   });
 
-  it('admin with portal preference goes to /portal', () => {
-    expect(resolveHomePath('admin', 'portal')).toBe('/portal');
+  it('admin with portal preference goes to the explicit portal home', () => {
+    expect(resolveHomePath('admin', 'portal')).toBe('/portal/project-select');
   });
 
   it('finance defaults to /', () => {
     expect(resolveHomePath('finance')).toBe('/');
   });
 
-  it('pm and viewer default to /portal', () => {
-    expect(resolveHomePath('pm')).toBe('/portal');
-    expect(resolveHomePath('viewer')).toBe('/portal');
+  it('pm and viewer default to the explicit portal home', () => {
+    expect(resolveHomePath('pm')).toBe('/portal/project-select');
+    expect(resolveHomePath('viewer')).toBe('/portal/project-select');
   });
 
-  it('unknown roles default to /portal', () => {
-    expect(resolveHomePath('unknown_role')).toBe('/portal');
-    expect(resolveHomePath('')).toBe('/portal');
-    expect(resolveHomePath(null)).toBe('/portal');
+  it('unknown roles default to the explicit portal home', () => {
+    expect(resolveHomePath('unknown_role')).toBe('/portal/project-select');
+    expect(resolveHomePath('')).toBe('/portal/project-select');
+    expect(resolveHomePath(null)).toBe('/portal/project-select');
   });
 
   it('normalizes role casing', () => {
-    expect(resolveHomePath(' PM ')).toBe('/portal');
+    expect(resolveHomePath(' PM ')).toBe('/portal/project-select');
     expect(resolveHomePath('ADMIN')).toBe('/');
     expect(resolveHomePath('FINANCE')).toBe('/');
   });
@@ -171,14 +170,14 @@ describe('resolvePostLoginPath', () => {
   });
 
   it('pm falls back to portal for admin-only paths', () => {
-    expect(resolvePostLoginPath('pm', undefined, '/approvals')).toBe('/portal');
-    expect(resolvePostLoginPath('pm', undefined, '/settings')).toBe('/portal');
-    expect(resolvePostLoginPath('pm', undefined, '/users')).toBe('/portal');
+    expect(resolvePostLoginPath('pm', undefined, '/approvals')).toBe('/portal/project-select');
+    expect(resolvePostLoginPath('pm', undefined, '/settings')).toBe('/portal/project-select');
+    expect(resolvePostLoginPath('pm', undefined, '/users')).toBe('/portal/project-select');
   });
 
   it('viewer falls back to portal for admin-only paths', () => {
-    expect(resolvePostLoginPath('viewer', undefined, '/settings')).toBe('/portal');
-    expect(resolvePostLoginPath('viewer', undefined, '/users')).toBe('/portal');
+    expect(resolvePostLoginPath('viewer', undefined, '/settings')).toBe('/portal/project-select');
+    expect(resolvePostLoginPath('viewer', undefined, '/users')).toBe('/portal/project-select');
   });
 
   // ── special paths ──
@@ -189,8 +188,8 @@ describe('resolvePostLoginPath', () => {
 
   it('no requestedPath → fallback home', () => {
     expect(resolvePostLoginPath('admin', 'admin')).toBe('/');
-    expect(resolvePostLoginPath('pm', undefined)).toBe('/portal');
-    expect(resolvePostLoginPath('admin', 'portal')).toBe('/portal');
+    expect(resolvePostLoginPath('pm', undefined)).toBe('/portal/project-select');
+    expect(resolvePostLoginPath('admin', 'portal')).toBe('/portal/project-select');
   });
 
   it('non-string requestedPath → fallback', () => {
@@ -203,15 +202,15 @@ describe('resolvePostLoginPath', () => {
   });
 
   it('empty role requesting portal path → fallback (canEnterPortalWorkspace false)', () => {
-    expect(resolvePostLoginPath('', undefined, '/portal/budget')).toBe('/portal');
+    expect(resolvePostLoginPath('', undefined, '/portal/budget')).toBe('/portal/project-select');
   });
 });
 
 describe('resolvePortalEntryPath', () => {
-  it('routes portal logins through project-select while preserving the requested portal path', () => {
-    expect(resolvePortalEntryPath('pm', undefined, '/portal/budget')).toBe('/portal/project-select?redirect=%2Fportal%2Fbudget');
-    expect(resolvePortalEntryPath('admin', 'portal', '/portal/cashflow')).toBe('/portal/project-select?redirect=%2Fportal%2Fcashflow');
-    expect(resolvePortalEntryPath('pm', undefined, '/portal/project-select?redirect=%2Fportal%2Fbudget')).toBe('/portal/project-select?redirect=%2Fportal%2Fbudget');
+  it('preserves explicit portal paths without adding project-select redirects', () => {
+    expect(resolvePortalEntryPath('pm', undefined, '/portal/budget')).toBe('/portal/budget');
+    expect(resolvePortalEntryPath('admin', 'portal', '/portal/cashflow')).toBe('/portal/cashflow');
+    expect(resolvePortalEntryPath('pm', undefined, '/portal/project-select?redirect=%2Fportal%2Fbudget')).toBe('/portal/project-select');
     expect(resolvePortalEntryPath('admin', 'admin', '/settings')).toBe('/settings');
   });
 });
@@ -236,18 +235,18 @@ describe('resolveLoginSuccessPath', () => {
 
   it('preserves explicit deep links after login when they are role-safe', () => {
     expect(resolveLoginSuccessPath('admin', 'admin', '/users')).toBe('/users');
-    expect(resolveLoginSuccessPath('pm', undefined, '/portal/budget')).toBe('/portal/project-select?redirect=%2Fportal%2Fbudget');
-    expect(resolveLoginSuccessPath('pm', undefined, '/users')).toBe('/portal/project-select?redirect=%2Fportal');
+    expect(resolveLoginSuccessPath('pm', undefined, '/portal/budget')).toBe('/portal/budget');
+    expect(resolveLoginSuccessPath('pm', undefined, '/users')).toBe('/portal/project-select');
     expect(resolveLoginSuccessPath('pm', undefined, '/portal/cashflow', {
       viewportWidth: 390,
-    })).toBe('/portal/project-select?redirect=%2Fportal%2Fcashflow');
+    })).toBe('/portal/cashflow');
   });
 });
 
 describe('resolveWorkspaceSelectionPath', () => {
-  it('keeps only portal redirects when the user explicitly selects portal space', () => {
+  it('keeps explicit portal paths when the user explicitly selects portal space', () => {
     expect(resolveWorkspaceSelectionPath('admin', 'portal', '/settings')).toBe('/portal/project-select');
-    expect(resolveWorkspaceSelectionPath('admin', 'portal', '/portal/budget')).toBe('/portal/project-select?redirect=%2Fportal%2Fbudget');
+    expect(resolveWorkspaceSelectionPath('admin', 'portal', '/portal/budget')).toBe('/portal/budget');
   });
 
   it('keeps only admin redirects when the user explicitly selects admin space', () => {
@@ -261,6 +260,7 @@ describe('requested redirect restoration', () => {
     expect(normalizeRequestedPath('/users')).toBe('/users');
     expect(normalizeRequestedPath('/login')).toBe('');
     expect(normalizeRequestedPath('/workspace-select')).toBe('');
+    expect(normalizeRequestedPath('/portal/project-select?redirect=%2Fportal%2Fbudget')).toBe('/portal/project-select');
     expect(normalizeRequestedPath('https://example.com/users')).toBe('');
   });
 
@@ -286,61 +286,5 @@ describe('portal standalone entry paths', () => {
     expect(isPortalStandaloneEntryPath('/portal/register-project')).toBe(true);
     expect(isPortalStandaloneEntryPath('/portal')).toBe(false);
     expect(isPortalStandaloneEntryPath('/portal/budget')).toBe(false);
-  });
-});
-
-describe('shouldForcePortalOnboarding', () => {
-  it('forces unregistered pm into onboarding', () => {
-    expect(shouldForcePortalOnboarding({
-      isAuthenticated: true, role: 'pm', isRegistered: false, pathname: '/portal',
-    })).toBe(true);
-  });
-
-  it('forces unregistered viewer into onboarding', () => {
-    expect(shouldForcePortalOnboarding({
-      isAuthenticated: true, role: 'viewer', isRegistered: false, pathname: '/portal/budget',
-    })).toBe(true);
-  });
-
-  it('does NOT force on bypass paths (onboarding, project-settings, project-select, weekly-expenses)', () => {
-    const bypassPaths = ['/portal/onboarding', '/portal/project-settings', '/portal/project-select', '/portal/register-project', '/portal/weekly-expenses'];
-    for (const pathname of bypassPaths) {
-      expect(shouldForcePortalOnboarding({
-        isAuthenticated: true, role: 'pm', isRegistered: false, pathname,
-      }), `pm on ${pathname}`).toBe(false);
-      expect(shouldForcePortalOnboarding({
-        isAuthenticated: true, role: 'viewer', isRegistered: false, pathname,
-      }), `viewer on ${pathname}`).toBe(false);
-    }
-  });
-
-  it('does NOT force if registered', () => {
-    expect(shouldForcePortalOnboarding({
-      isAuthenticated: true, role: 'pm', isRegistered: true, pathname: '/portal',
-    })).toBe(false);
-  });
-
-  it('does NOT force for admin-space roles (admin, finance)', () => {
-    expect(shouldForcePortalOnboarding({
-      isAuthenticated: true, role: 'admin', isRegistered: false, pathname: '/portal',
-    })).toBe(false);
-    expect(shouldForcePortalOnboarding({
-      isAuthenticated: true, role: 'finance', isRegistered: false, pathname: '/portal',
-    })).toBe(false);
-  });
-
-  it('does NOT force if not authenticated', () => {
-    expect(shouldForcePortalOnboarding({
-      isAuthenticated: false, role: 'pm', isRegistered: false, pathname: '/portal',
-    })).toBe(false);
-  });
-
-  it('does NOT force for empty/null role', () => {
-    expect(shouldForcePortalOnboarding({
-      isAuthenticated: true, role: '', isRegistered: false, pathname: '/portal',
-    })).toBe(false);
-    expect(shouldForcePortalOnboarding({
-      isAuthenticated: true, role: null, isRegistered: false, pathname: '/portal',
-    })).toBe(false);
   });
 });

--- a/src/app/platform/navigation.ts
+++ b/src/app/platform/navigation.ts
@@ -5,9 +5,8 @@ import {
   shouldUseBusinessCardMobileEntry,
   type MobileEntryContext,
 } from './mobile-entry';
-import { resolvePortalProjectSelectPath } from './portal-project-selection';
 
-export type HomePath = '/' | '/portal';
+export type HomePath = '/' | '/portal/project-select';
 
 function normalizeRole(value: unknown): string {
   const normalized = typeof value === 'string' ? value.trim().toLowerCase() : '';
@@ -55,13 +54,13 @@ export function resolveActiveWorkspacePreference(
 
 export function resolveHomePath(role: unknown, preferredWorkspace?: WorkspaceId | unknown): HomePath {
   const normalized = normalizeRole(role);
-  if (!normalized) return '/portal';
-  if (isPortalRole(normalized)) return '/portal';
+  if (!normalized) return '/portal/project-select';
+  if (isPortalRole(normalized)) return '/portal/project-select';
   if (normalized === 'admin' && normalizeWorkspaceId(preferredWorkspace) === 'portal') {
-    return '/portal';
+    return '/portal/project-select';
   }
   if (isAdminSpaceRole(normalized)) return '/';
-  return '/portal';
+  return '/portal/project-select';
 }
 
 export function normalizeRequestedPath(value: unknown): string {
@@ -69,6 +68,7 @@ export function normalizeRequestedPath(value: unknown): string {
   const trimmed = value.trim();
   if (!trimmed.startsWith('/')) return '';
   if (trimmed === '/login' || trimmed === '/workspace-select') return '';
+  if (trimmed.startsWith('/portal/project-select?')) return '/portal/project-select';
   return trimmed;
 }
 
@@ -108,11 +108,7 @@ export function resolvePortalEntryPath(
   preferredWorkspace: WorkspaceId | unknown,
   requestedPath?: unknown,
 ): string {
-  const target = resolvePostLoginPath(role, preferredWorkspace, requestedPath);
-  if (target === '/portal' || target.startsWith('/portal/')) {
-    return resolvePortalProjectSelectPath(target);
-  }
-  return target;
+  return resolvePostLoginPath(role, preferredWorkspace, requestedPath);
 }
 
 export function resolveLoginSuccessPath(
@@ -146,7 +142,7 @@ export function resolveWorkspaceSelectionPath(
       : undefined;
     return portalRequested
       ? resolvePortalEntryPath(role, normalizedWorkspace, portalRequested)
-      : resolvePortalProjectSelectPath();
+      : '/portal/project-select';
   }
 
   if (normalizedWorkspace === 'admin') {
@@ -157,13 +153,6 @@ export function resolveWorkspaceSelectionPath(
   }
 
   return resolvePostLoginPath(role, selectedWorkspace, requestedPath);
-}
-
-interface PortalOnboardingRedirectInput {
-  isAuthenticated: boolean;
-  role: unknown;
-  isRegistered: boolean;
-  pathname: string;
 }
 
 function matchesPathPrefix(pathname: string, prefix: string): boolean {
@@ -180,16 +169,4 @@ const PORTAL_STANDALONE_ENTRY_PATHS = [
 
 export function isPortalStandaloneEntryPath(pathname: string): boolean {
   return PORTAL_STANDALONE_ENTRY_PATHS.some((path) => matchesPathPrefix(pathname, path));
-}
-
-/**
- * Decide whether we should force a portal user into onboarding.
- * Admin-space roles must never be forced into portal onboarding.
- */
-export function shouldForcePortalOnboarding(input: PortalOnboardingRedirectInput): boolean {
-  if (!input.isAuthenticated) return false;
-  if (isAdminSpaceRole(input.role)) return false;
-  if (!canEnterPortalWorkspace(input.role)) return false;
-  if (input.isRegistered) return false;
-  return !isPortalStandaloneEntryPath(input.pathname);
 }

--- a/src/app/platform/portal-project-selection.test.ts
+++ b/src/app/platform/portal-project-selection.test.ts
@@ -84,12 +84,14 @@ describe('portal project selection helpers', () => {
     })).toBe('p-managed');
   });
 
-  it('wraps portal routes for project selection and preserves current work routes on switch', () => {
-    expect(resolvePortalProjectSelectPath('/portal/budget')).toBe('/portal/project-select?redirect=%2Fportal%2Fbudget');
+  it('keeps project selection and switch targets explicit without falling back to /portal', () => {
+    expect(resolvePortalProjectSelectPath('/portal')).toBe('/portal/project-select');
+    expect(resolvePortalProjectSelectPath('/portal/budget')).toBe('/portal/project-select');
     expect(resolvePortalProjectSelectPath('/portal/project-select')).toBe('/portal/project-select');
-    expect(resolvePortalProjectSelectPath('/portal/project-select?redirect=%2Fportal%2Fbudget')).toBe('/portal/project-select?redirect=%2Fportal%2Fbudget');
+    expect(resolvePortalProjectSelectPath('/portal/project-select?redirect=%2Fportal%2Fbudget')).toBe('/portal/project-select');
     expect(resolvePortalProjectSwitchPath('/portal/cashflow')).toBe('/portal/cashflow');
-    expect(resolvePortalProjectSwitchPath('/portal/project-select')).toBe('/portal');
-    expect(resolvePortalProjectSwitchPath('/portal/project-select?redirect=%2Fportal%2Fbudget')).toBe('/portal');
+    expect(resolvePortalProjectSwitchPath('/portal')).toBe('/portal/budget');
+    expect(resolvePortalProjectSwitchPath('/portal/project-select')).toBe('/portal/budget');
+    expect(resolvePortalProjectSwitchPath('/portal/project-select?redirect=%2Fportal%2Fbudget')).toBe('/portal/budget');
   });
 });

--- a/src/app/platform/portal-project-selection.ts
+++ b/src/app/platform/portal-project-selection.ts
@@ -8,7 +8,7 @@ export interface PortalProjectCandidateSet {
 
 const PORTAL_PATH_PREFIX = '/portal';
 const PORTAL_PROJECT_SELECT_PATH = '/portal/project-select';
-const PORTAL_PROJECT_SWITCH_FALLBACK_PATH = '/portal';
+const PORTAL_PROJECT_SWITCH_FALLBACK_PATH = '/portal/budget';
 const ADMIN_PROJECT_ROLES = new Set<UserRole>(['admin', 'finance']);
 
 function normalizeRole(role: unknown): UserRole | null {
@@ -95,18 +95,17 @@ export function resolveActivePortalProjectId(input: {
 export function resolvePortalProjectSelectPath(requestedPath?: string): string {
   const pathname = typeof requestedPath === 'string' ? requestedPath.trim() : '';
   if (!isPortalPath(pathname)) return PORTAL_PROJECT_SELECT_PATH;
-  if (pathname === PORTAL_PROJECT_SELECT_PATH) {
-    return PORTAL_PROJECT_SELECT_PATH;
-  }
-  if (pathname.startsWith(`${PORTAL_PROJECT_SELECT_PATH}?`)) return pathname;
-  return `${PORTAL_PROJECT_SELECT_PATH}?redirect=${encodeURIComponent(pathname)}`;
+  return PORTAL_PROJECT_SELECT_PATH;
 }
 
 export function resolvePortalProjectSwitchPath(pathname?: string): string {
   const normalizedPath = typeof pathname === 'string' ? pathname.trim() : '';
   if (!isPortalPath(normalizedPath)) return PORTAL_PROJECT_SWITCH_FALLBACK_PATH;
   if (
-    normalizedPath === PORTAL_PROJECT_SELECT_PATH
+    normalizedPath === PORTAL_PATH_PREFIX
+    || normalizedPath.startsWith(`${PORTAL_PATH_PREFIX}?`)
+    || normalizedPath.startsWith(`${PORTAL_PATH_PREFIX}#`)
+    || normalizedPath === PORTAL_PROJECT_SELECT_PATH
     || normalizedPath.startsWith(`${PORTAL_PROJECT_SELECT_PATH}/`)
     || normalizedPath.startsWith(`${PORTAL_PROJECT_SELECT_PATH}?`)
   ) {

--- a/src/app/routes.lazy-route.shell.test.ts
+++ b/src/app/routes.lazy-route.shell.test.ts
@@ -21,8 +21,9 @@ describe('route lazy loading safety', () => {
     expect(routesSource).toContain('{ index: true, element: <MobileAwareAdminHome /> }');
   });
 
-  it('closes the PM portal project dashboard route by sending /portal to project selection', () => {
-    expect(routesSource).toContain('{ index: true, element: <Navigate to="/portal/project-select" replace /> }');
+  it('keeps /portal on the project selection surface without a route-level redirect', () => {
+    expect(routesSource).toContain('{ index: true, element: <S C={PortalProjectSelectPage} /> }');
+    expect(routesSource).not.toContain('{ index: true, element: <Navigate to="/portal/project-select" replace /> }');
     expect(routesSource).not.toContain('{ index: true, element: <S C={PortalDashboard} /> }');
   });
 });

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -166,7 +166,7 @@ export const router = createBrowserRouter([
     path: '/portal',
     element: <PortalRouteShell />,
     children: [
-      { index: true, element: <Navigate to="/portal/project-select" replace /> },
+      { index: true, element: <S C={PortalProjectSelectPage} /> },
       // ── Company Board (전사 게시판) ──
       {
         path: 'board',
@@ -178,7 +178,7 @@ export const router = createBrowserRouter([
       { path: 'onboarding', element: <S C={PortalOnboarding} /> },
       { path: 'project-select', element: <S C={PortalProjectSelectPage} /> },
       { path: 'project-settings', element: <S C={PortalProjectSettings} /> },
-      { path: 'submissions', element: <Navigate to="/portal/project-select" replace /> },
+      { path: 'submissions', element: <S C={PortalProjectSelectPage} /> },
       { path: 'payroll', element: <S C={PortalPayrollPage} /> },
       { path: 'cashflow', element: <S C={PortalCashflowPage} /> },
       { path: 'budget', element: <S C={PortalBudget} /> },


### PR DESCRIPTION
## Summary
- remove route-level redirects from /portal and legacy portal submissions entry
- remove portal auto-forwarding to onboarding/project-select; keep auth/role guards only
- make top-left logo the explicit home action and send project selection to budget after user choice
- add id/name to project search input to avoid browser form warnings

## Verification
- npx vitest run src/app/platform/navigation.test.ts src/app/platform/portal-project-selection.test.ts src/app/components/portal/PortalProjectSelectPage.shell.test.ts src/app/components/portal/PortalDashboard.layout.test.ts src/app/components/portal/PortalLayout.shell.test.ts src/app/components/layout/AppLayout.shell.test.ts src/app/routes.lazy-route.shell.test.ts
- npm run build