### PR TITLE
feat(cashflow): add stage guide dialog

### DIFF
--- a/.github/workflows/stage-deploy.yml
+++ b/.github/workflows/stage-deploy.yml
@@ -1,0 +1,182 @@
+name: Stage Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Branch, tag, or commit SHA to deploy to stage
+        required: false
+        default: main
+        type: string
+      note:
+        description: Deployment note for the stage summary
+        required: false
+        type: string
+
+concurrency:
+  group: inner-platform-stage
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  deployments: write
+
+jobs:
+  deploy:
+    name: Deploy stage alias
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: Stage
+      url: https://inner-platform-stage-merryai-devs-projects.vercel.app
+    env:
+      VERCEL_CLI_PACKAGE: vercel@54.14.2
+      VERCEL_PROJECT: inner-platform
+      VERCEL_SCOPE: merryai-devs-projects
+      VERCEL_STAGE_ALIAS: inner-platform-stage-merryai-devs-projects.vercel.app
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+    steps:
+      - name: Verify Vercel token is configured
+        run: |
+          test -n "${VERCEL_TOKEN}" || { echo "Missing secret: VERCEL_TOKEN" >&2; exit 1; }
+
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || 'main' }}
+          fetch-depth: 1
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - run: npm ci
+
+      - name: Unit tests
+        run: npm test
+
+      - name: RBAC policy verify
+        run: npm run policy:verify
+
+      - name: Production build
+        run: npm run build
+
+      - name: Deploy Vercel stage artifact
+        id: vercel_deploy
+        run: |
+          set -euo pipefail
+          output_file="$(mktemp)"
+          npx --yes "${VERCEL_CLI_PACKAGE}" deploy \
+            --yes \
+            --target preview \
+            --project "${VERCEL_PROJECT}" \
+            --scope "${VERCEL_SCOPE}" \
+            --token "${VERCEL_TOKEN}" 2>&1 | tee "${output_file}"
+          deployment_url="$(grep -Eo 'https://[A-Za-z0-9.-]+\.vercel\.app' "${output_file}" | tail -n 1 || true)"
+          if [ -z "${deployment_url}" ]; then
+            echo "Could not parse Vercel preview deployment URL" >&2
+            exit 1
+          fi
+          deployment_host="${deployment_url#https://}"
+          echo "deployment_url=${deployment_url}" >> "${GITHUB_OUTPUT}"
+          echo "deployment_host=${deployment_host}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify stage artifact before alias
+        env:
+          DEPLOYMENT_HOST: ${{ steps.vercel_deploy.outputs.deployment_host }}
+        run: |
+          set -euo pipefail
+          inspect_file="$(mktemp)"
+          npx --yes "${VERCEL_CLI_PACKAGE}" inspect \
+            "${DEPLOYMENT_HOST}" \
+            --format=json \
+            --scope "${VERCEL_SCOPE}" \
+            --token "${VERCEL_TOKEN}" > "${inspect_file}"
+          node -e '
+            const fs = require("fs");
+            const path = process.argv[1];
+            const raw = fs.readFileSync(path, "utf8");
+            const jsonStart = raw.indexOf("{");
+            if (jsonStart < 0) {
+              throw new Error(`Could not parse Vercel inspect output: ${raw.slice(0, 200)}`);
+            }
+            const inspect = JSON.parse(raw.slice(jsonStart));
+            if (inspect.readyState !== "READY") {
+              throw new Error(`Stage artifact is not READY: ${inspect.readyState}`);
+            }
+            if (inspect.target === "production") {
+              throw new Error("Stage artifact must not be a production deployment");
+            }
+          ' "${inspect_file}"
+          status_and_type="$(curl -sS -o /tmp/stage-missing-asset.txt -w '%{http_code} %{content_type}' "https://${DEPLOYMENT_HOST}/assets/__stage_missing_asset_probe__.css")"
+          echo "Missing asset response: ${status_and_type}"
+          if [[ "${status_and_type}" != 404\ * ]]; then
+            cat /tmp/stage-missing-asset.txt
+            echo "Missing static assets must return 404." >&2
+            exit 1
+          fi
+          if [[ "${status_and_type}" == *"text/html"* ]]; then
+            cat /tmp/stage-missing-asset.txt
+            echo "Missing static assets must not return index.html." >&2
+            exit 1
+          fi
+
+      - name: Pin fixed stage alias
+        env:
+          DEPLOYMENT_HOST: ${{ steps.vercel_deploy.outputs.deployment_host }}
+        run: |
+          set -euo pipefail
+          npx --yes "${VERCEL_CLI_PACKAGE}" alias set \
+            "${DEPLOYMENT_HOST}" \
+            "${VERCEL_STAGE_ALIAS}" \
+            --scope "${VERCEL_SCOPE}" \
+            --token "${VERCEL_TOKEN}"
+
+      - name: Verify stage alias
+        env:
+          DEPLOYMENT_HOST: ${{ steps.vercel_deploy.outputs.deployment_host }}
+        run: |
+          set -euo pipefail
+          inspect_file="$(mktemp)"
+          npx --yes "${VERCEL_CLI_PACKAGE}" inspect \
+            "${VERCEL_STAGE_ALIAS}" \
+            --format=json \
+            --scope "${VERCEL_SCOPE}" \
+            --token "${VERCEL_TOKEN}" > "${inspect_file}"
+          node -e '
+            const fs = require("fs");
+            const path = process.argv[1];
+            const expectedHost = process.env.DEPLOYMENT_HOST;
+            const raw = fs.readFileSync(path, "utf8");
+            const jsonStart = raw.indexOf("{");
+            if (jsonStart < 0) {
+              throw new Error(`Could not parse Vercel inspect output: ${raw.slice(0, 200)}`);
+            }
+            const inspect = JSON.parse(raw.slice(jsonStart));
+            if (inspect.readyState !== "READY") {
+              throw new Error(`Stage alias is not READY: ${inspect.readyState}`);
+            }
+            if (inspect.target === "production") {
+              throw new Error("Stage alias must not point to a production deployment");
+            }
+            if (inspect.url !== expectedHost) {
+              throw new Error(`Stage alias points to ${inspect.url}, expected ${expectedHost}`);
+            }
+          ' "${inspect_file}"
+
+      - name: Stage summary
+        env:
+          DEPLOY_NOTE: ${{ inputs.note }}
+          DEPLOYMENT_URL: ${{ steps.vercel_deploy.outputs.deployment_url }}
+        run: |
+          {
+            printf '%s\n' "## InnerPlatform stage deploy"
+            printf '\n'
+            printf '%s\n' "- Stage URL: https://${VERCEL_STAGE_ALIAS}"
+            printf '%s\n' "- Deployment URL: ${DEPLOYMENT_URL}"
+            printf '%s\n' "- Ref: ${{ inputs.ref || 'main' }}"
+            printf '%s\n' "- Commit: $(git rev-parse HEAD)"
+            printf '%s\n' "- Actor: ${GITHUB_ACTOR}"
+            printf '%s\n' "- Note: ${DEPLOY_NOTE}"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/api/static-asset-not-found.js
+++ b/api/static-asset-not-found.js
@@ -1,0 +1,5 @@
+export default function handler(req, res) {
+  res.setHeader('Cache-Control', 'no-store, max-age=0');
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.status(404).send('Static asset not found. Reload the application to fetch the current release.');
+}

--- a/src/app/components/cashflow/CashflowGuideDialog.tsx
+++ b/src/app/components/cashflow/CashflowGuideDialog.tsx
@@ -1,0 +1,197 @@
+import { ArrowDown, CheckCircle2, FileSpreadsheet, HelpCircle, RefreshCcw, Save, ShieldCheck } from 'lucide-react';
+import { Button } from '../ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+
+interface CashflowGuideDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const FLOW_STEPS = [
+  {
+    icon: FileSpreadsheet,
+    label: 'Projection 작성',
+    title: '계획값을 먼저 서버 기준본으로 만듭니다.',
+    description: '기존 시트 가져오기 또는 직접 입력 후 주차별 작성완료를 눌러 Projection 업데이트 상태를 남깁니다.',
+  },
+  {
+    icon: RefreshCcw,
+    label: 'Actual 불러오기',
+    title: '주간 사업비 입력표에서 실제값을 계산합니다.',
+    description: '정산/사업비 입력표에 저장된 입금·지출을 읽어 캐시플로 Actual 칸에 채웁니다.',
+  },
+  {
+    icon: Save,
+    label: 'Actual 저장',
+    title: '화면 기준값을 확정 저장합니다.',
+    description: '불러온 값은 미리보기 단계입니다. Actual 저장을 눌러야 다음 접속과 다른 화면에 같은 값이 보입니다.',
+  },
+  {
+    icon: ShieldCheck,
+    label: '제출·결산',
+    title: '주차 상태를 잠그고 운영 흐름을 넘깁니다.',
+    description: 'PM은 작성완료, finance/admin은 제출현황과 Actual 상태를 확인한 뒤 결산완료를 진행합니다.',
+  },
+];
+
+const GUIDE_SECTIONS = [
+  {
+    badge: '원칙 1. 두 기준값 분리',
+    title: 'Projection과 Actual은 서로 덮어쓰지 않습니다.',
+    body: 'Projection은 계획 기준, Actual은 정산/사업비 입력 기준입니다. 비교 모드는 두 값을 같은 주차 구조에서 나란히 보는 화면이며, 저장 버튼도 각각의 기준값에만 반영됩니다.',
+  },
+  {
+    badge: '원칙 2. 불러오기와 저장 분리',
+    title: 'Actual 불러오기는 계산, Actual 저장은 확정입니다.',
+    body: 'Actual 불러오기는 현재 사업비 입력표를 기준으로 화면 값을 갱신합니다. 운영 기준본으로 반영하려면 반드시 Actual 저장까지 실행해야 합니다.',
+  },
+  {
+    badge: '원칙 3. 결산 전 체크',
+    title: '결산완료 전에는 제출현황과 주차 상태를 함께 봅니다.',
+    body: 'Projection 업데이트와 사업비 입력 체크가 모두 완료된 주차만 결산 흐름에 올리는 것이 기본입니다. 일부 검토 상태는 경고로 안내하되, 권한자는 필요한 경우 진행할 수 있습니다.',
+  },
+];
+
+export function CashflowGuideButton({ onClick }: { onClick: () => void }) {
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="h-8 gap-1.5 text-[12px]"
+      onClick={onClick}
+    >
+      <HelpCircle className="h-3.5 w-3.5" />
+      가이드
+    </Button>
+  );
+}
+
+export function CashflowGuideDialog({ open, onOpenChange }: CashflowGuideDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[min(1120px,calc(100vw-32px))] max-w-none gap-0 overflow-hidden rounded-[24px] border-0 bg-white p-0 text-slate-950 shadow-2xl">
+        <div className="max-h-[calc(100dvh-32px)] overflow-y-auto">
+          <DialogHeader className="px-6 pb-5 pt-8 text-left sm:px-10 sm:pt-10">
+            <p className="text-[13px] font-extrabold text-blue-600">Cashflow Guide</p>
+            <DialogTitle className="max-w-[760px] text-[26px] font-extrabold leading-[1.35] tracking-normal text-slate-950 sm:text-[32px]">
+              캐시플로우 입력과 결산 흐름을 같은 기준으로 맞춥니다
+            </DialogTitle>
+            <DialogDescription className="max-w-[680px] text-[13px] leading-6 text-slate-500">
+              Projection, Actual, 제출현황, 결산완료가 각각 어떤 값을 확정하는지 운영자가 빠르게 확인하는 안내입니다.
+            </DialogDescription>
+            <div className="mt-4 grid max-w-[720px] gap-2 rounded-xl bg-slate-50 px-4 py-3 sm:grid-cols-3">
+              <div>
+                <p className="text-[11px] font-bold text-blue-600">대상</p>
+                <p className="mt-1 text-[13px] font-bold">PM · finance · admin</p>
+              </div>
+              <div>
+                <p className="text-[11px] font-bold text-blue-600">주기</p>
+                <p className="mt-1 text-[13px] font-bold">월별 주차 관리</p>
+              </div>
+              <div>
+                <p className="text-[11px] font-bold text-blue-600">기준값</p>
+                <p className="mt-1 text-[13px] font-bold">Firestore 서버 기준본</p>
+              </div>
+            </div>
+          </DialogHeader>
+
+          <main className="space-y-8 px-6 pb-8 sm:px-10">
+            <section className="rounded-[24px] bg-slate-50 px-5 py-6 sm:px-8">
+              <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                <div>
+                  <p className="inline-flex rounded-md bg-blue-600 px-3 py-2 text-[12px] font-extrabold text-white">
+                    운영 순서도
+                  </p>
+                  <h2 className="mt-4 max-w-[540px] text-[22px] font-extrabold leading-[1.4] tracking-normal sm:text-[26px]">
+                    실제 반영은 저장 버튼 기준으로 끊어서 확인합니다
+                  </h2>
+                </div>
+                <p className="max-w-[360px] text-[12px] leading-5 text-slate-500">
+                  각 단계는 화면 값과 서버 기준값이 달라질 수 있는 지점을 명확히 분리합니다.
+                </p>
+              </div>
+
+              <div className="grid gap-3 lg:grid-cols-4">
+                {FLOW_STEPS.map((step, index) => {
+                  const Icon = step.icon;
+                  return (
+                    <div key={step.label} className="relative rounded-2xl bg-white p-4 shadow-sm">
+                      <div className="mb-4 flex items-center justify-between">
+                        <span className="rounded-full bg-blue-50 px-2.5 py-1 text-[11px] font-bold text-blue-700">
+                          {step.label}
+                        </span>
+                        <span className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-100 text-slate-700">
+                          <Icon className="h-4 w-4" />
+                        </span>
+                      </div>
+                      <h3 className="text-[15px] font-extrabold leading-6 tracking-normal text-slate-950">{step.title}</h3>
+                      <p className="mt-3 text-[12px] leading-5 text-slate-500">{step.description}</p>
+                      {index < FLOW_STEPS.length - 1 && (
+                        <ArrowDown className="absolute -bottom-5 left-1/2 z-10 h-5 w-5 -translate-x-1/2 text-slate-300 lg:-right-5 lg:bottom-auto lg:left-auto lg:top-1/2 lg:-translate-y-1/2 lg:rotate-[-90deg]" />
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+
+            {GUIDE_SECTIONS.map((section, index) => (
+              <section key={section.badge} className="grid gap-6 rounded-[24px] bg-slate-50 px-5 py-6 sm:px-8 lg:grid-cols-[1fr_1.1fr]">
+                <div className={index % 2 === 1 ? 'lg:order-2' : ''}>
+                  <p className="inline-flex rounded-md bg-blue-600 px-3 py-2 text-[12px] font-extrabold text-white">
+                    {section.badge}
+                  </p>
+                  <h2 className="mt-5 text-[22px] font-extrabold leading-[1.45] tracking-normal text-slate-950 sm:text-[25px]">
+                    {section.title}
+                  </h2>
+                  <p className="mt-24 text-[12px] leading-6 text-slate-600 sm:mt-28">
+                    {section.body}
+                  </p>
+                </div>
+                <div className="flex items-center justify-center rounded-[20px] bg-white p-5 shadow-sm">
+                  <div className="w-full max-w-[420px] space-y-3">
+                    <div className="flex items-center justify-between rounded-xl border border-slate-100 px-4 py-3">
+                      <span className="text-[12px] font-bold text-slate-500">화면에서 보이는 값</span>
+                      <span className="text-[13px] font-extrabold text-slate-950">편집/계산 중</span>
+                    </div>
+                    <div className="flex items-center justify-center">
+                      <ArrowDown className="h-5 w-5 text-blue-500" />
+                    </div>
+                    <div className="flex items-center justify-between rounded-xl border border-blue-100 bg-blue-50 px-4 py-3">
+                      <span className="text-[12px] font-bold text-blue-700">저장 액션</span>
+                      <span className="text-[13px] font-extrabold text-blue-700">서버 기준본 반영</span>
+                    </div>
+                    <div className="flex items-center justify-center">
+                      <ArrowDown className="h-5 w-5 text-blue-500" />
+                    </div>
+                    <div className="flex items-center justify-between rounded-xl border border-emerald-100 bg-emerald-50 px-4 py-3">
+                      <span className="text-[12px] font-bold text-emerald-700">운영 상태</span>
+                      <span className="inline-flex items-center gap-1 text-[13px] font-extrabold text-emerald-700">
+                        <CheckCircle2 className="h-4 w-4" />
+                        제출/결산 판단
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              </section>
+            ))}
+          </main>
+
+          <DialogFooter className="sticky bottom-0 border-t border-slate-100 bg-white/95 px-6 py-4 backdrop-blur sm:px-10">
+            <Button type="button" className="h-9 text-[12px]" onClick={() => onOpenChange(false)}>
+              확인
+            </Button>
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -12,6 +12,12 @@ const cashflowWeeksStoreSource = readFileSync(
 );
 
 describe('CashflowProjectSheet actual sync flow', () => {
+  it('exposes the cashflow guide dialog from the project sheet toolbar', () => {
+    expect(cashflowProjectSheetSource).toContain('CashflowGuideButton');
+    expect(cashflowProjectSheetSource).toContain('CashflowGuideDialog');
+    expect(cashflowProjectSheetSource).toContain('guideOpen');
+  });
+
   it('keeps actual sync separate from manual actual save', () => {
     expect(cashflowProjectSheetSource).toContain('Actual 불러오기');
     expect(cashflowProjectSheetSource).toContain('syncProjectActualsFromExpenseSheets');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -41,6 +41,7 @@ import { getOrgDocumentPath } from '../../lib/firebase';
 import { loadExcelJs, warmExcelJs } from '../../platform/lazy-heavy-modules';
 import { buildCashflowExportWorkbookSpec } from '../../platform/cashflow-export';
 import { exportCashflowWorkbookViaBff, isPlatformApiEnabled } from '../../lib/platform-bff-client';
+import { CashflowGuideButton, CashflowGuideDialog } from './CashflowGuideDialog';
 
 function fmt(n: number): string {
   return n.toLocaleString('ko-KR');
@@ -161,6 +162,7 @@ export function CashflowProjectSheet({
   const [monthSavingMode, setMonthSavingMode] = useState<null | 'actual'>(null);
   const [downloadPreparing, setDownloadPreparing] = useState(false);
   const [actualSyncing, setActualSyncing] = useState(false);
+  const [guideOpen, setGuideOpen] = useState(false);
 
   const hasDirty = useMemo(
     () => hasUnsavedChanges(weekSaveState) || Object.keys(drafts).length > 0,
@@ -972,6 +974,7 @@ export function CashflowProjectSheet({
         description={`${projectName} · ${yearMonth}`}
         actions={(
           <div className="flex flex-wrap items-center gap-2 xl:justify-end">
+            <CashflowGuideButton onClick={() => setGuideOpen(true)} />
             <Button
               variant="outline"
               size="sm"
@@ -1144,6 +1147,8 @@ export function CashflowProjectSheet({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <CashflowGuideDialog open={guideOpen} onOpenChange={setGuideOpen} />
 
       <AlertDialog
         open={blocker.state === 'blocked'}

--- a/vercel.json
+++ b/vercel.json
@@ -100,6 +100,10 @@
       "destination": "/api/bff?__path=/api/internal/workers/client-errors/run"
     },
     {
+      "source": "/assets/:path*",
+      "destination": "/api/static-asset-not-found?path=:path*"
+    },
+    {
       "source": "/(.*)",
       "destination": "/index.html"
     }


### PR DESCRIPTION
## Summary
- Add a Cashflow guide dialog with a stage-style operation flow and Toss-like visual treatment
- Surface the guide from the cashflow sheet toolbar
- Add the fixed stage deployment workflow and static asset 404 handling to prevent stale bundle MIME errors

## Verification
- npm test
- npm run policy:verify
- npm run build
- Playwright local smoke: /portal/cashflow guide button opens the dialog

## Deployment policy
- No Vercel automatic git deploy from main
- Stage is pinned through the fixed alias workflow: https://inner-platform-stage-merryai-devs-projects.vercel.app