### PR TITLE
hotfix: remove duplicate deploy gates

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -78,17 +78,6 @@ jobs:
           test -n "${VERCEL_PROJECT_ID}" || { echo "Missing secret: VERCEL_PROJECT_ID" >&2; exit 1; }
           npx --yes "${VERCEL_CLI_PACKAGE}" whoami --token "${VERCEL_TOKEN}" --scope merryai-devs-projects >/dev/null
 
-      - run: npm ci
-
-      - name: Unit tests
-        run: npm test
-
-      - name: RBAC policy verify
-        run: npm run policy:verify
-
-      - name: Production build
-        run: npm run build
-
       - name: Deploy to Vercel production
         id: vercel_deploy
         run: |

--- a/.github/workflows/stage-deploy.yml
+++ b/.github/workflows/stage-deploy.yml
@@ -75,24 +75,6 @@ jobs:
           npx --yes "${VERCEL_CLI_PACKAGE}" whoami --token "${VERCEL_TOKEN}" --scope merryai-devs-projects >/dev/null
           test -n "$(git rev-parse HEAD)" || { echo "Could not resolve deploy commit." >&2; exit 1; }
 
-      - run: npm ci
-
-      - name: Unit tests
-        run: npm test
-
-      - name: RBAC policy verify
-        run: npm run policy:verify
-
-      - name: Cashflow stage smoke tests
-        run: |
-          npx vitest run \
-            src/app/features/cashflow-sheet-compare/cashflow-sheet-preview-tables.test.ts \
-            server/bff/routes/cashflow-sheet-lab.test.mjs \
-            server/bff/cashflow-sheet-template.test.mjs
-
-      - name: Stage build
-        run: npm run build
-
       - name: Deploy Git artifact to Vercel preview
         id: vercel_deploy
         env:

--- a/server/production-deploy-workflow.test.ts
+++ b/server/production-deploy-workflow.test.ts
@@ -85,7 +85,7 @@ describe('stage release workflow safety', () => {
     expect(stageWorkflowText).toContain('Missing secret: VERCEL_DEPLOY_TOKEN_STAGE');
     expect(stageWorkflowText).toContain('whoami --token "${VERCEL_TOKEN}" --scope merryai-devs-projects');
     expect(stageWorkflowText.indexOf('whoami --token "${VERCEL_TOKEN}" --scope merryai-devs-projects')).toBeLessThan(
-      stageWorkflowText.indexOf('run: npm ci'),
+      stageWorkflowText.indexOf('Deploy Git artifact to Vercel preview'),
     );
   });
 

--- a/server/production-deploy-workflow.test.ts
+++ b/server/production-deploy-workflow.test.ts
@@ -106,4 +106,17 @@ describe('stage release workflow safety', () => {
     expect(stageWorkflowText).toContain('--timeout 10m');
     expect(stageWorkflowText).toContain('Stage artifact is not READY');
   });
+
+  it('keeps deploy workflows focused on deployment after CI gates have passed', () => {
+    expect(stageWorkflowText).not.toContain('run: npm ci');
+    expect(stageWorkflowText).not.toContain('Unit tests');
+    expect(stageWorkflowText).not.toContain('RBAC policy verify');
+    expect(stageWorkflowText).not.toContain('Stage build');
+
+    expect(workflowText).toContain('Verify CI succeeded for this commit');
+    expect(workflowText).not.toContain('run: npm ci');
+    expect(workflowText).not.toContain('Unit tests');
+    expect(workflowText).not.toContain('RBAC policy verify');
+    expect(workflowText).not.toContain('Production build');
+  });
 });


### PR DESCRIPTION
## Summary
- Remove duplicated install/test/smoke/build steps from stage and production deploy workflows.
- Keep deployment path focused on Vercel artifact deploy after CI policy gates.
- Keep production workflow CI verification of previous pipeline success.
- Update deploy workflow test to ensure duplicate gates are not reintroduced.