### PR TITLE
fix(projects): admin-managed departments and cashflow cleanup

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -13,6 +13,14 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+UNDERSTAND_GATE_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^(src/app/(components/(settings|projects|cashflow|portal)|data/project-department|platform/project-(cic|editor|change-request))|firebase/firestore\.rules)' || true)
+if [ -n "$UNDERSTAND_GATE_FILES" ]; then
+  node scripts/qa_understand_gate.mjs --staged
+  if [ $? -ne 0 ]; then
+    exit 1
+  fi
+fi
+
 if [ "$TOTAL" -gt 1500 ]; then
   echo "\033[31m⚠ XL COMMIT: ${TOTAL} LOC staged (${INS}+ / ${DEL}-)\033[0m"
   echo "\033[31m  Consider splitting into smaller commits for easier review/rollback.\033[0m"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -74,3 +74,4 @@
 | Date | Decision | Rationale |
 |------|----------|-----------|
 | 2026-05-27 | Initial MYSCube design system created | Remove AI SaaS/purple styling and align the platform with a Jira-like professional operations workspace. |
+| 2026-06-01 | Admin settings uses the MYSCube wordmark, navy active states, and compact operational metrics | Keep configuration screens branded without adding explanatory UI copy or decorative gradients. |

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -68,6 +68,11 @@ service cloud.firestore {
         || collection in ['projectRequestDrafts'];
     }
 
+    function isCatchallExcludedPath(collection, document) {
+      return isCatchallExcludedCollection(collection)
+        || (collection == 'settings' && document == 'project-departments');
+    }
+
     // ══════════════════════════════════════════════════════════════
     // orgs/{orgId}/** 규칙
     // 특정 컬렉션 override → 일반 규칙 순서로 적용
@@ -131,6 +136,12 @@ service cloud.firestore {
         && getMemberRole(orgId) in ['admin', 'finance'];
     }
 
