### PR TITLE
fix(settings): scope org DB registry reads

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -49,22 +49,6 @@ service cloud.firestore {
         && getMemberRole(orgId) in ['admin'];
     }
 
-    function canReadTenant() {
-      return resource.data.adminOrgId is string
-        && isAdmin(resource.data.adminOrgId);
-    }
-
-    function canCreateTenant(tenantId) {
-      return request.resource.data.id == tenantId
-        && request.resource.data.adminOrgId is string
-        && isAdmin(request.resource.data.adminOrgId);
-    }
-
-    function canUpdateTenant() {
-      return canReadTenant()
-        && request.resource.data.adminOrgId == resource.data.adminOrgId;
-    }
-
     // 감사/재무 접근 (audit_logs 읽기용)
     function canReadAuditLogs(orgId) {
       return isMember(orgId)
@@ -90,13 +74,12 @@ service cloud.firestore {
     }
 
     // ══════════════════════════════════════════════════════════════
-    // 최상위 조직 DB 규칙
+    // 최상위 tenants는 클라이언트 목록 쿼리 권한을 안정적으로 검증할 수 없으므로 사용하지 않는다.
+    // 조직DB는 orgs/{orgId}/tenant_registry에서 조직 admin 권한으로 관리한다.
     // ══════════════════════════════════════════════════════════════
 
     match /tenants/{tenantId} {
-      allow read, delete: if canReadTenant();
-      allow create: if canCreateTenant(tenantId);
-      allow update: if canUpdateTenant();
+      allow read, write: if false;
     }
 
     // ══════════════════════════════════════════════════════════════
@@ -124,6 +107,21 @@ service cloud.firestore {
 
       // Admin: 역할 변경·삭제·타인 문서 수정 포함 모든 쓰기
       allow write: if isAdmin(orgId);
+    }
+
+    // ── 조직DB: 현재 조직 admin만 조직 registry를 관리 ──
+    match /orgs/{orgId}/tenant_registry/{tenantId} {
+      allow read: if isAdmin(orgId);
+
+      allow create: if isAdmin(orgId)
+        && request.resource.data.id == tenantId
+        && request.resource.data.adminOrgId == orgId;
+
+      allow update: if isAdmin(orgId)
+        && request.resource.data.adminOrgId == resource.data.adminOrgId;
+
+      allow delete: if isAdmin(orgId)
+        && resource.data.protected != true;
     }
 
     // ── 감사 로그: 클라이언트 쓰기 금지, 특정 역할만 읽기 ──

--- a/src/app/components/settings/TenantManagementTab.shell.test.ts
+++ b/src/app/components/settings/TenantManagementTab.shell.test.ts
@@ -6,6 +6,8 @@ const source = readFileSync(resolve(import.meta.dirname, 'TenantManagementTab.ts
 
 describe('TenantManagementTab shell contract', () => {
   it('scopes organization DB entries to the active admin org without hard-coded org ids', () => {
+    expect(source).toContain("collection(db, 'orgs', orgId, 'tenant_registry')");
+    expect(source).not.toContain("collection(db, 'tenants')");
     expect(source).toContain("where('adminOrgId', '==', adminOrgId)");
     expect(source).toContain('adminOrgId,');
     expect(source).not.toContain("id === 'mysc'");

--- a/src/app/components/settings/TenantManagementTab.tsx
+++ b/src/app/components/settings/TenantManagementTab.tsx
@@ -32,8 +32,12 @@ interface TenantDoc {
 
 // ── Firestore helpers ──
 
+function tenantRegistryCollection(db: Firestore, orgId: string) {
+  return collection(db, 'orgs', orgId, 'tenant_registry');
+}
+
 async function fetchTenants(db: Firestore, adminOrgId: string): Promise<TenantDoc[]> {
-  const snap = await getDocs(query(collection(db, 'tenants'), where('adminOrgId', '==', adminOrgId), limit(100)));
+  const snap = await getDocs(query(tenantRegistryCollection(db, adminOrgId), where('adminOrgId', '==', adminOrgId), limit(100)));
   return snap.docs.map((d) => ({
     id: d.id,
     name: (d.data().name as string | undefined) || d.id,
@@ -45,7 +49,7 @@ async function fetchTenants(db: Firestore, adminOrgId: string): Promise<TenantDo
 }
 
 async function createTenant(db: Firestore, adminOrgId: string, id: string, name: string): Promise<void> {
-  await setDoc(doc(db, 'tenants', id), {
+  await setDoc(doc(tenantRegistryCollection(db, adminOrgId), id), {
     id,
     name: name || id,
     adminOrgId,
@@ -55,8 +59,8 @@ async function createTenant(db: Firestore, adminOrgId: string, id: string, name:
   });
 }
 
-async function removeTenant(db: Firestore, id: string): Promise<void> {
-  await deleteDoc(doc(db, 'tenants', id));
+async function removeTenant(db: Firestore, adminOrgId: string, id: string): Promise<void> {
+  await deleteDoc(doc(tenantRegistryCollection(db, adminOrgId), id));
 }
 
 // ── Component ──
@@ -113,7 +117,7 @@ export function TenantManagementTab() {
     if (id === orgId) { toast.error('현재 활성 조직은 삭제할 수 없습니다'); return; }
     if (!db) return;
     try {
-      await removeTenant(db, id);
+      await removeTenant(db, orgId, id);
       toast.success(`조직 "${id}" 삭제됨`);
       setTenants((prev) => prev.filter((t) => t.id !== id));
     } catch (err: any) {

--- a/src/app/components/settings/TenantSwitcher.shell.test.ts
+++ b/src/app/components/settings/TenantSwitcher.shell.test.ts
@@ -14,4 +14,9 @@ describe('TenantSwitcher redirect contract', () => {
     expect(source).toContain("navigate('/settings?tab=tenants')");
     expect(source).toContain('신규 조직 등록');
   });
+
+  it('loads known organizations from the org-scoped registry', () => {
+    expect(source).toContain("collection(db, 'orgs', orgId, 'tenant_registry')");
+    expect(source).not.toContain("collection(db, 'tenants')");
+  });
 });

--- a/src/app/components/settings/TenantSwitcher.tsx
+++ b/src/app/components/settings/TenantSwitcher.tsx
@@ -20,9 +20,9 @@ interface TenantEntry {
 
 // ── Firestore tenant list loader ──
 
-async function loadKnownTenants(db: Firestore): Promise<TenantEntry[]> {
+async function loadKnownTenants(db: Firestore, orgId: string): Promise<TenantEntry[]> {
   try {
-    const snap = await getDocs(query(collection(db, 'tenants'), limit(50)));
+    const snap = await getDocs(query(collection(db, 'orgs', orgId, 'tenant_registry'), limit(50)));
     return snap.docs.map((doc) => ({
       id: doc.id,
       name: (doc.data().name as string | undefined) || doc.id,
@@ -57,10 +57,10 @@ export function TenantSwitcher({ collapsed = false, userRole, userTenantId }: Te
   useEffect(() => {
     if (!open || !db || loadedRef.current) return;
     loadedRef.current = true;
-    void loadKnownTenants(db).then((list) => {
+    void loadKnownTenants(db, orgId).then((list) => {
       if (list.length > 0) setTenants(list);
     });
-  }, [open, db]);
+  }, [open, db, orgId]);
 
   const handleSelect = useCallback((nextId: string) => {
     if (nextId === orgId) { setOpen(false); return; }

--- a/src/app/platform/firestore-rules-policy.test.ts
+++ b/src/app/platform/firestore-rules-policy.test.ts
@@ -96,7 +96,9 @@ describe('firestore rules policy alignment', () => {
     expect(hasPermission('admin', 'user:manage')).toBe(true);
     expect(hasPermission('admin', 'tenant:manage')).toBe(true);
     expect(firestoreRulesText).toContain('match /tenants/{tenantId}');
-    expect(firestoreRulesText).toContain('resource.data.adminOrgId');
+    expect(firestoreRulesText).toContain('allow read, write: if false;');
+    expect(firestoreRulesText).toContain('match /orgs/{orgId}/tenant_registry/{tenantId}');
+    expect(firestoreRulesText).toContain('allow read: if isAdmin(orgId);');
     expect(firestoreRulesText).toContain('request.resource.data.adminOrgId');
     expect(firestoreRulesText).not.toContain('isPlatformAdmin');
     expect(firestoreRulesText).not.toContain("isAdmin('mysc')");


### PR DESCRIPTION
## Summary
- move organization DB reads from top-level tenants to org-scoped orgs/{orgId}/tenant_registry
- update TenantSwitcher to use the same org-scoped registry
- make top-level tenants client-inaccessible to avoid list-query permission failures
- keep org DB registry admin-only without hard-coded org ids

## Verification
- npx vitest run src/app/components/settings/TenantManagementTab.shell.test.ts src/app/components/settings/TenantSwitcher.shell.test.ts src/app/platform/firestore-rules-policy.test.ts src/app/components/settings/SettingsPage.shell.test.ts src/app/data/member-documents.test.ts
- npm run policy:verify
- npm run build
- npx firebase-tools deploy --only firestore:rules --project inner-platform-live-20260316 --dry-run