### PR TITLE
fix(cashflow): preserve dashboard status copy

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -96,6 +96,11 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('사업시트 열기');
   });
 
+  it('keeps server fallback copy intact without appending a duplicate sentence ending', () => {
+    expect(source).toContain("primaryReason?.title || '확인 항목을 확인해 주세요.'");
+    expect(source).not.toContain("primaryReason?.title || '확인 항목'}입니다");
+  });
+
   it('keeps sheet sync explicit and uses the approved action label', () => {
     expect(source).toContain('handleRefreshSheetMirror');
     expect(source).toContain('refreshCashflowSheetLabMirrorViaBff');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -2240,7 +2240,7 @@ export function CashflowProjectSheet({
       : `확인 항목 ${opsSummary.status.count}건`;
     const statusReason = opsSummary.status.kind === 'ready'
       ? '확인할 항목이 없습니다.'
-      : `${primaryReason?.title || '확인 항목'}입니다. 확인해 주세요.${remainingReasonCount > 0 ? ` 외 ${remainingReasonCount}건` : ''}`;
+      : `${primaryReason?.title || '확인 항목을 확인해 주세요.'}${remainingReasonCount > 0 ? ` 외 ${remainingReasonCount}건` : ''}`;
     return (
       <Card className="overflow-hidden rounded-[24px] border-0 bg-slate-50/80 shadow-[0_16px_40px_rgba(15,23,42,0.08)]">
         <CardContent className="space-y-3 p-4">


### PR DESCRIPTION
## 변경\n- 운영 대시보드 서버 fallback 문구에 중복 종결어미가 붙지 않도록 수정\n- 회귀 shell test 추가\n\n## 검증\n- CashflowProjectSheet shell test 14/14\n- npm run build\n- 로컬 브라우저에서 fallback 문구 확인