### PR TITLE
fix(projects): route portal edits through approval

### DIFF
--- a/server/bff/project-change-request.test.mjs
+++ b/server/bff/project-change-request.test.mjs
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { buildProjectPatchFromChangeRequestPayload } from './routes/projects.mjs';
+
+describe('BFF project change request payload merge', () => {
+  it('turns an approved change request payload into a concrete project patch', () => {
+    const patch = buildProjectPatchFromChangeRequestPayload({
+      name: '2026 CTS2 수정',
+      officialContractName: '2026 CTS2 공식 계약명',
+      type: 'D1',
+      status: 'IN_PROGRESS',
+      phase: 'CONFIRMED',
+      description: '수정 설명',
+      clientOrg: 'KOICA',
+      department: '개발협력센터',
+      contractAmount: 1230000,
+      salesVatAmount: 0,
+      totalRevenueAmount: 300000,
+      supportAmount: 0,
+      contractStart: '2026-01-01',
+      contractEnd: '2026-12-31',
+      settlementType: 'TYPE1',
+      basis: '공급가액',
+      accountType: 'OPERATING',
+      managerId: 'u-berry',
+      managerName: '김인효(베리)',
+      teamName: '개발협력센터',
+      note: '승인 전 수정값',
+      teamMembersDetailed: [
+        { memberName: '김인효', memberNickname: '베리', role: 'PM', participationRate: 50 },
+      ],
+    }, {
+      name: '2026 CTS2',
+      managerId: 'u-old',
+      managerName: '이전 담당자',
+      department: 'CIC2',
+      paymentPlan: { contract: 0, interim: 0, final: 0 },
+    });
+
+    expect(patch).toMatchObject({
+      name: '2026 CTS2 수정',
+      officialContractName: '2026 CTS2 공식 계약명',
+      clientOrg: 'KOICA',
+      department: '개발협력센터',
+      cic: '개발협력센터',
+      registeredById: 'u-berry',
+      registeredByName: '김인효(베리)',
+      managerId: 'u-berry',
+      managerName: '김인효(베리)',
+      note: '승인 전 수정값',
+    });
+    expect(patch.teamMembersDetailed).toHaveLength(1);
+  });
+});

--- a/server/bff/routes/projects.mjs
+++ b/server/bff/routes/projects.mjs
@@ -450,6 +450,74 @@ function buildProjectRequestPayloadFromProject(project, existingPayload = {}) {
   };
 }
 