+    // ── 관리자 설정: 프로젝트 선택값 ──
+    match /orgs/{orgId}/settings/project-departments {
+      allow read: if canRead(orgId);
+      allow write: if isAdmin(orgId);
+    }
+
     // ── 프로젝트 등록/수정 임시저장: 제출 전 개인 작업공간 ──
     // 관리자 승인 콘솔은 project_requests만 읽고, draft는 작성자 본인만 접근한다.
     match /orgs/{orgId}/projectRequestDrafts/{draftId} {
@@ -155,8 +166,8 @@ service cloud.firestore {
     // ── 일반 규칙: 나머지 모든 컬렉션 ──
     // (projects, ledgers, transactions, evidences, comments, 등)
     match /orgs/{orgId}/{collection}/{document=**} {
-      allow read: if !isCatchallExcludedCollection(collection) && canRead(orgId);
-      allow write: if !isCatchallExcludedCollection(collection) && canWrite(orgId);
+      allow read: if !isCatchallExcludedPath(collection, document) && canRead(orgId);
+      allow write: if !isCatchallExcludedPath(collection, document) && canWrite(orgId);
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "firebase:emulators:start": "bash scripts/firebase_emulator_bootstrap.sh --start",
     "seed:payroll:emulator-smoke": "npx tsx scripts/seed_payroll_emulator_smoke.ts",
     "qa:feedback:ingest": "npx tsx scripts/ingest_qa_feedback_tracker.ts",
+    "qa:understand:gate": "node scripts/qa_understand_gate.mjs",
     "phase:preflight": "npx tsx scripts/phase_preflight_qa.ts",
     "phase1:extract:usage-ledger": "npx tsx scripts/extract_usage_ledger_phase1_fixture.ts",
     "rust:settlement:build": "cargo build --quiet --manifest-path rust/spreadsheet-calculation-core/Cargo.toml",

--- a/scripts/qa_understand_gate.mjs
+++ b/scripts/qa_understand_gate.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+
+function run(command) {
+  return execSync(command, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+}
+
+function read(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8');
+}
+
+function fail(message) {
+  failures.push(message);
+}
+
+function expectContains(relativePath, needle) {
+  const source = read(relativePath);
+  if (!source.includes(needle)) fail(`${relativePath} must contain: ${needle}`);
+}
+
+function expectNotContains(relativePath, needle) {
+  const source = read(relativePath);
+  if (source.includes(needle)) fail(`${relativePath} must not contain: ${needle}`);
+}
+
+function getChangedFiles() {
+  const staged = process.argv.includes('--staged');
+  const command = staged
+    ? 'git diff --cached --name-only --diff-filter=ACM'
+    : 'git diff --name-only --diff-filter=ACM';
+  return run(command).split('\n').map((item) => item.trim()).filter(Boolean);
+}
+
+const repoRoot = run('git rev-parse --show-toplevel');
+const failures = [];
+const warnings = [];
+
+process.chdir(repoRoot);
+
+function resolveUnderstandRoot() {
+  try {
+    const commonDir = run('git rev-parse --git-common-dir');
+    const gitDir = run('git rev-parse --git-dir');
+    const commonAbs = path.resolve(repoRoot, commonDir);
+    const gitAbs = path.resolve(repoRoot, gitDir);
+    if (commonAbs !== gitAbs) return path.dirname(commonAbs);
+  } catch {
+    return repoRoot;
+  }
+  return repoRoot;
+}
+
+const understandRoot = resolveUnderstandRoot();
+const graphPath = path.join(understandRoot, '.understand-anything', 'knowledge-graph.json');
+if (!existsSync(graphPath)) {
+  warnings.push('Missing .understand-anything/knowledge-graph.json. Run $understand-anything:understand before architecture-sensitive QA.');
+} else {
+  try {
+    const graph = JSON.parse(readFileSync(graphPath, 'utf8'));
+    const nodeIds = new Set((graph.nodes || []).map((node) => node.id));
+    for (const filePath of getChangedFiles()) {
+      if (!filePath.startsWith('src/app/') && !filePath.startsWith('firebase/')) continue;
+      const expectedIds = [`file:${filePath}`, `config:${filePath}`];
+      if (!expectedIds.some((id) => nodeIds.has(id))) {
+        warnings.push(`Understand graph has no node for changed file: ${filePath}`);
+      }
+    }
+  } catch (error) {
+    warnings.push(`Could not parse understand graph: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+expectContains('firebase/firestore.rules', 'match /orgs/{orgId}/settings/project-departments');
+expectContains('firebase/firestore.rules', 'allow write: if isAdmin(orgId);');
+expectContains('firebase/firestore.rules', 'isCatchallExcludedPath(collection, document)');
+
+expectContains('src/app/data/project-department-options.ts', 'sortOrder: number');
+expectContains('src/app/data/project-department-options.ts', '.sort((a, b) => {');
+expectContains('src/app/data/project-department-options.ts', '`${baseId}-${nextCount}`');
+expectContains('src/app/components/settings/SettingsPage.tsx', 'renderProjectSelectionValuesCard');
+expectContains('src/app/components/settings/SettingsPage.tsx', 'handleMoveDepartment');
+expectContains('src/app/components/settings/SettingsPage.tsx', '이미 등록된 담당조직(CIC)입니다.');
+
+expectNotContains('src/app/components/projects/ProjectListPage.tsx', '모니터링 프리셋');
+expectNotContains('src/app/components/cashflow/CashflowProjectSheet.tsx', 'copyMonthValues');
+expectNotContains('src/app/components/cashflow/CashflowProjectSheet.tsx', 'Projection → Actual');
+expectNotContains('src/app/components/cashflow/CashflowProjectSheet.tsx', 'Actual → Projection');
+expectContains('src/app/components/cashflow/CashflowProjectSheet.tsx', 'formatAmountInput(String(persisted.amount))');
+expectNotContains('src/app/components/cashflow/ImportEditor.tsx', '행 정보');
+expectNotContains('src/app/components/cashflow/ImportEditorRow.tsx', '행 정보');
+expectNotContains('src/app/components/portal/PortalWeeklyExpensePage.tsx', '저장되지 않은 사업비 입력이 있습니다');
+expectNotContains('src/app/components/portal/PortalWeeklyExpensePage.tsx', '지금 이동하면 저장되지 않은 사업비 입력(주간) 편집 내용이 유실될 수 있습니다.');
+
+if (warnings.length) {
+  console.warn('[qa:understand:gate] warnings');
+  warnings.forEach((warning) => console.warn(`- ${warning}`));
+}
+
+if (failures.length) {
+  console.error('[qa:understand:gate] failed');
+  failures.forEach((failure) => console.error(`- ${failure}`));
+  process.exit(1);
+}
+
+console.log('[qa:understand:gate] passed');

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -28,12 +28,17 @@ describe('CashflowProjectSheet actual sync flow', () => {
     expect(cashflowProjectSheetSource).not.toContain('저장할 변경사항이 없습니다.');
   });
 
-  it('persists projection/actual copy through the canonical week upsert path', () => {
-    expect(cashflowProjectSheetSource).toContain('copyMonthValues');
-    expect(cashflowProjectSheetSource).toContain('setCopyingMode(direction)');
+  it('removes projection/actual copy buttons while keeping canonical week saves', () => {
+    expect(cashflowProjectSheetSource).not.toContain('copyMonthValues');
+    expect(cashflowProjectSheetSource).not.toContain('setCopyingMode(direction)');
+    expect(cashflowProjectSheetSource).not.toContain('Projection → Actual');
+    expect(cashflowProjectSheetSource).not.toContain('Actual → Projection');
     expect(cashflowProjectSheetSource).toContain('await upsertWeekAmounts({');
-    expect(cashflowProjectSheetSource).toContain('서버에 복사했습니다');
-    expect(cashflowProjectSheetSource).not.toContain('초안으로 복사했습니다');
+  });
+
+  it('formats persisted input values for display without changing numeric save parsing', () => {
+    expect(cashflowProjectSheetSource).toContain('formatAmountInput(String(persisted.amount))');
+    expect(cashflowProjectSheetSource).toContain('parseAmount(drafts[cellKey])');
   });
 
   it('shows projection 작성 from projectionUpdated on the project sheet header', () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { doc, getDoc } from 'firebase/firestore';
-import { ArrowLeftRight, CheckCircle2, ClipboardCheck, ClipboardList, Columns2, CircleDollarSign, ChevronLeft, ChevronRight, Download, Loader2 } from 'lucide-react';
+import { CheckCircle2, ClipboardCheck, ClipboardList, Columns2, CircleDollarSign, ChevronLeft, ChevronRight, Download, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useBlocker, useNavigate } from 'react-router';
 import { Button } from '../ui/button';
@@ -160,7 +160,6 @@ export function CashflowProjectSheet({
   const [monthSavingMode, setMonthSavingMode] = useState<null | 'actual'>(null);
   const [downloadPreparing, setDownloadPreparing] = useState(false);
   const [actualSyncing, setActualSyncing] = useState(false);
-  const [copyingMode, setCopyingMode] = useState<null | 'projection_to_actual' | 'actual_to_projection'>(null);
 
   const hasDirty = useMemo(
     () => hasUnsavedChanges(weekSaveState) || Object.keys(drafts).length > 0,
@@ -593,77 +592,6 @@ export function CashflowProjectSheet({
     });
   }, [monthWeeks, projectId, resolveWeekKey, syncProjectActualsFromExpenseSheets, yearMonth]);
 
-  const copyMonthValues = useCallback((sourceMode: 'projection' | 'actual', targetMode: 'projection' | 'actual') => {
-    if (sourceMode === targetMode) return;
-    if (targetMode === 'actual' && !canEdit) {
-      toast.error('Actual 복사는 편집 권한이 있을 때만 가능합니다.');
-      return;
-    }
-
-    const direction = sourceMode === 'projection' ? 'projection_to_actual' : 'actual_to_projection';
-    void (async () => {
-      setCopyingMode(direction);
-      for (const week of monthWeeks) {
-        const amounts = Object.fromEntries(CASHFLOW_ALL_LINES.map((lineId) => [
-          lineId,
-          getEffectiveAmount({ yearMonth, mode: sourceMode, weekNo: week.weekNo, lineId }),
-        ])) as Partial<Record<CashflowSheetLineId, number>>;
-
-        await upsertWeekAmounts({
-          projectId,
-          yearMonth,
-          weekNo: week.weekNo,
-          mode: targetMode,
-          amounts,
-        });
-
-        if (onUpdateWeeklySubmissionStatus) {
-          await onUpdateWeeklySubmissionStatus({
-            projectId,
-            yearMonth,
-            weekNo: week.weekNo,
-            ...(targetMode === 'projection'
-              ? { projectionEdited: true, projectionUpdated: true }
-              : { expenseEdited: true, expenseUpdated: true }),
-          });
-        }
-      }
-
-      setDrafts((prev) => {
-        const next = { ...prev };
-        for (const week of monthWeeks) {
-          for (const lineId of CASHFLOW_ALL_LINES) {
-            delete next[resolveCellKey({ yearMonth, mode: targetMode, weekNo: week.weekNo, lineId })];
-          }
-        }
-        return next;
-      });
-      setWeekSaveState((prev) => {
-        const next = { ...prev };
-        for (const week of monthWeeks) {
-          delete next[resolveWeekKey({ yearMonth, mode: targetMode, weekNo: week.weekNo })];
-        }
-        return next;
-      });
-      toast.success(`${sourceMode === 'projection' ? 'Projection' : 'Actual'} 값을 ${targetMode === 'projection' ? 'Projection' : 'Actual'} 서버에 복사했습니다.`);
-    })().catch((error) => {
-      console.error('[Cashflow] month value copy failed:', error);
-      toast.error('월 복사에 실패했습니다. 네트워크/권한을 확인해 주세요.');
-    }).finally(() => {
-      setCopyingMode((prev) => (prev === direction ? null : prev));
-    });
-  }, [
-    canEdit,
-    getEffectiveAmount,
-    monthWeeks,
-    onUpdateWeeklySubmissionStatus,
-    projectId,
-    resolveCellKey,
-    resolveWeekKey,
-    upsertWeekAmounts,
-    yearMonth,
-  ]);
-
   const handleSubmitWeek = useCallback(async (input: { weekNo: number; yearMonth: string }) => {
     setSubmitBusy(true);
     try {
@@ -909,7 +837,7 @@ export function CashflowProjectSheet({
                       const persisted = getPersistedCell({ doc, mode: tableMode, lineId });
                       const key = resolveCellKey({ yearMonth, mode: tableMode, weekNo: w.weekNo, lineId });
                       const raw = Object.prototype.hasOwnProperty.call(drafts, key) ? drafts[key] : undefined;
-                      const value = raw !== undefined ? raw : (persisted.hasValue ? String(persisted.amount) : '');
+                      const value = raw !== undefined ? raw : (persisted.hasValue ? formatAmountInput(String(persisted.amount)) : '');
 
                       return (
                         <td key={w.weekNo} className={`px-3 h-9 align-middle text-right ${colClass}`} style={{ fontVariantNumeric: 'tabular-nums' }}>
@@ -970,7 +898,7 @@ export function CashflowProjectSheet({
                       const persisted = getPersistedCell({ doc, mode: tableMode, lineId });
                       const key = resolveCellKey({ yearMonth, mode: tableMode, weekNo: w.weekNo, lineId });
                       const raw = Object.prototype.hasOwnProperty.call(drafts, key) ? drafts[key] : undefined;
-                      const value = raw !== undefined ? raw : (persisted.hasValue ? String(persisted.amount) : '');
+                      const value = raw !== undefined ? raw : (persisted.hasValue ? formatAmountInput(String(persisted.amount)) : '');
 
                       return (
                         <td key={w.weekNo} className={`px-3 h-9 align-middle text-right ${colClass}`} style={{ fontVariantNumeric: 'tabular-nums' }}>
@@ -1047,24 +975,6 @@ export function CashflowProjectSheet({
               variant="outline"
               size="sm"
               className="h-8 text-[12px] gap-1.5"
-              onClick={() => copyMonthValues('projection', 'actual')}
-              disabled={!canEdit || copyingMode !== null || actualSyncing || monthSavingMode !== null}
-            >
-              {copyingMode === 'projection_to_actual' ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <ArrowLeftRight className="w-3.5 h-3.5" />} Projection → Actual
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-8 text-[12px] gap-1.5"
-              onClick={() => copyMonthValues('actual', 'projection')}
-              disabled={copyingMode !== null || actualSyncing || monthSavingMode !== null}
-            >
-              {copyingMode === 'actual_to_projection' ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <ArrowLeftRight className="w-3.5 h-3.5" />} Actual → Projection
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-8 text-[12px] gap-1.5"
               onClick={handleDownload}
               onMouseEnter={() => warmExcelJs()}
               onFocus={() => warmExcelJs()}
@@ -1103,7 +1013,7 @@ export function CashflowProjectSheet({
       />
 
       <div className="rounded-2xl border border-slate-200/80 bg-slate-50/70 px-4 py-3 text-[11px] text-slate-600">
-        비교 모드에서는 Projection과 Actual을 동시에 보면서 바로 복사할 수 있습니다. 복사는 초안이 아니라 서버에 즉시 반영되고, 직접 수정한 입력값만 각 영역별 저장 버튼으로 반영됩니다.
+        비교 모드에서는 Firestore에 저장된 Projection과 Actual을 동시에 대조합니다. 직접 입력한 값은 각 영역의 저장/작성완료 버튼을 눌렀을 때 서버 기준값으로 반영됩니다.
       </div>
 
       <Tabs value={viewMode} onValueChange={(v) => (v === 'projection' || v === 'actual' || v === 'compare') && setViewMode(v)}>

--- a/src/app/components/cashflow/ImportEditor.tsx
+++ b/src/app/components/cashflow/ImportEditor.tsx
@@ -1813,7 +1813,6 @@ export function ImportEditor({
         >
           <table className="w-full text-[11px] border-collapse table-fixed">
           <colgroup>
-            <col style={{ width: 96 }} />
             {SETTLEMENT_COLUMNS.map((_, i) => (
               <col key={i} style={{ width: colWidths[i] }} />
             ))}
@@ -1821,7 +1820,6 @@ export function ImportEditor({
           <thead className="sticky top-0 z-10">
             {/* Group header */}
             <tr className="bg-slate-100 dark:bg-slate-800">
-              <th className="px-1 py-1 border-b border-r text-center text-[9px] w-24">상태</th>
               {SETTLEMENT_COLUMN_GROUPS.map((g) => (
                 <th
                   key={g.name}
@@ -1834,7 +1832,6 @@ export function ImportEditor({
             </tr>
             {/* Column header */}
             <tr className="bg-slate-50 dark:bg-slate-900">
-              <th className="px-1 py-1 border-b border-r text-[9px] w-24">행 정보</th>
               {SETTLEMENT_COLUMNS.map((col, i) => (
                 <th
                   key={i}
@@ -1885,7 +1882,7 @@ export function ImportEditor({
             {shouldVirtualizeRows && visibleRowWindow.paddingTop > 0 && (
               <tr aria-hidden="true">
                 <td
-                  colSpan={SETTLEMENT_COLUMNS.length + 1}
+                  colSpan={SETTLEMENT_COLUMNS.length}
                   style={{ height: visibleRowWindow.paddingTop }}
                   className="border-b-0 p-0"
                 />
@@ -1929,8 +1926,6 @@ export function ImportEditor({
                 subCodeIdx={subCodeIdx}
                 subSubCodeIdx={subSubCodeIdx}
                 evidenceIdx={evidenceIdx}
-                evidenceCompletedIdx={evidenceCompletedIdx}
-                evidencePendingIdx={evidencePendingIdx}
                 weekIdx={weekIdx}
                 cashflowIdx={cashflowIdx}
                 weekOptions={weekOptions}
@@ -1955,7 +1950,7 @@ export function ImportEditor({
             {shouldVirtualizeRows && visibleRowWindow.paddingBottom > 0 && (
               <tr aria-hidden="true">
                 <td
-                  colSpan={SETTLEMENT_COLUMNS.length + 1}
+                  colSpan={SETTLEMENT_COLUMNS.length}
                   style={{ height: visibleRowWindow.paddingBottom }}
                   className="border-b-0 p-0"
                 />
@@ -1964,7 +1959,7 @@ export function ImportEditor({
             {rows.length === 0 && (
               <tr>
                 <td
-                  colSpan={SETTLEMENT_COLUMNS.length + 1}
+                  colSpan={SETTLEMENT_COLUMNS.length}
                   className="px-4 py-8 text-center text-[12px] text-muted-foreground"
                 >
                   데이터가 없습니다. 행을 추가하세요.

--- a/src/app/components/cashflow/ImportEditorRow.tsx
+++ b/src/app/components/cashflow/ImportEditorRow.tsx
@@ -8,7 +8,7 @@ import { Check, ExternalLink, GripVertical, Plus, Upload, X } from 'lucide-react
 import type { BudgetCodeEntry, BudgetTreeV2, Transaction, SettlementSheetPolicy } from '../../data/types';
 import { parseNumber } from '../../platform/csv-utils';
 import { findBudgetTreeSubItem } from '../../platform/budget-tree-v2';
-import { isValidDriveUrl, resolveEvidenceChecklist } from '../../platform/evidence-helpers';
+import { isValidDriveUrl } from '../../platform/evidence-helpers';
 import type { CounterpartySuggestion } from '../../platform/counterparty-normalizer';
 import {
   SETTLEMENT_COLUMNS,
@@ -195,8 +195,6 @@ function ImportEditorRow({
   subCodeIdx,
   subSubCodeIdx,
   evidenceIdx,
-  evidenceCompletedIdx,
-  evidencePendingIdx,
   weekIdx,
   cashflowIdx,
   weekOptions,
@@ -240,8 +238,6 @@ function ImportEditorRow({
   subCodeIdx: number;
   subSubCodeIdx: number;
   evidenceIdx: number;
-  evidenceCompletedIdx: number;
-  evidencePendingIdx: number;
   weekIdx: number;
   cashflowIdx: number;
   weekOptions: { value: string; label: string }[];
@@ -300,10 +296,6 @@ function ImportEditorRow({
     [subItem],
   );
   const rowLabel = `${rowIdx + 1}행`;
-  const driveLinkIdx = useMemo(
-    () => SETTLEMENT_COLUMNS.findIndex((c) => c.csvHeader === '증빙자료 드라이브'),
-    [],
-  );
   const commentTransactionId = row.sourceTxId || buildSheetRowCommentId(row.tempId);
   const [driveAction, setDriveAction] = useState<'' | 'provision' | 'sync'>('');
   const hasSourceTransaction = Boolean(persistedTransactionId);
@@ -317,82 +309,6 @@ function ImportEditorRow({
     : persistedTransaction?.evidenceDriveSyncStatus === 'SYNCED'
       ? '동기화됨'
       : '';
-  const evidenceChecklist = useMemo(() => resolveEvidenceChecklist({
-    evidenceRequired: persistedTransaction?.evidenceRequired || [],
-    evidenceRequiredDesc: persistedTransaction?.evidenceRequiredDesc || String(evidenceIdx >= 0 ? row.cells[evidenceIdx] || '' : ''),
-    evidenceCompletedDesc: persistedTransaction?.evidenceCompletedDesc || String(evidenceCompletedIdx >= 0 ? row.cells[evidenceCompletedIdx] || '' : ''),
-    evidenceCompletedManualDesc: persistedTransaction?.evidenceCompletedManualDesc,
-    evidenceAutoListedDesc: persistedTransaction?.evidenceAutoListedDesc,
-    evidenceDriveLink: persistedTransaction?.evidenceDriveLink || String(driveLinkIdx >= 0 ? row.cells[driveLinkIdx] || '' : ''),
-    evidenceDriveFolderId: persistedTransaction?.evidenceDriveFolderId,
-  }), [
-    driveLinkIdx,
-    evidenceCompletedIdx,
-    evidenceIdx,
-    persistedTransaction?.evidenceAutoListedDesc,
-    persistedTransaction?.evidenceCompletedDesc,
-    persistedTransaction?.evidenceCompletedManualDesc,
-    persistedTransaction?.evidenceDriveFolderId,
-    persistedTransaction?.evidenceDriveLink,
-    persistedTransaction?.evidenceRequired,
-    persistedTransaction?.evidenceRequiredDesc,
-    row.cells,
-  ]);
-  const evidenceStatusBadge = useMemo(() => {
-    if (evidenceChecklist.required.length === 0 && evidenceChecklist.completed.length === 0 && !evidenceChecklist.hasLink) return null;
-    if (evidenceChecklist.status === 'COMPLETE') {
-      return {
-        label: '증빙완료',
-        className: 'border-emerald-200 bg-emerald-50 text-emerald-700',
-      };
-    }
-    if (evidenceChecklist.status === 'PARTIAL') {
-      return {
-        label: evidenceChecklist.missing.length > 0 ? `증빙 ${evidenceChecklist.missing.length}건 남음` : '증빙 일부완료',
-        className: 'border-amber-200 bg-amber-50 text-amber-700',
-      };
-    }
-    return {
-      label: '증빙미완료',
-      className: 'border-rose-200 bg-rose-50 text-rose-700',
-    };
-  }, [evidenceChecklist]);
-  const evidenceStatusTitle = useMemo(() => {
-    if (!evidenceStatusBadge) return '';
-    const pendingDesc = String(evidencePendingIdx >= 0 ? row.cells[evidencePendingIdx] || '' : '').trim();
-    const lines = [
-      evidenceChecklist.required.length > 0 ? `필수: ${evidenceChecklist.required.join(', ')}` : '',
-      evidenceChecklist.completed.length > 0 ? `완료: ${evidenceChecklist.completed.join(', ')}` : '완료: 없음',
-      evidenceChecklist.missing.length > 0 ? `미완료: ${evidenceChecklist.missing.join(', ')}` : '미완료: 없음',
-      pendingDesc ? `준비필요: ${pendingDesc}` : '',
-    ].filter(Boolean);
-    return lines.join('\n');
-  }, [evidenceChecklist, evidencePendingIdx, evidenceStatusBadge, row.cells]);
-  const rowSourceBadge = useMemo(() => {
-    if (isAdjustmentRow) return { label: '잔액 조정', className: 'border-amber-200 bg-amber-50 text-amber-700' };
-    if (row.entryKind === 'DEPOSIT') return { label: '직접 입금', className: 'border-sky-200 bg-sky-50 text-sky-700' };
-    if (row.entryKind === 'EXPENSE') return { label: '직접 지출', className: 'border-cyan-200 bg-cyan-50 text-cyan-700' };
-    if (row.sourceTxId) return { label: '업로드 반영', className: 'border-slate-200 bg-slate-50 text-slate-700' };
-    return { label: '수동 입력', className: 'border-emerald-200 bg-emerald-50 text-emerald-700' };
-  }, [isAdjustmentRow, row.entryKind, row.sourceTxId]);
-  const rowEditStateBadge = useMemo(() => {
-    if (hasError) {
-      return { label: '검토 필요', className: 'border-rose-200 bg-rose-50 text-rose-700' };
-    }
-    if (isReviewPending) {
-      return { label: '검토 루프', className: 'border-[#26415f]/25 bg-[#26415f]/5 text-[#26415f]' };
-    }
-    if (isReviewConfirmed) {
-      return { label: '확인 완료', className: 'border-slate-200 bg-slate-50 text-slate-700' };
-    }
-    if ((row.userEditedCells?.size || 0) > 0) {
-      return { label: '수정됨', className: 'border-slate-200 bg-white text-slate-700' };
-    }
-    if (hasMissingCell) {
-      return { label: '미입력', className: 'border-orange-200 bg-orange-50 text-orange-700' };
-    }
-    return null;
-  }, [hasError, hasMissingCell, isReviewConfirmed, isReviewPending, row.userEditedCells]);
   const isCellSelected = useCallback((colIdx: number) => {
     if (!selectionBounds || colIdx === noIdx) return false;
     return rowIdx >= selectionBounds.r1
@@ -502,102 +418,6 @@ function ImportEditorRow({
         ? 'bg-red-50/40 dark:bg-red-950/10'
         : 'hover:bg-muted/30'
     } transition-colors`}>
-      {/* Row controls */}
-      <td className="relative px-1 py-1 border-b border-r align-middle w-24">
-        <div className="flex items-start justify-between gap-1">
-          <div className="min-w-0 space-y-1">
-            <span className={`inline-flex rounded-full border px-1.5 py-0.5 text-[9px] leading-none ${rowSourceBadge.className}`}>
-              {rowSourceBadge.label}
-            </span>
-            {rowEditStateBadge && (
-              <span
-                title={hasReviewHint ? reviewHintLabel : undefined}
-                className={`inline-flex rounded-full border px-1.5 py-0.5 text-[9px] leading-none ${rowEditStateBadge.className}`}
-              >
-                {rowEditStateBadge.label}
-              </span>
-            )}
-            {evidenceStatusBadge && (
-              <span
-                title={evidenceStatusTitle}
-                className={`inline-flex rounded-full border px-1.5 py-0.5 text-[9px] leading-none ${evidenceStatusBadge.className}`}
-              >
-                {evidenceStatusBadge.label}
-              </span>
-            )}
-            <span className="block text-[9px] text-muted-foreground">#{rowIdx + 1}</span>
-          </div>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                className="inline-flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground/70 hover:bg-muted hover:text-foreground transition-colors"
-                title="행 작업"
-              >
-                <GripVertical className="h-2.5 w-2.5" />
-              </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="text-[11px]">
-              <DropdownMenuItem
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onInsertBelow();
-                }}
-              >
-                <Plus className="h-3.5 w-3.5" />
-                아래에 행 추가
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                variant="destructive"
-                disabled={!settlementSheetPolicy.allowRowDelete}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (!settlementSheetPolicy.allowRowDelete) return;
-                  onRemove();
-                }}
-              >
-                <X className="h-3.5 w-3.5" />
-                {settlementSheetPolicy.allowRowDelete ? '행 삭제' : '행 삭제 잠금'}
-              </DropdownMenuItem>
-              {hasReviewHint && (
-                <>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onRowChange((prev) => {
-                        if (!hasImportRowReviewRequirement(prev)) return prev;
-                        if (isImportRowReviewConfirmed(prev)) {
-                          const next: ImportRow = { ...prev, reviewStatus: 'pending' };
-                          delete next.reviewConfirmedAt;
-                          return next;
-                        }
-                        return {
-                          ...prev,
-                          reviewStatus: 'confirmed',
-                          reviewConfirmedAt: new Date().toISOString(),
-                        };
-                      });
-                    }}
-                  >
-                    <Check className="h-3.5 w-3.5" />
-                    {isReviewConfirmed ? '검토 완료 해제' : '검토 완료'}
-                  </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-        {(hasError || hasMissingCell || isReviewPending) && (
-          <span
-            className={`absolute right-1 top-1 h-1 w-1 rounded-full ${
-              hasError || hasMissingCell ? 'bg-rose-500' : 'bg-[#26415f]'
-            }`}
-            title={hasError ? (row.error || '행 오류') : hasMissingCell ? '미입력 셀 있음' : reviewHintLabel}
-          />
-        )}
-      </td>
       {/* Data cells */}
       {SETTLEMENT_COLUMNS.map((col, colIdx) => {
         const isReadOnly = col.csvHeader === 'No.';
@@ -616,6 +436,7 @@ function ImportEditorRow({
         const isManualPriorityField = isManualPriorityOutflowField(col.csvHeader);
         const cellSource = resolveCellSource(colIdx, col.csvHeader);
         const showCellBadge = Boolean(isDerivedLocked || cellSource);
+        const isFirstColumn = colIdx === 0;
         const cellToneClass = isExpenseAmount || isVatIn
           ? 'bg-yellow-50/80 dark:bg-yellow-950/15'
           : '';
@@ -639,6 +460,77 @@ function ImportEditorRow({
             onMouseEnter={() => onCellMouseEnter(rowIdx, colIdx)}
           >
             <div className={`group relative ${showCellBadge ? 'pt-4' : ''}`}>
+              {isFirstColumn && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      className="absolute right-1 top-1 z-10 inline-flex h-4 w-4 items-center justify-center rounded-sm text-muted-foreground/70 hover:bg-muted hover:text-foreground transition-colors"
+                      title="행 작업"
+                    >
+                      <GripVertical className="h-2.5 w-2.5" />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="start" className="text-[11px]">
+                    <DropdownMenuItem
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onInsertBelow();
+                      }}
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                      아래에 행 추가
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      variant="destructive"
+                      disabled={!settlementSheetPolicy.allowRowDelete}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        if (!settlementSheetPolicy.allowRowDelete) return;
+                        onRemove();
+                      }}
+                    >
+                      <X className="h-3.5 w-3.5" />
+                      {settlementSheetPolicy.allowRowDelete ? '행 삭제' : '행 삭제 잠금'}
+                    </DropdownMenuItem>
+                    {hasReviewHint && (
+                      <>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onRowChange((prev) => {
+                              if (!hasImportRowReviewRequirement(prev)) return prev;
+                              if (isImportRowReviewConfirmed(prev)) {
+                                const next: ImportRow = { ...prev, reviewStatus: 'pending' };
+                                delete next.reviewConfirmedAt;
+                                return next;
+                              }
+                              return {
+                                ...prev,
+                                reviewStatus: 'confirmed',
+                                reviewConfirmedAt: new Date().toISOString(),
+                              };
+                            });
+                          }}
+                        >
+                          <Check className="h-3.5 w-3.5" />
+                          {isReviewConfirmed ? '검토 완료 해제' : '검토 완료'}
+                        </DropdownMenuItem>
+                      </>
+                    )}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+              {isFirstColumn && (hasError || hasMissingCell || isReviewPending) && (
+                <span
+                  className={`absolute left-1 top-1 h-1 w-1 rounded-full ${
+                    hasError || hasMissingCell ? 'bg-rose-500' : 'bg-[#26415f]'
+                  }`}
+                  title={hasError ? (row.error || '행 오류') : hasMissingCell ? '미입력 셀 있음' : reviewHintLabel}
+                />
+              )}
               {isReadOnly ? (
                 <span className="block pr-6 text-[10px] text-muted-foreground px-1">
                   {row.cells[colIdx]}
@@ -1065,8 +957,6 @@ export const MemoizedImportEditorRow = memo(ImportEditorRow, (prev, next) => {
     && prev.subCodeIdx === next.subCodeIdx
     && prev.subSubCodeIdx === next.subSubCodeIdx
     && prev.evidenceIdx === next.evidenceIdx
-    && prev.evidenceCompletedIdx === next.evidenceCompletedIdx
-    && prev.evidencePendingIdx === next.evidencePendingIdx
     && prev.weekIdx === next.weekIdx
     && prev.cashflowIdx === next.cashflowIdx
     && prev.weekOptions === next.weekOptions

--- a/src/app/components/cashflow/settlement-comment-loop-ui.shell.test.ts
+++ b/src/app/components/cashflow/settlement-comment-loop-ui.shell.test.ts
@@ -44,7 +44,7 @@ describe('settlement comment and review loop UI copy', () => {
     expect(importEditorSource).toContain('검토 루프');
     expect(importEditorSource).toContain('셀 주석');
     expect(importEditorSource).toContain('후보값 또는 주석 확인 필요');
-    expect(importEditorRowSource).toContain('검토 루프');
+    expect(importEditorRowSource).toContain('행 작업');
     expect(importEditorRowSource).toContain('검토 완료');
     expect(cashflowProjectSheetSource).toContain('검토 루프 또는 동기화 확인');
     expect(importEditorSource).not.toContain('사람 확인');

--- a/src/app/components/portal/PortalProjectEdit.tsx
+++ b/src/app/components/portal/PortalProjectEdit.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, Loader2, Save, SendHorizontal } from 'lucide-react';
 import { collection, doc, limit, onSnapshot, orderBy, query, setDoc, where } from 'firebase/firestore';
 import { toast } from 'sonner';
 import { useAuth } from '../../data/auth-store';
+import { useProjectDepartmentSettings } from '../../data/project-department-settings';
 import { usePortalStore } from '../../data/portal-store';
 import type { Project, ProjectRequest, ProjectRequestDraft, ProjectRequestDraftStatus } from '../../data/types';
 import { getOrgCollectionPath, getOrgDocumentPath } from '../../lib/firebase';
@@ -69,6 +70,7 @@ export function PortalProjectEdit() {
   const { user: authUser } = useAuth();
   const { db, isOnline, orgId } = useFirebase();
   const { members, myProject } = usePortalStore();
+  const { options: departmentOptions } = useProjectDepartmentSettings();
   const [requestDoc, setRequestDoc] = useState<ProjectRequest | null>(null);
   const [busyActionId, setBusyActionId] = useState<string | null>(null);
   const [resubmitComment, setResubmitComment] = useState('');
@@ -261,6 +263,7 @@ export function PortalProjectEdit() {
       initialDraft={initialDraft}
       draftKey={`portal-edit-${myProject.id}-${requestDoc?.updatedAt || myProject.updatedAt}`}
       members={members}
+      departmentOptions={departmentOptions}
       autosave={autosaveConfig}
       actions={[
         { id: 'save', label: '저장', icon: Save },

--- a/src/app/components/portal/PortalProjectRegister.tsx
+++ b/src/app/components/portal/PortalProjectRegister.tsx
@@ -4,6 +4,7 @@ import { CheckCircle2, Send } from 'lucide-react';
 import { doc, setDoc } from 'firebase/firestore';
 import { toast } from 'sonner';
 import { useAuth } from '../../data/auth-store';
+import { useProjectDepartmentSettings } from '../../data/project-department-settings';
 import { usePortalStore } from '../../data/portal-store';
 import type { ProjectRequestDraft, ProjectRequestDraftStatus } from '../../data/types';
 import { getAuthInstance, getOrgDocumentPath } from '../../lib/firebase';
@@ -28,6 +29,7 @@ export function PortalProjectRegister() {
   const { db, orgId } = useFirebase();
   const { user: authUser } = useAuth();
   const { createProjectRequest, members, portalUser } = usePortalStore();
+  const { options: departmentOptions } = useProjectDepartmentSettings();
   const [busyActionId, setBusyActionId] = useState<string | null>(null);
   const [submitted, setSubmitted] = useState(false);
   const serverDraftRef = useRef<ProjectRequestDraft | null>(null);
@@ -167,6 +169,7 @@ export function PortalProjectRegister() {
       initialDraft={initialDraft}
       draftKey={`portal-register-${authUser?.uid || 'anonymous'}`}
       members={members}
+      departmentOptions={departmentOptions}
       autosave={autosaveConfig}
       actions={[{ id: 'submit', label: '등록 요청 저장', icon: Send }]}
       busyActionId={busyActionId}

--- a/src/app/components/portal/PortalWeeklyExpensePage.flow-layout.test.ts
+++ b/src/app/components/portal/PortalWeeklyExpensePage.flow-layout.test.ts
@@ -24,19 +24,19 @@ describe('PortalWeeklyExpensePage flow layout', () => {
     expect(weeklyExpenseSource).not.toContain('탭 삭제');
   });
 
-  it('shows a blocking full-screen saving overlay instead of the unsaved-changes dialog while save is in flight', () => {
-    expect(weeklyExpenseSource).toContain('if (isSettlementSaving) return;');
+  it('shows a blocking full-screen saving overlay while save is in flight', () => {
+    expect(weeklyExpenseSource).toContain('if (isSettlementSaving) {');
+    expect(weeklyExpenseSource).toContain('이동은 저장이 끝난 뒤 가능합니다.');
     expect(weeklyExpenseSource).toContain('사업비 입력을 저장하고 있습니다');
     expect(weeklyExpenseSource).toContain('저장이 끝날 때까지 잠시 기다려 주세요.');
     expect(weeklyExpenseSource).toContain('w-[min(92vw,56rem)] max-w-none');
     expect(weeklyExpenseSource).toContain('min-h-[22rem]');
   });
 
-  it('renders the unsaved-changes dialog as a large centered modal surface', () => {
-    expect(weeklyExpenseSource).toContain('data-testid="weekly-expense-unsaved-dialog"');
-    expect(weeklyExpenseSource).toContain('w-[min(92vw,56rem)] max-w-none');
-    expect(weeklyExpenseSource).toContain('min-h-[22rem]');
-    expect(weeklyExpenseSource).toContain('items-center gap-4 text-center');
+  it('does not block route changes with the retired unsaved weekly expense dialog', () => {
+    expect(weeklyExpenseSource).not.toContain('data-testid="weekly-expense-unsaved-dialog"');
+    expect(weeklyExpenseSource).not.toContain('저장되지 않은 사업비 입력이 있습니다');
+    expect(weeklyExpenseSource).not.toContain('지금 이동하면 저장되지 않은 사업비 입력(주간) 편집 내용이 유실될 수 있습니다.');
   });
 
   it('uses a Korean first-action heading instead of the previous English label', () => {

--- a/src/app/components/portal/PortalWeeklyExpensePage.tsx
+++ b/src/app/components/portal/PortalWeeklyExpensePage.tsx
@@ -124,7 +124,6 @@ export function PortalWeeklyExpensePage() {
   const [pendingQuickInsert, setPendingQuickInsert] = useState<PendingQuickInsert | null>(null);
   const [hasUnsavedSettlementChanges, setHasUnsavedSettlementChanges] = useState(false);
   const [isSettlementSaving, setIsSettlementSaving] = useState(false);
-  const [pendingNavigationAttempt, setPendingNavigationAttempt] = useState<{ path: string; label: string } | null>(null);
   const actualSyncSignatureRef = useRef('');
   const [participationRiskWarning, setParticipationRiskWarning] = useState<{
     yearMonth: string;
@@ -812,23 +811,20 @@ export function PortalWeeklyExpensePage() {
   }, []);
 
   const requestRouteNavigation = useCallback((path: string, label: string) => {
-    if (isSettlementSaving) return;
-    if (hasUnsavedSettlementChanges) {
-      setPendingNavigationAttempt({ path, label });
+    if (isSettlementSaving) {
+      toast.message(`${label} 이동은 저장이 끝난 뒤 가능합니다.`);
       return;
     }
     navigate(path);
-  }, [hasUnsavedSettlementChanges, isSettlementSaving, navigate]);
+  }, [isSettlementSaving, navigate]);
 
   useEffect(() => {
-    registerNavigationHandler((attempt) => {
+    registerNavigationHandler(() => {
       if (isSettlementSaving) return true;
-      if (!hasUnsavedSettlementChanges) return false;
-      setPendingNavigationAttempt(attempt);
-      return true;
+      return false;
     });
     return () => registerNavigationHandler(null);
-  }, [hasUnsavedSettlementChanges, isSettlementSaving, registerNavigationHandler]);
+  }, [isSettlementSaving, registerNavigationHandler]);
 
   useEffect(() => {
     if (!isSettlementSaving) return;
@@ -1194,47 +1190,6 @@ export function PortalWeeklyExpensePage() {
         </AlertDialogContent>
       </AlertDialog>
 
-      <AlertDialog
-        open={!!pendingNavigationAttempt}
-        onOpenChange={(open) => {
-          if (!open) setPendingNavigationAttempt(null);
-        }}
-      >
-        <AlertDialogContent
-          data-testid="weekly-expense-unsaved-dialog"
-          className="w-[min(92vw,56rem)] max-w-none overflow-hidden rounded-[28px] p-0 sm:max-w-none"
-        >
-          <div className="flex min-h-[22rem] flex-col items-center justify-center gap-8 px-8 py-10 text-center sm:px-12 sm:py-12">
-          <AlertDialogHeader className="items-center gap-4 text-center">
-            <AlertDialogTitle className="text-2xl font-bold tracking-[-0.03em] text-slate-950 sm:text-[2rem]">
-              저장되지 않은 사업비 입력이 있습니다
-            </AlertDialogTitle>
-            <AlertDialogDescription className="max-w-2xl text-base leading-8 text-slate-600 sm:text-lg">
-              지금 이동하면 저장되지 않은 사업비 입력(주간) 편집 내용이 유실될 수 있습니다.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter className="w-full items-center justify-center gap-3 sm:flex-row sm:justify-center">
-            <AlertDialogCancel
-              className="h-12 min-w-[11rem] rounded-xl px-6 text-sm font-semibold"
-              onClick={() => setPendingNavigationAttempt(null)}
-            >
-              계속 편집
-            </AlertDialogCancel>
-            <AlertDialogAction
-              className="h-12 min-w-[12rem] rounded-xl px-6 text-sm font-semibold"
-              onClick={() => {
-                if (!pendingNavigationAttempt) return;
-                const nextPath = pendingNavigationAttempt.path;
-                setPendingNavigationAttempt(null);
-                navigate(nextPath);
-              }}
-            >
-              변경 버리고 이동
-            </AlertDialogAction>
-          </AlertDialogFooter>
-          </div>
-        </AlertDialogContent>
-      </AlertDialog>
     </div>
   );
 }

--- a/src/app/components/projects/ProjectEditorWizard.shell.test.ts
+++ b/src/app/components/projects/ProjectEditorWizard.shell.test.ts
@@ -67,6 +67,16 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain('PROJECT_CURRENCY_LABELS[draft.currency]');
   });
 
+  it('receives department options instead of mapping hardcoded options directly in the wizard UI', () => {
+    expect(source).toContain('departmentOptions?: string[]');
+    expect(source).toContain('dedupeProjectDepartmentLabels(departmentOptions ? departmentOptions');
+    expect(source).toContain('<Label className="text-xs">담당조직(CIC) *</Label>');
+    expect(source).toContain('<SelectValue placeholder="담당조직 선택" />');
+    expect(source).not.toContain('PROJECT_DEPARTMENT_OPTIONS.map((department)');
+    expect(adminWizardSource).toContain('useProjectDepartmentSettings');
+    expect(adminWizardSource).toContain('departmentOptions={departmentOptions}');
+  });
+
   it('keeps manual team member input bound to the raw typed value instead of reparsing formatted text', () => {
     expect(source).toContain('formatTeamMemberIdentityInput(member)');
     expect(source).toContain('identityInput: event.target.value');

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -48,7 +48,7 @@ import {
   type ProjectType,
   type SettlementType,
 } from '../../data/types';
-import { PROJECT_DEPARTMENT_OPTIONS } from '../../data/project-department-options';
+import { PROJECT_DEPARTMENT_OPTIONS, dedupeProjectDepartmentLabels } from '../../data/project-department-options';
 import { PROJECT_TEAM_MEMBER_OPTION_MAP, PROJECT_TEAM_MEMBER_OPTIONS } from '../../data/project-team-member-options';
 import {
   formatProjectAmountInput,
@@ -60,6 +60,7 @@ import {
 import { buildContractDocumentEditPolicy } from '../../platform/project-contract-document-policy';
 import { formatProfitRatePercentInput } from '../../platform/project-financials';
 import { createProjectEditorDraft, type ProjectEditorDraft, type ProjectEditorMode } from '../../platform/project-editor';
+import { normalizeProjectDepartment } from '../../platform/project-cic';
 import {
   formatProjectTeamMembersSummary,
   normalizeProjectTeamMemberDraftRows,
@@ -110,6 +111,7 @@ interface ProjectEditorWizardProps {
   title: string;
   description?: string;
   members?: OrgMember[];
+  departmentOptions?: string[];
   topSlot?: ReactNode;
   actions: ProjectEditorAction[];
   busyActionId?: string | null;
@@ -421,6 +423,7 @@ export function ProjectEditorWizard({
   title,
   description,
   members = [],
+  departmentOptions,
   topSlot,
   actions,
   busyActionId,
@@ -443,6 +446,13 @@ export function ProjectEditorWizard({
   const initialDraftFingerprint = useMemo(() => JSON.stringify(createProjectEditorDraft(initialDraft)), [initialDraft]);
   const initialContractDocument = initialDraft.contractDocument ?? null;
   const initialContractAnalysis = initialDraft.contractAnalysis ?? null;
+  const normalizedDepartmentOptions = useMemo(
+    () => dedupeProjectDepartmentLabels(departmentOptions ? departmentOptions : [...PROJECT_DEPARTMENT_OPTIONS]),
+    [departmentOptions],
+  );
+  const departmentOptionSet = useMemo(() => new Set(normalizedDepartmentOptions), [normalizedDepartmentOptions]);
+  const selectedDepartment = normalizeProjectDepartment(draft.department);
+  const canUseSelectedDepartment = selectedDepartment && departmentOptionSet.has(selectedDepartment);
   const canRemoveExistingContractDocument = canRemoveContractDocument ?? isAdminMode(mode);
   const contractDocumentEditPolicy = buildContractDocumentEditPolicy({
     current: draft.contractDocument,
@@ -700,14 +710,15 @@ export function ProjectEditorWizard({
 
   const submitIssues = useMemo(() => {
     const issues: Array<{ step: ProjectEditorStep; label: string }> = [];
-    if (!draft.department.trim()) issues.push({ step: 'basic', label: '담당조직(CIC)' });
+    const normalizedDepartment = normalizeProjectDepartment(draft.department);
+    if (!normalizedDepartment || !departmentOptionSet.has(normalizedDepartment)) issues.push({ step: 'basic', label: '담당조직(CIC)' });
     if (!draft.name.trim()) issues.push({ step: 'basic', label: '프로젝트명' });
     if (draft.type !== 'I1' && !draft.contractStart.trim()) issues.push({ step: 'financial', label: '계약 시작일' });
     if (draft.type !== 'I1' && !draft.contractEnd.trim()) issues.push({ step: 'financial', label: '계약 종료일' });
     if (draft.type !== 'I1' && !hasContractAmountInput) issues.push({ step: 'financial', label: '계약금액' });
     if (!draft.managerName.trim()) issues.push({ step: 'team', label: 'PM' });
     return issues;
-  }, [draft, hasContractAmountInput]);
+  }, [departmentOptionSet, draft, hasContractAmountInput]);
 
   const canSubmit = submitIssues.length === 0;
 
@@ -716,16 +727,16 @@ export function ProjectEditorWizard({
       <div className="grid gap-4 lg:grid-cols-2">
         <div>
           <Label className="text-xs">담당조직(CIC) *</Label>
-          <datalist id={`project-editor-department-options-${mode}`}>
-            {PROJECT_DEPARTMENT_OPTIONS.map((department) => <option key={department} value={department} />)}
-          </datalist>
-          <Input
-            value={draft.department}
-            onChange={(event) => update('department', event.target.value)}
-            list={`project-editor-department-options-${mode}`}
-            placeholder="예: 투자센터"
-            className="mt-1 h-9 text-sm"
-          />
+          <Select value={canUseSelectedDepartment ? selectedDepartment : undefined} onValueChange={(value) => update('department', value)}>
+            <SelectTrigger className="mt-1 h-9 text-sm">
+              <SelectValue placeholder="담당조직 선택" />
+            </SelectTrigger>
+            <SelectContent>
+              {normalizedDepartmentOptions.map((department) => (
+                <SelectItem key={department} value={department}>{department}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
         <div>
           <Label className="text-xs">프로젝트 유형 *</Label>

--- a/src/app/components/projects/ProjectListPage.shell.test.ts
+++ b/src/app/components/projects/ProjectListPage.shell.test.ts
@@ -6,14 +6,12 @@ const source = readFileSync(resolve(import.meta.dirname, 'ProjectListPage.tsx'),
 const pendingHookSource = readFileSync(resolve(import.meta.dirname, 'usePendingProjectChangeRequests.ts'), 'utf8');
 
 describe('ProjectListPage shell contract', () => {
-  it('keeps the monitoring presets visible for admin exception detection', () => {
-    expect(source).toContain('data-testid="project-monitoring-presets"');
-    expect(source).toContain('data-testid="project-monitoring-preset-no-ledger"');
-    expect(source).toContain('data-testid="project-monitoring-preset-pending-approval"');
-    expect(source).toContain('data-testid="project-monitoring-preset-missing-evidence"');
-    expect(source).toContain('원장 없음');
-    expect(source).toContain('승인 대기');
-    expect(source).toContain('증빙 미제출');
+  it('does not show the retired monitoring preset filter bar', () => {
+    expect(source).not.toContain('data-testid="project-monitoring-presets"');
+    expect(source).not.toContain('data-testid="project-monitoring-preset-no-ledger"');
+    expect(source).not.toContain('data-testid="project-monitoring-preset-pending-approval"');
+    expect(source).not.toContain('data-testid="project-monitoring-preset-missing-evidence"');
+    expect(source).not.toContain('모니터링 프리셋');
   });
 
   it('shows settlement type labels instead of O/X settlement flags', () => {

--- a/src/app/components/projects/ProjectListPage.tsx
+++ b/src/app/components/projects/ProjectListPage.tsx
@@ -2,7 +2,7 @@ import { useState, useMemo } from 'react';
 import { useNavigate } from 'react-router';
 import {
   Search, ArrowUpDown, Sparkles, CheckCircle2, ArrowRight,
-  FolderKanban, RotateCcw, Trash2, FileText, Clock, AlertTriangle,
+  FolderKanban, RotateCcw, Trash2,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { Card, CardContent } from '../ui/card';
@@ -41,7 +41,7 @@ type SortKey = 'name' | 'contractAmount' | 'status';
 type SortDir = 'asc' | 'desc';
 
 export function ProjectListPage() {
-  const { allProjects, restoreProject, ledgers, transactions } = useAppStore();
+  const { allProjects, restoreProject } = useAppStore();
   const navigate = useNavigate();
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('ALL');
@@ -50,7 +50,6 @@ export function ProjectListPage() {
   const [sortKey, setSortKey] = useState<SortKey>('contractAmount');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [activeTab, setActiveTab] = useState<string>('confirmed');
-  const [monitoringPreset, setMonitoringPreset] = useState<'all' | 'no-ledger' | 'pending-approval' | 'missing-evidence'>('all');
   const pendingProjectChangeMap = usePendingProjectChangeRequests();
 
   const activeProjects = useMemo(
@@ -75,42 +74,14 @@ export function ProjectListPage() {
       ? confirmedProjects
       : prospectProjects;
 
-  const projectTransactions = useMemo(() => {
-    const map = new Map<string, typeof transactions>();
-    transactions.forEach((transaction) => {
-      const list = map.get(transaction.projectId) || [];
-      list.push(transaction);
-      map.set(transaction.projectId, list);
-    });
-    return map;
-  }, [transactions]);
-
-  const monitoringCounts = useMemo(() => {
-    const noLedger = activeProjects.filter((project) => project.phase === 'CONFIRMED' && !ledgers.some((ledger) => ledger.projectId === project.id)).length;
-    const pendingApproval = activeProjects.filter((project) => (projectTransactions.get(project.id) || []).some((transaction) => transaction.state === 'SUBMITTED')).length;
-    const missingEvidence = activeProjects.filter((project) => (projectTransactions.get(project.id) || []).some((transaction) => transaction.evidenceStatus !== 'COMPLETE' && transaction.state !== 'REJECTED')).length;
-    return { noLedger, pendingApproval, missingEvidence };
-  }, [activeProjects, ledgers, projectTransactions]);
-
-  const monitoringProjects = useMemo(() => {
-    if (monitoringPreset === 'all') return tabProjects;
-    if (monitoringPreset === 'no-ledger') {
-      return tabProjects.filter((project) => project.phase === 'CONFIRMED' && !ledgers.some((ledger) => ledger.projectId === project.id));
-    }
-    if (monitoringPreset === 'pending-approval') {
-      return tabProjects.filter((project) => (projectTransactions.get(project.id) || []).some((transaction) => transaction.state === 'SUBMITTED'));
-    }
-    return tabProjects.filter((project) => (projectTransactions.get(project.id) || []).some((transaction) => transaction.evidenceStatus !== 'COMPLETE' && transaction.state !== 'REJECTED'));
-  }, [ledgers, monitoringPreset, projectTransactions, tabProjects]);
-
   const departments = useMemo(() => {
-    const depts = new Set(monitoringProjects.map((project) => project.department).filter(Boolean));
+    const depts = new Set(tabProjects.map((project) => project.department).filter(Boolean));
     return Array.from(depts).sort();
-  }, [monitoringProjects]);
+  }, [tabProjects]);
   const hasActiveFilters = !!search || statusFilter !== 'ALL' || typeFilter !== 'ALL' || deptFilter !== 'ALL';
 
   const filtered = useMemo(() => {
-    let result = monitoringProjects.filter(p => {
+    let result = tabProjects.filter(p => {
       if (search) {
         const q = search.toLowerCase();
         const matches = p.name.toLowerCase().includes(q)
@@ -137,14 +108,7 @@ export function ProjectListPage() {
     });
 
     return result;
-  }, [monitoringProjects, search, statusFilter, typeFilter, deptFilter, sortKey, sortDir]);
-
-  const handleMonitoringPreset = (preset: 'all' | 'no-ledger' | 'pending-approval' | 'missing-evidence') => {
-    setMonitoringPreset(preset);
-    if (preset !== 'all' && activeTab === 'trash') {
-      setActiveTab('confirmed');
-    }
-  };
+  }, [tabProjects, search, statusFilter, typeFilter, deptFilter, sortKey, sortDir]);
 
   const handleSort = (key: SortKey) => {
     if (sortKey === key) {
@@ -354,71 +318,10 @@ export function ProjectListPage() {
         description={`활성 ${activeProjects.length}개 프로젝트 · 확정 ${confirmedProjects.length} / 예정 ${prospectProjects.length} / 휴지통 ${trashedProjects.length}`}
       />
 
-      <Card className="border-slate-200/80 bg-gradient-to-r from-slate-50 via-white to-teal-50/70">
-        <CardContent className="p-4">
-          <div className="flex flex-wrap items-center gap-2" data-testid="project-monitoring-presets">
-            <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-500">모니터링 프리셋</span>
-            <Button
-              variant={monitoringPreset === 'all' ? 'default' : 'outline'}
-              size="sm"
-              className="h-8 gap-1.5 text-[11px]"
-              onClick={() => handleMonitoringPreset('all')}
-            >
-              <FolderKanban className="h-3.5 w-3.5" />
-              전체
-            </Button>
-            <Button
-              variant={monitoringPreset === 'no-ledger' ? 'default' : 'outline'}
-              size="sm"
-              className="h-8 gap-1.5 text-[11px]"
-              onClick={() => handleMonitoringPreset('no-ledger')}
-              data-testid="project-monitoring-preset-no-ledger"
-            >
-              <FileText className="h-3.5 w-3.5" />
-              원장 없음
-              <Badge variant="secondary" className="ml-1 text-[10px] px-1.5 py-0">
-                {monitoringCounts.noLedger}
-              </Badge>
-            </Button>
-            <Button
-              variant={monitoringPreset === 'pending-approval' ? 'default' : 'outline'}
-              size="sm"
-              className="h-8 gap-1.5 text-[11px]"
-              onClick={() => handleMonitoringPreset('pending-approval')}
-              data-testid="project-monitoring-preset-pending-approval"
-            >
-              <Clock className="h-3.5 w-3.5" />
-              승인 대기
-              <Badge variant="secondary" className="ml-1 text-[10px] px-1.5 py-0">
-                {monitoringCounts.pendingApproval}
-              </Badge>
-            </Button>
-            <Button
-              variant={monitoringPreset === 'missing-evidence' ? 'default' : 'outline'}
-              size="sm"
-              className="h-8 gap-1.5 text-[11px]"
-              onClick={() => handleMonitoringPreset('missing-evidence')}
-              data-testid="project-monitoring-preset-missing-evidence"
-            >
-              <AlertTriangle className="h-3.5 w-3.5" />
-              증빙 미제출
-              <Badge variant="secondary" className="ml-1 text-[10px] px-1.5 py-0">
-                {monitoringCounts.missingEvidence}
-              </Badge>
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
-
       {/* Tabs */}
       <Tabs
         value={activeTab}
-        onValueChange={(value) => {
-          setActiveTab(value);
-          if (value === 'trash') {
-            setMonitoringPreset('all');
-          }
-        }}
+        onValueChange={setActiveTab}
       >
         <TabsList>
           <TabsTrigger value="confirmed" className="gap-1.5" data-testid="projects-tab-confirmed">

--- a/src/app/components/projects/ProjectWizard.tsx
+++ b/src/app/components/projects/ProjectWizard.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router';
 import { Save } from 'lucide-react';
 import { toast } from 'sonner';
 import { useAppStore } from '../../data/store';
+import { useProjectDepartmentSettings } from '../../data/project-department-settings';
 import type { Project, ProjectPhase } from '../../data/types';
 import { useFirebase } from '../../lib/firebase-context';
 import { uploadProjectRequestContractFile } from '../../platform/project-contract-upload';
@@ -13,7 +14,7 @@ import {
   type ProjectEditorDraft,
 } from '../../platform/project-editor';
 import { buildProjectOwnerAssignmentPatches } from '../../platform/project-owner-assignment';
-import { resolveProjectCic } from '../../platform/project-cic';
+import { normalizeProjectDepartment, resolveProjectCic } from '../../platform/project-cic';
 import { ProjectEditorWizard } from './ProjectEditorWizard';
 
 interface ProjectWizardProps {
@@ -73,7 +74,7 @@ function createProjectFromDraft(
     settlementGuide: draft.settlementGuide,
     contractDocument: draft.contractDocument,
     contractAnalysis: null,
-    department: draft.department,
+    department: normalizeProjectDepartment(draft.department),
     cic: resolveProjectCic({ department: draft.department }),
     teamName: draft.teamName,
     managerId: draft.registeredById,
@@ -98,6 +99,7 @@ export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: Projec
   const navigate = useNavigate();
   const { addProject, updateProject, upsertMember, members, currentUser } = useAppStore();
   const { orgId } = useFirebase();
+  const { options: departmentOptions } = useProjectDepartmentSettings();
   const [busyActionId, setBusyActionId] = useState<string | null>(null);
 
   const initialDraft = useMemo(
@@ -213,6 +215,7 @@ export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: Projec
       initialDraft={initialDraft}
       draftKey={`admin-${editProject?.id || 'new'}-${editProject?.updatedAt || initialPhase}`}
       members={members}
+      departmentOptions={departmentOptions}
       actions={editProject ? [
         { id: 'save', label: '수정 저장', icon: Save },
       ] : [

--- a/src/app/components/settings/SettingsPage.shell.test.ts
+++ b/src/app/components/settings/SettingsPage.shell.test.ts
@@ -5,13 +5,37 @@ import { describe, expect, it } from 'vitest';
 const source = readFileSync(resolve(import.meta.dirname, 'SettingsPage.tsx'), 'utf8');
 
 describe('SettingsPage member directory contract', () => {
+  it('keeps project selection values admin-managed in the member tab', () => {
+    expect(source).toContain('프로젝트 선택값');
+    expect(source).toContain('새 담당조직(CIC)');
+    expect(source).toContain('useProjectDepartmentSettings');
+    expect(source).toContain('saveDepartmentOptions');
+    expect(source).toContain('handleRemoveDepartment');
+    expect(source).toContain('handleMoveDepartment');
+    expect(source).toContain('이미 등록된 담당조직(CIC)입니다.');
+    expect(source).toContain('<ArrowUp className="h-3.5 w-3.5" />');
+    expect(source).toContain('<ArrowDown className="h-3.5 w-3.5" />');
+    expect(source.indexOf('{renderProjectSelectionValuesCard()}')).toBeLessThan(source.indexOf('구성원 원장 추가/수정'));
+    expect(source).toContain('xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]');
+    expect(source).toContain('구성원 원장 추가/수정');
+    expect(source).toContain("const PRIMARY_SETTINGS_TABS = ['org', 'members', 'templates', 'migration', 'permissions'] as const;");
+    expect(source).not.toContain("'project-options'");
+  });
+
   it('manages the canonical member directory through store CRUD', () => {
     expect(source).toContain('구성원 원장 추가/수정');
-    expect(source).toContain('orgs/{org.id}/members');
     expect(source).toContain('upsertMember({');
     expect(source).toContain('await removeMember(uid)');
     expect(source).toContain('Firebase UID');
     expect(source).toContain('이름, 이메일, UID 검색');
+  });
+
+  it('keeps the settings surface aligned with the MYSCube brand system', () => {
+    expect(source).toContain('MyscWordmark');
+    expect(source).toContain('text-primary');
+    expect(source).toContain('data-[state=active]:bg-primary');
+    expect(source).not.toContain('Primary Admin Settings');
+    expect(source).not.toContain('운영 설정 범위');
   });
 
   it('keeps unauthorized settings access in place instead of redirecting home', () => {

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
-  Settings, Users, BookOpen, Building2, Plus, Upload, Shield, Search, Save, Trash2,
+  Settings, Users, BookOpen, Building2, Upload, Shield, Search, Save, Trash2, ArrowUp, ArrowDown,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { ROLE_META } from '../../platform/role-meta';
@@ -15,8 +15,13 @@ import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow,
 } from '../ui/table';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '../ui/select';
 import { Separator } from '../ui/separator';
 import { useAppStore } from '../../data/store';
+import { useProjectDepartmentSettings } from '../../data/project-department-settings';
+import { normalizeProjectDepartmentOptionLabel } from '../../data/project-department-options';
 import {
   CASHFLOW_CATEGORY_LABELS, SETTLEMENT_TYPE_LABELS, BASIS_LABELS,
   type CashflowCategory,
@@ -24,6 +29,7 @@ import {
 import { DataMigrationTab } from './DataMigrationTab';
 import { PageHeader } from '../layout/PageHeader';
 import { useAuth } from '../../data/auth-store';
+import { MyscWordmark } from '../brand/MyscWordmark';
 
 const DISPLAY_ROLES = ['admin', 'finance', 'pm'] as const;
 type DisplayRole = typeof DISPLAY_ROLES[number];
@@ -44,6 +50,10 @@ const PERMISSION_LABELS: Partial<Record<PlatformPermission, string>> = {
 
 export function SettingsPage() {
   const { org, members, templates, upsertMember, removeMember } = useAppStore();
+  const {
+    options: departmentOptions,
+    saveOptions: saveDepartmentOptions,
+  } = useProjectDepartmentSettings();
   const { isAuthenticated, isLoading: authLoading, user } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
@@ -53,6 +63,9 @@ export function SettingsPage() {
   const [tab, setTab] = useState(initialTab);
   const [memberSearch, setMemberSearch] = useState('');
   const [savingMember, setSavingMember] = useState(false);
+  const [savingDepartment, setSavingDepartment] = useState(false);
+  const [departmentDraft, setDepartmentDraft] = useState('');
+  const [editingDepartment, setEditingDepartment] = useState('');
   const [memberDraft, setMemberDraft] = useState({
     uid: '',
     name: '',
@@ -76,6 +89,171 @@ export function SettingsPage() {
   const resetMemberDraft = () => {
     setMemberDraft({ uid: '', name: '', email: '', role: 'pm' });
   };
+
+  const resetDepartmentDraft = () => {
+    setDepartmentDraft('');
+    setEditingDepartment('');
+  };
+
+  const handleSaveDepartment = async () => {
+    const label = normalizeProjectDepartmentOptionLabel(departmentDraft);
+    if (!label) {
+      toast.error('담당조직(CIC)을 입력해 주세요.');
+      return;
+    }
+    if (departmentOptions.includes(label) && label !== editingDepartment) {
+      toast.error('이미 등록된 담당조직(CIC)입니다.');
+      return;
+    }
+
+    const withoutEditing = departmentOptions.filter((option) => option !== editingDepartment && option !== label);
+    const nextOptions = editingDepartment
+      ? departmentOptions.map((option) => (option === editingDepartment ? label : option)).filter((option, index, list) => list.indexOf(option) === index)
+      : [...withoutEditing, label];
+
+    setSavingDepartment(true);
+    try {
+      await saveDepartmentOptions(nextOptions, user?.uid);
+      toast.success('프로젝트 선택값을 저장했습니다.');
+      resetDepartmentDraft();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : '프로젝트 선택값 저장에 실패했습니다.');
+    } finally {
+      setSavingDepartment(false);
+    }
+  };
+
+  const handleRemoveDepartment = async (label: string) => {
+    if (!window.confirm(`${label} 옵션을 삭제할까요?`)) return;
+    setSavingDepartment(true);
+    try {
+      await saveDepartmentOptions(departmentOptions.filter((option) => option !== label), user?.uid);
+      toast.success('프로젝트 선택값을 삭제했습니다.');
+      if (editingDepartment === label) resetDepartmentDraft();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : '프로젝트 선택값 삭제에 실패했습니다.');
+    } finally {
+      setSavingDepartment(false);
+    }
+  };
+
+  const handleMoveDepartment = async (label: string, direction: -1 | 1) => {
+    const index = departmentOptions.indexOf(label);
+    const nextIndex = index + direction;
+    if (index < 0 || nextIndex < 0 || nextIndex >= departmentOptions.length) return;
+    const nextOptions = [...departmentOptions];
+    [nextOptions[index], nextOptions[nextIndex]] = [nextOptions[nextIndex], nextOptions[index]];
+    setSavingDepartment(true);
+    try {
+      await saveDepartmentOptions(nextOptions, user?.uid);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : '프로젝트 선택값 순서 저장에 실패했습니다.');
+    } finally {
+      setSavingDepartment(false);
+    }
+  };
+
+  const renderProjectSelectionValuesCard = () => (
+    <Card className="overflow-hidden border-slate-200 bg-white shadow-sm">
+      <CardHeader className="border-b border-slate-100 pb-4">
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="text-base">프로젝트 선택값</CardTitle>
+          <Badge variant="outline" className="border-cyan-200 bg-accent text-[11px] text-accent-foreground">
+            {departmentOptions.length}개
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4 pt-5">
+        <div className="grid gap-3 lg:grid-cols-[1fr_auto_auto] lg:items-end">
+          <div>
+            <Label className="text-xs">새 담당조직(CIC)</Label>
+            <Input
+              value={departmentDraft}
+              onChange={(event) => setDepartmentDraft(event.target.value)}
+              placeholder="담당조직(CIC)"
+              className="mt-1 border-slate-300"
+            />
+          </div>
+          <Button type="button" onClick={() => void handleSaveDepartment()} disabled={savingDepartment} className="gap-2">
+            <Save className="h-4 w-4" /> {editingDepartment ? '수정 저장' : '추가'}
+          </Button>
+          <Button type="button" variant="outline" onClick={resetDepartmentDraft}>
+            초기화
+          </Button>
+        </div>
+        <div className="overflow-hidden rounded-lg border border-slate-200">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-[72px]">순서</TableHead>
+                <TableHead>담당조직(CIC)</TableHead>
+                <TableHead className="w-[180px] text-right">관리</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {departmentOptions.length ? departmentOptions.map((label, index) => (
+                <TableRow key={label}>
+                  <TableCell className="text-xs tabular-nums text-slate-500">{index + 1}</TableCell>
+                  <TableCell className="font-medium">{label}</TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        aria-label={`${label} 위로 이동`}
+                        disabled={index === 0 || savingDepartment}
+                        onClick={() => void handleMoveDepartment(label, -1)}
+                      >
+                        <ArrowUp className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        aria-label={`${label} 아래로 이동`}
+                        disabled={index === departmentOptions.length - 1 || savingDepartment}
+                        onClick={() => void handleMoveDepartment(label, 1)}
+                      >
+                        <ArrowDown className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                          setDepartmentDraft(label);
+                          setEditingDepartment(label);
+                        }}
+                      >
+                        수정
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="border-slate-300 text-red-700 hover:text-red-700"
+                        aria-label={`${label} 삭제`}
+                        onClick={() => void handleRemoveDepartment(label)}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              )) : (
+                <TableRow>
+                  <TableCell colSpan={3} className="py-6 text-center text-sm text-slate-500">
+                    등록된 담당조직이 없습니다
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  );
 
   const handleSaveMember = async () => {
     const uid = memberDraft.uid.trim();
@@ -147,51 +325,60 @@ export function SettingsPage() {
     <div className="space-y-5">
       <PageHeader
         icon={Settings}
-        iconGradient="linear-gradient(135deg, #0891b2, #0891b2)"
+        iconGradient="linear-gradient(135deg, #001e46, #001e46)"
         title="설정"
         description="운영에 필요한 조직, 구성원, 템플릿, 권한 설정만 관리합니다"
       />
 
-      <Card className="border-slate-200/80 bg-slate-50/70">
-        <CardContent className="flex flex-col gap-3 p-4 md:flex-row md:items-center md:justify-between">
-          <div className="space-y-1">
-            <p className="text-[12px] font-semibold text-slate-900">운영 설정 범위</p>
-            <p className="text-[12px] leading-6 text-slate-600">
-              1차 운영 surface에서는 조직 정보, 구성원, 원장 템플릿, 데이터 마이그레이션, 권한 매트릭스만 노출합니다.
-            </p>
+      <div className="rounded-lg border border-slate-200 bg-white px-4 py-3 shadow-sm">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex min-w-0 items-center gap-3">
+            <MyscWordmark size="sm" />
+            <div className="hidden h-7 w-px bg-slate-200 sm:block" />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-slate-900">{org.name}</p>
+              <p className="truncate text-[11px] text-slate-500">{org.id}</p>
+            </div>
           </div>
-          <Badge variant="outline" className="h-7 self-start border-slate-300 bg-white px-3 text-[11px] text-slate-700">
-            Primary Admin Settings
-          </Badge>
-        </CardContent>
-      </Card>
+          <div className="grid grid-cols-2 gap-2 sm:flex sm:items-center">
+            <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2">
+              <p className="text-[10px] font-medium text-slate-500">구성원</p>
+              <p className="text-sm font-semibold tabular-nums text-primary">{members.length}명</p>
+            </div>
+            <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2">
+              <p className="text-[10px] font-medium text-slate-500">담당조직</p>
+              <p className="text-sm font-semibold tabular-nums text-primary">{departmentOptions.length}개</p>
+            </div>
+          </div>
+        </div>
+      </div>
 
       <Tabs value={tab} onValueChange={setTab}>
-        <TabsList>
-          <TabsTrigger value="org" className="gap-1.5">
+        <TabsList className="w-full justify-start overflow-x-auto rounded-lg border border-slate-200 bg-white p-1 shadow-sm">
+          <TabsTrigger value="org" className="flex-none rounded-md px-3 text-xs data-[state=active]:bg-primary data-[state=active]:text-primary-foreground">
             <Building2 className="w-3.5 h-3.5" /> 조직 정보
           </TabsTrigger>
-          <TabsTrigger value="members" className="gap-1.5">
+          <TabsTrigger value="members" className="flex-none rounded-md px-3 text-xs data-[state=active]:bg-primary data-[state=active]:text-primary-foreground">
             <Users className="w-3.5 h-3.5" /> 구성원
           </TabsTrigger>
-          <TabsTrigger value="templates" className="gap-1.5">
+          <TabsTrigger value="templates" className="flex-none rounded-md px-3 text-xs data-[state=active]:bg-primary data-[state=active]:text-primary-foreground">
             <BookOpen className="w-3.5 h-3.5" /> 원장 템플릿
           </TabsTrigger>
-          <TabsTrigger value="migration" className="gap-1.5">
+          <TabsTrigger value="migration" className="flex-none rounded-md px-3 text-xs data-[state=active]:bg-primary data-[state=active]:text-primary-foreground">
             <Upload className="w-3.5 h-3.5" /> 데이터 마이그레이션
           </TabsTrigger>
-          <TabsTrigger value="permissions" className="gap-1.5">
+          <TabsTrigger value="permissions" className="flex-none rounded-md px-3 text-xs data-[state=active]:bg-primary data-[state=active]:text-primary-foreground">
             <Shield className="w-3.5 h-3.5" /> 권한 설정
           </TabsTrigger>
         </TabsList>
 
         {/* Organization */}
         <TabsContent value="org">
-          <Card>
-            <CardHeader>
+          <Card className="border-slate-200 bg-white shadow-sm">
+            <CardHeader className="border-b border-slate-100 pb-4">
               <CardTitle className="text-base">조직 정보</CardTitle>
             </CardHeader>
-            <CardContent className="space-y-4">
+            <CardContent className="space-y-4 pt-5">
               <div>
                 <Label>조직명</Label>
                 <Input value={org.name} readOnly className="max-w-sm" />
@@ -222,71 +409,76 @@ export function SettingsPage() {
         {/* Members */}
         <TabsContent value="members">
           <div className="space-y-4">
-            <Card className="border-slate-200">
-              <CardHeader>
-                <CardTitle className="text-base">구성원 원장 추가/수정</CardTitle>
-                <p className="text-[12px] text-muted-foreground">
-                  사업 담당자 선택값은 이 원장의 UID를 저장합니다. 이미 로그인한 구성원은 Firebase UID를 사용하세요.
-                </p>
-              </CardHeader>
-              <CardContent className="grid gap-3 lg:grid-cols-[1fr_1fr_1fr_180px_auto_auto] lg:items-end">
-                <div>
-                  <Label className="text-xs">UID *</Label>
-                  <Input
-                    value={memberDraft.uid}
-                    onChange={(event) => setMemberDraft((prev) => ({ ...prev, uid: event.target.value }))}
-                    placeholder="Firebase UID"
-                    className="mt-1 border-slate-300"
-                  />
-                </div>
-                <div>
-                  <Label className="text-xs">이름 *</Label>
-                  <Input
-                    value={memberDraft.name}
-                    onChange={(event) => setMemberDraft((prev) => ({ ...prev, name: event.target.value }))}
-                    placeholder="홍길동(닉네임)"
-                    className="mt-1 border-slate-300"
-                  />
-                </div>
-                <div>
-                  <Label className="text-xs">이메일 *</Label>
-                  <Input
-                    value={memberDraft.email}
-                    onChange={(event) => setMemberDraft((prev) => ({ ...prev, email: event.target.value }))}
-                    placeholder="name@mysc.co.kr"
-                    className="mt-1 border-slate-300"
-                  />
-                </div>
-                <div>
-                  <Label className="text-xs">역할</Label>
-                  <Select value={memberDraft.role} onValueChange={(value) => setMemberDraft((prev) => ({ ...prev, role: value as DisplayRole }))}>
-                    <SelectTrigger className="mt-1 h-9 border-slate-300 bg-white">
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {DISPLAY_ROLES.map((role) => (
-                        <SelectItem key={role} value={role}>{ROLE_META[role]?.label ?? role}</SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-                <Button type="button" onClick={() => void handleSaveMember()} disabled={savingMember} className="gap-2">
-                  <Save className="h-4 w-4" /> 저장
-                </Button>
-                <Button type="button" variant="outline" onClick={resetMemberDraft}>
-                  초기화
-                </Button>
-              </CardContent>
-            </Card>
+            <div className="grid gap-4 xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
+              {renderProjectSelectionValuesCard()}
 
-            <Card className="border-slate-200">
-              <CardHeader>
+              <Card className="overflow-hidden border-slate-200 bg-white shadow-sm">
+                <CardHeader className="border-b border-slate-100 pb-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <CardTitle className="text-base">구성원 원장 추가/수정</CardTitle>
+                    <Badge variant="outline" className="border-slate-300 text-[11px] text-slate-700">
+                      {memberDraft.uid ? '수정' : '신규'}
+                    </Badge>
+                  </div>
+                </CardHeader>
+                <CardContent className="grid gap-3 pt-5 md:grid-cols-2 xl:grid-cols-1">
+                  <div>
+                    <Label className="text-xs">UID *</Label>
+                    <Input
+                      value={memberDraft.uid}
+                      onChange={(event) => setMemberDraft((prev) => ({ ...prev, uid: event.target.value }))}
+                      placeholder="Firebase UID"
+                      className="mt-1 border-slate-300"
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-xs">이름 *</Label>
+                    <Input
+                      value={memberDraft.name}
+                      onChange={(event) => setMemberDraft((prev) => ({ ...prev, name: event.target.value }))}
+                      placeholder="홍길동(닉네임)"
+                      className="mt-1 border-slate-300"
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-xs">이메일 *</Label>
+                    <Input
+                      value={memberDraft.email}
+                      onChange={(event) => setMemberDraft((prev) => ({ ...prev, email: event.target.value }))}
+                      placeholder="name@mysc.co.kr"
+                      className="mt-1 border-slate-300"
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-xs">역할</Label>
+                    <Select value={memberDraft.role} onValueChange={(value) => setMemberDraft((prev) => ({ ...prev, role: value as DisplayRole }))}>
+                      <SelectTrigger className="mt-1 h-9 border-slate-300 bg-white">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {DISPLAY_ROLES.map((role) => (
+                          <SelectItem key={role} value={role}>{ROLE_META[role]?.label ?? role}</SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  <div className="flex gap-2 md:col-span-2 xl:col-span-1">
+                    <Button type="button" onClick={() => void handleSaveMember()} disabled={savingMember} className="flex-1 gap-2">
+                      <Save className="h-4 w-4" /> 저장
+                    </Button>
+                    <Button type="button" variant="outline" onClick={resetMemberDraft}>
+                      초기화
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+
+            <Card className="overflow-hidden border-slate-200 bg-white shadow-sm">
+              <CardHeader className="border-b border-slate-100 pb-4">
                 <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
                   <div>
                     <CardTitle className="text-base">구성원 원장 ({members.length}명)</CardTitle>
-                    <p className="mt-1 text-[12px] text-muted-foreground">
-                      실제 데이터는 Firestore orgs/{org.id}/members에 저장됩니다.
-                    </p>
                   </div>
                   <div className="relative w-full lg:w-[320px]">
                     <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-slate-400" />
@@ -299,7 +491,7 @@ export function SettingsPage() {
                   </div>
                 </div>
               </CardHeader>
-              <CardContent>
+              <CardContent className="pt-5">
               <Table>
                 <TableHeader>
                   <TableRow>

--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -68,7 +68,7 @@ import {
 } from '../platform/bank-statement';
 import { normalizeSpace } from '../platform/csv-utils';
 import { isBankImportManualFieldsComplete, resolveBankImportProjectionStatus } from '../platform/bank-import-triage';
-import { resolveProjectCic } from '../platform/project-cic';
+import { normalizeProjectDepartment, resolveProjectCic } from '../platform/project-cic';
 import { normalizeProjectFinancialInputFlagsForAmounts } from '../platform/project-contract-amount';
 import { resolveProjectRevenueFinancials } from '../platform/project-financials';
 import {
@@ -2408,7 +2408,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
       financialInputFlags,
       settlementGuide: requestPayload.settlementGuide,
       contractDocument: requestPayload.contractDocument,
-      department: requestPayload.department,
+      department: normalizeProjectDepartment(requestPayload.department),
       cic: resolveProjectCic({ department: requestPayload.department }),
       teamName: requestPayload.teamName,
       managerId: ownerId,

--- a/src/app/data/project-department-options.test.ts
+++ b/src/app/data/project-department-options.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PROJECT_DEPARTMENT_OPTIONS,
+  buildProjectDepartmentSettingsOptions,
+  resolveProjectDepartmentSettingsOptions,
+} from './project-department-options';
+
+describe('project department settings options', () => {
+  it('uses defaults only when the settings document is missing', () => {
+    expect(resolveProjectDepartmentSettingsOptions(null)).toEqual([...PROJECT_DEPARTMENT_OPTIONS]);
+  });
+
+  it('uses exactly configured options when the settings document exists', () => {
+    expect(resolveProjectDepartmentSettingsOptions({
+      options: [
+        { id: 'space', label: '공간플랫폼센터', sortOrder: 1, active: true },
+        { id: 'investment', label: '투자센터', sortOrder: 0, active: true },
+      ],
+    })).toEqual(['투자센터', '공간플랫폼센터']);
+  });
+
+  it('does not resurrect defaults when an existing settings document is empty', () => {
+    expect(resolveProjectDepartmentSettingsOptions({ options: [] })).toEqual([]);
+  });
+
+  it('normalizes spaced CIC labels before saving settings options', () => {
+    expect(buildProjectDepartmentSettingsOptions(['CIC 2', 'CIC2', '공간플랫폼센터']).map((option) => option.label))
+      .toEqual(['CIC2', '공간플랫폼센터']);
+  });
+
+  it('keeps generated option ids unique when normalized ids collide', () => {
+    expect(buildProjectDepartmentSettingsOptions(['A', 'A!']).map((option) => option.id))
+      .toEqual(['a', 'a-2']);
+  });
+});

--- a/src/app/data/project-department-options.ts
+++ b/src/app/data/project-department-options.ts
@@ -6,6 +6,7 @@ export const PROJECT_DEPARTMENT_OPTIONS = [
   'CIC4',
   '글로벌센터',
   '개발협력센터',
+  '공간플랫폼센터',
   '투자센터',
   '조인트액션',
   'CI그룹',
@@ -14,3 +15,91 @@ export const PROJECT_DEPARTMENT_OPTIONS = [
 ] as const;
 
 export type ProjectDepartmentOption = (typeof PROJECT_DEPARTMENT_OPTIONS)[number];
+
+export interface ProjectDepartmentSettingsOption {
+  id: string;
+  label: string;
+  sortOrder: number;
+  active?: boolean;
+}
+
+function hashLabel(value: string): string {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = ((hash << 5) - hash) + value.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash).toString(36);
+}
+
+export function createProjectDepartmentOptionId(label: string): string {
+  const normalized = label.trim().toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9가-힣-]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  return normalized || `department-${hashLabel(label)}`;
+}
+
+export function normalizeProjectDepartmentOptionLabel(value: unknown): string {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+  if (/^cic\s*([1-4])$/i.test(raw)) return `CIC${raw.match(/[1-4]/)?.[0] || ''}`;
+  return raw;
+}
+
+export function dedupeProjectDepartmentLabels(values: unknown[]): string[] {
+  const seen = new Set<string>();
+  const labels: string[] = [];
+  values.forEach((value) => {
+    const label = normalizeProjectDepartmentOptionLabel(value);
+    if (!label || seen.has(label)) return;
+    seen.add(label);
+    labels.push(label);
+  });
+  return labels;
+}
+
+export function buildProjectDepartmentSettingsOptions(labels: unknown[]): ProjectDepartmentSettingsOption[] {
+  const usedIds = new Map<string, number>();
+  return dedupeProjectDepartmentLabels(labels).map((label, index) => {
+    const baseId = createProjectDepartmentOptionId(label);
+    const nextCount = (usedIds.get(baseId) || 0) + 1;
+    usedIds.set(baseId, nextCount);
+    return {
+      id: nextCount === 1 ? baseId : `${baseId}-${nextCount}`,
+      label,
+      sortOrder: index,
+      active: true,
+    };
+  });
+}
+
+export function resolveProjectDepartmentSettingsOptions(
+  settingsData: unknown,
+  fallbackLabels: readonly string[] = PROJECT_DEPARTMENT_OPTIONS,
+): string[] {
+  if (!settingsData || typeof settingsData !== 'object') {
+    return dedupeProjectDepartmentLabels([...fallbackLabels]);
+  }
+
+  const rawOptions = Array.isArray((settingsData as { options?: unknown }).options)
+    ? (settingsData as { options: unknown[] }).options
+    : [];
+
+  return dedupeProjectDepartmentLabels(
+    [...rawOptions]
+      .filter((option) => !option || typeof option !== 'object' || (option as { active?: unknown }).active !== false)
+      .sort((a, b) => {
+        const aOrder = a && typeof a === 'object' ? Number((a as { sortOrder?: unknown }).sortOrder) : Number.NaN;
+        const bOrder = b && typeof b === 'object' ? Number((b as { sortOrder?: unknown }).sortOrder) : Number.NaN;
+        const aRank = Number.isFinite(aOrder) ? aOrder : Number.MAX_SAFE_INTEGER;
+        const bRank = Number.isFinite(bOrder) ? bOrder : Number.MAX_SAFE_INTEGER;
+        if (aRank !== bRank) return aRank - bRank;
+        const aLabel = a && typeof a === 'object' ? String((a as { label?: unknown }).label || '') : String(a || '');
+        const bLabel = b && typeof b === 'object' ? String((b as { label?: unknown }).label || '') : String(b || '');
+        return aLabel.localeCompare(bLabel, 'ko');
+      })
+      .map((option) => (option && typeof option === 'object' ? (option as { label?: unknown }).label : option)),
+  );
+}

--- a/src/app/data/project-department-settings.tsx
+++ b/src/app/data/project-department-settings.tsx
@@ -1,0 +1,93 @@
+import { doc, onSnapshot, setDoc, type Firestore } from 'firebase/firestore';
+import { useEffect, useMemo, useState } from 'react';
+import { getOrgRootPath } from '../lib/firebase';
+import { useFirebase } from '../lib/firebase-context';
+import {
+  PROJECT_DEPARTMENT_OPTIONS,
+  buildProjectDepartmentSettingsOptions,
+  resolveProjectDepartmentSettingsOptions,
+  type ProjectDepartmentSettingsOption,
+} from './project-department-options';
+
+export const PROJECT_DEPARTMENT_SETTINGS_DOC_ID = 'project-departments';
+export const PROJECT_DEPARTMENT_SETTINGS_PATH = `settings/${PROJECT_DEPARTMENT_SETTINGS_DOC_ID}`;
+
+export interface ProjectDepartmentSettingsDoc {
+  options: ProjectDepartmentSettingsOption[];
+  updatedAt?: string;
+  updatedBy?: string;
+  version: 1;
+}
+
+function settingsDocRef(db: Firestore, orgId: string) {
+  return doc(db, `${getOrgRootPath(orgId)}/${PROJECT_DEPARTMENT_SETTINGS_PATH}`);
+}
+
+export function buildProjectDepartmentSettingsDoc(input: {
+  labels: unknown[];
+  actorId?: string;
+  now?: string;
+}): ProjectDepartmentSettingsDoc {
+  return {
+    options: buildProjectDepartmentSettingsOptions(input.labels),
+    updatedAt: input.now || new Date().toISOString(),
+    updatedBy: input.actorId || 'system',
+    version: 1,
+  };
+}
+
+export async function saveProjectDepartmentSettings(
+  db: Firestore,
+  orgId: string,
+  labels: unknown[],
+  actorId?: string,
+): Promise<void> {
+  await setDoc(
+    settingsDocRef(db, orgId),
+    buildProjectDepartmentSettingsDoc({ labels, actorId }),
+    { merge: false },
+  );
+}
+
+export function useProjectDepartmentSettings() {
+  const { db, isOnline, orgId } = useFirebase();
+  const [options, setOptions] = useState<string[]>(() => resolveProjectDepartmentSettingsOptions(null));
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!db || !isOnline || !orgId) {
+      setOptions(resolveProjectDepartmentSettingsOptions(null));
+      setIsLoading(false);
+      setError(null);
+      return undefined;
+    }
+
+    setIsLoading(true);
+    return onSnapshot(settingsDocRef(db, orgId), (snapshot) => {
+      setOptions(resolveProjectDepartmentSettingsOptions(snapshot.exists() ? snapshot.data() : null));
+      setIsLoading(false);
+      setError(null);
+    }, (snapshotError) => {
+      console.error('[ProjectDepartmentSettings] listen failed:', snapshotError);
+      setOptions(resolveProjectDepartmentSettingsOptions(null));
+      setIsLoading(false);
+      setError(snapshotError instanceof Error ? snapshotError.message : '조직/소속 옵션을 불러오지 못했습니다.');
+    });
+  }, [db, isOnline, orgId]);
+
+  const saveOptions = useMemo(() => async (labels: unknown[], actorId?: string) => {
+    if (!db || !orgId) {
+      throw new Error('Firestore 연결이 필요합니다.');
+    }
+    await saveProjectDepartmentSettings(db, orgId, labels, actorId);
+  }, [db, orgId]);
+
+  return {
+    options,
+    isLoading,
+    error,
+    saveOptions,
+    fallbackOptions: [...PROJECT_DEPARTMENT_OPTIONS],
+  };
+}

--- a/src/app/platform/firestore-rules-policy.test.ts
+++ b/src/app/platform/firestore-rules-policy.test.ts
@@ -159,8 +159,8 @@ describe('firestore rules policy alignment', () => {
   it('keeps business-card PII collections behind BFF-only Firestore rules', () => {
     expect(firestoreRulesText).toContain('function isBffOnlyCollection(collection)');
     expect(firestoreRulesText).toContain("['contacts', 'business_card_imports', 'contact_events']");
-    expect(firestoreRulesText).toContain('allow read: if !isCatchallExcludedCollection(collection) && canRead(orgId);');
-    expect(firestoreRulesText).toContain('allow write: if !isCatchallExcludedCollection(collection) && canWrite(orgId);');
+    expect(firestoreRulesText).toContain('allow read: if !isCatchallExcludedPath(collection, document) && canRead(orgId);');
+    expect(firestoreRulesText).toContain('allow write: if !isCatchallExcludedPath(collection, document) && canWrite(orgId);');
   });
 
   it('keeps project request drafts hidden from admin review surfaces until submission', () => {
@@ -170,8 +170,15 @@ describe('firestore rules policy alignment', () => {
     expect(firestoreRulesText).toContain("request.resource.data.status in ['DRAFT', 'SUBMITTED', 'DISCARDED']");
     expect(firestoreRulesText).toContain('function isCatchallExcludedCollection(collection)');
     expect(firestoreRulesText).toContain("collection in ['projectRequestDrafts']");
-    expect(firestoreRulesText).toContain('allow read: if !isCatchallExcludedCollection(collection) && canRead(orgId);');
-    expect(firestoreRulesText).toContain('allow write: if !isCatchallExcludedCollection(collection) && canWrite(orgId);');
+    expect(firestoreRulesText).toContain('allow read: if !isCatchallExcludedPath(collection, document) && canRead(orgId);');
+    expect(firestoreRulesText).toContain('allow write: if !isCatchallExcludedPath(collection, document) && canWrite(orgId);');
+  });
+
+  it('keeps project option settings admin-managed', () => {
+    expect(firestoreRulesText).toContain('match /orgs/{orgId}/settings/project-departments');
+    expect(firestoreRulesText).toContain('allow read: if canRead(orgId);');
+    expect(firestoreRulesText).toContain('allow write: if isAdmin(orgId);');
+    expect(firestoreRulesText).toContain("(collection == 'settings' && document == 'project-departments')");
   });
 
   it('keeps business-card source images behind BFF-only Storage rules', () => {

--- a/src/app/platform/project-change-request.test.ts
+++ b/src/app/platform/project-change-request.test.ts
@@ -109,6 +109,29 @@ describe('project change request helpers', () => {
     expect(collectUndefinedPaths(request)).toEqual([]);
   });
 
+  it('normalizes department labels in change request snapshots and payload', () => {
+    const draft = createProjectEditorDraft({
+      ...baseProject,
+      department: 'CIC 2',
+    });
+    const request = buildProjectChangeRequest({
+      baseProject: {
+        ...baseProject,
+        department: 'CIC 2',
+      },
+      draft,
+      actorId: 'u-berry',
+      actorName: '김인효(베리)',
+      actorEmail: 'berry@example.com',
+      tenantId: 'mysc',
+      requestedAt: '2026-05-29T01:29:00.000Z',
+    });
+
+    expect(request.beforeSnapshot?.department).toBe('CIC2');
+    expect(request.proposedSnapshot?.department).toBe('CIC2');
+    expect(request.payload.department).toBe('CIC2');
+  });
+
   it('applies an approved request payload as a project patch', () => {
     const draft = createProjectEditorDraft({
       ...baseProject,

--- a/src/app/platform/project-change-request.ts
+++ b/src/app/platform/project-change-request.ts
@@ -9,7 +9,7 @@ import { normalizeProjectStatus } from '../data/types';
 import { buildProjectRequestPayloadFromDraft, type ProjectEditorDraft } from './project-editor';
 import { buildProjectEditorReviewChanges } from './project-editor';
 import { normalizeProjectRevenueFields } from './project-financials';
-import { resolveProjectCic } from './project-cic';
+import { normalizeProjectDepartment, resolveProjectCic } from './project-cic';
 
 function text(value: unknown): string {
   return String(value || '').trim();
@@ -115,7 +115,7 @@ export function buildProjectPayloadFromProject(project: Project): ProjectRequest
     phase: project.phase,
     description: text(project.description),
     clientOrg: text(project.clientOrg),
-    department: text(project.department),
+    department: normalizeProjectDepartment(project.department),
     groupwareName: text(project.groupwareName),
     currency: project.currency || 'KRW',
     contractAmount: numeric(project.contractAmount),
@@ -227,7 +227,7 @@ export function buildProjectPatchFromRequestPayload(
     phase: payload.phase || input.baseProject.phase,
     description: text(payload.description),
     clientOrg: text(payload.clientOrg),
-    department: text(payload.department),
+    department: normalizeProjectDepartment(payload.department),
     cic: resolveProjectCic({ department: payload.department }),
     groupwareName: text(payload.groupwareName),
     currency: payload.currency || 'KRW',

--- a/src/app/platform/project-cic.test.ts
+++ b/src/app/platform/project-cic.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { deriveProjectCicFromDepartment, getProjectRegistrationCicOptions, normalizeStoredCic, resolveProjectCic } from './project-cic';
+import { deriveProjectCicFromDepartment, getProjectRegistrationCicOptions, normalizeProjectDepartment, normalizeStoredCic, resolveProjectCic } from './project-cic';
 
 describe('project-cic', () => {
   it('normalizes stored cic values', () => {
     expect(normalizeStoredCic('CIC1')).toBe('CIC1');
+    expect(normalizeStoredCic('CIC 2')).toBe('CIC2');
     expect(normalizeStoredCic('미지정')).toBeUndefined();
     expect(normalizeStoredCic('')).toBeUndefined();
   });
@@ -13,7 +14,14 @@ describe('project-cic', () => {
     expect(deriveProjectCicFromDepartment('cic 3')).toBe('CIC3');
     expect(deriveProjectCicFromDepartment('C-스템CIC')).toBe('C-스템CIC');
     expect(deriveProjectCicFromDepartment('개발협력센터')).toBe('개발협력센터');
+    expect(deriveProjectCicFromDepartment('공간플랫폼센터')).toBe('공간플랫폼센터');
     expect(deriveProjectCicFromDepartment('투자센터')).toBe('투자센터');
+  });
+
+  it('normalizes stored department labels before project writes', () => {
+    expect(normalizeProjectDepartment('CIC 2')).toBe('CIC2');
+    expect(normalizeProjectDepartment(' 투자센터 ')).toBe('투자센터');
+    expect(normalizeProjectDepartment('미지정')).toBe('');
   });
 
   it('prefers explicit cic and falls back to department-derived cic', () => {
@@ -25,6 +33,7 @@ describe('project-cic', () => {
   it('exposes registration organization options from the project registration source list', () => {
     expect(getProjectRegistrationCicOptions()).toEqual([
       '개발협력센터',
+      '공간플랫폼센터',
       '글로벌센터',
       '조인트액션',
       '투자센터',

--- a/src/app/platform/project-cic.ts
+++ b/src/app/platform/project-cic.ts
@@ -6,7 +6,7 @@ function normalizeRaw(value: unknown): string {
 }
 
 export function normalizeStoredCic(value: unknown): string | undefined {
-  const normalized = normalizeRaw(value);
+  const normalized = deriveProjectCicFromDepartment(value);
   if (!normalized || normalized === '미지정') return undefined;
   return normalized;
 }
@@ -17,6 +17,10 @@ export function deriveProjectCicFromDepartment(department: unknown): string | un
   return /^cic\s*\d+$/i.test(normalized)
     ? normalized.toUpperCase().replace(/\s+/g, '')
     : normalized;
+}
+
+export function normalizeProjectDepartment(value: unknown): string {
+  return deriveProjectCicFromDepartment(value) || '';
 }
 
 export function resolveProjectCic(projectLike: Pick<Project, 'cic' | 'department'> | { cic?: string; department?: string }): string | undefined {

--- a/src/app/platform/project-editor.test.ts
+++ b/src/app/platform/project-editor.test.ts
@@ -327,6 +327,29 @@ describe('project editor draft mapping', () => {
     expect(patch.cic).toBe('CIC2');
   });
 
+  it('normalizes legacy spaced CIC labels before saving 담당조직', () => {
+    const existingProject = {
+      ...baseProject,
+      cic: 'CIC1',
+      department: 'CIC1',
+    };
+    const draft = createProjectEditorDraft({
+      ...buildProjectEditorDraftFromProject(existingProject),
+      department: 'CIC 2',
+    });
+
+    const patch = buildProjectEditorProjectPatch(draft, {
+      baseProject: existingProject,
+      mode: 'admin',
+      actorId: 'admin-1',
+      actorName: '관리자',
+      now: '2026-05-20T00:00:00.000Z',
+    });
+
+    expect(patch.department).toBe('CIC2');
+    expect(patch.cic).toBe('CIC2');
+  });
+
   it('keeps zero-won payment split values visible in deterministic review changes', () => {
     const draft = createProjectEditorDraft({
       ...buildProjectEditorDraftFromProject({

--- a/src/app/platform/project-editor.ts
+++ b/src/app/platform/project-editor.ts
@@ -44,7 +44,7 @@ import {
   formatProjectTeamMembersSummary,
   normalizeProjectTeamMembers,
 } from './project-team-members';
-import { resolveProjectCic } from './project-cic';
+import { normalizeProjectDepartment, resolveProjectCic } from './project-cic';
 
 export type ProjectEditorMode = 'portal-register' | 'portal-edit' | 'admin';
 
@@ -288,7 +288,7 @@ export function buildProjectEditorDraftFromProject(
     type: normalizeProjectType(normalizedProject.type || payload?.type),
     description: text(normalizedProject.description || payload?.description),
     clientOrg: text(normalizedProject.clientOrg || payload?.clientOrg),
-    department: text(normalizedProject.department || payload?.department),
+    department: normalizeProjectDepartment(normalizedProject.department || payload?.department),
     projectPurpose: text(normalizedProject.projectPurpose || payload?.projectPurpose),
     status: normalizeProjectStatus(normalizedProject.status),
     phase: normalizeProjectPhase(normalizedProject.phase),
@@ -351,7 +351,7 @@ export function buildProjectRequestPayloadFromDraft(draftInput: ProjectEditorDra
     phase: normalizeProjectPhase(draft.phase),
     description: text(draft.description),
     clientOrg: text(draft.clientOrg),
-    department: text(draft.department),
+    department: normalizeProjectDepartment(draft.department),
     groupwareName: text(draft.groupwareName),
     currency: normalizeProjectCurrency(draft.currency),
     contractAmount: nonNegativeAmount(draft.contractAmount),
@@ -473,7 +473,7 @@ export function buildProjectEditorProjectPatch(
     settlementGuide: text(draft.settlementGuide),
     contractDocument: draft.contractDocument,
     contractAnalysis: draft.contractAnalysis,
-    department: text(draft.department),
+    department: normalizeProjectDepartment(draft.department),
     cic: resolveProjectCic({ department: draft.department }),
     teamName: text(draft.teamName),
     registeredById: text(draft.registeredById),


### PR DESCRIPTION
## Summary
- move project department/CIC options to admin-managed Firestore settings with rules guardrails
- remove cashflow monitoring presets, projection/actual copy actions, row-info display, and obsolete unsaved weekly expense dialog
- add comma-formatted numeric inputs without changing stored numeric data
- brand the admin settings/member surface with the MYSCube wordmark and navy active states

## Verification
- npm run qa:understand:gate
- vitest run targeted project/cashflow/settings/firestore tests
- npm run build
- Playwright smoke on /settings?tab=members
