### PR TITLE
[hotfix] hide stage sheet lab on live only

### DIFF
--- a/docs/operations/2026-06-19-myscube-cutover-retrospective.md
+++ b/docs/operations/2026-06-19-myscube-cutover-retrospective.md
@@ -1,0 +1,207 @@
+# MYSCube myscguard Cutover Retrospective
+
+Date: 2026-06-19
+Status: active policy
+
+## Summary
+
+`myscube.myscguard.app` cutover took longer than expected because app deployment, Firebase Auth, Vercel custom-domain certificate issuance, Cloudflare DNS/proxy mode, Vercel alias promotion, and stage redirect smoke were handled as one moving target.
+
+The financeWeek code change itself was already merged and tested. The long tail came from release infrastructure state that was not aligned before the stage/live deploy attempts started.
+
+## What Made It Slow
+
+1. Domain requirements changed during deploy verification.
+   - The release started with `soc.myscguard.app` still active.
+   - `myscube.myscguard.app` was added during the same change window.
+   - Firebase Auth, BFF origins, Vercel aliases, Cloudflare DNS, and stage redirect expectations all had to move together.
+
+2. Stage smoke expected the new canonical host before the edge path was fully ready.
+   - Stage artifact and alias promotion succeeded.
+   - The visible failure was the stage host redirecting to `soc.myscguard.app` while the workflow expected `myscube.myscguard.app`.
+   - The fix was to deploy the commit containing the updated `vercel.json` redirect and verify the actual stage host after alias promotion.
+
+3. Production was retried before all gates were ready.
+   - One production run started before the exact `main` CI run had completed.
+   - Later production artifacts deployed successfully, but alias promotion failed until the `myscube.myscguard.app` DNS and certificate path were prepared.
+
+4. Vercel certificate issuance needed a DNS-only bootstrap.
+   - Cloudflare proxied `A` records can produce `525` until Vercel has issued the certificate for the custom domain.
+   - The working sequence was:
+     - create the Cloudflare record,
+     - temporarily set `myscube.myscguard.app` to DNS-only,
+     - run production deploy so Vercel can issue and verify the certificate,
+     - return the record to proxied,
+     - verify Cloudflare edge returns 200.
+
+5. BFF origin configuration and runtime safety were a separate live blocker.
+   - Live BFF must allow the actual browser origin.
+   - During the cutover, `BFF_ALLOWED_ORIGINS` and `BFF_LIVE_ALLOWED_ORIGINS` had to include the active Cloudflare hosts.
+   - Any mismatch surfaces as live BFF health/API failure even when the frontend artifact is correct.
+
+6. Firebase Auth authorized domains were checked against the wrong project first.
+   - `mysc-bmp-14173451` had `myscube.myscguard.app`, but live users were using Firebase project `inner-platform-live-20260316`.
+   - The correct live Identity Toolkit project number was `969339097899`.
+   - `soc.myscguard.app` and `myscube.myscguard.app` both had to be present in the live project's Firebase Auth authorized domains before Google login could work.
+
+7. Frontend Firebase allowed-host env is build-time configuration.
+   - `VITE_FIREBASE_AUTH_ALLOWED_HOSTS` is compiled into the Vite bundle.
+   - Updating Vercel env alone does not change the already-deployed JS.
+   - After updating production env, a fresh GitHub Actions Production Deploy is required.
+   - Browser network logs showing an old `assets/index-*.js` from disk cache mean the user is still running the previous bundle.
+
+8. Some existing docs referenced stale Vercel route commands.
+   - The documented `vercel routes` command was not available in the current CLI.
+   - Current deployment protection is primarily through deployment `vercel.json` redirects and the fixed stage/live alias workflow.
+   - Do not spend time trying to make a missing CLI subcommand work during a hotfix; verify the actual deployed routing surface instead.
+
+9. Local resolver cache produced a false negative.
+   - Public DNS and Cloudflare API showed the new `myscube` record correctly.
+   - macOS `getaddrinfo` remained stale, so local `curl` and the final live PWA verify fetch failed.
+   - Use `dig @1.1.1.1`, `dig @8.8.8.8`, Cloudflare API evidence, and `curl --resolve` when local resolver cache disagrees.
+
+10. Stage-only UI/API work was merged to `main`, so production inherited it.
+   - `feat(cashflow): add stage guide dialog` and `fix(stage): merge rescue cashflow snapshot into main` put the cashflow sheet-lab surface on the shared production branch.
+   - Stage and live can share financeWeek policy code, but stage-only UX and experimental API surfaces must have an explicit live exposure guard.
+   - A production deploy from `main` is enough to expose stage-only UI unless the route, navigation, embedded component, and BFF mount are all guarded.
+
+## Policy For Next Time
+
+Do not start repeated stage/live retries until this preflight is complete.
+
+1. Canonical host is fixed in one place.
+   - Confirm the active host name.
+   - Confirm whether legacy hosts stay alive or are removed.
+   - Confirm the stage redirect expectation before running the stage workflow.
+
+2. Firebase Auth is ready before user-facing verification.
+   - Confirm every active login host is in Firebase Auth authorized domains for the actual Firebase project used by the deployed browser bundle.
+   - Pull or inspect production env to confirm `VITE_FIREBASE_PROJECT_ID` before editing Identity Toolkit config.
+   - For this POC, both `soc.myscguard.app` and `myscube.myscguard.app` may remain authorized during transition.
+
+3. Browser and BFF live origins are ready before production deploy.
+   - Confirm `VITE_FIREBASE_AUTH_ALLOWED_HOSTS` includes the active Cloudflare host.
+   - Confirm `VITE_FIREBASE_AUTH_FALLBACK_URL` points to the canonical host.
+   - Confirm Vercel production env includes the active Cloudflare host.
+   - Do not rely on source-code defaults alone during a domain cutover.
+
+4. New Vercel custom domains use DNS-only for certificate bootstrap.
+   - Create Cloudflare DNS record.
+   - Set new host DNS-only while Vercel issues the certificate.
+   - Promote the Vercel production alias.
+   - Verify the alias is READY.
+   - Return the DNS record to proxied.
+   - Confirm Terraform plan returns no changes.
+
+5. Do not rerun the same failing workflow without changing the failed external state.
+   - If production fails at CI gate, wait for CI success.
+   - If production fails at alias/certificate, fix DNS/custom-domain state first.
+   - If stage fails at redirect smoke, verify the deployment `vercel.json` and actual stage alias target first.
+
+6. Deployment authority remains GitHub Actions.
+   - Local production deployment is still forbidden.
+   - Local verification and Cloudflare DNS/Terraform operations are allowed only when the relevant production gate has explicit approval.
+
+7. Record run IDs and external changes as part of the release note.
+   - CI run ID
+   - stage workflow run ID
+   - Production Deploy run ID
+   - Vercel deployment URL
+   - Cloudflare DNS record id and final proxied state
+   - Firebase Auth authorized-domain evidence
+
+8. Keep stage-only product surfaces out of live by default.
+   - Do not merge a stage-only UI/API to `main` without a live exposure guard.
+   - The guard must cover all entry points: nav item, direct route, embedded component, and BFF route mount.
+   - The guard must not branch financeWeek calculation, financeYear, financeMonth, or financeWeek persistence logic.
+   - Add tests that prove live hosts hide the stage-only UI and live BFF returns 404 for the stage-only API.
+   - If the stage-only surface should become live, ship a separate release note and verification checklist that explicitly says it is no longer stage-only.
+
+## Required Cutover Order
+
+Use this order for the next canonical-host or live-origin change.
+
+```text
+1. Merge code to main.
+2. Wait for CI success on the exact commit.
+3. Confirm Firebase Auth authorized domains.
+4. Confirm Vercel production build env:
+   - `VITE_FIREBASE_PROJECT_ID`
+   - `VITE_FIREBASE_AUTH_DOMAIN`
+   - `VITE_FIREBASE_AUTH_ALLOWED_HOSTS`
+   - `VITE_FIREBASE_AUTH_FALLBACK_URL`
+   - BFF allowed origins
+5. Add or update Vercel custom domain.
+6. Add Cloudflare DNS record as DNS-only for new custom domains.
+7. Run Production Deploy from GitHub Actions.
+8. Confirm production alias points to the new deployment.
+9. Confirm the live HTML references a new `assets/index-*.js` and that the new JS contains the active host.
+10. Switch Cloudflare record back to proxied.
+11. Run Terraform plan and require "No changes".
+12. Run the stage release workflow from GitHub Actions.
+13. Verify stage redirects to the canonical host.
+14. Verify live root, health, PWA package, and critical BFF API paths.
+15. Only then report completion.
+```
+
+If step 7 is not possible because CI has not passed, stop. Do not start production deploy.
+
+If step 8 fails because of certificate issuance, stop and re-check DNS-only custom-domain bootstrap. Do not keep rerunning production deploy against a proxied-only hostname.
+
+## FinanceWeek Release-Specific Guard
+
+For financeWeek changes, stage and live must use the same shared code path.
+
+Required checks:
+
+```bash
+node --input-type=module - <<'NODE'
+import { resolveFinanceWeekForDate, getMonthFinanceWeeks } from './src/app/platform/cashflow-week-core.mjs';
+console.log(resolveFinanceWeekForDate('2026-06-29'));
+console.log(resolveFinanceWeekForDate('2026-07-01'));
+console.log(resolveFinanceWeekForDate('2026-08-31'));
+console.log(getMonthFinanceWeeks('2026-08'));
+NODE
+
+npm test -- \
+  src/app/platform/cashflow-weeks.test.ts \
+  server/bff/cashflow-canonical-store.test.mjs \
+  server/bff/cashflow-export.test.mjs \
+  server/bff/routes/cashflow-sheet-lab.test.mjs
+```
+
+Expected results:
+
+- `2026-06-29` -> `financeMonth 6`, `financeWeek 5`
+- `2026-07-01` -> `financeMonth 7`, `financeWeek 1`
+- `2026-08-31` -> `rawWeek 6`, `financeWeek 5`
+- `2026-08` week 5 spans `2026-08-24` through `2026-08-31`
+
+## Verification Evidence From This Cutover
+
+- CI: `27809537585`, success, commit `1fa2109b08bed7e4fdd9310e60c1fd75cc8636e1`
+- Stage release workflow: `27809537572`, success
+- Production Deploy: `27810019703`, success
+- Production alias: `myscube.myscguard.app` -> `inner-platform-c6l6kne74-merryai-devs-projects.vercel.app`
+- Follow-up Production Deploy after live Firebase env correction:
+  - `27810428034` rebuilt production with `VITE_FIREBASE_AUTH_ALLOWED_HOSTS` containing `myscube.myscguard.app`.
+  - Vercel alias promotion succeeded and `myscube.myscguard.app` pointed to `inner-platform-dsk6wdc3e-merryai-devs-projects.vercel.app`.
+  - The workflow failed only at the PWA smoke step because Cloudflare returned `403` to the GitHub Actions runner. Direct browser-path checks through Cloudflare returned 200.
+- Live bundle after Firebase env correction:
+  - `assets/index-DlYCdEEq.js`
+  - contains `soc.myscguard.app` and `myscube.myscguard.app` in `VITE_FIREBASE_AUTH_ALLOWED_HOSTS`.
+- Cloudflare DNS: `myscube.myscguard.app`, `A 76.76.21.21`, proxied `true`
+- Terraform final plan: `No changes`
+- Live Firebase Auth project `inner-platform-live-20260316` authorized domains include:
+  - `soc.myscguard.app`
+  - `myscube.myscguard.app`
+- Fixed stage alias redirects:
+  - the stage Vercel alias root -> `https://myscube.myscguard.app/`
+- Live health:
+  - `https://myscube.myscguard.app/api/v1/health` returned 200 through Cloudflare edge
+
+## Operator Notes
+
+- Never paste secrets into docs, commits, logs, or issue comments.
+- When a secret is supplied in chat, use it only for the immediate operation and do not persist it.
+- If a global Cloudflare key is used, prefer replacing it with a scoped API token after the incident.

