### PR TITLE
fix(settings): allow org DB reads and dedupe members

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -49,6 +49,11 @@ service cloud.firestore {
         && getMemberRole(orgId) in ['admin'];
     }
 
+    // 최상위 조직 DB(tenants)는 전역 운영 조직(mysc)의 admin만 관리한다.
+    function isPlatformAdmin() {
+      return isAdmin('mysc');
+    }
+
     // 감사/재무 접근 (audit_logs 읽기용)
     function canReadAuditLogs(orgId) {
       return isMember(orgId)
@@ -71,6 +76,14 @@ service cloud.firestore {
     function isCatchallExcludedPath(collection, document) {
       return isCatchallExcludedCollection(collection)
         || (collection == 'settings' && document == 'project-departments');
+    }
+
+    // ══════════════════════════════════════════════════════════════
+    // 최상위 조직 DB 규칙
+    // ══════════════════════════════════════════════════════════════
+
+    match /tenants/{tenantId} {
+      allow read, write: if isPlatformAdmin();
     }
 
     // ══════════════════════════════════════════════════════════════

--- a/src/app/data/member-documents.test.ts
+++ b/src/app/data/member-documents.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { resolveMemberProjectAccessState } from './member-workspace';
 import { buildLegacyMemberDocId, mergeMemberRecordSources } from './member-documents';
+import { buildMemberDirectoryList } from '../lib/firestore-service';
 
 describe('member document helpers', () => {
   it('builds the legacy email-key member id from normalized email', () => {
@@ -68,5 +69,37 @@ describe('member document helpers', () => {
       email: 'hong@mysc.co.kr',
       role: 'viewer',
     });
+  });
+
+  it('lets the member listener collapse canonical and legacy email documents', () => {
+    const members = buildMemberDirectoryList([
+      {
+        id: 'uid-1',
+        data: {
+          uid: 'uid-1',
+          name: '홍길동',
+          email: 'hong@mysc.co.kr',
+          role: 'pm',
+        },
+      },
+      {
+        id: 'hong_mysc_co_kr',
+        data: {
+          uid: 'uid-1',
+          name: '홍길동 legacy',
+          email: 'hong@mysc.co.kr',
+          role: 'admin',
+          projectIds: ['p1'],
+        },
+      },
+    ]);
+
+    expect(members).toEqual([{
+      uid: 'uid-1',
+      name: '홍길동',
+      email: 'hong@mysc.co.kr',
+      role: 'pm',
+      avatarUrl: undefined,
+    }]);
   });
 });

--- a/src/app/lib/firestore-service.ts
+++ b/src/app/lib/firestore-service.ts
@@ -17,6 +17,8 @@ import {
 import { getOrgCollectionPath, getOrgDocumentPath } from './firebase';
 import type { OrgMember, ParticipationEntry, TransactionState } from '../data/types';
 import type { MyscEmployee, ParticipationProject } from '../data/participation-data';
+import { buildLegacyMemberDocId, mergeMemberRecordSources } from '../data/member-documents';
+import { normalizeEmail } from '../data/auth-helpers';
 import {
   createAuditLogEntry,
   writeAuditLogDoc,
@@ -32,6 +34,11 @@ const SYSTEM_ACTOR: AuditActorContext = {
   name: 'System',
 };
 const TRANSACTION_STATES: TransactionState[] = ['DRAFT', 'SUBMITTED', 'APPROVED', 'REJECTED'];
+
+export interface MemberDirectoryDocInput {
+  id: string;
+  data: Record<string, unknown>;
+}
 
 function assertActorId(actorId: string | undefined): string {
   const normalized = (actorId || '').trim();
@@ -165,22 +172,53 @@ export function listenMembers(
   callback: (members: OrgMember[]) => void,
 ): Unsubscribe {
   return onSnapshot(colRef(db, orgId, 'members'), (snap) => {
-    const list: OrgMember[] = [];
+    const docs: MemberDirectoryDocInput[] = [];
+
     snap.forEach((d) => {
-      const raw = d.data() as Partial<OrgMember>;
-      list.push({
-        uid: (raw.uid || d.id).trim(),
-        name: raw.name || '',
-        email: raw.email || '',
-        role: raw.role || 'pm',
-        avatarUrl: raw.avatarUrl,
-      });
+      docs.push({ id: d.id, data: d.data() as Record<string, unknown> });
     });
-    list.sort((a, b) => String(a.name || '').localeCompare(String(b.name || ''), 'ko'));
-    callback(list);
+
+    callback(buildMemberDirectoryList(docs));
   }, (err) => {
     console.error('[Firestore] members listen error:', err);
   });
+}
+
+export function buildMemberDirectoryList(docs: MemberDirectoryDocInput[]): OrgMember[] {
+  const byIdentity = new Map<string, {
+    canonical?: Record<string, unknown>;
+    legacy?: Record<string, unknown>;
+  }>();
+
+  docs.forEach((docInput) => {
+    const raw = docInput.data;
+    const uid = typeof raw.uid === 'string' && raw.uid.trim() ? raw.uid.trim() : docInput.id;
+    const email = normalizeEmail(typeof raw.email === 'string' ? raw.email : '');
+    const legacyId = buildLegacyMemberDocId(email);
+    const key = email ? `email:${email}` : `uid:${uid}`;
+    const bucket = byIdentity.get(key) || {};
+    const record = { ...raw, uid };
+    if (legacyId && docInput.id === legacyId && legacyId !== uid) {
+      bucket.legacy = record;
+    } else {
+      bucket.canonical = record;
+    }
+    byIdentity.set(key, bucket);
+  });
+
+  const list: OrgMember[] = Array.from(byIdentity.values()).map(({ canonical, legacy }) => {
+    const merged = mergeMemberRecordSources(canonical, legacy) || {};
+    return {
+      uid: String(merged.uid || '').trim(),
+      name: String(merged.name || ''),
+      email: String(merged.email || ''),
+      role: (merged.role || 'pm') as OrgMember['role'],
+      avatarUrl: typeof merged.avatarUrl === 'string' ? merged.avatarUrl : undefined,
+    };
+  }).filter((member) => member.uid);
+
+  list.sort((a, b) => String(a.name || '').localeCompare(String(b.name || ''), 'ko'));
+  return list;
 }
 
 export async function upsertMember(

--- a/src/app/platform/firestore-rules-policy.test.ts
+++ b/src/app/platform/firestore-rules-policy.test.ts
@@ -95,6 +95,8 @@ describe('firestore rules policy alignment', () => {
   it('admin can manage users and tenants', () => {
     expect(hasPermission('admin', 'user:manage')).toBe(true);
     expect(hasPermission('admin', 'tenant:manage')).toBe(true);
+    expect(firestoreRulesText).toContain('match /tenants/{tenantId}');
+    expect(firestoreRulesText).toContain('allow read, write: if isPlatformAdmin();');
   });
 
   // ── canAccessProject: project-scoped ──


### PR DESCRIPTION
## Summary
- Allow platform admins to read/write the top-level tenants collection used by 조직DB
- Collapse canonical UID and legacy email member documents before rendering 멤버DB counts
- Add regression coverage for Firestore rules and member directory dedupe

## Why
Live 조직DB showed Missing or insufficient permissions because /tenants had no Firestore rule. 멤버DB showed inflated counts because canonical and legacy member docs were counted separately.

## Verification
- npx vitest run src/app/platform/firestore-rules-policy.test.ts src/app/data/member-documents.test.ts src/app/lib/firestore-service.test.ts
- npm run policy:verify
- npm run build
- npm test