### PR TITLE
fix(projects): align status tabs and portal navigation

### DIFF
--- a/src/app/components/dashboard/FeatureSearchPage.shell.test.ts
+++ b/src/app/components/dashboard/FeatureSearchPage.shell.test.ts
@@ -41,4 +41,11 @@ describe('FeatureSearchPage shell contract', () => {
     expect(searchSource).toContain("const SUGGESTIONS = ['프로젝트 등록', '계약서', '사업비 입력', '권한']");
     expect(searchSource).not.toContain("'CIC'");
   });
+
+  it('keeps only the registration request in practitioner quick links', () => {
+    expect(source).toContain("{ label: '프로젝트 등록 요청', to: '/portal/register-project' }");
+    expect(source).not.toContain("{ label: '프로젝트 선택', to: '/portal/project-select' }");
+    expect(source).not.toContain("{ label: '예산 편집', to: '/portal/budget' }");
+    expect(source).not.toContain("{ label: '사업비 입력', to: '/portal/weekly-expenses' }");
+  });
 });

--- a/src/app/components/dashboard/FeatureSearchPage.tsx
+++ b/src/app/components/dashboard/FeatureSearchPage.tsx
@@ -13,9 +13,6 @@ const ADMIN_ENTRY_POINTS = [
 ];
 
 const PM_ENTRY_POINTS = [
-  { label: '프로젝트 선택', to: '/portal/project-select' },
-  { label: '예산 편집', to: '/portal/budget' },
-  { label: '사업비 입력', to: '/portal/weekly-expenses' },
   { label: '프로젝트 등록 요청', to: '/portal/register-project' },
 ];
 