--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -1416,6 +1416,7 @@ export function createBffApp(options = {}) {
   mountCashflowSheetLabRoutes(app, {
     db,
     googleSheetsService,
+    enabled: runtimeSafetyConfig.deployEnv !== 'live',
   });
   mountCashflowLaborRiskRoutes(app, {
     db,

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -878,9 +878,20 @@ function createSheetPreviewLoader({ googleSheetsService, cacheTtlMs = DEFAULT_SH
 export function mountCashflowSheetLabRoutes(app, {
   db,
   googleSheetsService,
+  enabled = true,
   workspaceEmailDomain = 'mysc.co.kr',
   sheetPreviewCacheTtlMs = DEFAULT_SHEET_PREVIEW_CACHE_TTL_MS,
 } = {}) {
+  if (enabled === false) {
+    app.use('/api/v1/projects/:projectId/cashflow-sheet-lab', (_req, res) => {
+      res.status(404).json({
+        code: 'cashflow_sheet_lab_not_available',
+        message: 'Cashflow sheet lab is not available on this deployment surface.',
+      });
+    });
+    return;
+  }
+
   const loadSheetPreview = createSheetPreviewLoader({
     googleSheetsService,
     cacheTtlMs: sheetPreviewCacheTtlMs,

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -137,7 +137,29 @@ function createApp({ context = {}, db = createDb(), googleSheetsService } = {}) 
   return app;
 }
 
+function createDisabledApp() {
+  const app = express();
+  app.use(express.json());
+  mountCashflowSheetLabRoutes(app, {
+    enabled: false,
+    db: createDb(),
+    googleSheetsService: {
+      previewSpreadsheet: vi.fn(),
+    },
+  });
+  return app;
+}
+
 describe('cashflow sheet lab route', () => {
+  it('returns 404 when the deployment surface disables sheet lab', async () => {
+    await request(createDisabledApp())
+      .get('/api/v1/projects/project-a/cashflow-sheet-lab/config')
+      .expect(404)
+      .expect((response) => {
+        expect(response.body.code).toBe('cashflow_sheet_lab_not_available');
+      });
+  });
+
   it('saves the validated cashflow sheet config', async () => {
     const db = createDb();
 

--- a/src/app/components/portal/PortalCashflowPage.tsx
+++ b/src/app/components/portal/PortalCashflowPage.tsx
@@ -5,6 +5,7 @@ import { CashflowSheetLabPage } from '../../features/cashflow-sheet-compare/Cash
 import { usePortalStore } from '../../data/portal-store';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
+import { shouldShowStageOnlyCashflowSheetLab } from '../../platform/deployment-surface';
 
 export function PortalCashflowPage() {
   const {
@@ -23,6 +24,7 @@ export function PortalCashflowPage() {
   });
 
   const ready = useMemo(() => Boolean(projectId), [projectId]);
+  const showSheetLab = shouldShowStageOnlyCashflowSheetLab();
   const sheetRangeLabel = sheetHeader.startWeek || sheetHeader.endWeek
     ? `합계 기준 ${sheetHeader.startWeek || '시작 미지정'} ~ ${sheetHeader.endWeek || '종료 미지정'}`
     : '합계 기준 미지정';
@@ -42,58 +44,62 @@ export function PortalCashflowPage() {
 
   return (
     <div className="space-y-3">
-      <section className="flex flex-wrap items-center justify-between gap-2 border border-slate-200 bg-white px-3 py-2 shadow-sm">
-        <div className="min-w-0">
-          <div className="flex min-w-0 items-center gap-2">
-            <div className="truncate text-[12px] font-semibold text-slate-950">
-              {sheetHeader.spreadsheetTitle || myProject?.name || '저장된 시트'}
+      {showSheetLab && (
+        <section className="flex flex-wrap items-center justify-between gap-2 border border-slate-200 bg-white px-3 py-2 shadow-sm">
+          <div className="min-w-0">
+            <div className="flex min-w-0 items-center gap-2">
+              <div className="truncate text-[12px] font-semibold text-slate-950">
+                {sheetHeader.spreadsheetTitle || myProject?.name || '저장된 시트'}
+              </div>
+              <Badge variant="outline" className="h-5 rounded-full px-2 text-[9px] text-blue-700">
+                시트 연동
+              </Badge>
             </div>
-            <Badge variant="outline" className="h-5 rounded-full px-2 text-[9px] text-blue-700">
-              시트 연동
-            </Badge>
+            <div className="mt-0.5 truncate text-[10px] text-slate-500">
+              {sheetHeader.sheetName || 'cashflow(사용내역 연동)'} · {sheetRangeLabel}
+            </div>
           </div>
-          <div className="mt-0.5 truncate text-[10px] text-slate-500">
-            {sheetHeader.sheetName || 'cashflow(사용내역 연동)'} · {sheetRangeLabel}
+          <div className="flex shrink-0 items-center gap-1.5">
+            <Button
+              type="button"
+              size="sm"
+              className="h-7 gap-1 rounded-none px-2 text-[10px]"
+              onClick={() => dispatchSheetAction('apply')}
+            >
+              <Settings className="h-3 w-3" />
+              시트와 연동하기
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-7 gap-1 rounded-none px-2 text-[10px]"
+              onClick={() => dispatchSheetAction('preview')}
+            >
+              <Search className="h-3 w-3" />
+              검토
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-7 gap-1 rounded-none px-2 text-[10px]"
+              onClick={() => dispatchSheetAction('edit')}
+            >
+              <Pencil className="h-3 w-3" />
+              수정
+            </Button>
           </div>
-        </div>
-        <div className="flex shrink-0 items-center gap-1.5">
-          <Button
-            type="button"
-            size="sm"
-            className="h-7 gap-1 rounded-none px-2 text-[10px]"
-            onClick={() => dispatchSheetAction('apply')}
-          >
-            <Settings className="h-3 w-3" />
-            시트와 연동하기
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            className="h-7 gap-1 rounded-none px-2 text-[10px]"
-            onClick={() => dispatchSheetAction('preview')}
-          >
-            <Search className="h-3 w-3" />
-            검토
-          </Button>
-          <Button
-            type="button"
-            size="sm"
-            variant="outline"
-            className="h-7 gap-1 rounded-none px-2 text-[10px]"
-            onClick={() => dispatchSheetAction('edit')}
-          >
-            <Pencil className="h-3 w-3" />
-            수정
-          </Button>
-        </div>
-      </section>
-      <CashflowSheetLabPage
-        projectIdOverride={projectId}
-        embedded
-        hideConfigChrome
-        onHeaderSummaryChange={setSheetHeader}
-      />
+        </section>
+      )}
+      {showSheetLab && (
+        <CashflowSheetLabPage
+          projectIdOverride={projectId}
+          embedded
+          hideConfigChrome
+          onHeaderSummaryChange={setSheetHeader}
+        />
+      )}
       <CashflowProjectSheet
         projectId={projectId}
         roleOverride={portalUser?.role}

--- a/src/app/components/portal/PortalLayout.tsx
+++ b/src/app/components/portal/PortalLayout.tsx
@@ -75,6 +75,7 @@ import { rememberRecentPortalProject } from '../../platform/portal-recent-projec
 import { buildPortalShellCommandItems, buildPortalShellNotificationItems } from '../../platform/portal-shell-actions';
 import { shouldShowShellRoute, useShellLabEnabled } from '../../platform/shell-lab-visibility';
 import { resolvePortalProjectCandidates } from '../../platform/portal-project-selection';
+import { shouldShowStageOnlyCashflowSheetLab } from '../../platform/deployment-surface';
 
 // ═══════════════════════════════════════════════════════════════
 // PortalLayout — 사용자(PM) 전용 레이아웃
@@ -338,18 +339,20 @@ function PortalContent() {
   const portalDisplayName = portalUser?.name || authUser?.name || '사용자';
   const portalDisplayRole = portalUser?.role || authUser?.role || 'pm';
   const currentFundInputMode = normalizeProjectFundInputMode(currentProject?.fundInputMode);
+  const showSheetLab = shouldShowStageOnlyCashflowSheetLab();
   const navSections = useMemo(() => (
     NAV_SECTIONS.map((section) => ({
       ...section,
       items: section.items.filter((item) => {
         if ('hidden' in item && item.hidden) return false;
+        if (item.to === '/portal/cashflow/sheets-lab' && !showSheetLab) return false;
         return shouldShowShellRoute(item.to, 'portal', 'nav', {
           fundInputMode: currentFundInputMode,
           labEnabled,
         });
       }),
     }))
-  ), [currentFundInputMode, labEnabled]);
+  ), [currentFundInputMode, labEnabled, showSheetLab]);
   const topNavItems = useMemo(() => navSections.flatMap((section) => section.items), [navSections]);
   const currentSectionLabel = useMemo(() => {
     const current = topNavItems.find((item) => isActive(item.to, item.exact));

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
@@ -24,8 +24,11 @@ describe('CashflowSheetLabPage shell', () => {
     expect(routesSource).toContain("path: '/portal'");
     expect(routesSource).toContain("path: 'cashflow/sheets-lab'");
     expect(routesSource).toContain('CashflowSheetLabPage');
+    expect(routesSource).toContain('StageOnlyCashflowSheetLabRoute');
+    expect(routesSource).toContain('shouldShowStageOnlyCashflowSheetLab');
     expect(portalLayoutSource).toContain('/portal/cashflow/sheets-lab');
     expect(portalCashflowSource).toContain('CashflowSheetLabPage');
+    expect(portalCashflowSource).toContain('shouldShowStageOnlyCashflowSheetLab');
     expect(portalCashflowSource).toContain('projectIdOverride={projectId}');
     expect(portalCashflowSource).toContain('embedded');
     expect(portalCashflowSource).toContain('hideConfigChrome');

--- a/src/app/platform/deployment-surface.test.ts
+++ b/src/app/platform/deployment-surface.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { isLiveMyscguardHost, shouldShowStageOnlyCashflowSheetLab } from './deployment-surface';
+
+describe('deployment surface visibility', () => {
+  it('treats live myscguard hosts as live surfaces', () => {
+    expect(isLiveMyscguardHost('myscube.myscguard.app')).toBe(true);
+    expect(isLiveMyscguardHost('soc.myscguard.app')).toBe(true);
+    expect(shouldShowStageOnlyCashflowSheetLab('myscube.myscguard.app')).toBe(false);
+  });
+
+  it('keeps stage and preview hosts eligible for stage-only sheet lab work', () => {
+    expect(isLiveMyscguardHost('inner-platform-stage-merryai-devs-projects.vercel.app')).toBe(false);
+    expect(shouldShowStageOnlyCashflowSheetLab('inner-platform-stage-merryai-devs-projects.vercel.app')).toBe(true);
+    expect(shouldShowStageOnlyCashflowSheetLab('inner-platform-7lwazqaf6-merryai-devs-projects.vercel.app')).toBe(true);
+    expect(shouldShowStageOnlyCashflowSheetLab('localhost')).toBe(true);
+  });
+});

--- a/src/app/platform/deployment-surface.ts
+++ b/src/app/platform/deployment-surface.ts
@@ -1,0 +1,30 @@
+const LIVE_MYSCGUARD_HOSTS = new Set([
+  'myscube.myscguard.app',
+  'soc.myscguard.app',
+  'edge.myscguard.app',
+  'audit.myscguard.app',
+  'firestore.myscguard.app',
+  'github.myscguard.app',
+  'drive.myscguard.app',
+  'devops.myscguard.app',
+]);
+
+function normalizeHostname(value: unknown): string {
+  return String(value || '').trim().toLowerCase().replace(/:\d+$/, '');
+}
+
+function readCurrentHostname(): string {
+  if (typeof window === 'undefined') return '';
+  return normalizeHostname(window.location?.hostname);
+}
+
+export function isLiveMyscguardHost(hostname = readCurrentHostname()): boolean {
+  const normalized = normalizeHostname(hostname);
+  if (!normalized) return false;
+  if (LIVE_MYSCGUARD_HOSTS.has(normalized)) return true;
+  return normalized.endsWith('.myscguard.app') && !normalized.includes('stage');
+}
+
+export function shouldShowStageOnlyCashflowSheetLab(hostname = readCurrentHostname()): boolean {
+  return !isLiveMyscguardHost(hostname);
+}

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -6,6 +6,7 @@ import { AdminRouteProviders } from './data/admin-route-providers';
 import { PortalRouteProviders } from './data/portal-route-providers';
 import { loadLazyRouteModule } from './platform/lazy-route';
 import { shouldUseBusinessCardMobileEntry } from './platform/mobile-entry';
+import { shouldShowStageOnlyCashflowSheetLab } from './platform/deployment-surface';
 
 // Lazy-loaded pages — each becomes a separate chunk
 const LoginPage = lazy(() => import('./components/auth/LoginPage').then(m => ({ default: m.LoginPage })));
@@ -103,6 +104,12 @@ function MobileAwareAdminHome() {
     : <S C={FeatureSearchPage} />;
 }
 
+function StageOnlyCashflowSheetLabRoute() {
+  return shouldShowStageOnlyCashflowSheetLab()
+    ? <S C={CashflowSheetLabPage} />
+    : <S C={NotFoundPage} />;
+}
+
 export const router = createBrowserRouter([
   // ── Login ──
   { path: '/login', element: <S C={LoginPage} /> },
@@ -176,7 +183,7 @@ export const router = createBrowserRouter([
       { path: 'submissions', element: <S C={PortalProjectSelectPage} /> },
       { path: 'payroll', element: <S C={PortalPayrollPage} /> },
       { path: 'cashflow', element: <S C={PortalCashflowPage} /> },
-      { path: 'cashflow/sheets-lab', element: <S C={CashflowSheetLabPage} /> },
+      { path: 'cashflow/sheets-lab', element: <StageOnlyCashflowSheetLabRoute /> },
       { path: 'budget', element: <S C={PortalBudget} /> },
       { path: 'weekly-expenses', element: <S C={PortalWeeklyExpensePage} /> },
       { path: 'bank-statements', element: <S C={PortalBankStatementPage} /> },


### PR DESCRIPTION
## Summary

- Keep the existing stage cashflow sheet-lab/dashboard logic available on stage/preview.
- Hide the sheet-lab nav, embedded UI, and direct route on live myscguard hosts.
- Disable the sheet-lab BFF mount when `BFF_DEPLOY_ENV=live`.
- Keep the shared financeWeek calculation path unchanged.

## DB / Data Safety

- No Firestore/business DB write or migration is included.
- This is UI/API exposure control only.

## Validation

- `npm test -- src/app/platform/deployment-surface.test.ts src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts server/bff/routes/cashflow-sheet-lab.test.mjs src/app/platform/cashflow-weeks.test.ts`
- `npm run build`

## Expected Behavior

- Stage/preview: `/portal/cashflow/sheets-lab` and embedded sheet-lab remain available.
- Live: `myscube.myscguard.app` hides sheet-lab entry points and BFF sheet-lab routes return 404.

## Deployment Checklist

- Merge to `main` after CI.
- Stage Deploy: verify stage still has sheet-lab.
- Production Deploy: verify live no longer exposes sheet-lab UI/API.
