### PR TITLE
fix(projects): persist portal edit snapshots

### DIFF
--- a/server/bff/routes/projects.mjs
+++ b/server/bff/routes/projects.mjs
@@ -444,7 +444,7 @@ function buildProjectRequestPayloadFromProject(project, existingPayload = {}) {
     teamMembers,
     teamMembersDetailed,
     participantCondition: pickText('participantCondition'),
-    note: readOptionalText(existingPayload.note),
+    note: pickText('note'),
     contractDocument: project?.contractDocument ?? existingPayload.contractDocument ?? null,
     contractAnalysis: project?.contractAnalysis ?? existingPayload.contractAnalysis ?? null,
   };

--- a/src/app/components/portal/PortalProjectEdit.persist-shell.test.ts
+++ b/src/app/components/portal/PortalProjectEdit.persist-shell.test.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(import.meta.dirname, 'PortalProjectEdit.tsx'), 'utf8');
+
+describe('PortalProjectEdit persistence shell', () => {
+  it('patches the portal project snapshot after a successful save', () => {
+    expect(source).toContain('patchProjectSnapshot');
+    expect(source).toContain('const savedProject = await persistProject');
+    expect(source).toContain('if (savedProject) patchProjectSnapshot(savedProject)');
+  });
+});

--- a/src/app/components/portal/PortalProjectEdit.tsx
+++ b/src/app/components/portal/PortalProjectEdit.tsx
@@ -85,7 +85,7 @@ export function PortalProjectEdit() {
   const navigate = useNavigate();
   const { user: authUser } = useAuth();
   const { db, isOnline, orgId } = useFirebase();
-  const { members, myProject } = usePortalStore();
+  const { members, myProject, patchProjectSnapshot } = usePortalStore();
   const [requestDoc, setRequestDoc] = useState<ProjectRequest | null>(null);
   const [loadingRequest, setLoadingRequest] = useState(true);
   const [busyActionId, setBusyActionId] = useState<string | null>(null);
@@ -301,10 +301,11 @@ export function PortalProjectEdit() {
     setBusyActionId(actionId);
     try {
       const forcePendingReview = actionId === 'resubmit';
-      await persistProject(draft, {
+      const savedProject = await persistProject(draft, {
         forcePendingReview,
         reviewComment: forcePendingReview ? resubmitComment.trim() || null : null,
       });
+      if (savedProject) patchProjectSnapshot(savedProject);
       if (forcePendingReview) {
         setResubmitComment('');
         toast.success('수정 후 다시 제출했습니다.');

--- a/src/app/data/portal-store.helpers.test.ts
+++ b/src/app/data/portal-store.helpers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { ExpenseSet } from './budget-data';
 import type { Project } from './types';
-import { areProjectsEqual } from './portal-store';
+import { areProjectsEqual, mergeProjectSnapshot } from './portal-store';
 import {
   computeExpenseTotals,
   duplicateExpenseSetAsDraft,
@@ -135,5 +135,27 @@ describe('portal-store helpers', () => {
     const right = [{ ...baseProject, updatedAt: '2026-01-02T00:00:00Z' }];
 
     expect(areProjectsEqual(left, right)).toBe(false);
+  });
+
+  it('replaces a saved project snapshot without dropping unrelated projects', () => {
+    const next = mergeProjectSnapshot([
+      { ...baseProject, id: 'p001', name: '기존 사업', version: 1 },
+      { ...baseProject, id: 'p002', name: '다른 사업', version: 1 },
+    ], {
+      ...baseProject,
+      id: 'p001',
+      name: '수정된 사업',
+      note: '저장된 비고',
+      version: 3,
+      updatedAt: '2026-05-29T00:00:00.000Z',
+    });
+
+    expect(next).toHaveLength(2);
+    expect(next.find((project) => project.id === 'p001')).toMatchObject({
+      name: '수정된 사업',
+      note: '저장된 비고',
+      version: 3,
+    });
+    expect(next.find((project) => project.id === 'p002')).toMatchObject({ name: '다른 사업' });
   });
 });

--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -222,6 +222,14 @@ export function areProjectsEqual(left: Project[], right: Project[]): boolean {
   return true;
 }
 
+export function mergeProjectSnapshot(projects: Project[], project: Project): Project[] {
+  const map = new Map(projects.map((item) => [item.id, item]));
+  map.set(project.id, project);
+  return Array.from(map.values()).sort((a, b) =>
+    String(a.name || '').localeCompare(String(b.name || ''), 'ko'),
+  );
+}
+
 export function areExpenseSheetRowsEqual(
   left: ImportRow[] | null | undefined,
   right: ImportRow[] | null | undefined,
@@ -453,6 +461,7 @@ interface PortalActions {
     },
   ) => Promise<boolean>;
   setSessionActiveProject: (projectId: string) => Promise<boolean>;
+  patchProjectSnapshot: (project: Project) => void;
   updateProjectStatus: (projectId: string, status: ProjectStatus) => Promise<boolean>;
   logout: () => void;
   addExpenseSet: (set: ExpenseSet) => void;
@@ -2929,6 +2938,15 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     return true;
   }, [scopedProjectIds]);
 
+  const patchProjectSnapshot = useCallback((project: Project) => {
+    if (!project.id) return;
+    setProjects((prev) => {
+      const next = mergeProjectSnapshot(prev, project);
+      projectsRef.current = next;
+      return next;
+    });
+  }, []);
+
   const updateProjectStatus = useCallback(async (projectId: string, status: ProjectStatus): Promise<boolean> => {
     const targetProjectId = projectId.trim();
     if (!targetProjectId || !includesProject(scopedProjectIds, targetProjectId)) {
@@ -3325,6 +3343,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     weeklySubmissionStatuses,
     register,
     setSessionActiveProject,
+    patchProjectSnapshot,
     updateProjectStatus,
     logout,
     addExpenseSet,

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -556,6 +556,7 @@ export interface Project {
   clientOrg: string;             // 발주기관(계약기관)
   groupwareName: string;         // 그룹웨어 프로젝트등록명
   participantCondition: string;  // 참여기업 조건
+  note?: string;                  // PM/관리자 참고 메모
   teamMembersDetailed?: ProjectTeamMemberAssignment[];
   contractType: string;          // 계약서 유형 (계약서(날인), 기타 등)
   projectPurpose?: string;

--- a/src/app/platform/project-editor.test.ts
+++ b/src/app/platform/project-editor.test.ts
@@ -417,4 +417,25 @@ describe('project editor draft mapping', () => {
       },
     ]));
   });
+
+  it('persists PM edit notes into the project source of truth as well as request payload', () => {
+    const draft = createProjectEditorDraft({
+      ...buildProjectEditorDraftFromProject(baseProject, {
+        note: '기존 등록 원문 비고',
+      } as never),
+      note: '마고와 써니 참여율 보정 메모',
+    });
+
+    const patch = buildProjectEditorProjectPatch(draft, {
+      baseProject,
+      mode: 'portal-edit',
+      actorId: 'pm-1',
+      actorName: '김다은',
+      now: '2026-05-29T00:00:00.000Z',
+    });
+    const payload = buildProjectRequestPayloadFromDraft(draft);
+
+    expect(patch.note).toBe('마고와 써니 참여율 보정 메모');
+    expect(payload.note).toBe('마고와 써니 참여율 보정 메모');
+  });
 });

--- a/src/app/platform/project-editor.ts
+++ b/src/app/platform/project-editor.ts
@@ -229,6 +229,7 @@ const REVIEW_CHANGE_FIELDS: Array<{
   { key: 'finalPaymentNote', label: '최종 입금 메모', before: (project) => normalizeChangeValue(project.finalPaymentNote), after: (draft) => normalizeChangeValue(draft.finalPaymentNote) },
   { key: 'projectPurpose', label: '프로젝트 목적', before: (project) => normalizeChangeValue(project.projectPurpose), after: (draft) => normalizeChangeValue(draft.projectPurpose) },
   { key: 'description', label: '주요 내용', before: (project) => normalizeChangeValue(project.description), after: (draft) => normalizeChangeValue(draft.description) },
+  { key: 'note', label: '비고', before: (project) => normalizeChangeValue(project.note), after: (draft) => normalizeChangeValue(draft.note) },
   { key: 'contractDocument', label: '계약서 PDF', before: (project) => normalizeChangeValue(project.contractDocument?.name), after: (draft) => normalizeChangeValue(draft.contractDocument?.name) },
 ];
 
@@ -326,7 +327,7 @@ export function buildProjectEditorDraftFromProject(
     teamName: text(normalizedProject.teamName || payload?.teamName),
     teamMembersDetailed,
     participantCondition: text(normalizedProject.participantCondition || payload?.participantCondition),
-    note: text(payload?.note),
+    note: text(normalizedProject.note || payload?.note),
     paymentPlanDesc: text(normalizedProject.paymentPlanDesc || payload?.paymentPlanDesc),
     settlementGuide: text(normalizedProject.settlementGuide || payload?.settlementGuide),
     groupwareName: text(normalizedProject.groupwareName),
@@ -461,6 +462,7 @@ export function buildProjectEditorProjectPatch(
     clientOrg: text(draft.clientOrg),
     groupwareName: text(draft.groupwareName),
     participantCondition: text(draft.participantCondition),
+    note: text(draft.note),
     teamMembersDetailed,
     contractType: normalizeProjectContractType(draft.contractType),
     projectPurpose: text(draft.projectPurpose),


### PR DESCRIPTION
## Summary
- persist PM edit notes into the project source of truth, not only request payload
- patch the portal project snapshot immediately after a successful project edit save
- preserve backend project-to-request payload note propagation

## Verification
- npm test -- src/app/platform/project-editor.test.ts src/app/data/portal-store.helpers.test.ts src/app/components/portal/PortalProjectEdit.persist-shell.test.ts
- npm test -- src/app/platform/project-edit-save.test.ts src/app/components/portal/PortalProjectRegister.shell.test.ts src/app/components/portal/PortalProjectSettings.shell.test.ts src/app/components/projects/ProjectRequestApprovalPage.shell.test.ts src/app/platform/project-request-review.test.ts
- npm test -- server/bff/routes/projects.test.ts
- npm run build

## Data safety
- No Firestore writes or live DB migration included
- Code-only change for project edit persistence and BFF payload propagation