### PR TITLE
feat(projects): add protected portal request drafts

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -61,6 +61,13 @@ service cloud.firestore {
       return collection in ['contacts', 'business_card_imports', 'contact_events'];
     }
 
+    // 일반 org 멤버 catchall에서 제외할 컬렉션.
+    // 각 컬렉션의 상단 override 규칙만 적용되도록 막는다.
+    function isCatchallExcludedCollection(collection) {
+      return isBffOnlyCollection(collection)
+        || collection in ['projectRequestDrafts'];
+    }
+
     // ══════════════════════════════════════════════════════════════
     // orgs/{orgId}/** 규칙
     // 특정 컬렉션 override → 일반 규칙 순서로 적용
@@ -124,11 +131,32 @@ service cloud.firestore {
         && getMemberRole(orgId) in ['admin', 'finance'];
     }
 
+    // ── 프로젝트 등록/수정 임시저장: 제출 전 개인 작업공간 ──
+    // 관리자 승인 콘솔은 project_requests만 읽고, draft는 작성자 본인만 접근한다.
+    match /orgs/{orgId}/projectRequestDrafts/{draftId} {
+      allow read: if isMember(orgId)
+        && resource.data.ownerId == request.auth.uid;
+
+      allow create: if isMember(orgId)
+        && request.resource.data.ownerId == request.auth.uid
+        && request.resource.data.tenantId == orgId
+        && request.resource.data.status in ['DRAFT', 'SUBMITTED'];
+
+      allow update: if isMember(orgId)
+        && resource.data.ownerId == request.auth.uid
+        && request.resource.data.ownerId == resource.data.ownerId
+        && request.resource.data.tenantId == orgId
+        && request.resource.data.status in ['DRAFT', 'SUBMITTED', 'DISCARDED'];
+
+      allow delete: if isMember(orgId)
+        && resource.data.ownerId == request.auth.uid;
+    }
+
     // ── 일반 규칙: 나머지 모든 컬렉션 ──
     // (projects, ledgers, transactions, evidences, comments, 등)
     match /orgs/{orgId}/{collection}/{document=**} {
-      allow read: if !isBffOnlyCollection(collection) && canRead(orgId);
-      allow write: if !isBffOnlyCollection(collection) && canWrite(orgId);
+      allow read: if !isCatchallExcludedCollection(collection) && canRead(orgId);
+      allow write: if !isCatchallExcludedCollection(collection) && canWrite(orgId);
     }
   }
 }

--- a/src/app/components/portal/PortalProjectEdit.tsx
+++ b/src/app/components/portal/PortalProjectEdit.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { AlertTriangle, Loader2, Save, SendHorizontal } from 'lucide-react';
 import { collection, doc, limit, onSnapshot, orderBy, query, setDoc, where } from 'firebase/firestore';
 import { toast } from 'sonner';
 import { useAuth } from '../../data/auth-store';
 import { usePortalStore } from '../../data/portal-store';
-import type { Project, ProjectRequest } from '../../data/types';
+import type { Project, ProjectRequest, ProjectRequestDraft, ProjectRequestDraftStatus } from '../../data/types';
 import { getOrgCollectionPath, getOrgDocumentPath } from '../../lib/firebase';
 import { useFirebase } from '../../lib/firebase-context';
 import { uploadProjectRequestContractFile } from '../../platform/project-contract-upload';
@@ -18,6 +18,7 @@ import {
   buildProjectChangeRequest,
   resolveProjectRequestKind,
 } from '../../platform/project-change-request';
+import { buildProjectRequestDraft } from '../../platform/project-request-draft';
 import { Button } from '../ui/button';
 import { Card, CardContent } from '../ui/card';
 import { Label } from '../ui/label';
