### PR TITLE
fix(cashflow): unify finance week policy

### DIFF
--- a/docs/wiki/patch-notes/log.md
+++ b/docs/wiki/patch-notes/log.md
@@ -147,6 +147,10 @@
 - pages: [portal-dashboard](./pages/portal-dashboard.md)
 - summary: 내사업 현황을 좌측 포털형 툴에서 상단 workspace bar, 앱 탭, 사업 전환 rail을 가진 cold enterprise SaaS 구조로 재편했다.
 
+## [2026-06-19] patch-note | shared-portal-architecture | finance week 공통화 hotfix
+- pages: [shared-portal-architecture](./pages/shared-portal-architecture.md)
+- summary: cashflow/actual/projection/expense 주차 계산을 stage/live 공통 core로 모으고, 2026년 8월처럼 raw 6주차가 생기는 달은 financeWeek 5에 강제 산입되도록 저장/API/export 경로를 맞췄다.
+
 ## [2026-04-14] patch-note | portal-dashboard | 0건 운영 정보 축소와 주간 상태 전면 배치
 - pages: [portal-dashboard](./pages/portal-dashboard.md)
 - summary: 0건 운영 알림과 설정성 바로가기를 걷어내고, 이번 주 Projection 작성 여부·최근 Projection 수정일·사업비 입력 상태를 홈 첫 화면에서 바로 보이도록 압축했다.

--- a/docs/wiki/patch-notes/pages/shared-portal-architecture.md
+++ b/docs/wiki/patch-notes/pages/shared-portal-architecture.md
@@ -34,6 +34,7 @@
 
 ## Recent Changes
 
+- [2026-06-19] Cashflow/사업비 주차 계산을 stage/live 공통 finance week core로 통합했다. 월 내부 Monday-based 5-slot 정책을 적용하고 raw 6주차는 financeWeek 5로 저장/집계되도록 BFF, 포털 저장, export 표면을 같은 로직으로 맞췄다.
 - [2026-06-02] 프로젝트 등록/수정 editor contract에 견적서와 제안서 첨부를 추가하고, 25MB를 넘는 문서는 BFF raw upload 대신 Firebase Storage direct upload로 처리하도록 분리했다. 포털 safe fetch 경로는 ledgers/transactions/comments/evidences/auditLogs/partEntries를 초기 fetch하고 write 후 로컬 상태도 갱신해 화면 데이터 공백을 줄였다.
 - [2026-05-20] 프로젝트 등록, 포털 수정, Admin 승인 화면이 같은 5단계 editor contract를 쓰도록 공통 draft/payload/patch builder를 분리했다. 승인/재제출은 request 조회를 먼저 검증하고 project/request 상태 patch를 같은 Firestore transaction에서 쓰도록 보강했다.
 - [2026-04-21] 세세목 도입 프로젝트는 `budget_tree_v2`를 원본으로 사용하고, 저장 시 `budget_code_book`을 2단 파생본으로 함께 동기화하도록 정리했다.

--- a/server/bff/cashflow-canonical-store.mjs
+++ b/server/bff/cashflow-canonical-store.mjs
@@ -1,4 +1,9 @@
 import cashflowPolicyData from '../../src/app/policies/cashflow-policy.json' with { type: 'json' };
+import {
+  findFinanceWeekForDate,
+  getMonthFinanceWeeks,
+  getYearFinanceWeeks,
+} from '../../src/app/platform/cashflow-week-core.mjs';
 import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES } from './cashflow-policy.mjs';
 
 const SETTLEMENT_COLUMN_HEADERS = [
@@ -40,123 +45,25 @@ for (const entry of cashflowPolicyData.lineEntries || []) {
   }
 }
 