+function resolveProjectCicFromPayload(payload, currentProject = {}) {
+  return readOptionalText(payload?.cic)
+    || readOptionalText(payload?.department)
+    || readOptionalText(currentProject?.cic)
+    || readOptionalText(currentProject?.department);
+}
+
+export function buildProjectPatchFromChangeRequestPayload(payload = {}, currentProject = {}) {
+  const managerId = readOptionalText(payload.registeredById)
+    || readOptionalText(payload.managerId)
+    || readOptionalText(currentProject.registeredById)
+    || readOptionalText(currentProject.managerId);
+  const managerName = readOptionalText(payload.registeredByName)
+    || readOptionalText(payload.managerName)
+    || readOptionalText(currentProject.registeredByName)
+    || readOptionalText(currentProject.managerName);
+  const teamMembersDetailed = normalizeProjectTeamMembersDetailed(payload.teamMembersDetailed);
+  return normalizeProjectRevenueFields(stripUndefinedDeep({
+    name: readOptionalText(payload.name) || readOptionalText(currentProject.name),
+    officialContractName: readOptionalText(payload.officialContractName),
+    type: normalizeProjectType(readOptionalText(payload.type)),
+    status: normalizeProjectStatus(readOptionalText(payload.status) || currentProject.status),
+    phase: normalizeProjectPhase(readOptionalText(payload.phase) || currentProject.phase),
+    description: readOptionalText(payload.description),
+    clientOrg: readOptionalText(payload.clientOrg),
+    department: readOptionalText(payload.department),
+    cic: resolveProjectCicFromPayload(payload, currentProject),
+    groupwareName: readOptionalText(payload.groupwareName),
+    currency: normalizeProjectCurrency(readOptionalText(payload.currency)),
+    contractAmount: Number.isFinite(Number(payload.contractAmount)) ? Math.max(0, Math.round(Number(payload.contractAmount))) : 0,
+    salesVatAmount: Number.isFinite(Number(payload.salesVatAmount)) ? Math.max(0, Math.round(Number(payload.salesVatAmount))) : 0,
+    totalRevenueAmount: Number.isFinite(Number(payload.totalRevenueAmount)) ? Math.max(0, Math.round(Number(payload.totalRevenueAmount))) : 0,
+    supportAmount: Number.isFinite(Number(payload.supportAmount)) ? Math.max(0, Math.round(Number(payload.supportAmount))) : 0,
+    financialInputFlags: payload.financialInputFlags,
+    contractStart: readOptionalText(payload.contractStart),
+    contractEnd: readOptionalText(payload.contractEnd),
+    contractType: normalizeProjectContractType(payload.contractType),
+    settlementType: normalizeSettlementType(readOptionalText(payload.settlementType)),
+    basis: normalizeBasis(readOptionalText(payload.basis)),
+    accountType: normalizeAccountType(readOptionalText(payload.accountType)),
+    fundInputMode: normalizeProjectFundInputMode(readOptionalText(payload.fundInputMode)),
+    settlementSheetPolicy: payload.settlementSheetPolicy,
+    paymentPlan: payload.paymentPlan || currentProject.paymentPlan || { contract: 0, interim: 0, final: 0 },
+    paymentPlanDesc: readOptionalText(payload.paymentPlanDesc),
+    settlementGuide: readOptionalText(payload.settlementGuide),
+    finalPaymentNote: readOptionalText(payload.finalPaymentNote),
+    projectPurpose: readOptionalText(payload.projectPurpose),
+    registeredById: managerId,
+    registeredByName: managerName,
+    registeredByEmail: readOptionalText(payload.registeredByEmail) || readOptionalText(currentProject.registeredByEmail),
+    managerId,
+    managerName,
+    teamName: readOptionalText(payload.teamName),
+    teamMembersDetailed,
+    participantCondition: readOptionalText(payload.participantCondition),
+    note: readOptionalText(payload.note),
+    contractDocument: payload.contractDocument || null,
+    contractAnalysis: payload.contractAnalysis || null,
+    budgetCurrentYear: Number.isFinite(Number(payload.contractAmount))
+      ? Math.max(0, Math.round(Number(payload.contractAmount)))
+      : currentProject.budgetCurrentYear,
+  }), 'totalRevenueAmount');
+}
+
+function isProjectChangeRequest(request) {
+  return readOptionalText(request?.requestKind) === 'CHANGE';
+}
+
 function normalizeParticipationRate(value) {
   const parsed = typeof value === 'number' ? value : Number(value);
   if (!Number.isFinite(parsed)) return 0;
@@ -1187,7 +1255,13 @@ export function mountProjectRoutes(app, {
       buildProjectPatch: (currentProject) => {
         const previousStatus = readOptionalText(currentProject.executiveReviewStatus) || 'PENDING';
         const currentHistory = Array.isArray(currentProject.executiveReviewHistory) ? currentProject.executiveReviewHistory : [];
+        const isApprovedChangeRequest = parsed.reviewStatus === 'APPROVED' && isProjectChangeRequest(request);
+        const requestChanges = Array.isArray(request?.changedFields) ? request.changedFields : [];
+        const payloadPatch = isApprovedChangeRequest
+          ? buildProjectPatchFromChangeRequestPayload(request?.payload, currentProject)
+          : {};
         return {
+          ...payloadPatch,
           executiveReviewStatus: parsed.reviewStatus,
           executiveReviewedAt: now,
           executiveReviewedById: actorId,
@@ -1202,6 +1276,7 @@ export function mountProjectRoutes(app, {
               reviewedById: actorId,
               reviewedByName: reviewerName,
               reviewComment: readOptionalText(parsed.reviewComment) || null,
+              ...(requestChanges.length > 0 ? { changes: requestChanges } : {}),
             },
           ],
         };
@@ -1215,6 +1290,10 @@ export function mountProjectRoutes(app, {
         reviewComment: readOptionalText(parsed.reviewComment) || null,
         rejectedReason: parsed.reviewStatus === 'APPROVED' ? null : (readOptionalText(parsed.reviewComment) || null),
         approvedProjectId: projectId,
+        targetProjectId: projectId,
+        ...(parsed.reviewStatus === 'APPROVED' && isProjectChangeRequest(request) ? {
+          approvedSnapshot: request?.payload || null,
+        } : {}),
         updatedAt: now,
       }) : null,
       requestRefs: resolvedRequestId ? refs : [],

--- a/src/app/components/portal/PortalProjectEdit.persist-shell.test.ts
+++ b/src/app/components/portal/PortalProjectEdit.persist-shell.test.ts
@@ -5,9 +5,10 @@ import { describe, expect, it } from 'vitest';
 const source = readFileSync(resolve(import.meta.dirname, 'PortalProjectEdit.tsx'), 'utf8');
 
 describe('PortalProjectEdit persistence shell', () => {
-  it('patches the portal project snapshot after a successful save', () => {
-    expect(source).toContain('patchProjectSnapshot');
-    expect(source).toContain('const savedProject = await persistProject');
-    expect(source).toContain('if (savedProject) patchProjectSnapshot(savedProject)');
+  it('stores portal edits as approval-gated change requests instead of mutating the project snapshot', () => {
+    expect(source).toContain('buildProjectChangeRequest');
+    expect(source).toContain("doc(db, getOrgDocumentPath(orgId, 'projectRequests', changeRequest.id))");
+    expect(source).not.toContain('patchProjectSnapshot');
+    expect(source).not.toContain('upsertProjectViaBff');
   });
 });

--- a/src/app/components/portal/PortalProjectEdit.tsx
+++ b/src/app/components/portal/PortalProjectEdit.tsx
@@ -1,31 +1,23 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { AlertTriangle, Loader2, Save, SendHorizontal } from 'lucide-react';
-import { collection, doc, getDoc, limit, onSnapshot, orderBy, query, setDoc, where } from 'firebase/firestore';
+import { collection, doc, limit, onSnapshot, orderBy, query, setDoc, where } from 'firebase/firestore';
 import { toast } from 'sonner';
 import { useAuth } from '../../data/auth-store';
 import { usePortalStore } from '../../data/portal-store';
 import type { Project, ProjectRequest } from '../../data/types';
-import { getAuthInstance, getOrgCollectionPath, getOrgDocumentPath } from '../../lib/firebase';
+import { getOrgCollectionPath, getOrgDocumentPath } from '../../lib/firebase';
 import { useFirebase } from '../../lib/firebase-context';
-import {
-  isPlatformApiEnabled,
-  upsertProjectViaBff,
-  type UpsertProjectPayload,
-} from '../../lib/platform-bff-client';
 import { uploadProjectRequestContractFile } from '../../platform/project-contract-upload';
-import { buildProjectRequestPayloadFromDraft } from '../../platform/project-editor';
 import {
   buildProjectEditorDraftFromProject,
-  buildProjectEditorProjectPatch,
   createProjectEditorDraft,
   type ProjectEditorDraft,
 } from '../../platform/project-editor';
 import {
-  buildPortalProjectEditSavePayload,
-  isProjectVersionConflictError,
-} from '../../platform/project-edit-save';
-import { buildProjectOwnerAssignmentPatches } from '../../platform/project-owner-assignment';
+  buildProjectChangeRequest,
+  resolveProjectRequestKind,
+} from '../../platform/project-change-request';
 import { Button } from '../ui/button';
 import { Card, CardContent } from '../ui/card';
 import { Label } from '../ui/label';
@@ -71,34 +63,21 @@ function bannerClassName(tone: string) {
   return 'border-slate-200 bg-white text-red-700';
 }
 
-async function loadLatestProjectSnapshot(
-  db: NonNullable<ReturnType<typeof useFirebase>['db']>,
-  orgId: string,
-  projectId: string,
-): Promise<Project | null> {
-  const snap = await getDoc(doc(db, getOrgDocumentPath(orgId, 'projects', projectId)));
-  if (!snap.exists()) return null;
-  return { ...(snap.data() as Project), id: projectId };
-}
-
 export function PortalProjectEdit() {
   const navigate = useNavigate();
   const { user: authUser } = useAuth();
   const { db, isOnline, orgId } = useFirebase();
-  const { members, myProject, patchProjectSnapshot } = usePortalStore();
+  const { members, myProject } = usePortalStore();
   const [requestDoc, setRequestDoc] = useState<ProjectRequest | null>(null);
-  const [loadingRequest, setLoadingRequest] = useState(true);
   const [busyActionId, setBusyActionId] = useState<string | null>(null);
   const [resubmitComment, setResubmitComment] = useState('');
 
   useEffect(() => {
     if (!db || !isOnline || !myProject?.id) {
       setRequestDoc(null);
-      setLoadingRequest(false);
       return;
     }
 
-    setLoadingRequest(true);
     const q = query(
       collection(db, getOrgCollectionPath(orgId, 'projectRequests')),
       where('approvedProjectId', '==', myProject.id),
@@ -107,18 +86,34 @@ export function PortalProjectEdit() {
     );
     return onSnapshot(q, (snapshot) => {
       setRequestDoc(snapshot.docs[0]?.data() as ProjectRequest || null);
-      setLoadingRequest(false);
     }, (error) => {
       console.error('[PortalProjectEdit] request listen failed:', error);
       setRequestDoc(null);
-      setLoadingRequest(false);
     });
   }, [db, isOnline, myProject?.id, orgId]);
 
   const initialDraft = useMemo(
-    () => (myProject
-      ? buildProjectEditorDraftFromProject(myProject, requestDoc?.payload)
-      : createProjectEditorDraft()),
+    () => {
+      if (!myProject) return createProjectEditorDraft();
+      const shouldReadPendingChange = requestDoc?.status === 'PENDING'
+        && resolveProjectRequestKind(requestDoc) === 'CHANGE';
+      if (!shouldReadPendingChange) {
+        return buildProjectEditorDraftFromProject(myProject, requestDoc?.payload);
+      }
+      return buildProjectEditorDraftFromProject({
+        ...myProject,
+        ...requestDoc.payload,
+        id: myProject.id,
+        slug: myProject.slug,
+        orgId: myProject.orgId,
+        createdAt: myProject.createdAt,
+        updatedAt: myProject.updatedAt,
+        isSettled: myProject.isSettled,
+        confirmerName: myProject.confirmerName,
+        lastCheckedAt: myProject.lastCheckedAt,
+        cashflowDiffNote: myProject.cashflowDiffNote,
+      } as Project);
+    },
     [myProject, requestDoc?.payload],
   );
 
@@ -130,169 +125,41 @@ export function PortalProjectEdit() {
   const canResubmit = myProject?.executiveReviewStatus === 'REVISION_REJECTED'
     || myProject?.executiveReviewStatus === 'DUPLICATE_DISCARDED';
 
-  const shouldAutoResetApprovedReview = (project: Project) => (
-    project.registrationSource === 'pm_portal'
-    && project.executiveReviewStatus === 'APPROVED'
-  );
-
-  const syncProjectOwnerAssignment = async (draft: ProjectEditorDraft) => {
-    if (!db || !myProject?.id || !draft.registeredById) return;
-    const previousOwnerId = myProject.registeredById || myProject.managerId || '';
-    const nextOwnerId = draft.registeredById;
-    const previousRef = previousOwnerId && previousOwnerId !== nextOwnerId
-      ? doc(db, getOrgDocumentPath(orgId, 'members', previousOwnerId))
-      : null;
-    const nextRef = doc(db, getOrgDocumentPath(orgId, 'members', nextOwnerId));
-    const [previousSnap, nextSnap] = await Promise.all([
-      previousRef ? getDoc(previousRef) : Promise.resolve(null),
-      getDoc(nextRef),
-    ]);
-    if (!nextSnap.exists()) {
-      throw new Error('선택한 사업 담당자 계정을 찾을 수 없습니다.');
-    }
-    const previousMember = previousSnap?.exists() ? previousSnap.data() : undefined;
-    const nextMember = nextSnap.data();
-    const patches = buildProjectOwnerAssignmentPatches({
-      projectId: myProject.id,
-      projectName: draft.name || myProject.name,
-      previousOwnerId,
-      nextOwner: {
-        uid: nextOwnerId,
-        name: draft.registeredByName,
-        email: draft.registeredByEmail,
-      },
-      previousMember,
-      nextMember,
-    });
-    const now = new Date().toISOString();
-    if (previousRef && patches.previous) {
-      await setDoc(previousRef, {
-        projectIds: patches.previous.projectIds,
-        projectNames: patches.previous.projectNames,
-        portalProfile: {
-          projectIds: patches.previous.projectIds,
-          projectNames: patches.previous.projectNames,
-        },
-        updatedAt: now,
-      }, { merge: true });
-    }
-    if (patches.next) {
-      await setDoc(nextRef, {
-        projectId: patches.next.projectId,
-        projectIds: patches.next.projectIds,
-        projectNames: patches.next.projectNames,
-        portalProfile: {
-          projectId: patches.next.projectId,
-          projectIds: patches.next.projectIds,
-          projectNames: patches.next.projectNames,
-        },
-        updatedAt: now,
-      }, { merge: true });
-    }
-  };
-
   const persistProject = async (
     draft: ProjectEditorDraft,
     options: { forcePendingReview?: boolean; reviewComment?: string | null } = {},
   ) => {
     if (!orgId || !myProject || !authUser?.uid) return null;
+    if (!db) {
+      throw new Error('프로젝트 변경 요청을 저장하려면 Firestore 연결이 필요합니다.');
+    }
     const now = new Date().toISOString();
     const actorName = authUser.name || authUser.email || 'PM';
-    const autoReset = shouldAutoResetApprovedReview(myProject);
-    const shouldSyncRequestPayload = !!requestDoc?.id && (
-      requestDoc.status === 'PENDING' || options.forcePendingReview || autoReset
-    );
-    const requestPatch = shouldSyncRequestPayload
-      ? ((options.forcePendingReview || autoReset)
-          ? {
-              status: 'PENDING',
-              reviewOutcome: null,
-              reviewedBy: null,
-              reviewedByName: null,
-              reviewedAt: null,
-              reviewComment: null,
-              rejectedReason: null,
-              approvedProjectId: myProject.id,
-              payload: buildProjectRequestPayloadFromDraft(draft),
-              updatedAt: now,
-            }
-          : {
-              payload: buildProjectRequestPayloadFromDraft(draft),
-              updatedAt: now,
-            })
+    const previousChangeRequest = requestDoc?.status === 'PENDING'
+      && resolveProjectRequestKind(requestDoc) === 'CHANGE'
+      ? requestDoc
       : null;
-    const patch = buildProjectEditorProjectPatch(draft, {
+    const changeRequest = buildProjectChangeRequest({
       baseProject: myProject,
-      mode: 'portal-edit',
+      draft,
+      previousRequest: previousChangeRequest,
       actorId: authUser.uid,
       actorName,
-      now,
-      forceExecutiveReviewPending: options.forcePendingReview,
-      executiveReviewComment: options.reviewComment,
+      actorEmail: authUser.email || '',
+      tenantId: orgId,
+      requestedAt: now,
     });
-    const buildSavePayload = async () => buildPortalProjectEditSavePayload({
-      baseProject: myProject,
-      latestProject: db ? await loadLatestProjectSnapshot(db, orgId, myProject.id) : null,
-      patch,
-      orgId,
-      updatedAt: now,
-    });
-    let savedProject: Project | null = null;
 
-    if (isPlatformApiEnabled()) {
-      const idToken = authUser.idToken || await getAuthInstance()?.currentUser?.getIdToken() || undefined;
-      const actor = {
-        uid: authUser.uid,
-        email: authUser.email,
-        role: authUser.role,
-        idToken,
-      };
-      const saveViaBff = (payload: Awaited<ReturnType<typeof buildSavePayload>>) => upsertProjectViaBff({
-        tenantId: orgId,
-        actor,
-        project: {
-          ...payload.project,
-          expectedVersion: payload.expectedVersion,
-        } as UpsertProjectPayload,
-      });
+    await setDoc(
+      doc(db, getOrgDocumentPath(orgId, 'projectRequests', changeRequest.id)),
+      {
+        ...changeRequest,
+        ...(options.reviewComment ? { reviewComment: options.reviewComment } : {}),
+      },
+      { merge: true },
+    );
 
-      const savePayload = await buildSavePayload();
-      try {
-        await saveViaBff(savePayload);
-        savedProject = savePayload.project;
-      } catch (error) {
-        if (!db || !isProjectVersionConflictError(error)) throw error;
-        const retryPayload = await buildSavePayload();
-        await saveViaBff(retryPayload);
-        savedProject = retryPayload.project;
-      }
-
-      if (requestPatch && requestDoc?.id) {
-        if (!db) {
-          throw new Error('검토 요청 동기화에 필요한 Firestore 연결이 없습니다.');
-        }
-        await setDoc(
-          doc(db, getOrgDocumentPath(orgId, 'projectRequests', requestDoc.id)),
-          requestPatch,
-          { merge: true },
-        );
-      }
-    } else if (db) {
-      const savePayload = await buildSavePayload();
-      await setDoc(doc(db, getOrgDocumentPath(orgId, 'projects', myProject.id)), savePayload.project, { merge: true });
-      savedProject = savePayload.project;
-      if (requestPatch && requestDoc?.id) {
-        await setDoc(
-          doc(db, getOrgDocumentPath(orgId, 'projectRequests', requestDoc.id)),
-          requestPatch,
-          { merge: true },
-        );
-      }
-    }
-
-    await syncProjectOwnerAssignment(draft);
-
-    return savedProject;
+    return changeRequest;
   };
 
   const handleSubmit = async (draft: ProjectEditorDraft, actionId: string) => {
@@ -301,18 +168,17 @@ export function PortalProjectEdit() {
     setBusyActionId(actionId);
     try {
       const forcePendingReview = actionId === 'resubmit';
-      const savedProject = await persistProject(draft, {
+      await persistProject(draft, {
         forcePendingReview,
         reviewComment: forcePendingReview ? resubmitComment.trim() || null : null,
       });
-      if (savedProject) patchProjectSnapshot(savedProject);
       if (forcePendingReview) {
         setResubmitComment('');
-        toast.success('수정 후 다시 제출했습니다.');
-      } else if (shouldAutoResetApprovedReview(myProject)) {
-        toast.success('수정 내용을 저장하고 재검토 대기로 전환했습니다.');
+        toast.success('프로젝트 변경 요청을 다시 제출했습니다.');
       } else {
-        toast.success('프로젝트 수정 내용이 저장되었습니다.');
+        toast.success('프로젝트 변경 요청을 저장했습니다.', {
+          description: '관리자 승인 전까지 프로젝트 원장은 바뀌지 않습니다.',
+        });
       }
     } catch (error) {
       console.error('[PortalProjectEdit] save failed:', error);

--- a/src/app/components/projects/ProjectListPage.tsx
+++ b/src/app/components/projects/ProjectListPage.tsx
@@ -1,9 +1,10 @@
-import { useState, useMemo } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router';
 import {
   Search, ArrowUpDown, Sparkles, CheckCircle2, ArrowRight,
   FolderKanban, RotateCcw, Trash2, FileText, Clock, AlertTriangle,
 } from 'lucide-react';
+import { collection, onSnapshot, query, where } from 'firebase/firestore';
 import { toast } from 'sonner';
 import { Card, CardContent } from '../ui/card';
 import { Button } from '../ui/button';
@@ -20,10 +21,12 @@ import { useAppStore } from '../../data/store';
 import {
   PROJECT_STATUS_LABELS, PROJECT_TYPE_LABELS, PROJECT_TYPE_SHORT_LABELS,
   SETTLEMENT_TYPE_LABELS, SETTLEMENT_TYPE_SHORT, normalizeSettlementType,
-  type ProjectStatus, type ProjectType, type Project,
+  type ProjectStatus, type ProjectType, type Project, type ProjectRequest,
 } from '../../data/types';
 import { PageHeader } from '../layout/PageHeader';
 import { resolveApiErrorMessage } from '../../platform/api-error-message';
+import { getOrgCollectionPath } from '../../lib/firebase';
+import { useFirebase } from '../../lib/firebase-context';
 
 const statusColor: Record<string, string> = {
   CONTRACT_PENDING: 'bg-amber-100 text-amber-800',
@@ -41,6 +44,7 @@ type SortDir = 'asc' | 'desc';
 
 export function ProjectListPage() {
   const { allProjects, restoreProject, ledgers, transactions } = useAppStore();
+  const { db, isOnline, orgId } = useFirebase();
   const navigate = useNavigate();
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('ALL');
@@ -50,6 +54,36 @@ export function ProjectListPage() {
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [activeTab, setActiveTab] = useState<string>('confirmed');
   const [monitoringPreset, setMonitoringPreset] = useState<'all' | 'no-ledger' | 'pending-approval' | 'missing-evidence'>('all');
+  const [pendingProjectChangeMap, setPendingProjectChangeMap] = useState<Map<string, ProjectRequest>>(new Map());
+
+  useEffect(() => {
+    if (!db || !isOnline) {
+      setPendingProjectChangeMap(new Map());
+      return undefined;
+    }
+
+    const q = query(
+      collection(db, getOrgCollectionPath(orgId, 'projectRequests')),
+      where('status', '==', 'PENDING'),
+    );
+    return onSnapshot(q, (snapshot) => {
+      const next = new Map<string, ProjectRequest>();
+      snapshot.docs.forEach((docSnap) => {
+        const request = { ...(docSnap.data() as ProjectRequest), id: docSnap.id };
+        if (request.requestKind !== 'CHANGE') return;
+        const projectId = request.targetProjectId || request.approvedProjectId;
+        if (!projectId) return;
+        const previous = next.get(projectId);
+        if (!previous || String(request.requestedAt || '').localeCompare(String(previous.requestedAt || '')) > 0) {
+          next.set(projectId, request);
+        }
+      });
+      setPendingProjectChangeMap(next);
+    }, (error) => {
+      console.error('[ProjectListPage] pending change request listen failed:', error);
+      setPendingProjectChangeMap(new Map());
+    });
+  }, [db, isOnline, orgId]);
 
   const activeProjects = useMemo(
     () => allProjects.filter((project) => !project.trashedAt),
@@ -257,7 +291,14 @@ export function ProjectListPage() {
                     {p.department || '-'}
                   </TableCell>
                   <TableCell style={{ fontWeight: 500 }} className="max-w-[220px] truncate text-sm">
-                    {p.name}
+                    <span className="inline-flex max-w-full items-center gap-1.5">
+                      <span className="truncate">{p.name}</span>
+                      {pendingProjectChangeMap.has(p.id) ? (
+                        <span className="shrink-0 rounded-full border border-amber-200 bg-amber-50 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700">
+                          수정 검토 중
+                        </span>
+                      ) : null}
+                    </span>
                   </TableCell>
                   <TableCell className="text-[11px] whitespace-nowrap">{p.clientOrg || '-'}</TableCell>
                   <TableCell className="text-[11px] whitespace-nowrap">

--- a/src/app/components/projects/ProjectMigrationAuditPage.tsx
+++ b/src/app/components/projects/ProjectMigrationAuditPage.tsx
@@ -27,6 +27,10 @@ import {
   findMigrationAuditRecord,
   summarizeMigrationAuditConsole,
 } from '../../platform/project-migration-console';
+import {
+  buildProjectPatchFromRequestPayload,
+  resolveProjectRequestKind,
+} from '../../platform/project-change-request';
 import { PageHeader } from '../layout/PageHeader';
 import { Card, CardContent } from '../ui/card';
 import { MigrationAuditControlBar } from './migration-audit/MigrationAuditControlBar';
@@ -62,6 +66,14 @@ function getReviewDialogDescription(mode: ReviewActionMode): string {
   if (mode === 'approve') return 'PM이 올린 원문을 기준으로 이 프로젝트를 등록 대상으로 확정합니다.';
   if (mode === 'reject') return '수정이 필요한 이유를 반드시 남기고 PM이 다시 보완하도록 돌려보냅니다.';
   return '중복 또는 폐기 대상으로 정리하고, 왜 그렇게 판단했는지 사유를 반드시 남깁니다.';
+}
+
+function getProjectRequestReviewDescription(mode: ReviewActionMode, request: ProjectRequest | null | undefined): string {
+  const isChangeRequest = resolveProjectRequestKind(request) === 'CHANGE';
+  if (!isChangeRequest) return getReviewDialogDescription(mode);
+  if (mode === 'approve') return 'PM이 제출한 수정 중 값을 프로젝트 원장에 반영하고 변경 요청을 승인 완료로 닫습니다.';
+  if (mode === 'reject') return '프로젝트 원장은 유지하고, 수정이 필요한 이유를 남겨 PM에게 돌려보냅니다.';
+  return '프로젝트 원장은 유지하고, 중복 또는 폐기된 수정 요청으로 정리합니다.';
 }
 
 function toExecutiveStatus(mode: ReviewActionMode): ProjectExecutiveReviewStatus {
@@ -102,6 +114,8 @@ function buildProjectRequestReviewPatch(input: {
   nextStatus: ProjectExecutiveReviewStatus;
   reviewComment: string;
   reviewedAt: string;
+  request?: ProjectRequest | null;
+  targetProjectVersion?: number;
 }) {
   return {
     status: input.nextStatus === 'APPROVED' ? 'APPROVED' : 'REJECTED',
@@ -112,6 +126,9 @@ function buildProjectRequestReviewPatch(input: {
     reviewComment: input.reviewComment || null,
     rejectedReason: input.nextStatus === 'APPROVED' ? null : (input.reviewComment || null),
     approvedProjectId: input.projectId,
+    targetProjectId: input.projectId,
+    ...(input.nextStatus === 'APPROVED' && input.request?.payload ? { approvedSnapshot: input.request.payload } : {}),
+    ...(input.targetProjectVersion ? { targetProjectVersion: input.targetProjectVersion } : {}),
     updatedAt: input.reviewedAt,
   };
 }
@@ -284,19 +301,32 @@ export function ProjectMigrationAuditPage({
       } else {
         const requestCollectionName = (activeRecord.request as ProjectRequestWithSource | null)?.__collectionName || 'project_requests';
         await updateProject(activeRecord.project.id, {
-          executiveReviewStatus: nextExecutiveStatus,
-          executiveReviewedAt: now,
-          executiveReviewedById: reviewerId,
-          executiveReviewedByName: reviewerName,
-          executiveReviewComment: trimmedComment || undefined,
-          executiveReviewHistory: appendExecutiveReviewHistory(activeRecord.project, {
-            nextStatus: nextExecutiveStatus,
-            reviewerId,
-            reviewerName,
-            reviewComment: trimmedComment,
-            reviewedAt: now,
-            previousStatus: activeRecord.status,
-          }),
+          ...(nextExecutiveStatus === 'APPROVED'
+            && activeRecord.request
+            && resolveProjectRequestKind(activeRecord.request) === 'CHANGE'
+            ? buildProjectPatchFromRequestPayload(activeRecord.request.payload, {
+                baseProject: activeRecord.project,
+                approvedAt: now,
+                reviewerId,
+                reviewerName,
+                reviewComment: trimmedComment,
+                changedFields: activeRecord.request.changedFields,
+              })
+            : {
+                executiveReviewStatus: nextExecutiveStatus,
+                executiveReviewedAt: now,
+                executiveReviewedById: reviewerId,
+                executiveReviewedByName: reviewerName,
+                executiveReviewComment: trimmedComment || undefined,
+                executiveReviewHistory: appendExecutiveReviewHistory(activeRecord.project, {
+                  nextStatus: nextExecutiveStatus,
+                  reviewerId,
+                  reviewerName,
+                  reviewComment: trimmedComment,
+                  reviewedAt: now,
+                  previousStatus: activeRecord.status,
+                }),
+              }),
           ...(shouldTrashProject
             ? {
               trashedAt: now,
@@ -320,6 +350,10 @@ export function ProjectMigrationAuditPage({
               nextStatus: nextExecutiveStatus,
               reviewComment: trimmedComment,
               reviewedAt: now,
+              request: activeRecord.request,
+              targetProjectVersion: nextExecutiveStatus === 'APPROVED'
+                ? Number(activeRecord.project.version || 1) + 1
+                : undefined,
             }),
             { merge: true },
           );
@@ -427,7 +461,7 @@ export function ProjectMigrationAuditPage({
           <AlertDialogHeader>
             <AlertDialogTitle>{getReviewDialogTitle(actionMode || 'approve')}</AlertDialogTitle>
             <AlertDialogDescription>
-              {getReviewDialogDescription(actionMode || 'approve')}
+              {getProjectRequestReviewDescription(actionMode || 'approve', activeRecord?.request)}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <div className="space-y-2">

--- a/src/app/components/projects/migration-audit/MigrationAuditDetailPanel.tsx
+++ b/src/app/components/projects/migration-audit/MigrationAuditDetailPanel.tsx
@@ -366,6 +366,8 @@ export function MigrationAuditDetailPanel({
           >
             <ReviewFactGrid
               items={[
+                { label: '요청 요약', value: dossier.audit.requestSummary, wide: true },
+                { label: '요청 버전', value: dossier.audit.requestVersion },
                 { label: '요청자', value: dossier.audit.requestedByName },
                 { label: '접수일', value: dossier.audit.requestedAt },
               ]}

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -600,6 +600,7 @@ export interface Project {
 export type ProjectRequestStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
 export type ProjectExecutiveReviewStatus = 'PENDING' | 'APPROVED' | 'REVISION_REJECTED' | 'DUPLICATE_DISCARDED';
 export type ProjectRequestReviewOutcome = 'APPROVED' | 'REVISION_REJECTED' | 'DUPLICATE_DISCARDED';
+export type ProjectRequestKind = 'REGISTRATION' | 'CHANGE';
 
 export interface ProjectReviewFieldChange {
   key: string;
@@ -745,6 +746,16 @@ export interface ProjectRequestPayload {
 export interface ProjectRequest {
   id: string;
   tenantId?: string;
+  requestKind?: ProjectRequestKind;
+  targetProjectId?: string;
+  baseProjectVersion?: number;
+  requestVersion?: number;
+  targetProjectVersion?: number;
+  beforeSnapshot?: ProjectRequestPayload | null;
+  proposedSnapshot?: ProjectRequestPayload | null;
+  approvedSnapshot?: ProjectRequestPayload | null;
+  changedFields?: ProjectReviewFieldChange[];
+  humanSummary?: string;
   status: ProjectRequestStatus;
   reviewOutcome?: ProjectRequestReviewOutcome;
   payload: ProjectRequestPayload;

--- a/src/app/platform/project-change-request.test.ts
+++ b/src/app/platform/project-change-request.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import type { Project } from '../data/types';
+import { createProjectEditorDraft } from './project-editor';
+import {
+  buildProjectChangeRequest,
+  buildProjectPatchFromRequestPayload,
+  resolveProjectRequestKind,
+} from './project-change-request';
+
+const baseProject = {
+  id: 'p-cts2',
+  version: 7,
+  slug: 'cts2',
+  orgId: 'mysc',
+  name: '2026 CTS2',
+  officialContractName: 'CTS2 원본',
+  status: 'IN_PROGRESS',
+  type: 'D1',
+  phase: 'CONFIRMED',
+  contractAmount: 1000,
+  contractStart: '2026-01-01',
+  contractEnd: '2026-12-31',
+  settlementType: 'TYPE1',
+  basis: '공급가액',
+  accountType: 'OPERATING',
+  paymentPlan: { contract: 0, interim: 0, final: 0 },
+  paymentPlanDesc: '',
+  clientOrg: 'KOICA',
+  groupwareName: '',
+  participantCondition: '',
+  department: '개발협력센터',
+  teamName: '',
+  managerId: 'u-old',
+  managerName: '이전 담당자',
+  registeredById: 'u-old',
+  registeredByName: '이전 담당자',
+  budgetCurrentYear: 1000,
+  taxInvoiceAmount: 0,
+  profitRate: 0,
+  profitAmount: 0,
+  isSettled: false,
+  finalPaymentNote: '',
+  confirmerName: '',
+  lastCheckedAt: '',
+  cashflowDiffNote: '',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+} satisfies Project;
+
+describe('project change request helpers', () => {
+  it('keeps legacy requests as registration requests', () => {
+    expect(resolveProjectRequestKind(null)).toBe('REGISTRATION');
+    expect(resolveProjectRequestKind({ requestKind: 'CHANGE' } as any)).toBe('CHANGE');
+  });
+
+  it('stores before/proposed snapshots, changed fields, and request version', () => {
+    const draft = createProjectEditorDraft({
+      name: '2026 CTS2 수정',
+      officialContractName: 'CTS2 수정 계약명',
+      type: 'D1',
+      status: 'IN_PROGRESS',
+      phase: 'CONFIRMED',
+      clientOrg: 'KOICA',
+      department: '개발협력센터',
+      contractAmount: 2000,
+      registeredById: 'u-berry',
+      registeredByName: '김인효(베리)',
+    });
+
+    const request = buildProjectChangeRequest({
+      baseProject,
+      draft,
+      actorId: 'u-berry',
+      actorName: '김인효(베리)',
+      actorEmail: 'berry@example.com',
+      tenantId: 'mysc',
+      requestedAt: '2026-05-29T01:29:00.000Z',
+    });
+
+    expect(request).toMatchObject({
+      id: 'change-p-cts2',
+      requestKind: 'CHANGE',
+      targetProjectId: 'p-cts2',
+      baseProjectVersion: 7,
+      requestVersion: 1,
+      status: 'PENDING',
+      requestedByName: '김인효(베리)',
+    });
+    expect(request.beforeSnapshot?.name).toBe('2026 CTS2');
+    expect(request.proposedSnapshot?.name).toBe('2026 CTS2 수정');
+    expect(request.changedFields?.some((change) => change.key === 'name')).toBe(true);
+    expect(request.humanSummary).toContain('기준 프로젝트 v7');
+  });
+
+  it('applies an approved request payload as a project patch', () => {
+    const draft = createProjectEditorDraft({
+      ...baseProject,
+      name: '2026 CTS2 수정',
+      contractAmount: 3000,
+      registeredById: 'u-berry',
+      registeredByName: '김인효(베리)',
+    });
+    const request = buildProjectChangeRequest({
+      baseProject,
+      draft,
+      actorId: 'u-berry',
+      actorName: '김인효(베리)',
+      actorEmail: 'berry@example.com',
+      tenantId: 'mysc',
+      requestedAt: '2026-05-29T01:29:00.000Z',
+    });
+    const patch = buildProjectPatchFromRequestPayload(request.payload, {
+      baseProject,
+      approvedAt: '2026-05-29T02:00:00.000Z',
+      reviewerId: 'admin',
+      reviewerName: '관리자',
+      changedFields: request.changedFields,
+    });
+
+    expect(patch).toMatchObject({
+      name: '2026 CTS2 수정',
+      contractAmount: 3000,
+      registeredById: 'u-berry',
+      managerId: 'u-berry',
+      executiveReviewStatus: 'APPROVED',
+    });
+    expect(patch.executiveReviewHistory?.at(-1)?.changes?.length).toBeGreaterThan(0);
+  });
+});

--- a/src/app/platform/project-change-request.ts
+++ b/src/app/platform/project-change-request.ts
@@ -1,0 +1,230 @@
+import type {
+  Project,
+  ProjectExecutiveReviewHistoryEntry,
+  ProjectRequest,
+  ProjectRequestKind,
+  ProjectRequestPayload,
+} from '../data/types';
+import { normalizeProjectStatus } from '../data/types';
+import { buildProjectRequestPayloadFromDraft, type ProjectEditorDraft } from './project-editor';
+import { buildProjectEditorReviewChanges } from './project-editor';
+import { normalizeProjectRevenueFields } from './project-financials';
+import { resolveProjectCic } from './project-cic';
+
+function text(value: unknown): string {
+  return String(value || '').trim();
+}
+
+function numeric(value: unknown): number {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(parsed) ? Math.max(0, Math.round(parsed)) : 0;
+}
+
+function nextPositiveInt(value: unknown): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed + 1 : 1;
+}
+
+function formatKst(iso: string): string {
+  try {
+    return new Intl.DateTimeFormat('ko-KR', {
+      timeZone: 'Asia/Seoul',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+export function resolveProjectRequestKind(request: ProjectRequest | null | undefined): ProjectRequestKind {
+  return request?.requestKind === 'CHANGE' ? 'CHANGE' : 'REGISTRATION';
+}
+
+export function buildProjectPayloadFromProject(project: Project): ProjectRequestPayload {
+  return {
+    name: text(project.name),
+    officialContractName: text(project.officialContractName || project.name),
+    type: project.type,
+    status: normalizeProjectStatus(project.status),
+    phase: project.phase,
+    description: text(project.description),
+    clientOrg: text(project.clientOrg),
+    department: text(project.department),
+    groupwareName: text(project.groupwareName),
+    currency: project.currency || 'KRW',
+    contractAmount: numeric(project.contractAmount),
+    salesVatAmount: numeric(project.salesVatAmount),
+    totalRevenueAmount: numeric(project.totalRevenueAmount),
+    supportAmount: numeric(project.supportAmount),
+    financialInputFlags: project.financialInputFlags,
+    contractStart: text(project.contractStart),
+    contractEnd: text(project.contractEnd),
+    contractType: text(project.contractType),
+    settlementType: project.settlementType,
+    basis: project.basis,
+    accountType: project.accountType,
+    fundInputMode: project.fundInputMode,
+    settlementSheetPolicy: project.settlementSheetPolicy,
+    paymentPlan: project.paymentPlan,
+    paymentPlanDesc: text(project.paymentPlanDesc),
+    settlementGuide: text(project.settlementGuide),
+    finalPaymentNote: text(project.finalPaymentNote),
+    projectPurpose: text(project.projectPurpose),
+    registeredById: text(project.registeredById || project.managerId),
+    registeredByName: text(project.registeredByName || project.managerName),
+    registeredByEmail: text(project.registeredByEmail),
+    managerId: text(project.registeredById || project.managerId),
+    managerName: text(project.registeredByName || project.managerName),
+    teamName: text(project.teamName),
+    teamMembers: '',
+    teamMembersDetailed: project.teamMembersDetailed || [],
+    participantCondition: text(project.participantCondition),
+    note: text(project.note),
+    contractDocument: project.contractDocument || null,
+    contractAnalysis: project.contractAnalysis || null,
+  };
+}
+
+export function resolveProjectRequestAuditTitle(input: {
+  actorName: string;
+  requestedAt: string;
+  baseProjectVersion: number;
+  requestVersion: number;
+}): string {
+  return `${input.actorName || '요청자'}가 ${formatKst(input.requestedAt)}에 요청한 프로젝트 변경입니다. 기준 프로젝트 v${input.baseProjectVersion} · 요청 v${input.requestVersion}`;
+}
+
+export function buildProjectChangeRequest(input: {
+  baseProject: Project;
+  draft: ProjectEditorDraft;
+  previousRequest?: ProjectRequest | null;
+  actorId: string;
+  actorName: string;
+  actorEmail: string;
+  tenantId: string;
+  requestedAt: string;
+}): ProjectRequest {
+  const proposedSnapshot = buildProjectRequestPayloadFromDraft(input.draft);
+  const beforeSnapshot = buildProjectPayloadFromProject(input.baseProject);
+  const changedFields = buildProjectEditorReviewChanges(input.baseProject, input.draft);
+  const requestVersion = nextPositiveInt(input.previousRequest?.requestVersion);
+  const baseProjectVersion = Number.isInteger(input.baseProject.version) && Number(input.baseProject.version) > 0
+    ? Number(input.baseProject.version)
+    : 1;
+  const id = text(input.previousRequest?.id) || `change-${input.baseProject.id}`;
+  return {
+    id,
+    tenantId: input.tenantId,
+    requestKind: 'CHANGE',
+    targetProjectId: input.baseProject.id,
+    baseProjectVersion,
+    requestVersion,
+    beforeSnapshot,
+    proposedSnapshot,
+    changedFields,
+    humanSummary: resolveProjectRequestAuditTitle({
+      actorName: input.actorName,
+      requestedAt: input.requestedAt,
+      baseProjectVersion,
+      requestVersion,
+    }),
+    status: 'PENDING',
+    reviewOutcome: undefined,
+    payload: proposedSnapshot,
+    requestedBy: input.actorId,
+    requestedByName: input.actorName,
+    requestedByEmail: input.actorEmail,
+    requestedAt: input.requestedAt,
+    reviewedBy: undefined,
+    reviewedByName: undefined,
+    reviewedAt: undefined,
+    reviewComment: null,
+    rejectedReason: null,
+    approvedProjectId: input.baseProject.id,
+    createdAt: input.previousRequest?.createdAt || input.requestedAt,
+    updatedAt: input.requestedAt,
+  };
+}
+
+export function buildProjectPatchFromRequestPayload(
+  payload: ProjectRequestPayload,
+  input: {
+    baseProject: Project;
+    approvedAt: string;
+    reviewerId: string;
+    reviewerName: string;
+    reviewComment?: string | null;
+    changedFields?: ProjectExecutiveReviewHistoryEntry['changes'];
+  },
+): Partial<Project> {
+  const patch = normalizeProjectRevenueFields({
+    name: text(payload.name),
+    officialContractName: text(payload.officialContractName),
+    type: payload.type,
+    status: normalizeProjectStatus(payload.status || input.baseProject.status),
+    phase: payload.phase || input.baseProject.phase,
+    description: text(payload.description),
+    clientOrg: text(payload.clientOrg),
+    department: text(payload.department),
+    cic: resolveProjectCic({ department: payload.department }),
+    groupwareName: text(payload.groupwareName),
+    currency: payload.currency || 'KRW',
+    contractAmount: numeric(payload.contractAmount),
+    salesVatAmount: numeric(payload.salesVatAmount),
+    totalRevenueAmount: numeric(payload.totalRevenueAmount),
+    supportAmount: numeric(payload.supportAmount),
+    financialInputFlags: payload.financialInputFlags,
+    contractStart: text(payload.contractStart),
+    contractEnd: text(payload.contractEnd),
+    contractType: text(payload.contractType),
+    settlementType: payload.settlementType,
+    basis: payload.basis,
+    accountType: payload.accountType,
+    fundInputMode: payload.fundInputMode,
+    settlementSheetPolicy: payload.settlementSheetPolicy,
+    paymentPlan: payload.paymentPlan || input.baseProject.paymentPlan,
+    paymentPlanDesc: text(payload.paymentPlanDesc),
+    settlementGuide: text(payload.settlementGuide),
+    finalPaymentNote: text(payload.finalPaymentNote),
+    projectPurpose: text(payload.projectPurpose),
+    registeredById: text(payload.registeredById || payload.managerId),
+    registeredByName: text(payload.registeredByName || payload.managerName),
+    registeredByEmail: text(payload.registeredByEmail),
+    managerId: text(payload.registeredById || payload.managerId),
+    managerName: text(payload.registeredByName || payload.managerName),
+    teamName: text(payload.teamName),
+    teamMembersDetailed: payload.teamMembersDetailed || [],
+    participantCondition: text(payload.participantCondition),
+    note: text(payload.note),
+    contractDocument: payload.contractDocument || null,
+    contractAnalysis: payload.contractAnalysis || null,
+    budgetCurrentYear: numeric(payload.contractAmount || input.baseProject.budgetCurrentYear),
+    taxInvoiceAmount: input.baseProject.taxInvoiceAmount,
+    profitRate: input.baseProject.profitRate,
+    profitAmount: input.baseProject.profitAmount,
+    executiveReviewStatus: 'APPROVED',
+    executiveReviewedAt: input.approvedAt,
+    executiveReviewedById: input.reviewerId,
+    executiveReviewedByName: input.reviewerName,
+    executiveReviewComment: input.reviewComment || null,
+    executiveReviewHistory: [
+      ...(Array.isArray(input.baseProject.executiveReviewHistory) ? input.baseProject.executiveReviewHistory : []),
+      {
+        status: 'APPROVED',
+        previousStatus: input.baseProject.executiveReviewStatus || 'PENDING',
+        reviewedAt: input.approvedAt,
+        reviewedById: input.reviewerId,
+        reviewedByName: input.reviewerName,
+        reviewComment: input.reviewComment || undefined,
+        ...(input.changedFields?.length ? { changes: input.changedFields } : {}),
+      },
+    ],
+    updatedAt: input.approvedAt,
+  }, 'totalRevenueAmount');
+  return patch as Partial<Project>;
+}

--- a/src/app/platform/project-migration-console.ts
+++ b/src/app/platform/project-migration-console.ts
@@ -44,10 +44,11 @@ export function normalizeCicLabel(value: unknown): string {
 function deriveProjectRequestMap(requests: ProjectRequest[]): Map<string, ProjectRequest> {
   const map = new Map<string, ProjectRequest>();
   requests.forEach((request) => {
-    if (request.approvedProjectId) {
-      const previous = map.get(request.approvedProjectId);
+    const projectId = request.targetProjectId || request.approvedProjectId;
+    if (projectId) {
+      const previous = map.get(projectId);
       if (!previous || String(request.requestedAt || '').localeCompare(String(previous.requestedAt || '')) > 0) {
-        map.set(request.approvedProjectId, request);
+        map.set(projectId, request);
       }
     }
   });

--- a/src/app/platform/project-migration-review-dossier.ts
+++ b/src/app/platform/project-migration-review-dossier.ts
@@ -21,6 +21,7 @@ import {
   normalizeProjectTeamMembers,
 } from './project-team-members';
 import { getMigrationAuditStatusLabel } from './project-migration-console';
+import { resolveProjectRequestKind } from './project-change-request';
 
 export interface MigrationReviewDossier {
   headerTitle: string;
@@ -62,6 +63,8 @@ export interface MigrationReviewDossier {
     note: string;
   };
   audit: {
+    requestSummary: string;
+    requestVersion: string;
     requestedByName: string;
     requestedAt: string;
     reviewedByName: string;
@@ -184,16 +187,39 @@ function findLatestReviewChanges(history: ReturnType<typeof buildAuditHistory>) 
   return history.find((entry) => entry.changes.length > 0)?.changes || [];
 }
 
+function readReviewChangesFromRequest(request: ProjectRequest | null) {
+  return normalizeReviewChanges(request?.changedFields);
+}
+
+function preferRequestPayloadForChange<T>(
+  request: ProjectRequest | null,
+  projectValue: T,
+  payloadValue: T | undefined,
+): T | undefined {
+  return resolveProjectRequestKind(request) === 'CHANGE'
+    ? (payloadValue ?? projectValue)
+    : (projectValue ?? payloadValue);
+}
+
 export function buildMigrationReviewDossier(
   project: Project,
   request: ProjectRequest | null,
 ): MigrationReviewDossier {
   const payload = request?.payload;
+  const usePayloadAsCurrent = resolveProjectRequestKind(request) === 'CHANGE' && request?.status === 'PENDING';
   const contractDocument = project.contractDocument || payload?.contractDocument || null;
   const contractAnalysis = project.contractAnalysis || payload?.contractAnalysis || null;
-  const rawMembers = Array.isArray(project.teamMembersDetailed)
-    ? project.teamMembersDetailed
-    : payload?.teamMembersDetailed;
+  const currentName = preferRequestPayloadForChange(request, project.name, payload?.name);
+  const currentOfficialContractName = preferRequestPayloadForChange(request, project.officialContractName, payload?.officialContractName);
+  const currentClientOrg = preferRequestPayloadForChange(request, project.clientOrg, payload?.clientOrg);
+  const currentDepartment = preferRequestPayloadForChange(request, project.department, payload?.department);
+  const currentManagerName = preferRequestPayloadForChange(request, project.registeredByName || project.managerName, payload?.registeredByName || payload?.managerName);
+  const currentTeamName = preferRequestPayloadForChange(request, project.teamName, payload?.teamName);
+  const rawMembers = usePayloadAsCurrent && Array.isArray(payload?.teamMembersDetailed)
+    ? payload?.teamMembersDetailed
+    : Array.isArray(project.teamMembersDetailed)
+      ? project.teamMembersDetailed
+      : payload?.teamMembersDetailed;
   const members = Array.isArray(rawMembers)
     ? normalizeProjectTeamMembers(rawMembers).map(formatProjectTeamMemberLine)
     : readable(payload?.teamMembers, '')
@@ -201,51 +227,55 @@ export function buildMigrationReviewDossier(
         .map((member) => member.trim())
         .filter(Boolean);
   const auditHistory = buildAuditHistory(project, request);
-  const changes = findLatestReviewChanges(auditHistory);
+  const changes = readReviewChangesFromRequest(request).length > 0
+    ? readReviewChangesFromRequest(request)
+    : findLatestReviewChanges(auditHistory);
 
   return {
-    headerTitle: readable(project.name),
+    headerTitle: readable(currentName),
     identity: {
-      clientOrg: readable(project.clientOrg || payload?.clientOrg),
-      cic: readable(project.cic || project.department || payload?.department),
-      pmName: readable(project.registeredByName || payload?.registeredByName || project.managerName || payload?.managerName),
-      department: readable(project.department || payload?.department),
-      officialContractName: readable(project.officialContractName || payload?.officialContractName || project.name),
-      groupwareName: readable(project.groupwareName || payload?.groupwareName),
+      clientOrg: readable(currentClientOrg),
+      cic: readable(project.cic || currentDepartment),
+      pmName: readable(currentManagerName),
+      department: readable(currentDepartment),
+      officialContractName: readable(currentOfficialContractName || currentName),
+      groupwareName: readable(preferRequestPayloadForChange(request, project.groupwareName, payload?.groupwareName)),
     },
     contract: {
-      projectTypeLabel: PROJECT_TYPE_LABELS[normalizeProjectType(project.type || payload?.type)] || readable(project.type || payload?.type),
-      periodLabel: `${readable(project.contractStart || payload?.contractStart)} ~ ${readable(project.contractEnd || payload?.contractEnd)}`,
-      contractType: readable(normalizeProjectContractType(project.contractType || payload?.contractType)),
-      settlementTypeLabel: SETTLEMENT_TYPE_LABELS[normalizeSettlementType(project.settlementType || payload?.settlementType)] || '-',
-      basisLabel: BASIS_LABELS[normalizeBasis(project.basis || payload?.basis)] || '-',
-      accountTypeLabel: ACCOUNT_TYPE_LABELS[normalizeAccountType(project.accountType || payload?.accountType)] || '-',
-      fundInputModeLabel: PROJECT_FUND_INPUT_MODE_LABELS[normalizeProjectFundInputMode(project.fundInputMode || payload?.fundInputMode)] || '-',
+      projectTypeLabel: PROJECT_TYPE_LABELS[normalizeProjectType(preferRequestPayloadForChange(request, project.type, payload?.type))] || readable(project.type || payload?.type),
+      periodLabel: `${readable(preferRequestPayloadForChange(request, project.contractStart, payload?.contractStart))} ~ ${readable(preferRequestPayloadForChange(request, project.contractEnd, payload?.contractEnd))}`,
+      contractType: readable(normalizeProjectContractType(preferRequestPayloadForChange(request, project.contractType, payload?.contractType))),
+      settlementTypeLabel: SETTLEMENT_TYPE_LABELS[normalizeSettlementType(preferRequestPayloadForChange(request, project.settlementType, payload?.settlementType))] || '-',
+      basisLabel: BASIS_LABELS[normalizeBasis(preferRequestPayloadForChange(request, project.basis, payload?.basis))] || '-',
+      accountTypeLabel: ACCOUNT_TYPE_LABELS[normalizeAccountType(preferRequestPayloadForChange(request, project.accountType, payload?.accountType))] || '-',
+      fundInputModeLabel: PROJECT_FUND_INPUT_MODE_LABELS[normalizeProjectFundInputMode(preferRequestPayloadForChange(request, project.fundInputMode, payload?.fundInputMode))] || '-',
     },
     budget: {
-      currencyLabel: PROJECT_CURRENCY_LABELS[normalizeProjectCurrency(project.currency || payload?.currency)] || 'KRW',
-      contractAmountLabel: formatStoredProjectAmount(project.contractAmount ?? payload?.contractAmount),
-      salesVatAmountLabel: formatStoredProjectAmount(project.salesVatAmount ?? payload?.salesVatAmount),
-      paymentPlanDesc: readable(project.paymentPlanDesc || payload?.paymentPlanDesc),
+      currencyLabel: PROJECT_CURRENCY_LABELS[normalizeProjectCurrency(preferRequestPayloadForChange(request, project.currency, payload?.currency))] || 'KRW',
+      contractAmountLabel: formatStoredProjectAmount(preferRequestPayloadForChange(request, project.contractAmount, payload?.contractAmount)),
+      salesVatAmountLabel: formatStoredProjectAmount(preferRequestPayloadForChange(request, project.salesVatAmount, payload?.salesVatAmount)),
+      paymentPlanDesc: readable(preferRequestPayloadForChange(request, project.paymentPlanDesc, payload?.paymentPlanDesc)),
       paymentPlanSplitLabel: formatPaymentPlanSplit(
-        project.paymentPlan || payload?.paymentPlan,
-        project.contractAmount ?? payload?.contractAmount,
+        preferRequestPayloadForChange(request, project.paymentPlan, payload?.paymentPlan),
+        preferRequestPayloadForChange(request, project.contractAmount, payload?.contractAmount),
       ),
-      finalPaymentNote: readable(project.finalPaymentNote || payload?.finalPaymentNote),
-      totalRevenueAmountLabel: formatStoredProjectAmount(project.totalRevenueAmount ?? payload?.totalRevenueAmount),
-      supportAmountLabel: formatStoredProjectAmount(project.supportAmount ?? payload?.supportAmount),
+      finalPaymentNote: readable(preferRequestPayloadForChange(request, project.finalPaymentNote, payload?.finalPaymentNote)),
+      totalRevenueAmountLabel: formatStoredProjectAmount(preferRequestPayloadForChange(request, project.totalRevenueAmount, payload?.totalRevenueAmount)),
+      supportAmountLabel: formatStoredProjectAmount(preferRequestPayloadForChange(request, project.supportAmount, payload?.supportAmount)),
     },
     people: {
-      teamName: readable(project.teamName || payload?.teamName),
+      teamName: readable(currentTeamName),
       members,
     },
     notes: {
-      description: readable(project.description || payload?.description),
-      projectPurpose: readable(project.projectPurpose || payload?.projectPurpose),
-      participantCondition: readable(project.participantCondition || payload?.participantCondition),
+      description: readable(preferRequestPayloadForChange(request, project.description, payload?.description)),
+      projectPurpose: readable(preferRequestPayloadForChange(request, project.projectPurpose, payload?.projectPurpose)),
+      participantCondition: readable(preferRequestPayloadForChange(request, project.participantCondition, payload?.participantCondition)),
       note: readable(payload?.note),
     },
     audit: {
+      requestSummary: readable(request?.humanSummary),
+      requestVersion: request?.requestVersion ? `v${request.requestVersion}` : '-',
       requestedByName: readable(request?.requestedByName),
       requestedAt: formatDate(request?.requestedAt),
       reviewedByName: readable(project.executiveReviewedByName || request?.reviewedByName),


### PR DESCRIPTION
## Summary
- route PM portal project edits into pending projectRequests instead of directly mutating project master data
- store before/proposed snapshots, changed fields, request version, and human-readable request summary
- apply CHANGE request payload to the project master only when executive review approves it through the BFF
- show pending change badges in the admin project list and current pending values in approval review

## Verification
- npx vitest run src/app/platform/project-change-request.test.ts src/app/platform/project-migration-console.test.ts src/app/platform/project-migration-review-dossier.test.ts src/app/components/projects/ProjectMigrationAuditPage.shell.test.ts src/app/components/projects/ProjectListPage.shell.test.ts server/bff/project-change-request.test.mjs --reporter=dot
- npm run build