### PR TITLE
fix(settings): bootstrap default org registry

### DIFF
--- a/src/app/components/settings/TenantManagementTab.shell.test.ts
+++ b/src/app/components/settings/TenantManagementTab.shell.test.ts
@@ -8,6 +8,7 @@ describe('TenantManagementTab shell contract', () => {
   it('scopes organization DB entries to the active admin org without hard-coded org ids', () => {
     expect(source).toContain("collection(db, 'orgs', orgId, 'tenant_registry')");
     expect(source).not.toContain("collection(db, 'tenants')");
+    expect(source).toContain('mergeTenantRegistryEntries(adminOrgId');
     expect(source).toContain("where('adminOrgId', '==', adminOrgId)");
     expect(source).toContain('adminOrgId,');
     expect(source).not.toContain("id === 'mysc'");

--- a/src/app/components/settings/TenantManagementTab.tsx
+++ b/src/app/components/settings/TenantManagementTab.tsx
@@ -17,18 +17,15 @@ import {
 import { Separator } from '../ui/separator';
 import { toast } from 'sonner';
 import { isValidTenantId } from '../../platform/tenant';
+import {
+  mergeTenantRegistryEntries,
+  type TenantRegistryEntry,
+} from '../../platform/tenant-registry';
 import { useFirebase } from '../../lib/firebase-context';
 
 // ── Types ──
 
-interface TenantDoc {
-  id: string;
-  name: string;
-  adminOrgId?: string;
-  createdAt?: string;
-  protected?: boolean;
-  branding?: { primaryColor?: string; logoUrl?: string };
-}
+type TenantDoc = TenantRegistryEntry;
 
 // ── Firestore helpers ──
 
@@ -38,14 +35,14 @@ function tenantRegistryCollection(db: Firestore, orgId: string) {
 
 async function fetchTenants(db: Firestore, adminOrgId: string): Promise<TenantDoc[]> {
   const snap = await getDocs(query(tenantRegistryCollection(db, adminOrgId), where('adminOrgId', '==', adminOrgId), limit(100)));
-  return snap.docs.map((d) => ({
+  return mergeTenantRegistryEntries(adminOrgId, snap.docs.map((d) => ({
     id: d.id,
     name: (d.data().name as string | undefined) || d.id,
     adminOrgId: d.data().adminOrgId as string | undefined,
     createdAt: (d.data().createdAt as any)?.toDate?.()?.toISOString?.() || '',
     protected: d.data().protected === true,
     branding: d.data().branding as TenantDoc['branding'],
-  }));
+  })));
 }
 
 async function createTenant(db: Firestore, adminOrgId: string, id: string, name: string): Promise<void> {

--- a/src/app/components/settings/TenantSwitcher.shell.test.ts
+++ b/src/app/components/settings/TenantSwitcher.shell.test.ts
@@ -17,6 +17,7 @@ describe('TenantSwitcher redirect contract', () => {
 
   it('loads known organizations from the org-scoped registry', () => {
     expect(source).toContain("collection(db, 'orgs', orgId, 'tenant_registry')");
+    expect(source).toContain('mergeTenantRegistryEntries(orgId');
     expect(source).not.toContain("collection(db, 'tenants')");
   });
 });

--- a/src/app/components/settings/TenantSwitcher.tsx
+++ b/src/app/components/settings/TenantSwitcher.tsx
@@ -10,6 +10,7 @@ import { Input } from '../ui/input';
 import { Separator } from '../ui/separator';
 import { useFirebase } from '../../lib/firebase-context';
 import { isValidTenantId } from '../../platform/tenant';
+import { mergeTenantRegistryEntries } from '../../platform/tenant-registry';
 
 // ── Types ──
 
@@ -23,12 +24,12 @@ interface TenantEntry {
 async function loadKnownTenants(db: Firestore, orgId: string): Promise<TenantEntry[]> {
   try {
     const snap = await getDocs(query(collection(db, 'orgs', orgId, 'tenant_registry'), limit(50)));
-    return snap.docs.map((doc) => ({
+    return mergeTenantRegistryEntries(orgId, snap.docs.map((doc) => ({
       id: doc.id,
       name: (doc.data().name as string | undefined) || doc.id,
-    }));
+    }))).map(({ id, name }) => ({ id, name }));
   } catch {
-    return [];
+    return mergeTenantRegistryEntries(orgId, []).map(({ id, name }) => ({ id, name }));
   }
 }
 
@@ -58,7 +59,7 @@ export function TenantSwitcher({ collapsed = false, userRole, userTenantId }: Te
     if (!open || !db || loadedRef.current) return;
     loadedRef.current = true;
     void loadKnownTenants(db, orgId).then((list) => {
-      if (list.length > 0) setTenants(list);
+      setTenants(list);
     });
   }, [open, db, orgId]);
 

--- a/src/app/platform/tenant-registry.test.ts
+++ b/src/app/platform/tenant-registry.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { BOOTSTRAP_TENANT_REGISTRY, mergeTenantRegistryEntries } from './tenant-registry';
+
+describe('tenant registry defaults', () => {
+  it('keeps MYSC as a protected bootstrap organization', () => {
+    expect(BOOTSTRAP_TENANT_REGISTRY).toContainEqual({
+      id: 'mysc',
+      name: 'MYSC',
+      adminOrgId: 'mysc',
+      protected: true,
+      branding: {},
+    });
+  });
+
+  it('merges firestore entries over bootstrap defaults', () => {
+    expect(mergeTenantRegistryEntries('mysc', [{
+      id: 'mysc',
+      name: 'MYSC 수정',
+      adminOrgId: 'mysc',
+      protected: true,
+    }])).toContainEqual({
+      id: 'mysc',
+      name: 'MYSC 수정',
+      adminOrgId: 'mysc',
+      protected: true,
+      branding: {},
+    });
+  });
+
+  it('adds the active org when it is not in the bootstrap list', () => {
+    expect(mergeTenantRegistryEntries('partner-org', [])).toEqual([
+      {
+        id: 'mysc',
+        name: 'MYSC',
+        adminOrgId: 'mysc',
+        protected: true,
+        branding: {},
+      },
+      {
+        id: 'partner-org',
+        name: 'partner-org',
+        adminOrgId: 'partner-org',
+        protected: true,
+        branding: {},
+      },
+    ]);
+  });
+});

--- a/src/app/platform/tenant-registry.ts
+++ b/src/app/platform/tenant-registry.ts
@@ -1,0 +1,49 @@
+export interface TenantRegistryEntry {
+  id: string;
+  name: string;
+  adminOrgId?: string;
+  createdAt?: string;
+  protected?: boolean;
+  branding?: { primaryColor?: string; logoUrl?: string };
+}
+
+export const BOOTSTRAP_TENANT_REGISTRY: TenantRegistryEntry[] = [
+  {
+    id: 'mysc',
+    name: 'MYSC',
+    adminOrgId: 'mysc',
+    protected: true,
+    branding: {},
+  },
+];
+
+export function mergeTenantRegistryEntries(
+  activeOrgId: string,
+  entries: TenantRegistryEntry[],
+): TenantRegistryEntry[] {
+  const byId = new Map<string, TenantRegistryEntry>();
+
+  for (const entry of BOOTSTRAP_TENANT_REGISTRY) {
+    byId.set(entry.id, entry);
+  }
+
+  const normalizedActiveOrgId = activeOrgId.trim().toLowerCase();
+  if (normalizedActiveOrgId && !byId.has(normalizedActiveOrgId)) {
+    byId.set(normalizedActiveOrgId, {
+      id: normalizedActiveOrgId,
+      name: normalizedActiveOrgId,
+      adminOrgId: normalizedActiveOrgId,
+      protected: true,
+      branding: {},
+    });
+  }
+
+  for (const entry of entries) {
+    byId.set(entry.id, {
+      ...byId.get(entry.id),
+      ...entry,
+    });
+  }
+
+  return Array.from(byId.values()).sort((a, b) => a.name.localeCompare(b.name, 'ko'));
+}


### PR DESCRIPTION
## Summary
- add a small bootstrap org registry with protected MYSC default
- merge bootstrap orgs with Firestore org-scoped tenant_registry entries
- use the same merged list in 조직DB and the org switcher

## Verification
- npx vitest run src/app/platform/tenant-registry.test.ts src/app/components/settings/TenantManagementTab.shell.test.ts src/app/components/settings/TenantSwitcher.shell.test.ts
- npm run build