@@ -71,6 +72,8 @@ export function PortalProjectEdit() {
   const [requestDoc, setRequestDoc] = useState<ProjectRequest | null>(null);
   const [busyActionId, setBusyActionId] = useState<string | null>(null);
   const [resubmitComment, setResubmitComment] = useState('');
+  const serverDraftRef = useRef<ProjectRequestDraft | null>(null);
+  const autosaveKey = `portal-edit-${orgId}-${myProject?.id || 'no-project'}-${authUser?.uid || 'anonymous'}`;
 
   useEffect(() => {
     if (!db || !isOnline || !myProject?.id) {
@@ -125,6 +128,43 @@ export function PortalProjectEdit() {
   const canResubmit = myProject?.executiveReviewStatus === 'REVISION_REJECTED'
     || myProject?.executiveReviewStatus === 'DUPLICATE_DISCARDED';
 
+  const persistDraft = useCallback(async (
+    draft: ProjectEditorDraft,
+    stepIndex: number,
+    status: ProjectRequestDraftStatus = 'DRAFT',
+  ) => {
+    if (!db || !orgId || !myProject?.id || !authUser?.uid) return;
+    const now = new Date().toISOString();
+    const nextDraft = buildProjectRequestDraft({
+      tenantId: orgId,
+      kind: 'CHANGE',
+      ownerId: authUser.uid,
+      ownerName: authUser.name || authUser.email || 'PM',
+      ownerEmail: authUser.email || '',
+      targetProjectId: myProject.id,
+      draftKey: autosaveKey,
+      draft,
+      stepIndex,
+      previousDraft: serverDraftRef.current,
+      status,
+      now,
+    });
+    await setDoc(
+      doc(db, getOrgDocumentPath(orgId, 'projectRequestDrafts', nextDraft.id)),
+      nextDraft,
+      { merge: true },
+    );
+    serverDraftRef.current = nextDraft;
+  }, [authUser?.email, authUser?.name, authUser?.uid, autosaveKey, db, myProject?.id, orgId]);
+
+  const autosaveConfig = useMemo(
+    () => (authUser?.uid ? {
+      key: autosaveKey,
+      onSave: persistDraft,
+    } : undefined),
+    [authUser?.uid, autosaveKey, persistDraft],
+  );
+
   const persistProject = async (
     draft: ProjectEditorDraft,
     options: { forcePendingReview?: boolean; reviewComment?: string | null } = {},
@@ -172,6 +212,11 @@ export function PortalProjectEdit() {
         forcePendingReview,
         reviewComment: forcePendingReview ? resubmitComment.trim() || null : null,
       });
+      try {
+        await persistDraft(draft, 4, 'SUBMITTED');
+      } catch (draftError) {
+        console.warn('[PortalProjectEdit] submitted draft marker failed:', draftError);
+      }
       if (forcePendingReview) {
         setResubmitComment('');
         toast.success('프로젝트 변경 요청을 다시 제출했습니다.');
@@ -183,6 +228,7 @@ export function PortalProjectEdit() {
     } catch (error) {
       console.error('[PortalProjectEdit] save failed:', error);
       toast.error(error instanceof Error ? error.message : '저장에 실패했습니다. 다시 시도해주세요.');
+      throw error;
     } finally {
       setBusyActionId(null);
     }
@@ -215,6 +261,7 @@ export function PortalProjectEdit() {
       initialDraft={initialDraft}
       draftKey={`portal-edit-${myProject.id}-${requestDoc?.updatedAt || myProject.updatedAt}`}
       members={members}
+      autosave={autosaveConfig}
       actions={[
         { id: 'save', label: '저장', icon: Save },
         ...(canResubmit ? [{ id: 'resubmit', label: '수정 후 다시 제출', icon: SendHorizontal, variant: 'secondary' as const }] : []),
@@ -222,7 +269,7 @@ export function PortalProjectEdit() {
       busyActionId={busyActionId}
       onContractFileUpload={handleContractFileUpload}
       onCancel={() => navigate('/portal/project-select')}
-      onSubmit={(draft, actionId) => void handleSubmit(draft, actionId)}
+      onSubmit={(draft, actionId) => handleSubmit(draft, actionId)}
       topSlot={executiveBanner ? (
         <div className={`rounded-2xl border px-4 py-4 ${bannerClassName(executiveBanner.tone)}`}>
           <div className="flex items-start gap-3">

--- a/src/app/components/portal/PortalProjectRegister.tsx
+++ b/src/app/components/portal/PortalProjectRegister.tsx
@@ -1,10 +1,12 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { CheckCircle2, Send } from 'lucide-react';
+import { doc, setDoc } from 'firebase/firestore';
 import { toast } from 'sonner';
 import { useAuth } from '../../data/auth-store';
 import { usePortalStore } from '../../data/portal-store';
-import { getAuthInstance } from '../../lib/firebase';
+import type { ProjectRequestDraft, ProjectRequestDraftStatus } from '../../data/types';
+import { getAuthInstance, getOrgDocumentPath } from '../../lib/firebase';
 import { useFirebase } from '../../lib/firebase-context';
 import {
   isPlatformApiEnabled,
@@ -16,17 +18,20 @@ import {
   createProjectEditorDraft,
   type ProjectEditorDraft,
 } from '../../platform/project-editor';
+import { buildProjectRequestDraft } from '../../platform/project-request-draft';
 import { Button } from '../ui/button';
 import { Card, CardContent } from '../ui/card';
 import { ProjectEditorWizard } from '../projects/ProjectEditorWizard';
 
 export function PortalProjectRegister() {
   const navigate = useNavigate();
-  const { orgId } = useFirebase();
+  const { db, orgId } = useFirebase();
   const { user: authUser } = useAuth();
   const { createProjectRequest, members, portalUser } = usePortalStore();
   const [busyActionId, setBusyActionId] = useState<string | null>(null);
   const [submitted, setSubmitted] = useState(false);
+  const serverDraftRef = useRef<ProjectRequestDraft | null>(null);
+  const autosaveKey = `portal-register-${orgId}-${authUser?.uid || 'anonymous'}`;
 
   const initialDraft = useMemo(
     () => createProjectEditorDraft({
@@ -39,6 +44,42 @@ export function PortalProjectRegister() {
     [authUser?.email, authUser?.name, authUser?.uid, portalUser?.email, portalUser?.name],
   );
 
+  const persistDraft = useCallback(async (
+    draft: ProjectEditorDraft,
+    stepIndex: number,
+    status: ProjectRequestDraftStatus = 'DRAFT',
+  ) => {
+    if (!db || !authUser?.uid) return;
+    const now = new Date().toISOString();
+    const nextDraft = buildProjectRequestDraft({
+      tenantId: orgId,
+      kind: 'REGISTRATION',
+      ownerId: authUser.uid,
+      ownerName: authUser.name || portalUser?.name || authUser.email || 'PM',
+      ownerEmail: authUser.email || portalUser?.email || '',
+      draftKey: autosaveKey,
+      draft,
+      stepIndex,
+      previousDraft: serverDraftRef.current,
+      status,
+      now,
+    });
+    await setDoc(
+      doc(db, getOrgDocumentPath(orgId, 'projectRequestDrafts', nextDraft.id)),
+      nextDraft,
+      { merge: true },
+    );
+    serverDraftRef.current = nextDraft;
+  }, [authUser?.email, authUser?.name, authUser?.uid, autosaveKey, db, orgId, portalUser?.email, portalUser?.name]);
+
+  const autosaveConfig = useMemo(
+    () => (authUser?.uid ? {
+      key: autosaveKey,
+      onSave: persistDraft,
+    } : undefined),
+    [authUser?.uid, autosaveKey, persistDraft],
+  );
+
   const handleSubmit = async (draft: ProjectEditorDraft) => {
     if (busyActionId) return;
     setBusyActionId('submit');
@@ -46,8 +87,12 @@ export function PortalProjectRegister() {
       const payload = buildProjectRequestPayloadFromDraft(draft);
       const createdId = await createProjectRequest(payload);
       if (!createdId) {
-        toast.error('프로젝트 등록 요청 저장에 실패했습니다. 다시 시도해 주세요.');
-        return;
+        throw new Error('프로젝트 등록 요청 저장에 실패했습니다. 다시 시도해 주세요.');
+      }
+      try {
+        await persistDraft(draft, 4, 'SUBMITTED');
+      } catch (draftError) {
+        console.warn('[PortalProjectRegister] submitted draft marker failed:', draftError);
       }
 
       if (authUser && isPlatformApiEnabled()) {
@@ -77,6 +122,7 @@ export function PortalProjectRegister() {
     } catch (error) {
       console.error('[PortalProjectRegister] create project request failed:', error);
       toast.error(error instanceof Error ? error.message : '프로젝트 등록 요청 저장에 실패했습니다.');
+      throw error;
     } finally {
       setBusyActionId(null);
     }
@@ -121,11 +167,12 @@ export function PortalProjectRegister() {
       initialDraft={initialDraft}
       draftKey={`portal-register-${authUser?.uid || 'anonymous'}`}
       members={members}
+      autosave={autosaveConfig}
       actions={[{ id: 'submit', label: '등록 요청 저장', icon: Send }]}
       busyActionId={busyActionId}
       onContractFileUpload={handleContractFileUpload}
       onCancel={() => navigate('/portal/project-select')}
-      onSubmit={(draft) => void handleSubmit(draft)}
+      onSubmit={(draft) => handleSubmit(draft)}
     />
   );
 }

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -18,7 +18,7 @@ import {
   Users,
   Wallet,
 } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState, type ChangeEvent, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type ReactNode } from 'react';
 import { toast } from 'sonner';
 import {
   ACCOUNT_TYPE_LABELS,
@@ -119,14 +119,29 @@ interface ProjectEditorWizardProps {
   }>;
   contractAnalysisMergeMode?: 'fill-empty' | 'none';
   canRemoveContractDocument?: boolean;
+  autosave?: {
+    key: string;
+    disabled?: boolean;
+    onSave?: (draft: ProjectEditorDraft, stepIndex: number) => void | Promise<void>;
+    onDiscard?: () => void | Promise<void>;
+  };
   onCancel?: () => void;
   onSubmit: (draft: ProjectEditorDraft, actionId: string) => void | Promise<void>;
 }
 
 const MAX_CONTRACT_UPLOAD_SIZE_BYTES = 4 * 1024 * 1024;
 const MAX_CONTRACT_UPLOAD_SIZE_LABEL = '4MB';
+const PROJECT_EDITOR_AUTOSAVE_SCHEMA_VERSION = 1;
 
 type ContractUploadState = 'idle' | 'extracting' | 'ready' | 'error';
+type AutosaveState = 'idle' | 'saving' | 'saved' | 'error';
+type StoredProjectEditorDraft = {
+  schemaVersion: number;
+  draftKey: string;
+  draft: ProjectEditorDraft;
+  stepIndex: number;
+  updatedAt: string;
+};
 
 const STEPS: Array<{
   id: ProjectEditorStep;
@@ -161,6 +176,43 @@ const PROJECT_EDITOR_FORM_SURFACE_CLASS = [
   '[&_[role=combobox]]:bg-white',
   '[&_[role=combobox]]:shadow-[inset_0_1px_0_rgba(15,23,42,0.03)]',
 ].join(' ');
+
+function getProjectEditorAutosaveStorageKey(key: string) {
+  return `mysc:project-editor-autosave:${key}`;
+}
+
+function readStoredProjectEditorDraft(key: string): StoredProjectEditorDraft | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const parsed = JSON.parse(localStorage.getItem(getProjectEditorAutosaveStorageKey(key)) || 'null') as StoredProjectEditorDraft | null;
+    if (!parsed || parsed.schemaVersion !== PROJECT_EDITOR_AUTOSAVE_SCHEMA_VERSION || !parsed.draft) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredProjectEditorDraft(key: string, value: StoredProjectEditorDraft) {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(getProjectEditorAutosaveStorageKey(key), JSON.stringify(value));
+}
+
+function removeStoredProjectEditorDraft(key: string) {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.removeItem(getProjectEditorAutosaveStorageKey(key));
+}
+
+function formatAutosaveTime(value: string) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleString('ko-KR', {
+    month: 'numeric',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
 
 function fmtKRW(value: number) {
   return value ? value.toLocaleString('ko-KR') : '0';
@@ -375,6 +427,7 @@ export function ProjectEditorWizard({
   onContractFileUpload,
   contractAnalysisMergeMode = 'fill-empty',
   canRemoveContractDocument,
+  autosave,
   onCancel,
   onSubmit,
 }: ProjectEditorWizardProps) {
@@ -382,7 +435,12 @@ export function ProjectEditorWizard({
   const [draft, setDraft] = useState<ProjectEditorDraft>(() => createProjectEditorWizardDraft(initialDraft));
   const [contractUploadState, setContractUploadState] = useState<ContractUploadState>('idle');
   const [contractUploadError, setContractUploadError] = useState('');
+  const [restoreCandidate, setRestoreCandidate] = useState<StoredProjectEditorDraft | null>(null);
+  const [autosaveState, setAutosaveState] = useState<AutosaveState>('idle');
+  const [lastAutosavedAt, setLastAutosavedAt] = useState('');
+  const [preloadWarningVisible, setPreloadWarningVisible] = useState(false);
   const contractUploadInputRef = useRef<HTMLInputElement | null>(null);
+  const initialDraftFingerprint = useMemo(() => JSON.stringify(createProjectEditorDraft(initialDraft)), [initialDraft]);
   const initialContractDocument = initialDraft.contractDocument ?? null;
   const initialContractAnalysis = initialDraft.contractAnalysis ?? null;
   const canRemoveExistingContractDocument = canRemoveContractDocument ?? isAdminMode(mode);
@@ -397,7 +455,90 @@ export function ProjectEditorWizard({
     setStepIndex(0);
     setContractUploadState('idle');
     setContractUploadError('');
-  }, [draftKey]);
+    setAutosaveState('idle');
+    setLastAutosavedAt('');
+    setPreloadWarningVisible(false);
+    setRestoreCandidate(autosave?.key ? readStoredProjectEditorDraft(autosave.key) : null);
+  }, [autosave?.key, draftKey, initialDraft]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const handlePreloadError = () => setPreloadWarningVisible(true);
+    window.addEventListener('mysc:preloadError', handlePreloadError);
+    return () => window.removeEventListener('mysc:preloadError', handlePreloadError);
+  }, []);
+
+  const persistAutosaveSnapshot = useCallback(async (
+    nextDraft: ProjectEditorDraft,
+    nextStepIndex: number,
+  ) => {
+    if (!autosave?.key || autosave.disabled) return false;
+    const now = new Date().toISOString();
+    const storedDraft: StoredProjectEditorDraft = {
+      schemaVersion: PROJECT_EDITOR_AUTOSAVE_SCHEMA_VERSION,
+      draftKey,
+      draft: createProjectEditorDraft(nextDraft),
+      stepIndex: nextStepIndex,
+      updatedAt: now,
+    };
+    setAutosaveState('saving');
+    try {
+      writeStoredProjectEditorDraft(autosave.key, storedDraft);
+      await autosave.onSave?.(storedDraft.draft, nextStepIndex);
+      setLastAutosavedAt(now);
+      setAutosaveState('saved');
+      return true;
+    } catch (error) {
+      console.error('[ProjectEditorWizard] autosave failed:', error);
+      setLastAutosavedAt(now);
+      setAutosaveState('error');
+      return false;
+    }
+  }, [autosave, draftKey]);
+
+  useEffect(() => {
+    if (!autosave?.key || autosave.disabled || restoreCandidate) return undefined;
+    const isInitialDraft = stepIndex === 0 && JSON.stringify(createProjectEditorDraft(draft)) === initialDraftFingerprint;
+    if (isInitialDraft) return undefined;
+
+    const timer = window.setTimeout(() => {
+      void persistAutosaveSnapshot(draft, stepIndex);
+    }, 1000);
+    return () => window.clearTimeout(timer);
+  }, [autosave?.disabled, autosave?.key, draft, initialDraftFingerprint, persistAutosaveSnapshot, restoreCandidate, stepIndex]);
+
+  const restoreLocalDraft = () => {
+    if (!restoreCandidate) return;
+    setDraft(createProjectEditorWizardDraft(restoreCandidate.draft));
+    setStepIndex(Math.max(0, Math.min(STEPS.length - 1, restoreCandidate.stepIndex || 0)));
+    setLastAutosavedAt(restoreCandidate.updatedAt);
+    setAutosaveState('saved');
+    setRestoreCandidate(null);
+  };
+
+  const discardLocalDraft = () => {
+    if (autosave?.key) removeStoredProjectEditorDraft(autosave.key);
+    setRestoreCandidate(null);
+    void autosave?.onDiscard?.();
+  };
+
+  const handleManualAutosave = async () => {
+    const saved = await persistAutosaveSnapshot(draft, stepIndex);
+    if (saved) toast.success('임시저장되었습니다.');
+    else toast.error('임시저장에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+  };
+
+  const handleActionSubmit = async (actionId: string) => {
+    try {
+      await persistAutosaveSnapshot(draft, stepIndex);
+      await onSubmit(createProjectEditorDraft(draft), actionId);
+      if (autosave?.key) removeStoredProjectEditorDraft(autosave.key);
+      setAutosaveState('idle');
+      setLastAutosavedAt('');
+    } catch (error) {
+      console.error('[ProjectEditorWizard] submit failed:', error);
+    }
+  };
 
   const step = STEPS[stepIndex];
   const financialInputFlags = useMemo(
@@ -1271,6 +1412,50 @@ export function ProjectEditorWizard({
 
       {topSlot}
 
+      {preloadWarningVisible ? (
+        <div className="rounded-xl border border-slate-300 bg-white px-4 py-3 text-sm text-slate-800 shadow-sm">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <p className="font-semibold text-slate-950">새 버전이 배포되었습니다</p>
+              <p className="mt-1 text-[12px] leading-5 text-slate-600">
+                작성 중인 내용 보호를 위해 자동 새로고침은 막았습니다. 임시저장 후 새로고침하면 됩니다.
+              </p>
+            </div>
+            {autosave?.key ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => void handleManualAutosave()}
+              >
+                지금 임시저장
+              </Button>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+
+      {restoreCandidate ? (
+        <div className="rounded-xl border border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-800">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <p className="font-semibold text-slate-950">이전에 작성 중이던 임시저장이 있습니다</p>
+              <p className="mt-1 text-[12px] leading-5 text-slate-600">
+                {formatAutosaveTime(restoreCandidate.updatedAt) || '최근'}에 저장된 작성 내용을 불러올 수 있습니다.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" variant="outline" size="sm" onClick={discardLocalDraft}>
+                버리기
+              </Button>
+              <Button type="button" size="sm" onClick={restoreLocalDraft}>
+                임시저장 불러오기
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
       <Card className="border-slate-200/80 shadow-sm">
         <CardContent className="p-4">
           <div className="mb-4 flex items-center justify-between text-xs text-muted-foreground">
@@ -1319,9 +1504,36 @@ export function ProjectEditorWizard({
             <span>{draft.contractStart || '-'} ~ {draft.contractEnd || '-'}</span>
             <span className="hidden lg:inline">·</span>
             <span className="hidden lg:inline">{draft.name || '프로젝트명 미입력'}</span>
+            {autosave?.key ? (
+              <>
+                <span className="hidden lg:inline">·</span>
+                <span className={autosaveState === 'error' ? 'text-red-600' : 'text-muted-foreground'}>
+                  {autosaveState === 'saving'
+                    ? '임시저장 중'
+                    : autosaveState === 'saved'
+                      ? `임시저장됨${lastAutosavedAt ? ` ${formatAutosaveTime(lastAutosavedAt)}` : ''}`
+                      : autosaveState === 'error'
+                        ? '임시저장 실패'
+                        : '임시저장 대기'}
+                </span>
+              </>
+            ) : null}
           </div>
           <div className="flex flex-wrap gap-2">
+            {autosave?.key ? (
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void handleManualAutosave()}
+                disabled={autosaveState === 'saving'}
+                className="gap-2"
+              >
+                {autosaveState === 'saving' ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+                임시저장
+              </Button>
+            ) : null}
             <Button
+              type="button"
               variant="outline"
               onClick={() => setStepIndex((value) => Math.max(0, value - 1))}
               disabled={stepIndex === 0}
@@ -1331,7 +1543,7 @@ export function ProjectEditorWizard({
               이전
             </Button>
             {stepIndex < STEPS.length - 1 ? (
-              <Button onClick={() => setStepIndex((value) => Math.min(STEPS.length - 1, value + 1))} className="gap-2">
+              <Button type="button" onClick={() => setStepIndex((value) => Math.min(STEPS.length - 1, value + 1))} className="gap-2">
                 다음
                 <ArrowRight className="h-4 w-4" />
               </Button>
@@ -1341,9 +1553,10 @@ export function ProjectEditorWizard({
                 return (
                   <Button
                     key={action.id}
+                    type="button"
                     variant={action.variant || 'default'}
                     disabled={!!busyActionId || action.disabled || !canSubmit}
-                    onClick={() => void onSubmit(createProjectEditorDraft(draft), action.id)}
+                    onClick={() => void handleActionSubmit(action.id)}
                     className="gap-2"
                   >
                     <Icon className={`h-4 w-4 ${busyActionId === action.id ? 'animate-spin' : ''}`} />

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -773,6 +773,27 @@ export interface ProjectRequest {
   updatedAt?: string;
 }
 
+export type ProjectRequestDraftKind = 'REGISTRATION' | 'CHANGE';
+export type ProjectRequestDraftStatus = 'DRAFT' | 'SUBMITTED' | 'DISCARDED';
+
+export interface ProjectRequestDraft {
+  id: string;
+  tenantId: string;
+  kind: ProjectRequestDraftKind;
+  ownerId: string;
+  ownerName: string;
+  ownerEmail: string;
+  targetProjectId?: string;
+  draftKey: string;
+  payloadSnapshot: ProjectRequestPayload;
+  stepIndex: number;
+  status: ProjectRequestDraftStatus;
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+  submittedAt?: string;
+}
+
 export interface Ledger {
   id: string;
   version?: number;

--- a/src/app/lib/firebase.ts
+++ b/src/app/lib/firebase.ts
@@ -311,6 +311,7 @@ export const ORG_COLLECTIONS = {
   guideQa: 'guide_qa',
   weeklySubmissionStatus: 'weekly_submission_status',
   projectRequests: 'project_requests',
+  projectRequestDrafts: 'projectRequestDrafts',
   projectDashboardProjects: 'project_dashboard_projects',
   projectMigrationCandidates: 'project_migration_candidates',
   careerProfiles: 'careerProfiles',

--- a/src/app/platform/firestore-rules-policy.test.ts
+++ b/src/app/platform/firestore-rules-policy.test.ts
@@ -159,8 +159,19 @@ describe('firestore rules policy alignment', () => {
   it('keeps business-card PII collections behind BFF-only Firestore rules', () => {
     expect(firestoreRulesText).toContain('function isBffOnlyCollection(collection)');
     expect(firestoreRulesText).toContain("['contacts', 'business_card_imports', 'contact_events']");
-    expect(firestoreRulesText).toContain('allow read: if !isBffOnlyCollection(collection) && canRead(orgId);');
-    expect(firestoreRulesText).toContain('allow write: if !isBffOnlyCollection(collection) && canWrite(orgId);');
+    expect(firestoreRulesText).toContain('allow read: if !isCatchallExcludedCollection(collection) && canRead(orgId);');
+    expect(firestoreRulesText).toContain('allow write: if !isCatchallExcludedCollection(collection) && canWrite(orgId);');
+  });
+
+  it('keeps project request drafts hidden from admin review surfaces until submission', () => {
+    expect(firestoreRulesText).toContain('match /orgs/{orgId}/projectRequestDrafts/{draftId}');
+    expect(firestoreRulesText).toContain('resource.data.ownerId == request.auth.uid');
+    expect(firestoreRulesText).toContain('request.resource.data.ownerId == request.auth.uid');
+    expect(firestoreRulesText).toContain("request.resource.data.status in ['DRAFT', 'SUBMITTED', 'DISCARDED']");
+    expect(firestoreRulesText).toContain('function isCatchallExcludedCollection(collection)');
+    expect(firestoreRulesText).toContain("collection in ['projectRequestDrafts']");
+    expect(firestoreRulesText).toContain('allow read: if !isCatchallExcludedCollection(collection) && canRead(orgId);');
+    expect(firestoreRulesText).toContain('allow write: if !isCatchallExcludedCollection(collection) && canWrite(orgId);');
   });
 
   it('keeps business-card source images behind BFF-only Storage rules', () => {

--- a/src/app/platform/preload-recovery.test.ts
+++ b/src/app/platform/preload-recovery.test.ts
@@ -15,6 +15,7 @@ describe('installVitePreloadRecovery', () => {
       addEventListener: vi.fn((type: string, callback: EventListener) => {
         if (type === 'vite:preloadError') listener = callback;
       }),
+      dispatchEvent: vi.fn(),
       location: { pathname: '/portal/cashflow' },
       sessionStorage: {
         getItem: vi.fn((key: string) => storage.get(key) || null),
@@ -30,6 +31,9 @@ describe('installVitePreloadRecovery', () => {
     listener?.(event);
 
     expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(target.dispatchEvent).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'mysc:preloadError',
+    }));
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Keeping current URL. User must choose when to refresh after saving current work.'));
     listener?.(event);
     expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('already reported recently'));
@@ -46,6 +50,7 @@ describe('installVitePreloadRecovery', () => {
       addEventListener: vi.fn((type: string, callback: EventListener) => {
         if (type === 'vite:preloadError') listener = callback;
       }),
+      dispatchEvent: vi.fn(),
       location: { pathname: '/portal/cashflow' },
       sessionStorage: {
         getItem: vi.fn(() => JSON.stringify({

--- a/src/app/platform/preload-recovery.ts
+++ b/src/app/platform/preload-recovery.ts
@@ -1,4 +1,4 @@
-type PreloadRecoveryTarget = Pick<Window, 'addEventListener'> & {
+type PreloadRecoveryTarget = Pick<Window, 'addEventListener' | 'dispatchEvent'> & {
   location: Pick<Location, 'pathname'>;
   sessionStorage?: Pick<Storage, 'getItem' | 'setItem'>;
 };
@@ -45,6 +45,13 @@ export function installVitePreloadRecovery(target: PreloadRecoveryTarget = windo
     const customEvent = event as unknown as CustomEvent<{ message?: string } | undefined>;
     customEvent.preventDefault();
     console.warn('[MYSC] Vite preload error detected:', customEvent.detail);
+    target.dispatchEvent(new CustomEvent('mysc:preloadError', {
+      detail: {
+        route: target.location.pathname || '/',
+        source: 'vite:preloadError',
+        originalDetail: customEvent.detail,
+      },
+    }));
 
     if (!shouldReportPreloadError(target)) {
       console.error('[MYSC] Vite preload error already reported recently; keeping current URL without auto reload.');

--- a/src/app/platform/project-request-draft.test.ts
+++ b/src/app/platform/project-request-draft.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { createProjectEditorDraft } from './project-editor';
+import { buildProjectRequestDraft, buildProjectRequestDraftId } from './project-request-draft';
+
+describe('project request draft', () => {
+  it('uses stable owner-scoped draft ids for registration and change drafts', () => {
+    expect(buildProjectRequestDraftId({
+      kind: 'REGISTRATION',
+      ownerId: 'user-1',
+    })).toBe('registration-user-1');
+    expect(buildProjectRequestDraftId({
+      kind: 'CHANGE',
+      ownerId: 'user-1',
+      targetProjectId: 'project-1',
+    })).toBe('change-project-1-user-1');
+  });
+
+  it('stores payload snapshots without undefined fields and increments draft version', () => {
+    const first = buildProjectRequestDraft({
+      tenantId: 'mysc',
+      kind: 'REGISTRATION',
+      ownerId: 'user-1',
+      ownerName: '테스터',
+      ownerEmail: 'tester@mysc.co.kr',
+      draftKey: 'draft-key',
+      draft: createProjectEditorDraft({
+        name: '테스트 사업',
+        department: 'CIC1',
+        contractDocument: undefined,
+      }),
+      stepIndex: 2,
+      now: '2026-05-29T09:00:00.000Z',
+    });
+    const second = buildProjectRequestDraft({
+      tenantId: 'mysc',
+      kind: 'REGISTRATION',
+      ownerId: 'user-1',
+      ownerName: '테스터',
+      ownerEmail: 'tester@mysc.co.kr',
+      draftKey: 'draft-key',
+      draft: createProjectEditorDraft({ name: '테스트 사업 수정' }),
+      stepIndex: 4,
+      previousDraft: first,
+      status: 'SUBMITTED',
+      now: '2026-05-29T09:03:00.000Z',
+    });
+
+    expect(first.version).toBe(1);
+    expect(second.id).toBe(first.id);
+    expect(second.version).toBe(2);
+    expect(second.status).toBe('SUBMITTED');
+    expect(second.submittedAt).toBe('2026-05-29T09:03:00.000Z');
+    expect(JSON.stringify(second)).not.toContain('undefined');
+  });
+});

--- a/src/app/platform/project-request-draft.ts
+++ b/src/app/platform/project-request-draft.ts
@@ -1,0 +1,82 @@
+import type {
+  ProjectRequestDraft,
+  ProjectRequestDraftKind,
+  ProjectRequestDraftStatus,
+} from '../data/types';
+import {
+  buildProjectRequestPayloadFromDraft,
+  type ProjectEditorDraft,
+} from './project-editor';
+
+export const PROJECT_REQUEST_DRAFT_SCHEMA_VERSION = 1;
+
+function text(value: unknown): string {
+  return String(value || '').trim();
+}
+
+function safeId(value: unknown): string {
+  const normalized = text(value).replace(/[^A-Za-z0-9가-힣._-]+/g, '_').replace(/^_+|_+$/g, '');
+  return normalized || 'unknown';
+}
+
+function omitUndefinedFields<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((item) => omitUndefinedFields(item)) as T;
+  }
+  if (!value || typeof value !== 'object') return value;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .filter(([, item]) => item !== undefined)
+      .map(([key, item]) => [key, omitUndefinedFields(item)]),
+  ) as T;
+}
+
+export function buildProjectRequestDraftId(input: {
+  kind: ProjectRequestDraftKind;
+  ownerId: string;
+  targetProjectId?: string;
+}): string {
+  const ownerId = safeId(input.ownerId);
+  if (input.kind === 'CHANGE') return `change-${safeId(input.targetProjectId)}-${ownerId}`;
+  return `registration-${ownerId}`;
+}
+
+export function buildProjectRequestDraft(input: {
+  tenantId: string;
+  kind: ProjectRequestDraftKind;
+  ownerId: string;
+  ownerName: string;
+  ownerEmail: string;
+  targetProjectId?: string;
+  draftKey: string;
+  draft: ProjectEditorDraft;
+  stepIndex: number;
+  previousDraft?: ProjectRequestDraft | null;
+  status?: ProjectRequestDraftStatus;
+  now: string;
+}): ProjectRequestDraft {
+  const id = input.previousDraft?.id || buildProjectRequestDraftId({
+    kind: input.kind,
+    ownerId: input.ownerId,
+    targetProjectId: input.targetProjectId,
+  });
+  const version = Math.max(1, Number(input.previousDraft?.version || 0) + 1);
+  return omitUndefinedFields({
+    id,
+    tenantId: input.tenantId,
+    kind: input.kind,
+    ownerId: input.ownerId,
+    ownerName: input.ownerName,
+    ownerEmail: input.ownerEmail,
+    targetProjectId: input.targetProjectId,
+    draftKey: input.draftKey,
+    payloadSnapshot: buildProjectRequestPayloadFromDraft(input.draft),
+    stepIndex: Math.max(0, Math.round(Number(input.stepIndex) || 0)),
+    status: input.status || 'DRAFT',
+    version,
+    createdAt: input.previousDraft?.createdAt || input.now,
+    updatedAt: input.now,
+    ...(input.status === 'SUBMITTED' ? { submittedAt: input.now } : {}),
+  });
+}
+


### PR DESCRIPTION
## Summary
- add local/server autosave for portal project registration and edit wizard
- store pre-submit drafts in owner-only `projectRequestDrafts` with payload snapshots and versions
- keep admin review surfaces on submitted `project_requests`; exclude drafts from Firestore catchall rules
- turn Vite preload errors into an in-app warning event instead of forced refresh

## Validation
- node_modules/.bin/vitest --run src/app/platform/project-request-draft.test.ts src/app/platform/preload-recovery.test.ts src/app/platform/firestore-rules-policy.test.ts src/app/components/projects/ProjectEditorWizard.shell.test.ts src/app/components/portal/PortalProjectEdit.persist-shell.test.ts src/app/components/portal/PortalMinimalSweep.layout.test.ts
- node_modules/.bin/vite build

## Notes
- `node_modules/.bin/tsc --noEmit` still reports existing unrelated repository type errors in cashflow, portal layout, settlement tests, etc.; changed files are not in the error list.