### PR TITLE
fix(settings): simplify admin DB surface

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -49,9 +49,20 @@ service cloud.firestore {
         && getMemberRole(orgId) in ['admin'];
     }
 
-    // 최상위 조직 DB(tenants)는 전역 운영 조직(mysc)의 admin만 관리한다.
-    function isPlatformAdmin() {
-      return isAdmin('mysc');
+    function canReadTenant() {
+      return resource.data.adminOrgId is string
+        && isAdmin(resource.data.adminOrgId);
+    }
+
+    function canCreateTenant(tenantId) {
+      return request.resource.data.id == tenantId
+        && request.resource.data.adminOrgId is string
+        && isAdmin(request.resource.data.adminOrgId);
+    }
+
+    function canUpdateTenant() {
+      return canReadTenant()
+        && request.resource.data.adminOrgId == resource.data.adminOrgId;
     }
 
     // 감사/재무 접근 (audit_logs 읽기용)
@@ -83,7 +94,9 @@ service cloud.firestore {
     // ══════════════════════════════════════════════════════════════
 
     match /tenants/{tenantId} {
-      allow read, write: if isPlatformAdmin();
+      allow read, delete: if canReadTenant();
+      allow create: if canCreateTenant(tenantId);
+      allow update: if canUpdateTenant();
     }
 
     // ══════════════════════════════════════════════════════════════

--- a/scripts/qa_understand_gate.mjs
+++ b/scripts/qa_understand_gate.mjs
@@ -79,9 +79,14 @@ expectContains('firebase/firestore.rules', 'isCatchallExcludedPath(collection, d
 expectContains('src/app/data/project-department-options.ts', 'sortOrder: number');
 expectContains('src/app/data/project-department-options.ts', '.sort((a, b) => {');
 expectContains('src/app/data/project-department-options.ts', '`${baseId}-${nextCount}`');
-expectContains('src/app/components/settings/SettingsPage.tsx', 'renderProjectSelectionValuesCard');
-expectContains('src/app/components/settings/SettingsPage.tsx', 'handleMoveDepartment');
-expectContains('src/app/components/settings/SettingsPage.tsx', '이미 등록된 담당조직(CIC)입니다.');
+expectContains('src/app/components/settings/SettingsPage.tsx', "const PRIMARY_SETTINGS_TABS = ['members', 'tenants'] as const;");
+expectContains('src/app/components/settings/SettingsPage.tsx', '관리자에게 필요한 멤버DB와 조직DB만 관리합니다');
+expectNotContains('src/app/components/settings/SettingsPage.tsx', 'renderProjectSelectionValuesCard');
+expectNotContains('src/app/components/settings/SettingsPage.tsx', 'handleMoveDepartment');
+expectNotContains('src/app/components/settings/SettingsPage.tsx', '이미 등록된 담당조직(CIC)입니다.');
+expectNotContains('src/app/components/settings/SettingsPage.tsx', '원장 템플릿');
+expectNotContains('src/app/components/settings/SettingsPage.tsx', '데이터 마이그레이션');
+expectNotContains('src/app/components/settings/SettingsPage.tsx', '조직 정보</CardTitle>');
 
 expectNotContains('src/app/components/projects/ProjectListPage.tsx', '모니터링 프리셋');
 expectNotContains('src/app/components/cashflow/CashflowProjectSheet.tsx', 'copyMonthValues');

--- a/src/app/components/settings/SettingsPage.shell.test.ts
+++ b/src/app/components/settings/SettingsPage.shell.test.ts
@@ -5,20 +5,23 @@ import { describe, expect, it } from 'vitest';
 const source = readFileSync(resolve(import.meta.dirname, 'SettingsPage.tsx'), 'utf8');
 
 describe('SettingsPage member directory contract', () => {
-  it('keeps project selection values admin-managed in the member tab', () => {
-    expect(source).toContain('프로젝트 선택값');
-    expect(source).toContain('새 담당조직(CIC)');
-    expect(source).toContain('useProjectDepartmentSettings');
-    expect(source).toContain('saveDepartmentOptions');
-    expect(source).toContain('handleRemoveDepartment');
-    expect(source).toContain('handleMoveDepartment');
-    expect(source).toContain('이미 등록된 담당조직(CIC)입니다.');
-    expect(source).toContain('<ArrowUp className="h-3.5 w-3.5" />');
-    expect(source).toContain('<ArrowDown className="h-3.5 w-3.5" />');
-    expect(source.indexOf('{renderProjectSelectionValuesCard()}')).toBeLessThan(source.indexOf('구성원 원장 추가/수정'));
-    expect(source).toContain('xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]');
+  it('keeps the admin DB surface limited to member and org databases', () => {
+    expect(source).toContain("const PRIMARY_SETTINGS_TABS = ['members', 'tenants'] as const;");
+    expect(source).toContain('관리자에게 필요한 멤버DB와 조직DB만 관리합니다');
     expect(source).toContain('구성원 원장 추가/수정');
-    expect(source).toContain("const PRIMARY_SETTINGS_TABS = ['org', 'members', 'tenants', 'templates', 'migration', 'permissions'] as const;");
+    expect(source).toContain('조직DB');
+    expect(source).not.toContain('프로젝트 선택값');
+    expect(source).not.toContain('새 담당조직(CIC)');
+    expect(source).not.toContain('useProjectDepartmentSettings');
+    expect(source).not.toContain('saveDepartmentOptions');
+    expect(source).not.toContain('handleMoveDepartment');
+    expect(source).not.toContain('원장 템플릿');
+    expect(source).not.toContain('데이터 마이그레이션');
+    expect(source).not.toContain('조직 정보</CardTitle>');
+    expect(source).not.toContain("value=\"templates\"");
+    expect(source).not.toContain("value=\"migration\"");
+    expect(source).not.toContain("value=\"org\"");
+    expect(source).toContain('구성원 원장 추가/수정');
     expect(source).not.toContain("'project-options'");
   });
 
@@ -46,7 +49,7 @@ describe('SettingsPage member directory contract', () => {
 
   it('restores the tenant ledger tab instead of falling back to org settings', () => {
     expect(source).toContain("import { TenantManagementTab } from './TenantManagementTab';");
-    expect(source).toContain("PRIMARY_SETTINGS_TAB_SET.has(requestedTab) ? requestedTab : 'org'");
+    expect(source).toContain("PRIMARY_SETTINGS_TAB_SET.has(requestedTab) ? requestedTab : 'members'");
     expect(source).toContain('setTab(initialTab)');
     expect(source).toContain('<TabsTrigger value="tenants"');
     expect(source).toContain('조직DB');

--- a/src/app/components/settings/SettingsPage.tsx
+++ b/src/app/components/settings/SettingsPage.tsx
@@ -1,10 +1,9 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
-  Settings, Users, BookOpen, Building2, Upload, Shield, Search, Save, Trash2, ArrowUp, ArrowDown,
+  Settings, Users, Building2, Shield, Search, Save, Trash2,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { ROLE_META } from '../../platform/role-meta';
-import { hasPermission, type PlatformPermission } from '../../platform/rbac';
 import { useLocation, useNavigate } from 'react-router';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Button } from '../ui/button';
@@ -18,15 +17,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from '../ui/select';
-import { Separator } from '../ui/separator';
 import { useAppStore } from '../../data/store';
-import { useProjectDepartmentSettings } from '../../data/project-department-settings';
-import { normalizeProjectDepartmentOptionLabel } from '../../data/project-department-options';
-import {
-  CASHFLOW_CATEGORY_LABELS, SETTLEMENT_TYPE_LABELS, BASIS_LABELS,
-  type CashflowCategory,
-} from '../../data/types';
-import { DataMigrationTab } from './DataMigrationTab';
 import { TenantManagementTab } from './TenantManagementTab';
 import { PageHeader } from '../layout/PageHeader';
 import { useAuth } from '../../data/auth-store';
@@ -34,39 +25,20 @@ import { MyscWordmark } from '../brand/MyscWordmark';
 
 const DISPLAY_ROLES = ['admin', 'finance', 'pm'] as const;
 type DisplayRole = typeof DISPLAY_ROLES[number];
-const PRIMARY_SETTINGS_TABS = ['org', 'members', 'tenants', 'templates', 'migration', 'permissions'] as const;
+const PRIMARY_SETTINGS_TABS = ['members', 'tenants'] as const;
 const PRIMARY_SETTINGS_TAB_SET = new Set<string>(PRIMARY_SETTINGS_TABS);
 
-const PERMISSION_LABELS: Partial<Record<PlatformPermission, string>> = {
-  'project:write':       '프로젝트 생성/수정',
-  'ledger:write':        '원장 생성',
-  'transaction:submit':  '거래 입력/수정',
-  'transaction:approve': '거래 승인/반려',
-  'evidence:write':      '증빙 첨부',
-  'comment:write':       '댓글/제출',
-  'audit:read':          '감사 로그 조회',
-  'user:manage':         '구성원 관리',
-  'tenant:manage':       '설정 변경',
-};
-
 export function SettingsPage() {
-  const { org, members, templates, upsertMember, removeMember } = useAppStore();
-  const {
-    options: departmentOptions,
-    saveOptions: saveDepartmentOptions,
-  } = useProjectDepartmentSettings();
+  const { org, members, upsertMember, removeMember } = useAppStore();
   const { isAuthenticated, isLoading: authLoading, user } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
-  const requestedTab = searchParams.get('tab') || 'org';
-  const initialTab = PRIMARY_SETTINGS_TAB_SET.has(requestedTab) ? requestedTab : 'org';
+  const requestedTab = searchParams.get('tab') || 'members';
+  const initialTab = PRIMARY_SETTINGS_TAB_SET.has(requestedTab) ? requestedTab : 'members';
   const [tab, setTab] = useState(initialTab);
   const [memberSearch, setMemberSearch] = useState('');
   const [savingMember, setSavingMember] = useState(false);
-  const [savingDepartment, setSavingDepartment] = useState(false);
-  const [departmentDraft, setDepartmentDraft] = useState('');
-  const [editingDepartment, setEditingDepartment] = useState('');
   const [memberDraft, setMemberDraft] = useState({
     uid: '',
     name: '',
@@ -90,171 +62,6 @@ export function SettingsPage() {
   const resetMemberDraft = () => {
     setMemberDraft({ uid: '', name: '', email: '', role: 'pm' });
   };
-
-  const resetDepartmentDraft = () => {
-    setDepartmentDraft('');
-    setEditingDepartment('');
-  };
-
-  const handleSaveDepartment = async () => {
-    const label = normalizeProjectDepartmentOptionLabel(departmentDraft);
-    if (!label) {
-      toast.error('담당조직(CIC)을 입력해 주세요.');
-      return;
-    }
-    if (departmentOptions.includes(label) && label !== editingDepartment) {
-      toast.error('이미 등록된 담당조직(CIC)입니다.');
-      return;
-    }
-
-    const withoutEditing = departmentOptions.filter((option) => option !== editingDepartment && option !== label);
-    const nextOptions = editingDepartment
-      ? departmentOptions.map((option) => (option === editingDepartment ? label : option)).filter((option, index, list) => list.indexOf(option) === index)
-      : [...withoutEditing, label];
-
-    setSavingDepartment(true);
-    try {
-      await saveDepartmentOptions(nextOptions, user?.uid);
-      toast.success('프로젝트 선택값을 저장했습니다.');
-      resetDepartmentDraft();
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : '프로젝트 선택값 저장에 실패했습니다.');
-    } finally {
-      setSavingDepartment(false);
-    }
-  };
-
-  const handleRemoveDepartment = async (label: string) => {
-    if (!window.confirm(`${label} 옵션을 삭제할까요?`)) return;
-    setSavingDepartment(true);
-    try {
-      await saveDepartmentOptions(departmentOptions.filter((option) => option !== label), user?.uid);
-      toast.success('프로젝트 선택값을 삭제했습니다.');
-      if (editingDepartment === label) resetDepartmentDraft();
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : '프로젝트 선택값 삭제에 실패했습니다.');
-    } finally {
-      setSavingDepartment(false);
-    }
-  };
-
-  const handleMoveDepartment = async (label: string, direction: -1 | 1) => {
-    const index = departmentOptions.indexOf(label);
-    const nextIndex = index + direction;
-    if (index < 0 || nextIndex < 0 || nextIndex >= departmentOptions.length) return;
-    const nextOptions = [...departmentOptions];
-    [nextOptions[index], nextOptions[nextIndex]] = [nextOptions[nextIndex], nextOptions[index]];
-    setSavingDepartment(true);
-    try {
-      await saveDepartmentOptions(nextOptions, user?.uid);
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : '프로젝트 선택값 순서 저장에 실패했습니다.');
-    } finally {
-      setSavingDepartment(false);
-    }
-  };
-
-  const renderProjectSelectionValuesCard = () => (
-    <Card className="overflow-hidden border-slate-200 bg-white shadow-sm">
-      <CardHeader className="border-b border-slate-100 pb-4">
-        <div className="flex items-center justify-between gap-3">
-          <CardTitle className="text-base">프로젝트 선택값</CardTitle>
-          <Badge variant="outline" className="border-cyan-200 bg-accent text-[11px] text-accent-foreground">
-            {departmentOptions.length}개
-          </Badge>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-4 pt-5">
-        <div className="grid gap-3 lg:grid-cols-[1fr_auto_auto] lg:items-end">
-          <div>
-            <Label className="text-xs">새 담당조직(CIC)</Label>
-            <Input
-              value={departmentDraft}
-              onChange={(event) => setDepartmentDraft(event.target.value)}
-              placeholder="담당조직(CIC)"
-              className="mt-1 border-slate-300"
-            />
-          </div>
-          <Button type="button" onClick={() => void handleSaveDepartment()} disabled={savingDepartment} className="gap-2">
-            <Save className="h-4 w-4" /> {editingDepartment ? '수정 저장' : '추가'}
-          </Button>
-          <Button type="button" variant="outline" onClick={resetDepartmentDraft}>
-            초기화
-          </Button>
-        </div>
-        <div className="overflow-hidden rounded-lg border border-slate-200">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-[72px]">순서</TableHead>
-                <TableHead>담당조직(CIC)</TableHead>
-                <TableHead className="w-[180px] text-right">관리</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {departmentOptions.length ? departmentOptions.map((label, index) => (
-                <TableRow key={label}>
-                  <TableCell className="text-xs tabular-nums text-slate-500">{index + 1}</TableCell>
-                  <TableCell className="font-medium">{label}</TableCell>
-                  <TableCell className="text-right">
-                    <div className="flex justify-end gap-2">
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        aria-label={`${label} 위로 이동`}
-                        disabled={index === 0 || savingDepartment}
-                        onClick={() => void handleMoveDepartment(label, -1)}
-                      >
-                        <ArrowUp className="h-3.5 w-3.5" />
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        aria-label={`${label} 아래로 이동`}
-                        disabled={index === departmentOptions.length - 1 || savingDepartment}
-                        onClick={() => void handleMoveDepartment(label, 1)}
-                      >
-                        <ArrowDown className="h-3.5 w-3.5" />
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={() => {
-                          setDepartmentDraft(label);
-                          setEditingDepartment(label);
-                        }}
-                      >
-                        수정
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="border-slate-300 text-red-700 hover:text-red-700"
-                        aria-label={`${label} 삭제`}
-                        onClick={() => void handleRemoveDepartment(label)}
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </Button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              )) : (
-                <TableRow>
-                  <TableCell colSpan={3} className="py-6 text-center text-sm text-slate-500">
-                    등록된 담당조직이 없습니다
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
-        </div>
-      </CardContent>
-    </Card>
-  );
 
   const handleSaveMember = async () => {
     const uid = memberDraft.uid.trim();
@@ -331,8 +138,8 @@ export function SettingsPage() {
       <PageHeader
         icon={Settings}
         iconGradient="linear-gradient(135deg, #001e46, #001e46)"
-        title="설정"
-        description="운영에 필요한 조직, 멤버DB, 조직DB, 템플릿, 권한 설정만 관리합니다"
+        title="관리자 DB"
+        description="관리자에게 필요한 멤버DB와 조직DB만 관리합니다"
       />
 
       <div className="rounded-lg border border-slate-200 bg-white px-4 py-3 shadow-sm">
@@ -351,8 +158,8 @@ export function SettingsPage() {
               <p className="text-sm font-semibold tabular-nums text-primary">{members.length}명</p>
             </div>
             <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2">
-              <p className="text-[10px] font-medium text-slate-500">담당조직</p>
-              <p className="text-sm font-semibold tabular-nums text-primary">{departmentOptions.length}개</p>
+              <p className="text-[10px] font-medium text-slate-500">현재 조직</p>
+              <p className="text-sm font-semibold tabular-nums text-primary">{org.id}</p>
             </div>
           </div>
         </div>
@@ -360,66 +167,17 @@ export function SettingsPage() {
 
       <Tabs value={tab} onValueChange={setTab}>
         <TabsList className="w-full justify-start overflow-x-auto rounded-lg border border-slate-200 bg-white p-1 shadow-sm">
-          <TabsTrigger value="org" className="flex-none rounded-md px-3 text-xs data-[state=active]:bg-primary data-[state=active]:text-primary-foreground">
-            <Building2 className="w-3.5 h-3.5" /> 조직 정보
-          </TabsTrigger>
           <TabsTrigger value="members" className="flex-none rounded-md px-3 text-xs data-[state=active]:bg-primary data-[state=active]:text-primary-foreground">
             <Users className="w-3.5 h-3.5" /> 멤버DB
           </TabsTrigger>
           <TabsTrigger value="tenants" className="flex-none rounded-md px-3 text-xs data-[state=active]:bg-primary data-[state=active]:text-primary-foreground">
             <Building2 className="w-3.5 h-3.5" /> 조직DB
           </TabsTrigger>
-          <TabsTrigger value="templates" className="flex-none rounded-md px-3 text-xs data-[state=active]:bg-primary data-[state=active]:text-primary-foreground">
-            <BookOpen className="w-3.5 h-3.5" /> 원장 템플릿
-          </TabsTrigger>
-          <TabsTrigger value="migration" className="flex-none rounded-md px-3 text-xs data-[state=active]:bg-primary data-[state=active]:text-primary-foreground">
-            <Upload className="w-3.5 h-3.5" /> 데이터 마이그레이션
-          </TabsTrigger>
-          <TabsTrigger value="permissions" className="flex-none rounded-md px-3 text-xs data-[state=active]:bg-primary data-[state=active]:text-primary-foreground">
-            <Shield className="w-3.5 h-3.5" /> 권한 설정
-          </TabsTrigger>
         </TabsList>
-
-        {/* Organization */}
-        <TabsContent value="org">
-          <Card className="border-slate-200 bg-white shadow-sm">
-            <CardHeader className="border-b border-slate-100 pb-4">
-              <CardTitle className="text-base">조직 정보</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4 pt-5">
-              <div>
-                <Label>조직명</Label>
-                <Input value={org.name} readOnly className="max-w-sm" />
-              </div>
-              <div>
-                <Label>조직 ID</Label>
-                <Input value={org.id} readOnly className="max-w-sm" />
-              </div>
-              <div>
-                <Label>생성일</Label>
-                <Input value={new Date(org.createdAt).toLocaleDateString('ko-KR')} readOnly className="max-w-sm" />
-              </div>
-              <Separator />
-              <div>
-                <h4 className="mb-2">캐시플로 표준 항목 (Enum)</h4>
-                <div className="flex flex-wrap gap-1.5">
-                  {(Object.entries(CASHFLOW_CATEGORY_LABELS) as [CashflowCategory, string][]).map(([key, label]) => (
-                    <Badge key={key} variant="outline" className="text-xs">
-                      {label} ({key})
-                    </Badge>
-                  ))}
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </TabsContent>
 
         {/* Members */}
         <TabsContent value="members">
           <div className="space-y-4">
-            <div className="grid gap-4 xl:grid-cols-[minmax(0,0.95fr)_minmax(0,1.05fr)]">
-              {renderProjectSelectionValuesCard()}
-
               <Card className="overflow-hidden border-slate-200 bg-white shadow-sm">
                 <CardHeader className="border-b border-slate-100 pb-4">
                   <div className="flex items-center justify-between gap-3">
@@ -480,7 +238,6 @@ export function SettingsPage() {
                   </div>
                 </CardContent>
               </Card>
-            </div>
 
             <Card className="overflow-hidden border-slate-200 bg-white shadow-sm">
               <CardHeader className="border-b border-slate-100 pb-4">
@@ -559,108 +316,6 @@ export function SettingsPage() {
         {/* Tenants */}
         <TabsContent value="tenants">
           <TenantManagementTab />
-        </TabsContent>
-
-        {/* Templates */}
-        <TabsContent value="templates">
-          <div className="space-y-4">
-            {templates.map(tpl => (
-              <Card key={tpl.id}>
-                <CardHeader>
-                  <div className="flex items-center justify-between">
-                    <CardTitle className="text-base">{tpl.name}</CardTitle>
-                    <div className="flex items-center gap-2">
-                      <Badge variant="outline">v{tpl.version}</Badge>
-                      <Badge variant="secondary">{tpl.id}</Badge>
-                    </div>
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-3">
-                  <div className="grid grid-cols-2 gap-4 text-sm">
-                    <div>
-                      <p className="text-xs text-muted-foreground mb-1">기본 기준 (Basis)</p>
-                      <p>{BASIS_LABELS[tpl.defaultBasis]}</p>
-                    </div>
-                    <div>
-                      <p className="text-xs text-muted-foreground mb-1">승인 기준 금액</p>
-                      <p>{tpl.approvalThreshold.toLocaleString()}원 이상</p>
-                    </div>
-                    <div>
-                      <p className="text-xs text-muted-foreground mb-1">허용 정산유형</p>
-                      <div className="flex gap-1">
-                        {tpl.allowedSettlementTypes.map(s => (
-                          <Badge key={s} variant="outline" className="text-xs">{SETTLEMENT_TYPE_LABELS[s]}</Badge>
-                        ))}
-                      </div>
-                    </div>
-                    <div>
-                      <p className="text-xs text-muted-foreground mb-1">필수 증빙</p>
-                      <div className="flex gap-1">
-                        {tpl.evidenceRules.map(r => (
-                          <Badge key={r} variant="secondary" className="text-xs">{r}</Badge>
-                        ))}
-                      </div>
-                    </div>
-                  </div>
-                  <Separator />
-                  <div>
-                    <p className="text-xs text-muted-foreground mb-1">캐시플로 항목</p>
-                    <div className="flex flex-wrap gap-1">
-                      {tpl.cashflowEnums.map(c => (
-                        <Badge key={c} variant="outline" className="text-[10px]">
-                          {CASHFLOW_CATEGORY_LABELS[c]}
-                        </Badge>
-                      ))}
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </TabsContent>
-
-        {/* Data migration */}
-        <TabsContent value="migration">
-          <DataMigrationTab />
-        </TabsContent>
-
-        {/* Permissions */}
-        <TabsContent value="permissions">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">역할별 권한 매트릭스</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>권한</TableHead>
-                    {DISPLAY_ROLES.map(role => (
-                      <TableHead key={role} className="text-center">
-                        {ROLE_META[role].label}
-                      </TableHead>
-                    ))}
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {(Object.entries(PERMISSION_LABELS) as [PlatformPermission, string][]).map(([perm, label]) => (
-                    <TableRow key={perm}>
-                      <TableCell className="text-sm">{label}</TableCell>
-                      {DISPLAY_ROLES.map((role: DisplayRole) => (
-                        <TableCell key={role} className="text-center">
-                          {hasPermission(role, perm) ? (
-                            <span className="text-green-600">&#10003;</span>
-                          ) : (
-                            <span className="text-gray-300">&#10005;</span>
-                          )}
-                        </TableCell>
-                      ))}
-                    </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
-            </CardContent>
-          </Card>
         </TabsContent>
       </Tabs>
     </div>

--- a/src/app/components/settings/TenantManagementTab.shell.test.ts
+++ b/src/app/components/settings/TenantManagementTab.shell.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(import.meta.dirname, 'TenantManagementTab.tsx'), 'utf8');
+
+describe('TenantManagementTab shell contract', () => {
+  it('scopes organization DB entries to the active admin org without hard-coded org ids', () => {
+    expect(source).toContain("where('adminOrgId', '==', adminOrgId)");
+    expect(source).toContain('adminOrgId,');
+    expect(source).not.toContain("id === 'mysc'");
+    expect(source).not.toContain('mysc 기본 조직');
+  });
+});

--- a/src/app/components/settings/TenantManagementTab.tsx
+++ b/src/app/components/settings/TenantManagementTab.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Building2, Check, Loader2, Plus, RefreshCw, Trash2 } from 'lucide-react';
 import type { Firestore } from 'firebase/firestore';
 import {
-  collection, deleteDoc, doc, getDocs, limit, query, serverTimestamp, setDoc,
+  collection, deleteDoc, doc, getDocs, limit, query, serverTimestamp, setDoc, where,
 } from 'firebase/firestore';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
@@ -24,27 +24,33 @@ import { useFirebase } from '../../lib/firebase-context';
 interface TenantDoc {
   id: string;
   name: string;
+  adminOrgId?: string;
   createdAt?: string;
+  protected?: boolean;
   branding?: { primaryColor?: string; logoUrl?: string };
 }
 
 // ── Firestore helpers ──
 
-async function fetchTenants(db: Firestore): Promise<TenantDoc[]> {
-  const snap = await getDocs(query(collection(db, 'tenants'), limit(100)));
+async function fetchTenants(db: Firestore, adminOrgId: string): Promise<TenantDoc[]> {
+  const snap = await getDocs(query(collection(db, 'tenants'), where('adminOrgId', '==', adminOrgId), limit(100)));
   return snap.docs.map((d) => ({
     id: d.id,
     name: (d.data().name as string | undefined) || d.id,
+    adminOrgId: d.data().adminOrgId as string | undefined,
     createdAt: (d.data().createdAt as any)?.toDate?.()?.toISOString?.() || '',
+    protected: d.data().protected === true,
     branding: d.data().branding as TenantDoc['branding'],
   }));
 }
 
-async function createTenant(db: Firestore, id: string, name: string): Promise<void> {
+async function createTenant(db: Firestore, adminOrgId: string, id: string, name: string): Promise<void> {
   await setDoc(doc(db, 'tenants', id), {
     id,
     name: name || id,
+    adminOrgId,
     createdAt: serverTimestamp(),
+    protected: false,
     branding: {},
   });
 }
@@ -68,14 +74,14 @@ export function TenantManagementTab() {
     if (!db) return;
     setLoading(true);
     try {
-      const list = await fetchTenants(db);
+      const list = await fetchTenants(db, orgId);
       setTenants(list);
     } catch (err: any) {
       toast.error('조직 목록 로드 실패: ' + (err.message || ''));
     } finally {
       setLoading(false);
     }
-  }, [db]);
+  }, [db, orgId]);
 
   useEffect(() => { void loadTenants(); }, [loadTenants]);
 
@@ -89,7 +95,7 @@ export function TenantManagementTab() {
     if (!db) return;
     setCreating(true);
     try {
-      await createTenant(db, id, newName.trim() || id);
+      await createTenant(db, orgId, id, newName.trim() || id);
       toast.success(`조직 "${id}" 등록 완료`);
       setNewId('');
       setNewName('');
@@ -102,7 +108,8 @@ export function TenantManagementTab() {
   }, [db, newId, newName, loadTenants]);
 
   const handleDelete = useCallback(async (id: string) => {
-    if (id === 'mysc') { toast.error('mysc 기본 조직은 삭제할 수 없습니다'); return; }
+    const target = tenants.find((tenant) => tenant.id === id);
+    if (target?.protected) { toast.error('보호된 조직은 삭제할 수 없습니다'); return; }
     if (id === orgId) { toast.error('현재 활성 조직은 삭제할 수 없습니다'); return; }
     if (!db) return;
     try {
@@ -112,7 +119,7 @@ export function TenantManagementTab() {
     } catch (err: any) {
       toast.error('삭제 실패: ' + (err.message || ''));
     }
-  }, [db, orgId]);
+  }, [db, orgId, tenants]);
 
   return (
     <div className="space-y-6">
@@ -222,8 +229,8 @@ export function TenantManagementTab() {
                         variant="ghost"
                         size="sm"
                         className="h-6 w-6 p-0 text-muted-foreground hover:text-destructive"
-                        disabled={t.id === 'mysc' || t.id === orgId}
-                        title={t.id === 'mysc' ? '기본 조직은 삭제 불가' : t.id === orgId ? '활성 조직은 삭제 불가' : '삭제'}
+                        disabled={t.protected || t.id === orgId}
+                        title={t.protected ? '보호된 조직은 삭제 불가' : t.id === orgId ? '활성 조직은 삭제 불가' : '삭제'}
                         onClick={() => void handleDelete(t.id)}
                       >
                         <Trash2 className="w-3.5 h-3.5" />

--- a/src/app/data/member-documents.test.ts
+++ b/src/app/data/member-documents.test.ts
@@ -102,4 +102,39 @@ describe('member document helpers', () => {
       avatarUrl: undefined,
     }]);
   });
+
+  it('deduplicates multiple uid-keyed documents for the same email without relying on legacy ids', () => {
+    const members = buildMemberDirectoryList([
+      {
+        id: 'uid-old',
+        data: {
+          uid: 'uid-old',
+          name: '홍길동 이전',
+          email: 'hong@mysc.co.kr',
+          role: 'viewer',
+          status: 'INACTIVE',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        },
+      },
+      {
+        id: 'uid-current',
+        data: {
+          uid: 'uid-current',
+          name: '홍길동',
+          email: 'hong@mysc.co.kr',
+          role: 'pm',
+          status: 'ACTIVE',
+          updatedAt: '2026-02-01T00:00:00.000Z',
+        },
+      },
+    ]);
+
+    expect(members).toEqual([{
+      uid: 'uid-current',
+      name: '홍길동',
+      email: 'hong@mysc.co.kr',
+      role: 'pm',
+      avatarUrl: undefined,
+    }]);
+  });
 });

--- a/src/app/lib/firestore-service.ts
+++ b/src/app/lib/firestore-service.ts
@@ -186,8 +186,8 @@ export function listenMembers(
 
 export function buildMemberDirectoryList(docs: MemberDirectoryDocInput[]): OrgMember[] {
   const byIdentity = new Map<string, {
-    canonical?: Record<string, unknown>;
-    legacy?: Record<string, unknown>;
+    canonical: Record<string, unknown>[];
+    legacy: Record<string, unknown>[];
   }>();
 
   docs.forEach((docInput) => {
@@ -196,18 +196,20 @@ export function buildMemberDirectoryList(docs: MemberDirectoryDocInput[]): OrgMe
     const email = normalizeEmail(typeof raw.email === 'string' ? raw.email : '');
     const legacyId = buildLegacyMemberDocId(email);
     const key = email ? `email:${email}` : `uid:${uid}`;
-    const bucket = byIdentity.get(key) || {};
+    const bucket = byIdentity.get(key) || { canonical: [], legacy: [] };
     const record = { ...raw, uid };
     if (legacyId && docInput.id === legacyId && legacyId !== uid) {
-      bucket.legacy = record;
+      bucket.legacy.push(record);
     } else {
-      bucket.canonical = record;
+      bucket.canonical.push(record);
     }
     byIdentity.set(key, bucket);
   });
 
   const list: OrgMember[] = Array.from(byIdentity.values()).map(({ canonical, legacy }) => {
-    const merged = mergeMemberRecordSources(canonical, legacy) || {};
+    const canonicalRecord = mergeMemberRecordsByPreference(canonical);
+    const legacyRecord = mergeMemberRecordsByPreference(legacy);
+    const merged = mergeMemberRecordSources(canonicalRecord, legacyRecord) || {};
     return {
       uid: String(merged.uid || '').trim(),
       name: String(merged.name || ''),
@@ -219,6 +221,47 @@ export function buildMemberDirectoryList(docs: MemberDirectoryDocInput[]): OrgMe
 
   list.sort((a, b) => String(a.name || '').localeCompare(String(b.name || ''), 'ko'));
   return list;
+}
+
+function mergeMemberRecordsByPreference(records: Record<string, unknown>[]): Record<string, unknown> | undefined {
+  const ranked = [...records].sort(compareMemberRecordPreference);
+  if (!ranked.length) return undefined;
+
+  return ranked.slice(1).reduce<Record<string, unknown>>((merged, record) => (
+    mergeMemberRecordSources(merged, record) || merged
+  ), ranked[0]);
+}
+
+function compareMemberRecordPreference(a: Record<string, unknown>, b: Record<string, unknown>): number {
+  return memberRecordScore(b) - memberRecordScore(a);
+}
+
+function memberRecordScore(record: Record<string, unknown>): number {
+  const status = String(record.status || '').trim().toUpperCase();
+  const activeScore = status === 'ACTIVE' ? 1000 : status === 'INACTIVE' || status === 'DELETED' ? -1000 : 0;
+  const completenessScore = ['uid', 'name', 'email', 'role'].reduce((score, field) => (
+    typeof record[field] === 'string' && String(record[field]).trim() ? score + 10 : score
+  ), 0);
+  const recencyScore = Math.max(
+    getTimestampScore(record.updatedAt),
+    getTimestampScore(record.lastLoginAt),
+    getTimestampScore(record.createdAt),
+  );
+
+  return activeScore + completenessScore + recencyScore;
+}
+
+function getTimestampScore(value: unknown): number {
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed / 1_000_000_000 : 0;
+  }
+  if (typeof value === 'object' && value !== null) {
+    const maybeDate = (value as { toDate?: () => Date }).toDate?.();
+    const millis = maybeDate?.getTime?.();
+    return typeof millis === 'number' && Number.isFinite(millis) ? millis / 1_000_000_000 : 0;
+  }
+  return 0;
 }
 
 export async function upsertMember(

--- a/src/app/platform/admin-foundation.shell.test.ts
+++ b/src/app/platform/admin-foundation.shell.test.ts
@@ -20,8 +20,8 @@ describe('admin monitoring foundation shell contract', () => {
     expect(navConfigSource).toContain("label: '프로젝트 등록/승인'");
     expect(navConfigSource).toContain("to: '/users'");
     expect(navConfigSource).toContain("label: '사용자 관리'");
-    expect(navConfigSource).toContain("to: '/settings?tab=org'");
-    expect(navConfigSource).toContain("label: '조직 정보'");
+    expect(navConfigSource).not.toContain("to: '/settings?tab=org'");
+    expect(navConfigSource).not.toContain("label: '조직 정보'");
     expect(navConfigSource).toContain("to: '/settings?tab=members'");
     expect(navConfigSource).toContain("label: '멤버DB'");
     expect(navConfigSource).toContain("to: '/settings?tab=tenants'");

--- a/src/app/platform/firestore-rules-policy.test.ts
+++ b/src/app/platform/firestore-rules-policy.test.ts
@@ -96,7 +96,10 @@ describe('firestore rules policy alignment', () => {
     expect(hasPermission('admin', 'user:manage')).toBe(true);
     expect(hasPermission('admin', 'tenant:manage')).toBe(true);
     expect(firestoreRulesText).toContain('match /tenants/{tenantId}');
-    expect(firestoreRulesText).toContain('allow read, write: if isPlatformAdmin();');
+    expect(firestoreRulesText).toContain('resource.data.adminOrgId');
+    expect(firestoreRulesText).toContain('request.resource.data.adminOrgId');
+    expect(firestoreRulesText).not.toContain('isPlatformAdmin');
+    expect(firestoreRulesText).not.toContain("isAdmin('mysc')");
   });
 
   // ── canAccessProject: project-scoped ──

--- a/src/app/platform/nav-config.ts
+++ b/src/app/platform/nav-config.ts
@@ -54,7 +54,6 @@ export const NAV_GROUPS: NavGroup[] = [
       { to: '/business-cards', icon: UserRoundCheck, label: '명함 DB' },
       { to: '/approvals', icon: ListChecks, label: '승인 대기열', accent: true },
       { to: '/users', icon: UserCog, label: '사용자 관리' },
-      { to: '/settings?tab=org', icon: Building2, label: '조직 정보' },
       { to: '/settings?tab=members', icon: UserCog, label: '멤버DB' },
       { to: '/settings?tab=tenants', icon: Building2, label: '조직DB' },
     ],


### PR DESCRIPTION
## Summary
- limit SettingsPage to 멤버DB and 조직DB only
- remove 조직 정보, 원장 템플릿, 데이터 마이그레이션, 권한 설정 from the admin DB surface
- remove hard-coded mysc tenant handling from org DB rules/UI and scope org DB by adminOrgId
- dedupe member DB rows by email instead of document-id assumptions
- update QA gate/tests for the reduced settings surface

## Verification
- npx vitest run src/app/components/settings/SettingsPage.shell.test.ts src/app/components/settings/TenantManagementTab.shell.test.ts src/app/platform/admin-foundation.shell.test.ts src/app/platform/firestore-rules-policy.test.ts src/app/data/member-documents.test.ts
- npm run policy:verify
- npm run build
- npx firebase-tools deploy --only firestore:rules --project inner-platform-live-20260316 --dry-run