### PR TITLE
fix(bff): retry ambiguous project registration submits

### DIFF
--- a/server/bff/edit-lease.mjs
+++ b/server/bff/edit-lease.mjs
@@ -48,7 +48,7 @@ function serverNow(clock) {
   return value;
 }
 
-function isInvalidOrClosedTransactionError(error) {
+export function isInvalidOrClosedTransactionError(error) {
   if (Number(error?.code) !== 3) return false;
   return /transaction is invalid or closed/i.test(`${error?.details || ''} ${error?.message || ''}`);
 }

--- a/server/bff/routes/project-registration-drafts.mjs
+++ b/server/bff/routes/project-registration-drafts.mjs
@@ -12,6 +12,7 @@ import {
   assertOwnedInTransaction,
   buildActiveEditLeaseDocument,
   buildEditLeaseAuditEntry,
+  isInvalidOrClosedTransactionError,
   resolveEditLeaseDocumentId,
 } from '../edit-lease.mjs';
 import {
@@ -445,6 +446,15 @@ export function createProjectRegistrationDraftService({
     }
   }
 
+  async function runFinalSubmitTransaction(callback) {
+    try {
+      return await db.runTransaction(callback);
+    } catch (error) {
+      if (!isInvalidOrClosedTransactionError(error)) throw error;
+      return db.runTransaction(callback);
+    }
+  }
+
   function assertRevision(draft, expectedDraftRevision) {
     const actual = Number.isInteger(draft.draftRevision) ? draft.draftRevision : 0;
     if (actual !== expectedDraftRevision) {
@@ -691,7 +701,7 @@ export function createProjectRegistrationDraftService({
       const outboxRef = db.doc(`outbox/${documentId(outboxTemplate?.id, 'outboxEvent.id')}`);
 
       try {
-        return await db.runTransaction(async (tx) => {
+        return await runFinalSubmitTransaction(async (tx) => {
         const submissionDate = clockDate(now);
         const timestamp = submissionDate.toISOString();
         const { actorRole, member, ref, draft } = await ownedDraft(tx, current);
@@ -819,7 +829,7 @@ export function createProjectRegistrationDraftService({
         return { status: 201, body, replayed: false };
         });
       } catch (error) {
-        if (isFirestoreTransactionConflict(error)) {
+        if (isFirestoreTransactionConflict(error) || isInvalidOrClosedTransactionError(error)) {
           throw createHttpError(409, 'Another final submission won the project registration race.', 'canonical_submit_conflict');
         }
         throw error;

--- a/server/bff/routes/project-registration-drafts.test.mjs
+++ b/server/bff/routes/project-registration-drafts.test.mjs
@@ -634,6 +634,45 @@ describe('project registration draft service', () => {
       .toEqual(['PROJECT_REGISTRATION_SUBMIT', 'EDIT_LEASE_RELEASE']);
   });
 
+  it('replays a committed final submit when Firestore reports an invalid-or-closed transaction', async () => {
+    const { db, service, base, auditChainService } = createHarness();
+    const created = await service.create({
+      ...base,
+      idempotencyKey: 'idem-submit-closed-create',
+      payload: validRegistrationV2Payload(),
+    });
+    addRequiredRegistrationAttachments(db, created.body.draft.draftId);
+    const runTransaction = db.runTransaction.bind(db);
+    let submitTransactionCalls = 0;
+    db.runTransaction = async (callback) => {
+      submitTransactionCalls += 1;
+      const result = await runTransaction(callback);
+      if (submitTransactionCalls === 1) {
+        throw Object.assign(new Error('3 INVALID_ARGUMENT: Transaction is invalid or closed.'), {
+          code: 3,
+          details: 'Transaction is invalid or closed.',
+        });
+      }
+      return result;
+    };
+
+    const submitted = await service.submit({
+      ...base,
+      idempotencyKey: 'idem-submit-closed',
+      draftId: created.body.draft.draftId,
+      leaseId: created.body.lease.leaseId,
+      fence: created.body.lease.fence,
+      expectedDraftRevision: 0,
+    });
+
+    expect(submitted).toMatchObject({ status: 201, replayed: true, body: { status: 'SUBMITTED' } });
+    expect(submitTransactionCalls).toBe(2);
+    expect([...db.documents.keys()].filter((path) => path.includes('/projects/'))).toHaveLength(1);
+    expect([...db.documents.keys()].filter((path) => path.includes('/project_requests/'))).toHaveLength(1);
+    expect([...db.documents.keys()].filter((path) => path.startsWith('outbox/'))).toHaveLength(1);
+    expect(auditChainService.appendManyInTransaction).toHaveBeenCalledTimes(2);
+  });
+
   it('passes all four required private attachment kinds into registration v2 final-submit validation', async () => {
     const storageService = {
       uploadDraftAttachment: vi.fn(async ({ tenantId, draftId, attachmentId, fileName, buffer, mimeType }) => ({


### PR DESCRIPTION
## 변경
- Firestore가 최종 제출 커밋 직후 `Transaction is invalid or closed`를 반환하는 희귀 경합을 1회 재실행합니다.
- 같은 idempotency key는 이미 커밋된 201 응답을 재생하고, 다른 key의 패자는 409로 정리합니다.
- 프로젝트/요청/초안/lease/outbox/audit/idempotency의 단일 트랜잭션 원자성은 유지합니다.

## 검증
- project registration/edit lease unit: 75/75
- BFF Firestore integration: 175/175 (2 skipped)
- Storage integration: 2/2
- project portfolio focused: 17/17
- `git diff --check`

Stage-only 후속 패치이며 Live 배포는 수행하지 않습니다.