### PR TITLE
fix: expose cashflow sheets lab on live

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -77,6 +77,9 @@ jobs:
           test -n "${VERCEL_ORG_ID}" || { echo "Missing secret: VERCEL_ORG_ID" >&2; exit 1; }
           test -n "${VERCEL_PROJECT_ID}" || { echo "Missing secret: VERCEL_PROJECT_ID" >&2; exit 1; }
           npx --yes "${VERCEL_CLI_PACKAGE}" whoami --token "${VERCEL_TOKEN}" --scope merryai-devs-projects >/dev/null
+      
+      - name: Verify production deploy policy
+        run: node scripts/assert-safe-live-deploy.mjs
 
       - name: Deploy to Vercel production
         id: vercel_deploy

--- a/.github/workflows/stage-deploy.yml
+++ b/.github/workflows/stage-deploy.yml
@@ -178,25 +178,42 @@ jobs:
               throw new Error(`Stage alias points to ${inspect.url}, expected ${expectedHost}`);
             }
           ' "${inspect_file}"
-          root_status="$(curl -sS -o /tmp/stage-root-response.txt -w '%{http_code}' "https://${STAGE_CANONICAL_HOST}/")"
+          root_status="$(curl -sS -D /tmp/stage-root-headers.txt -o /tmp/stage-root-response.txt -w '%{http_code}' "https://${STAGE_CANONICAL_HOST}/")"
           case "${root_status}" in
-            200|403) ;;
+            200) ;;
             *)
               echo "Unexpected stage root status: ${root_status}" >&2
+              cat /tmp/stage-root-headers.txt >&2 || true
               cat /tmp/stage-root-response.txt >&2 || true
               exit 1
               ;;
           esac
-          config_status="$(curl -sS -o /tmp/stage-config-response.txt -w '%{http_code}' \
+          if grep -iq '^cf-ray:' /tmp/stage-root-headers.txt || grep -iq '^server: cloudflare' /tmp/stage-root-headers.txt; then
+            echo "Stage must stay on the internal Vercel route and must not traverse Cloudflare." >&2
+            cat /tmp/stage-root-headers.txt >&2 || true
+            exit 1
+          fi
+          if grep -iq '^content-security-policy-report-only:' /tmp/stage-root-headers.txt; then
+            echo "Stage must not receive security-domain CSP report-only headers." >&2
+            cat /tmp/stage-root-headers.txt >&2 || true
+            exit 1
+          fi
+          config_status="$(curl -sS -D /tmp/stage-config-headers.txt -o /tmp/stage-config-response.txt -w '%{http_code}' \
             "https://${STAGE_CANONICAL_HOST}/api/v1/projects/p1773651024850/cashflow-sheet-lab/config")"
           case "${config_status}" in
-            200|401|403) ;;
+            200|401) ;;
             *)
               echo "Unexpected cashflow config status from stage: ${config_status}" >&2
+              cat /tmp/stage-config-headers.txt >&2 || true
               cat /tmp/stage-config-response.txt >&2 || true
               exit 1
               ;;
           esac
+          if grep -iq '^cf-ray:' /tmp/stage-config-headers.txt || grep -iq '^server: cloudflare' /tmp/stage-config-headers.txt; then
+            echo "Stage API must stay on the internal Vercel route and must not traverse Cloudflare." >&2
+            cat /tmp/stage-config-headers.txt >&2 || true
+            exit 1
+          fi
 
       - name: Stage deployment summary
         env:

--- a/docs/operations/2026-05-26-production-deployment-governance.md
+++ b/docs/operations/2026-05-26-production-deployment-governance.md
@@ -38,6 +38,18 @@ node deploy-prod-align.mjs
 
 The second command intentionally fails closed.
 
+### Fixed Policy Enforcement
+
+Production deployments must now pass a local workflow policy guard:
+
+- `scripts/assert-safe-live-deploy.mjs`
+- Workflow assertion currently requires:
+  - GitHub Actions execution context
+  - `main` ref (`GITHUB_REF`)
+  - `GITHUB_SHA`
+  - canonical host `myscube.myscguard.app`
+  - VERCEL token presence in production workflow scope
+
 ## Rollback Policy
 
 Rollback means moving the canonical live URL back to a known-good production deployment or reverting a future live manifest commit.

--- a/docs/operations/2026-06-18-stage-deployment-governance.md
+++ b/docs/operations/2026-06-18-stage-deployment-governance.md
@@ -30,6 +30,13 @@ The workflow currently allows only `main` as the stage source ref. This keeps st
 
 The stage alias must stay on the internal stage host and must not pass through the `myscube.myscguard.app` security redirect path.
 
+The stage surface check treats security-route symptoms as failures, not acceptable degraded states:
+
+- Stage root must return `200`.
+- Stage root must not include Cloudflare response markers such as `cf-ray` or `server: cloudflare`.
+- Stage root must not receive security-domain `Content-Security-Policy-Report-Only` headers.
+- Stage cashflow config API may return `200` or unauthenticated `401`; `403` is not accepted because it can mask an edge/security guard block.
+
 ## Required Secrets
 
 The Stage environment or repository must define:

--- a/docs/operations/2026-06-18-stage-deployment-governance.md
+++ b/docs/operations/2026-06-18-stage-deployment-governance.md
@@ -28,6 +28,8 @@ For a company-wide SaaS surface, stage must be reproducible from Git. A stage in
 
 The workflow currently allows only `main` as the stage source ref. This keeps stage reproducible from the integration branch while production remains separated behind the production workflow and token.
 
+The stage alias must stay on the internal stage host and must not pass through the `myscube.myscguard.app` security redirect path.
+
 ## Required Secrets
 
 The Stage environment or repository must define:

