### PR TITLE
fix: separate production deploy token secret

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -30,7 +30,9 @@ jobs:
       VERCEL_CLI_PACKAGE: vercel@50.14.0
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      # Use a production-scoped secret name so a stale repository-level
+      # VERCEL_TOKEN cannot be confused with the Production environment token.
+      VERCEL_TOKEN: ${{ secrets.VERCEL_DEPLOY_TOKEN_PRODUCTION }}
 
     steps:
       - name: Check production ref
@@ -70,7 +72,7 @@ jobs:
 
       - name: Verify Vercel credentials are configured
         run: |
-          test -n "${VERCEL_TOKEN}" || { echo "Missing secret: VERCEL_TOKEN" >&2; exit 1; }
+          test -n "${VERCEL_TOKEN}" || { echo "Missing secret: VERCEL_DEPLOY_TOKEN_PRODUCTION" >&2; exit 1; }
           test -n "${VERCEL_ORG_ID}" || { echo "Missing secret: VERCEL_ORG_ID" >&2; exit 1; }
           test -n "${VERCEL_PROJECT_ID}" || { echo "Missing secret: VERCEL_PROJECT_ID" >&2; exit 1; }
 

--- a/docs/operations/2026-05-26-production-deployment-governance.md
+++ b/docs/operations/2026-05-26-production-deployment-governance.md
@@ -80,7 +80,8 @@ Applied on 2026-05-26 in this branch:
 
 Still required before using the workflow:
 
-- Create a dedicated Vercel deploy token and set it as `VERCEL_TOKEN` in the GitHub `Production` environment.
+- Create a dedicated Vercel deploy token and set it as `VERCEL_DEPLOY_TOKEN_PRODUCTION` in the GitHub `Production` environment.
+  Do not use a generic `VERCEL_TOKEN` secret for this workflow: GitHub Actions resolves environment secrets ahead of repository secrets when a job declares `environment: Production`, so changing only the repository secret can leave production deploys using a stale environment-scoped token.
 - Keep `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` set in the GitHub `Production` environment.
 - Keep production BFF environment variables in Vercel:
   - `BFF_DEPLOY_ENV=live`
@@ -92,7 +93,7 @@ Still required before using the workflow:
 Operational check on 2026-05-26:
 
 - GitHub `Production` environment has `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID`.
-- GitHub `Production` environment is missing `VERCEL_TOKEN`.
+- GitHub `Production` environment is missing `VERCEL_DEPLOY_TOKEN_PRODUCTION`.
 - Vercel production environment contains `BFF_DEPLOY_ENV`, `FIREBASE_PROJECT_ID`, `BFF_ALLOWED_ORIGINS`, `BFF_SCHEDULER_OWNER`, and `CRON_SECRET`.
 
 ## Stage And Live Separation

--- a/server/production-deploy-workflow.test.ts
+++ b/server/production-deploy-workflow.test.ts
@@ -54,4 +54,10 @@ describe('production deployment workflow safety', () => {
     expect(workflowText).toContain('| tail -n 1 || true)"');
     expect(workflowText).toContain('Could not parse Vercel deployment URL');
   });
+
+  it('uses a production-scoped Vercel token secret to avoid repo/environment name shadowing', () => {
+    expect(workflowText).toContain('VERCEL_DEPLOY_TOKEN_PRODUCTION');
+    expect(workflowText).not.toContain('VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}');
+    expect(workflowText).toContain('Missing secret: VERCEL_DEPLOY_TOKEN_PRODUCTION');
+  });
 });

--- a/src/app/platform/admin-foundation.shell.test.ts
+++ b/src/app/platform/admin-foundation.shell.test.ts
@@ -19,7 +19,9 @@ describe('admin monitoring foundation shell contract', () => {
     expect(navConfigSource).toContain("label: '캐시플로 모니터링'");
     expect(navConfigSource).toContain("label: '프로젝트 등록/승인'");
     expect(navConfigSource).toContain("to: '/users'");
-    expect(navConfigSource).toContain("label: '권한/사용자'");
+    expect(navConfigSource).toContain("label: '사용자 관리'");
+    expect(navConfigSource).toContain("to: '/settings?tab=org'");
+    expect(navConfigSource).toContain("label: '조직 관리'");
     expect(navConfigSource).not.toContain("label: '캐시플로 추출'");
     expect(navConfigSource).not.toContain("label: '사업이관'");
   });

--- a/src/app/platform/nav-config.ts
+++ b/src/app/platform/nav-config.ts
@@ -1,7 +1,7 @@
 import type { LucideIcon } from 'lucide-react';
 import {
   LayoutDashboard, FolderKanban, BarChart3,
-  FileCheck, Settings, Shield, ClipboardList, ClipboardCheck,
+  FileCheck, Building2, Shield, ClipboardList, ClipboardCheck,
   Calculator, Wallet, UserCog,
   ListChecks, MessagesSquare, UserRoundCheck,
   CircleDollarSign, ArrowLeftRight,
@@ -53,8 +53,8 @@ export const NAV_GROUPS: NavGroup[] = [
     items: [
       { to: '/business-cards', icon: UserRoundCheck, label: '명함 DB' },
       { to: '/approvals', icon: ListChecks, label: '승인 대기열', accent: true },
-      { to: '/users', icon: UserCog, label: '권한/사용자' },
-      { to: '/settings', icon: Settings, label: '설정' },
+      { to: '/users', icon: UserCog, label: '사용자 관리' },
+      { to: '/settings?tab=org', icon: Building2, label: '조직 관리' },
     ],
   },
 ];


### PR DESCRIPTION
## Summary
- use VERCEL_DEPLOY_TOKEN_PRODUCTION for the Production Deploy workflow to avoid repository/environment VERCEL_TOKEN shadowing
- expose 사용자 관리 and 조직 관리 as explicit admin nav entries
- add workflow/nav regression coverage and update the production deployment governance note

## Verification
- npx vitest run server/production-deploy-workflow.test.ts src/app/platform/admin-foundation.shell.test.ts
- npm run build
- git diff --check

Note: GitNexus detect-changes could not be run because npx gitnexus would require fetching/executing an npm package and the sandbox approval was rejected.