### PR TITLE
fix(projects): use member directory for project owner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,9 @@ npm run build
 - Components/pages: `PascalCase.tsx` (example: `AdminPayrollPage.tsx`).
 - Route segments/folders: lowercase/kebab (example: `expense-management`).
 - Keep cross-cutting rules in `src/app/platform/`; keep feature UI in `src/app/components/<feature>/`.
+- UI wording must use the same Korean business terms across admin and portal. Prefer domain labels already used in `src/app/data/types.ts` or shared label maps; avoid one-off labels like `X`, `N/A`, or developer-only shorthand in user-facing screens.
+- User-facing helper text should explain the operational meaning, not the implementation. Example: say "구성원 원장에서 사업 담당자를 선택합니다" instead of "registeredById 값을 설정합니다".
+- Code comments should be rare and explain why a rule exists or why a non-obvious dependency is necessary. Do not comment what the next line mechanically does.
 
 ## Commit & PR Guidelines
 - Prefer Conventional Commits: `feat(cashflow): ...`, `fix(rbac): ...`, `docs: ...`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 MYSC 사업관리 통합 플랫폼 — an enterprise business management platform for a Korean social enterprise (MYSC). Manages projects, ledgers, transactions, payroll, cashflow, personnel, budgets, training, and career profiles. **All user-facing UI text is in Korean (한국어).**
 
