### PR TITLE
fix: remove state-driven redirect loops

### DIFF
--- a/src/app/components/layout/AppLayout.shell.test.ts
+++ b/src/app/components/layout/AppLayout.shell.test.ts
@@ -41,4 +41,10 @@ describe('AppLayout root entry contract', () => {
     expect(source).toContain('<main className="min-h-dvh">');
     expect(source).toContain('<Outlet />');
   });
+
+  it('keeps permission or workspace loss in-place instead of redirecting home', () => {
+    expect(source).toContain('blockedAdminPath');
+    expect(source).not.toContain("navigate('/portal/project-select', { replace: true })");
+    expect(source).not.toContain('navigate(resolveHomePath(role, activeWorkspace), { replace: true })');
+  });
 });

--- a/src/app/components/layout/AppLayout.tsx
+++ b/src/app/components/layout/AppLayout.tsx
@@ -23,7 +23,7 @@ import { ScrollToTop } from './ScrollToTop';
 import { QuickActionFab } from './QuickActionFab';
 import { PageTransition } from './PageTransition';
 import { ErrorBoundary } from './ErrorBoundary';
-import { canChooseWorkspace, isPortalRole, resolveActiveWorkspacePreference, resolveHomePath } from '../../platform/navigation';
+import { canChooseWorkspace, isPortalRole } from '../../platform/navigation';
 import { canAccessAdminPath, canShowAdminNavItem } from '../../platform/admin-nav';
 import { NAV_GROUPS } from '../../platform/nav-config';
 import { readShellLabEnabled, shouldShowShellRoute, writeShellLabEnabled } from '../../platform/shell-lab-visibility';