--- a/src/app/components/portal/PortalLayout.shell.test.ts
+++ b/src/app/components/portal/PortalLayout.shell.test.ts
@@ -59,6 +59,9 @@ describe('PortalLayout shell actions', () => {
 
   it('uses a compact MYSC logo without extra workspace subtitle copy', () => {
     expect(portalLayoutSource).toContain('MyscWordmark');
+    expect(portalLayoutSource.match(/aria-label="처음 화면으로 이동"/g)).toHaveLength(2);
+    expect(portalLayoutSource.match(/aria-label="처음 화면으로 이동"[\s\S]*?onClick=\{\(\) => navigate\('\/'\)\}/g)).toHaveLength(2);
+    expect(portalLayoutSource).not.toContain('aria-label="포털 홈으로 이동"');
     expect(portalLayoutSource).not.toContain('MYSC Workspace');
     expect(portalLayoutSource).not.toContain('Project Operations');
     expect(portalLayoutSource).not.toContain('My Work');

--- a/src/app/components/portal/PortalLayout.shell.test.ts
+++ b/src/app/components/portal/PortalLayout.shell.test.ts
@@ -60,7 +60,8 @@ describe('PortalLayout shell actions', () => {
   it('uses a compact MYSC logo without extra workspace subtitle copy', () => {
     expect(portalLayoutSource).toContain('MyscWordmark');
     expect(portalLayoutSource.match(/aria-label="처음 화면으로 이동"/g)).toHaveLength(2);
-    expect(portalLayoutSource.match(/aria-label="처음 화면으로 이동"[\s\S]*?onClick=\{\(\) => navigate\('\/'\)\}/g)).toHaveLength(2);
+    expect(portalLayoutSource.match(/aria-label="처음 화면으로 이동"[\s\S]*?onClick=\{\(\) => requestPortalNavigation\('\/', '처음 화면'\)\}/g)).toHaveLength(2);
+    expect(portalLayoutSource).not.toContain("onClick={() => navigate('/')}\n");
     expect(portalLayoutSource).not.toContain('aria-label="포털 홈으로 이동"');
     expect(portalLayoutSource).not.toContain('MYSC Workspace');
     expect(portalLayoutSource).not.toContain('Project Operations');

--- a/src/app/components/portal/PortalLayout.tsx
+++ b/src/app/components/portal/PortalLayout.tsx
@@ -565,7 +565,7 @@ function PortalContent() {
             <button
               type="button"
               aria-label="처음 화면으로 이동"
-              onClick={() => navigate('/')}
+              onClick={() => requestPortalNavigation('/', '처음 화면')}
               className="rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
             >
               <MyscWordmark
@@ -807,7 +807,7 @@ function PortalContent() {
                 <button
                   type="button"
                   aria-label="처음 화면으로 이동"
-                  onClick={() => navigate('/')}
+                  onClick={() => requestPortalNavigation('/', '처음 화면')}
                   className="shrink-0 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
                 >
                   <MyscWordmark tone="onDark" size="md" />

--- a/src/app/components/portal/PortalLayout.tsx
+++ b/src/app/components/portal/PortalLayout.tsx
@@ -564,8 +564,8 @@ function PortalContent() {
           <div className={`flex items-center gap-2.5 h-[48px] px-3 ${collapsed ? 'justify-center' : ''}`}>
             <button
               type="button"
-              aria-label="포털 홈으로 이동"
-              onClick={() => navigate('/portal/project-select')}
+              aria-label="처음 화면으로 이동"
+              onClick={() => navigate('/')}
               className="rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
             >
               <MyscWordmark
@@ -806,8 +806,8 @@ function PortalContent() {
               <div className="flex min-w-0 items-center gap-2">
                 <button
                   type="button"
-                  aria-label="포털 홈으로 이동"
-                  onClick={() => navigate('/portal/project-select')}
+                  aria-label="처음 화면으로 이동"
+                  onClick={() => navigate('/')}
                   className="shrink-0 rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
                 >
                   <MyscWordmark tone="onDark" size="md" />

--- a/src/app/components/projects/ProjectListPage.mobile-tabs.regression-1.test.ts
+++ b/src/app/components/projects/ProjectListPage.mobile-tabs.regression-1.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(import.meta.dirname, 'ProjectListPage.tsx'), 'utf8');
+
+describe('ProjectListPage mobile lifecycle tabs', () => {
+  // Regression: ISSUE-001 — 375px에서 네 번째 휴지통 탭이 잘림
+  // Found by /qa on 2026-07-14
+  // Report: .gstack/qa-reports/qa-report-project-navigation-2026-07-14.md
+  it('fits all four lifecycle tabs in one responsive grid', () => {
+    expect(source).toContain('<TabsList className="grid w-full grid-cols-4">');
+    expect(source.match(/className="gap-1 px-1\.5 sm:gap-1\.5 sm:px-3"/g)).toHaveLength(4);
+  });
+});

--- a/src/app/components/projects/ProjectListPage.shell.test.ts
+++ b/src/app/components/projects/ProjectListPage.shell.test.ts
@@ -41,6 +41,22 @@ describe('ProjectListPage shell contract', () => {
     expect(source).toContain('p.registeredByName || p.managerName');
   });
 
+  it('orders lifecycle tabs as contract-pending, in-progress, completed, then trash', () => {
+    expect(source).toContain('data-testid="projects-tab-contract-pending"');
+    expect(source).toContain('data-testid="projects-tab-in-progress"');
+    expect(source).toContain('data-testid="projects-tab-completed"');
+    expect(source.indexOf('data-testid="projects-tab-contract-pending"')).toBeLessThan(
+      source.indexOf('data-testid="projects-tab-in-progress"'),
+    );
+    expect(source.indexOf('data-testid="projects-tab-in-progress"')).toBeLessThan(
+      source.indexOf('data-testid="projects-tab-completed"'),
+    );
+    expect(source.indexOf('data-testid="projects-tab-completed"')).toBeLessThan(
+      source.indexOf('data-testid="projects-tab-trash"'),
+    );
+    expect(source).not.toContain('data-testid="projects-tab-confirmed"');
+  });
+
   it('surfaces pending PM change requests from both request collections', () => {
     expect(source).toContain('usePendingProjectChangeRequests');
     expect(source).toContain('수정 검토 중');

--- a/src/app/components/projects/ProjectListPage.tsx
+++ b/src/app/components/projects/ProjectListPage.tsx
@@ -334,32 +334,32 @@ export function ProjectListPage() {
         value={activeTab}
         onValueChange={setActiveTab}
       >
-        <TabsList>
-          <TabsTrigger value="contract-pending" className="gap-1.5" data-testid="projects-tab-contract-pending">
+        <TabsList className="grid w-full grid-cols-4">
+          <TabsTrigger value="contract-pending" className="gap-1 px-1.5 sm:gap-1.5 sm:px-3" data-testid="projects-tab-contract-pending">
             <Sparkles className="w-3.5 h-3.5" />
             계약 전
-            <Badge variant="secondary" className="ml-1 text-[10px] px-1.5 py-0">
+            <Badge variant="secondary" className="ml-0.5 px-1 py-0 text-[10px] sm:ml-1 sm:px-1.5">
               {contractPendingProjects.length}
             </Badge>
           </TabsTrigger>
-          <TabsTrigger value="in-progress" className="gap-1.5" data-testid="projects-tab-in-progress">
+          <TabsTrigger value="in-progress" className="gap-1 px-1.5 sm:gap-1.5 sm:px-3" data-testid="projects-tab-in-progress">
             <ArrowRight className="w-3.5 h-3.5" />
             진행
-            <Badge variant="secondary" className="ml-1 text-[10px] px-1.5 py-0">
+            <Badge variant="secondary" className="ml-0.5 px-1 py-0 text-[10px] sm:ml-1 sm:px-1.5">
               {inProgressProjects.length}
             </Badge>
           </TabsTrigger>
-          <TabsTrigger value="completed" className="gap-1.5" data-testid="projects-tab-completed">
+          <TabsTrigger value="completed" className="gap-1 px-1.5 sm:gap-1.5 sm:px-3" data-testid="projects-tab-completed">
             <CheckCircle2 className="w-3.5 h-3.5" />
             종료
-            <Badge variant="secondary" className="ml-1 text-[10px] px-1.5 py-0">
+            <Badge variant="secondary" className="ml-0.5 px-1 py-0 text-[10px] sm:ml-1 sm:px-1.5">
               {completedProjects.length}
             </Badge>
           </TabsTrigger>
-          <TabsTrigger value="trash" className="gap-1.5" data-testid="projects-tab-trash">
+          <TabsTrigger value="trash" className="gap-1 px-1.5 sm:gap-1.5 sm:px-3" data-testid="projects-tab-trash">
             <Trash2 className="w-3.5 h-3.5" />
             휴지통
-            <Badge variant="secondary" className="ml-1 text-[10px] px-1.5 py-0">
+            <Badge variant="secondary" className="ml-0.5 px-1 py-0 text-[10px] sm:ml-1 sm:px-1.5">
               {trashedProjects.length}
             </Badge>
           </TabsTrigger>

--- a/src/app/components/projects/ProjectListPage.tsx
+++ b/src/app/components/projects/ProjectListPage.tsx
@@ -51,20 +51,23 @@ export function ProjectListPage() {
   const [deptFilter, setDeptFilter] = useState<string>('ALL');
   const [sortKey, setSortKey] = useState<SortKey>('contractAmount');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
-  const [activeTab, setActiveTab] = useState<string>('registered');
+  const [activeTab, setActiveTab] = useState<string>('contract-pending');
   const pendingProjectChangeMap = usePendingProjectChangeRequests();
 
   const {
     active: activeProjects,
-    registered: registeredProjects,
     contractPending: contractPendingProjects,
+    inProgress: inProgressProjects,
+    completed: completedProjects,
     trashed: trashedProjects,
   } = useMemo(() => groupProjectListItems(allProjects), [allProjects]);
   const tabProjects = activeTab === 'trash'
     ? trashedProjects
-    : activeTab === 'registered'
-      ? registeredProjects
-      : contractPendingProjects;
+    : activeTab === 'completed'
+      ? completedProjects
+      : activeTab === 'in-progress'
+        ? inProgressProjects
+        : contractPendingProjects;
 
   const departments = useMemo(() => {
     const depts = new Set(tabProjects.map((project) => project.department).filter(Boolean));
@@ -129,14 +132,24 @@ export function ProjectListPage() {
           title: '계약 전 프로젝트가 없습니다',
           description: '등록 요청은 실무자 포털에서 접수되고, 여기서는 계약 전 상태의 프로젝트를 확인합니다.',
         }
-        : activeTab === 'trash'
+        : activeTab === 'in-progress'
+          ? {
+            title: '진행 중인 프로젝트가 없습니다',
+            description: '계약이 완료되어 운영을 시작한 프로젝트가 이 탭에 표시됩니다.',
+          }
+          : activeTab === 'completed'
+            ? {
+              title: '종료된 프로젝트가 없습니다',
+              description: '완료되었거나 잔금 입금을 기다리는 프로젝트가 이 탭에 표시됩니다.',
+            }
+            : activeTab === 'trash'
           ? {
             title: '휴지통이 비어 있습니다',
             description: '삭제된 프로젝트가 생기면 이 탭에서 복구할 수 있습니다.',
           }
           : {
-            title: '등록 프로젝트가 없습니다',
-            description: '프로젝트가 생성되면 이 탭에서 운영 현황과 원장을 바로 확인할 수 있습니다.',
+            title: '프로젝트가 없습니다',
+            description: '프로젝트 상태를 다시 확인해 주세요.',
           };
 
     return (
@@ -299,7 +312,7 @@ export function ProjectListPage() {
         icon={FolderKanban}
         iconGradient="linear-gradient(135deg, #0891b2, #22d3ee)"
         title="프로젝트 통합 관리"
-        description={`활성 ${activeProjects.length}개 프로젝트 · 계약 전 ${contractPendingProjects.length} / 진행 ${activeProjects.filter((project) => project.status === 'IN_PROGRESS').length} / 종료 ${activeProjects.filter((project) => project.status === 'COMPLETED' || project.status === 'COMPLETED_PENDING_PAYMENT').length}`}
+        description={`활성 ${activeProjects.length}개 프로젝트 · 계약 전 ${contractPendingProjects.length} / 진행 ${inProgressProjects.length} / 종료 ${completedProjects.length}`}
         actions={(canAccessAdminPath(currentUser?.role, '/projects/new') || canAccessAdminPath(currentUser?.role, '/approvals')) ? (
           <>
             {canAccessAdminPath(currentUser?.role, '/approvals') ? (
@@ -322,18 +335,25 @@ export function ProjectListPage() {
         onValueChange={setActiveTab}
       >
         <TabsList>
-          <TabsTrigger value="registered" className="gap-1.5" data-testid="projects-tab-confirmed">
-            <CheckCircle2 className="w-3.5 h-3.5" />
-            등록 프로젝트
-            <Badge variant="secondary" className="ml-1 text-[10px] px-1.5 py-0">
-              {registeredProjects.length}
-            </Badge>
-          </TabsTrigger>
-          <TabsTrigger value="contract-pending" className="gap-1.5" data-testid="projects-tab-prospect">
+          <TabsTrigger value="contract-pending" className="gap-1.5" data-testid="projects-tab-contract-pending">
             <Sparkles className="w-3.5 h-3.5" />
             계약 전
             <Badge variant="secondary" className="ml-1 text-[10px] px-1.5 py-0">
               {contractPendingProjects.length}
+            </Badge>
+          </TabsTrigger>
+          <TabsTrigger value="in-progress" className="gap-1.5" data-testid="projects-tab-in-progress">
+            <ArrowRight className="w-3.5 h-3.5" />
+            진행
+            <Badge variant="secondary" className="ml-1 text-[10px] px-1.5 py-0">
+              {inProgressProjects.length}
+            </Badge>
+          </TabsTrigger>
+          <TabsTrigger value="completed" className="gap-1.5" data-testid="projects-tab-completed">
+            <CheckCircle2 className="w-3.5 h-3.5" />
+            종료
+            <Badge variant="secondary" className="ml-1 text-[10px] px-1.5 py-0">
+              {completedProjects.length}
             </Badge>
           </TabsTrigger>
           <TabsTrigger value="trash" className="gap-1.5" data-testid="projects-tab-trash">
@@ -392,11 +412,14 @@ export function ProjectListPage() {
           </CardContent>
         </Card>
 
-        <TabsContent value="registered" className="mt-0">
-          {activeTab === 'registered' && (filtered.length === 0 ? renderEmptyState() : renderProjectTable(filtered))}
-        </TabsContent>
         <TabsContent value="contract-pending" className="mt-0">
           {activeTab === 'contract-pending' && (filtered.length === 0 ? renderEmptyState() : renderProjectTable(filtered))}
+        </TabsContent>
+        <TabsContent value="in-progress" className="mt-0">
+          {activeTab === 'in-progress' && (filtered.length === 0 ? renderEmptyState() : renderProjectTable(filtered))}
+        </TabsContent>
+        <TabsContent value="completed" className="mt-0">
+          {activeTab === 'completed' && (filtered.length === 0 ? renderEmptyState() : renderProjectTable(filtered))}
         </TabsContent>
         <TabsContent value="trash" className="mt-0">
           {activeTab === 'trash' && (filtered.length === 0 ? renderEmptyState() : renderProjectTable(filtered))}

--- a/src/app/platform/project-list-view.test.ts
+++ b/src/app/platform/project-list-view.test.ts
@@ -16,14 +16,17 @@ const baseProject = {
 } as unknown as Project;
 
 describe('project list view', () => {
-  it('groups contract-pending projects by status even when their phase is confirmed', () => {
+  it('groups active projects into contract-pending, in-progress, and completed tabs', () => {
     const contractPending = { ...baseProject, id: 'pending', status: 'CONTRACT_PENDING', phase: 'CONFIRMED' } as Project;
     const prospectInProgress = { ...baseProject, id: 'in-progress', status: 'IN_PROGRESS', phase: 'PROSPECT' } as Project;
+    const completed = { ...baseProject, id: 'completed', status: 'COMPLETED' } as Project;
+    const pendingPayment = { ...baseProject, id: 'pending-payment', status: 'COMPLETED_PENDING_PAYMENT' } as Project;
 
-    const grouped = groupProjectListItems([contractPending, prospectInProgress]);
+    const grouped = groupProjectListItems([contractPending, prospectInProgress, completed, pendingPayment]);
 
     expect(grouped.contractPending.map((project) => project.id)).toEqual(['pending']);
-    expect(grouped.registered.map((project) => project.id)).toEqual(['in-progress']);
+    expect(grouped.inProgress.map((project) => project.id)).toEqual(['in-progress']);
+    expect(grouped.completed.map((project) => project.id)).toEqual(['completed', 'pending-payment']);
   });
 
   it('combines settlement type, status, department, and text filters', () => {

--- a/src/app/platform/project-list-view.ts
+++ b/src/app/platform/project-list-view.ts
@@ -6,8 +6,11 @@ export function groupProjectListItems(projects: Project[]) {
   const active = projects.filter((project) => !project.trashedAt);
   return {
     active,
-    registered: active.filter((project) => project.status !== 'CONTRACT_PENDING'),
     contractPending: active.filter((project) => project.status === 'CONTRACT_PENDING'),
+    inProgress: active.filter((project) => project.status === 'IN_PROGRESS'),
+    completed: active.filter((project) => (
+      project.status === 'COMPLETED' || project.status === 'COMPLETED_PENDING_PAYMENT'
+    )),
     trashed: projects.filter((project) => !!project.trashedAt),
   };
 }


### PR DESCRIPTION
## Summary
- 프로젝트 상태 탭을 `계약 전 → 진행 → 종료 → 휴지통`으로 재구성했습니다.
- `CONTRACT_PENDING`, `IN_PROGRESS`, `COMPLETED + COMPLETED_PENDING_PAYMENT` 상태를 각 탭에 명시적으로 매핑했습니다.
- PPT 23 기준으로 실무자 빠른 메뉴에서 프로젝트 선택·예산 편집·사업비 입력을 제거하고 등록 요청만 유지했습니다.
- 포털 로고 목적지를 처음 화면(`/`)으로 바꾸되, 기존 미저장 변경(dirty) 이동 가드를 유지했습니다.
- 조직장, 역할/권한, DB 스키마, 서버/BFF 로직은 변경하지 않았습니다.

## Contract / PPT traceability
- 상태 탭: 계약 전 → 진행 → 종료
- PPT 23: 빠른 메뉴 제거
- PPT 24: 포털 로고 → 처음 화면

## Test Coverage
- Focused contract tests: 5 files / 25 tests PASS
- Resource-contention rerun: 3 files / 52 tests PASS with `--maxWorkers=1`
- `npm run policy:verify`: PASS
- `npm run build`: PASS
- `git diff --check`: PASS

전체 `npm test`를 빌드와 동시에 실행한 로컬 조건에서는 변경 범위 밖의 성능/worker 테스트 5건이 5초 타임아웃에 걸렸습니다. 실패한 3개 파일은 빌드 종료 후 단독·단일 워커로 재실행해 52/52 PASS를 확인했습니다. PR CI는 테스트와 빌드를 순차 실행하므로 그 결과를 병합 게이트로 사용합니다.

## QA
- Desktop 1440px: 상태별 목록과 개수 확인
- Mobile 375px: 4개 탭이 한 줄에 잘림 없이 노출
- Feature search: 실무자 빠른 메뉴는 등록 요청만 노출
- Portal logo: dirty guard 경유 후 `/` 이동
- Browser console: affected pages 0 errors
- Independent subagent audit: PASS

## Pre-Landing Review
- No SQL/data, race, trust-boundary, shell, enum-completeness issues found.
- All four existing `ProjectStatus` values are covered by the three lifecycle tabs.
- No server, database, policy, or organization-head changes in the diff.

## Design Review
- 375px clipping found during QA and fixed with a four-column responsive tab grid.
- Final design QA: PASS (87/100); no unresolved findings.

## Test plan
- [x] 상태 탭 순서와 상태 매핑 확인
- [x] 빠른 메뉴 제거 확인
- [x] 포털 로고 목적지와 dirty guard 확인
- [x] 375px 모바일 탭 회귀 확인
- [x] Production build
- [x] Policy verification
