### PR TITLE
feat: implement PPT 38 cashflow operations dashboard

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -11,6 +11,15 @@ import {
   resolveCashflowComparisonAsOf,
 } from '../cashflow-comparison.mjs';
 import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES } from '../cashflow-policy.mjs';
+import { stableStringify } from '../utils.mjs';
+import { getMonthFinanceWeeks } from '../../../src/app/platform/cashflow-week-core.mjs';
+
+const CASHFLOW_MANAGEMENT_CHECK_IDS = [
+  'labor-transfer',
+  'profit-vat-after-deposit',
+  'negative-projection-balance',
+  'future-prepay-over-million',
+];
 
 function resolveJavaWeeklyApiBaseUrl(options = {}, env = process.env) {
   return readOptionalText(options.jvmWeeklyApiBaseUrl)
@@ -323,6 +332,246 @@ function buildMonthModeReadModel(cells, mode) {
   };
 }
 
+function monthWeeksFromCells(cells, yearMonth) {
+  const modes = {
+    projection: buildMonthModeReadModel(cells, 'projection'),
+    actual: buildMonthModeReadModel(cells, 'actual'),
+  };
+  return Array.from({ length: 5 }, (_, index) => {
+    const weekNo = index + 1;
+    const financeWeek = getMonthFinanceWeeks(yearMonth).find((week) => week.weekNo === weekNo) || {};
+    return {
+      yearMonth,
+      weekNo,
+      weekStart: financeWeek.weekStart || '',
+      weekEnd: financeWeek.weekEnd || '',
+      projection: modes.projection?.weeks?.find((week) => week.weekNo === weekNo)?.amounts || {},
+      actual: modes.actual?.weeks?.find((week) => week.weekNo === weekNo)?.amounts || {},
+    };
+  });
+}
+
+function canonicalCashflowWeeks(cashflow, cells, yearMonth) {
+  const byKey = new Map();
+  for (const month of Array.isArray(cashflow?.readModel?.months) ? cashflow.readModel.months : []) {
+    const monthKey = readOptionalText(month?.yearMonth);
+    if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(monthKey)) continue;
+    const financeWeeks = getMonthFinanceWeeks(monthKey);
+    for (let weekNo = 1; weekNo <= 5; weekNo += 1) {
+      const financeWeek = financeWeeks.find((week) => week.weekNo === weekNo) || {};
+      byKey.set(`${monthKey}:${weekNo}`, {
+        yearMonth: monthKey,
+        weekNo,
+        weekStart: financeWeek.weekStart || '',
+        weekEnd: financeWeek.weekEnd || '',
+        projection: month?.projection?.weeks?.find((week) => Number(week?.weekNo) === weekNo)?.amounts || {},
+        actual: month?.actual?.weeks?.find((week) => Number(week?.weekNo) === weekNo)?.amounts || {},
+      });
+    }
+  }
+  if (completeMonthCloseCells(cells)) {
+    for (const week of monthWeeksFromCells(cells, yearMonth)) byKey.set(`${yearMonth}:${week.weekNo}`, week);
+  }
+  return [...byKey.values()].sort((left, right) => (
+    cashflowRangeSortKey(left) - cashflowRangeSortKey(right)
+  ));
+}
+
+function managementCheck(id, status, title, detail) {
+  return { id, status, title, detail };
+}
+
+function laborTransferCheck(project, weeks, yearMonth, asOfKey) {
+  const plan = objectValue(project?.laborTransferPlan) || {};
+  const monthWeeks = weeks.filter((week) => week.yearMonth === yearMonth);
+  const projectionTotal = monthWeeks.reduce((sum, week) => sum + safeAmount(week.projection?.MYSC_LABOR_OUT), 0);
+  const actualTotal = monthWeeks.reduce((sum, week) => sum + safeAmount(week.actual?.MYSC_LABOR_OUT), 0);
+  if (plan.mode === 'MONTHLY_WEEK_3') {
+    const week = monthWeeks.find((candidate) => candidate.weekNo === 3);
+    const projectionOk = safeAmount(week?.projection?.MYSC_LABOR_OUT) > 0;
+    const actualDue = cashflowRangeSortKey({ yearMonth, weekNo: 3 }) <= asOfKey;
+    const actualOk = !actualDue || safeAmount(week?.actual?.MYSC_LABOR_OUT) > 0;
+    return managementCheck(
+      'labor-transfer',
+      projectionOk && actualOk ? 'OK' : 'WARNING',
+      'MYSC 인건비 이관',
+      `3주차 Projection ${projectionOk ? '정상' : '미이관'} · Actual ${actualDue ? (actualOk ? '정상' : '미이관') : '기한 전'}`,
+    );
+  }
+  if (plan.mode === 'PAYMENT_MILESTONE') {
+    const amounts = objectValue(plan.milestoneAmounts) || {};
+    const expectedMonths = objectValue(project?.paymentExpectedMonths) || {};
+    const expected = ['contract', 'interim', 'final'].reduce((sum, key) => (
+      readOptionalText(expectedMonths[key]) === yearMonth ? sum + safeAmount(amounts[key]) : sum
+    ), 0);
+    if (expected <= 0) {
+      return managementCheck('labor-transfer', 'REVIEW_REQUIRED', 'MYSC 인건비 이관', '선금·중도금·잔금별 인건비 할당액을 프로젝트 등록에서 확인해 주세요.');
+    }
+    const projectionOk = projectionTotal >= expected;
+    const actualOk = actualTotal >= expected;
+    return managementCheck(
+      'labor-transfer',
+      projectionOk && actualOk ? 'OK' : 'WARNING',
+      'MYSC 인건비 이관',
+      `할당 ${expected.toLocaleString('ko-KR')}원 · Projection ${projectionTotal.toLocaleString('ko-KR')}원 · Actual ${actualTotal.toLocaleString('ko-KR')}원`,
+    );
+  }
+  return managementCheck('labor-transfer', 'REVIEW_REQUIRED', 'MYSC 인건비 이관', '프로젝트 등록에서 인건비 이관 방식을 선택해 주세요.');
+}
+
+function profitVatAfterDepositCheck(weeks, deposits, asOfKey) {
+  const byKey = new Map(weeks.map((week, index) => [`${week.yearMonth}:${week.weekNo}`, { week, index }]));
+  const due = [];
+  for (const deposit of Array.isArray(deposits) ? deposits : []) {
+    if (!readOptionalText(deposit?.actualDepositDate) || safeAmount(deposit?.actualDepositAmount) <= 0) continue;
+    const key = `${readOptionalText(deposit.yearMonth)}:${Number(deposit.weekNo)}`;
+    const current = byKey.get(key);
+    const candidate = current ? weeks[current.index + 1] : null;
+    const calendarGapMs = candidate && current?.week?.weekEnd && candidate.weekStart
+      ? Date.parse(`${candidate.weekStart}T00:00:00Z`) - Date.parse(`${current.week.weekEnd}T00:00:00Z`)
+      : Number.POSITIVE_INFINITY;
+    const target = candidate && calendarGapMs <= 8 * 86_400_000 ? candidate : null;
+    if (!target) {
+      due.push(`${readOptionalText(deposit.yearMonth)} ${Number(deposit.weekNo)}주차 입금의 다음 주차 원장 없음`);
+      continue;
+    }
+    const targetKey = cashflowRangeSortKey(target);
+    const missing = [
+      safeAmount(target.actual?.MYSC_PROFIT_OUT) > 0 ? null : 'MYSC 수익',
+      safeAmount(target.actual?.SALES_VAT_OUT) > 0 ? null : '매출부가세',
+    ].filter(Boolean);
+    if (targetKey <= asOfKey && missing.length > 0) due.push(`${target.yearMonth} ${target.weekNo}주차 ${missing.join('·')}`);
+  }
+  const actualDeposits = (Array.isArray(deposits) ? deposits : []).filter((row) => (
+    readOptionalText(row?.actualDepositDate) && safeAmount(row?.actualDepositAmount) > 0
+  ));
+  if (actualDeposits.length === 0) {
+    return managementCheck('profit-vat-after-deposit', 'REVIEW_REQUIRED', '입금 후 MYSC 수익·매출부가세 이관', '실제 입금 확인 건이 없습니다. 해당 없음 여부를 사람이 확인해 주세요.');
+  }
+  return managementCheck(
+    'profit-vat-after-deposit',
+    due.length > 0 ? 'WARNING' : 'OK',
+    '입금 후 MYSC 수익·매출부가세 이관',
+    due.length > 0 ? `다음 주차까지 미이관: ${due.join(', ')}` : '실제 입금 건의 다음 주차 이관을 확인했습니다.',
+  );
+}
+
+function negativeProjectionCheck(weeks) {
+  let balance = 0;
+  let prepay = 0;
+  for (const week of weeks) {
+    const totalIn = sumSafe(CASHFLOW_IN_LINES.map((lineId) => week.projection?.[lineId])) || 0;
+    const totalOut = sumSafe(CASHFLOW_OUT_LINES.map((lineId) => week.projection?.[lineId])) || 0;
+    balance += totalIn - totalOut;
+    prepay += safeAmount(week.projection?.MYSC_PREPAY_IN);
+    if (balance < 0) {
+      return managementCheck(
+        'negative-projection-balance',
+        'WARNING',
+        'Projection 잔액 마이너스',
+        `${week.yearMonth} ${week.weekNo}주차부터 ${balance.toLocaleString('ko-KR')}원${prepay > 0 ? '' : ' · MYSC 선입금 Projection 없음'}`,
+      );
+    }
+  }
+  return managementCheck('negative-projection-balance', 'OK', 'Projection 잔액 마이너스', 'Projection 누적 잔액이 0원 이상입니다.');
+}
+
+function futurePrepayCheck(weeks, asOfKey) {
+  const occurrences = weeks.filter((week) => (
+    cashflowRangeSortKey(week) > asOfKey && safeAmount(week.projection?.MYSC_PREPAY_IN) > 1_000_000
+  ));
+  return managementCheck(
+    'future-prepay-over-million',
+    occurrences.length > 0 ? 'WARNING' : 'OK',
+    '금주 이후 선입금 요청 100만원 초과',
+    occurrences.length > 0
+      ? occurrences.map((week) => `${week.yearMonth} ${week.weekNo}주차 ${safeAmount(week.projection?.MYSC_PREPAY_IN).toLocaleString('ko-KR')}원`).join(', ')
+      : '금주 이후 100만원 초과 요청이 없습니다.',
+  );
+}
+
+export function buildCashflowManagementChecks({ project, cashflow, cells, yearMonth, depositScheduleRows, comparisonBoundary }) {
+  const weeks = canonicalCashflowWeeks(cashflow, cells, yearMonth);
+  const asOfKey = cashflowRangeSortKey(comparisonBoundary?.asOfWeek || { yearMonth, weekNo: 5 });
+  const deposits = (Array.isArray(depositScheduleRows) ? depositScheduleRows : []).map((row) => ({ ...row, yearMonth }));
+  return [
+    laborTransferCheck(project, weeks, yearMonth, asOfKey),
+    profitVatAfterDepositCheck(weeks, deposits, asOfKey),
+    negativeProjectionCheck(weeks),
+    futurePrepayCheck(weeks, asOfKey),
+  ];
+}
+
+function validManagementConfirmations(confirmations) {
+  const byId = new Map();
+  for (const item of Array.isArray(confirmations) ? confirmations : []) {
+    const checkId = readOptionalText(item?.checkId);
+    const decision = readOptionalText(item?.decision).toUpperCase();
+    if (!CASHFLOW_MANAGEMENT_CHECK_IDS.includes(checkId) || !['CONFIRMED', 'NOT_APPLICABLE'].includes(decision)) continue;
+    byId.set(checkId, { checkId, decision });
+  }
+  return byId;
+}
+
+function completeManagementConfirmations(confirmations) {
+  return validManagementConfirmations(confirmations).size === CASHFLOW_MANAGEMENT_CHECK_IDS.length;
+}
+
+function matchingManagementChecks(expected, actual) {
+  const select = (items) => (Array.isArray(items) ? items : [])
+    .map((item) => ({
+      id: readOptionalText(item?.id),
+      status: readOptionalText(item?.status),
+      title: readOptionalText(item?.title),
+      detail: readOptionalText(item?.detail),
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+  return select(expected).length === CASHFLOW_MANAGEMENT_CHECK_IDS.length
+    && stableStringify(select(expected)) === stableStringify(select(actual));
+}
+
+function actualWrittenProgressPercent(cells, yearMonth, comparisonBoundary) {
+  const asOfYearMonth = readOptionalText(comparisonBoundary?.asOfWeek?.yearMonth);
+  const asOfWeekNo = Number(comparisonBoundary?.asOfWeek?.weekNo);
+  const targetWeekCount = yearMonth < asOfYearMonth ? 5 : yearMonth === asOfYearMonth ? Math.max(0, Math.min(5, asOfWeekNo)) : 0;
+  if (targetWeekCount === 0) return 0;
+  const target = cells.filter((cell) => cell.mode === 'actual' && cell.weekNo <= targetWeekCount);
+  if (target.length === 0) return 0;
+  return Math.round((target.filter((cell) => cell.cellState === 'VALUE').length / target.length) * 10_000) / 100;
+}
+
+function postCloseAdjustment(close, currentSnapshot) {
+  const previous = objectValue(close?.previousSnapshot);
+  if (!previous || Object.keys(previous).length === 0) return null;
+  const amounts = (snapshot) => {
+    const result = new Map();
+    for (const week of Array.isArray(snapshot?.weeklyTotals) ? snapshot.weeklyTotals : []) {
+      const weekNo = Number(week?.weekNo);
+      for (const mode of ['projection', 'actual']) {
+        const values = objectValue(week?.[mode]) || {};
+        for (const lineId of CASHFLOW_ALL_LINES) result.set(`${mode}:${weekNo}:${lineId}`, safeAmount(values[lineId]));
+      }
+    }
+    return result;
+  };
+  const before = amounts(previous);
+  const after = amounts(currentSnapshot);
+  const changes = [...after.entries()].flatMap(([key, afterAmount]) => {
+    const beforeAmount = before.get(key) || 0;
+    if (beforeAmount === afterAmount) return [];
+    const [mode, weekNo, cashflowLine] = key.split(':');
+    return [{ mode, weekNo: Number(weekNo), cashflowLine, beforeAmount, afterAmount }];
+  });
+  const reopenContext = objectValue(currentSnapshot?.reopenContext) || {};
+  const request = objectValue(reopenContext.request) || {};
+  const decision = objectValue(reopenContext.decision) || {};
+  return {
+    reason: readOptionalText(request.reason) || readOptionalText(decision.reason) || '재오픈 후 조정',
+    changedCount: changes.length,
+    changes: changes.slice(0, 200),
+  };
+}
+
 function parseCashflowRangeBoundary(value, fieldName) {
   const normalized = readOptionalText(value);
   if (!normalized) return null;
@@ -434,26 +683,6 @@ function dashboardTotals(mode) {
   };
 }
 
-function actualProgressPercent(confirmations, yearMonth, comparisonBoundary) {
-  const asOfYearMonth = readOptionalText(comparisonBoundary?.asOfWeek?.yearMonth);
-  const asOfWeekNo = Number(comparisonBoundary?.asOfWeek?.weekNo);
-  const targetWeekCount = yearMonth < asOfYearMonth
-    ? 5
-    : (yearMonth === asOfYearMonth ? Math.max(0, Math.min(5, asOfWeekNo)) : 0);
-  if (targetWeekCount === 0) return 0;
-  const confirmedKeys = new Set((Array.isArray(confirmations) ? confirmations : [])
-    .filter((confirmation) => (
-      confirmation?.mode === 'actual'
-      && Number.isInteger(Number(confirmation?.weekNo))
-      && Number(confirmation.weekNo) >= 1
-      && Number(confirmation.weekNo) <= targetWeekCount
-      && CASHFLOW_ALL_LINES.includes(readOptionalText(confirmation?.cashflowLine))
-      && ['CONFIRMED', 'NOT_APPLICABLE'].includes(readOptionalText(confirmation?.decision))
-    ))
-    .map((confirmation) => `${Number(confirmation.weekNo)}:${confirmation.cashflowLine}`));
-  return Math.round(Math.min(1, confirmedKeys.size / (CASHFLOW_ALL_LINES.length * targetWeekCount)) * 10_000) / 100;
-}
-
 function validConfirmationKeys(confirmations) {
   const keys = new Set();
   for (const confirmation of Array.isArray(confirmations) ? confirmations : []) {
@@ -528,6 +757,90 @@ function projectSheetWarnings(project, metadata) {
     warnings.push({ code: 'PROJECT_SHEET_SETTLEMENT_STATUS_MISMATCH', message: '프로젝트 등록 정보와 시트의 정산 여부가 다릅니다.' });
   }
   return warnings;
+}
+
+function projectMetadata(project) {
+  const settlementType = readOptionalText(project?.settlementType).toUpperCase();
+  const basis = readOptionalText(project?.basis);
+  return {
+    businessType: [settlementType && settlementType !== 'NONE' ? settlementType : '', basis && basis !== 'NONE' ? basis : '']
+      .filter(Boolean).join(' · ') || '미정',
+    accountType: project?.accountType === 'DEDICATED' ? '전용계좌사업' : project?.accountType ? '운영계좌사업' : '미정',
+    settlementStatus: !settlementType ? '미정' : settlementType !== 'NONE' ? '정산진행' : '정산없음',
+  };
+}
+
+function addIsoDays(isoDate, days) {
+  const date = new Date(`${isoDate}T00:00:00Z`);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+function thursdayDeadlineMs(week) {
+  for (let offset = 0; offset < 7; offset += 1) {
+    const date = addIsoDays(week.weekStart, offset);
+    if (date > week.weekEnd) break;
+    if (new Date(`${date}T00:00:00Z`).getUTCDay() === 4) {
+      return Date.parse(`${addIsoDays(date, 1)}T00:00:00+09:00`);
+    }
+  }
+  return Date.parse(`${addIsoDays(week.weekEnd, 1)}T00:00:00+09:00`);
+}
+
+function monthsBetween(startYearMonth, endYearMonth) {
+  const result = [];
+  let cursor = new Date(`${startYearMonth}-01T00:00:00Z`);
+  const end = new Date(`${endYearMonth}-01T00:00:00Z`);
+  while (cursor <= end && result.length < 240) {
+    result.push(cursor.toISOString().slice(0, 7));
+    cursor = new Date(Date.UTC(cursor.getUTCFullYear(), cursor.getUTCMonth() + 1, 1));
+  }
+  return result;
+}
+
+async function readCashflowDeadlineSummary({ db, tenantId, projectId, comparisonBoundary }) {
+  if (!db?.collection) return { trackingStartedAt: null, missedCount: 0, completedCount: 0, current: null };
+  const snap = await db.collection(`orgs/${tenantId}/cashflow_sheet_stage_runs`)
+    .where('projectId', '==', projectId)
+    .limit(500)
+    .get();
+  const runs = snap.docs.map((doc) => doc.data() || {})
+    .filter((run) => run.status === 'APPLIED' || (run.status === 'READY' && safeAmount(run.stagedLineCount) === 0))
+    .map((run) => readOptionalText(run.appliedAt) || readOptionalText(run.createdAt))
+    .filter((value) => Number.isFinite(Date.parse(value)))
+    .sort();
+  if (runs.length === 0) return { trackingStartedAt: null, missedCount: 0, completedCount: 0, current: null };
+  const trackingStartedAt = runs[0];
+  const asOfDate = readOptionalText(comparisonBoundary?.asOfDate);
+  const startYearMonth = trackingStartedAt.slice(0, 7);
+  const endYearMonth = asOfDate.slice(0, 7);
+  const asOfMs = Date.parse(`${asOfDate}T23:59:59+09:00`);
+  const weeks = monthsBetween(startYearMonth, endYearMonth).flatMap(getMonthFinanceWeeks)
+    .filter((week) => Date.parse(`${week.weekEnd}T23:59:59+09:00`) >= Date.parse(trackingStartedAt));
+  let missedCount = 0;
+  let completedCount = 0;
+  let current = null;
+  for (const week of weeks) {
+    const deadlineMs = thursdayDeadlineMs(week);
+    const startMs = Date.parse(`${week.weekStart}T00:00:00+09:00`);
+    const completedAt = runs.find((value) => {
+      const time = Date.parse(value);
+      return time >= startMs && time <= deadlineMs;
+    }) || null;
+    const deadlinePassed = asOfMs >= deadlineMs;
+    if (deadlinePassed && completedAt) completedCount += 1;
+    if (deadlinePassed && !completedAt) missedCount += 1;
+    if (week.yearMonth === comparisonBoundary?.asOfWeek?.yearMonth && week.weekNo === comparisonBoundary?.asOfWeek?.weekNo) {
+      current = {
+        yearMonth: week.yearMonth,
+        weekNo: week.weekNo,
+        deadline: new Date(deadlineMs).toISOString(),
+        completedAt,
+        status: completedAt ? 'COMPLETED' : deadlinePassed ? 'MISSED' : 'PENDING',
+      };
+    }
+  }
+  return { trackingStartedAt, missedCount, completedCount, current };
 }
 
 function sheetControlBlockers(sheetFacts) {
@@ -646,10 +959,29 @@ async function composeCashflowMonthDashboard({ db, req, projectId, yearMonth, cl
     }, comparisonBoundary).months[0] || null
     : null;
   const confirmations = closedSnapshot?.confirmations || (draftMatches ? draftInput?.confirmations : []) || [];
+  const managementConfirmations = closedSnapshot?.managementConfirmations
+    || (draftMatches ? draftInput?.managementConfirmations : [])
+    || [];
   const sourceRows = sourceDepositRows(sheetFacts, yearMonth);
   const depositScheduleRows = closedSnapshot?.depositScheduleRows
     || (draftSourceMatches ? draftInput?.depositScheduleRows : sourceRows)
     || [];
+  const managementChecks = Array.isArray(closedSnapshot?.managementChecks)
+    ? closedSnapshot.managementChecks
+    : buildCashflowManagementChecks({
+      project,
+      cashflow,
+      cells,
+      yearMonth,
+      depositScheduleRows,
+      comparisonBoundary,
+    });
+  const deadlineSummary = closedSnapshot?.deadlineSummary || await readCashflowDeadlineSummary({
+    db,
+    tenantId,
+    projectId,
+    comparisonBoundary,
+  });
   const blockers = [];
   if (readOptionalText(close?.status) !== 'OPEN') {
     blockers.push({ code: 'MONTH_NOT_OPEN', message: '결산 또는 재오픈 검토 중인 월은 수정할 수 없습니다.' });
@@ -674,14 +1006,23 @@ async function composeCashflowMonthDashboard({ db, req, projectId, yearMonth, cl
     if (!completeMonthCloseConfirmations(confirmations)) {
       blockers.push({ code: 'CONFIRMATIONS_INCOMPLETE', message: '모든 캐시플로우 항목을 확인 또는 해당 없음으로 판정해 주세요.' });
     }
+    if (!completeManagementConfirmations(managementConfirmations)) {
+      blockers.push({ code: 'MANAGEMENT_CONFIRMATIONS_INCOMPLETE', message: '주요 관리 항목 4개를 모두 확인 또는 해당 없음으로 판정해 주세요.' });
+    }
   }
   const contractAmount = safeAmount(project?.contractAmount);
   const rawProjectionProgressPercent = contractAmount === 0
     ? 100
     : Math.round((projection.totalIn / contractAmount) * 10_000) / 100;
   const projectionProgressPercent = Math.max(0, Math.min(100, rawProjectionProgressPercent));
+  const requiredCellConfirmationCount = CASHFLOW_ALL_LINES.length * 2 * 5;
+  const requiredManagementConfirmationCount = CASHFLOW_MANAGEMENT_CHECK_IDS.length;
   const confirmationProgressPercent = Math.round(
-    Math.min(1, validConfirmationKeys(confirmations).size / (CASHFLOW_ALL_LINES.length * 2 * 5)) * 10_000,
+    Math.min(
+      1,
+      (validConfirmationKeys(confirmations).size + validManagementConfirmations(managementConfirmations).size)
+        / (requiredCellConfirmationCount + requiredManagementConfirmationCount),
+    ) * 10_000,
   ) / 100;
   const source = closedSnapshot ? {
     kind: 'MONTH_CLOSE_SNAPSHOT',
@@ -699,6 +1040,7 @@ async function composeCashflowMonthDashboard({ db, req, projectId, yearMonth, cl
   return {
     source,
     project,
+    projectMetadata: projectMetadata(project),
     sheetMetadata: sheetFacts?.metadata || {},
     sheetControlTotals: {
       deposit: objectValue(sheetFacts?.controlTotals?.deposit) || null,
@@ -708,12 +1050,16 @@ async function composeCashflowMonthDashboard({ db, req, projectId, yearMonth, cl
     depositScheduleRows,
     cells,
     confirmations,
+    managementChecks,
+    managementConfirmations,
+    deadlineSummary,
+    postCloseAdjustment: closedSnapshot ? postCloseAdjustment(close, closedSnapshot) : null,
     draftRevision: draftMatches && Number.isSafeInteger(Number(draft?.draftRevision)) ? Number(draft.draftRevision) : null,
     totals: { projection, actual, difference },
     comparison,
     summary: {
       projectionProgressPercent,
-      actualProgressPercent: actualProgressPercent(confirmations, yearMonth, comparisonBoundary),
+      actualProgressPercent: actualWrittenProgressPercent(cells, yearMonth, comparisonBoundary),
       confirmationProgressPercent,
       comparisonMatches: Boolean(comparison) && comparison.weeks.every((week) => week.net === 0 && week.totalIn === 0 && week.totalOut === 0),
       comparisonAsOfDate: comparisonBoundary.asOfDate,
@@ -731,7 +1077,7 @@ async function composeCashflowMonthDashboard({ db, req, projectId, yearMonth, cl
   };
 }
 
-async function composeCashflowMonthCloseBody({ db, req, projectId }) {
+async function composeCashflowMonthCloseBody({ db, req, projectId, cashflow, comparisonBoundary }) {
   if (!db?.doc) {
     throw createHttpError(503, 'Cashflow month close source storage is unavailable.', 'cashflow_month_close_source_unavailable');
   }
@@ -744,9 +1090,10 @@ async function composeCashflowMonthCloseBody({ db, req, projectId }) {
     throw createHttpError(400, 'Cashflow month close scope is invalid.', 'cashflow_month_close_request_invalid');
   }
 
-  const [draftSnap, mirrorSnap] = await Promise.all([
+  const [draftSnap, mirrorSnap, projectSnap] = await Promise.all([
     db.doc(`orgs/${tenantId}/privateEditDrafts/${privateCashflowDraftId(projectId, actorId)}`).get(),
     db.doc(`orgs/${tenantId}/cashflow_sheet_mirrors/${projectId}`).get(),
+    db.doc(`orgs/${tenantId}/projects/${projectId}`).get(),
   ]);
   if (!draftSnap.exists) {
     throw createHttpError(409, 'Save a private cashflow draft before closing the month.', 'cashflow_month_close_draft_required');
@@ -771,6 +1118,8 @@ async function composeCashflowMonthCloseBody({ db, req, projectId }) {
     && Array.isArray(submittedRequest?.depositScheduleRows)
     && Array.isArray(submittedRequest?.cells)
     && Array.isArray(submittedRequest?.confirmations)
+    && Array.isArray(submittedRequest?.managementChecks)
+    && Array.isArray(submittedRequest?.managementConfirmations)
   ) {
     return {
       idempotencyKey: requested.idempotencyKey,
@@ -782,6 +1131,9 @@ async function composeCashflowMonthCloseBody({ db, req, projectId }) {
       depositScheduleRows: submittedRequest.depositScheduleRows,
       cells: submittedRequest.cells,
       confirmations: submittedRequest.confirmations,
+      managementChecks: submittedRequest.managementChecks,
+      managementConfirmations: submittedRequest.managementConfirmations,
+      deadlineSummary: submittedRequest.deadlineSummary || null,
     };
   }
   if (
@@ -813,6 +1165,23 @@ async function composeCashflowMonthCloseBody({ db, req, projectId }) {
     throw createHttpError(409, 'The pinned cashflow source changed. Refresh it before closing.', 'cashflow_month_close_source_conflict');
   }
   assertCloseableSheetFacts(mirror, yearMonth, closeInput);
+  const project = projectSnap.exists ? projectSnap.data() || {} : {};
+  const normalizedCells = normalizeMonthCloseCells(closeInput.cells, yearMonth);
+  const managementChecks = buildCashflowManagementChecks({
+    project,
+    cashflow,
+    cells: normalizedCells,
+    yearMonth,
+    depositScheduleRows: closeInput.depositScheduleRows,
+    comparisonBoundary,
+  });
+  if (!matchingManagementChecks(managementChecks, closeInput.managementChecks)) {
+    throw createHttpError(409, '주요 관리 항목 판정이 변경되었습니다. 다시 확인해 주세요.', 'cashflow_management_checks_stale');
+  }
+  if (!completeManagementConfirmations(closeInput.managementConfirmations)) {
+    throw createHttpError(409, '주요 관리 항목 4개를 모두 확인해 주세요.', 'cashflow_management_confirmations_incomplete');
+  }
+  const deadlineSummary = await readCashflowDeadlineSummary({ db, tenantId, projectId, comparisonBoundary });
 
   return {
     idempotencyKey: requested.idempotencyKey,
@@ -824,6 +1193,9 @@ async function composeCashflowMonthCloseBody({ db, req, projectId }) {
     depositScheduleRows: closeInput.depositScheduleRows,
     cells: closeInput.cells,
     confirmations: closeInput.confirmations,
+    managementChecks,
+    managementConfirmations: [...validManagementConfirmations(closeInput.managementConfirmations).values()],
+    deadlineSummary,
   };
 }
 
@@ -1131,7 +1503,19 @@ export function mountJvmWeeklyApiRoutes(app, {
     }
     const rawProjectId = readOptionalText(req.params.projectId);
     const projectId = encodeURIComponent(rawProjectId);
-    const closeBody = await composeCashflowMonthCloseBody({ db, req, projectId: rawProjectId });
+    const comparisonBoundary = resolveCashflowComparisonAsOf('', now());
+    const cashflow = await proxyJavaWeeklyRequest({
+      context: req.context,
+      method: 'GET',
+      path: `/api/v1/cashflow/${projectId}`,
+    });
+    const closeBody = await composeCashflowMonthCloseBody({
+      db,
+      req,
+      projectId: rawProjectId,
+      cashflow,
+      comparisonBoundary,
+    });
     const result = await proxyMutation(
       req,
       `/api/v1/cashflow/${projectId}/month-close`,

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -1,7 +1,7 @@
 import express from 'express';
 import request from 'supertest';
 import { describe, expect, it, vi } from 'vitest';
-import { mountJvmWeeklyApiRoutes } from './jvm-weekly-api.mjs';
+import { buildCashflowManagementChecks, mountJvmWeeklyApiRoutes } from './jvm-weekly-api.mjs';
 
 function createIdempotencyService() {
   return {
@@ -30,6 +30,20 @@ const cashflowLineIds = [
   'MYSC_PREPAY_DIRECT_OUT', 'MYSC_PREPAY_LABOR_OUT', 'DIRECT_COST_OUT',
   'INPUT_VAT_OUT', 'MYSC_LABOR_OUT', 'MYSC_PROFIT_OUT', 'SALES_VAT_OUT',
   'TEAM_SUPPORT_OUT', 'BANK_INTEREST_OUT',
+];
+
+const managementConfirmations = [
+  'labor-transfer',
+  'profit-vat-after-deposit',
+  'negative-projection-balance',
+  'future-prepay-over-million',
+].map((checkId) => ({ checkId, decision: 'CONFIRMED' }));
+
+const emptyManagementChecks = [
+  { id: 'labor-transfer', status: 'REVIEW_REQUIRED', title: 'MYSC 인건비 이관', detail: '프로젝트 등록에서 인건비 이관 방식을 선택해 주세요.' },
+  { id: 'profit-vat-after-deposit', status: 'REVIEW_REQUIRED', title: '입금 후 MYSC 수익·매출부가세 이관', detail: '실제 입금 확인 건이 없습니다. 해당 없음 여부를 사람이 확인해 주세요.' },
+  { id: 'negative-projection-balance', status: 'OK', title: 'Projection 잔액 마이너스', detail: 'Projection 누적 잔액이 0원 이상입니다.' },
+  { id: 'future-prepay-over-million', status: 'OK', title: '금주 이후 선입금 요청 100만원 초과', detail: '금주 이후 100만원 초과 요청이 없습니다.' },
 ];
 
 function matchingControlRows(startRow, matches = true) {
@@ -98,6 +112,7 @@ function fullMonthCloseSource({ mirrorStatus = 'FRESH', controlMatches = true, c
         depositScheduleRows, cells: cells.map(({ lineId, state, yearMonth: _yearMonth, direction: _direction, ...cell }) => ({
           ...cell, cashflowLine: lineId, cellState: state,
         })), confirmations,
+        managementConfirmations,
       } },
     }],
     ['orgs/tenant-a/cashflow_sheet_mirrors/project-a', {
@@ -139,6 +154,9 @@ function createMonthCloseDb() {
         depositScheduleRows,
         cells: [{ mode: 'projection', weekNo: 1, cashflowLine: 'SALES_IN', cellState: 'VALUE', amount: 1234 }],
         confirmations: [{ mode: 'projection', weekNo: 1, cashflowLine: 'SALES_IN', decision: 'CONFIRMED' }],
+        managementChecks: emptyManagementChecks,
+        managementConfirmations,
+        deadlineSummary: { trackingStartedAt: null, missedCount: 0, completedCount: 0, current: null },
       } },
     }],
     ['orgs/tenant-a/cashflow_sheet_mirrors/project-a', {
@@ -420,6 +438,66 @@ describe('JVM weekly API BFF proxy', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
+  it('returns the four PPT 38 management checks from canonical server values', () => {
+    const { documents } = fullMonthCloseSource();
+    const draft = [...documents.values()].find((value) => value?.resourceType === 'cashflow');
+    const project = documents.get('orgs/tenant-a/projects/project-a');
+    const checks = buildCashflowManagementChecks({
+      project,
+      cashflow: { readModel: { months: [] } },
+      cells: draft.payload.monthClose.cells,
+      yearMonth: '2026-06',
+      depositScheduleRows: draft.payload.monthClose.depositScheduleRows,
+      comparisonBoundary: { asOfWeek: { yearMonth: '2026-07', weekNo: 2 } },
+    });
+
+    expect(checks).toHaveLength(4);
+    expect(checks.map((check) => [check.id, check.status])).toEqual([
+      ['labor-transfer', 'REVIEW_REQUIRED'],
+      ['profit-vat-after-deposit', 'REVIEW_REQUIRED'],
+      ['negative-projection-balance', 'WARNING'],
+      ['future-prepay-over-million', 'OK'],
+    ]);
+  });
+
+  it('flags missing labor, post-deposit transfer, negative balance, and future prepay on the server', () => {
+    const { documents } = fullMonthCloseSource();
+    const draft = [...documents.values()].find((value) => value?.resourceType === 'cashflow');
+    const cells = draft.payload.monthClose.cells.map((cell) => (
+      cell.weekNo === 3 && cell.cashflowLine === 'MYSC_LABOR_OUT' ? { ...cell, amount: 0 } : cell
+    ));
+    const depositScheduleRows = draft.payload.monthClose.depositScheduleRows.map((row) => (
+      row.weekNo === 5
+        ? { ...row, actualDepositDate: '2026-06-30', actualDepositAmount: 1_000_000, actualSource: 'SHEET' }
+        : row
+    ));
+    const checks = buildCashflowManagementChecks({
+      project: { laborTransferPlan: { mode: 'MONTHLY_WEEK_3', milestoneAmounts: {} } },
+      cashflow: {
+        readModel: {
+          months: [{
+            yearMonth: '2026-08',
+            projection: { weeks: [{ weekNo: 1, amounts: { MYSC_PREPAY_IN: 1_000_001 } }] },
+            actual: { weeks: [] },
+          }],
+        },
+      },
+      cells,
+      yearMonth: '2026-06',
+      depositScheduleRows,
+      comparisonBoundary: { asOfWeek: { yearMonth: '2026-07', weekNo: 2 } },
+    });
+
+    expect(checks.map((check) => [check.id, check.status])).toEqual([
+      ['labor-transfer', 'WARNING'],
+      ['profit-vat-after-deposit', 'WARNING'],
+      ['negative-projection-balance', 'WARNING'],
+      ['future-prepay-over-million', 'WARNING'],
+    ]);
+    expect(checks[1].detail).toContain('다음 주차 원장 없음');
+    expect(checks[3].detail).toContain('1,000,001원');
+  });
+
   it('returns an empty usable dashboard when the project has no linked sheet', async () => {
     const documents = new Map([
       ['orgs/tenant-a/projects/project-a', { id: 'project-a', contractAmount: 1000 }],
@@ -536,18 +614,24 @@ describe('JVM weekly API BFF proxy', () => {
       projection: Object.fromEntries(cashflowLineIds.map((lineId) => [lineId, 20])),
       actual: Object.fromEntries(cashflowLineIds.map((lineId) => [lineId, 10])),
     }));
+    const previousWeeklyTotals = weeklyTotals.map((week, index) => ({
+      ...week,
+      projection: index === 0 ? { ...week.projection, SALES_IN: 19 } : week.projection,
+    }));
     const fetchImpl = vi.fn(async () => ({
       ok: true,
       status: 200,
       text: async () => JSON.stringify({
         ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'CLOSED', revision: 1,
         reopenCount: 0, projectWarningCount: 0,
+        previousSnapshot: { weeklyTotals: previousWeeklyTotals },
         snapshot: {
           project: { settlementType: 'TYPE5', basis: '공급가액', accountType: 'DEDICATED', contractAmount: 2000 },
           sourceFingerprint: `sha256:${'f'.repeat(64)}`,
           targetRevision: `sha256:${'a'.repeat(64)}`,
           sourceReadAt: '2026-07-09T00:00:00.000Z',
           weeklyTotals,
+          reopenContext: { request: { reason: '입금 반영 오류 수정' }, decision: { reason: '증빙 확인 완료' } },
           depositScheduleRows: [], confirmations: [],
           sheetFacts: { metadata: { businessType: { value: 'snapshot metadata' } }, depositScheduleRows: [] },
         },
@@ -569,6 +653,11 @@ describe('JVM weekly API BFF proxy', () => {
             actual: { totalIn: 350, totalOut: 450, balance: -100 },
           },
           validation: { canClose: false },
+          postCloseAdjustment: {
+            reason: '입금 반영 오류 수정',
+            changedCount: 1,
+            changes: [{ mode: 'projection', weekNo: 1, cashflowLine: 'SALES_IN', beforeAmount: 19, afterAmount: 20 }],
+          },
         });
       });
     expect(fetchImpl).toHaveBeenCalledTimes(1);
@@ -661,8 +750,8 @@ describe('JVM weekly API BFF proxy', () => {
       })
       .expect(200);
 
-    expect(fetchImpl).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchImpl.mock.calls[0];
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const [url, init] = fetchImpl.mock.calls[1];
     expect(url).toBe('http://jvm-weekly.local/api/v1/cashflow/project-a/month-close');
     expect(init.headers).toMatchObject({
       'x-actor-id': 'pm-1',
@@ -724,7 +813,7 @@ describe('JVM weekly API BFF proxy', () => {
       .send({ yearMonth: '2026-06', expectedRevision: 3 })
       .expect(200);
 
-    expect(JSON.parse(fetchImpl.mock.calls[0][1].body)).toEqual(originalRequest);
+    expect(JSON.parse(fetchImpl.mock.calls[1][1].body)).toEqual(originalRequest);
   });
 
   it('forwards PM reopen requests without edit-lease headers', async () => {

--- a/server/bff/routes/projects.mjs
+++ b/server/bff/routes/projects.mjs
@@ -497,6 +497,20 @@ function assertRegistrationFinancials(payload, type) {
       assertRegistrationAmount(payload.paymentPlan[field], `paymentPlan.${field}`, { required: true });
     }
   }
+  if (payload.laborTransferPlan !== undefined && payload.laborTransferPlan !== null) {
+    if (typeof payload.laborTransferPlan !== 'object' || Array.isArray(payload.laborTransferPlan)) {
+      invalidRegistration('Project registration laborTransferPlan is invalid');
+    }
+    if (!['UNDECIDED', 'MONTHLY_WEEK_3', 'PAYMENT_MILESTONE'].includes(readOptionalText(payload.laborTransferPlan.mode))) {
+      invalidRegistration('Project registration laborTransferPlan.mode is invalid');
+    }
+    if (!payload.laborTransferPlan.milestoneAmounts || typeof payload.laborTransferPlan.milestoneAmounts !== 'object') {
+      invalidRegistration('Project registration laborTransferPlan.milestoneAmounts is invalid');
+    }
+    for (const field of REGISTRATION_PAYMENT_FIELDS) {
+      assertRegistrationAmount(payload.laborTransferPlan.milestoneAmounts[field], `laborTransferPlan.milestoneAmounts.${field}`, { required: true });
+    }
+  }
 
   if (payload.financialInputFlags !== undefined && payload.financialInputFlags !== null) {
     if (typeof payload.financialInputFlags !== 'object' || Array.isArray(payload.financialInputFlags)) {
@@ -614,6 +628,21 @@ function normalizePaymentExpectedMonths(value) {
     contract: normalizeExpectedMonth(value?.contract),
     interim: normalizeExpectedMonth(value?.interim),
     final: normalizeExpectedMonth(value?.final),
+  };
+}
+
+function normalizeLaborTransferPlan(value) {
+  const source = value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+  const mode = ['MONTHLY_WEEK_3', 'PAYMENT_MILESTONE'].includes(readOptionalText(source.mode))
+    ? readOptionalText(source.mode)
+    : 'UNDECIDED';
+  return {
+    mode,
+    milestoneAmounts: {
+      contract: registrationAmount(source.milestoneAmounts?.contract),
+      interim: registrationAmount(source.milestoneAmounts?.interim),
+      final: registrationAmount(source.milestoneAmounts?.final),
+    },
   };
 }
 
@@ -989,6 +1018,7 @@ export function buildProjectRegistrationCanonicalDocuments({
     accountType: normalizeAccountType(readOptionalText(payload.accountType)),
     settlementSystem: normalizeSettlementSystemCode(payload.settlementSystem),
     laborSettlementBasis: normalizeLaborSettlementBasis(payload.laborSettlementBasis),
+    laborTransferPlan: normalizeLaborTransferPlan(payload.laborTransferPlan),
     fundInputMode,
     settlementSheetPolicy: registrationSettlementSheetPolicy(payload.settlementSheetPolicy, fundInputMode),
     paymentPlan: {
@@ -1143,6 +1173,7 @@ function buildProjectRequestPayloadFromProject(project, existingPayload = {}) {
     accountType: normalizeAccountType(pickText('accountType')),
     settlementSystem: normalizeSettlementSystemCode(pickText('settlementSystem')),
     laborSettlementBasis: normalizeLaborSettlementBasis(pickText('laborSettlementBasis')),
+    laborTransferPlan: normalizeLaborTransferPlan(pickValue('laborTransferPlan')),
     fundInputMode: normalizeProjectFundInputMode(pickText('fundInputMode')),
     settlementSheetPolicy: pickValue('settlementSheetPolicy') || undefined,
     paymentPlan: pickValue('paymentPlan') || { contract: 0, interim: 0, final: 0 },
@@ -1237,6 +1268,7 @@ export function buildProjectPatchFromChangeRequestPayload(payload = {}, currentP
     accountType: normalizeAccountType(readOptionalText(payload.accountType)),
     settlementSystem: normalizeSettlementSystemCode(payload.settlementSystem),
     laborSettlementBasis: normalizeLaborSettlementBasis(payload.laborSettlementBasis),
+    laborTransferPlan: normalizeLaborTransferPlan(payload.laborTransferPlan),
     fundInputMode: normalizeProjectFundInputMode(readOptionalText(payload.fundInputMode)),
     settlementSheetPolicy: payload.settlementSheetPolicy,
     paymentPlan: payload.paymentPlan || currentProject.paymentPlan || { contract: 0, interim: 0, final: 0 },
@@ -1292,6 +1324,7 @@ const PROJECT_INFO_CHANGE_LABELS = {
   accountType: '통장 유형',
   settlementSystem: '정산 시스템',
   laborSettlementBasis: '인건비 정산 기준',
+  laborTransferPlan: 'MYSC 인건비 이관 계획',
   fundInputMode: '자금 입력 방식',
   registeredByName: '사업 담당자',
   teamName: '사내기업팀',
@@ -1327,7 +1360,7 @@ const PROJECT_INFO_PAYLOAD_FIELDS = [
   'totalRevenueAmount', 'supportAmount', 'financialInputFlags', 'registrationRequirementsVersion',
   'financialYears', 'registrationConfirmations', 'registrationOptionalDocumentNotes', 'checkout', 'contractStart', 'contractEnd',
   'contractType', 'settlementType', 'basis', 'accountType', 'settlementSystem',
-  'laborSettlementBasis', 'fundInputMode', 'settlementSheetPolicy', 'paymentPlan',
+  'laborSettlementBasis', 'laborTransferPlan', 'fundInputMode', 'settlementSheetPolicy', 'paymentPlan',
   'paymentExpectedMonths', 'advanceInterimBelow70Reason', 'paymentPlanDesc', 'settlementGuide',
   'finalPaymentNote', 'projectPurpose', 'registeredById', 'registeredByName',
   'registeredByEmail', 'managerId', 'managerName', 'teamName', 'teamMembers',

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowMonthCloseResponse.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowMonthCloseResponse.java
@@ -14,6 +14,7 @@ public record CashflowMonthCloseResponse(
     String snapshotHash,
     String previousSnapshotHash,
     Map<String, Object> snapshot,
+    Map<String, Object> previousSnapshot,
     boolean closeEligible,
     String evaluatedBusinessDate,
     String closeDeadline,
@@ -32,6 +33,7 @@ public record CashflowMonthCloseResponse(
 ) {
     public CashflowMonthCloseResponse {
         snapshot = snapshot == null ? Map.of() : Map.copyOf(snapshot);
+        previousSnapshot = previousSnapshot == null ? Map.of() : Map.copyOf(previousSnapshot);
         snapshotHash = nullableText(snapshotHash);
         previousSnapshotHash = nullableText(previousSnapshotHash);
         evaluatedBusinessDate = nullableText(evaluatedBusinessDate);

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CloseCashflowMonthRequest.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CloseCashflowMonthRequest.java
@@ -33,8 +33,18 @@ public record CloseCashflowMonthRequest(
     @Valid @NotNull @Size(min = CashflowSheetLabApplyRequest.EXPECTED_CELL_COUNT, max = CashflowSheetLabApplyRequest.EXPECTED_CELL_COUNT)
     List<CashflowSheetLabApplyRequest.Cell> cells,
     @Valid @NotNull @Size(min = CashflowSheetLabApplyRequest.EXPECTED_CELL_COUNT, max = CashflowSheetLabApplyRequest.EXPECTED_CELL_COUNT)
-    List<Confirmation> confirmations
+    List<Confirmation> confirmations,
+    @Valid @NotNull @Size(min = 4, max = 4) List<ManagementCheck> managementChecks,
+    @Valid @NotNull @Size(min = 4, max = 4) List<ManagementConfirmation> managementConfirmations,
+    @Valid @NotNull DeadlineSummary deadlineSummary
 ) {
+    private static final List<String> MANAGEMENT_CHECK_IDS = List.of(
+        "labor-transfer",
+        "profit-vat-after-deposit",
+        "negative-projection-balance",
+        "future-prepay-over-million"
+    );
+
     public record Confirmation(
         @NotBlank @Pattern(regexp = "projection|actual") String mode,
         @Min(1) @Max(CashflowSheetLabApplyRequest.FINANCE_WEEK_COUNT) int weekNo,
@@ -62,10 +72,50 @@ public record CloseCashflowMonthRequest(
         }
     }
 
+    public record ManagementCheck(
+        @NotBlank @Pattern(regexp = "labor-transfer|profit-vat-after-deposit|negative-projection-balance|future-prepay-over-million") String id,
+        @NotBlank @Pattern(regexp = "OK|WARNING|REVIEW_REQUIRED") String status,
+        @NotBlank @Size(max = 200) String title,
+        @NotBlank @Size(max = 2000) String detail
+    ) {
+    }
+
+    public record ManagementConfirmation(
+        @NotBlank @Pattern(regexp = "labor-transfer|profit-vat-after-deposit|negative-projection-balance|future-prepay-over-million") String checkId,
+        @NotBlank @Pattern(regexp = "CONFIRMED|NOT_APPLICABLE") String decision
+    ) {
+    }
+
+    public record DeadlineSummary(
+        @Size(max = 64) String trackingStartedAt,
+        @PositiveOrZero long missedCount,
+        @PositiveOrZero long completedCount,
+        @Valid CurrentDeadline current
+    ) {
+        public DeadlineSummary {
+            trackingStartedAt = trackingStartedAt == null ? "" : trackingStartedAt.trim();
+        }
+    }
+
+    public record CurrentDeadline(
+        @NotBlank @Pattern(regexp = "20\\d{2}-(0[1-9]|1[0-2])") String yearMonth,
+        @Min(1) @Max(CashflowSheetLabApplyRequest.FINANCE_WEEK_COUNT) int weekNo,
+        @NotBlank @Size(max = 64) String deadline,
+        @Size(max = 64) String completedAt,
+        @NotBlank @Pattern(regexp = "COMPLETED|MISSED|PENDING") String status
+    ) {
+        public CurrentDeadline {
+            completedAt = completedAt == null ? "" : completedAt.trim();
+        }
+    }
+
     public CloseCashflowMonthRequest {
         depositScheduleRows = depositScheduleRows == null ? List.of() : List.copyOf(depositScheduleRows);
         cells = cells == null ? List.of() : List.copyOf(cells);
         confirmations = confirmations == null ? List.of() : List.copyOf(confirmations);
+        managementChecks = managementChecks == null ? List.of() : List.copyOf(managementChecks);
+        managementConfirmations = managementConfirmations == null ? List.of() : List.copyOf(managementConfirmations);
+        deadlineSummary = deadlineSummary == null ? new DeadlineSummary("", 0, 0, null) : deadlineSummary;
     }
 
     public static List<DepositScheduleRow> requireCompleteDepositSchedule(List<DepositScheduleRow> rows) {
@@ -167,5 +217,51 @@ public record CloseCashflowMonthRequest(
             }
         }
         return List.copyOf(byKey.values());
+    }
+
+    public static List<ManagementCheck> requireCompleteManagementChecks(List<ManagementCheck> checks) {
+        if (checks == null || checks.size() != MANAGEMENT_CHECK_IDS.size()) {
+            throw new IllegalArgumentException("Cashflow month close requires all four management checks.");
+        }
+        Map<String, ManagementCheck> byId = new LinkedHashMap<>();
+        for (ManagementCheck check : checks) {
+            if (check == null || !MANAGEMENT_CHECK_IDS.contains(check.id())) {
+                throw new IllegalArgumentException("Unsupported cashflow management check.");
+            }
+            String status = check.status() == null ? "" : check.status().trim().toUpperCase(Locale.ROOT);
+            String title = check.title() == null ? "" : check.title().trim();
+            String detail = check.detail() == null ? "" : check.detail().trim();
+            if (!List.of("OK", "WARNING", "REVIEW_REQUIRED").contains(status) || title.isBlank() || detail.isBlank()) {
+                throw new IllegalArgumentException("Cashflow management check status, title, and detail are required.");
+            }
+            ManagementCheck canonical = new ManagementCheck(check.id(), status, title, detail);
+            if (byId.putIfAbsent(check.id(), canonical) != null) {
+                throw new IllegalArgumentException("Cashflow month close contains duplicate management checks.");
+            }
+        }
+        return MANAGEMENT_CHECK_IDS.stream().map(byId::get).toList();
+    }
+
+    public static List<ManagementConfirmation> requireCompleteManagementConfirmations(List<ManagementConfirmation> confirmations) {
+        if (confirmations == null || confirmations.size() != MANAGEMENT_CHECK_IDS.size()) {
+            throw new IllegalArgumentException("Cashflow month close requires a decision for all four management checks.");
+        }
+        Map<String, ManagementConfirmation> byId = new LinkedHashMap<>();
+        for (ManagementConfirmation confirmation : confirmations) {
+            if (confirmation == null || !MANAGEMENT_CHECK_IDS.contains(confirmation.checkId())) {
+                throw new IllegalArgumentException("Unsupported cashflow management confirmation.");
+            }
+            String decision = confirmation.decision() == null
+                ? ""
+                : confirmation.decision().trim().toUpperCase(Locale.ROOT);
+            if (!List.of("CONFIRMED", "NOT_APPLICABLE").contains(decision)) {
+                throw new IllegalArgumentException("Cashflow management confirmation decision is invalid.");
+            }
+            ManagementConfirmation canonical = new ManagementConfirmation(confirmation.checkId(), decision);
+            if (byId.putIfAbsent(confirmation.checkId(), canonical) != null) {
+                throw new IllegalArgumentException("Cashflow month close contains duplicate management confirmations.");
+            }
+        }
+        return MANAGEMENT_CHECK_IDS.stream().map(byId::get).toList();
     }
 }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -801,6 +801,8 @@ public class WeeklyExpenseCommandService {
         CashflowSheetLabApplyRequest.requireCompleteMonth(request.cells());
         CloseCashflowMonthRequest.requireCompleteDepositSchedule(request.depositScheduleRows());
         CloseCashflowMonthRequest.requireCompleteConfirmations(request.confirmations());
+        CloseCashflowMonthRequest.requireCompleteManagementChecks(request.managementChecks());
+        CloseCashflowMonthRequest.requireCompleteManagementConfirmations(request.managementConfirmations());
         CashflowEditSession finalSession = finalizedSession(editSession);
         assertAtomicWriteBudget(
             CashflowSheetLabApplyRequest.FINANCE_WEEK_COUNT,
@@ -2648,6 +2650,7 @@ public class WeeklyExpenseCommandService {
             close.snapshotHash(),
             close.previousSnapshotHash(),
             close.snapshot(),
+            close.previousSnapshot(),
             close.closeEligible(),
             close.evaluatedBusinessDate(),
             close.closeDeadline(),

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -458,6 +458,8 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             .requireCompleteDepositSchedule(request.depositScheduleRows());
         List<CloseCashflowMonthRequest.Confirmation> confirmations = CloseCashflowMonthRequest
             .requireCompleteConfirmations(request.confirmations());
+        CloseCashflowMonthRequest.requireCompleteManagementChecks(request.managementChecks());
+        CloseCashflowMonthRequest.requireCompleteManagementConfirmations(request.managementConfirmations());
         requireConfirmationStatesMatchCells(cells, confirmations);
         ValidatedCloseSource source = requireActiveDraftAndPinnedSource(actor, projectId, request);
 
@@ -497,6 +499,12 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             now,
             today
         );
+        if (!nestedMap(current.get("reopenRequest")).isEmpty() || !nestedMap(current.get("reopenDecision")).isEmpty()) {
+            snapshot.put("reopenContext", Map.of(
+                "request", nestedMap(current.get("reopenRequest")),
+                "decision", nestedMap(current.get("reopenDecision"))
+            ));
+        }
         String snapshotHash = hashCanonicalJson(snapshot);
         String previousSnapshotHash = text(current.get("snapshotHash"), "");
         boolean late = today.isAfter(targetMonth.plusMonths(1).atDay(10));
@@ -510,6 +518,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         patch.put("revision", revision);
         patch.put("reopenCount", reopenCount);
         patch.put("snapshot", snapshot);
+        patch.put("previousSnapshot", nestedMap(current.get("snapshot")));
         patch.put("snapshotHash", snapshotHash);
         patch.put("previousSnapshotHash", previousSnapshotHash);
         patch.put("late", late);
@@ -1328,6 +1337,9 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         input.put("depositScheduleRows", request.depositScheduleRows());
         input.put("cells", request.cells());
         input.put("confirmations", request.confirmations());
+        input.put("managementChecks", request.managementChecks());
+        input.put("managementConfirmations", request.managementConfirmations());
+        input.put("deadlineSummary", request.deadlineSummary());
         return JSON.convertValue(input, Map.class);
     }
 
@@ -1340,7 +1352,10 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                 "targetRevision",
                 "depositScheduleRows",
                 "cells",
-                "confirmations"
+                "confirmations",
+                "managementChecks",
+                "managementConfirmations",
+                "deadlineSummary"
             )) {
                 selected.put(field, raw.get(field));
             }
@@ -1356,6 +1371,10 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                 .requireCompleteDepositSchedule(input.depositScheduleRows());
             List<CloseCashflowMonthRequest.Confirmation> confirmations = CloseCashflowMonthRequest
                 .requireCompleteConfirmations(input.confirmations());
+            List<CloseCashflowMonthRequest.ManagementCheck> managementChecks = CloseCashflowMonthRequest
+                .requireCompleteManagementChecks(input.managementChecks());
+            List<CloseCashflowMonthRequest.ManagementConfirmation> managementConfirmations = CloseCashflowMonthRequest
+                .requireCompleteManagementConfirmations(input.managementConfirmations());
             requireConfirmationStatesMatchCells(cells, confirmations);
 
             Map<String, Object> canonical = new LinkedHashMap<>();
@@ -1365,6 +1384,9 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             canonical.put("depositScheduleRows", deposits);
             canonical.put("cells", cells);
             canonical.put("confirmations", confirmations);
+            canonical.put("managementChecks", managementChecks);
+            canonical.put("managementConfirmations", managementConfirmations);
+            canonical.put("deadlineSummary", input.deadlineSummary());
             return JSON.convertValue(canonical, Map.class);
         } catch (WeeklyExpenseConflictException error) {
             throw error;
@@ -1543,6 +1565,17 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                 return item;
             })
             .toList();
+        List<Map<String, Object>> managementConfirmationSnapshot = request.managementConfirmations().stream()
+            .map(confirmation -> {
+                Map<String, Object> item = new LinkedHashMap<>();
+                item.put("checkId", confirmation.checkId());
+                item.put("decision", confirmation.decision());
+                item.put("confirmedByUid", actor.id());
+                item.put("confirmedByName", actor.name());
+                item.put("confirmedAt", now.toString());
+                return item;
+            })
+            .toList();
 
         Map<String, Object> projectDocument = cachedDocumentIfPresent(
             db.document("orgs/" + actor.tenantId() + "/projects/" + projectId)
@@ -1552,7 +1585,10 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             "Canonical project data is unavailable for the month close snapshot."
         ));
         Map<String, Object> project = new LinkedHashMap<>();
-        for (String field : List.of("settlementType", "basis", "accountType", "fundInputMode", "contractAmount")) {
+        for (String field : List.of(
+            "settlementType", "basis", "accountType", "fundInputMode", "contractAmount",
+            "paymentExpectedMonths", "laborTransferPlan"
+        )) {
             project.put(field, projectDocument.get(field));
         }
 
@@ -1562,6 +1598,9 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         snapshot.put("sheetFacts", source.sheetFacts());
         snapshot.put("depositScheduleRows", depositSnapshot);
         snapshot.put("confirmations", confirmationSnapshot);
+        snapshot.put("managementChecks", JSON.convertValue(request.managementChecks(), List.class));
+        snapshot.put("managementConfirmations", managementConfirmationSnapshot);
+        snapshot.put("deadlineSummary", JSON.convertValue(request.deadlineSummary(), Map.class));
         snapshot.put("weeklyTotals", weeklyTotals);
         snapshot.put("projectionTotal", FirestoreCashflowWeekActualMerge.cashflowTotals(projectionTotal));
         snapshot.put("actualTotal", FirestoreCashflowWeekActualMerge.cashflowTotals(actualTotal));
@@ -1638,6 +1677,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             text(document.get("snapshotHash"), ""),
             text(document.get("previousSnapshotHash"), ""),
             nestedMap(document.get("snapshot")),
+            nestedMap(document.get("previousSnapshot")),
             closeEligible,
             evaluatedBusinessDate.toString(),
             closeDeadline.toString(),
@@ -2711,7 +2751,10 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         String targetRevision,
         List<CloseCashflowMonthRequest.DepositScheduleRow> depositScheduleRows,
         List<CashflowSheetLabApplyRequest.Cell> cells,
-        List<CloseCashflowMonthRequest.Confirmation> confirmations
+        List<CloseCashflowMonthRequest.Confirmation> confirmations,
+        List<CloseCashflowMonthRequest.ManagementCheck> managementChecks,
+        List<CloseCashflowMonthRequest.ManagementConfirmation> managementConfirmations,
+        CloseCashflowMonthRequest.DeadlineSummary deadlineSummary
     ) {
     }
 }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
@@ -55,6 +55,7 @@ public interface WeeklyExpensePersistence {
         String snapshotHash,
         String previousSnapshotHash,
         Map<String, Object> snapshot,
+        Map<String, Object> previousSnapshot,
         boolean closeEligible,
         String evaluatedBusinessDate,
         String closeDeadline,
@@ -72,6 +73,7 @@ public interface WeeklyExpensePersistence {
     ) {
         public CashflowMonthCloseRecord {
             snapshot = snapshot == null ? Map.of() : Map.copyOf(snapshot);
+            previousSnapshot = previousSnapshot == null ? Map.of() : Map.copyOf(previousSnapshot);
         }
     }
 

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
@@ -1971,16 +1971,28 @@ class WeeklyExpenseControllerTest {
                 }
             }
         }
-        return objectMapper.writeValueAsString(Map.of(
-            "idempotencyKey", idempotencyKey,
-            "sourceRevision", "sha256:" + "a".repeat(64),
-            "targetRevision", "sha256:" + "b".repeat(64),
-            "yearMonth", "2026-06",
-            "expectedRevision", 0,
-            "expectedDraftRevision", 0,
-            "depositScheduleRows", depositScheduleRows,
-            "cells", cells,
-            "confirmations", confirmations
+        List<Map<String, Object>> managementChecks = List.of(
+            Map.of("id", "labor-transfer", "status", "OK", "title", "인건비", "detail", "확인"),
+            Map.of("id", "profit-vat-after-deposit", "status", "OK", "title", "수익·부가세", "detail", "확인"),
+            Map.of("id", "negative-projection-balance", "status", "OK", "title", "Projection 잔액", "detail", "확인"),
+            Map.of("id", "future-prepay-over-million", "status", "OK", "title", "선입금", "detail", "확인")
+        );
+        List<Map<String, Object>> managementConfirmations = managementChecks.stream()
+            .map(check -> Map.<String, Object>of("checkId", check.get("id"), "decision", "CONFIRMED"))
+            .toList();
+        return objectMapper.writeValueAsString(Map.ofEntries(
+            Map.entry("idempotencyKey", idempotencyKey),
+            Map.entry("sourceRevision", "sha256:" + "a".repeat(64)),
+            Map.entry("targetRevision", "sha256:" + "b".repeat(64)),
+            Map.entry("yearMonth", "2026-06"),
+            Map.entry("expectedRevision", 0),
+            Map.entry("expectedDraftRevision", 0),
+            Map.entry("depositScheduleRows", depositScheduleRows),
+            Map.entry("cells", cells),
+            Map.entry("confirmations", confirmations),
+            Map.entry("managementChecks", managementChecks),
+            Map.entry("managementConfirmations", managementConfirmations),
+            Map.entry("deadlineSummary", Map.of("trackingStartedAt", "", "missedCount", 0, "completedCount", 0))
         ));
     }
 

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -863,7 +863,12 @@ class FirestoreCashflowLeaseGuardTest {
             .containsEntry("sourceReadAt", NOW.minusSeconds(120).toString())
             .containsEntry("draftRevision", 3L)
             .hasEntrySatisfying("draftInputHash", value -> assertThat(value).asString().startsWith("sha256:"))
-            .containsKeys("project", "sheetFacts", "depositScheduleRows", "confirmations", "weeklyTotals", "projectionTotal", "actualTotal");
+            .containsKeys(
+                "project", "sheetFacts", "depositScheduleRows", "confirmations",
+                "managementChecks", "managementConfirmations", "deadlineSummary",
+                "weeklyTotals", "projectionTotal", "actualTotal"
+            );
+        assertThat(response.previousSnapshot()).isEmpty();
         assertThat((List<?>) ((Map<String, Object>) close.get("snapshot")).get("depositScheduleRows"))
             .hasSize(5);
         assertThat(fixture.documents.get("orgs/tenant-a/cashflow_weeks/project-a-2026-06-w1"))
@@ -1564,7 +1569,20 @@ class FirestoreCashflowLeaseGuardTest {
             expectedDraftRevision,
             depositScheduleRows,
             month.cells(),
-            confirmations
+            confirmations,
+            List.of(
+                new CloseCashflowMonthRequest.ManagementCheck("labor-transfer", "OK", "MYSC 인건비 이관", "확인"),
+                new CloseCashflowMonthRequest.ManagementCheck("profit-vat-after-deposit", "OK", "수익·부가세 이관", "확인"),
+                new CloseCashflowMonthRequest.ManagementCheck("negative-projection-balance", "OK", "Projection 잔액", "확인"),
+                new CloseCashflowMonthRequest.ManagementCheck("future-prepay-over-million", "OK", "선입금 요청", "확인")
+            ),
+            List.of(
+                new CloseCashflowMonthRequest.ManagementConfirmation("labor-transfer", "CONFIRMED"),
+                new CloseCashflowMonthRequest.ManagementConfirmation("profit-vat-after-deposit", "CONFIRMED"),
+                new CloseCashflowMonthRequest.ManagementConfirmation("negative-projection-balance", "CONFIRMED"),
+                new CloseCashflowMonthRequest.ManagementConfirmation("future-prepay-over-million", "CONFIRMED")
+            ),
+            new CloseCashflowMonthRequest.DeadlineSummary("", 0, 0, null)
         );
     }
 
@@ -1867,6 +1885,9 @@ class FirestoreCashflowLeaseGuardTest {
         closeInput.put("depositScheduleRows", request.depositScheduleRows());
         closeInput.put("cells", request.cells());
         closeInput.put("confirmations", request.confirmations());
+        closeInput.put("managementChecks", request.managementChecks());
+        closeInput.put("managementConfirmations", request.managementConfirmations());
+        closeInput.put("deadlineSummary", request.deadlineSummary());
         Map<String, Object> storedCloseInput = (Map<String, Object>) stripNullValues(
             new ObjectMapper().convertValue(closeInput, Map.class)
         );

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -26,9 +26,11 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('applyCashflowMonthCloseProjectionDrafts');
   });
 
-  it('requires explicit human decisions for 160 cells and five deposit rows', () => {
+  it('requires explicit human decisions for 160 cells, five deposit rows, and four management checks', () => {
     expect(source).toContain('monthCloseProgress.confirmedCells');
     expect(source).toContain('monthCloseProgress.confirmedDepositRows');
+    expect(source).toContain('monthCloseProgress.confirmedManagementChecks');
+    expect(source).toContain('monthCloseResult?.dashboard?.managementChecks');
     expect(source).toContain('캐시플로 항목 사람 확인');
     expect(source).toContain("requiredDecision === 'CONFIRMED' ? '확인' : '해당 없음'");
     expect(source).toContain("decision: 'CONFIRMED'");
@@ -55,6 +57,7 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('rangeEnd: cashflowSnapshotRange.end');
     expect(source).toContain('monthCloseResult.dashboard.comparison');
     expect(source).toContain('dashboard?.summary?.projectionProgressPercent');
+    expect(source).toContain('monthCloseResult.dashboard.projectMetadata.businessType');
     expect(source).toContain("monthCloseSheetMetadataValue('businessType')");
     expect(source).toContain("monthCloseSheetControlValue('deposit')");
     expect(source).toContain("monthCloseSheetControlValue('unpaid')");
@@ -79,6 +82,18 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('차이 항목만');
     expect(source).not.toContain('setDifferenceViewMode');
     expect(source).toContain("'bg-blue-50 text-blue-700'");
+  });
+
+  it('places the operations dashboard before comparison and the monthly board', () => {
+    const operations = source.indexOf('{renderOperationsPanel()}');
+    const comparison = source.indexOf('data-cashflow-block="comparison"');
+    const monthlyBoard = source.lastIndexOf('{renderUnifiedMonthlyBoard()}');
+    expect(operations).toBeGreaterThan(-1);
+    expect(operations).toBeLessThan(comparison);
+    expect(comparison).toBeLessThan(monthlyBoard);
+    expect(source).toContain('프로젝트 등록');
+    expect(source).toContain('연결 시트');
+    expect(source).toContain('사업시트 열기');
   });
 
   it('keeps sheet sync explicit and uses the approved action label', () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -44,9 +44,11 @@ import {
   type CashflowMonthCloseCell,
   type CashflowMonthCloseDraftInput,
   type CashflowMonthCloseResult,
+  type CashflowDeadlineSummary,
   type CashflowSnapshotResult,
 } from '../../lib/platform-bff-client';
 import { getCashflowModeLineLabel } from '../../platform/policies/cashflow-policy';
+import { extractSpreadsheetId } from '../../integrations/google-sheets/link';
 import { getSnappedWeekScrollLeft } from './cashflow-board-scroll';
 import type { CashflowOpsTone } from './cashflow-ops-summary';
 import {
@@ -73,6 +75,7 @@ import {
   requiredCashflowMonthCloseDecision,
   type CashflowMonthCloseDecisionMap,
   type CashflowMonthCloseDepositReviewRow,
+  type CashflowManagementDecisionMap,
 } from './cashflow-month-close';
 
 function fmt(n: number): string {
@@ -369,6 +372,7 @@ export function CashflowProjectSheet({
   const [monthCloseBusy, setMonthCloseBusy] = useState(false);
   const [monthCloseReviewOpen, setMonthCloseReviewOpen] = useState(false);
   const [monthCloseDecisions, setMonthCloseDecisions] = useState<CashflowMonthCloseDecisionMap>({});
+  const [managementDecisions, setManagementDecisions] = useState<CashflowManagementDecisionMap>({});
   const [monthCloseDepositRows, setMonthCloseDepositRows] = useState<CashflowMonthCloseDepositReviewRow[]>(
     () => createEmptyCashflowMonthCloseDepositRows(),
   );
@@ -498,6 +502,7 @@ export function CashflowProjectSheet({
     setPrivateDraftPayload({});
     setMonthCloseResult(null);
     setMonthCloseDecisions({});
+    setManagementDecisions({});
     setMonthCloseDepositRows(createEmptyCashflowMonthCloseDepositRows());
     setMonthCloseReviewDirty(false);
     loadedPrivateDraftKeyRef.current = '';
@@ -550,8 +555,10 @@ export function CashflowProjectSheet({
     if (restored) {
       setMonthCloseDecisions(restored.decisions);
       setMonthCloseDepositRows(restored.depositScheduleRows);
+      setManagementDecisions(restored.managementDecisions);
     } else {
       setMonthCloseDecisions({});
+      setManagementDecisions({});
       setMonthCloseDepositRows(createEmptyCashflowMonthCloseDepositRows());
     }
     setMonthCloseReviewDirty(false);
@@ -596,12 +603,16 @@ export function CashflowProjectSheet({
       if ((mode !== 'projection' && mode !== 'actual') || !Number.isInteger(Number(weekNo)) || lineParts.length === 0) return [];
       return [{ mode, weekNo: Number(weekNo), cashflowLine: lineParts.join(':'), decision }];
     });
+    const managementConfirmations = Object.entries(managementDecisions).flatMap(([checkId, decision]) => (
+      decision ? [{ checkId, decision }] : []
+    ));
     const nextPayload = {
       ...payload,
       board: { drafts, weekSaveState, yearMonth },
       monthCloseReview: {
         yearMonth,
         confirmations: reviewConfirmations,
+        managementConfirmations,
         depositScheduleRows: monthCloseDepositRows,
       },
       ...(monthCloseInput ? { monthClose: monthCloseInput } : {}),
@@ -620,6 +631,7 @@ export function CashflowProjectSheet({
     drafts,
     monthCloseDecisions,
     monthCloseDepositRows,
+    managementDecisions,
     privateDraftRevision,
     privateDraftPayload,
     weekSaveState,
@@ -1018,7 +1030,9 @@ export function CashflowProjectSheet({
     cells: monthCloseCellsState.cells,
     decisions: monthCloseDecisions,
     depositScheduleRows: monthCloseDepositRows,
-  }), [monthCloseCellsState.cells, monthCloseDecisions, monthCloseDepositRows]);
+    managementChecks: monthCloseResult?.dashboard?.managementChecks,
+    managementDecisions,
+  }), [managementDecisions, monthCloseCellsState.cells, monthCloseDecisions, monthCloseDepositRows, monthCloseResult?.dashboard?.managementChecks]);
 
   const handleFinalizeMonthClose = useCallback(async (): Promise<void> => {
     if (!isPm || monthCloseResult?.status !== 'OPEN') {
@@ -1033,6 +1047,14 @@ export function CashflowProjectSheet({
         decisions: monthCloseDecisions,
         depositScheduleRows: monthCloseDepositRows,
         projectionDrafts: drafts,
+        managementChecks: monthCloseResult?.dashboard?.managementChecks || [],
+        managementDecisions,
+        deadlineSummary: monthCloseResult?.dashboard?.deadlineSummary || {
+          trackingStartedAt: null,
+          missedCount: 0,
+          completedCount: 0,
+          current: null,
+        } satisfies CashflowDeadlineSummary,
       });
     } catch (error) {
       toast.error(resolveApiErrorMessage(error, '사람 확인이 필요한 항목을 모두 처리해 주세요.'));
@@ -1073,6 +1095,7 @@ export function CashflowProjectSheet({
       setWeekSaveState({});
       setPrivateDraftRevision(null);
       setPrivateDraftPayload({});
+      setManagementDecisions({});
       setMonthCloseReviewDirty(false);
       await cashflowLease.checkStatus();
       await Promise.all([
@@ -1099,6 +1122,7 @@ export function CashflowProjectSheet({
     loadCashflowSheetRangeWeeks,
     monthCloseDecisions,
     monthCloseDepositRows,
+    managementDecisions,
     monthCloseResult,
     orgId,
     projectId,
@@ -1513,6 +1537,10 @@ export function CashflowProjectSheet({
   const sheetIdentityLabel = cashflowSheetConfig
     ? cashflowSheetConfig.spreadsheetTitle || cashflowSheetConfig.spreadsheetId || 'Google Sheet'
     : '시트 연결 필요';
+  const linkedSpreadsheetId = cashflowSheetConfig?.spreadsheetId || extractSpreadsheetId(cashflowSheetConfig?.value || '');
+  const linkedSpreadsheetUrl = linkedSpreadsheetId
+    ? `https://docs.google.com/spreadsheets/d/${encodeURIComponent(linkedSpreadsheetId)}/edit`
+    : '';
   const sheetMirrorStatus = cashflowSheetMirror?.status || 'EMPTY';
   const sheetMirrorCapturedAt = formatSheetAppliedAt(cashflowSheetMirror?.capturedAt)
     || cashflowSheetMirror?.capturedAt
@@ -2326,15 +2354,21 @@ export function CashflowProjectSheet({
                 >
                   {cashflowSheetConfig ? '시트 설정' : '시트 연동 설정'}
                 </Button>
+                {linkedSpreadsheetUrl ? (
+                  <Button asChild type="button" size="sm" variant="outline" className="h-7 rounded-full border-blue-200 bg-white px-2.5 text-[10px] text-blue-700">
+                    <a href={linkedSpreadsheetUrl} target="_blank" rel="noreferrer">사업시트 열기</a>
+                  </Button>
+                ) : null}
               </div>
             </div>
           </div>
 
-          {cashflowSheetConfig && monthCloseResult?.dashboard ? (
+          {monthCloseResult?.dashboard ? (
             <div className="overflow-x-auto rounded-[18px] border border-slate-200 bg-white">
-              <table className="w-full min-w-[720px] table-fixed text-left text-[10px]">
+              <table className="w-full min-w-[780px] table-fixed text-left text-[10px]">
                 <thead className="bg-slate-50 text-slate-500">
                   <tr>
+                    <th className="w-[90px] px-3 py-2 font-semibold">출처</th>
                     <th className="px-3 py-2 font-semibold">사업 구분</th>
                     <th className="px-3 py-2 font-semibold">전용계좌사업</th>
                     <th className="px-3 py-2 font-semibold">정산 여부</th>
@@ -2344,6 +2378,15 @@ export function CashflowProjectSheet({
                 </thead>
                 <tbody>
                   <tr className="text-slate-900">
+                    <td className="px-3 py-2 font-semibold text-blue-700">프로젝트 등록</td>
+                    <td className="truncate px-3 py-2">{monthCloseResult.dashboard.projectMetadata.businessType}</td>
+                    <td className="truncate px-3 py-2">{monthCloseResult.dashboard.projectMetadata.accountType}</td>
+                    <td className="truncate px-3 py-2">{monthCloseResult.dashboard.projectMetadata.settlementStatus}</td>
+                    <td className="px-3 py-2 text-slate-400">-</td>
+                    <td className="px-3 py-2 text-slate-400">-</td>
+                  </tr>
+                  <tr className="border-t border-slate-100 text-slate-900">
+                    <td className="px-3 py-2 font-semibold text-emerald-700">연결 시트</td>
                     <td className="truncate px-3 py-2">{monthCloseSheetMetadataValue('businessType')}</td>
                     <td className="truncate px-3 py-2">{monthCloseSheetMetadataValue('accountType')}</td>
                     <td className="truncate px-3 py-2">{monthCloseSheetMetadataValue('settlementStatus')}</td>
@@ -2352,6 +2395,103 @@ export function CashflowProjectSheet({
                   </tr>
                 </tbody>
               </table>
+            </div>
+          ) : null}
+
+          <div className="grid gap-3 xl:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)]">
+            <div className="rounded-[20px] bg-white px-3.5 py-3 shadow-[0_8px_24px_rgba(15,23,42,0.06)]">
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <div className="text-[11px] font-bold text-slate-900">주요 관리 항목</div>
+                <span className="text-[9px] text-slate-400">BFF/JVM 서버 판정</span>
+              </div>
+              <div className="space-y-2">
+                {(monthCloseResult?.dashboard?.managementChecks || []).map((check) => {
+                  const decision = managementDecisions[check.id];
+                  const tone: CashflowOpsTone = check.status === 'OK' ? 'success' : check.status === 'WARNING' ? 'warning' : 'neutral';
+                  return (
+                    <div key={check.id} className="rounded-xl border border-slate-100 bg-slate-50 px-3 py-2">
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                        <div className="min-w-0">
+                          <div className="flex items-center gap-2">
+                            <span className={`h-2 w-2 rounded-full ${opsDotClass(tone)}`} />
+                            <span className="text-[10px] font-bold text-slate-900">{check.title}</span>
+                          </div>
+                          <div className="mt-1 text-[9px] leading-4 text-slate-500">{check.detail}</div>
+                        </div>
+                        <div className="flex shrink-0 gap-1">
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant={decision === 'CONFIRMED' ? 'default' : 'outline'}
+                            className="h-6 rounded-full px-2 text-[9px]"
+                            disabled={!canEdit}
+                            onClick={() => {
+                              setManagementDecisions((current) => ({ ...current, [check.id]: 'CONFIRMED' }));
+                              setMonthCloseReviewDirty(true);
+                            }}
+                          >확인</Button>
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant={decision === 'NOT_APPLICABLE' ? 'default' : 'outline'}
+                            className="h-6 rounded-full px-2 text-[9px]"
+                            disabled={!canEdit}
+                            onClick={() => {
+                              setManagementDecisions((current) => ({ ...current, [check.id]: 'NOT_APPLICABLE' }));
+                              setMonthCloseReviewDirty(true);
+                            }}
+                          >해당 없음</Button>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <div className="rounded-[20px] bg-white px-3.5 py-3 shadow-[0_8px_24px_rgba(15,23,42,0.06)]">
+                <div className="text-[11px] font-bold text-slate-900">목요일 자정 업데이트</div>
+                <div className="mt-2 grid grid-cols-2 gap-2 text-[10px]">
+                  <div className="rounded-xl bg-slate-50 px-3 py-2"><div className="text-slate-400">누적 미준수</div><div className="mt-1 font-bold text-rose-700">{monthCloseResult?.dashboard?.deadlineSummary?.missedCount || 0}회</div></div>
+                  <div className="rounded-xl bg-slate-50 px-3 py-2"><div className="text-slate-400">기한 내 완료</div><div className="mt-1 font-bold text-emerald-700">{monthCloseResult?.dashboard?.deadlineSummary?.completedCount || 0}회</div></div>
+                </div>
+                <div className="mt-2 text-[9px] leading-4 text-slate-500">
+                  {monthCloseResult?.dashboard?.deadlineSummary?.current
+                    ? `${monthCloseResult.dashboard.deadlineSummary.current.yearMonth} ${monthCloseResult.dashboard.deadlineSummary.current.weekNo}주차 · ${monthCloseResult.dashboard.deadlineSummary.current.status}`
+                    : '첫 시트 검토 완료 시점부터 집계합니다.'}
+                </div>
+              </div>
+              <div className="rounded-[20px] bg-white px-3.5 py-3 shadow-[0_8px_24px_rgba(15,23,42,0.06)]">
+                <div className="text-[11px] font-bold text-slate-900">세금계산서·입금 일정</div>
+                <div className="mt-2 space-y-1.5">
+                  {(monthCloseResult?.dashboard?.sheetDepositScheduleRows || []).map((row) => (
+                    <div key={row.weekNo} className="grid grid-cols-[42px_1fr] gap-2 text-[9px] leading-4 text-slate-600">
+                      <span className="font-semibold text-slate-800">{row.weekNo}주차</span>
+                      <span>발행 {row.taxInvoiceIssuedDate || '-'} · 입금 {row.expectedDepositDate || '-'} · {row.expectedDepositAmount == null ? '-' : `${fmt(row.expectedDepositAmount)}원`}</span>
+                    </div>
+                  ))}
+                  {(monthCloseResult?.dashboard?.sheetDepositScheduleRows || []).length === 0 ? <div className="text-[9px] text-slate-400">시트 연동 후 일정이 표시됩니다.</div> : null}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {monthCloseResult?.dashboard?.postCloseAdjustment ? (
+            <div className="rounded-[18px] border border-amber-200 bg-amber-50 px-3 py-2 text-[10px] text-amber-950">
+              <div className="font-bold">결산 후 조정 특이사항</div>
+              <div className="mt-1">{monthCloseResult.dashboard.postCloseAdjustment.reason} · 변경 {monthCloseResult.dashboard.postCloseAdjustment.changedCount}건</div>
+              <div className="mt-1.5 space-y-1 text-[9px] leading-4 text-amber-900">
+                {monthCloseResult.dashboard.postCloseAdjustment.changes.slice(0, 5).map((change) => (
+                  <div key={`${change.mode}:${change.weekNo}:${change.cashflowLine}`}>
+                    {change.mode === 'projection' ? 'Projection' : 'Actual'} {change.weekNo}주차 · {CASHFLOW_SHEET_LINE_LABELS[change.cashflowLine as CashflowSheetLineId] || change.cashflowLine}
+                    {' '}{fmt(change.beforeAmount)}원 → {fmt(change.afterAmount)}원
+                  </div>
+                ))}
+                {monthCloseResult.dashboard.postCloseAdjustment.changedCount > 5 ? (
+                  <div>외 {monthCloseResult.dashboard.postCloseAdjustment.changedCount - 5}건</div>
+                ) : null}
+              </div>
             </div>
           ) : null}
 
@@ -2699,6 +2839,11 @@ export function CashflowProjectSheet({
         </section>
       ) : null}
 
+      <section className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_320px]">
+        {renderOperationsPanel()}
+        {renderOpsTimeline()}
+      </section>
+
       <section data-cashflow-block="comparison" className="space-y-3 rounded-[24px] bg-white p-4 shadow-[0_16px_40px_rgba(15,23,42,0.08)]">
         <div className="flex items-center gap-2">
           <span className="inline-flex h-8 w-8 items-center justify-center rounded-2xl bg-slate-100">
@@ -2714,11 +2859,6 @@ export function CashflowProjectSheet({
 
       {renderUnifiedMonthlyBoard()}
 
-      <section className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_320px]">
-        {renderOperationsPanel()}
-        {renderOpsTimeline()}
-      </section>
-
       <AlertDialog
         open={monthCloseReviewOpen}
         onOpenChange={(open) => {
@@ -2733,7 +2873,7 @@ export function CashflowProjectSheet({
             </AlertDialogDescription>
           </AlertDialogHeader>
 
-          <div className="grid gap-2 sm:grid-cols-3">
+          <div className="grid gap-2 sm:grid-cols-4">
             <div className="rounded-xl bg-slate-50 px-3 py-2">
               <div className="text-[10px] text-slate-500">시트 고정본</div>
               <div className="mt-1 truncate text-[11px] font-semibold text-slate-900">{monthCloseResult?.dashboard?.source?.sourceRevision || cashflowSheetMirror?.sourceRevision || '준비되지 않음'}</div>
@@ -2745,6 +2885,10 @@ export function CashflowProjectSheet({
             <div className="rounded-xl bg-emerald-50 px-3 py-2">
               <div className="text-[10px] text-emerald-600">입금 일정 확인</div>
               <div className="mt-1 text-[13px] font-bold text-emerald-900">{monthCloseProgress.confirmedDepositRows} / 5</div>
+            </div>
+            <div className="rounded-xl bg-amber-50 px-3 py-2">
+              <div className="text-[10px] text-amber-700">주요 관리 항목 확인</div>
+              <div className="mt-1 text-[13px] font-bold text-amber-900">{monthCloseProgress.confirmedManagementChecks} / 4</div>
             </div>
           </div>
 
@@ -3211,6 +3355,8 @@ export function CashflowProjectSheet({
         expiredOpen={cashflowLease.expiredOpen}
         conflictOpen={cashflowLease.conflictOpen}
         holder={cashflowLease.holder}
+        expiresAt={cashflowLease.expiresAt}
+        remainingMs={cashflowLease.remainingMs}
         busy={cashflowLease.busy}
         onDismissWarning={cashflowLease.dismissWarning}
         onExtend={() => { void cashflowLease.extend(); }}

--- a/src/app/components/cashflow/cashflow-month-close.test.ts
+++ b/src/app/components/cashflow/cashflow-month-close.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { CASHFLOW_ALL_LINES } from '../../platform/cashflow-sheet';
 import type { CashflowSheetLabMirrorResult } from '../../lib/sheets-cashflow-readonly-client';
+import type { CashflowDeadlineSummary, CashflowManagementCheck } from '../../lib/platform-bff-client';
 import {
   applyCashflowMonthCloseProjectionDrafts,
   buildCashflowMonthCloseDraftInput,
@@ -34,6 +35,20 @@ function mirror(): CashflowSheetLabMirrorResult {
   };
 }
 
+const managementChecks: CashflowManagementCheck[] = [
+  { id: 'labor-transfer', status: 'OK', title: '인건비', detail: '확인' },
+  { id: 'profit-vat-after-deposit', status: 'OK', title: '수익·부가세', detail: '확인' },
+  { id: 'negative-projection-balance', status: 'OK', title: '잔액', detail: '확인' },
+  { id: 'future-prepay-over-million', status: 'OK', title: '선입금', detail: '확인' },
+];
+const managementDecisions = Object.fromEntries(managementChecks.map((check) => [check.id, 'CONFIRMED' as const]));
+const deadlineSummary: CashflowDeadlineSummary = {
+  trackingStartedAt: null,
+  missedCount: 0,
+  completedCount: 0,
+  current: null,
+};
+
 describe('cashflow month close contract', () => {
   it('normalizes exactly 160 pinned cells in Projection then Actual order', () => {
     const cells = normalizeCashflowMonthCloseCells(mirror(), '2026-07');
@@ -48,6 +63,9 @@ describe('cashflow month close contract', () => {
       yearMonth: '2026-07',
       decisions: {},
       depositScheduleRows: createEmptyCashflowMonthCloseDepositRows(),
+      managementChecks,
+      managementDecisions: {},
+      deadlineSummary,
     })).toThrow('확인');
   });
 
@@ -86,6 +104,9 @@ describe('cashflow month close contract', () => {
         ...row,
         decision: 'NOT_APPLICABLE' as const,
       })),
+      managementChecks,
+      managementDecisions,
+      deadlineSummary,
     });
 
     expect(result.cells.find((cell) => cell.mode === 'projection' && cell.weekNo === 1 && cell.cashflowLine === lineId))
@@ -107,12 +128,16 @@ describe('cashflow month close contract', () => {
         ...row,
         decision: 'NOT_APPLICABLE' as const,
       })),
+      managementChecks,
+      managementDecisions,
+      deadlineSummary,
     });
     expect(result.sourceRevision).toBe('sheet-r1');
     expect(result.targetRevision).toBe('ledger-r1');
     expect(result.cells).toHaveLength(160);
     expect(result.confirmations).toHaveLength(160);
     expect(result.depositScheduleRows).toHaveLength(5);
+    expect(result.managementConfirmations).toHaveLength(4);
   });
 
   it('rejects an invalid or incomplete pinned mirror', () => {

--- a/src/app/components/cashflow/cashflow-month-close.ts
+++ b/src/app/components/cashflow/cashflow-month-close.ts
@@ -4,11 +4,15 @@ import type {
   CashflowMonthCloseConfirmation,
   CashflowMonthCloseDepositScheduleRow,
   CashflowMonthCloseDraftInput,
+  CashflowManagementCheck,
+  CashflowManagementConfirmation,
+  CashflowDeadlineSummary,
 } from '../../lib/platform-bff-client';
 import type { CashflowSheetLabMirrorResult } from '../../lib/sheets-cashflow-readonly-client';
 
 export type CashflowMonthCloseDecision = CashflowMonthCloseConfirmation['decision'];
 export type CashflowMonthCloseDecisionMap = Record<string, CashflowMonthCloseDecision | undefined>;
+export type CashflowManagementDecisionMap = Record<string, CashflowManagementConfirmation['decision'] | undefined>;
 export type CashflowMonthCloseDepositReviewRow = Omit<CashflowMonthCloseDepositScheduleRow, 'decision'> & {
   decision: CashflowMonthCloseDepositScheduleRow['decision'] | null;
 };
@@ -185,6 +189,9 @@ export function buildCashflowMonthCloseDraftInput(input: {
   decisions: CashflowMonthCloseDecisionMap;
   depositScheduleRows: CashflowMonthCloseDepositReviewRow[];
   projectionDrafts?: Record<string, string>;
+  managementChecks: CashflowManagementCheck[];
+  managementDecisions: CashflowManagementDecisionMap;
+  deadlineSummary: CashflowDeadlineSummary;
 }): CashflowMonthCloseDraftInput {
   const cells = applyCashflowMonthCloseProjectionDrafts(
     normalizeCashflowMonthCloseCells(input.mirror, input.yearMonth),
@@ -207,6 +214,14 @@ export function buildCashflowMonthCloseDraftInput(input: {
   });
 
   assertPinnedMirror(input.mirror, input.yearMonth);
+  if (input.managementChecks.length !== 4) throw new Error('주요 관리 항목 4개를 불러온 뒤 다시 시도해 주세요.');
+  const managementConfirmations = input.managementChecks.map<CashflowManagementConfirmation>((check) => {
+    const decision = input.managementDecisions[check.id];
+    if (decision !== 'CONFIRMED' && decision !== 'NOT_APPLICABLE') {
+      throw new Error(`${check.title}을 확인 또는 해당 없음 처리해 주세요.`);
+    }
+    return { checkId: check.id, decision };
+  });
   return {
     sourceRevision: input.mirror.sourceRevision,
     targetRevision: input.mirror.targetRevisionAtFetch,
@@ -214,18 +229,23 @@ export function buildCashflowMonthCloseDraftInput(input: {
     depositScheduleRows: normalizeDepositRows(input.depositScheduleRows),
     cells,
     confirmations,
+    managementChecks: input.managementChecks,
+    managementConfirmations,
+    deadlineSummary: input.deadlineSummary,
   };
 }
 
 export function readCashflowMonthCloseReview(value: unknown, yearMonth: string): {
   decisions: CashflowMonthCloseDecisionMap;
   depositScheduleRows: CashflowMonthCloseDepositReviewRow[];
+  managementDecisions: CashflowManagementDecisionMap;
 } | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const source = value as {
     yearMonth?: unknown;
     confirmations?: unknown;
     depositScheduleRows?: unknown;
+    managementConfirmations?: unknown;
   };
   if (source.yearMonth !== yearMonth || !Array.isArray(source.confirmations) || !Array.isArray(source.depositScheduleRows)) return null;
   const decisions: CashflowMonthCloseDecisionMap = {};
@@ -249,14 +269,24 @@ export function readCashflowMonthCloseReview(value: unknown, yearMonth: string):
     Boolean(row && typeof row === 'object' && !Array.isArray(row) && Number.isInteger((row as { weekNo?: unknown }).weekNo))
   ));
   if (depositRows.length !== CASHFLOW_MONTH_CLOSE_WEEK_NOS.length) return null;
-  return { decisions, depositScheduleRows: depositRows.map((row) => ({ ...row })) };
+  const managementDecisions: CashflowManagementDecisionMap = {};
+  for (const raw of Array.isArray(source.managementConfirmations) ? source.managementConfirmations : []) {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+    const item = raw as Partial<CashflowManagementConfirmation>;
+    if (typeof item.checkId === 'string' && (item.decision === 'CONFIRMED' || item.decision === 'NOT_APPLICABLE')) {
+      managementDecisions[item.checkId] = item.decision;
+    }
+  }
+  return { decisions, depositScheduleRows: depositRows.map((row) => ({ ...row })), managementDecisions };
 }
 
 export function cashflowMonthCloseReviewProgress(input: {
   cells: CashflowMonthCloseCell[];
   decisions: CashflowMonthCloseDecisionMap;
   depositScheduleRows: CashflowMonthCloseDepositReviewRow[];
-}): { confirmedCells: number; totalCells: number; confirmedDepositRows: number; complete: boolean } {
+  managementChecks?: CashflowManagementCheck[];
+  managementDecisions?: CashflowManagementDecisionMap;
+}): { confirmedCells: number; totalCells: number; confirmedDepositRows: number; confirmedManagementChecks: number; complete: boolean } {
   const confirmedCells = input.cells.filter((cell) => (
     input.decisions[cashflowMonthCloseConfirmationKey(cell)] === requiredCashflowMonthCloseDecision(cell)
   )).length;
@@ -274,12 +304,18 @@ export function cashflowMonthCloseReviewProgress(input: {
     return (hasExpected || hasActual)
       && (hasActual ? row.actualSource !== 'NOT_APPLICABLE' : row.actualSource === 'NOT_APPLICABLE');
   }).length;
+  const confirmedManagementChecks = (input.managementChecks || []).filter((check) => (
+    ['CONFIRMED', 'NOT_APPLICABLE'].includes(String(input.managementDecisions?.[check.id] || ''))
+  )).length;
   return {
     confirmedCells,
     totalCells: input.cells.length,
     confirmedDepositRows,
+    confirmedManagementChecks,
     complete: input.cells.length > 0
       && confirmedCells === input.cells.length
-      && confirmedDepositRows === CASHFLOW_MONTH_CLOSE_WEEK_NOS.length,
+      && confirmedDepositRows === CASHFLOW_MONTH_CLOSE_WEEK_NOS.length
+      && (input.managementChecks || []).length === 4
+      && confirmedManagementChecks === 4,
   };
 }

--- a/src/app/components/editing/EditLeaseDialogs.tsx
+++ b/src/app/components/editing/EditLeaseDialogs.tsx
@@ -14,11 +14,30 @@ export function editLeaseHolderMessage(holder: EditLeaseHolder | null): string {
   return `현재 ${holder?.holderDisplayName.trim() || '다른 사용자'}님이 수정 중입니다.`;
 }
 
+function formatLeaseExpiry(expiresAt: string | null | undefined): string {
+  if (!expiresAt) return '';
+  const timestamp = Date.parse(expiresAt);
+  if (!Number.isFinite(timestamp)) return '';
+  return new Intl.DateTimeFormat('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(timestamp));
+}
+
+function formatLeaseRemaining(remainingMs: number | undefined): string {
+  if (remainingMs == null || remainingMs <= 0) return '';
+  const minutes = Math.max(1, Math.ceil(remainingMs / 60_000));
+  return `약 ${minutes}분 남음`;
+}
+
 export function EditLeaseDialogs({
   warningOpen,
   expiredOpen,
   conflictOpen,
   holder,
+  expiresAt,
+  remainingMs,
   busy = false,
   onDismissWarning,
   onExtend,
@@ -30,6 +49,8 @@ export function EditLeaseDialogs({
   expiredOpen: boolean;
   conflictOpen: boolean;
   holder: EditLeaseHolder | null;
+  expiresAt?: string | null;
+  remainingMs?: number;
   busy?: boolean;
   onDismissWarning: () => void;
   onExtend: () => void | Promise<void>;
@@ -45,6 +66,7 @@ export function EditLeaseDialogs({
             <AlertDialogTitle>수정 시간이 5분 남았습니다</AlertDialogTitle>
             <AlertDialogDescription>
               수정 세션은 자동으로 연장되지 않습니다. 계속 수정하려면 직접 연장해주세요.
+              {formatLeaseExpiry(expiresAt) ? ` 현재 만료 예정 ${formatLeaseExpiry(expiresAt)} · ${formatLeaseRemaining(remainingMs)}` : ''}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -79,7 +101,10 @@ export function EditLeaseDialogs({
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>{editLeaseHolderMessage(holder)}</AlertDialogTitle>
-            <AlertDialogDescription>지금은 수정은 불가능하지만 읽기/조회는 가능해요!</AlertDialogDescription>
+            <AlertDialogDescription>
+              지금은 수정은 불가능하지만 읽기/조회는 가능해요!
+              {formatLeaseExpiry(holder?.expiresAt) ? ` 수정 권한 만료 예정 ${formatLeaseExpiry(holder?.expiresAt)}` : ''}
+            </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel disabled={busy} onClick={onContinueReadOnly}>

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -1937,6 +1937,45 @@ export function ProjectEditorWizard({
           <Input type="month" value={draft.paymentExpectedMonths.final} onChange={(event) => update('paymentExpectedMonths', { ...draft.paymentExpectedMonths, final: event.target.value })} className="mt-1 h-9 text-sm" />
         </div>
       </div>
+      <div className="space-y-3 rounded-xl border border-slate-200 bg-slate-50/70 p-4">
+        <div>
+          <Label className="text-xs font-semibold">MYSC 인건비 이관 방식</Label>
+          <Select
+            value={draft.laborTransferPlan.mode}
+            onValueChange={(mode) => update('laborTransferPlan', {
+              ...draft.laborTransferPlan,
+              mode: mode as typeof draft.laborTransferPlan.mode,
+            })}
+          >
+            <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="UNDECIDED">미정</SelectItem>
+              <SelectItem value="MONTHLY_WEEK_3">매월 3주차 이관</SelectItem>
+              <SelectItem value="PAYMENT_MILESTONE">선금·중도금·잔금별 일괄 이관</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        {draft.laborTransferPlan.mode === 'PAYMENT_MILESTONE' ? (
+          <div className="grid gap-3 lg:grid-cols-3">
+            {(['contract', 'interim', 'final'] as const).map((key) => (
+              <div key={key}>
+                <Label className="text-xs">{key === 'contract' ? '선금' : key === 'interim' ? '중도금' : '잔금'} 인건비 할당액</Label>
+                <Input
+                  value={formatProjectAmountInput(draft.laborTransferPlan.milestoneAmounts[key], true)}
+                  onChange={(event) => update('laborTransferPlan', {
+                    ...draft.laborTransferPlan,
+                    milestoneAmounts: {
+                      ...draft.laborTransferPlan.milestoneAmounts,
+                      [key]: parseProjectAmountInput(event.target.value),
+                    },
+                  })}
+                  className="mt-1 h-9 text-sm"
+                />
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </div>
       {advanceInterimRatio !== null && paymentPlanTotal > 0 ? (
         <div className={`rounded-lg border px-3 py-2 text-[12px] ${requiresAdvanceInterimReason ? 'border-amber-300 bg-amber-50 text-amber-900' : 'border-slate-200 bg-slate-50 text-slate-700'}`}>
           선금+중도금 비율 {(advanceInterimRatio * 100).toFixed(1)}%
@@ -2199,6 +2238,14 @@ export function ProjectEditorWizard({
             <ReviewRow label="중도금 예상월" value={draft.paymentExpectedMonths.interim} />
             <ReviewRow label="잔금" value={formatPaymentPlanAmount(draft.paymentPlan.final, draft.contractAmount)} />
             <ReviewRow label="잔금 예상월" value={draft.paymentExpectedMonths.final} />
+            <ReviewRow
+              label="MYSC 인건비 이관"
+              value={draft.laborTransferPlan.mode === 'MONTHLY_WEEK_3'
+                ? '매월 3주차'
+                : draft.laborTransferPlan.mode === 'PAYMENT_MILESTONE'
+                  ? `선금 ${fmtKRW(draft.laborTransferPlan.milestoneAmounts.contract)}원 · 중도금 ${fmtKRW(draft.laborTransferPlan.milestoneAmounts.interim)}원 · 잔금 ${fmtKRW(draft.laborTransferPlan.milestoneAmounts.final)}원`
+                  : '미정'}
+            />
             <ReviewRow label="선금+중도금 비율" value={advanceInterimRatio === null ? '-' : `${(advanceInterimRatio * 100).toFixed(1)}%`} />
             {requiresAdvanceInterimReason ? <ReviewRow label="70% 미만 사유" value={draft.advanceInterimBelow70Reason} /> : null}
             <ReviewRow label="입금 계획" value={draft.paymentPlanDesc} />

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -424,6 +424,17 @@ export interface ProjectPaymentExpectedMonths {
   final: string;
 }
 
+export type ProjectLaborTransferMode = 'UNDECIDED' | 'MONTHLY_WEEK_3' | 'PAYMENT_MILESTONE';
+
+export interface ProjectLaborTransferPlan {
+  mode: ProjectLaborTransferMode;
+  milestoneAmounts: {
+    contract: number;
+    interim: number;
+    final: number;
+  };
+}
+
 export const SETTLEMENT_SYSTEM_LABELS: Record<SettlementSystemCode, string> = {
   E_NARA_DOUM: 'e나라도움 (국고보조금통합관리)',
   IRIS: 'IRIS (범부처통합연구지원)',
@@ -631,6 +642,7 @@ export interface Project {
     final: number;       // 잔금
   };
   paymentExpectedMonths?: ProjectPaymentExpectedMonths;
+  laborTransferPlan?: ProjectLaborTransferPlan;
   advanceInterimBelow70Reason?: string;
   paymentPlanDesc: string;       // 입금계획 텍스트 (e.g. "선금80%, 잔금20%")
   // MYSC-specific fields
@@ -830,6 +842,7 @@ export interface ProjectRequestPayload {
   settlementSheetPolicy?: SettlementSheetPolicy;
   paymentPlan?: Project['paymentPlan'];
   paymentExpectedMonths?: ProjectPaymentExpectedMonths;
+  laborTransferPlan?: ProjectLaborTransferPlan;
   advanceInterimBelow70Reason?: string;
   paymentPlanDesc: string;
   settlementGuide: string;

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -721,6 +721,18 @@ export interface CashflowMonthCloseConfirmation {
   decision: 'CONFIRMED' | 'NOT_APPLICABLE';
 }
 
+export interface CashflowManagementCheck {
+  id: 'labor-transfer' | 'profit-vat-after-deposit' | 'negative-projection-balance' | 'future-prepay-over-million';
+  status: 'OK' | 'WARNING' | 'REVIEW_REQUIRED';
+  title: string;
+  detail: string;
+}
+
+export interface CashflowManagementConfirmation {
+  checkId: CashflowManagementCheck['id'];
+  decision: 'CONFIRMED' | 'NOT_APPLICABLE';
+}
+
 export interface CashflowMonthCloseDepositScheduleRow {
   weekNo: number;
   taxInvoiceIssuedDate: string;
@@ -739,6 +751,22 @@ export interface CashflowMonthCloseDraftInput {
   depositScheduleRows: CashflowMonthCloseDepositScheduleRow[];
   cells: CashflowMonthCloseCell[];
   confirmations: CashflowMonthCloseConfirmation[];
+  managementChecks: CashflowManagementCheck[];
+  managementConfirmations: CashflowManagementConfirmation[];
+  deadlineSummary: CashflowDeadlineSummary;
+}
+
+export interface CashflowDeadlineSummary {
+  trackingStartedAt: string | null;
+  missedCount: number;
+  completedCount: number;
+  current: {
+    yearMonth: string;
+    weekNo: number;
+    deadline: string;
+    completedAt: string | null;
+    status: 'COMPLETED' | 'MISSED' | 'PENDING';
+  } | null;
 }
 
 export interface CashflowMonthCloseDashboard {
@@ -750,6 +778,7 @@ export interface CashflowMonthCloseDashboard {
     capturedAt: string;
   };
   project: Record<string, unknown>;
+  projectMetadata: { businessType: string; accountType: string; settlementStatus: string };
   sheetMetadata: Record<string, unknown>;
   sheetControlTotals: {
     deposit: {
@@ -774,6 +803,20 @@ export interface CashflowMonthCloseDashboard {
   depositScheduleRows: Array<Record<string, unknown>>;
   cells: CashflowMonthCloseCell[];
   confirmations: CashflowMonthCloseConfirmation[];
+  managementChecks: CashflowManagementCheck[];
+  managementConfirmations: CashflowManagementConfirmation[];
+  deadlineSummary: CashflowDeadlineSummary;
+  postCloseAdjustment: {
+    reason: string;
+    changedCount: number;
+    changes: Array<{
+      mode: 'projection' | 'actual';
+      weekNo: number;
+      cashflowLine: string;
+      beforeAmount: number;
+      afterAmount: number;
+    }>;
+  } | null;
   draftRevision: number | null;
   totals: {
     projection: {
@@ -846,6 +889,7 @@ export interface CashflowMonthCloseResult {
   snapshotHash: string | null;
   previousSnapshotHash: string | null;
   snapshot: Record<string, unknown>;
+  previousSnapshot: Record<string, unknown>;
   late: boolean;
   closedAt: string | null;
   closedByUid: string | null;

--- a/src/app/platform/project-editor.ts
+++ b/src/app/platform/project-editor.ts
@@ -9,6 +9,7 @@ import type {
   ProjectFundInputMode,
   ProjectFinancialYear,
   ProjectPaymentExpectedMonths,
+  ProjectLaborTransferPlan,
   ProjectRegistrationConfirmations,
   ProjectRegistrationOptionalDocumentNotes,
   ProjectCheckout,
@@ -106,6 +107,7 @@ export interface ProjectEditorDraft {
   groupwareName: string;
   paymentPlan: Project['paymentPlan'];
   paymentExpectedMonths: ProjectPaymentExpectedMonths;
+  laborTransferPlan: ProjectLaborTransferPlan;
   advanceInterimBelow70Reason: string;
   finalPaymentNote: string;
   budgetCurrentYear: number;
@@ -199,6 +201,7 @@ const DEFAULT_DRAFT: ProjectEditorDraft = {
   groupwareName: '',
   paymentPlan: { contract: 0, interim: 0, final: 0 },
   paymentExpectedMonths: { contract: '', interim: '', final: '' },
+  laborTransferPlan: { mode: 'UNDECIDED', milestoneAmounts: { contract: 0, interim: 0, final: 0 } },
   advanceInterimBelow70Reason: '',
   finalPaymentNote: '',
   budgetCurrentYear: 0,
@@ -341,6 +344,16 @@ function normalizePaymentExpectedMonths(
   };
 }
 
+function normalizeLaborTransferPlan(value: Partial<ProjectLaborTransferPlan> | null | undefined): ProjectLaborTransferPlan {
+  const mode = ['MONTHLY_WEEK_3', 'PAYMENT_MILESTONE'].includes(String(value?.mode || ''))
+    ? value?.mode as ProjectLaborTransferPlan['mode']
+    : 'UNDECIDED';
+  return {
+    mode,
+    milestoneAmounts: normalizePaymentPlan(value?.milestoneAmounts),
+  };
+}
+
 function formatAmountForChange(value: unknown) {
   const amount = nonNegativeAmount(value);
   return amount > 0 ? `${amount.toLocaleString('ko-KR')}원` : '-';
@@ -476,6 +489,9 @@ export function createProjectEditorDraft(overrides: Partial<ProjectEditorDraft> 
     paymentExpectedMonths: normalizePaymentExpectedMonths(
       overrides.paymentExpectedMonths ?? DEFAULT_DRAFT.paymentExpectedMonths,
     ),
+    laborTransferPlan: normalizeLaborTransferPlan(
+      overrides.laborTransferPlan ?? DEFAULT_DRAFT.laborTransferPlan,
+    ),
     teamMembersDetailed: normalizeProjectTeamMembers(overrides.teamMembersDetailed),
     registrationRequirementsVersion: version,
     financialYears: projectFinancialYears(
@@ -597,6 +613,9 @@ export function buildProjectEditorDraftFromProject(
     paymentExpectedMonths: normalizePaymentExpectedMonths(
       normalizedProject.paymentExpectedMonths || payload?.paymentExpectedMonths,
     ),
+    laborTransferPlan: normalizeLaborTransferPlan(
+      normalizedProject.laborTransferPlan || payload?.laborTransferPlan,
+    ),
     advanceInterimBelow70Reason: text(
       normalizedProject.advanceInterimBelow70Reason || payload?.advanceInterimBelow70Reason,
     ),
@@ -654,6 +673,7 @@ export function buildProjectRequestPayloadFromDraft(draftInput: ProjectEditorDra
     settlementSheetPolicy: normalizeSettlementSheetPolicy(draft.settlementSheetPolicy, normalizeProjectFundInputMode(draft.fundInputMode)),
     paymentPlan: normalizePaymentPlan(draft.paymentPlan),
     paymentExpectedMonths: normalizePaymentExpectedMonths(draft.paymentExpectedMonths),
+    laborTransferPlan: normalizeLaborTransferPlan(draft.laborTransferPlan),
     advanceInterimBelow70Reason: text(draft.advanceInterimBelow70Reason),
     paymentPlanDesc: text(draft.paymentPlanDesc),
     settlementGuide: text(draft.settlementGuide),
@@ -758,6 +778,7 @@ export function buildProjectEditorProjectPatch(
     settlementSheetPolicy: normalizeSettlementSheetPolicy(draft.settlementSheetPolicy, normalizeProjectFundInputMode(draft.fundInputMode)),
     paymentPlan: normalizePaymentPlan(draft.paymentPlan),
     paymentExpectedMonths: normalizePaymentExpectedMonths(draft.paymentExpectedMonths),
+    laborTransferPlan: normalizeLaborTransferPlan(draft.laborTransferPlan),
     advanceInterimBelow70Reason: text(draft.advanceInterimBelow70Reason),
     paymentPlanDesc: text(draft.paymentPlanDesc),
     clientOrg: text(draft.clientOrg),


### PR DESCRIPTION
## Summary
- move the operations dashboard above Projection/Actual and the monthly board
- add the four server-evaluated management checks with private human confirmation
- make JVM month close persist checks, deadline summary, and previous snapshots
- compare project registration metadata with linked sheet values and add labor transfer planning
- show lease expiry details without automatic takeover

## Verification
- 157 Vitest tests passed across BFF, project editor, cashflow close, and lease dialogs
- CashflowProjectSheet shell tests: 13 passed
- JVM CloseCashflowMonthRequestTest: 2 passed
- JVM Firestore month-close transaction test: 1 passed
- npm run build passed

## Deployment
Stage only. Do not deploy or promote to Live.