+### UI Wording & Comments Policy
+- Admin and portal screens must use the same Korean business terms for the same concept. Reuse shared label maps and domain types where possible.
+- User-facing copy should explain the operational meaning in non-developer language. Avoid internal field names, unexplained acronyms, `X`, `N/A`, or temporary labels.
+- Code comments should be short and reserved for intent, policy, or non-obvious dependencies. Do not add comments that simply restate the code.
+
 ## Commands
 
 ```bash

--- a/src/app/components/portal/PortalProjectEdit.tsx
+++ b/src/app/components/portal/PortalProjectEdit.tsx
@@ -85,7 +85,7 @@ export function PortalProjectEdit() {
   const navigate = useNavigate();
   const { user: authUser } = useAuth();
   const { db, isOnline, orgId } = useFirebase();
-  const { myProject } = usePortalStore();
+  const { members, myProject } = usePortalStore();
   const [requestDoc, setRequestDoc] = useState<ProjectRequest | null>(null);
   const [loadingRequest, setLoadingRequest] = useState(true);
   const [busyActionId, setBusyActionId] = useState<string | null>(null);
@@ -347,6 +347,7 @@ export function PortalProjectEdit() {
       description="등록 화면과 같은 5단계 구조로 수정하고, 승인 상태는 변경 이력과 함께 관리됩니다."
       initialDraft={initialDraft}
       draftKey={`portal-edit-${myProject.id}-${requestDoc?.updatedAt || myProject.updatedAt}`}
+      members={members}
       actions={[
         { id: 'save', label: '저장', icon: Save },
         ...(canResubmit ? [{ id: 'resubmit', label: '수정 후 다시 제출', icon: SendHorizontal, variant: 'secondary' as const }] : []),

--- a/src/app/components/portal/PortalProjectRegister.tsx
+++ b/src/app/components/portal/PortalProjectRegister.tsx
@@ -24,7 +24,7 @@ export function PortalProjectRegister() {
   const navigate = useNavigate();
   const { orgId } = useFirebase();
   const { user: authUser } = useAuth();
-  const { createProjectRequest, portalUser } = usePortalStore();
+  const { createProjectRequest, members, portalUser } = usePortalStore();
   const [busyActionId, setBusyActionId] = useState<string | null>(null);
   const [submitted, setSubmitted] = useState(false);
 
@@ -120,6 +120,7 @@ export function PortalProjectRegister() {
       description="기본 정보, 계약/재무, 팀/인력, 입금/정산 정보를 같은 기준으로 입력합니다."
       initialDraft={initialDraft}
       draftKey={`portal-register-${authUser?.uid || 'anonymous'}`}
+      members={members}
       actions={[{ id: 'submit', label: '등록 요청 저장', icon: Send }]}
       busyActionId={busyActionId}
       onContractFileUpload={handleContractFileUpload}

--- a/src/app/components/projects/ProjectEditorWizard.shell.test.ts
+++ b/src/app/components/projects/ProjectEditorWizard.shell.test.ts
@@ -24,8 +24,11 @@ describe('ProjectEditorWizard dropdown contract', () => {
 
   it('keeps select values representable in their option lists', () => {
     expect(source).toContain('const ownerOptions = useMemo');
-    expect(source).toContain('uid: draft.registeredById');
-    expect(source).toContain("if (value === 'none')");
+    expect(source).toContain('const selectedOwner = useMemo');
+    expect(source).toContain('const hasUnlinkedStoredOwner');
+    expect(source).toContain('구성원 원장에서 선택');
+    expect(source).not.toContain('<SelectItem value="none">선택 안 함</SelectItem>');
+    expect(source).not.toContain('uid: draft.registeredById');
     expect(source).toContain("onSelect({ memberName: '', memberNickname: '' })");
     expect(source).toContain('currentTeamMemberOptionExists');
     expect(source).toContain('member.memberNickname ? `${member.memberName} (${member.memberNickname})` : member.memberName');
@@ -34,7 +37,7 @@ describe('ProjectEditorWizard dropdown contract', () => {
   it('uses a member select for project owner instead of free text manager input', () => {
     expect(source).toContain('사업 담당자');
     expect(source).toContain('registeredById');
-    expect(source).toContain('registeredByName: member?.name ||');
+    expect(source).toContain('registeredByName: member.name || member.email || member.uid');
     expect(source).not.toContain('<Input value={draft.managerName}');
   });
 

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -412,20 +412,17 @@ export function ProjectEditorWizard({
   const teamMembersSummary = formatProjectTeamMembersSummary(draft.teamMembersDetailed, '', '\n');
   const projectTypeOptions = getProjectTypeSelectableOptions(draft.type);
   const contractTypeOptions = getProjectContractTypeSelectableOptions(draft.contractType);
-  const ownerOptions = useMemo(() => {
-    if (!draft.registeredById || members.some((member) => member.uid === draft.registeredById)) {
-      return members;
-    }
-    return [
-      ...members,
-      {
-        uid: draft.registeredById,
-        name: draft.registeredByName || draft.registeredById,
-        email: draft.registeredByEmail || '',
-        role: 'pm' as const,
-      },
-    ];
-  }, [draft.registeredByEmail, draft.registeredById, draft.registeredByName, members]);
+  const ownerOptions = useMemo(
+    () => [...members]
+      .filter((member) => String(member.uid || '').trim())
+      .sort((left, right) => String(left.name || left.email || left.uid).localeCompare(String(right.name || right.email || right.uid), 'ko')),
+    [members],
+  );
+  const selectedOwner = useMemo(
+    () => ownerOptions.find((member) => member.uid === draft.registeredById) || null,
+    [draft.registeredById, ownerOptions],
+  );
+  const hasUnlinkedStoredOwner = Boolean(draft.registeredById && !selectedOwner);
 
   useEffect(() => {
     if (!draft.registeredById) return;
@@ -961,30 +958,38 @@ export function ProjectEditorWizard({
       <div className="grid gap-4 lg:grid-cols-2">
         <div>
           <Label className="text-xs">사업 담당자 *</Label>
-          <Select value={draft.registeredById || 'none'} onValueChange={(value) => {
-            const member = members.find((item) => item.uid === value);
+          <Select value={selectedOwner?.uid} onValueChange={(value) => {
+            const member = ownerOptions.find((item) => item.uid === value);
+            if (!member) return;
             setDraft((prev) => createProjectEditorDraft({
               ...prev,
-              registeredById: value === 'none' ? '' : value,
-              registeredByName: member?.name || '',
-              registeredByEmail: member?.email || '',
-              managerId: value === 'none' ? '' : value,
-              managerName: member?.name || '',
+              registeredById: member.uid,
+              registeredByName: member.name || member.email || member.uid,
+              registeredByEmail: member.email || '',
+              managerId: member.uid,
+              managerName: member.name || member.email || member.uid,
             }));
-          }}>
-            <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue placeholder="조직원 선택" /></SelectTrigger>
+          }} disabled={ownerOptions.length === 0}>
+            <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue placeholder="구성원 원장에서 선택" /></SelectTrigger>
             <SelectContent>
-              <SelectItem value="none">선택 안 함</SelectItem>
               {ownerOptions.map((member) => (
                 <SelectItem key={member.uid} value={member.uid}>
-                  {member.email ? `${member.name} (${member.email})` : member.name}
+                  {member.email ? `${member.name || member.uid} (${member.email})` : (member.name || member.uid)}
                 </SelectItem>
               ))}
+              {ownerOptions.length === 0 ? (
+                <SelectItem value="__no_org_members__" disabled>구성원 원장을 불러오는 중입니다</SelectItem>
+              ) : null}
             </SelectContent>
           </Select>
           <p className="mt-1 text-[11px] text-muted-foreground">
-            프로젝트 현황과 PM 포털 노출은 이 조직원 계정 기준으로 연결됩니다.
+            구성원 원장(orgs/{'{'}orgId{'}'}/members)의 UID를 저장합니다. 프로젝트 현황과 PM 포털 노출은 이 UID 기준으로 연결됩니다.
           </p>
+          {hasUnlinkedStoredOwner ? (
+            <p className="mt-1 text-[11px] text-red-700">
+              현재 저장된 담당자 값이 구성원 원장에 없습니다. 원장에서 다시 선택해야 저장 후 연결됩니다.
+            </p>
+          ) : null}
         </div>
       </div>
       <div className="flex items-center justify-between gap-3">

--- a/src/app/components/projects/ProjectWizard.tsx
+++ b/src/app/components/projects/ProjectWizard.tsx
@@ -129,13 +129,13 @@ export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: Projec
 
       if (editProject) {
         await updateProject(editProject.id, patch);
-        syncProjectOwnerAssignment(editProject.id, draft.name || editProject.name, editProject.registeredById || editProject.managerId || '', draft);
+        await syncProjectOwnerAssignment(editProject.id, draft.name || editProject.name, editProject.registeredById || editProject.managerId || '', draft);
         toast.success('프로젝트 수정 내용이 저장되었습니다.');
         navigate(`/projects/${editProject.id}`);
       } else {
         const project = createProjectFromDraft(draft, patch, now);
         await addProject(project);
-        syncProjectOwnerAssignment(project.id, project.name, '', draft);
+        await syncProjectOwnerAssignment(project.id, project.name, '', draft);
         toast.success(draft.phase === 'PROSPECT' ? '예정 프로젝트로 저장했습니다.' : '프로젝트를 등록했습니다.');
         navigate(`/projects/${project.id}`);
       }
@@ -147,7 +147,7 @@ export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: Projec
     }
   };
 
-  const syncProjectOwnerAssignment = (
+  const syncProjectOwnerAssignment = async (
     projectId: string,
     projectName: string,
     previousOwnerId: string,
@@ -170,7 +170,7 @@ export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: Projec
       nextMember,
     });
     if (previousMember && patches.previous) {
-      upsertMember({
+      await upsertMember({
         ...previousMember,
         projectIds: patches.previous.projectIds,
         projectNames: patches.previous.projectNames,
@@ -182,7 +182,7 @@ export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: Projec
       });
     }
     if (patches.next) {
-      upsertMember({
+      await upsertMember({
         ...nextMember,
         projectId: patches.next.projectId,
         projectIds: patches.next.projectIds,

--- a/src/app/components/settings/SettingsPage.shell.test.ts
+++ b/src/app/components/settings/SettingsPage.shell.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(import.meta.dirname, 'SettingsPage.tsx'), 'utf8');
+
+describe('SettingsPage member directory contract', () => {
+  it('manages the canonical member directory through store CRUD', () => {
+    expect(source).toContain('구성원 원장 추가/수정');
+    expect(source).toContain('orgs/{org.id}/members');
+    expect(source).toContain('upsertMember({');
+    expect(source).toContain('await removeMember(uid)');
+    expect(source).toContain('Firebase UID');
+    expect(source).toContain('이름, 이메일, UID 검색');
+  });
+});

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import {
-  Settings, Users, BookOpen, Building2, Plus, Upload, Shield,
+  Settings, Users, BookOpen, Building2, Plus, Upload, Shield, Search, Save, Trash2,
 } from 'lucide-react';
+import { toast } from 'sonner';
 import { ROLE_META } from '../../platform/role-meta';
 import { hasPermission, type PlatformPermission } from '../../platform/rbac';
 import { useLocation, useNavigate } from 'react-router';
@@ -43,7 +44,7 @@ const PERMISSION_LABELS: Partial<Record<PlatformPermission, string>> = {
 };
 
 export function SettingsPage() {
-  const { org, members, templates } = useAppStore();
+  const { org, members, templates, upsertMember, removeMember } = useAppStore();
   const { isAuthenticated, user } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
@@ -51,8 +52,69 @@ export function SettingsPage() {
   const requestedTab = searchParams.get('tab') || 'org';
   const initialTab = PRIMARY_SETTINGS_TAB_SET.has(requestedTab) ? requestedTab : 'org';
   const [tab, setTab] = useState(initialTab);
+  const [memberSearch, setMemberSearch] = useState('');
+  const [savingMember, setSavingMember] = useState(false);
+  const [memberDraft, setMemberDraft] = useState({
+    uid: '',
+    name: '',
+    email: '',
+    role: 'pm' as DisplayRole,
+  });
   const currentPath = `${location.pathname}${location.search}${location.hash}`;
   const activeWorkspace = resolveActiveWorkspacePreference(user?.lastWorkspace, user?.defaultWorkspace);
+  const filteredMembers = useMemo(() => {
+    const query = memberSearch.trim().toLowerCase();
+    if (!query) return members;
+    return members.filter((member) => [
+      member.name,
+      member.email,
+      member.uid,
+      ROLE_META[member.role]?.label,
+      member.role,
+    ].some((value) => String(value || '').toLowerCase().includes(query)));
+  }, [memberSearch, members]);
+
+  const resetMemberDraft = () => {
+    setMemberDraft({ uid: '', name: '', email: '', role: 'pm' });
+  };
+
+  const handleSaveMember = async () => {
+    const uid = memberDraft.uid.trim();
+    const name = memberDraft.name.trim();
+    const email = memberDraft.email.trim().toLowerCase();
+    if (!uid || !name || !email) {
+      toast.error('UID, 이름, 이메일을 모두 입력해 주세요.');
+      return;
+    }
+
+    setSavingMember(true);
+    try {
+      await upsertMember({
+        uid,
+        name,
+        email,
+        role: memberDraft.role,
+        status: 'ACTIVE',
+      });
+      toast.success('구성원 원장을 저장했습니다.');
+      resetMemberDraft();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : '구성원 원장 저장에 실패했습니다.');
+    } finally {
+      setSavingMember(false);
+    }
+  };
+
+  const handleRemoveMember = async (uid: string, name: string) => {
+    if (!window.confirm(`${name || uid} 구성원을 원장에서 제거할까요?`)) return;
+    try {
+      await removeMember(uid);
+      toast.success('구성원 원장에서 제거했습니다.');
+      if (memberDraft.uid === uid) resetMemberDraft();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : '구성원 제거에 실패했습니다.');
+    }
+  };
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -152,20 +214,85 @@ export function SettingsPage() {
 
         {/* Members */}
         <TabsContent value="members">
-          <Card>
-            <CardHeader>
-              <div className="flex items-center justify-between">
-                <CardTitle className="text-base">구성원 ({members.length}명)</CardTitle>
-                <Button variant="outline" size="sm" className="gap-1.5" onClick={() => navigate('/users')}>
-                  <Plus className="w-3.5 h-3.5" /> 구성원·역할 관리
+          <div className="space-y-4">
+            <Card className="border-slate-200">
+              <CardHeader>
+                <CardTitle className="text-base">구성원 원장 추가/수정</CardTitle>
+                <p className="text-[12px] text-muted-foreground">
+                  사업 담당자 선택값은 이 원장의 UID를 저장합니다. 이미 로그인한 구성원은 Firebase UID를 사용하세요.
+                </p>
+              </CardHeader>
+              <CardContent className="grid gap-3 lg:grid-cols-[1fr_1fr_1fr_180px_auto_auto] lg:items-end">
+                <div>
+                  <Label className="text-xs">UID *</Label>
+                  <Input
+                    value={memberDraft.uid}
+                    onChange={(event) => setMemberDraft((prev) => ({ ...prev, uid: event.target.value }))}
+                    placeholder="Firebase UID"
+                    className="mt-1 border-slate-300"
+                  />
+                </div>
+                <div>
+                  <Label className="text-xs">이름 *</Label>
+                  <Input
+                    value={memberDraft.name}
+                    onChange={(event) => setMemberDraft((prev) => ({ ...prev, name: event.target.value }))}
+                    placeholder="홍길동(닉네임)"
+                    className="mt-1 border-slate-300"
+                  />
+                </div>
+                <div>
+                  <Label className="text-xs">이메일 *</Label>
+                  <Input
+                    value={memberDraft.email}
+                    onChange={(event) => setMemberDraft((prev) => ({ ...prev, email: event.target.value }))}
+                    placeholder="name@mysc.co.kr"
+                    className="mt-1 border-slate-300"
+                  />
+                </div>
+                <div>
+                  <Label className="text-xs">역할</Label>
+                  <Select value={memberDraft.role} onValueChange={(value) => setMemberDraft((prev) => ({ ...prev, role: value as DisplayRole }))}>
+                    <SelectTrigger className="mt-1 h-9 border-slate-300 bg-white">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {DISPLAY_ROLES.map((role) => (
+                        <SelectItem key={role} value={role}>{ROLE_META[role]?.label ?? role}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <Button type="button" onClick={() => void handleSaveMember()} disabled={savingMember} className="gap-2">
+                  <Save className="h-4 w-4" /> 저장
                 </Button>
-              </div>
-              <p className="text-[12px] text-muted-foreground">
-                신규 구성원은 첫 로그인 시 자동 등록됩니다 (기본 역할: PM).
-                역할 변경·추가·삭제는 <button type="button" className="underline underline-offset-2" onClick={() => navigate('/users')}>구성원 관리 페이지</button>에서 할 수 있어요.
-              </p>
-            </CardHeader>
-            <CardContent>
+                <Button type="button" variant="outline" onClick={resetMemberDraft}>
+                  초기화
+                </Button>
+              </CardContent>
+            </Card>
+
+            <Card className="border-slate-200">
+              <CardHeader>
+                <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                  <div>
+                    <CardTitle className="text-base">구성원 원장 ({members.length}명)</CardTitle>
+                    <p className="mt-1 text-[12px] text-muted-foreground">
+                      실제 데이터는 Firestore orgs/{org.id}/members에 저장됩니다.
+                    </p>
+                  </div>
+                  <div className="relative w-full lg:w-[320px]">
+                    <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-slate-400" />
+                    <Input
+                      value={memberSearch}
+                      onChange={(event) => setMemberSearch(event.target.value)}
+                      placeholder="이름, 이메일, UID 검색"
+                      className="h-9 border-slate-300 pl-9"
+                    />
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
               <Table>
                 <TableHeader>
                   <TableRow>
@@ -173,10 +300,11 @@ export function SettingsPage() {
                     <TableHead>이메일</TableHead>
                     <TableHead>역할</TableHead>
                     <TableHead>UID</TableHead>
+                    <TableHead className="w-[160px] text-right">관리</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {members.map(m => (
+                  {filteredMembers.map(m => (
                     <TableRow key={m.uid}>
                       <TableCell style={{ fontWeight: 500 }}>{m.name}</TableCell>
                       <TableCell className="text-sm text-muted-foreground">{m.email}</TableCell>
@@ -186,12 +314,39 @@ export function SettingsPage() {
                         </span>
                       </TableCell>
                       <TableCell className="text-xs text-muted-foreground font-mono">{m.uid}</TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex justify-end gap-2">
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setMemberDraft({
+                              uid: m.uid,
+                              name: m.name,
+                              email: m.email || '',
+                              role: DISPLAY_ROLES.includes(m.role as DisplayRole) ? m.role as DisplayRole : 'pm',
+                            })}
+                          >
+                            수정
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            className="border-slate-300 text-red-700 hover:text-red-700"
+                            onClick={() => void handleRemoveMember(m.uid, m.name)}
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        </div>
+                      </TableCell>
                     </TableRow>
                   ))}
                 </TableBody>
               </Table>
-            </CardContent>
-          </Card>
+              </CardContent>
+            </Card>
+          </div>
         </TabsContent>
 
         {/* Templates */}

--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -28,6 +28,7 @@ import type {
   ProjectSheetSourceType,
   Project,
   ProjectStatus,
+  OrgMember,
   ParticipationEntry,
   Transaction,
   TransactionState,
@@ -114,6 +115,7 @@ import {
   resolveActivePortalProjectId,
   resolvePortalProjectCandidates,
 } from '../platform/portal-project-selection';
+import { listenMembers } from '../lib/firestore-service';
 
 export interface PortalUser {
   id: string;
@@ -421,6 +423,7 @@ interface PortalState {
   isLoading: boolean;
   portalUser: PortalUser | null;
   activeProjectId: string;
+  members: OrgMember[];
   projects: Project[];
   ledgers: Ledger[];
   myProject: Project | null;
@@ -635,6 +638,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
   const [expenseSets, setExpenseSets] = useState<ExpenseSet[]>(EXPENSE_SETS);
   const [changeRequests, setChangeRequests] = useState<ChangeRequest[]>(CHANGE_REQUESTS);
   const [projects, setProjects] = useState<Project[]>([]);
+  const [members, setMembers] = useState<OrgMember[]>([]);
   const [ledgers, setLedgers] = useState<Ledger[]>([]);
   const [participationEntries, setParticipationEntries] = useState<ParticipationEntry[]>(PARTICIPATION_ENTRIES);
   const [transactions, setTransactions] = useState<Transaction[]>([]);
@@ -729,6 +733,14 @@ export function PortalProvider({ children }: { children: ReactNode }) {
   }, [activeProjectId, projects]);
   const currentProjectId = activeProjectId;
   const { allowRealtimeListeners: livePortalMode } = useFirestoreAccessPolicy(portalUser?.role || authUser?.role);
+
+  useEffect(() => {
+    if (!firestoreEnabled || !db || !isAuthenticated || !authUser) {
+      setMembers([]);
+      return;
+    }
+    return listenMembers(db, orgId, setMembers);
+  }, [authUser?.uid, db, firestoreEnabled, isAuthenticated, orgId]);
 
   useEffect(() => {
     const uid = authUser?.uid;
@@ -3291,6 +3303,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     isLoading: projectCatalogLoading || projectScopeLoading || isMemberLoading,
     portalUser,
     activeProjectId,
+    members,
     projects,
     ledgers,
     myProject,

--- a/src/app/data/store.tsx
+++ b/src/app/data/store.tsx
@@ -94,8 +94,8 @@ interface AppState {
 }
 
 interface AppActions {
-  upsertMember: (member: OrgMember & Record<string, unknown>) => void;
-  removeMember: (uid: string) => void;
+  upsertMember: (member: OrgMember & Record<string, unknown>) => Promise<void>;
+  removeMember: (uid: string) => Promise<void>;
   addProject: (p: Project) => Promise<void>;
   updateProject: (id: string, updates: Partial<Project>) => Promise<void>;
   trashProject: (id: string, reason?: string) => Promise<void>;
@@ -351,27 +351,31 @@ export function AppProvider({ children }: { children: ReactNode }) {
     });
   }, [runStoreMutation, writeStrategy, orgId, bffActor, db, auditActor]);
 
-  const upsertMember = useCallback((member: OrgMember & Record<string, unknown>) => {
-    if (firestoreEnabled && db) {
-      upsertMemberFS(db, orgId, member, auditActor).catch(console.error);
-      return;
-    }
-    setLocalMembers((prev) => {
-      const idx = prev.findIndex((m) => m.uid === member.uid);
-      if (idx === -1) return [member, ...prev];
-      const next = [...prev];
-      next[idx] = { ...next[idx], ...member };
-      return next;
+  const upsertMember = useCallback(async (member: OrgMember & Record<string, unknown>) => {
+    await runStoreMutation('upsertMember', async () => {
+      if (firestoreEnabled && db) {
+        await upsertMemberFS(db, orgId, member, auditActor);
+        return;
+      }
+      setLocalMembers((prev) => {
+        const idx = prev.findIndex((m) => m.uid === member.uid);
+        if (idx === -1) return [member, ...prev];
+        const next = [...prev];
+        next[idx] = { ...next[idx], ...member };
+        return next;
+      });
     });
-  }, [firestoreEnabled, db, orgId, auditActor]);
+  }, [runStoreMutation, firestoreEnabled, db, orgId, auditActor]);
 
-  const removeMember = useCallback((uid: string) => {
-    if (firestoreEnabled && db) {
-      deleteMemberFS(db, orgId, uid, auditActor).catch(console.error);
-      return;
-    }
-    setLocalMembers((prev) => prev.filter((m) => m.uid !== uid));
-  }, [firestoreEnabled, db, orgId, auditActor]);
+  const removeMember = useCallback(async (uid: string) => {
+    await runStoreMutation('removeMember', async () => {
+      if (firestoreEnabled && db) {
+        await deleteMemberFS(db, orgId, uid, auditActor);
+        return;
+      }
+      setLocalMembers((prev) => prev.filter((m) => m.uid !== uid));
+    });
+  }, [runStoreMutation, firestoreEnabled, db, orgId, auditActor]);
 
   const updateProject = useCallback(async (id: string, updates: Partial<Project>) => {
     await runStoreMutation('updateProject', async () => {


### PR DESCRIPTION
## Summary\n- make project owner selection use the canonical org member directory instead of free/synthetic options\n- expose member directory CRUD in admin settings backed by the existing members store/Firestore service\n- load org members in portal registration/edit flows and document UI wording/comment policy\n\n## Tests\n- npx vitest run src/app/components/projects/ProjectEditorWizard.shell.test.ts src/app/components/settings/SettingsPage.shell.test.ts\n- npm run build