### PR TITLE
fix(deploy): use configured stage token environment

### DIFF
--- a/.github/workflows/stage-deploy.yml
+++ b/.github/workflows/stage-deploy.yml
@@ -27,7 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment:
-      name: Stage
+      # VERCEL_TOKEN is currently scoped to this GitHub environment.
+      # The deployment itself is still promoted only to the fixed stage alias below.
+      name: Preview
       url: https://inner-platform-stage-merryai-devs-projects.vercel.app
     env:
       VERCEL_CLI_PACKAGE: vercel@54.14.2


### PR DESCRIPTION
## Summary
- Restore the GitHub environment name that owns the Vercel token secret
- Keep stage deployment pinned to https://inner-platform-stage-merryai-devs-projects.vercel.app

## Verification
- Previous stage run passed npm ci, npm test, policy verify, and production build before failing at Vercel auth
- This PR only changes workflow environment secret selection