### PR TITLE
fix(projects): show pending portal edit versions

### DIFF
--- a/src/app/components/projects/ProjectDetailPage.shell.test.ts
+++ b/src/app/components/projects/ProjectDetailPage.shell.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(import.meta.dirname, 'ProjectDetailPage.tsx'), 'utf8');
+
+describe('ProjectDetailPage shell contract', () => {
+  it('shows a pending PM change request without replacing the approved project master values', () => {
+    expect(source).toContain('usePendingProjectChangeRequests');
+    expect(source).toContain('pendingProjectChangeRequest');
+    expect(source).toContain('수정 중');
+    expect(source).toContain('describeProjectRequestVersion');
+    expect(source).toContain('승인 전까지 이 화면은 현재 확정된 원장 값을 보여줍니다.');
+  });
+});

--- a/src/app/components/projects/ProjectDetailPage.tsx
+++ b/src/app/components/projects/ProjectDetailPage.tsx
@@ -43,6 +43,8 @@ import { computeProjectCompleteness } from '../../data/project-completeness';
 import { resolveApiErrorMessage } from '../../platform/api-error-message';
 import { normalizeProjectRevenueFields } from '../../platform/project-financials';
 import { buildProjectTeamParticipationEntries } from '../../platform/project-team-participation';
+import { describeProjectRequestVersion } from '../../platform/project-change-request';
+import { usePendingProjectChangeRequests } from './usePendingProjectChangeRequests';
 
 const statusColor: Record<string, string> = {
   CONTRACT_PENDING: 'bg-amber-100 text-amber-800',
@@ -87,6 +89,8 @@ export function ProjectDetailPage() {
 
   const project = getProjectById(projectId || '');
   const projectLedgers = getProjectLedgers(projectId || '');
+  const pendingProjectChangeMap = usePendingProjectChangeRequests();
+  const pendingProjectChangeRequest = project ? pendingProjectChangeMap.get(project.id) || null : null;
 
   const revenueFinancials = project ? normalizeProjectRevenueFields(project, 'totalRevenueAmount') : null;
   const contractAmount = toFiniteNumber(project?.contractAmount);
@@ -232,6 +236,11 @@ export function ProjectDetailPage() {
                   입찰/예정
                 </span>
               )}
+              {pendingProjectChangeRequest && (
+                <Badge variant="outline" className="border-amber-300 bg-amber-50 text-amber-800">
+                  수정 중
+                </Badge>
+              )}
               <span className={`inline-flex rounded px-1.5 py-0.5 text-[10px] ${
                 project.accountType === 'DEDICATED'
                   ? 'bg-blue-50 text-blue-700'
@@ -243,6 +252,16 @@ export function ProjectDetailPage() {
               </span>
             </div>
             <p className="text-[12px] text-muted-foreground mt-0.5">{project.description}</p>
+            {pendingProjectChangeRequest && (
+              <p className="mt-1 text-[12px] font-medium text-amber-700">
+                {describeProjectRequestVersion({
+                  request: pendingProjectChangeRequest,
+                  project,
+                  fallbackActorName: project.registeredByName || project.managerName,
+                  fallbackRequestedAt: pendingProjectChangeRequest.requestedAt,
+                })} 승인 전까지 이 화면은 현재 확정된 원장 값을 보여줍니다.
+              </p>
+            )}
           </div>
         </div>
         <div className="flex items-center gap-2 shrink-0">

--- a/src/app/components/projects/ProjectListPage.shell.test.ts
+++ b/src/app/components/projects/ProjectListPage.shell.test.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const source = readFileSync(resolve(import.meta.dirname, 'ProjectListPage.tsx'), 'utf8');
+const pendingHookSource = readFileSync(resolve(import.meta.dirname, 'usePendingProjectChangeRequests.ts'), 'utf8');
 
 describe('ProjectListPage shell contract', () => {
   it('keeps the monitoring presets visible for admin exception detection', () => {
@@ -25,5 +26,13 @@ describe('ProjectListPage shell contract', () => {
   it('shows the business owner from registeredBy fields', () => {
     expect(source).toContain('사업 담당자');
     expect(source).toContain('p.registeredByName || p.managerName');
+  });
+
+  it('surfaces pending PM change requests from both request collections', () => {
+    expect(source).toContain('usePendingProjectChangeRequests');
+    expect(source).toContain('수정 검토 중');
+    expect(pendingHookSource).toContain("const PROJECT_REQUEST_COLLECTIONS: ProjectRequestCollectionName[] = ['project_requests', 'projectRequests']");
+    expect(pendingHookSource).toContain("request.requestKind !== 'CHANGE'");
+    expect(pendingHookSource).toContain("request.targetProjectId || request.approvedProjectId");
   });
 });

--- a/src/app/components/projects/ProjectListPage.tsx
+++ b/src/app/components/projects/ProjectListPage.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useState, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router';
 import {
   Search, ArrowUpDown, Sparkles, CheckCircle2, ArrowRight,
   FolderKanban, RotateCcw, Trash2, FileText, Clock, AlertTriangle,
 } from 'lucide-react';
-import { collection, onSnapshot, query, where } from 'firebase/firestore';
 import { toast } from 'sonner';
 import { Card, CardContent } from '../ui/card';
 import { Button } from '../ui/button';
@@ -21,12 +20,11 @@ import { useAppStore } from '../../data/store';
 import {
   PROJECT_STATUS_LABELS, PROJECT_TYPE_LABELS, PROJECT_TYPE_SHORT_LABELS,
   SETTLEMENT_TYPE_LABELS, SETTLEMENT_TYPE_SHORT, normalizeSettlementType,
-  type ProjectStatus, type ProjectType, type Project, type ProjectRequest,
+  type ProjectStatus, type ProjectType, type Project,
 } from '../../data/types';
 import { PageHeader } from '../layout/PageHeader';
 import { resolveApiErrorMessage } from '../../platform/api-error-message';
-import { getOrgCollectionPath } from '../../lib/firebase';
-import { useFirebase } from '../../lib/firebase-context';
+import { usePendingProjectChangeRequests } from './usePendingProjectChangeRequests';
 
 const statusColor: Record<string, string> = {
   CONTRACT_PENDING: 'bg-amber-100 text-amber-800',
@@ -44,7 +42,6 @@ type SortDir = 'asc' | 'desc';
 
 export function ProjectListPage() {
   const { allProjects, restoreProject, ledgers, transactions } = useAppStore();
-  const { db, isOnline, orgId } = useFirebase();
   const navigate = useNavigate();
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('ALL');
@@ -54,36 +51,7 @@ export function ProjectListPage() {
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [activeTab, setActiveTab] = useState<string>('confirmed');
   const [monitoringPreset, setMonitoringPreset] = useState<'all' | 'no-ledger' | 'pending-approval' | 'missing-evidence'>('all');
-  const [pendingProjectChangeMap, setPendingProjectChangeMap] = useState<Map<string, ProjectRequest>>(new Map());
-
-  useEffect(() => {
-    if (!db || !isOnline) {
-      setPendingProjectChangeMap(new Map());
-      return undefined;
-    }
-
-    const q = query(
-      collection(db, getOrgCollectionPath(orgId, 'projectRequests')),
-      where('status', '==', 'PENDING'),
-    );
-    return onSnapshot(q, (snapshot) => {
-      const next = new Map<string, ProjectRequest>();
-      snapshot.docs.forEach((docSnap) => {
-        const request = { ...(docSnap.data() as ProjectRequest), id: docSnap.id };
-        if (request.requestKind !== 'CHANGE') return;
-        const projectId = request.targetProjectId || request.approvedProjectId;
-        if (!projectId) return;
-        const previous = next.get(projectId);
-        if (!previous || String(request.requestedAt || '').localeCompare(String(previous.requestedAt || '')) > 0) {
-          next.set(projectId, request);
-        }
-      });
-      setPendingProjectChangeMap(next);
-    }, (error) => {
-      console.error('[ProjectListPage] pending change request listen failed:', error);
-      setPendingProjectChangeMap(new Map());
-    });
-  }, [db, isOnline, orgId]);
+  const pendingProjectChangeMap = usePendingProjectChangeRequests();
 
   const activeProjects = useMemo(
     () => allProjects.filter((project) => !project.trashedAt),

--- a/src/app/components/projects/ProjectMigrationAuditPage.shell.test.ts
+++ b/src/app/components/projects/ProjectMigrationAuditPage.shell.test.ts
@@ -30,6 +30,9 @@ describe('ProjectMigrationAuditPage shell contract', () => {
     expect(compositeSource).toContain('CIC 대표 검토 대기열');
     expect(compositeSource).toContain('CIC 대표 검토 결정');
     expect(compositeSource).toContain('이번 수정에서 바뀐 값');
+    expect(compositeSource).toContain('describeProjectRequestVersion');
+    expect(compositeSource).toContain('수정 중');
+    expect(compositeSource).toContain('PM 수정 요청');
     expect(compositeSource).not.toContain('사업명으로 검색');
     expect(compositeSource).not.toContain('우리 사업으로 승인');
     expect(compositeSource).not.toContain('연결 필요');
@@ -49,6 +52,7 @@ describe('ProjectMigrationAuditPage shell contract', () => {
     expect(detailSource).not.toContain('DetailFact label="검토자"');
     expect(detailSource).not.toContain('DetailFact label="검토일"');
     expect(detailSource).not.toContain('DetailFact label="검토 메모"');
+    expect(detailSource).not.toContain("{isPmPortalProject ? 'PM 등록' : '기존 등록'}");
   });
 
   it('routes duplicate-discard decisions through the project trash flow', () => {
@@ -80,7 +84,7 @@ describe('ProjectMigrationAuditPage shell contract', () => {
     expect(detailSource).toContain('ReviewSection');
     expect(detailSource).toContain('ReviewFactGrid');
     expect(detailSource).toContain('sticky bottom-0');
-    expect(detailSource).toContain('PM이 포털에서 입력한 내용을 그대로');
+    expect(detailSource).toContain('requestVersionDescription');
     expect(detailSource).not.toContain('ProjectEditorWizard');
     expect(detailSource).not.toContain('수정 저장');
   });

--- a/src/app/components/projects/migration-audit/MigrationAuditDetailPanel.tsx
+++ b/src/app/components/projects/migration-audit/MigrationAuditDetailPanel.tsx
@@ -14,6 +14,10 @@ import {
   getMigrationAuditStatusLabel,
   isMigrationAuditPmRegistration,
 } from '../../../platform/project-migration-console';
+import {
+  describeProjectRequestVersion,
+  resolveProjectRequestKind,
+} from '../../../platform/project-change-request';
 import { buildMigrationReviewDossier } from '../../../platform/project-migration-review-dossier';
 import { Badge } from '../../ui/badge';
 import { Button } from '../../ui/button';
@@ -169,6 +173,13 @@ export function MigrationAuditDetailPanel({
   const dossier = buildMigrationReviewDossier(record.project, record.request);
   const actionState = describeMigrationAuditActionState(record);
   const isPmPortalProject = isMigrationAuditPmRegistration(record);
+  const isChangeRequest = resolveProjectRequestKind(record.request) === 'CHANGE';
+  const requestVersionDescription = describeProjectRequestVersion({
+    request: record.request,
+    project: record.project,
+    fallbackActorName: record.managerName,
+    fallbackRequestedAt: record.requestedAt,
+  });
   const contractDocument = record.project.contractDocument || record.request?.payload.contractDocument || null;
 
   return (
@@ -186,15 +197,19 @@ export function MigrationAuditDetailPanel({
                 </Badge>
                 <Badge variant="outline">{record.cic}</Badge>
                 <Badge variant="outline">{record.clientOrg || '계약 대상 미지정'}</Badge>
-                <Badge variant="outline">{isPmPortalProject ? 'PM 등록' : '기존 등록'}</Badge>
+                {isChangeRequest && record.status === 'PENDING' ? (
+                  <Badge variant="outline" className="border-amber-300 bg-amber-50 text-amber-800">수정 중</Badge>
+                ) : null}
               </div>
               <div>
-                <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">PM 등록 원문</p>
+                <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">
+                  {isChangeRequest ? 'PM 수정 요청' : isPmPortalProject ? 'PM 등록 요청' : '프로젝트 원장'}
+                </p>
                 <h2 className="mt-1 text-[24px] font-semibold tracking-[-0.02em] text-slate-950">
                   {record.title}
                 </h2>
                 <p className="mt-2 max-w-3xl text-[12px] leading-6 text-slate-600">
-                  PM이 포털에서 입력한 내용을 그대로 보되, 항목을 등록/수정 흐름과 같은 묶음으로 정리해 빠르게 대조합니다.
+                  {requestVersionDescription}
                 </p>
               </div>
             </div>

--- a/src/app/components/projects/migration-audit/MigrationAuditQueueRail.tsx
+++ b/src/app/components/projects/migration-audit/MigrationAuditQueueRail.tsx
@@ -7,8 +7,11 @@ import type {
 } from '../../../platform/project-migration-console';
 import {
   getMigrationAuditStatusLabel,
-  isMigrationAuditPmRegistration,
 } from '../../../platform/project-migration-console';
+import {
+  describeProjectRequestVersion,
+  resolveProjectRequestKind,
+} from '../../../platform/project-change-request';
 
 interface MigrationAuditQueueRailProps {
   records: MigrationAuditConsoleRecord[];
@@ -21,14 +24,6 @@ function statusClass(status: MigrationAuditConsoleStatus) {
   if (status === 'REVISION_REJECTED') return 'border-rose-200 bg-rose-50 text-rose-700';
   if (status === 'DUPLICATE_DISCARDED') return 'border-slate-300 bg-slate-100 text-slate-700';
   return 'border-amber-200 bg-amber-50 text-amber-700';
-}
-
-function formatRequestedAt(value: string) {
-  return String(value || '').slice(0, 10).replace(/-/g, '.');
-}
-
-function getSourceLabel(record: MigrationAuditConsoleRecord) {
-  return isMigrationAuditPmRegistration(record) ? 'PM 등록' : '기존 등록';
 }
 
 export function MigrationAuditQueueRail({
@@ -63,6 +58,13 @@ export function MigrationAuditQueueRail({
 
           {records.map((item) => {
             const selected = item.id === selectedId;
+            const isChangeRequest = resolveProjectRequestKind(item.request) === 'CHANGE';
+            const requestVersionDescription = describeProjectRequestVersion({
+              request: item.request,
+              project: item.project,
+              fallbackActorName: item.managerName,
+              fallbackRequestedAt: item.requestedAt,
+            });
             return (
               <button
                 key={item.id}
@@ -83,9 +85,11 @@ export function MigrationAuditQueueRail({
                       <Badge variant="outline" className={`text-[10px] ${selected ? 'border-white/20 text-white' : 'border-slate-200 text-slate-600'}`}>
                         {item.cic}
                       </Badge>
-                      <Badge variant="outline" className={`text-[10px] ${selected ? 'border-white/20 text-white' : 'border-slate-200 text-slate-600'}`}>
-                        {getSourceLabel(item)}
-                      </Badge>
+                      {isChangeRequest && item.status === 'PENDING' ? (
+                        <Badge variant="outline" className={`text-[10px] ${selected ? 'border-white/20 text-white' : 'border-amber-300 bg-amber-50 text-amber-800'}`}>
+                          수정 중
+                        </Badge>
+                      ) : null}
                     </div>
                     <div className="space-y-1">
                       <p className={`truncate text-[13px] font-semibold ${selected ? 'text-white' : 'text-slate-950'}`}>
@@ -94,10 +98,9 @@ export function MigrationAuditQueueRail({
                       <p className={`truncate text-[11px] ${selected ? 'text-slate-200' : 'text-slate-500'}`}>
                         {item.clientOrg || '계약 대상 미지정'}
                       </p>
-                      <div className={`flex flex-wrap gap-x-3 gap-y-1 text-[11px] ${selected ? 'text-slate-200' : 'text-slate-500'}`}>
-                        <span>PM {item.managerName || '미지정'}</span>
-                        <span>접수 {formatRequestedAt(item.requestedAt)}</span>
-                      </div>
+                      <p className={`text-[11px] leading-5 ${selected ? 'text-slate-200' : 'text-slate-500'}`}>
+                        {requestVersionDescription}
+                      </p>
                     </div>
                   </div>
                   <ArrowRight className={`mt-1 h-4 w-4 shrink-0 ${selected ? 'text-slate-200' : 'text-slate-400'}`} />

--- a/src/app/components/projects/usePendingProjectChangeRequests.ts
+++ b/src/app/components/projects/usePendingProjectChangeRequests.ts
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { collection, onSnapshot, query, where } from 'firebase/firestore';
+import type { ProjectRequest } from '../../data/types';
+import { getOrgRootPath } from '../../lib/firebase';
+import { useFirebase } from '../../lib/firebase-context';
+
+type ProjectRequestCollectionName = 'project_requests' | 'projectRequests';
+
+const PROJECT_REQUEST_COLLECTIONS: ProjectRequestCollectionName[] = ['project_requests', 'projectRequests'];
+
+function buildPendingChangeMap(requests: ProjectRequest[]): Map<string, ProjectRequest> {
+  const next = new Map<string, ProjectRequest>();
+  requests.forEach((request) => {
+    if (request.requestKind !== 'CHANGE') return;
+    const projectId = request.targetProjectId || request.approvedProjectId;
+    if (!projectId) return;
+    const previous = next.get(projectId);
+    if (!previous || String(request.requestedAt || '').localeCompare(String(previous.requestedAt || '')) > 0) {
+      next.set(projectId, request);
+    }
+  });
+  return next;
+}
+
+export function usePendingProjectChangeRequests(): Map<string, ProjectRequest> {
+  const { db, isOnline, orgId } = useFirebase();
+  const [pendingProjectChangeMap, setPendingProjectChangeMap] = useState<Map<string, ProjectRequest>>(new Map());
+
+  useEffect(() => {
+    if (!db || !isOnline) {
+      setPendingProjectChangeMap(new Map());
+      return undefined;
+    }
+
+    const collectionRows = new Map<ProjectRequestCollectionName, ProjectRequest[]>();
+    const publish = () => {
+      setPendingProjectChangeMap(buildPendingChangeMap(Array.from(collectionRows.values()).flat()));
+    };
+
+    const unsubscribes = PROJECT_REQUEST_COLLECTIONS.map((collectionName) => {
+      const q = query(
+        collection(db, `${getOrgRootPath(orgId)}/${collectionName}`),
+        where('status', '==', 'PENDING'),
+      );
+      return onSnapshot(q, (snapshot) => {
+        collectionRows.set(collectionName, snapshot.docs.map((docSnap) => ({
+          ...(docSnap.data() as ProjectRequest),
+          id: docSnap.id,
+        })));
+        publish();
+      }, (error) => {
+        console.error(`[usePendingProjectChangeRequests] ${collectionName} listen failed:`, error);
+        collectionRows.set(collectionName, []);
+        publish();
+      });
+    });
+
+    return () => {
+      unsubscribes.forEach((unsubscribe) => unsubscribe());
+    };
+  }, [db, isOnline, orgId]);
+
+  return pendingProjectChangeMap;
+}

--- a/src/app/platform/project-change-request.test.ts
+++ b/src/app/platform/project-change-request.test.ts
@@ -4,6 +4,7 @@ import { createProjectEditorDraft } from './project-editor';
 import {
   buildProjectChangeRequest,
   buildProjectPatchFromRequestPayload,
+  describeProjectRequestVersion,
   resolveProjectRequestKind,
 } from './project-change-request';
 
@@ -90,6 +91,9 @@ describe('project change request helpers', () => {
     expect(request.proposedSnapshot?.name).toBe('2026 CTS2 수정');
     expect(request.changedFields?.some((change) => change.key === 'name')).toBe(true);
     expect(request.humanSummary).toContain('기준 프로젝트 v7');
+    expect(describeProjectRequestVersion({ request, project: baseProject })).toBe(
+      '김인효(베리) 님이 5월 29일 10시 29분에 수정 요청한 버전입니다 · v1',
+    );
   });
 
   it('applies an approved request payload as a project patch', () => {

--- a/src/app/platform/project-change-request.ts
+++ b/src/app/platform/project-change-request.ts
@@ -41,8 +41,56 @@ function formatKst(iso: string): string {
   }
 }
 
+function formatKstSentence(iso: string): string {
+  const value = text(iso);
+  if (!value) return '시간 미상';
+
+  try {
+    const parts = new Intl.DateTimeFormat('ko-KR', {
+      timeZone: 'Asia/Seoul',
+      month: 'numeric',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    }).formatToParts(new Date(value));
+    const part = (type: string) => parts.find((item) => item.type === type)?.value || '';
+    const month = part('month');
+    const day = part('day');
+    const hour = part('hour');
+    const minute = part('minute');
+    if (month && day && hour && minute) return `${month}월 ${day}일 ${hour}시 ${minute}분`;
+  } catch {
+    // fall through to raw value
+  }
+
+  return value;
+}
+
 export function resolveProjectRequestKind(request: ProjectRequest | null | undefined): ProjectRequestKind {
   return request?.requestKind === 'CHANGE' ? 'CHANGE' : 'REGISTRATION';
+}
+
+export function describeProjectRequestVersion(input: {
+  request?: ProjectRequest | null;
+  project?: Project | null;
+  fallbackActorName?: string;
+  fallbackRequestedAt?: string;
+}): string {
+  const request = input.request || null;
+  const project = input.project || null;
+  const actorName = text(
+    request?.requestedByName
+    || input.fallbackActorName
+    || project?.registeredByName
+    || project?.managerName,
+  ) || '요청자';
+  const requestedAt = text(request?.requestedAt || input.fallbackRequestedAt || project?.createdAt);
+  const action = request
+    ? resolveProjectRequestKind(request) === 'CHANGE' ? '수정 요청' : '등록 요청'
+    : '등록';
+  const version = request?.requestVersion || request?.targetProjectVersion || request?.baseProjectVersion;
+  return `${actorName} 님이 ${formatKstSentence(requestedAt)}에 ${action}한 버전입니다${version ? ` · v${version}` : ''}`;
 }
 
 export function buildProjectPayloadFromProject(project: Project): ProjectRequestPayload {


### PR DESCRIPTION
## Summary
- show PM registration/change requests as human-readable version text instead of generic source badges
- surface pending PM edit status on project detail dashboards
- reuse one pending-change listener across project list/detail and read both project_requests and projectRequests

## Verification
- npx vitest run src/app/platform/project-change-request.test.ts src/app/components/projects/ProjectListPage.shell.test.ts src/app/components/projects/ProjectDetailPage.shell.test.ts src/app/components/projects/ProjectMigrationAuditPage.shell.test.ts --reporter=dot
- npm run build