@@ -40,7 +40,13 @@ function AppLayoutContent() {
   const location = useLocation();
   const navigate = useNavigate();
   const currentPath = `${location.pathname}${location.search}${location.hash}`;
-  const activeWorkspace = resolveActiveWorkspacePreference(authUser?.lastWorkspace, authUser?.defaultWorkspace);
+  const displayUser = authUser || currentUser;
+  const blockedAdminPath = Boolean(
+    !authLoading
+    && isAuthenticated
+    && displayUser?.role
+    && !canAccessAdminPath(displayUser.role, location.pathname)
+  );
 
   // Auth guard — 미인증 시 로그인 페이지로
   useEffect(() => {
@@ -49,25 +55,6 @@ function AppLayoutContent() {
       navigate('/login', { replace: true, state: { from: currentPath } });
     }
   }, [authLoading, currentPath, isAuthenticated, navigate]);
-
-  useEffect(() => {
-    if (authLoading) return;
-    const role = (authUser || currentUser)?.role;
-    if (!isAuthenticated || !role) return;
-    if (isPortalRole(role) && !canAccessAdminPath(role, location.pathname)) {
-      if (location.pathname.startsWith('/board')) {
-        navigate(`/portal${location.pathname}`, { replace: true });
-        return;
-      }
-
-      navigate('/portal/project-select', { replace: true });
-      return;
-    }
-
-    if (!canAccessAdminPath(role, location.pathname)) {
-      navigate(resolveHomePath(role, activeWorkspace), { replace: true });
-    }
-  }, [activeWorkspace, authLoading, authUser, currentUser, isAuthenticated, location.pathname, navigate]);
 
   useEffect(() => {
     if (authLoading) return;
@@ -84,7 +71,6 @@ function AppLayoutContent() {
     setMobileOpen(false);
   }, [location.pathname]);
 
-  const displayUser = authUser || currentUser;
   const navGroups = React.useMemo(() => {
     return NAV_GROUPS
       .map((group) => ({
@@ -136,6 +122,29 @@ function AppLayoutContent() {
   const totalAlerts = pendingCount + (participationDangerCount > 0 ? participationDangerCount : 0);
 
   if (authLoading || !isAuthenticated) return null;
+
+  if (blockedAdminPath) {
+    return (
+      <TooltipProvider delayDuration={300}>
+        <CommandPalette />
+        <KeyboardShortcuts />
+        <main className="min-h-dvh bg-background p-6">
+          <div className="mx-auto max-w-xl rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+            <Badge variant="outline">접근 제한</Badge>
+            <h1 className="mt-4 text-lg font-semibold text-slate-950">이 화면을 열 수 없습니다</h1>
+            <p className="mt-2 text-sm text-slate-600">
+              권한 또는 작업 공간 상태를 확인해 주세요. 현재 URL은 유지했습니다.
+            </p>
+            {isPortalRole(displayUser?.role) && (
+              <Button type="button" className="mt-5" onClick={openPortalWorkspace}>
+                사용자 포털 열기
+              </Button>
+            )}
+          </div>
+        </main>
+      </TooltipProvider>
+    );
+  }
 
   if (location.pathname === '/') {
     return (

--- a/src/app/components/portal/PortalLayout.shell.test.ts
+++ b/src/app/components/portal/PortalLayout.shell.test.ts
@@ -70,9 +70,11 @@ describe('PortalLayout shell actions', () => {
 
   it('keeps portal navigation explicit without onboarding or project-select redirect effects', () => {
     expect(portalLayoutSource).toContain('isPortalStandaloneEntryPath');
+    expect(portalLayoutSource).toContain('blockedPortalAccess');
     expect(portalLayoutSource).toContain("navigate('/portal/project-select')");
     expect(portalLayoutSource).toContain("navigate('/portal/weekly-expenses')");
     expect(portalLayoutSource).toContain("navigate('/portal/register-project')");
+    expect(portalLayoutSource).not.toContain("navigate('/', { replace: true })");
     expect(portalLayoutSource).not.toContain('shouldForcePortalOnboarding');
     expect(portalLayoutSource).not.toContain('resolvePortalProjectSelectPath(currentPath)');
   });

--- a/src/app/components/portal/PortalLayout.tsx
+++ b/src/app/components/portal/PortalLayout.tsx
@@ -174,6 +174,13 @@ function PortalContent() {
   const [labEnabled, setLabEnabled] = useShellLabEnabled();
   const navigationHandlerRef = useRef<((attempt: PortalNavigationAttempt) => boolean) | null>(null);
   const currentPath = `${location.pathname}${location.search}${location.hash}`;
+  const blockedPortalAccess = Boolean(
+    !authLoading
+    && !portalLoading
+    && isAuthenticated
+    && authUser?.role
+    && !canEnterPortalWorkspace(authUser.role)
+  );
   const registerNavigationHandler = useCallback((handler: ((attempt: PortalNavigationAttempt) => boolean) | null) => {
     navigationHandlerRef.current = handler;
   }, []);
@@ -297,21 +304,6 @@ function PortalContent() {
   useEffect(() => {
     if (authLoading) return;
     const role = authUser?.role;
-    if (!isAuthenticated || !role) return;
-    if (!canEnterPortalWorkspace(role)) {
-      if (location.pathname.startsWith('/portal/board')) {
-        const suffix = location.pathname.slice('/portal'.length);
-        navigate(suffix, { replace: true });
-        return;
-      }
-
-      navigate('/', { replace: true });
-    }
-  }, [authLoading, isAuthenticated, authUser, location.pathname, navigate]);
-
-  useEffect(() => {
-    if (authLoading) return;
-    const role = authUser?.role;
     if (!isAuthenticated || !role || !canChooseWorkspace(role)) return;
     // admin/finance가 portal을 잠깐 방문할 때 workspace를 덮어쓰지 않음
     if (isAdminSpaceRole(role)) return;
@@ -349,6 +341,25 @@ function PortalContent() {
         <div className="text-center">
           <Loader2 className="w-5 h-5 mx-auto animate-spin text-muted-foreground" />
           <p className="mt-2 text-[12px] text-muted-foreground">포털 데이터를 불러오는 중...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (blockedPortalAccess) {
+    return (
+      <div className="min-h-screen bg-slate-50 px-6 py-8 dark:bg-slate-950">
+        <div className="mx-auto max-w-xl rounded-lg border border-slate-200 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+          <Badge variant="outline">접근 제한</Badge>
+          <h1 className="mt-4 text-lg font-semibold text-slate-950 dark:text-slate-50">이 포털 화면을 열 수 없습니다</h1>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+            권한 또는 작업 공간 상태를 확인해 주세요. 현재 URL은 유지했습니다.
+          </p>
+          {isAdminSpaceRole(authUser?.role) && (
+            <Button type="button" className="mt-5" onClick={requestAdminNavigation}>
+              관리자 공간 열기
+            </Button>
+          )}
         </div>
       </div>
     );

--- a/src/app/components/portal/PortalOnboarding.shell.test.ts
+++ b/src/app/components/portal/PortalOnboarding.shell.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(import.meta.dirname, 'PortalOnboarding.tsx'), 'utf8');
+
+describe('PortalOnboarding redirect contract', () => {
+  it('keeps admin-space users in place instead of redirecting home', () => {
+    expect(source).toContain('isAdminSpaceUser');
+    expect(source).toContain('포털 접근 권한을 확인해 주세요');
+    expect(source).not.toContain("navigate('/', { replace: true })");
+  });
+});

--- a/src/app/components/portal/PortalOnboarding.tsx
+++ b/src/app/components/portal/PortalOnboarding.tsx
@@ -33,7 +33,7 @@ export function PortalOnboarding() {
     resolvePrimaryProjectId(projectIds, portalUser?.projectId || authUser?.projectId) || ''
   ));
 
-  const isAdminSpaceUser = !canEnterPortalWorkspace(authUser?.role);
+  const isAdminSpaceUser = Boolean(authUser?.role && !canEnterPortalWorkspace(authUser.role));
 
   useEffect(() => {
     if (authLoading) return;
@@ -41,11 +41,7 @@ export function PortalOnboarding() {
       navigate('/login', { replace: true, state: { from: '/portal/onboarding' } });
       return;
     }
-
-    if (isAdminSpaceUser) {
-      navigate('/', { replace: true });
-    }
-  }, [authLoading, isAuthenticated, isAdminSpaceUser, navigate]);
+  }, [authLoading, isAuthenticated, navigate]);
 
   useEffect(() => {
     const merged = normalizeProjectIds([
@@ -126,6 +122,24 @@ export function PortalOnboarding() {
           <Loader2 className="w-5 h-5 mx-auto animate-spin text-muted-foreground" />
           <p className="mt-2 text-[12px] text-muted-foreground">프로젝트 목록을 불러오는 중...</p>
         </div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) return null;
+
+  if (isAdminSpaceUser) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 p-4 dark:bg-slate-950">
+        <Card className="w-full max-w-xl border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+          <CardContent className="p-6">
+            <Badge variant="outline">접근 제한</Badge>
+            <h1 className="mt-4 text-lg font-semibold text-slate-950 dark:text-slate-50">포털 접근 권한을 확인해 주세요</h1>
+            <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+              권한 또는 작업 공간 상태를 확인해 주세요. 현재 URL은 유지했습니다.
+            </p>
+          </CardContent>
+        </Card>
       </div>
     );
   }

--- a/src/app/components/portal/PortalProjectSelectPage.shell.test.ts
+++ b/src/app/components/portal/PortalProjectSelectPage.shell.test.ts
@@ -12,8 +12,10 @@ describe('PortalProjectSelectPage shell', () => {
     expect(source).toContain('id="portal-project-search"');
     expect(source).toContain('name="portalProjectSearch"');
     expect(source).toContain("resolvePortalProjectSwitchPath('/portal/budget')");
+    expect(source).toContain('blockedPortalAccess');
     expect(source).not.toContain('resolveRequestedRedirectPath');
     expect(source).not.toContain("navigate('/portal/onboarding'");
+    expect(source).not.toContain("navigate('/', { replace: true })");
     expect(source).not.toContain('주사업으로 지정');
     expect(source).not.toContain('증빙 드라이브 연결');
   });

--- a/src/app/components/portal/PortalProjectSelectPage.tsx
+++ b/src/app/components/portal/PortalProjectSelectPage.tsx
@@ -100,6 +100,13 @@ export function PortalProjectSelectPage() {
 
   const currentPath = `${location.pathname}${location.search}${location.hash}`;
   const redirectTarget = resolvePortalProjectSwitchPath('/portal/budget');
+  const blockedPortalAccess = Boolean(
+    !authLoading
+    && !portalLoading
+    && isAuthenticated
+    && authUser?.role
+    && !canEnterPortalWorkspace(authUser.role)
+  );
   const assignedProjectIds = useMemo(() => normalizeProjectIds([
     ...(Array.isArray(portalUser?.projectIds) ? portalUser.projectIds : []),
     portalUser?.projectId,
@@ -125,13 +132,8 @@ export function PortalProjectSelectPage() {
     if (authLoading || portalLoading) return;
     if (!isAuthenticated) {
       navigate('/login', { replace: true, state: { from: currentPath } });
-      return;
     }
-    if (!canEnterPortalWorkspace(authUser?.role)) {
-      navigate('/', { replace: true });
-      return;
-    }
-  }, [authLoading, authUser?.role, currentPath, isAuthenticated, navigate, portalLoading]);
+  }, [authLoading, currentPath, isAuthenticated, navigate, portalLoading]);
 
   const handleStart = async (projectId: string) => {
     setPendingProjectId(projectId);
@@ -145,6 +147,29 @@ export function PortalProjectSelectPage() {
     return (
       <div className="flex min-h-screen items-center justify-center bg-slate-50">
         <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) return null;
+
+  if (blockedPortalAccess) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50 px-4">
+        <Card className="w-full max-w-xl border-slate-200 bg-white shadow-sm">
+          <CardContent className="p-6">
+            <Badge variant="outline">접근 제한</Badge>
+            <h1 className="mt-4 text-lg font-semibold text-slate-950">프로젝트 선택 권한을 확인해 주세요</h1>
+            <p className="mt-2 text-sm text-slate-600">
+              권한 또는 작업 공간 상태를 확인해 주세요. 현재 URL은 유지했습니다.
+            </p>
+            {isAdminSpaceRole(authUser?.role) && (
+              <Button type="button" className="mt-5" onClick={() => navigate('/')}>
+                관리자 공간 열기
+              </Button>
+            )}
+          </CardContent>
+        </Card>
       </div>
     );
   }

--- a/src/app/components/projects/ProjectRegisterRedirectPage.shell.test.ts
+++ b/src/app/components/projects/ProjectRegisterRedirectPage.shell.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(import.meta.dirname, 'ProjectRegisterRedirectPage.tsx'), 'utf8');
+
+describe('ProjectRegisterRedirectPage redirect contract', () => {
+  it('keeps legacy project registration entry explicit instead of auto redirecting', () => {
+    expect(source).toContain('프로젝트 등록 요청 열기');
+    expect(source).not.toContain('Navigate');
+    expect(source).not.toContain('replace');
+  });
+});

--- a/src/app/components/projects/ProjectRegisterRedirectPage.tsx
+++ b/src/app/components/projects/ProjectRegisterRedirectPage.tsx
@@ -1,8 +1,25 @@
-import { Navigate, useLocation } from 'react-router';
+import { useLocation } from 'react-router';
 
 export function ProjectRegisterRedirectPage() {
   const location = useLocation();
-  return <Navigate to={`/portal/register-project${location.search}`} replace />;
+  const target = `/portal/register-project${location.search}`;
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center px-4">
+      <div className="w-full max-w-md rounded-lg border border-slate-200 bg-white p-5 text-center shadow-sm">
+        <p className="text-sm font-semibold text-slate-950">프로젝트 등록 요청 화면으로 이동합니다</p>
+        <p className="mt-2 text-xs leading-5 text-slate-600">
+          자동 이동은 사용하지 않습니다. 아래 버튼을 눌러 등록 요청 화면을 여세요.
+        </p>
+        <a
+          className="mt-4 inline-flex h-9 items-center justify-center rounded-md bg-[#001e46] px-4 text-sm font-semibold text-white"
+          href={target}
+        >
+          프로젝트 등록 요청 열기
+        </a>
+      </div>
+    </div>
+  );
 }
 
 export default ProjectRegisterRedirectPage;

--- a/src/app/components/pwa/MobileEntryPage.shell.test.ts
+++ b/src/app/components/pwa/MobileEntryPage.shell.test.ts
@@ -5,10 +5,12 @@ import { describe, expect, it } from 'vitest';
 const source = readFileSync(resolve(import.meta.dirname, 'MobileEntryPage.tsx'), 'utf8');
 
 describe('MobileEntryPage route contract', () => {
-  it('sends mobile PWA launches to business cards and desktop launches to the existing root', () => {
+  it('renders mobile business cards in place without route-level redirects', () => {
     expect(source).toContain('shouldUseBusinessCardMobileEntry');
-    expect(source).toContain('BUSINESS_CARD_MOBILE_ENTRY_PATH');
+    expect(source).toContain('BusinessCardLabPage');
     expect(source).toContain("'/mobile-entry'");
-    expect(source).toContain("to={useBusinessCardEntry ? BUSINESS_CARD_MOBILE_ENTRY_PATH : '/'}");
+    expect(source).toContain('return <BusinessCardLabPage />');
+    expect(source).not.toContain('Navigate');
+    expect(source).not.toContain('replace');
   });
 });

--- a/src/app/components/pwa/MobileEntryPage.tsx
+++ b/src/app/components/pwa/MobileEntryPage.tsx
@@ -1,8 +1,5 @@
-import { Navigate } from 'react-router';
-import {
-  BUSINESS_CARD_MOBILE_ENTRY_PATH,
-  shouldUseBusinessCardMobileEntry,
-} from '../../platform/mobile-entry';
+import { shouldUseBusinessCardMobileEntry } from '../../platform/mobile-entry';
+import { BusinessCardLabPage } from '../business-cards/BusinessCardLabPage';
 
 export function MobileEntryPage() {
   const useBusinessCardEntry = shouldUseBusinessCardMobileEntry({
@@ -11,5 +8,21 @@ export function MobileEntryPage() {
     requestedPath: typeof window !== 'undefined' ? window.location.pathname : '/mobile-entry',
   });
 
-  return <Navigate to={useBusinessCardEntry ? BUSINESS_CARD_MOBILE_ENTRY_PATH : '/'} replace />;
+  if (useBusinessCardEntry) {
+    return <BusinessCardLabPage />;
+  }
+
+  return (
+    <div className="flex min-h-dvh items-center justify-center bg-slate-50 px-4 text-center">
+      <div className="max-w-sm rounded-lg border border-slate-200 bg-white p-5 shadow-sm">
+        <p className="text-sm font-semibold text-slate-950">모바일 명함 DB 진입 화면입니다</p>
+        <p className="mt-2 text-xs leading-5 text-slate-600">
+          데스크톱에서는 좌측 상단 로고 또는 메뉴를 통해 필요한 화면으로 이동해 주세요.
+        </p>
+        <a className="mt-4 inline-flex text-sm font-semibold text-[#001e46]" href="/">
+          홈으로 이동
+        </a>
+      </div>
+    </div>
+  );
 }

--- a/src/app/components/settings/SettingsPage.shell.test.ts
+++ b/src/app/components/settings/SettingsPage.shell.test.ts
@@ -13,4 +13,10 @@ describe('SettingsPage member directory contract', () => {
     expect(source).toContain('Firebase UID');
     expect(source).toContain('이름, 이메일, UID 검색');
   });
+
+  it('keeps unauthorized settings access in place instead of redirecting home', () => {
+    expect(source).toContain('settingsAccessBlocked');
+    expect(source).toContain('설정 접근 권한이 없습니다');
+    expect(source).not.toContain('navigate(resolveHomePath(role, activeWorkspace), { replace: true })');
+  });
 });

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -24,7 +24,6 @@ import {
 import { DataMigrationTab } from './DataMigrationTab';
 import { PageHeader } from '../layout/PageHeader';
 import { useAuth } from '../../data/auth-store';
-import { resolveActiveWorkspacePreference, resolveHomePath } from '../../platform/navigation';
 
 const DISPLAY_ROLES = ['admin', 'finance', 'pm'] as const;
 type DisplayRole = typeof DISPLAY_ROLES[number];
@@ -45,7 +44,7 @@ const PERMISSION_LABELS: Partial<Record<PlatformPermission, string>> = {
 
 export function SettingsPage() {
   const { org, members, templates, upsertMember, removeMember } = useAppStore();
-  const { isAuthenticated, user } = useAuth();
+  const { isAuthenticated, isLoading: authLoading, user } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
@@ -61,7 +60,7 @@ export function SettingsPage() {
     role: 'pm' as DisplayRole,
   });
   const currentPath = `${location.pathname}${location.search}${location.hash}`;
-  const activeWorkspace = resolveActiveWorkspacePreference(user?.lastWorkspace, user?.defaultWorkspace);
+  const settingsAccessBlocked = Boolean(isAuthenticated && user && user.role !== 'admin');
   const filteredMembers = useMemo(() => {
     const query = memberSearch.trim().toLowerCase();
     if (!query) return members;
@@ -117,24 +116,32 @@ export function SettingsPage() {
   };
 
   useEffect(() => {
+    if (authLoading) return;
     if (!isAuthenticated) {
       navigate('/login', { replace: true, state: { from: currentPath } });
-      return;
     }
+  }, [authLoading, currentPath, isAuthenticated, navigate]);
 
-    const role = user?.role;
-    if (!role) return;
-
-    // Keep operational settings (Firebase/feature toggles, member management) admin-scoped.
-    const allowed = role === 'admin';
-    if (!allowed) {
-      navigate(resolveHomePath(role, activeWorkspace), { replace: true });
-    }
-  }, [activeWorkspace, currentPath, isAuthenticated, navigate, user?.role]);
-
-  if (!isAuthenticated) return null;
+  if (authLoading || !isAuthenticated) return null;
   if (!user) return null;
-  if (user.role !== 'admin') return null;
+
+  if (settingsAccessBlocked) {
+    return (
+      <div className="space-y-5">
+        <PageHeader
+          icon={Shield}
+          iconGradient="linear-gradient(135deg, #001e46, #001e46)"
+          title="설정 접근 권한이 없습니다"
+          description="운영 설정은 관리자만 변경할 수 있습니다. 현재 URL은 유지했습니다."
+        />
+        <Card className="border-slate-200 bg-white">
+          <CardContent className="p-5 text-sm text-slate-600">
+            필요한 경우 관리자에게 권한 확인을 요청해 주세요.
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-5">

--- a/src/app/components/settings/TenantSwitcher.shell.test.ts
+++ b/src/app/components/settings/TenantSwitcher.shell.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(import.meta.dirname, 'TenantSwitcher.tsx'), 'utf8');
+
+describe('TenantSwitcher redirect contract', () => {
+  it('does not force root navigation after tenant selection', () => {
+    expect(source).toContain('setOrgId(nextId)');
+    expect(source).not.toContain("navigate('/', { replace: true })");
+  });
+});

--- a/src/app/components/settings/TenantSwitcher.tsx
+++ b/src/app/components/settings/TenantSwitcher.tsx
@@ -70,9 +70,8 @@ export function TenantSwitcher({ collapsed = false, userRole, userTenantId }: Te
     if (ok) {
       setOpen(false);
       setCustomInput('');
-      navigate('/', { replace: true });
     }
-  }, [orgId, setOrgId, navigate, isTenantAdmin, userTenantId]);
+  }, [orgId, setOrgId, isTenantAdmin, userTenantId]);
 
   const handleCustomSwitch = useCallback(() => {
     const value = customInput.trim().toLowerCase();

--- a/src/app/platform/navigation.test.ts
+++ b/src/app/platform/navigation.test.ts
@@ -110,8 +110,9 @@ describe('resolveHomePath', () => {
     expect(resolveHomePath('admin', 'admin')).toBe('/');
   });
 
-  it('admin with portal preference goes to the explicit portal home', () => {
+  it('dual-space roles with portal preference go to the explicit portal home', () => {
     expect(resolveHomePath('admin', 'portal')).toBe('/portal/project-select');
+    expect(resolveHomePath('finance', 'portal')).toBe('/portal/project-select');
   });
 
   it('finance defaults to /', () => {
@@ -216,11 +217,17 @@ describe('resolvePortalEntryPath', () => {
 });
 
 describe('resolveLoginSuccessPath', () => {
-  it('uses the full-screen feature search as the default post-login entry for every role', () => {
+  it('uses the full-screen feature search as the default post-login entry for admin-space users', () => {
     expect(resolveLoginSuccessPath('admin', undefined)).toBe('/');
-    expect(resolveLoginSuccessPath('finance', 'portal')).toBe('/');
-    expect(resolveLoginSuccessPath('pm', undefined)).toBe('/');
-    expect(resolveLoginSuccessPath('viewer', undefined, '/')).toBe('/');
+    expect(resolveLoginSuccessPath('admin', 'admin')).toBe('/');
+    expect(resolveLoginSuccessPath('finance', undefined)).toBe('/');
+  });
+
+  it('does not force portal-context users back to the admin homepage after login or auth refresh', () => {
+    expect(resolveLoginSuccessPath('pm', undefined)).toBe('/portal/project-select');
+    expect(resolveLoginSuccessPath('viewer', undefined, '/')).toBe('/portal/project-select');
+    expect(resolveLoginSuccessPath('admin', 'portal')).toBe('/portal/project-select');
+    expect(resolveLoginSuccessPath('finance', 'portal')).toBe('/portal/project-select');
   });
 
   it('uses business cards as the mobile default post-login entry', () => {

--- a/src/app/platform/navigation.ts
+++ b/src/app/platform/navigation.ts
@@ -56,7 +56,7 @@ export function resolveHomePath(role: unknown, preferredWorkspace?: WorkspaceId 
   const normalized = normalizeRole(role);
   if (!normalized) return '/portal/project-select';
   if (isPortalRole(normalized)) return '/portal/project-select';
-  if (normalized === 'admin' && normalizeWorkspaceId(preferredWorkspace) === 'portal') {
+  if (isAdminSpaceRole(normalized) && normalizeWorkspaceId(preferredWorkspace) === 'portal') {
     return '/portal/project-select';
   }
   if (isAdminSpaceRole(normalized)) return '/';
@@ -124,7 +124,7 @@ export function resolveLoginSuccessPath(
   })) {
     return BUSINESS_CARD_MOBILE_ENTRY_PATH;
   }
-  if (!normalizedPath || normalizedPath === '/') return '/';
+  if (!normalizedPath || normalizedPath === '/') return resolveHomePath(role, preferredWorkspace);
   return resolvePortalEntryPath(role, preferredWorkspace, normalizedPath);
 }
 

--- a/src/app/platform/preload-recovery.test.ts
+++ b/src/app/platform/preload-recovery.test.ts
@@ -1,16 +1,26 @@
-import { describe, expect, it, vi } from 'vitest';
-import { installVitePreloadRecovery } from './preload-recovery';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('installVitePreloadRecovery', () => {
-  it('reloads the app shell when Vite reports a stale preload chunk', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('reloads the app shell once when Vite reports a stale preload chunk', async () => {
+    const { installVitePreloadRecovery } = await import('./preload-recovery');
     let listener: ((event: Event) => void) | undefined;
     const reload = vi.fn();
+    const storage = new Map<string, string>();
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const target = {
       addEventListener: vi.fn((type: string, callback: EventListener) => {
         if (type === 'vite:preloadError') listener = callback;
       }),
-      location: { reload },
+      location: { pathname: '/portal/cashflow', reload },
+      sessionStorage: {
+        getItem: vi.fn((key: string) => storage.get(key) || null),
+        setItem: vi.fn((key: string, value: string) => storage.set(key, value)),
+      },
     };
     const event = {
       preventDefault: vi.fn(),
@@ -22,6 +32,43 @@ describe('installVitePreloadRecovery', () => {
 
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
     expect(reload).toHaveBeenCalledTimes(1);
+    listener?.(event);
+    expect(reload).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
     warnSpy.mockRestore();
+  });
+
+  it('does not reload again after a same-path recovery marker survives reload', async () => {
+    const { installVitePreloadRecovery } = await import('./preload-recovery');
+    let listener: ((event: Event) => void) | undefined;
+    const reload = vi.fn();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const target = {
+      addEventListener: vi.fn((type: string, callback: EventListener) => {
+        if (type === 'vite:preloadError') listener = callback;
+      }),
+      location: { pathname: '/portal/cashflow', reload },
+      sessionStorage: {
+        getItem: vi.fn(() => JSON.stringify({
+          path: '/portal/cashflow',
+          requestedAt: Date.now(),
+        })),
+        setItem: vi.fn(),
+      },
+    };
+    const event = {
+      preventDefault: vi.fn(),
+      detail: { message: 'failed to fetch dynamically imported module' },
+    } as unknown as Event;
+
+    installVitePreloadRecovery(target);
+    listener?.(event);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(reload).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('already attempted recently'));
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
   });
 });

--- a/src/app/platform/preload-recovery.ts
+++ b/src/app/platform/preload-recovery.ts
@@ -1,15 +1,57 @@
-type PreloadRecoveryTarget = Pick<Window, 'addEventListener' | 'location'>;
+type PreloadRecoveryTarget = Pick<Window, 'addEventListener'> & {
+  location: Pick<Location, 'pathname' | 'reload'>;
+  sessionStorage?: Pick<Storage, 'getItem' | 'setItem'>;
+};
 
 let reloadRequested = false;
+const PRELOAD_RECOVERY_SESSION_KEY = 'mysc:vite-preload-recovery';
+const PRELOAD_RECOVERY_THROTTLE_MS = 30_000;
+
+function shouldReloadForPreloadError(target: PreloadRecoveryTarget): boolean {
+  if (reloadRequested) return false;
+
+  const path = target.location.pathname || '/';
+  const now = Date.now();
+  const sessionStorage = target.sessionStorage;
+  if (!sessionStorage) {
+    reloadRequested = true;
+    return true;
+  }
+
+  try {
+    const previous = JSON.parse(sessionStorage.getItem(PRELOAD_RECOVERY_SESSION_KEY) || 'null') as {
+      path?: string;
+      requestedAt?: number;
+    } | null;
+    if (
+      previous?.path === path
+      && typeof previous.requestedAt === 'number'
+      && now - previous.requestedAt < PRELOAD_RECOVERY_THROTTLE_MS
+    ) {
+      return false;
+    }
+
+    sessionStorage.setItem(PRELOAD_RECOVERY_SESSION_KEY, JSON.stringify({ path, requestedAt: now }));
+  } catch {
+    // Storage can be blocked in some auth/browser modes. Fall back to in-memory protection.
+  }
+
+  reloadRequested = true;
+  return true;
+}
 
 export function installVitePreloadRecovery(target: PreloadRecoveryTarget = window): void {
   target.addEventListener('vite:preloadError', (event) => {
     const customEvent = event as unknown as CustomEvent<{ message?: string } | undefined>;
     customEvent.preventDefault();
-    console.warn('[MYSC] Vite preload error detected; reloading app shell:', customEvent.detail);
+    console.warn('[MYSC] Vite preload error detected:', customEvent.detail);
 
-    if (reloadRequested) return;
-    reloadRequested = true;
+    if (!shouldReloadForPreloadError(target)) {
+      console.error('[MYSC] Vite preload recovery already attempted recently; keeping current URL without another reload.');
+      return;
+    }
+
+    console.warn('[MYSC] Reloading app shell once to recover stale chunks.');
     target.location.reload();
   });
 }

--- a/src/app/platform/redirect-policy.test.ts
+++ b/src/app/platform/redirect-policy.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { isStateDrivenRedirectForbidden, isSystemRedirectAllowed } from './redirect-policy';
+
+describe('redirect policy', () => {
+  it('allows only auth-boundary redirects', () => {
+    expect(isSystemRedirectAllowed('unauthenticated-login')).toBe(true);
+    expect(isSystemRedirectAllowed('post-login-success')).toBe(true);
+    expect(isSystemRedirectAllowed('preview-auth-fallback')).toBe(true);
+  });
+
+  it('forbids redirects caused by transient app state', () => {
+    expect(isStateDrivenRedirectForbidden('role-missing')).toBe(true);
+    expect(isStateDrivenRedirectForbidden('role-denied')).toBe(true);
+    expect(isStateDrivenRedirectForbidden('workspace-missing')).toBe(true);
+    expect(isStateDrivenRedirectForbidden('tenant-changed')).toBe(true);
+    expect(isStateDrivenRedirectForbidden('portal-user-missing')).toBe(true);
+    expect(isStateDrivenRedirectForbidden('active-project-missing')).toBe(true);
+    expect(isStateDrivenRedirectForbidden('project-status-changed')).toBe(true);
+  });
+});

--- a/src/app/platform/redirect-policy.ts
+++ b/src/app/platform/redirect-policy.ts
@@ -1,0 +1,24 @@
+export type SystemRedirectReason =
+  | 'unauthenticated-login'
+  | 'post-login-success'
+  | 'preview-auth-fallback';
+
+const STATE_DRIVEN_REDIRECT_REASONS = new Set([
+  'role-missing',
+  'role-denied',
+  'workspace-missing',
+  'tenant-changed',
+  'portal-user-missing',
+  'active-project-missing',
+  'project-status-changed',
+]);
+
+export function isSystemRedirectAllowed(reason: SystemRedirectReason): boolean {
+  return reason === 'unauthenticated-login'
+    || reason === 'post-login-success'
+    || reason === 'preview-auth-fallback';
+}
+
+export function isStateDrivenRedirectForbidden(reason: string): boolean {
+  return STATE_DRIVEN_REDIRECT_REASONS.has(reason);
+}

--- a/src/app/routes.lazy-route.shell.test.ts
+++ b/src/app/routes.lazy-route.shell.test.ts
@@ -16,6 +16,8 @@ describe('route lazy loading safety', () => {
     expect(routesSource).toContain('function MobileAwareAdminHome()');
     expect(routesSource).toContain('shouldUseBusinessCardMobileEntry');
     expect(routesSource).toContain('{ index: true, element: <MobileAwareAdminHome /> }');
+    expect(routesSource).toContain('? <S C={BusinessCardLabPage} />');
+    expect(routesSource).not.toContain('<Navigate to={BUSINESS_CARD_MOBILE_ENTRY_PATH} replace />');
   });
 
   it('keeps /portal on the project selection surface without a route-level redirect', () => {

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,11 +1,11 @@
 import { lazy, Suspense, type ComponentType } from 'react';
-import { createBrowserRouter, Navigate } from 'react-router';
+import { createBrowserRouter } from 'react-router';
 import { AppLayout } from './components/layout/AppLayout';
 import { PortalLayout } from './components/portal/PortalLayout';
 import { AdminRouteProviders } from './data/admin-route-providers';
 import { PortalRouteProviders } from './data/portal-route-providers';
 import { loadLazyRouteModule } from './platform/lazy-route';
-import { BUSINESS_CARD_MOBILE_ENTRY_PATH, shouldUseBusinessCardMobileEntry } from './platform/mobile-entry';
+import { shouldUseBusinessCardMobileEntry } from './platform/mobile-entry';
 
 // Lazy-loaded pages — each becomes a separate chunk
 const LoginPage = lazy(() => import('./components/auth/LoginPage').then(m => ({ default: m.LoginPage })));
@@ -98,7 +98,7 @@ function MobileAwareAdminHome() {
   });
 
   return useBusinessCardEntry
-    ? <Navigate to={BUSINESS_CARD_MOBILE_ENTRY_PATH} replace />
+    ? <S C={BusinessCardLabPage} />
     : <S C={FeatureSearchPage} />;
 }
 


### PR DESCRIPTION
## Summary
- Remove state-driven home/project-select redirects from admin, portal, settings, tenant switch, and mobile entry flows
- Keep blocked/unauthorized states in place with explicit user actions instead of automatic navigation
- Throttle Vite stale preload recovery across reloads to prevent repeated reload loops

## Verification
- npx vitest run src/app/platform/redirect-policy.test.ts src/app/platform/preload-recovery.test.ts src/app/components/layout/AppLayout.shell.test.ts src/app/components/portal/PortalLayout.shell.test.ts src/app/components/portal/PortalProjectSelectPage.shell.test.ts src/app/components/portal/PortalOnboarding.shell.test.ts src/app/components/settings/SettingsPage.shell.test.ts src/app/components/settings/TenantSwitcher.shell.test.ts src/app/routes.lazy-route.shell.test.ts src/app/components/pwa/MobileEntryPage.shell.test.ts src/app/components/projects/ProjectRegisterRedirectPage.shell.test.ts
- npm run build
- npm test