### PR TITLE
fix(cashflow): show stored projection totals

### DIFF
--- a/server/bff/cashflow-canonical-store.mjs
+++ b/server/bff/cashflow-canonical-store.mjs
@@ -1,5 +1,5 @@
 import cashflowPolicyData from '../../src/app/policies/cashflow-policy.json' with { type: 'json' };
-import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES } from './cashflow-policy.mjs';
+import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES } from './cashflow-policy.mjs';
 
 const SETTLEMENT_COLUMN_HEADERS = [
   '작성자',
@@ -282,6 +282,13 @@ function normalizeAmounts(amounts) {
   return normalized;
 }
 
+function computeCashflowTotals(amounts) {
+  const normalized = normalizeAmounts(amounts);
+  const totalIn = CASHFLOW_IN_LINES.reduce((sum, lineId) => sum + (Number(normalized[lineId]) || 0), 0);
+  const totalOut = CASHFLOW_OUT_LINES.reduce((sum, lineId) => sum + (Number(normalized[lineId]) || 0), 0);
+  return { totalIn, totalOut, net: totalIn - totalOut };
+}
+
 function parseDateOnlyUtc(value) {
   const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(String(value || '').trim());
   if (!match) return null;
@@ -409,6 +416,10 @@ async function commitInChunks(db, mutations) {
 function buildWeekPatch({ tenantId, actorId, actorName, projectId, mode, week, amounts, now, existingData }) {
   const normalizedAmounts = normalizeAmounts(amounts);
   const existingModeAmounts = normalizeAmounts(existingData?.[mode] || {});
+  const nextModeAmounts = {
+    ...existingModeAmounts,
+    ...normalizedAmounts,
+  };
   const patch = {
     id: resolveWeekDocId(projectId, week.yearMonth, week.weekNo),
     tenantId,
@@ -422,24 +433,18 @@ function buildWeekPatch({ tenantId, actorId, actorName, projectId, mode, week, a
     updatedAt: now,
     updatedByUid: actorId,
     updatedByName: actorName,
+    [`${mode}Totals`]: computeCashflowTotals(nextModeAmounts),
   };
   if (Object.keys(normalizedAmounts).length > 0) {
-    patch[mode] = {
-      ...existingModeAmounts,
-      ...normalizedAmounts,
-    };
+    patch[mode] = nextModeAmounts;
     if (mode === 'projection') {
-      const nextProjection = {
-        ...existingModeAmounts,
-        ...normalizedAmounts,
-      };
       patch.projectionUpdated = true;
       patch.projectionUpdatedAt = now;
       patch.projectionUpdatedByUid = actorId;
       patch.projectionUpdatedByName = actorName;
       patch.projectionChangeAlert = buildProjectionChangeAlert({
         previousProjection: existingModeAmounts,
-        nextProjection,
+        nextProjection: nextModeAmounts,
         weekStart: week.weekStart,
         now,
         actorId,

--- a/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
+++ b/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
@@ -17,6 +17,17 @@ describe('CashflowWeeklyPage status semantics', () => {
     expect(cashflowWeeklyPageSource).not.toContain('작성완료=PM 작성완료');
   });
 
+  it('reads stored in/out totals from cashflow week docs instead of recomputing NET in the monitor', () => {
+    expect(cashflowWeeklyPageSource).toContain('projectionTotals');
+    expect(cashflowWeeklyPageSource).toContain('totals: w.projectionTotals || emptyTotals()');
+    expect(cashflowWeeklyPageSource).toContain('입금 {fmtShort(totals.totalIn)}');
+    expect(cashflowWeeklyPageSource).toContain('출금 {fmtShort(totals.totalOut)}');
+    expect(cashflowWeeklyPageSource).not.toContain('chooseCashflowSheetForNet');
+    expect(cashflowWeeklyPageSource).not.toContain('computeCashflowTotals');
+    expect(cashflowWeeklyPageSource).not.toContain('NET {fmtShort');
+    expect(cashflowWeeklyPageSource).not.toContain('actualTotals');
+  });
+
   it('uses projection change alerts for 급변 warnings instead of projection-vs-actual variance', () => {
     expect(cashflowWeeklyPageSource).toContain('sheet?.projectionChangeAlert');
     expect(cashflowWeeklyPageSource).toContain('D-7 1천만↑');

--- a/src/app/components/cashflow/CashflowWeeklyPage.tsx
+++ b/src/app/components/cashflow/CashflowWeeklyPage.tsx
@@ -9,15 +9,18 @@ import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { useAppStore } from '../../data/store';
 import { useAuth } from '../../data/auth-store';
 import { useCashflowWeeks } from '../../data/cashflow-weeks-store';
-import { chooseCashflowSheetForNet, computeCashflowTotals } from '../../platform/cashflow-sheet';
 import { getMonthMondayWeeks } from '../../platform/cashflow-weeks';
-import type { CashflowWeekSheet, VarianceFlag, VarianceFlagEvent } from '../../data/types';
+import type { CashflowWeekSheet, CashflowWeekTotals, VarianceFlag, VarianceFlagEvent } from '../../data/types';
 
 function fmtShort(n: number): string {
   const abs = Math.abs(n);
   if (abs >= 1e8) return (n / 1e8).toFixed(1) + '억';
   if (abs >= 1e4) return (n / 1e4).toFixed(0) + '만';
   return n.toLocaleString('ko-KR');
+}
+
+function emptyTotals(): CashflowWeekTotals {
+  return { totalIn: 0, totalOut: 0, net: 0 };
 }
 
 export function CashflowWeeklyPage() {
@@ -37,16 +40,13 @@ export function CashflowWeeklyPage() {
   }, [weeks, yearMonth]);
 
   const byProjectWeek = useMemo(() => {
-    const map = new Map<string, { projectionUpdated: boolean; adminClosed: boolean; net: number; netSource: 'actual' | 'projection' }>();
+    const map = new Map<string, { projectionUpdated: boolean; adminClosed: boolean; totals: CashflowWeekTotals }>();
     for (const w of weeks.filter((x) => x.yearMonth === yearMonth)) {
       const key = `${w.projectId}:${w.weekNo}`;
-      const { source, sheet } = chooseCashflowSheetForNet({ actual: w.actual, projection: w.projection });
-      const { net } = computeCashflowTotals(sheet);
       map.set(key, {
         projectionUpdated: Boolean(w.projectionUpdated),
         adminClosed: Boolean(w.adminClosed),
-        net,
-        netSource: source,
+        totals: w.projectionTotals || emptyTotals(),
       });
     }
     return map;
@@ -110,8 +110,7 @@ export function CashflowWeeklyPage() {
                       const sheet = weekSheetMap.get(cellKey);
                       const projectionUpdated = Boolean(status?.projectionUpdated);
                       const adminClosed = Boolean(status?.adminClosed);
-                      const net = status?.net ?? 0;
-                      const netSource = status?.netSource ?? 'actual';
+                      const totals = status?.totals || emptyTotals();
 
                       const projectionChangeAlert = sheet?.projectionChangeAlert;
                       const hasProjectionChangeAlert = Boolean(projectionChangeAlert?.triggered);
@@ -133,7 +132,10 @@ export function CashflowWeeklyPage() {
                               {chip.label}
                             </span>
                             <span className="text-[10px] text-muted-foreground" style={{ fontVariantNumeric: 'tabular-nums' }}>
-                              NET {fmtShort(net)}{netSource === 'projection' ? ' (예상)' : ''}
+                              입금 {fmtShort(totals.totalIn)}
+                            </span>
+                            <span className="text-[10px] text-muted-foreground" style={{ fontVariantNumeric: 'tabular-nums' }}>
+                              출금 {fmtShort(totals.totalOut)}
                             </span>
                             {hasProjectionChangeAlert && projectionChangeAlert && (
                               <span className="text-[9px] text-amber-700 dark:text-amber-300" style={{ fontWeight: 600 }}>

--- a/src/app/data/cashflow-weeks-store.tsx
+++ b/src/app/data/cashflow-weeks-store.tsx
@@ -257,6 +257,7 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
       now,
       weekStart: def.weekStart,
       existingProjection: existingData?.projection,
+      existingActual: existingData?.actual,
     });
 
     if (existingSnap?.exists()) {

--- a/src/app/data/cashflow-weeks.local-state.ts
+++ b/src/app/data/cashflow-weeks.local-state.ts
@@ -1,5 +1,6 @@
 import type { CashflowSheetLineId, CashflowWeekSheet } from './types';
 import { buildProjectionChangeAlert, normalizeWeekAmounts, resolveWeekDocId } from './cashflow-weeks.persistence';
+import { computeCashflowTotals } from '../platform/cashflow-sheet';
 
 export function applyWeekAmountsToLocalWeeks(input: {
   weeks: CashflowWeekSheet[];
@@ -28,12 +29,17 @@ export function applyWeekAmountsToLocalWeeks(input: {
         ...normalizedAmounts,
       }
       : current.projection;
+    const nextModeAmounts = {
+      ...current[input.mode],
+      ...normalizedAmounts,
+    };
     next[existingIndex] = {
       ...current,
       [input.mode]: {
         ...current[input.mode],
         ...normalizedAmounts,
       },
+      [`${input.mode}Totals`]: computeCashflowTotals(nextModeAmounts),
       ...(input.mode === 'projection'
         ? {
           projectionUpdated: true,
@@ -69,6 +75,8 @@ export function applyWeekAmountsToLocalWeeks(input: {
       weekEnd: input.weekEnd,
       projection: input.mode === 'projection' ? normalizedAmounts : {},
       actual: input.mode === 'actual' ? normalizedAmounts : {},
+      projectionTotals: computeCashflowTotals(input.mode === 'projection' ? normalizedAmounts : {}),
+      actualTotals: computeCashflowTotals(input.mode === 'actual' ? normalizedAmounts : {}),
       ...(input.mode === 'projection'
         ? {
           projectionUpdated: true,

--- a/src/app/data/cashflow-weeks.persistence.ts
+++ b/src/app/data/cashflow-weeks.persistence.ts
@@ -1,4 +1,5 @@
 import type { CashflowSheetLineId, CashflowWeekSheet, ProjectionChangeAlert } from './types';
+import { computeCashflowTotals } from '../platform/cashflow-sheet';
 
 export const PROJECTION_CHANGE_ALERT_THRESHOLD_AMOUNT = 10_000_000;
 
@@ -104,23 +105,28 @@ export function buildCashflowWeekUpdatePatch(params: {
   now: string;
   weekStart?: string;
   existingProjection?: Partial<Record<CashflowSheetLineId, number>>;
+  existingActual?: Partial<Record<CashflowSheetLineId, number>>;
 }) {
+  const normalizedAmounts = normalizeWeekAmounts(params.amounts);
+  const existingModeAmounts = params.mode === 'projection'
+    ? normalizeWeekAmounts(params.existingProjection || {})
+    : normalizeWeekAmounts(params.existingActual || {});
+  const nextModeAmounts = {
+    ...existingModeAmounts,
+    ...normalizedAmounts,
+  };
   const patch: Record<string, unknown> = {
     tenantId: params.orgId,
     updatedAt: params.now,
     updatedByUid: params.actorUid,
     updatedByName: params.actorName,
+    [`${params.mode}Totals`]: computeCashflowTotals(nextModeAmounts),
   };
   if (params.mode === 'projection') {
-    const normalizedAmounts = normalizeWeekAmounts(params.amounts);
-    const nextProjection = {
-      ...(params.existingProjection || {}),
-      ...normalizedAmounts,
-    };
     const alert = params.weekStart
       ? buildProjectionChangeAlert({
         previousProjection: params.existingProjection,
-        nextProjection,
+        nextProjection: nextModeAmounts,
         weekStart: params.weekStart,
         now: params.now,
         actorUid: params.actorUid,
@@ -133,7 +139,7 @@ export function buildCashflowWeekUpdatePatch(params: {
     patch.projectionUpdatedByName = params.actorName;
     patch.projectionChangeAlert = alert;
   }
-  for (const [lineId, amount] of Object.entries(normalizeWeekAmounts(params.amounts))) {
+  for (const [lineId, amount] of Object.entries(normalizedAmounts)) {
     patch[`${params.mode}.${lineId}`] = amount;
   }
   return patch;
@@ -153,6 +159,8 @@ export function buildInitialCashflowWeekDoc(params: {
   now: string;
 }): CashflowWeekSheet {
   const normalizedAmounts = normalizeWeekAmounts(params.amounts);
+  const projection = params.mode === 'projection' ? normalizedAmounts : {};
+  const actual = params.mode === 'actual' ? normalizedAmounts : {};
   return {
     id: resolveWeekDocId(params.projectId, params.yearMonth, params.weekNo),
     tenantId: params.orgId,
@@ -161,8 +169,10 @@ export function buildInitialCashflowWeekDoc(params: {
     weekNo: params.weekNo,
     weekStart: params.weekStart,
     weekEnd: params.weekEnd,
-    projection: params.mode === 'projection' ? normalizedAmounts : {},
-    actual: params.mode === 'actual' ? normalizedAmounts : {},
+    projection,
+    actual,
+    projectionTotals: computeCashflowTotals(projection),
+    actualTotals: computeCashflowTotals(actual),
     ...(params.mode === 'projection'
       ? {
         projectionUpdated: true,

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -1188,6 +1188,8 @@ export interface CashflowWeekSheet {
   weekEnd: string; // "YYYY-MM-DD" (Sunday)
   projection: Partial<Record<CashflowSheetLineId, number>>;
   actual: Partial<Record<CashflowSheetLineId, number>>;
+  projectionTotals?: CashflowWeekTotals;
+  actualTotals?: CashflowWeekTotals;
   projectionUpdated?: boolean;
   projectionUpdatedAt?: string;
   projectionUpdatedByUid?: string;
@@ -1209,6 +1211,12 @@ export interface CashflowWeekSheet {
   varianceFlag?: VarianceFlag;
   // 편차 확인 영구 이력 — 모든 플래그/답변/해결 기록 (삭제 불가)
   varianceHistory?: VarianceFlagEvent[];
+}
+
+export interface CashflowWeekTotals {
+  totalIn: number;
+  totalOut: number;
+  net: number;
 }
 
 export interface ProjectionChangeAlert {


### PR DESCRIPTION
## Summary
- persist weekly cashflow in/out/net totals when projection or actual values are saved through client/local/BFF paths
- make weekly projection monitor read stored projectionTotals instead of recomputing NET in the UI
- backfilled live cashflow_weeks documents with projectionTotals/actualTotals before this code deploy

## Verification
- npx vitest run src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts src/app/platform/cashflow-sheet.test.ts
- npm test -- --run server/bff/cashflow-canonical-store.test.mjs
- npm run build