### PR TITLE
fix(stage): wire Firestore persistence constructor

### DIFF
--- a/server/bff/routes/project-registration-drafts.mjs
+++ b/server/bff/routes/project-registration-drafts.mjs
@@ -53,6 +53,11 @@ function positiveFence(value) {
   return fence;
 }
 
+function isFirestoreTransactionConflict(error) {
+  return error?.code === 10 || error?.code === '10' || error?.code === 'ABORTED'
+    || /transaction.*aborted|aborted.*transaction/i.test(String(error?.message || ''));
+}
+
 function clockDate(clock) {
   const date = new Date(clock());
   if (!Number.isFinite(date.getTime())) throw new Error('Project registration draft clock returned an invalid time');
@@ -676,7 +681,8 @@ export function createProjectRegistrationDraftService({
       const projectRequestRef = db.doc(`orgs/${current.tenantId}/project_requests/${projectRequestId}`);
       const outboxRef = db.doc(`outbox/${documentId(outboxTemplate?.id, 'outboxEvent.id')}`);
 
-      return db.runTransaction(async (tx) => {
+      try {
+        return await db.runTransaction(async (tx) => {
         const submissionDate = clockDate(now);
         const timestamp = submissionDate.toISOString();
         const { actorRole, member, ref, draft } = await ownedDraft(tx, current);
@@ -801,7 +807,13 @@ export function createProjectRegistrationDraftService({
           ttlSeconds: 86_400,
         }, submissionDate);
         return { status: 201, body, replayed: false };
-      });
+        });
+      } catch (error) {
+        if (isFirestoreTransactionConflict(error)) {
+          throw createHttpError(409, 'Another final submission won the project registration race.', 'canonical_submit_conflict');
+        }
+        throw error;
+      }
     },
 
     async addAttachment(input) {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -27,6 +27,7 @@ import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseProjectionEntity;
 import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseSheetEntity;
 import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseWeeklyStatusEntity;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Repository;
 
@@ -79,6 +80,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     private final ThreadLocal<Map<String, Map<String, Object>>> transactionDocumentCache = new ThreadLocal<>();
     private final ThreadLocal<CashflowLeaseScope> currentCashflowLeaseScope = new ThreadLocal<>();
 
+    @Autowired
     public FirestoreInheritedWeeklyExpensePersistence(
         @Value("${weekly.firestore-project-id:}") String firestoreProjectId
     ) {


### PR DESCRIPTION
Stage Cloud Run startup fix: explicitly mark the Firestore persistence constructor for Spring injection. This prevents the Stage JVM service from failing startup while leaving Live untouched.