-function pad2(value) {
-  return String(value).padStart(2, '0');
-}
-
 function parseYearMonth(value) {
   const match = /^(\d{4})-(\d{2})$/.exec(String(value || '').trim());
   if (!match) return null;
   const year = Number.parseInt(match[1], 10);
   const month = Number.parseInt(match[2], 10);
   if (!Number.isFinite(year) || !Number.isFinite(month) || month < 1 || month > 12) return null;
-  return { year, month, yearMonth: `${String(year).padStart(4, '0')}-${pad2(month)}` };
-}
-
-function formatIsoDate(year, month, day) {
-  return `${String(year)}-${pad2(month)}-${pad2(day)}`;
-}
-
-function addDaysUtc(isoDate, deltaDays) {
-  const [yRaw, mRaw, dRaw] = String(isoDate || '').split('-');
-  const year = Number.parseInt(yRaw, 10);
-  const month = Number.parseInt(mRaw, 10);
-  const day = Number.parseInt(dRaw, 10);
-  const base = Date.UTC(year, month - 1, day);
-  const next = new Date(base + deltaDays * 24 * 60 * 60 * 1000);
-  return formatIsoDate(next.getUTCFullYear(), next.getUTCMonth() + 1, next.getUTCDate());
-}
-
-function dayOfWeekUtc(year, month, day) {
-  return new Date(Date.UTC(year, month - 1, day)).getUTCDay();
-}
-
-function daysInMonthUtc(year, month) {
-  return new Date(Date.UTC(year, month, 0)).getUTCDate();
-}
-
-function startOfWeekWednesday(isoDate) {
-  const [yRaw, mRaw, dRaw] = String(isoDate || '').split('-');
-  const year = Number.parseInt(yRaw, 10);
-  const month = Number.parseInt(mRaw, 10);
-  const day = Number.parseInt(dRaw, 10);
-  const dow = dayOfWeekUtc(year, month, day);
-  const delta = -((dow - 3 + 7) % 7);
-  return addDaysUtc(isoDate, delta);
-}
-
-function countDaysInMonthForWeek(weekStart, year, month) {
-  let count = 0;
-  for (let i = 0; i < 7; i += 1) {
-    const date = addDaysUtc(weekStart, i);
-    const [yy, mm] = date.split('-');
-    if (Number.parseInt(yy, 10) === year && Number.parseInt(mm, 10) === month) count += 1;
-  }
-  return count;
+  return { year, month, yearMonth: `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}` };
 }
 
 export function getMonthCashflowWeeks(yearMonth) {
-  const parsed = parseYearMonth(yearMonth);
-  if (!parsed) return [];
-
-  const { year, month } = parsed;
-  const firstDay = formatIsoDate(year, month, 1);
-  const lastDay = formatIsoDate(year, month, daysInMonthUtc(year, month));
-  let weekStart = startOfWeekWednesday(firstDay);
-  const weeks = [];
-  const yy = year % 100;
-  let weekNo = 0;
-
-  while (weekStart <= lastDay) {
-    const daysInMonth = countDaysInMonthForWeek(weekStart, year, month);
-    if (daysInMonth >= 4) {
-      weekNo += 1;
-      weeks.push({
-        yearMonth: parsed.yearMonth,
-        weekNo,
-        weekStart,
-        weekEnd: addDaysUtc(weekStart, 6),
-        label: `${yy}-${month}-${weekNo}`,
-      });
-    }
-    weekStart = addDaysUtc(weekStart, 7);
-  }
-
-  return weeks;
+  return getMonthFinanceWeeks(yearMonth);
 }
 
 function getYearCashflowWeeks(year) {
-  const all = [];
-  for (let month = 1; month <= 12; month += 1) {
-    all.push(...getMonthCashflowWeeks(`${year}-${pad2(month)}`));
-  }
-  return all;
+  return getYearFinanceWeeks(year);
 }
 
 function findWeekForDate(dateStr, weeks) {
-  if (!dateStr) return undefined;
-  const direct = weeks.find((week) => dateStr >= week.weekStart && dateStr <= week.weekEnd);
-  if (direct) return direct;
-
-  const [yRaw, mRaw] = dateStr.split('-');
-  const year = Number.parseInt(yRaw, 10);
-  const month = Number.parseInt(mRaw, 10);
-  if (!Number.isFinite(year) || !Number.isFinite(month)) return undefined;
-
-  const current = getMonthCashflowWeeks(`${year}-${pad2(month)}`);
-  const inCurrent = current.find((week) => dateStr >= week.weekStart && dateStr <= week.weekEnd);
-  if (inCurrent) return inCurrent;
-
-  const prevMonth = month === 1 ? 12 : month - 1;
-  const prevYear = month === 1 ? year - 1 : year;
-  const prev = getMonthCashflowWeeks(`${prevYear}-${pad2(prevMonth)}`);
-  const inPrev = prev.find((week) => dateStr >= week.weekStart && dateStr <= week.weekEnd);
-  if (inPrev) return inPrev;
-
-  const nextMonth = month === 12 ? 1 : month + 1;
-  const nextYear = month === 12 ? year + 1 : year;
-  return getMonthCashflowWeeks(`${nextYear}-${pad2(nextMonth)}`)
-    .find((week) => dateStr >= week.weekStart && dateStr <= week.weekEnd);
+  return findFinanceWeekForDate(dateStr, weeks);
 }
 
 function resolveWeekFromLabel(label, anchorWeeks) {
@@ -171,7 +78,7 @@ function resolveWeekFromLabel(label, anchorWeeks) {
   const month = Number.parseInt(match[2], 10);
   const weekNo = Number.parseInt(match[3], 10);
   if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(weekNo)) return undefined;
-  return getMonthCashflowWeeks(`${year}-${pad2(month)}`).find((week) => week.weekNo === weekNo);
+  return getMonthCashflowWeeks(`${year}-${String(month).padStart(2, '0')}`).find((week) => week.weekNo === weekNo);
 }
 
 function parseDateIso(value) {
@@ -179,11 +86,11 @@ function parseDateIso(value) {
   if (!raw) return '';
   const compact = raw.match(/^(\d{4})[./-](\d{1,2})[./-](\d{1,2})/);
   if (compact) {
-    return `${compact[1]}-${pad2(Number.parseInt(compact[2], 10))}-${pad2(Number.parseInt(compact[3], 10))}`;
+    return `${compact[1]}-${String(Number.parseInt(compact[2], 10)).padStart(2, '0')}-${String(Number.parseInt(compact[3], 10)).padStart(2, '0')}`;
   }
   const date = new Date(raw);
   if (Number.isNaN(date.getTime())) return '';
-  return formatIsoDate(date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate());
+  return `${String(date.getUTCFullYear())}-${String(date.getUTCMonth() + 1).padStart(2, '0')}-${String(date.getUTCDate()).padStart(2, '0')}`;
 }
 
 function resolveWeekFromRow(row, anchorWeeks) {

--- a/server/bff/cashflow-canonical-store.test.mjs
+++ b/server/bff/cashflow-canonical-store.test.mjs
@@ -19,7 +19,7 @@ function row(cells, extra = {}) {
 }
 
 describe('cashflow canonical BFF helpers', () => {
-  it('uses the same Wednesday-based week buckets as the app cashflow sheet', () => {
+  it('uses the shared finance week buckets as the app cashflow sheet', () => {
     expect(getMonthCashflowWeeks('2027-01').map((week) => week.label)).toEqual([
       '27-1-1',
       '27-1-2',
@@ -30,8 +30,14 @@ describe('cashflow canonical BFF helpers', () => {
     expect(getMonthCashflowWeeks('2027-01')[0]).toMatchObject({
       yearMonth: '2027-01',
       weekNo: 1,
-      weekStart: '2026-12-30',
-      weekEnd: '2027-01-05',
+      weekStart: '2027-01-01',
+      weekEnd: '2027-01-03',
+    });
+    expect(getMonthCashflowWeeks('2026-08')[4]).toMatchObject({
+      rawWeek: 6,
+      weekNo: 5,
+      weekStart: '2026-08-24',
+      weekEnd: '2026-08-31',
     });
   });
 
@@ -183,7 +189,7 @@ describe('cashflow canonical BFF helpers', () => {
       totalAbsDelta: 100000000,
       largestLineId: 'DIRECT_COST_OUT',
       largestLineDelta: 100000000,
-      daysBeforeWeekStart: 2,
+      daysBeforeWeekStart: 0,
     });
   });
 

--- a/server/bff/cashflow-export.mjs
+++ b/server/bff/cashflow-export.mjs
@@ -1,4 +1,5 @@
 import ExcelJS from 'exceljs';
+import { getMonthFinanceWeeks } from '../../src/app/platform/cashflow-week-core.mjs';
 import {
   CASHFLOW_ALL_LINES,
   CASHFLOW_IN_LINES,
@@ -38,78 +39,8 @@ function formatWeekLabel(yearMonth, weekNo) {
   return `${String(parsed.year % 100).padStart(2, '0')}-${parsed.month}-${weekNo}`;
 }
 
-function pad2(value) {
-  return String(value).padStart(2, '0');
-}
-
-function formatIsoDate(year, month, day) {
-  return `${String(year)}-${pad2(month)}-${pad2(day)}`;
-}
-
-function addDaysUtc(isoDate, deltaDays) {
-  const [yRaw, mRaw, dRaw] = isoDate.split('-');
-  const year = Number.parseInt(yRaw, 10);
-  const month = Number.parseInt(mRaw, 10);
-  const day = Number.parseInt(dRaw, 10);
-  const base = Date.UTC(year, month - 1, day);
-  const next = new Date(base + deltaDays * 24 * 60 * 60 * 1000);
-  return formatIsoDate(next.getUTCFullYear(), next.getUTCMonth() + 1, next.getUTCDate());
-}
-
-function dayOfWeekUtc(year, month, day) {
-  return new Date(Date.UTC(year, month - 1, day)).getUTCDay();
-}
-
-function daysInMonthUtc(year, month) {
-  return new Date(Date.UTC(year, month, 0)).getUTCDate();
-}
-
-function startOfWeekWednesday(isoDate) {
-  const [yRaw, mRaw, dRaw] = isoDate.split('-');
-  const year = Number.parseInt(yRaw, 10);
-  const month = Number.parseInt(mRaw, 10);
-  const day = Number.parseInt(dRaw, 10);
-  const dow = dayOfWeekUtc(year, month, day);
-  const delta = -((dow - 3 + 7) % 7);
-  return addDaysUtc(isoDate, delta);
-}
-
-function countDaysInMonthForWeek(weekStart, year, month) {
-  let count = 0;
-  for (let i = 0; i < 7; i += 1) {
-    const date = addDaysUtc(weekStart, i);
-    const [yy, mm] = date.split('-');
-    if (Number.parseInt(yy, 10) === year && Number.parseInt(mm, 10) === month) count += 1;
-  }
-  return count;
-}
-
 function getMonthWeeks(yearMonth) {
-  const parsed = parseYearMonth(yearMonth);
-  if (!parsed) return [];
-  const { year, month } = parsed;
-  const firstDay = formatIsoDate(year, month, 1);
-  const lastDay = formatIsoDate(year, month, daysInMonthUtc(year, month));
-  let weekStart = startOfWeekWednesday(firstDay);
-  const weeks = [];
-  const yy = year % 100;
-  let weekNo = 0;
-  while (weekStart <= lastDay) {
-    const daysInMonth = countDaysInMonthForWeek(weekStart, year, month);
-    if (daysInMonth >= 4) {
-      weekNo += 1;
-      const weekEnd = addDaysUtc(weekStart, 6);
-      weeks.push({
-        yearMonth,
-        weekNo,
-        weekStart,
-        weekEnd,
-        label: `${yy}-${month}-${weekNo}`,
-      });
-    }
-    weekStart = addDaysUtc(weekStart, 7);
-  }
-  return weeks;
+  return getMonthFinanceWeeks(yearMonth);
 }
 
 export function expandCashflowYearMonthRange(startYearMonth, endYearMonth) {

--- a/server/bff/cashflow-export.test.mjs
+++ b/server/bff/cashflow-export.test.mjs
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import ExcelJS from 'exceljs';
-import { parseWithSchema, cashflowExportSchema } from './schemas.mjs';
+import { parseWithSchema, cashflowExportSchema, cashflowWeekAmountsSchema } from './schemas.mjs';
 import {
   buildCashflowExportFileName,
   buildCashflowExportWorkbookBuffer,
@@ -32,6 +32,15 @@ describe('cashflow export bff helper', () => {
     })).not.toThrow();
   });
 
+  it('rejects raw week 6 for cashflow week writes because storage uses financeWeek 1..5', () => {
+    expect(() => parseWithSchema(cashflowWeekAmountsSchema, {
+      yearMonth: '2026-08',
+      weekNo: 6,
+      mode: 'actual',
+      amounts: { DIRECT_COST_OUT: 1000 },
+    }, 'Invalid cashflow week request')).toThrow(/expected number to be <=5/);
+  });
+
   it('creates a non-empty xlsx buffer', async () => {
     const buffer = await buildCashflowExportWorkbookBuffer({
       variant: 'single-project',
@@ -47,8 +56,8 @@ describe('cashflow export bff helper', () => {
               projectId: 'proj-a',
               yearMonth: '2026-01',
               weekNo: 1,
-              weekStart: '2025-12-31',
-              weekEnd: '2026-01-06',
+              weekStart: '2026-01-01',
+              weekEnd: '2026-01-04',
               projection: { SALES_IN: 1000 },
               actual: { SALES_IN: 900 },
               pmSubmitted: true,

--- a/server/bff/cashflow-sheet-template.mjs
+++ b/server/bff/cashflow-sheet-template.mjs
@@ -52,7 +52,7 @@ export function parseCashflowWeekLabel(value) {
   const month = Number.parseInt(match[2], 10);
   const weekNo = Number.parseInt(match[3], 10);
   if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(weekNo)) return null;
-  if (month < 1 || month > 12 || weekNo < 1 || weekNo > 6) return null;
+  if (month < 1 || month > 12 || weekNo < 1 || weekNo > 5) return null;
   return {
     raw: normalizeText(value),
     year: 2000 + year,

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -310,7 +310,7 @@ describe('cashflow sheet lab route', () => {
     });
   });
 
-  it('applies fixed-sheet week labels even when they are not canonical cashflow weeks', async () => {
+  it('applies fixed-sheet week labels through canonical finance weeks', async () => {
     const db = createDb({
       project: {
         id: 'project-a',
@@ -349,7 +349,6 @@ describe('cashflow sheet lab route', () => {
     expect(db.__getDocument('orgs/tenant-a/cashflow_weeks/project-a-2026-02-w5')).toMatchObject({
       projection: { MYSC_PREPAY_IN: 999 },
       actual: { MYSC_PREPAY_IN: 999 },
-      sheetWeekSource: 'cashflow-sheet-lab',
     });
   });
 

--- a/server/bff/schemas.mjs
+++ b/server/bff/schemas.mjs
@@ -320,7 +320,7 @@ export const cashflowExportSchema = z.object({
 
 export const cashflowWeekAmountsSchema = z.object({
   yearMonth: z.string().trim().regex(/^\d{4}-\d{2}$/),
-  weekNo: z.number().int().min(1).max(6),
+  weekNo: z.number().int().min(1).max(5),
   mode: z.enum(['projection', 'actual']),
   amounts: z.record(z.string().trim().min(1), z.number().finite()),
 }).strict();

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -220,7 +220,7 @@ function parseCashflowSheetWeekLabel(value: unknown): { year: number; month: num
   const month = Number.parseInt(match[2], 10);
   const weekNo = Number.parseInt(match[3], 10);
   if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(weekNo)) return null;
-  if (month < 1 || month > 12 || weekNo < 1 || weekNo > 6) return null;
+  if (month < 1 || month > 12 || weekNo < 1 || weekNo > 5) return null;
   return {
     year,
     month,

--- a/src/app/data/cashflow-weeks-store.tsx
+++ b/src/app/data/cashflow-weeks-store.tsx
@@ -210,7 +210,7 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
 
     const projectId = input.projectId.trim();
     const ym = input.yearMonth.trim();
-    const weekNo = Math.max(1, Math.min(6, Math.trunc(input.weekNo)));
+    const weekNo = Math.max(1, Math.min(5, Math.trunc(input.weekNo)));
     if (!projectId || !/^\d{4}-\d{2}$/.test(ym)) return;
 
     const monthWeeks = getMonthMondayWeeks(ym);
@@ -563,7 +563,7 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
     if (!actor) return;
     const projectId = input.projectId.trim();
     const ym = input.yearMonth.trim();
-    const weekNo = Math.max(1, Math.min(6, Math.trunc(input.weekNo)));
+    const weekNo = Math.max(1, Math.min(5, Math.trunc(input.weekNo)));
     if (!projectId || !/^\d{4}-\d{2}$/.test(ym)) return;
 
     const monthWeeks = getMonthMondayWeeks(ym);
@@ -678,7 +678,7 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
     if (!actor) return;
     const projectId = input.projectId.trim();
     const ym = input.yearMonth.trim();
-    const weekNo = Math.max(1, Math.min(6, Math.trunc(input.weekNo)));
+    const weekNo = Math.max(1, Math.min(5, Math.trunc(input.weekNo)));
     if (!projectId || !/^\d{4}-\d{2}$/.test(ym)) return;
 
     const monthWeeks = getMonthMondayWeeks(ym);

--- a/src/app/data/cashflow-weeks.local-state.test.ts
+++ b/src/app/data/cashflow-weeks.local-state.test.ts
@@ -59,8 +59,8 @@ describe('applyWeekAmountsToLocalWeeks', () => {
       projectId: 'p002',
       yearMonth: '2026-06',
       weekNo: 1,
-      weekStart: '2026-06-03',
-      weekEnd: '2026-06-09',
+      weekStart: '2026-06-01',
+      weekEnd: '2026-06-07',
       projection: { DIRECT_COST_OUT: 1000000 },
       actual: {},
       pmSubmitted: false,
@@ -77,8 +77,8 @@ describe('applyWeekAmountsToLocalWeeks', () => {
       projectId: 'p002',
       yearMonth: '2026-06',
       weekNo: 1,
-      weekStart: '2026-06-03',
-      weekEnd: '2026-06-09',
+      weekStart: '2026-06-01',
+      weekEnd: '2026-06-07',
       mode: 'projection',
       amounts: { DIRECT_COST_OUT: 101000000 },
       now: '2026-06-01T10:00:00.000Z',
@@ -88,7 +88,7 @@ describe('applyWeekAmountsToLocalWeeks', () => {
       triggered: true,
       totalAbsDelta: 100000000,
       largestLineId: 'DIRECT_COST_OUT',
-      daysBeforeWeekStart: 2,
+      daysBeforeWeekStart: 0,
     });
   });
 

--- a/src/app/data/cashflow-weeks.persistence.ts
+++ b/src/app/data/cashflow-weeks.persistence.ts
@@ -6,7 +6,7 @@ export const PROJECTION_CHANGE_ALERT_THRESHOLD_AMOUNT = 10_000_000;
 export function resolveWeekDocId(projectId: string, yearMonth: string, weekNo: number): string {
   const safeProjectId = projectId.trim();
   const safeYm = yearMonth.trim();
-  const safeNo = Math.max(1, Math.min(6, Math.trunc(weekNo)));
+  const safeNo = Math.max(1, Math.min(5, Math.trunc(weekNo)));
   return `${safeProjectId}-${safeYm}-w${safeNo}`;
 }
 

--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -2323,7 +2323,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     }
     const projectId = input.projectId?.trim();
     const yearMonth = input.yearMonth?.trim();
-    const weekNo = Math.max(1, Math.min(6, Math.trunc(input.weekNo)));
+    const weekNo = Math.max(1, Math.min(5, Math.trunc(input.weekNo)));
     if (!projectId || !/^\d{4}-\d{2}$/.test(yearMonth)) return;
 
     const now = new Date().toISOString();

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -940,7 +940,7 @@ export interface WeeklySubmissionStatus {
   tenantId?: string;
   projectId: string;
   yearMonth: string; // "YYYY-MM"
-  weekNo: number; // 1..6
+  weekNo: number; // financeWeek 1..5
   projectionEdited?: boolean;
   projectionEditedAt?: string;
   projectionEditedByName?: string;
@@ -1221,7 +1221,7 @@ export interface CashflowWeekSheet {
   tenantId?: string;
   projectId: string;
   yearMonth: string; // "2026-01"
-  weekNo: number; // sheet-range cashflow week number, usually 1..5 and occasionally 6
+  weekNo: number; // financeWeek 1..5
   weekStart: string; // "YYYY-MM-DD"
   weekEnd: string; // "YYYY-MM-DD"
   sheetWeekSource?: 'cashflow-sheet-lab';

--- a/src/app/platform/__tests__/settlement-e2e-scenarios.test.ts
+++ b/src/app/platform/__tests__/settlement-e2e-scenarios.test.ts
@@ -887,8 +887,8 @@ describe('스트레스 2: 5년치 주차 계산 — 빈틈 없는 커버리지',
 
       expect(weeks.length).toBeGreaterThan(40,
         `${year}년 주차 수가 40 이상이어야 한다 (일반적으로 48~53)`);
-      expect(weeks.length).toBeLessThan(60,
-        `${year}년 주차 수가 60 미만이어야 한다`);
+      expect(weeks.length).toBe(60,
+        `${year}년 주차 수는 월별 5개 고정 슬롯이므로 60이어야 한다`);
 
       // 해당 연도의 모든 날짜가 어딘가의 주차에 속하는지 검증
       const isLeap = (year % 4 === 0 && year % 100 !== 0) || (year % 400 === 0);
@@ -925,7 +925,7 @@ describe('스트레스 2: 5년치 주차 계산 — 빈틈 없는 커버리지',
     }
   });
 
-  it('모든 주차가 정확히 7일(수~화)이다', () => {
+  it('모든 주차가 월 내부 Monday-based finance slot이다', () => {
     const weeks = getYearMondayWeeks(2026);
 
     for (const week of weeks) {
@@ -934,26 +934,37 @@ describe('스트레스 2: 5년치 주차 계산 — 빈틈 없는 커버리지',
       const diffMs = end.getTime() - start.getTime();
       const diffDays = diffMs / (1000 * 60 * 60 * 24);
 
-      expect(diffDays).toBe(6,
-        `주차 ${week.label}의 기간이 6일(수~화, 7일간)이어야 한다 (weekStart~weekEnd 차이)`);
+      expect(diffDays).toBeGreaterThanOrEqual(0,
+        `주차 ${week.label}의 종료일은 시작일 이후여야 한다`);
+      expect(diffDays).toBeLessThanOrEqual(8,
+        `주차 ${week.label}은 raw 6주차 병합을 포함해 최대 9일 이내여야 한다`);
+      expect(week.weekStart.slice(0, 7)).toBe(week.yearMonth,
+        `주차 ${week.label}의 시작일은 finance month 내부여야 한다`);
+      expect(week.weekEnd.slice(0, 7)).toBe(week.yearMonth,
+        `주차 ${week.label}의 종료일은 finance month 내부여야 한다`);
 
-      // 수요일(3) 시작 확인
       const startDay = new Date(Date.UTC(
         parseInt(week.weekStart.slice(0, 4)),
         parseInt(week.weekStart.slice(5, 7)) - 1,
         parseInt(week.weekStart.slice(8, 10)),
       )).getUTCDay();
-      expect(startDay).toBe(3,
-        `주차 ${week.label}이 수요일(3)에 시작해야 한다 (실제: ${startDay})`);
+      expect([1, new Date(Date.UTC(
+        parseInt(week.yearMonth.slice(0, 4)),
+        parseInt(week.yearMonth.slice(5, 7)) - 1,
+        1,
+      )).getUTCDay()]).toContain(startDay);
 
-      // 화요일(2) 종료 확인
       const endDay = new Date(Date.UTC(
         parseInt(week.weekEnd.slice(0, 4)),
         parseInt(week.weekEnd.slice(5, 7)) - 1,
         parseInt(week.weekEnd.slice(8, 10)),
       )).getUTCDay();
-      expect(endDay).toBe(2,
-        `주차 ${week.label}이 화요일(2)에 끝나야 한다 (실제: ${endDay})`);
+      const monthEndDay = new Date(Date.UTC(
+        parseInt(week.yearMonth.slice(0, 4)),
+        parseInt(week.yearMonth.slice(5, 7)),
+        0,
+      )).getUTCDay();
+      expect([0, monthEndDay]).toContain(endDay);
     }
   });
 });

--- a/src/app/platform/cashflow-export-surface.test.ts
+++ b/src/app/platform/cashflow-export-surface.test.ts
@@ -44,12 +44,18 @@ function createStatus(input: {
 }
 
 describe('cashflow-export-surface', () => {
-  it('resolves the current week using Wednesday-based buckets', () => {
+  it('resolves the current week using finance month buckets', () => {
     expect(resolveCurrentCashflowWeek('2026-04-09')).toMatchObject({
       yearMonth: '2026-04',
       weekNo: 2,
-      weekStart: '2026-04-08',
-      weekEnd: '2026-04-14',
+      weekStart: '2026-04-06',
+      weekEnd: '2026-04-12',
+    });
+    expect(resolveCurrentCashflowWeek('2026-07-01')).toMatchObject({
+      yearMonth: '2026-07',
+      weekNo: 1,
+      weekStart: '2026-07-01',
+      weekEnd: '2026-07-05',
     });
   });
 
@@ -64,8 +70,8 @@ describe('cashflow-export-surface', () => {
           projectId: 'p1',
           yearMonth: '2026-04',
           weekNo: 2,
-          weekStart: '2026-04-08',
-          weekEnd: '2026-04-14',
+          weekStart: '2026-04-06',
+          weekEnd: '2026-04-12',
           updatedAt: '2026-04-09T09:00:00.000Z',
         }),
       ],

--- a/src/app/platform/cashflow-export-surface.ts
+++ b/src/app/platform/cashflow-export-surface.ts
@@ -1,5 +1,5 @@
 import type { CashflowWeekSheet, WeeklySubmissionStatus } from '../data/types';
-import { getMonthMondayWeeks, type MonthMondayWeek } from './cashflow-weeks';
+import { findWeekForDate, getMonthMondayWeeks, type MonthMondayWeek } from './cashflow-weeks';
 
 export interface CashflowExportSurfaceProject {
   id: string;
@@ -25,7 +25,7 @@ function buildStatusKey(projectId: string, yearMonth: string, weekNo: number): s
 export function resolveCurrentCashflowWeek(todayIso: string): MonthMondayWeek | undefined {
   const yearMonth = typeof todayIso === 'string' ? todayIso.slice(0, 7) : '';
   if (!/^\d{4}-\d{2}$/.test(yearMonth)) return undefined;
-  return getMonthMondayWeeks(yearMonth).find((week) => todayIso >= week.weekStart && todayIso <= week.weekEnd);
+  return findWeekForDate(todayIso, getMonthMondayWeeks(yearMonth));
 }
 
 export function buildCashflowExportProjectRows(input: {

--- a/src/app/platform/cashflow-export.test.ts
+++ b/src/app/platform/cashflow-export.test.ts
@@ -32,38 +32,27 @@ function findRow(rows: Array<Array<string | number>>, label: string): Array<stri
   return rows.find((row) => row[0] === label);
 }
 
-function findMonthWithMissingFifthWeek(year: number): string {
-  for (let month = 1; month <= 12; month += 1) {
-    const ym = `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}`;
-    const slots = buildCashflowWeekSlots(ym);
-    if (slots.length === 5 && slots.filter((slot) => slot.present).length === 4) {
-      return ym;
-    }
-  }
-  throw new Error('Expected at least one month with only four fixed weeks');
-}
-
 describe('cashflow-export', () => {
   it('normalizes year-month input and expands contiguous ranges', () => {
     expect(normalizeCashflowYearMonths(['2026-03', '2026-01', 'bad', '2026-01'])).toEqual(['2026-01', '2026-03']);
     expect(expandCashflowYearMonthRange('2026-01', '2026-03')).toEqual(['2026-01', '2026-02', '2026-03']);
   });
 
-  it('keeps a fixed five-slot month shape even when the fifth week does not exist', () => {
-    const yearMonth = findMonthWithMissingFifthWeek(2026);
+  it('keeps a fixed five-slot month shape and merges raw week 6 into finance week 5', () => {
+    const yearMonth = '2026-08';
     const slots = buildCashflowWeekSlots(yearMonth);
 
     expect(slots).toHaveLength(5);
     expect(slots[4]).toMatchObject({
       weekNo: 5,
-      present: false,
-      weekStart: '',
-      weekEnd: '',
+      present: true,
+      weekStart: '2026-08-24',
+      weekEnd: '2026-08-31',
     });
   });
 
   it('builds single-project workbook sheets with projection and actual separated', () => {
-    const yearMonth = findMonthWithMissingFifthWeek(2026);
+    const yearMonth = '2026-08';
     const slots = buildCashflowWeekSlots(yearMonth);
     const week1 = slots[0];
     const week2 = slots[1];
@@ -116,7 +105,7 @@ describe('cashflow-export', () => {
   });
 
   it('builds combined and multi-sheet workbooks for multiple projects', () => {
-    const yearMonth = findMonthWithMissingFifthWeek(2026);
+    const yearMonth = '2026-08';
     const slots = buildCashflowWeekSlots(yearMonth);
     const week1 = slots[0];
 

--- a/src/app/platform/cashflow-week-core.d.mts
+++ b/src/app/platform/cashflow-week-core.d.mts
@@ -1,0 +1,20 @@
+export interface FinanceWeek {
+  financeYear: number;
+  financeMonth: number;
+  rawWeek: number;
+  financeWeek: number;
+  yearMonth: string;
+  weekNo: number;
+  weekStart: string;
+  weekEnd: string;
+  label: string;
+}
+
+export function isYearMonth(value: unknown): value is string;
+export function resolveFinanceWeekForDate(dateStr: string): FinanceWeek | undefined;
+export function getMonthFinanceWeeks(yearMonth: string): FinanceWeek[];
+export function getYearFinanceWeeks(year: number): FinanceWeek[];
+export function findFinanceWeekForDate<T extends Pick<FinanceWeek, 'yearMonth' | 'weekNo'>>(
+  dateStr: string,
+  weeks?: T[],
+): T | FinanceWeek | undefined;

--- a/src/app/platform/cashflow-week-core.mjs
+++ b/src/app/platform/cashflow-week-core.mjs
@@ -1,0 +1,149 @@
+function pad2(value) {
+  return String(value).padStart(2, '0');
+}
+
+function isValidYearMonth(value) {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (!/^\d{4}-\d{2}$/.test(trimmed)) return false;
+  const [, mmRaw] = trimmed.split('-');
+  const mm = Number.parseInt(mmRaw, 10);
+  return Number.isFinite(mm) && mm >= 1 && mm <= 12;
+}
+
+function parseYearMonth(value) {
+  if (!isValidYearMonth(value)) return null;
+  const [yyyyRaw, mmRaw] = value.trim().split('-');
+  const year = Number.parseInt(yyyyRaw, 10);
+  const month = Number.parseInt(mmRaw, 10);
+  if (!Number.isFinite(year) || !Number.isFinite(month)) return null;
+  return { year, month, yearMonth: `${String(year).padStart(4, '0')}-${pad2(month)}` };
+}
+
+function formatIsoDate(year, month, day) {
+  return `${String(year)}-${pad2(month)}-${pad2(day)}`;
+}
+
+function addDaysUtc(isoDate, deltaDays) {
+  const [yRaw, mRaw, dRaw] = String(isoDate || '').split('-');
+  const year = Number.parseInt(yRaw, 10);
+  const month = Number.parseInt(mRaw, 10);
+  const day = Number.parseInt(dRaw, 10);
+  const base = Date.UTC(year, month - 1, day);
+  const next = new Date(base + deltaDays * 24 * 60 * 60 * 1000);
+  return formatIsoDate(next.getUTCFullYear(), next.getUTCMonth() + 1, next.getUTCDate());
+}
+
+function dayOfWeekUtc(year, month, day) {
+  return new Date(Date.UTC(year, month - 1, day)).getUTCDay();
+}
+
+function daysInMonthUtc(year, month) {
+  return new Date(Date.UTC(year, month, 0)).getUTCDate();
+}
+
+function startOfWeekMonday(isoDate) {
+  const [yRaw, mRaw, dRaw] = String(isoDate || '').split('-');
+  const year = Number.parseInt(yRaw, 10);
+  const month = Number.parseInt(mRaw, 10);
+  const day = Number.parseInt(dRaw, 10);
+  const dow = dayOfWeekUtc(year, month, day);
+  const delta = -((dow + 6) % 7);
+  return addDaysUtc(isoDate, delta);
+}
+
+function parseIsoDateOnly(value) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(value || '').trim());
+  if (!match) return null;
+  const year = Number.parseInt(match[1], 10);
+  const month = Number.parseInt(match[2], 10);
+  const day = Number.parseInt(match[3], 10);
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return null;
+  if (month < 1 || month > 12) return null;
+  const lastDay = daysInMonthUtc(year, month);
+  if (day < 1 || day > lastDay) return null;
+  return { year, month, day, yearMonth: `${String(year).padStart(4, '0')}-${pad2(month)}` };
+}
+
+function rawWeekForMonthDate(year, month, day) {
+  const firstDow = dayOfWeekUtc(year, month, 1);
+  const firstDayOffsetFromMonday = (firstDow + 6) % 7;
+  return Math.floor((firstDayOffsetFromMonday + day - 1) / 7) + 1;
+}
+
+function buildWeek(year, month, rawWeek) {
+  const yearMonth = `${String(year).padStart(4, '0')}-${pad2(month)}`;
+  const firstDay = formatIsoDate(year, month, 1);
+  const firstWeekStart = startOfWeekMonday(firstDay);
+  const financeWeek = Math.max(1, Math.min(5, rawWeek));
+  const lastDay = formatIsoDate(year, month, daysInMonthUtc(year, month));
+  const weekStart = financeWeek === 1
+    ? firstDay
+    : addDaysUtc(firstWeekStart, (financeWeek - 1) * 7);
+  const weekEnd = financeWeek === 5
+    ? lastDay
+    : addDaysUtc(firstWeekStart, financeWeek * 7 - 1);
+  return {
+    financeYear: year,
+    financeMonth: month,
+    rawWeek,
+    financeWeek,
+    yearMonth,
+    weekNo: financeWeek,
+    weekStart,
+    weekEnd,
+    label: `${year % 100}-${month}-${financeWeek}`,
+  };
+}
+
+export function isYearMonth(value) {
+  return isValidYearMonth(value);
+}
+
+export function resolveFinanceWeekForDate(dateStr) {
+  const parsed = parseIsoDateOnly(dateStr);
+  if (!parsed) return undefined;
+  const rawWeek = rawWeekForMonthDate(parsed.year, parsed.month, parsed.day);
+  return buildWeek(parsed.year, parsed.month, rawWeek);
+}
+
+export function getMonthFinanceWeeks(yearMonth) {
+  const parsed = parseYearMonth(yearMonth);
+  if (!parsed) return [];
+
+  const weeks = [];
+  for (let rawWeek = 1; rawWeek <= 5; rawWeek += 1) {
+    weeks.push(buildWeek(parsed.year, parsed.month, rawWeek));
+  }
+
+  const rawWeekForLastDay = rawWeekForMonthDate(parsed.year, parsed.month, daysInMonthUtc(parsed.year, parsed.month));
+  if (rawWeekForLastDay > 5) {
+    const rawSix = buildWeek(parsed.year, parsed.month, rawWeekForLastDay);
+    weeks[4] = {
+      ...weeks[4],
+      rawWeek: rawWeekForLastDay,
+      weekEnd: rawSix.weekEnd,
+    };
+  }
+
+  return weeks;
+}
+
+export function getYearFinanceWeeks(year) {
+  const parsedYear = Number.parseInt(String(year), 10);
+  if (!Number.isFinite(parsedYear)) return [];
+  const all = [];
+  for (let m = 1; m <= 12; m += 1) {
+    all.push(...getMonthFinanceWeeks(`${parsedYear}-${pad2(m)}`));
+  }
+  return all;
+}
+
+export function findFinanceWeekForDate(dateStr, weeks = []) {
+  const resolved = resolveFinanceWeekForDate(dateStr);
+  if (!resolved) return undefined;
+  return weeks.find((week) => (
+    week.yearMonth === resolved.yearMonth
+    && Number(week.weekNo) === resolved.weekNo
+  )) || resolved;
+}

--- a/src/app/platform/cashflow-weeks.test.ts
+++ b/src/app/platform/cashflow-weeks.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import { getMonthMondayWeeks, isYearMonth } from './cashflow-weeks';
+import { findWeekForDate, getMonthMondayWeeks, getYearMondayWeeks, isYearMonth, resolveFinanceWeekForDate } from './cashflow-weeks';
 
-describe('cashflow week buckets (Wednesday-based)', () => {
+describe('cashflow week buckets (finance month policy)', () => {
   it('validates YYYY-MM inputs', () => {
     expect(isYearMonth('2026-01')).toBe(true);
     expect(isYearMonth('2026-1')).toBe(false);
@@ -10,29 +10,70 @@ describe('cashflow week buckets (Wednesday-based)', () => {
     expect(isYearMonth(null)).toBe(false);
   });
 
-  it('computes January 2026 as 5 Wednesday-based weeks', () => {
+  it('computes January 2026 as 5 Monday-based finance weeks', () => {
     const weeks = getMonthMondayWeeks('2026-01');
     expect(weeks.map((w) => w.weekStart)).toEqual([
-      '2025-12-31',
-      '2026-01-07',
-      '2026-01-14',
-      '2026-01-21',
-      '2026-01-28',
+      '2026-01-01',
+      '2026-01-05',
+      '2026-01-12',
+      '2026-01-19',
+      '2026-01-26',
     ]);
     expect(weeks.map((w) => w.label)).toEqual(['26-1-1', '26-1-2', '26-1-3', '26-1-4', '26-1-5']);
-    expect(weeks[0]).toMatchObject({ yearMonth: '2026-01', weekNo: 1, weekEnd: '2026-01-06' });
-    expect(weeks[4]).toMatchObject({ weekNo: 5, weekEnd: '2026-02-03' });
+    expect(weeks[0]).toMatchObject({ yearMonth: '2026-01', weekNo: 1, weekEnd: '2026-01-04' });
+    expect(weeks[4]).toMatchObject({ weekNo: 5, weekEnd: '2026-01-31' });
   });
 
-  it('computes March 2026 as 4 Wednesday-based weeks', () => {
+  it('computes every month as 5 finance weeks for cashflow slots', () => {
     const weeks = getMonthMondayWeeks('2026-03');
     expect(weeks.map((w) => w.weekStart)).toEqual([
-      '2026-03-04',
-      '2026-03-11',
-      '2026-03-18',
-      '2026-03-25',
+      '2026-03-01',
+      '2026-03-02',
+      '2026-03-09',
+      '2026-03-16',
+      '2026-03-23',
     ]);
-    expect(weeks.map((w) => w.label)).toEqual(['26-3-1', '26-3-2', '26-3-3', '26-3-4']);
+    expect(weeks.map((w) => w.label)).toEqual(['26-3-1', '26-3-2', '26-3-3', '26-3-4', '26-3-5']);
+    expect(weeks[4]).toMatchObject({ weekNo: 5, weekEnd: '2026-03-31' });
+  });
+
+  it('resolves required stage/live finance week boundary dates without environment branching', () => {
+    expect(resolveFinanceWeekForDate('2026-06-29')).toMatchObject({
+      financeYear: 2026,
+      financeMonth: 6,
+      rawWeek: 5,
+      financeWeek: 5,
+      yearMonth: '2026-06',
+      weekNo: 5,
+      label: '26-6-5',
+    });
+    expect(resolveFinanceWeekForDate('2026-07-01')).toMatchObject({
+      financeYear: 2026,
+      financeMonth: 7,
+      rawWeek: 1,
+      financeWeek: 1,
+      yearMonth: '2026-07',
+      weekNo: 1,
+      label: '26-7-1',
+    });
+    expect(resolveFinanceWeekForDate('2026-08-31')).toMatchObject({
+      financeYear: 2026,
+      financeMonth: 8,
+      rawWeek: 6,
+      financeWeek: 5,
+      yearMonth: '2026-08',
+      weekNo: 5,
+      label: '26-8-5',
+      weekStart: '2026-08-24',
+      weekEnd: '2026-08-31',
+    });
+  });
+
+  it('finds dates by their own finance month even when adjacent month ranges overlap', () => {
+    const weeks = getYearMondayWeeks(2026);
+    expect(findWeekForDate('2026-06-29', weeks)).toMatchObject({ yearMonth: '2026-06', weekNo: 5 });
+    expect(findWeekForDate('2026-07-01', weeks)).toMatchObject({ yearMonth: '2026-07', weekNo: 1 });
+    expect(findWeekForDate('2026-08-31', weeks)).toMatchObject({ yearMonth: '2026-08', weekNo: 5, rawWeek: 6 });
   });
 
   it('returns empty for invalid yearMonth', () => {

--- a/src/app/platform/cashflow-weeks.ts
+++ b/src/app/platform/cashflow-weeks.ts
@@ -1,119 +1,40 @@
-function pad2(value: number): string {
-  return String(value).padStart(2, '0');
-}
-
-function isValidYearMonth(value: unknown): value is string {
-  if (typeof value !== 'string') return false;
-  const trimmed = value.trim();
-  if (!/^\d{4}-\d{2}$/.test(trimmed)) return false;
-  const [, mmRaw] = trimmed.split('-');
-  const mm = Number.parseInt(mmRaw, 10);
-  return Number.isFinite(mm) && mm >= 1 && mm <= 12;
-}
-
-function parseYearMonth(value: string): { year: number; month: number } | null {
-  if (!isValidYearMonth(value)) return null;
-  const [yyyyRaw, mmRaw] = value.trim().split('-');
-  const year = Number.parseInt(yyyyRaw, 10);
-  const month = Number.parseInt(mmRaw, 10);
-  if (!Number.isFinite(year) || !Number.isFinite(month)) return null;
-  return { year, month };
-}
-
-function formatIsoDate(year: number, month: number, day: number): string {
-  return `${String(year)}-${pad2(month)}-${pad2(day)}`;
-}
-
-function addDaysUtc(isoDate: string, deltaDays: number): string {
-  const [yRaw, mRaw, dRaw] = isoDate.split('-');
-  const year = Number.parseInt(yRaw, 10);
-  const month = Number.parseInt(mRaw, 10);
-  const day = Number.parseInt(dRaw, 10);
-  const base = Date.UTC(year, month - 1, day);
-  const next = new Date(base + deltaDays * 24 * 60 * 60 * 1000);
-  return formatIsoDate(next.getUTCFullYear(), next.getUTCMonth() + 1, next.getUTCDate());
-}
-
-function dayOfWeekUtc(year: number, month: number, day: number): number {
-  return new Date(Date.UTC(year, month - 1, day)).getUTCDay();
-}
+import {
+  findFinanceWeekForDate,
+  getMonthFinanceWeeks,
+  getYearFinanceWeeks,
+  isYearMonth as isCashflowYearMonth,
+  resolveFinanceWeekForDate,
+} from './cashflow-week-core.mjs';
 
 export interface MonthMondayWeek {
+  financeYear?: number;
+  financeMonth?: number;
+  rawWeek?: number;
+  financeWeek?: number;
   yearMonth: string; // YYYY-MM
   weekNo: number; // 1..5
-  weekStart: string; // YYYY-MM-DD (Wednesday)
-  weekEnd: string; // YYYY-MM-DD (Tuesday)
+  weekStart: string; // YYYY-MM-DD (Monday)
+  weekEnd: string; // YYYY-MM-DD (Sunday, or merged week 5)
   label: string; // e.g. "26-1-4"
-}
-
-function daysInMonthUtc(year: number, month: number): number {
-  return new Date(Date.UTC(year, month, 0)).getUTCDate();
-}
-
-function startOfWeekWednesday(isoDate: string): string {
-  const [yRaw, mRaw, dRaw] = isoDate.split('-');
-  const year = Number.parseInt(yRaw, 10);
-  const month = Number.parseInt(mRaw, 10);
-  const day = Number.parseInt(dRaw, 10);
-  const dow = dayOfWeekUtc(year, month, day); // 0..6, Sunday=0
-  const delta = -((dow - 3 + 7) % 7);
-  return addDaysUtc(isoDate, delta);
-}
-
-function countDaysInMonthForWeek(weekStart: string, year: number, month: number): number {
-  let count = 0;
-  for (let i = 0; i < 7; i += 1) {
-    const date = addDaysUtc(weekStart, i);
-    const [yy, mm] = date.split('-');
-    if (Number.parseInt(yy, 10) === year && Number.parseInt(mm, 10) === month) count += 1;
-  }
-  return count;
 }
 
 /**
  * Month week buckets used by the finance sheet:
- * - Weeks are Wednesday..Tuesday.
- * - ISO-like month rule: a week belongs to the month if it contains 4+ days of that month.
- *   (week 1 = first Wednesday..Tuesday window with 4+ days in the month)
+ * - Weeks are Monday..Sunday calendar rows within the selected finance month.
+ * - Cashflow storage and sheet slots are fixed to financeWeek 1..5.
+ * - A raw calendar week 6 is merged into financeWeek 5.
  */
 export function getMonthMondayWeeks(yearMonth: string): MonthMondayWeek[] {
-  const parsed = parseYearMonth(yearMonth);
-  if (!parsed) return [];
-
-  const { year, month } = parsed;
-  const firstDay = formatIsoDate(year, month, 1);
-  const lastDay = formatIsoDate(year, month, daysInMonthUtc(year, month));
-  let weekStart = startOfWeekWednesday(firstDay);
-  const weeks: MonthMondayWeek[] = [];
-  const yy = year % 100;
-  let weekNo = 0;
-
-  while (weekStart <= lastDay) {
-    const daysInMonth = countDaysInMonthForWeek(weekStart, year, month);
-    if (daysInMonth >= 4) {
-      weekNo += 1;
-      const weekEnd = addDaysUtc(weekStart, 6);
-      const label = `${yy}-${month}-${weekNo}`;
-      weeks.push({ yearMonth, weekNo, weekStart, weekEnd, label });
-    }
-    weekStart = addDaysUtc(weekStart, 7);
-  }
-
-  return weeks;
+  return getMonthFinanceWeeks(yearMonth);
 }
 
 export function isYearMonth(value: unknown): value is string {
-  return isValidYearMonth(value);
+  return isCashflowYearMonth(value);
 }
 
-/** All Monday-based weeks for an entire year (Jan..Dec), ~48-53 weeks. */
+/** All finance weeks for an entire year (Jan..Dec), 60 fixed slots. */
 export function getYearMondayWeeks(year: number): MonthMondayWeek[] {
-  const all: MonthMondayWeek[] = [];
-  for (let m = 1; m <= 12; m++) {
-    const ym = `${year}-${pad2(m)}`;
-    all.push(...getMonthMondayWeeks(ym));
-  }
-  return all;
+  return getYearFinanceWeeks(year);
 }
 
 /** Find which MonthMondayWeek a date (YYYY-MM-DD) falls into. */
@@ -121,28 +42,7 @@ export function findWeekForDate(
   dateStr: string,
   weeks: MonthMondayWeek[],
 ): MonthMondayWeek | undefined {
-  if (!dateStr) return undefined;
-  const direct = weeks.find((w) => dateStr >= w.weekStart && dateStr <= w.weekEnd);
-  if (direct) return direct;
-
-  // Fallback: compute week bucket by month rule (handles edge days belonging to prev/next month)
-  const [yRaw, mRaw] = dateStr.split('-');
-  const year = Number.parseInt(yRaw, 10);
-  const month = Number.parseInt(mRaw, 10);
-  if (!Number.isFinite(year) || !Number.isFinite(month)) return undefined;
-
-  const current = getMonthMondayWeeks(`${year}-${pad2(month)}`);
-  const inCurrent = current.find((w) => dateStr >= w.weekStart && dateStr <= w.weekEnd);
-  if (inCurrent) return inCurrent;
-
-  const prevMonth = month === 1 ? 12 : month - 1;
-  const prevYear = month === 1 ? year - 1 : year;
-  const prev = getMonthMondayWeeks(`${prevYear}-${pad2(prevMonth)}`);
-  const inPrev = prev.find((w) => dateStr >= w.weekStart && dateStr <= w.weekEnd);
-  if (inPrev) return inPrev;
-
-  const nextMonth = month === 12 ? 1 : month + 1;
-  const nextYear = month === 12 ? year + 1 : year;
-  const next = getMonthMondayWeeks(`${nextYear}-${pad2(nextMonth)}`);
-  return next.find((w) => dateStr >= w.weekStart && dateStr <= w.weekEnd);
+  return findFinanceWeekForDate(dateStr, weeks);
 }
+
+export { resolveFinanceWeekForDate };

--- a/src/app/platform/payroll-cashflow-alignment.test.ts
+++ b/src/app/platform/payroll-cashflow-alignment.test.ts
@@ -68,8 +68,8 @@ describe('payroll-cashflow-alignment', () => {
           projectId: 'p-1',
           yearMonth: '2026-04',
           weekNo: 3,
-          weekStart: '2026-04-15',
-          weekEnd: '2026-04-21',
+          weekStart: '2026-04-13',
+          weekEnd: '2026-04-19',
           projection: {
             MYSC_LABOR_OUT: 3100000,
           },
@@ -81,8 +81,8 @@ describe('payroll-cashflow-alignment', () => {
       yearMonth: '2026-04',
       weekNo: 3,
       weekLabel: '26-4-3',
-      weekStart: '2026-04-15',
-      weekEnd: '2026-04-21',
+      weekStart: '2026-04-13',
+      weekEnd: '2026-04-19',
     });
     expect(alignment.cashflowProjectedPayrollAmount).toBe(3100000);
     expect(alignment.pmExpectedPayrollAmount).toBe(3500000);

--- a/src/app/platform/settlement-sheet-sync.test.ts
+++ b/src/app/platform/settlement-sheet-sync.test.ts
@@ -180,7 +180,7 @@ describe('buildSettlementActualSyncPayload', () => {
 
     expect(payload).toHaveLength(1);
     expect(payload[0]?.yearMonth).toBe('2026-03');
-    expect(payload[0]?.weekNo).toBe(1);
+    expect(payload[0]?.weekNo).toBe(2);
     expect(payload[0]?.amounts.DIRECT_COST_OUT).toBe(30000);
   });
 


### PR DESCRIPTION
## Summary
- Unifies cashflow finance week calculation into a shared core used by frontend and BFF paths.
- Applies month-internal Monday-based 5-slot policy; raw week 6 is persisted and aggregated as financeWeek 5.
- Locks cashflow week writes to financeWeek 1..5 and updates export/current-week/actual sync tests.

## Required verification
- 2026-06-29 resolves to 2026-06 week 5.
- 2026-07-01 resolves to 2026-07 week 1.
- 2026-08-31 resolves to rawWeek 6 / financeWeek 5.
- 2026-08 slots are 8/1-8/2, 8/3-8/9, 8/10-8/16, 8/17-8/23, 8/24-8/31.

## Local verification
- npx vitest run src/app/platform/cashflow-weeks.test.ts src/app/platform/cashflow-export.test.ts src/app/platform/cashflow-export-surface.test.ts src/app/data/cashflow-weeks.local-state.test.ts src/app/data/cashflow-weeks.helpers.test.ts src/app/platform/settlement-sheet-sync.test.ts src/app/platform/settlement-csv.test.ts src/app/platform/settlement-row-derivation.test.ts src/app/platform/__tests__/settlement-e2e-scenarios.test.ts server/bff/cashflow-canonical-store.test.mjs server/bff/cashflow-export.test.mjs
- npm run build

## Notes
- npm test is blocked locally by sandbox/runtime port binding failures in BFF supertest suites, plus pre-existing test assumptions. Targeted finance-week tests and production build pass.
- Production deploy remains GitHub Actions only; do not run local vercel --prod.