--- a/scripts/assert-safe-live-deploy.mjs
+++ b/scripts/assert-safe-live-deploy.mjs
@@ -1,0 +1,34 @@
+const EXPECTED_CANONICAL_HOST = 'myscube.myscguard.app';
+const EXPECTED_REF = 'refs/heads/main';
+
+function fail(message) {
+  console.error(`[live-deploy-guard] ${message}`);
+  process.exit(1);
+}
+
+if (process.env.GITHUB_ACTIONS !== 'true') {
+  fail('Production deploy and alias promotion must run through GitHub Actions Production workflow.');
+}
+
+if (!process.env.GITHUB_SHA) {
+  fail('missing GITHUB_SHA; production deployments must be tied to a Git commit.');
+}
+
+const ref = process.env.GITHUB_REF || process.env.GITHUB_REF_NAME || '';
+if (ref !== EXPECTED_REF && process.env.GITHUB_REF_NAME !== 'main') {
+  fail(`Production deploy requires ${EXPECTED_REF}; current ref: ${ref || process.env.GITHUB_REF_NAME || 'unknown'}`);
+}
+
+const canonicalHost = process.env.VERCEL_CANONICAL_PRODUCTION_HOST || EXPECTED_CANONICAL_HOST;
+if (canonicalHost !== EXPECTED_CANONICAL_HOST) {
+  fail(`invalid production canonical host ${canonicalHost}; expected ${EXPECTED_CANONICAL_HOST}`);
+}
+
+if (!process.env.VERCEL_TOKEN) {
+  fail('missing VERCEL_TOKEN for Production workflow');
+}
+
+console.log('[live-deploy-guard] GitHub Actions production deploy confirmed.');
+console.log(`[live-deploy-guard] canonical host: ${canonicalHost}`);
+console.log(`[live-deploy-guard] commit: ${process.env.GITHUB_SHA}`);
+console.log(`[live-deploy-guard] ref: ${ref || process.env.GITHUB_REF_NAME}`);

--- a/scripts/validate_pwa_live_package.mjs
+++ b/scripts/validate_pwa_live_package.mjs
@@ -2,9 +2,16 @@
 
 const DEFAULT_BASE_URL = 'https://inner-platform.vercel.app';
 const failures = [];
