### PR TITLE
fix(projects): omit undefined change request fields

### DIFF
--- a/src/app/platform/preload-recovery.test.ts
+++ b/src/app/platform/preload-recovery.test.ts
@@ -5,10 +5,9 @@ describe('installVitePreloadRecovery', () => {
     vi.resetModules();
   });
 
-  it('reloads the app shell once when Vite reports a stale preload chunk', async () => {
+  it('does not auto reload when Vite reports a stale preload chunk', async () => {
     const { installVitePreloadRecovery } = await import('./preload-recovery');
     let listener: ((event: Event) => void) | undefined;
-    const reload = vi.fn();
     const storage = new Map<string, string>();
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -16,7 +15,7 @@ describe('installVitePreloadRecovery', () => {
       addEventListener: vi.fn((type: string, callback: EventListener) => {
         if (type === 'vite:preloadError') listener = callback;
       }),
-      location: { pathname: '/portal/cashflow', reload },
+      location: { pathname: '/portal/cashflow' },
       sessionStorage: {
         getItem: vi.fn((key: string) => storage.get(key) || null),
         setItem: vi.fn((key: string, value: string) => storage.set(key, value)),
@@ -31,24 +30,23 @@ describe('installVitePreloadRecovery', () => {
     listener?.(event);
 
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
-    expect(reload).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Keeping current URL. User must choose when to refresh after saving current work.'));
     listener?.(event);
-    expect(reload).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('already reported recently'));
     errorSpy.mockRestore();
     warnSpy.mockRestore();
   });
 
-  it('does not reload again after a same-path recovery marker survives reload', async () => {
+  it('does not auto reload after a same-path recovery marker survives reload', async () => {
     const { installVitePreloadRecovery } = await import('./preload-recovery');
     let listener: ((event: Event) => void) | undefined;
-    const reload = vi.fn();
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const target = {
       addEventListener: vi.fn((type: string, callback: EventListener) => {
         if (type === 'vite:preloadError') listener = callback;
       }),
-      location: { pathname: '/portal/cashflow', reload },
+      location: { pathname: '/portal/cashflow' },
       sessionStorage: {
         getItem: vi.fn(() => JSON.stringify({
           path: '/portal/cashflow',
@@ -66,8 +64,7 @@ describe('installVitePreloadRecovery', () => {
     listener?.(event);
 
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
-    expect(reload).not.toHaveBeenCalled();
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('already attempted recently'));
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('already reported recently'));
     warnSpy.mockRestore();
     errorSpy.mockRestore();
   });

--- a/src/app/platform/preload-recovery.ts
+++ b/src/app/platform/preload-recovery.ts
@@ -1,20 +1,20 @@
 type PreloadRecoveryTarget = Pick<Window, 'addEventListener'> & {
-  location: Pick<Location, 'pathname' | 'reload'>;
+  location: Pick<Location, 'pathname'>;
   sessionStorage?: Pick<Storage, 'getItem' | 'setItem'>;
 };
 
-let reloadRequested = false;
+let reportRequested = false;
 const PRELOAD_RECOVERY_SESSION_KEY = 'mysc:vite-preload-recovery';
 const PRELOAD_RECOVERY_THROTTLE_MS = 30_000;
 
-function shouldReloadForPreloadError(target: PreloadRecoveryTarget): boolean {
-  if (reloadRequested) return false;
+function shouldReportPreloadError(target: PreloadRecoveryTarget): boolean {
+  if (reportRequested) return false;
 
   const path = target.location.pathname || '/';
   const now = Date.now();
   const sessionStorage = target.sessionStorage;
   if (!sessionStorage) {
-    reloadRequested = true;
+    reportRequested = true;
     return true;
   }
 
@@ -36,7 +36,7 @@ function shouldReloadForPreloadError(target: PreloadRecoveryTarget): boolean {
     // Storage can be blocked in some auth/browser modes. Fall back to in-memory protection.
   }
 
-  reloadRequested = true;
+  reportRequested = true;
   return true;
 }
 
@@ -46,12 +46,11 @@ export function installVitePreloadRecovery(target: PreloadRecoveryTarget = windo
     customEvent.preventDefault();
     console.warn('[MYSC] Vite preload error detected:', customEvent.detail);
 
-    if (!shouldReloadForPreloadError(target)) {
-      console.error('[MYSC] Vite preload recovery already attempted recently; keeping current URL without another reload.');
+    if (!shouldReportPreloadError(target)) {
+      console.error('[MYSC] Vite preload error already reported recently; keeping current URL without auto reload.');
       return;
     }
 
-    console.warn('[MYSC] Reloading app shell once to recover stale chunks.');
-    target.location.reload();
+    console.warn('[MYSC] Keeping current URL. User must choose when to refresh after saving current work.');
   });
 }

--- a/src/app/platform/project-change-request.test.ts
+++ b/src/app/platform/project-change-request.test.ts
@@ -48,6 +48,17 @@ const baseProject = {
   updatedAt: '2026-01-01T00:00:00.000Z',
 } satisfies Project;
 
+function collectUndefinedPaths(value: unknown, prefix = ''): string[] {
+  if (value === undefined) return [prefix || '<root>'];
+  if (Array.isArray(value)) {
+    return value.flatMap((item, index) => collectUndefinedPaths(item, `${prefix}[${index}]`));
+  }
+  if (!value || typeof value !== 'object') return [];
+  return Object.entries(value as Record<string, unknown>).flatMap(([key, item]) => (
+    collectUndefinedPaths(item, prefix ? `${prefix}.${key}` : key)
+  ));
+}
+
 describe('project change request helpers', () => {
   it('keeps legacy requests as registration requests', () => {
     expect(resolveProjectRequestKind(null)).toBe('REGISTRATION');
@@ -94,6 +105,8 @@ describe('project change request helpers', () => {
     expect(describeProjectRequestVersion({ request, project: baseProject })).toBe(
       '김인효(베리) 님이 5월 29일 10시 29분에 수정 요청한 버전입니다 · v1',
     );
+    expect(Object.prototype.hasOwnProperty.call(request, 'reviewOutcome')).toBe(false);
+    expect(collectUndefinedPaths(request)).toEqual([]);
   });
 
   it('applies an approved request payload as a project patch', () => {

--- a/src/app/platform/project-change-request.ts
+++ b/src/app/platform/project-change-request.ts
@@ -25,6 +25,19 @@ function nextPositiveInt(value: unknown): number {
   return Number.isInteger(parsed) && parsed > 0 ? parsed + 1 : 1;
 }
 
+function omitUndefinedFields<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => omitUndefinedFields(item)) as T;
+  }
+  if (!value || typeof value !== 'object') return value;
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .map(([key, item]) => [key, omitUndefinedFields(item)]),
+  ) as T;
+}
+
 function formatKst(iso: string): string {
   try {
     return new Intl.DateTimeFormat('ko-KR', {
@@ -165,7 +178,7 @@ export function buildProjectChangeRequest(input: {
     ? Number(input.baseProject.version)
     : 1;
   const id = text(input.previousRequest?.id) || `change-${input.baseProject.id}`;
-  return {
+  return omitUndefinedFields({
     id,
     tenantId: input.tenantId,
     requestKind: 'CHANGE',
@@ -182,21 +195,17 @@ export function buildProjectChangeRequest(input: {
       requestVersion,
     }),
     status: 'PENDING',
-    reviewOutcome: undefined,
     payload: proposedSnapshot,
     requestedBy: input.actorId,
     requestedByName: input.actorName,
     requestedByEmail: input.actorEmail,
     requestedAt: input.requestedAt,
-    reviewedBy: undefined,
-    reviewedByName: undefined,
-    reviewedAt: undefined,
     reviewComment: null,
     rejectedReason: null,
     approvedProjectId: input.baseProject.id,
     createdAt: input.previousRequest?.createdAt || input.requestedAt,
     updatedAt: input.requestedAt,
-  };
+  });
 }
 
 export function buildProjectPatchFromRequestPayload(


### PR DESCRIPTION
## Summary
- remove explicit undefined fields from PM project change request payloads
- recursively omit undefined values before Firestore setDoc
- add regression coverage so project change requests are Firestore-safe

## Verification
- npx vitest run src/app/platform/project-change-request.test.ts src/app/components/portal/PortalProjectEdit.persist-shell.test.ts --reporter=dot
- npm run build