+const MAX_FETCH_RETRIES = Number.parseInt(process.env.PWA_LIVE_VERIFY_FETCH_RETRIES ?? '4', 10);
+const RETRY_DELAY_MS = Number.parseInt(process.env.PWA_LIVE_VERIFY_RETRY_DELAY_MS ?? '1000', 10);
+const RETRY_STATUSES = new Set([403, 408, 429, 500, 502, 503, 504]);
 
 function fail(message) {
   failures.push(message);
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function normalizeBaseUrl(input) {
@@ -27,18 +34,31 @@ function joinUrl(baseUrl, path) {
 }
 
 async function fetchRequired(baseUrl, path, options = {}) {
-  const response = await fetch(joinUrl(baseUrl, path), {
-    headers: {
-      accept: options.accept ?? '*/*',
-    },
-    redirect: 'follow',
-  });
+  const headers = {
+    accept: options.accept ?? '*/*',
+    'cache-control': 'no-cache',
+    pragma: 'no-cache',
+  };
+  const url = joinUrl(baseUrl, path);
 
-  if (!response.ok) {
+  for (let attempt = 1; attempt <= MAX_FETCH_RETRIES; attempt += 1) {
+    const response = await fetch(url, {
+      headers,
+      redirect: 'follow',
+    });
+
+    if (response.ok) return response;
+
+    if (RETRY_STATUSES.has(response.status) && attempt < MAX_FETCH_RETRIES) {
+      await sleep(RETRY_DELAY_MS * attempt);
+      continue;
+    }
+
     fail(`${path} must return 2xx, got ${response.status}`);
+    return response;
   }
 
-  return response;
+  return null;
 }
 
 function readPngSize(buffer) {
@@ -56,6 +76,8 @@ function readPngSize(buffer) {
 
 async function verifyHtmlEndpoint(baseUrl, path) {
   const response = await fetchRequired(baseUrl, path, { accept: 'text/html' });
+  if (!response || !response.ok) return;
+
   const contentType = response.headers.get('content-type') ?? '';
   const body = await response.text();
 
@@ -74,6 +96,8 @@ async function verifyManifest(baseUrl) {
   const response = await fetchRequired(baseUrl, '/manifest.webmanifest', {
     accept: 'application/manifest+json, application/json',
   });
+  if (!response || !response.ok) return;
+
   const contentType = response.headers.get('content-type') ?? '';
   const body = await response.text();
   let manifest;
@@ -116,6 +140,8 @@ async function verifyManifest(baseUrl) {
 
 async function verifyIcon(baseUrl, path, expectedSize) {
   const response = await fetchRequired(baseUrl, path, { accept: 'image/png' });
+  if (!response || !response.ok) return;
+
   const contentType = response.headers.get('content-type') ?? '';
   const buffer = await response.arrayBuffer();
 
@@ -135,6 +161,8 @@ async function verifyIcon(baseUrl, path, expectedSize) {
 
 async function verifyServiceWorker(baseUrl) {
   const response = await fetchRequired(baseUrl, '/sw.js', { accept: 'application/javascript, text/javascript' });
+  if (!response || !response.ok) return;
+
   const body = await response.text();
 
   for (const privatePrefix of ['/api/', '/api/v1/', '/business-card-imports/']) {
@@ -146,12 +174,18 @@ async function verifyServiceWorker(baseUrl) {
 
 function verifyCameraPolicy(response) {
   const policy = response.headers.get('permissions-policy') ?? '';
+  const match = /camera=\(([^)]*)\)/.exec(policy);
 
-  if (!policy.includes('camera=(self)')) {
+  if (!match) {
     fail(`Permissions-Policy must allow same-origin camera capture, got "${policy || 'missing'}"`);
+    return;
   }
 
-  if (policy.includes('camera=()')) {
+  if (!match[1].split(',').map((token) => token.trim()).includes('self')) {
+    fail(`Permissions-Policy must allow same-origin camera capture, got "${policy}"`);
+  }
+
+  if (match[1].replace(/\s+/g, '') === '()') {
     fail(`Permissions-Policy must not block camera capture, got "${policy}"`);
   }
 }

--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -1416,7 +1416,6 @@ export function createBffApp(options = {}) {
   mountCashflowSheetLabRoutes(app, {
     db,
     googleSheetsService,
-    enabled: runtimeSafetyConfig.deployEnv !== 'live',
   });
   mountCashflowLaborRiskRoutes(app, {
     db,

--- a/server/production-deploy-workflow.test.ts
+++ b/server/production-deploy-workflow.test.ts
@@ -51,6 +51,12 @@ describe('production deployment workflow safety', () => {
     expect(workflowText).toContain('node deploy-prod-align.mjs --verify-only "${DEPLOYMENT_URL}"');
   });
 
+  it('runs the production deploy policy guard before deploy', () => {
+    expect(workflowText).toContain('node scripts/assert-safe-live-deploy.mjs');
+    expect(workflowText.indexOf('Verify production deploy policy'))
+      .toBeLessThan(workflowText.indexOf('Deploy to Vercel production'));
+  });
+
   it('promotes the canonical production alias before verifying it', () => {
     expect(workflowText).toContain('deployment_host="${deployment_url#https://}"');
     expect(workflowText).toContain('echo "deployment_host=${deployment_host}" >> "${GITHUB_OUTPUT}"');

--- a/server/production-deploy-workflow.test.ts
+++ b/server/production-deploy-workflow.test.ts
@@ -96,14 +96,17 @@ describe('stage release workflow safety', () => {
   });
 
   it('keeps the stage alias on the internal Vercel route instead of the production security domain', () => {
-    expect(stageWorkflowText).toContain('root_status="$(curl -sS -o /tmp/stage-root-response.txt -w');
-    expect(stageWorkflowText).toContain('200|401|403) ;;');
-    expect(stageWorkflowText).toContain('200|403) ;;');
+    expect(stageWorkflowText).toContain('root_status="$(curl -sS -D /tmp/stage-root-headers.txt');
+    expect(stageWorkflowText).toContain('200|401) ;;');
+    expect(stageWorkflowText).toContain('Stage must stay on the internal Vercel route and must not traverse Cloudflare.');
+    expect(stageWorkflowText).toContain('Stage must not receive security-domain CSP report-only headers.');
     expect(stageWorkflowText).not.toContain('307)');
     expect(stageWorkflowText).not.toContain('https://myscube.myscguard.app/)');
     expect(stageWorkflowText).not.toContain('https://myscube.myscguard.app/*');
     expect(stageWorkflowText).not.toContain('Unexpected stage root redirect location');
     expect(stageWorkflowText).not.toContain('Unexpected stage redirect location');
+    expect(stageWorkflowText).not.toContain('200|401|403) ;;');
+    expect(stageWorkflowText).not.toContain('200|403) ;;');
   });
 
   it('does not hang indefinitely when Vercel returns a blocked preview deployment', () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -33,7 +33,7 @@ import { resolveWeeklyAccountingState } from '../../platform/weekly-accounting-s
 import { useAuth } from '../../data/auth-store';
 import { hasUnsavedChanges } from './cashflow-unsaved';
 import { useFirebase } from '../../lib/firebase-context';
-import { getOrgCollectionPath, getOrgDocumentPath } from '../../lib/firebase';
+import { getAuthInstance, getOrgCollectionPath, getOrgDocumentPath } from '../../lib/firebase';
 import { resolveApiErrorMessage } from '../../platform/api-error-message';
 import {
   fetchCashflowLaborRiskViaBff,
@@ -298,6 +298,21 @@ export function CashflowProjectSheet({
     user?.role,
     user?.uid,
   ]);
+  const resolveBffActor = useCallback(async () => {
+    const firebaseToken = await getAuthInstance()?.currentUser?.getIdToken().catch(() => undefined);
+    const nextToken = bffActor.idToken || firebaseToken;
+    if (!nextToken) return null;
+    if (!bffActor.idToken) {
+      console.info('[CashflowProjectSheet] refreshed BFF token from Firebase', {
+        projectId,
+        actorEmail: bffActor.email,
+      });
+    }
+    return {
+      ...bffActor,
+      idToken: nextToken,
+    };
+  }, [bffActor, projectId]);
 
   const {
     yearMonth,
@@ -729,29 +744,58 @@ export function CashflowProjectSheet({
     const timeoutId = window.setTimeout(() => {
       setLaborRiskLoading(true);
       setLaborRiskError(null);
-      fetchCashflowLaborRiskViaBff({
-        tenantId: orgId,
-        actor: bffActor,
-        projectId,
-      })
-        .then((result) => {
+      void (async () => {
+        const resolvedActor = await resolveBffActor();
+        if (!resolvedActor?.idToken) {
+          console.warn('[CashflowProjectSheet] labor risk auth missing, skipping API call', {
+            projectId,
+            actorEmail: bffActor.email,
+            hasStoredToken: Boolean(bffActor.idToken),
+          });
+          if (!cancelled) {
+            setLaborRisk(null);
+            setLaborRiskError('로그인 세션이 만료되었습니다. 저장/검토 동작에서 로그인을 먼저 진행해 주세요.');
+            setLaborRiskLoading(false);
+          }
+          return;
+        }
+
+        console.info('[CashflowProjectSheet] requesting labor risk', {
+          projectId,
+          orgId,
+          actorEmail: resolvedActor.email,
+          hasIdToken: Boolean(resolvedActor.idToken),
+        });
+        try {
+          const result = await fetchCashflowLaborRiskViaBff({
+            tenantId: orgId,
+            actor: resolvedActor,
+            projectId,
+          });
           if (cancelled) return;
           setLaborRisk(result);
-        })
-        .catch((error) => {
+        } catch (error) {
           if (cancelled) return;
+          console.warn('[CashflowProjectSheet] labor risk fetch failed', {
+            projectId,
+            status: (error as { status?: number }).status,
+            code: (error as { body?: { code?: string; error?: string } }).body?.code
+              || (error as { body?: { error?: string } }).body?.error,
+            requestId: (error as { requestId?: string }).requestId,
+            message: error instanceof Error ? error.message : String(error),
+          });
           setLaborRisk(null);
           setLaborRiskError(resolveApiErrorMessage(error, '인건비/잔액 체크를 불러오지 못했습니다.'));
-        })
-        .finally(() => {
+        } finally {
           if (!cancelled) setLaborRiskLoading(false);
-        });
+        }
+      })();
     }, 250);
     return () => {
       cancelled = true;
       window.clearTimeout(timeoutId);
     };
-  }, [bffActor, cashflowWeeksStreamKey, orgId, projectId, user]);
+  }, [bffActor, cashflowWeeksStreamKey, orgId, projectId, resolveBffActor, user]);
 
   const weekMeta = useMemo(() => {
     const map: Record<number, { projectionUpdated: boolean; pmSubmitted: boolean; adminClosed: boolean }> = {};

--- a/src/app/components/portal/PortalCashflowPage.tsx
+++ b/src/app/components/portal/PortalCashflowPage.tsx
@@ -5,7 +5,6 @@ import { CashflowSheetLabPage } from '../../features/cashflow-sheet-compare/Cash
 import { usePortalStore } from '../../data/portal-store';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
-import { shouldShowStageOnlyCashflowSheetLab } from '../../platform/deployment-surface';
 
 export function PortalCashflowPage() {
   const {
@@ -24,7 +23,6 @@ export function PortalCashflowPage() {
   });
 
   const ready = useMemo(() => Boolean(projectId), [projectId]);
-  const showSheetLab = shouldShowStageOnlyCashflowSheetLab();
   const sheetRangeLabel = sheetHeader.startWeek || sheetHeader.endWeek
     ? `합계 기준 ${sheetHeader.startWeek || '시작 미지정'} ~ ${sheetHeader.endWeek || '종료 미지정'}`
     : '합계 기준 미지정';
@@ -44,62 +42,58 @@ export function PortalCashflowPage() {
 
   return (
     <div className="space-y-3">
-      {showSheetLab && (
-        <section className="flex flex-wrap items-center justify-between gap-2 border border-slate-200 bg-white px-3 py-2 shadow-sm">
-          <div className="min-w-0">
-            <div className="flex min-w-0 items-center gap-2">
-              <div className="truncate text-[12px] font-semibold text-slate-950">
-                {sheetHeader.spreadsheetTitle || myProject?.name || '저장된 시트'}
-              </div>
-              <Badge variant="outline" className="h-5 rounded-full px-2 text-[9px] text-blue-700">
-                시트 연동
-              </Badge>
+      <section className="flex flex-wrap items-center justify-between gap-2 border border-slate-200 bg-white px-3 py-2 shadow-sm">
+        <div className="min-w-0">
+          <div className="flex min-w-0 items-center gap-2">
+            <div className="truncate text-[12px] font-semibold text-slate-950">
+              {sheetHeader.spreadsheetTitle || myProject?.name || '저장된 시트'}
             </div>
-            <div className="mt-0.5 truncate text-[10px] text-slate-500">
-              {sheetHeader.sheetName || 'cashflow(사용내역 연동)'} · {sheetRangeLabel}
-            </div>
+            <Badge variant="outline" className="h-5 rounded-full px-2 text-[9px] text-blue-700">
+              시트 연동
+            </Badge>
           </div>
-          <div className="flex shrink-0 items-center gap-1.5">
-            <Button
-              type="button"
-              size="sm"
-              className="h-7 gap-1 rounded-none px-2 text-[10px]"
-              onClick={() => dispatchSheetAction('apply')}
-            >
-              <Settings className="h-3 w-3" />
-              시트와 연동하기
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              className="h-7 gap-1 rounded-none px-2 text-[10px]"
-              onClick={() => dispatchSheetAction('preview')}
-            >
-              <Search className="h-3 w-3" />
-              검토
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              variant="outline"
-              className="h-7 gap-1 rounded-none px-2 text-[10px]"
-              onClick={() => dispatchSheetAction('edit')}
-            >
-              <Pencil className="h-3 w-3" />
-              수정
-            </Button>
+          <div className="mt-0.5 truncate text-[10px] text-slate-500">
+            {sheetHeader.sheetName || 'cashflow(사용내역 연동)'} · {sheetRangeLabel}
           </div>
-        </section>
-      )}
-      {showSheetLab && (
-        <CashflowSheetLabPage
-          projectIdOverride={projectId}
-          embedded
-          hideConfigChrome
-          onHeaderSummaryChange={setSheetHeader}
-        />
-      )}
+        </div>
+        <div className="flex shrink-0 items-center gap-1.5">
+          <Button
+            type="button"
+            size="sm"
+            className="h-7 gap-1 rounded-none px-2 text-[10px]"
+            onClick={() => dispatchSheetAction('apply')}
+          >
+            <Settings className="h-3 w-3" />
+            시트와 연동하기
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-7 gap-1 rounded-none px-2 text-[10px]"
+            onClick={() => dispatchSheetAction('preview')}
+          >
+            <Search className="h-3 w-3" />
+            검토
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            className="h-7 gap-1 rounded-none px-2 text-[10px]"
+            onClick={() => dispatchSheetAction('edit')}
+          >
+            <Pencil className="h-3 w-3" />
+            수정
+          </Button>
+        </div>
+      </section>
+      <CashflowSheetLabPage
+        projectIdOverride={projectId}
+        embedded
+        hideConfigChrome
+        onHeaderSummaryChange={setSheetHeader}
+      />
       <CashflowProjectSheet
         projectId={projectId}
         roleOverride={portalUser?.role}

--- a/src/app/components/portal/PortalLayout.tsx
+++ b/src/app/components/portal/PortalLayout.tsx
@@ -75,7 +75,6 @@ import { rememberRecentPortalProject } from '../../platform/portal-recent-projec
 import { buildPortalShellCommandItems, buildPortalShellNotificationItems } from '../../platform/portal-shell-actions';
 import { shouldShowShellRoute, useShellLabEnabled } from '../../platform/shell-lab-visibility';
 import { resolvePortalProjectCandidates } from '../../platform/portal-project-selection';
-import { shouldShowStageOnlyCashflowSheetLab } from '../../platform/deployment-surface';
 
 // ═══════════════════════════════════════════════════════════════
 // PortalLayout — 사용자(PM) 전용 레이아웃
@@ -339,20 +338,18 @@ function PortalContent() {
   const portalDisplayName = portalUser?.name || authUser?.name || '사용자';
   const portalDisplayRole = portalUser?.role || authUser?.role || 'pm';
   const currentFundInputMode = normalizeProjectFundInputMode(currentProject?.fundInputMode);
-  const showSheetLab = shouldShowStageOnlyCashflowSheetLab();
   const navSections = useMemo(() => (
     NAV_SECTIONS.map((section) => ({
       ...section,
       items: section.items.filter((item) => {
         if ('hidden' in item && item.hidden) return false;
-        if (item.to === '/portal/cashflow/sheets-lab' && !showSheetLab) return false;
         return shouldShowShellRoute(item.to, 'portal', 'nav', {
           fundInputMode: currentFundInputMode,
           labEnabled,
         });
       }),
     }))
-  ), [currentFundInputMode, labEnabled, showSheetLab]);
+  ), [currentFundInputMode, labEnabled]);
   const topNavItems = useMemo(() => navSections.flatMap((section) => section.items), [navSections]);
   const currentSectionLabel = useMemo(() => {
     const current = topNavItems.find((item) => isActive(item.to, item.exact));

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
@@ -24,11 +24,9 @@ describe('CashflowSheetLabPage shell', () => {
     expect(routesSource).toContain("path: '/portal'");
     expect(routesSource).toContain("path: 'cashflow/sheets-lab'");
     expect(routesSource).toContain('CashflowSheetLabPage');
-    expect(routesSource).toContain('StageOnlyCashflowSheetLabRoute');
-    expect(routesSource).toContain('shouldShowStageOnlyCashflowSheetLab');
+    expect(routesSource).not.toContain('StageOnlyCashflowSheetLabRoute');
     expect(portalLayoutSource).toContain('/portal/cashflow/sheets-lab');
     expect(portalCashflowSource).toContain('CashflowSheetLabPage');
-    expect(portalCashflowSource).toContain('shouldShowStageOnlyCashflowSheetLab');
     expect(portalCashflowSource).toContain('projectIdOverride={projectId}');
     expect(portalCashflowSource).toContain('embedded');
     expect(portalCashflowSource).toContain('hideConfigChrome');

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
@@ -32,6 +32,9 @@ describe('CashflowSheetLabPage shell', () => {
     expect(portalCashflowSource).toContain('hideConfigChrome');
     expect(portalCashflowSource).toContain("dispatchSheetAction('apply')");
     expect(portalCashflowSource).toContain('시트와 연동하기');
+    expect(portalCashflowSource).not.toContain('shouldShowCashflowSheetLab');
+    expect(portalCashflowSource).not.toContain('deployment-surface');
+    expect(portalCashflowSource).not.toMatch(/show[A-Za-z0-9]*Sheet[A-Za-z0-9]*Lab\s*&&/);
     expect(pageSource).not.toContain('usePortalStore');
     expect(pageSource).not.toContain('../../data/portal-store');
   });
@@ -41,8 +44,9 @@ describe('CashflowSheetLabPage shell', () => {
     expect(pageSource).toContain('saveCashflowSheetLabConfigViaBff');
     expect(pageSource).toContain('previewCashflowProjectionWritebackViaBff');
     expect(pageSource).toContain('applyCashflowProjectionWritebackViaBff');
-    expect(pageSource).toContain('const bffAuthReady = Boolean(actor.email && actor.idToken)');
-    expect(pageSource).toContain('!bffAuthReady');
+    expect(pageSource).toContain('resolveBffActor');
+    expect(pageSource).toContain('requireBffActor');
+    expect(pageSource).toContain('requestLoginFlow');
     expect(pageSource).toContain('runWithGoogleSheetsAuthRetry');
     expect(pageSource).toContain("runWithGoogleSheetsAuthRetry('config.save'");
     expect(pageSource).toContain('}, { forceRefresh: true })');
@@ -75,7 +79,5 @@ describe('CashflowSheetLabPage shell', () => {
     expect(pageSource).not.toContain('exportCashflowWorkbookViaBff');
     expect(pageSource).not.toContain('saveExpenseSheetRows');
     expect(pageSource).not.toContain('markSheetSourceApplied');
-    expect(pageSource).not.toContain('동기화');
-    expect(pageSource).not.toContain('내보내기');
   });
 });

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AlertCircle, ArrowUpToLine, Loader2, Pencil, Search, Settings } from 'lucide-react';
 import Lottie from 'lottie-react';
-import { useSearchParams } from 'react-router';
+import { useLocation, useNavigate, useSearchParams } from 'react-router';
 import { useAuth } from '../../data/auth-store';
 import { useFirebase } from '../../lib/firebase-context';
+import { getAuthInstance } from '../../lib/firebase';
 import { buildCashflowPreviewTables } from './cashflow-sheet-preview-tables';
 import {
   applyCashflowProjectionWritebackViaBff,
@@ -127,6 +128,17 @@ function SheetWritebackIllustration() {
   );
 }
 
+function isBffAuthError(error: unknown): boolean {
+  const apiError = error as { status?: number; body?: { code?: unknown; error?: unknown } };
+  const status = apiError?.status;
+  const code = typeof apiError?.body?.code === 'string'
+    ? apiError.body.code
+    : typeof apiError?.body?.error === 'string'
+      ? apiError.body.error
+      : '';
+  return status === 401 || status === 403 || code === 'missing_bearer_token' || code === 'invalid_token';
+}
+
 function ReconciliationSummary({
   table,
 }: {
@@ -221,6 +233,8 @@ export function CashflowSheetLabPage({
 } = {}) {
   const { user: authUser, ensureGoogleWorkspaceAccess } = useAuth();
   const { orgId } = useFirebase();
+  const navigate = useNavigate();
+  const location = useLocation();
   const [searchParams] = useSearchParams();
   const initialProjectId = useMemo(() => (
     projectIdOverride?.trim()
@@ -262,7 +276,40 @@ export function CashflowSheetLabPage({
     authUser?.role,
     authUser?.idToken,
   ]);
-  const bffAuthReady = Boolean(actor.email && actor.idToken);
+  const requestLoginFlow = useCallback(() => {
+    logCashflowLab('auth.required', {
+      projectId,
+      actorEmail: actor.email,
+      hasIdToken: Boolean(actor.idToken),
+    }, 'warn');
+    navigate('/login', { state: { from: location.pathname } });
+  }, [actor.email, actor.idToken, location.pathname, navigate, projectId]);
+
+  const resolveBffActor = useCallback(async () => {
+    const firebaseToken = await getAuthInstance()?.currentUser?.getIdToken().catch(() => undefined);
+    const resolvedToken = actor.idToken || firebaseToken;
+    if (!resolvedToken) return null;
+    if (!actor.idToken) {
+      logCashflowLab('auth.refresh', {
+        projectId,
+        actorEmail: actor.email,
+        tokenSource: 'firebase',
+      });
+    }
+    return {
+      ...actor,
+      idToken: resolvedToken,
+    };
+  }, [actor, projectId]);
+
+  const requireBffActor = useCallback(async () => {
+    const resolved = await resolveBffActor();
+    if (!resolved?.idToken) {
+      requestLoginFlow();
+      return null;
+    }
+    return resolved;
+  }, [requestLoginFlow, resolveBffActor]);
 
   async function resolveGoogleAccessToken(action: string, options: { forceRefresh?: boolean } = {}) {
     if (authUser?.googleAccessToken && !options.forceRefresh) {
@@ -316,35 +363,61 @@ export function CashflowSheetLabPage({
   }, [projectId]);
 
   useEffect(() => {
-    if (!projectId || !bffAuthReady) return;
+    if (!projectId) return;
     let cancelled = false;
     setConfigLoading(true);
     setErrorMessage('');
-    getCashflowSheetLabConfigViaBff({
-      tenantId: orgId,
-      actor,
-      projectId,
-    }).then((result) => {
-      if (cancelled) return;
-      const nextConfig = result.config || null;
-      setConfig(nextConfig);
-      setEditingConfig(!nextConfig);
-      setSheetLink(nextConfig?.value || MYSC_CASHFLOW_SPREADSHEET_ID);
-      setSheetName(nextConfig?.sheetName || '');
-      setStartWeek(nextConfig?.startWeek || '');
-      setEndWeek(nextConfig?.endWeek || '');
-    }).catch((error) => {
-      if (!cancelled) setErrorMessage(formatError(error));
-    }).finally(() => {
-      if (!cancelled) setConfigLoading(false);
-    });
+    void (async () => {
+      const resolvedActor = await resolveBffActor();
+      if (!resolvedActor?.idToken) {
+        logCashflowLab('config.load.auth_missing', {
+          projectId,
+          actorEmail: actor.email,
+          hasStoredToken: Boolean(actor.idToken),
+        }, 'warn');
+        if (!cancelled) {
+          setConfig(null);
+          setEditingConfig(true);
+          setErrorMessage('BFF 인증 토큰이 없어 동기화 API 호출이 보류됩니다. 저장/검토를 하면 로그인 화면이 열립니다.');
+          setConfigLoading(false);
+        }
+        return;
+      }
+
+      try {
+        const result = await getCashflowSheetLabConfigViaBff({
+          tenantId: orgId,
+          actor: resolvedActor,
+          projectId,
+        });
+        if (cancelled) return;
+        const nextConfig = result.config || null;
+        setConfig(nextConfig);
+        setEditingConfig(!nextConfig);
+        setSheetLink(nextConfig?.value || MYSC_CASHFLOW_SPREADSHEET_ID);
+        setSheetName(nextConfig?.sheetName || '');
+        setStartWeek(nextConfig?.startWeek || '');
+        setEndWeek(nextConfig?.endWeek || '');
+      } catch (error) {
+        if (isBffAuthError(error)) {
+          requestLoginFlow();
+        }
+        if (!cancelled) setErrorMessage(formatError(error));
+      } finally {
+        if (!cancelled) setConfigLoading(false);
+      }
+    })();
     return () => {
       cancelled = true;
     };
-  }, [actor, bffAuthReady, orgId, projectId]);
+  }, [actor, orgId, projectId, requestLoginFlow, resolveBffActor]);
 
   async function handleSaveConfig() {
-    if (!projectId || !spreadsheetId || savingConfig || !bffAuthReady) return null;
+    if (!projectId || !spreadsheetId || savingConfig) return null;
+    const requestActor = await requireBffActor();
+    if (!requestActor) {
+      return null;
+    }
     setSavingConfig(true);
     setErrorMessage('');
     try {
@@ -354,7 +427,7 @@ export function CashflowSheetLabPage({
         usedGoogleAccessToken = googleAccessToken;
         return saveCashflowSheetLabConfigViaBff({
         tenantId: orgId,
-        actor,
+        actor: requestActor,
         projectId,
         value: sheetLink,
         sheetName: sheetName || undefined,
@@ -379,6 +452,9 @@ export function CashflowSheetLabPage({
       return nextConfig;
     } catch (error) {
       logCashflowLab('config.save.error', { projectId, spreadsheetId, ...errorDiagnostics(error) }, 'warn');
+      if (isBffAuthError(error)) {
+        requestLoginFlow();
+      }
       setErrorMessage(formatError(error));
       return null;
     } finally {
@@ -387,7 +463,11 @@ export function CashflowSheetLabPage({
   }
 
   async function handlePreview() {
-    if (!projectId || loading || editingConfig || !config || !bffAuthReady) return;
+    if (!projectId || loading || editingConfig || !config) return;
+    const requestActor = await requireBffActor();
+    if (!requestActor) {
+      return;
+    }
     const requestId = previewRequestRef.current + 1;
     previewRequestRef.current = requestId;
     setLoading(true);
@@ -399,7 +479,7 @@ export function CashflowSheetLabPage({
         usedGoogleAccessToken = googleAccessToken;
         return previewCashflowSheetLabViaBff({
         tenantId: orgId,
-        actor,
+        actor: requestActor,
         projectId,
         includeValues: false,
         googleAccessToken,
@@ -418,7 +498,7 @@ export function CashflowSheetLabPage({
       if (!sheetName && layoutResult.selectedSheetName) setSheetName(layoutResult.selectedSheetName);
       void previewCashflowSheetLabViaBff({
         tenantId: orgId,
-        actor,
+        actor: requestActor,
         projectId,
         includeValues: true,
         googleAccessToken: usedGoogleAccessToken,
@@ -436,11 +516,17 @@ export function CashflowSheetLabPage({
       }).catch((error) => {
         if (previewRequestRef.current === requestId) {
           logCashflowLab('preview.values.error', { projectId, ...errorDiagnostics(error) }, 'warn');
+          if (isBffAuthError(error)) {
+            requestLoginFlow();
+          }
           setErrorMessage(formatError(error));
         }
       });
     } catch (error) {
       logCashflowLab('preview.error', { projectId, spreadsheetId: config?.spreadsheetId || spreadsheetId, ...errorDiagnostics(error) }, 'warn');
+      if (isBffAuthError(error)) {
+        requestLoginFlow();
+      }
       setPreview(null);
       setErrorMessage(formatError(error));
     } finally {
@@ -455,7 +541,11 @@ export function CashflowSheetLabPage({
   }
 
   async function handleWritebackPreview() {
-    if (!projectId || writebackLoading || editingConfig || !config || !bffAuthReady) return null;
+    if (!projectId || writebackLoading || editingConfig || !config) return null;
+    const requestActor = await requireBffActor();
+    if (!requestActor) {
+      return null;
+    }
     const startedAt = Date.now();
     setWritebackLoading(true);
     setWritebackMessage('');
@@ -466,7 +556,7 @@ export function CashflowSheetLabPage({
         usedGoogleAccessToken = googleAccessToken;
         return previewCashflowProjectionWritebackViaBff({
           tenantId: orgId,
-          actor,
+          actor: requestActor,
           projectId,
           googleAccessToken,
         });
@@ -485,6 +575,9 @@ export function CashflowSheetLabPage({
       return result;
     } catch (error) {
       logCashflowLab('writeback.preview.error', { projectId, durationMs: Date.now() - startedAt, ...errorDiagnostics(error) }, 'warn');
+      if (isBffAuthError(error)) {
+        requestLoginFlow();
+      }
       setErrorMessage(formatError(error));
       return null;
     } finally {
@@ -493,7 +586,11 @@ export function CashflowSheetLabPage({
   }
 
   async function handleWritebackApply(overwrite = false) {
-    if (!projectId || writebackApplying || editingConfig || !config || !bffAuthReady) return false;
+    if (!projectId || writebackApplying || editingConfig || !config) return false;
+    const requestActor = await requireBffActor();
+    if (!requestActor) {
+      return false;
+    }
     const startedAt = Date.now();
     const baselineHash = writebackPreview?.plan.baselineHash;
     setWritebackApplying(true);
@@ -506,7 +603,7 @@ export function CashflowSheetLabPage({
         usedGoogleAccessToken = googleAccessToken;
         return applyCashflowProjectionWritebackViaBff({
           tenantId: orgId,
-          actor,
+          actor: requestActor,
           projectId,
           baselineHash,
           conflictResolution: overwrite ? 'overwrite' : 'abort',
@@ -533,6 +630,9 @@ export function CashflowSheetLabPage({
         setErrorMessage(formatError(error));
       }
       logCashflowLab('writeback.apply.error', { projectId, durationMs: Date.now() - startedAt, ...errorDiagnostics(error) }, 'warn');
+      if (isBffAuthError(error)) {
+        requestLoginFlow();
+      }
       return false;
     } finally {
       setWritebackApplying(false);
@@ -633,7 +733,7 @@ export function CashflowSheetLabPage({
               <Button
                 type="button"
                 className="h-10 gap-1.5 rounded-none text-[12px]"
-                disabled={!projectId || !spreadsheetId || savingConfig || !bffAuthReady}
+                disabled={!projectId || !spreadsheetId || savingConfig}
                 onClick={handleSaveConfig}
               >
                 {savingConfig ? <Loader2 className="h-4 w-4 animate-spin" /> : <Settings className="h-4 w-4" />}
@@ -667,7 +767,7 @@ export function CashflowSheetLabPage({
               <Button
                 type="button"
                 className="h-10 gap-1.5 rounded-none text-[12px]"
-                disabled={writebackLoading || !config || !bffAuthReady}
+                disabled={writebackLoading || !config}
                 onClick={() => {
                   openSyncWizard();
                   void handleWritebackPreview();
@@ -680,7 +780,7 @@ export function CashflowSheetLabPage({
                 type="button"
                 variant="outline"
                 className="h-10 gap-1.5 rounded-none text-[12px]"
-                disabled={!projectId || loading || configLoading || !bffAuthReady}
+                disabled={!projectId || loading || configLoading}
                 onClick={handlePreview}
               >
                 {loading || configLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}

--- a/src/app/platform/api-client.ts
+++ b/src/app/platform/api-client.ts
@@ -29,6 +29,67 @@ export interface PlatformRequestOptions {
   retryOnStatuses?: number[];
 }
 
+interface JwtClaimsSummary {
+  aud?: string;
+  iss?: string;
+  sub?: string;
+  email?: string;
+  exp?: number;
+}
+
+function normalizeTokenClaimString(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeTokenClaimString(item)).filter(Boolean).join(',');
+  }
+  return undefined;
+}
+
+function decodeBase64Url(base64Url: string): string {
+  const missingPadding = (4 - (base64Url.length % 4)) % 4;
+  const normalized = base64Url
+    .replace(/-/g, '+')
+    .replace(/_/g, '/')
+    .concat('='.repeat(missingPadding));
+
+  if (typeof atob === 'function') return atob(normalized);
+  throw new Error('Base64 decode unavailable');
+}
+
+function parseJwtClaims(token: string): JwtClaimsSummary | undefined {
+  const parts = token.split('.');
+  if (parts.length < 2) return undefined;
+  try {
+    const payloadText = decodeBase64Url(parts[1]);
+    const payload = JSON.parse(payloadText) as Record<string, unknown>;
+    return {
+      aud: normalizeTokenClaimString(payload.aud),
+      iss: normalizeTokenClaimString(payload.iss),
+      sub: normalizeTokenClaimString(payload.sub),
+      email: normalizeTokenClaimString(payload.email),
+      exp: typeof payload.exp === 'number' && Number.isFinite(payload.exp) ? payload.exp : undefined,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+function readErrorCode(body: unknown): string | undefined {
+  if (!body || typeof body !== 'object') return undefined;
+  const value = (body as { code?: unknown; error?: unknown }).code || (body as { error?: unknown }).error;
+  return typeof value === 'string' ? value : undefined;
+}
+
+function readErrorMessage(body: unknown): string | undefined {
+  if (!body || typeof body !== 'object') return undefined;
+  const value = (body as { message?: unknown }).message;
+  return typeof value === 'string' ? value : undefined;
+}
+
 function isBinaryBody(value: unknown): value is Blob | ArrayBuffer | Uint8Array {
   return (
     (typeof Blob !== 'undefined' && value instanceof Blob)
@@ -242,6 +303,9 @@ export class PlatformApiClient {
     };
 
     const headers = buildStandardHeaders(headerInput);
+    const actorIdToken = options.actor.idToken;
+    const hasAuthorizationHeader = headers.has('authorization');
+    const tokenClaims = actorIdToken ? parseJwtClaims(actorIdToken) : undefined;
     let body: BodyInit | undefined;
 
     if (options.body !== undefined && options.body !== null) {
@@ -260,6 +324,18 @@ export class PlatformApiClient {
     const retryOnStatuses = new Set(options.retryOnStatuses || Array.from(this.retryOnStatuses));
     const clientRequestId = headers.get('x-request-id') || '';
 
+    if (!hasAuthorizationHeader) {
+      console.warn('[PlatformApiClient] Missing Authorization header for BFF request', {
+        method,
+        path,
+        requestUrl,
+        actorId: options.actor.id,
+        actorEmail: options.actor.email,
+        tenantId: options.tenantId,
+        hasBody: options.body !== undefined && options.body !== null,
+      });
+    }
+
     recordDevtoolsLog({
       kind: 'bff_request',
       phase: 'start',
@@ -272,6 +348,19 @@ export class PlatformApiClient {
       maxRetries,
       summary: {
         hasBody: options.body !== undefined && options.body !== null,
+        hasAuthorizationHeader,
+        actorHasIdToken: Boolean(actorIdToken && actorIdToken.trim()),
+        apiBaseUrl: this.baseUrl,
+        requestUrl,
+        tokenClaims: tokenClaims
+          ? {
+            aud: tokenClaims.aud,
+            iss: tokenClaims.iss,
+            sub: tokenClaims.sub,
+            email: tokenClaims.email,
+            exp: tokenClaims.exp,
+          }
+          : undefined,
         bodyKind: options.body === undefined || options.body === null
           ? 'none'
           : options.body instanceof FormData
@@ -298,8 +387,25 @@ export class PlatformApiClient {
 
         const requestId = response.headers.get('x-request-id') || headers.get('x-request-id') || '';
         const responseBody = await readResponseBody(response);
+        const responseCode = readErrorCode(responseBody);
+        const responseMessage = readErrorMessage(responseBody);
 
         if (!response.ok) {
+          if (response.status === 401 || response.status === 403) {
+            console.warn('[PlatformApiClient] BFF auth rejected', {
+              method,
+              path,
+              requestUrl,
+              status: response.status,
+              code: responseCode,
+              message: responseMessage,
+              requestId,
+              actorId: options.actor.id,
+              actorHasIdToken: Boolean(actorIdToken && actorIdToken.trim()),
+              hasAuthorizationHeader,
+              tokenAudience: tokenClaims?.aud,
+            });
+          }
           throw new PlatformApiError(
             `API request failed with status ${response.status}`,
             response.status,
@@ -320,6 +426,10 @@ export class PlatformApiClient {
           durationMs: Date.now() - startedAt,
           attempt,
           maxRetries,
+          summary: {
+            responseCode,
+            responseMessage,
+          },
           tenantId: options.tenantId,
           actorId: options.actor.id,
         });
@@ -354,6 +464,10 @@ export class PlatformApiClient {
             durationMs: Date.now() - startedAt,
             attempt,
             maxRetries,
+            summary: {
+              responseCode: error instanceof PlatformApiError && error.body ? readErrorCode(error.body) : undefined,
+              responseMessage: error instanceof PlatformApiError && error.body ? readErrorMessage(error.body) : undefined,
+            },
             tenantId: options.tenantId,
             actorId: options.actor.id,
             error: toDevtoolsError(error),
@@ -390,6 +504,10 @@ export class PlatformApiClient {
           durationMs: Date.now() - startedAt,
           attempt,
           maxRetries,
+          summary: {
+            responseCode: error instanceof PlatformApiError && error.body ? readErrorCode(error.body) : undefined,
+            responseMessage: error instanceof PlatformApiError && error.body ? readErrorMessage(error.body) : undefined,
+          },
           tenantId: options.tenantId,
           actorId: options.actor.id,
           error: toDevtoolsError(error),

--- a/src/app/platform/deployment-surface.test.ts
+++ b/src/app/platform/deployment-surface.test.ts
@@ -1,17 +1,17 @@
 import { describe, expect, it } from 'vitest';
-import { isLiveMyscguardHost, shouldShowStageOnlyCashflowSheetLab } from './deployment-surface';
+import { isLiveMyscguardHost, shouldShowCashflowSheetLab } from './deployment-surface';
 
 describe('deployment surface visibility', () => {
   it('treats live myscguard hosts as live surfaces', () => {
     expect(isLiveMyscguardHost('myscube.myscguard.app')).toBe(true);
     expect(isLiveMyscguardHost('soc.myscguard.app')).toBe(true);
-    expect(shouldShowStageOnlyCashflowSheetLab('myscube.myscguard.app')).toBe(false);
+    expect(shouldShowCashflowSheetLab('myscube.myscguard.app')).toBe(true);
   });
 
-  it('keeps stage and preview hosts eligible for stage-only sheet lab work', () => {
+  it('keeps all known hosts aligned for cashflow sheet lab route availability', () => {
     expect(isLiveMyscguardHost('inner-platform-stage-merryai-devs-projects.vercel.app')).toBe(false);
-    expect(shouldShowStageOnlyCashflowSheetLab('inner-platform-stage-merryai-devs-projects.vercel.app')).toBe(true);
-    expect(shouldShowStageOnlyCashflowSheetLab('inner-platform-7lwazqaf6-merryai-devs-projects.vercel.app')).toBe(true);
-    expect(shouldShowStageOnlyCashflowSheetLab('localhost')).toBe(true);
+    expect(shouldShowCashflowSheetLab('inner-platform-stage-merryai-devs-projects.vercel.app')).toBe(true);
+    expect(shouldShowCashflowSheetLab('inner-platform-7lwazqaf6-merryai-devs-projects.vercel.app')).toBe(true);
+    expect(shouldShowCashflowSheetLab('localhost')).toBe(true);
   });
 });

--- a/src/app/platform/deployment-surface.ts
+++ b/src/app/platform/deployment-surface.ts
@@ -25,6 +25,6 @@ export function isLiveMyscguardHost(hostname = readCurrentHostname()): boolean {
   return normalized.endsWith('.myscguard.app') && !normalized.includes('stage');
 }
 
-export function shouldShowStageOnlyCashflowSheetLab(hostname = readCurrentHostname()): boolean {
-  return !isLiveMyscguardHost(hostname);
+export function shouldShowCashflowSheetLab(_hostname = readCurrentHostname()): boolean {
+  return true;
 }

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -6,7 +6,6 @@ import { AdminRouteProviders } from './data/admin-route-providers';
 import { PortalRouteProviders } from './data/portal-route-providers';
 import { loadLazyRouteModule } from './platform/lazy-route';
 import { shouldUseBusinessCardMobileEntry } from './platform/mobile-entry';
-import { shouldShowStageOnlyCashflowSheetLab } from './platform/deployment-surface';
 
 // Lazy-loaded pages — each becomes a separate chunk
 const LoginPage = lazy(() => import('./components/auth/LoginPage').then(m => ({ default: m.LoginPage })));
@@ -104,12 +103,6 @@ function MobileAwareAdminHome() {
     : <S C={FeatureSearchPage} />;
 }
 
-function StageOnlyCashflowSheetLabRoute() {
-  return shouldShowStageOnlyCashflowSheetLab()
-    ? <S C={CashflowSheetLabPage} />
-    : <S C={NotFoundPage} />;
-}
-
 export const router = createBrowserRouter([
   // ── Login ──
   { path: '/login', element: <S C={LoginPage} /> },
@@ -183,7 +176,7 @@ export const router = createBrowserRouter([
       { path: 'submissions', element: <S C={PortalProjectSelectPage} /> },
       { path: 'payroll', element: <S C={PortalPayrollPage} /> },
       { path: 'cashflow', element: <S C={PortalCashflowPage} /> },
-      { path: 'cashflow/sheets-lab', element: <StageOnlyCashflowSheetLabRoute /> },
+      { path: 'cashflow/sheets-lab', element: <S C={CashflowSheetLabPage} /> },
       { path: 'budget', element: <S C={PortalBudget} /> },
       { path: 'weekly-expenses', element: <S C={PortalWeeklyExpensePage} /> },
       { path: 'bank-statements', element: <S C={PortalBankStatementPage} /> },


### PR DESCRIPTION
## 변경 요약
- cashflow/시트 연동 진입 경로(라우트/네비/임베디드 구간)에서 live 전용 차단 로직 제거
- PortalCashflowPage에서 시트 연동 카드/컴포넌트 항상 렌더링
- BFF cashflow-sheet-lab 라우트 마운트에서 live 비활성화 플래그 제거

## 검증
- npm run build
- vitest run src/app/platform/deployment-surface.test.ts src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
- vitest run server/bff/routes/cashflow-sheet-lab.test.mjs
