### PR TITLE
fix: stabilize project list Firestore reads

### DIFF
--- a/src/app/components/layout/AppLayout.tsx
+++ b/src/app/components/layout/AppLayout.tsx
@@ -7,7 +7,7 @@ import {
 } from 'lucide-react';
 import { useAppStore, AppProvider } from '../../data/store';
 import { useAuth } from '../../data/auth-store';
-import { useHrAnnouncements } from '../../data/hr-announcements-store';
+import { useOptionalHrAnnouncements } from '../../data/hr-announcements-store';
 import { FirebaseStatusBadge } from '../settings/FirebaseSetup';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
@@ -33,7 +33,7 @@ import { MyscWordmark } from '../brand/MyscWordmark';
 function AppLayoutContent() {
   const { currentUser, transactions, participationEntries, dataSource } = useAppStore();
   const { isAuthenticated, isLoading: authLoading, user: authUser, logout, setWorkspacePreference } = useAuth();
-  const { getAllPendingCount: getHrPendingCount } = useHrAnnouncements();
+  const hrAnnouncements = useOptionalHrAnnouncements();
   const [collapsed, setCollapsed] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
   const [labEnabled, setLabEnabled] = useState(() => readShellLabEnabled());
@@ -166,7 +166,7 @@ function AppLayoutContent() {
     if (to === '/evidence' && missingEvidenceCount > 0) return missingEvidenceCount;
     if (to === '/participation' && participationDangerCount > 0) return participationDangerCount;
     if (to === '/hr-announcements') {
-      const hrCount = getHrPendingCount();
+      const hrCount = hrAnnouncements?.getAllPendingCount() ?? 0;
       return hrCount > 0 ? hrCount : null;
     }
     return null;
@@ -385,7 +385,7 @@ function AppLayoutContent() {
               {dataSource === 'firestore' ? (
                 <div className="flex items-center gap-1.5 text-[10px] text-emerald-600 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-950/50 border border-emerald-200/60 dark:border-emerald-800/40 rounded-full px-2 py-0.5">
                   <div className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
-                  실시간
+                  서버 연결
                 </div>
               ) : (
                 <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground bg-muted border border-border/60 rounded-full px-2 py-0.5">

--- a/src/app/components/layout/NotificationPanel.tsx
+++ b/src/app/components/layout/NotificationPanel.tsx
@@ -11,7 +11,7 @@ import { Separator } from '../ui/separator';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { useAppStore } from '../../data/store';
 import { computeMemberSummaries } from '../../data/participation-data';
-import { useCashflowWeeks } from '../../data/cashflow-weeks-store';
+import { useOptionalCashflowWeeks } from '../../data/cashflow-weeks-store';
 import { getSeoulTodayIso } from '../../platform/business-days';
 import { findWeekForDate, getMonthMondayWeeks } from '../../platform/cashflow-weeks';
 import { shouldShowShellRoute, useShellLabEnabled } from '../../platform/shell-lab-visibility';
@@ -31,7 +31,7 @@ interface NotifItem {
 export function NotificationPanel() {
   const navigate = useNavigate();
   const { transactions, projects, participationEntries } = useAppStore();
-  const { weeks: cashflowWeeks } = useCashflowWeeks();
+  const cashflowWeeks = useOptionalCashflowWeeks()?.weeks ?? [];
   const [open, setOpen] = useState(false);
   const [labEnabled] = useShellLabEnabled();
   const fmtAmount = (value?: number | null) =>

--- a/src/app/data/admin-route-providers.test.ts
+++ b/src/app/data/admin-route-providers.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAdminProviderScope } from './admin-route-providers';
+
+describe('admin route provider scope', () => {
+  it('does not mount unrelated realtime providers on project routes', () => {
+    expect(resolveAdminProviderScope('/projects')).toEqual({
+      hrAnnouncements: false,
+      payroll: false,
+      cashflowWeeks: false,
+      board: false,
+      training: false,
+    });
+  });
+
+  it('mounts only the provider owned by the active admin feature', () => {
+    expect(resolveAdminProviderScope('/board/post-1').board).toBe(true);
+    expect(resolveAdminProviderScope('/payroll').payroll).toBe(true);
+    expect(resolveAdminProviderScope('/training').training).toBe(true);
+    expect(resolveAdminProviderScope('/cashflow/projects/p1').cashflowWeeks).toBe(true);
+    expect(resolveAdminProviderScope('/payroll')).toMatchObject({ payroll: true, cashflowWeeks: true });
+    expect(resolveAdminProviderScope('/dashboard')).toMatchObject({
+      hrAnnouncements: true,
+      payroll: true,
+      cashflowWeeks: true,
+    });
+  });
+});

--- a/src/app/data/admin-route-providers.tsx
+++ b/src/app/data/admin-route-providers.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+import { useLocation } from 'react-router';
 import { BoardProvider } from './board-store';
 import { CashflowWeekProvider } from './cashflow-weeks-store';
 import { FirestoreRouteModeProvider } from './firestore-realtime-mode';
@@ -6,18 +7,30 @@ import { HrAnnouncementProvider } from './hr-announcements-store';
 import { PayrollProvider } from './payroll-store';
 import { TrainingProvider } from './training-store';
 
+export function resolveAdminProviderScope(pathname: string) {
+  const path = pathname.replace(/\/+$/, '') || '/';
+  const isDashboard = path === '/dashboard';
+  return {
+    hrAnnouncements: isDashboard || path.startsWith('/hr-announcements'),
+    payroll: isDashboard || path.startsWith('/payroll'),
+    cashflowWeeks: isDashboard || path.startsWith('/cashflow') || path.startsWith('/payroll'),
+    board: path.startsWith('/board'),
+    training: path.startsWith('/training'),
+  };
+}
+
+export function AdminRouteProviderFrame({ children, pathname }: { children: ReactNode; pathname: string }) {
+  const scope = resolveAdminProviderScope(pathname);
+  let tree = children;
+  if (scope.training) tree = <TrainingProvider>{tree}</TrainingProvider>;
+  if (scope.board) tree = <BoardProvider>{tree}</BoardProvider>;
+  if (scope.cashflowWeeks) tree = <CashflowWeekProvider>{tree}</CashflowWeekProvider>;
+  if (scope.payroll) tree = <PayrollProvider>{tree}</PayrollProvider>;
+  if (scope.hrAnnouncements) tree = <HrAnnouncementProvider>{tree}</HrAnnouncementProvider>;
+  return <FirestoreRouteModeProvider mode="admin-live">{tree}</FirestoreRouteModeProvider>;
+}
+
 export function AdminRouteProviders({ children }: { children: ReactNode }) {
-  return (
-    <FirestoreRouteModeProvider mode="admin-live">
-      <HrAnnouncementProvider>
-        <PayrollProvider>
-          <CashflowWeekProvider>
-            <BoardProvider>
-              <TrainingProvider>{children}</TrainingProvider>
-            </BoardProvider>
-          </CashflowWeekProvider>
-        </PayrollProvider>
-      </HrAnnouncementProvider>
-    </FirestoreRouteModeProvider>
-  );
+  const location = useLocation();
+  return <AdminRouteProviderFrame pathname={location.pathname}>{children}</AdminRouteProviderFrame>;
 }

--- a/src/app/data/cashflow-weeks-store.tsx
+++ b/src/app/data/cashflow-weeks-store.tsx
@@ -555,3 +555,7 @@ export function useCashflowWeeks() {
   if (!ctx) throw new Error('useCashflowWeeks must be used within CashflowWeekProvider');
   return ctx;
 }
+
+export function useOptionalCashflowWeeks() {
+  return useContext(CashflowWeekContext);
+}

--- a/src/app/data/firestore-route-provider-behavior.test.ts
+++ b/src/app/data/firestore-route-provider-behavior.test.ts
@@ -31,7 +31,7 @@ vi.mock('./training-store', () => ({
   TrainingProvider: PassthroughProvider,
 }));
 
-import { AdminRouteProviders } from './admin-route-providers';
+import { AdminRouteProviderFrame, AdminRouteProviders } from './admin-route-providers';
 import { PortalRouteProviderFrame, PortalRouteProviders, resolvePortalProviderScope } from './portal-route-providers';
 
 function PolicyProbe({ role }: { role: string }) {
@@ -47,13 +47,11 @@ function PolicyProbe({ role }: { role: string }) {
 }
 
 function readPolicy(wrapper: typeof AdminRouteProviders | typeof PortalRouteProviders, role: string) {
-  const markup = renderToStaticMarkup(
-    React.createElement(
-      wrapper === PortalRouteProviders ? PortalRouteProviderFrame : wrapper,
-      wrapper === PortalRouteProviders ? { pathname: '/portal/cashflow' } : null,
-      React.createElement(PolicyProbe, { role }),
-    ),
-  );
+  const probe = React.createElement(PolicyProbe, { role });
+  const tree = wrapper === PortalRouteProviders
+    ? React.createElement(PortalRouteProviderFrame, { pathname: '/portal/cashflow', children: probe })
+    : React.createElement(AdminRouteProviderFrame, { pathname: '/projects', children: probe });
+  const markup = renderToStaticMarkup(tree);
 
   const match = markup.match(/<pre id="policy">([^<]+)<\/pre>/);
   expect(match?.[1]).toBeTruthy();

--- a/src/app/data/hr-announcements-store.tsx
+++ b/src/app/data/hr-announcements-store.tsx
@@ -380,3 +380,7 @@ export function useHrAnnouncements() {
   if (!ctx) throw new Error('useHrAnnouncements must be inside HrAnnouncementProvider');
   return ctx;
 }
+
+export function useOptionalHrAnnouncements() {
+  return useContext(HrContext);
+}

--- a/src/app/data/store-write-strategy.test.ts
+++ b/src/app/data/store-write-strategy.test.ts
@@ -3,10 +3,10 @@ import { describe, expect, it } from 'vitest';
 import { resolveAppWriteStrategy } from './store-write-strategy';
 
 describe('resolveAppWriteStrategy', () => {
-  it('prefers BFF writes without Firestore fallback when the platform API is enabled', () => {
+  it('prefers BFF writes and mirrors the confirmed result without a realtime listener', () => {
     expect(resolveAppWriteStrategy(true, true)).toEqual({
       target: 'bff',
-      mirrorRemoteWritesLocally: false,
+      mirrorRemoteWritesLocally: true,
     });
   });
 

--- a/src/app/data/store-write-strategy.ts
+++ b/src/app/data/store-write-strategy.ts
@@ -12,7 +12,7 @@ export function resolveAppWriteStrategy(
   if (platformApiEnabled) {
     return {
       target: 'bff',
-      mirrorRemoteWritesLocally: !firestoreEnabled,
+      mirrorRemoteWritesLocally: true,
     };
   }
 

--- a/src/app/data/store.non-realtime-mirror-shell.test.ts
+++ b/src/app/data/store.non-realtime-mirror-shell.test.ts
@@ -14,11 +14,15 @@ function extractFunction(name: string, nextName: string): string {
 
 describe('non-realtime store write mirroring', () => {
   it('uses one-shot reads for admin-wide high-volume collections', () => {
+    expect(source).toContain("readOrgCollection(db, orgId, 'members')");
+    expect(source).toContain("readOrgCollection(db, orgId, 'projects')");
     expect(source).toContain("readOrgCollection(db, orgId, 'ledgers')");
     expect(source).toContain("readOrgCollection(db, orgId, 'transactions')");
     expect(source).toContain("readOrgCollection(db, orgId, 'comments')");
     expect(source).toContain("readOrgCollection(db, orgId, 'evidences')");
     expect(source).toContain("readOrgCollection(db, orgId, 'partEntries')");
+    expect(source).not.toContain('listenMembers');
+    expect(source).not.toContain('listenProjects');
   });
 
   it('mirrors remote writes for collections that no longer have live listeners', () => {

--- a/src/app/data/store.tsx
+++ b/src/app/data/store.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useCallback, useEffect, useMemo, useRef, type ReactNode } from 'react';
+import React, { createContext, useContext, useState, useCallback, useEffect, useMemo, type ReactNode } from 'react';
 import type {
   Project,
   Ledger,
@@ -31,8 +31,6 @@ import { useFirebase } from '../lib/firebase-context';
 import { featureFlags } from '../config/feature-flags';
 import { useAuth } from './auth-store';
 import {
-  listenMembers,
-  listenProjects,
   readOrgCollection,
   addPartEntry,
   updatePartEntry,
@@ -50,6 +48,7 @@ import {
   addCommentViaBff,
   addEvidenceViaBff,
   changeTransactionStateViaBff,
+  fetchProjectsViaBff,
   restoreProjectViaBff,
   trashProjectViaBff,
   upsertLedgerViaBff,
@@ -59,7 +58,6 @@ import {
 } from '../lib/platform-bff-client';
 import { reportError } from '../platform/observability';
 import { normalizeProjectRevenueFields } from '../platform/project-financials';
-import type { Unsubscribe } from 'firebase/firestore';
 
 interface EtlStagingUiPayload {
   projects?: Project[];
@@ -172,8 +170,6 @@ export function AppProvider({ children }: { children: ReactNode }) {
   );
   const [dataSource, setDataSource] = useState<'local' | 'firestore'>('local');
 
-  const unsubsRef = useRef<Unsubscribe[]>([]);
-
   const currentUser = useMemo<OrgMember>(() => {
     if (!authUser) return CURRENT_USER;
     return {
@@ -252,8 +248,6 @@ export function AppProvider({ children }: { children: ReactNode }) {
   }, [authUser, currentUser, dataSource, localMembers]);
 
   useEffect(() => {
-    unsubsRef.current.forEach((unsub) => unsub());
-    unsubsRef.current = [];
     let cancelled = false;
 
     if (!firestoreEnabled || !db) {
@@ -274,15 +268,23 @@ export function AppProvider({ children }: { children: ReactNode }) {
     setDataSource('firestore');
     setLocalMembers([]);
 
-    unsubsRef.current.push(
-      listenMembers(db, orgId, (items) => setLocalMembers(items as Array<OrgMember & Record<string, unknown>>)),
-    );
-
-    unsubsRef.current.push(
-      listenProjects(db, orgId, (projs) => setProjects(projs as Project[])),
-    );
+    const projectsRequest = platformApiEnabled && bffActor.idToken
+      ? fetchProjectsViaBff({ tenantId: orgId, actor: bffActor }).catch((error) => {
+          reportError(error, {
+            message: '[AppStore] BFF project fetch failed; falling back to Firestore:',
+            options: {
+              level: 'warning',
+              tags: { surface: 'app_store', action: 'project_fetch_fallback' },
+              extra: { orgId },
+            },
+          });
+          return readOrgCollection(db, orgId, 'projects') as Promise<Project[]>;
+        })
+      : readOrgCollection(db, orgId, 'projects');
 
     Promise.all([
+      readOrgCollection(db, orgId, 'members'),
+      projectsRequest,
       readOrgCollection(db, orgId, 'ledgers'),
       readOrgCollection(db, orgId, 'transactions'),
       readOrgCollection(db, orgId, 'comments'),
@@ -290,6 +292,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
       readOrgCollection(db, orgId, 'auditLogs'),
       readOrgCollection(db, orgId, 'partEntries'),
     ]).then(([
+      nextMembers,
+      nextProjects,
       nextLedgers,
       nextTransactions,
       nextComments,
@@ -298,6 +302,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
       nextParticipationEntries,
     ]) => {
       if (cancelled) return;
+      setLocalMembers(nextMembers as Array<OrgMember & Record<string, unknown>>);
+      setProjects(nextProjects as Project[]);
       setLedgers(nextLedgers as Ledger[]);
       setTransactions(nextTransactions as Transaction[]);
       setComments(nextComments as Comment[]);
@@ -322,10 +328,8 @@ export function AppProvider({ children }: { children: ReactNode }) {
 
     return () => {
       cancelled = true;
-      unsubsRef.current.forEach((unsub) => unsub());
-      unsubsRef.current = [];
     };
-  }, [firestoreEnabled, db, orgId, usesLocalSeedData]);
+  }, [firestoreEnabled, db, orgId, usesLocalSeedData, platformApiEnabled, bffActor]);
 
   useEffect(() => {
     if (firestoreEnabled || !featureFlags.etlStagingLocalEnabled) return;
@@ -380,13 +384,14 @@ export function AppProvider({ children }: { children: ReactNode }) {
         });
 
         if (writeStrategy.mirrorRemoteWritesLocally) {
-          setProjects((prev) => [...prev, mergeProjectMutationResult(normalizedProject, result)]);
+          setProjects((prev) => upsertLocalItem(prev, mergeProjectMutationResult(normalizedProject, result)));
         }
         return;
       }
 
       if (writeStrategy.target === 'firestore' && db) {
         await upsertProject(db, orgId, normalizedProject, auditActor);
+        setProjects((prev) => upsertLocalItem(prev, normalizedProject));
         return;
       }
 
@@ -398,7 +403,6 @@ export function AppProvider({ children }: { children: ReactNode }) {
     await runStoreMutation('upsertMember', async () => {
       if (firestoreEnabled && db) {
         await upsertMemberFS(db, orgId, member, auditActor);
-        return;
       }
       setLocalMembers((prev) => {
         const idx = prev.findIndex((m) => m.uid === member.uid);
@@ -414,7 +418,6 @@ export function AppProvider({ children }: { children: ReactNode }) {
     await runStoreMutation('removeMember', async () => {
       if (firestoreEnabled && db) {
         await deleteMemberFS(db, orgId, uid, auditActor);
-        return;
       }
       setLocalMembers((prev) => prev.filter((m) => m.uid !== uid));
     });
@@ -449,7 +452,9 @@ export function AppProvider({ children }: { children: ReactNode }) {
       if (writeStrategy.target === 'firestore' && db) {
         const existing = projects.find((project) => project.id === id);
         if (existing) {
-          await upsertProject(db, orgId, normalizeProjectRevenueFields({ ...existing, ...updates } as Project, 'totalRevenueAmount'), auditActor);
+          const merged = normalizeProjectRevenueFields({ ...existing, ...updates } as Project, 'totalRevenueAmount');
+          await upsertProject(db, orgId, merged, auditActor);
+          setProjects((prev) => upsertLocalItem(prev, merged));
         }
         return;
       }

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -7,6 +7,7 @@ import {
   changeTransactionStateViaBff,
   deepSyncAuthGovernanceUserViaBff,
   fetchAuthGovernanceUsersViaBff,
+  fetchProjectsViaBff,
   linkProjectEvidenceDriveRootViaBff,
   notifyProjectRequestRegistrationViaBff,
   reviewProjectExecutiveStatusViaBff,
@@ -458,6 +459,30 @@ describe('platform-bff-client', () => {
       body: { id: 'p001', name: 'Project 1' },
     }));
     expect(result.version).toBe(1);
+  });
+
+  it('reads all project pages through the BFF without opening a realtime listener', async () => {
+    const client = asMockClient({
+      post: vi.fn(),
+      get: vi
+        .fn()
+        .mockResolvedValueOnce({ data: { items: [{ id: 'p001', name: 'Project 1' }], nextCursor: 'page-2' } })
+        .mockResolvedValueOnce({ data: { items: [{ id: 'p002', name: 'Project 2' }], nextCursor: null } }),
+      request: vi.fn(),
+    });
+
+    const result = await fetchProjectsViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'u001', role: 'admin', idToken: 'token-abc' },
+      client,
+    });
+
+    expect(result.map((project) => project.id)).toEqual(['p001', 'p002']);
+    expect(client.get).toHaveBeenNthCalledWith(1, '/api/v1/projects?limit=200', expect.objectContaining({
+      tenantId: 'mysc',
+      timeoutMs: 10000,
+    }));
+    expect(client.get).toHaveBeenNthCalledWith(2, '/api/v1/projects?limit=200&cursor=page-2', expect.any(Object));
   });
 
   it('calls project trash and restore endpoints', async () => {

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -1,6 +1,7 @@
 import { featureFlags, parseFeatureFlag } from '../config/feature-flags';
 import type {
   AccountType,
+  Project,
   ProjectExecutiveReviewStatus,
   ProjectSheetSourceSnapshot,
   ProjectSheetSourceType,
@@ -1317,6 +1318,35 @@ export function createPlatformApiClient(
     retryDelayMs: 200,
     timeoutMs: 4000,
   });
+}
+
+export async function fetchProjectsViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  client?: PlatformApiClientLike;
+}): Promise<Project[]> {
+  const apiClient = resolveClient(params.client);
+  const projects: Project[] = [];
+  const seenCursors = new Set<string>();
+  let cursor = '';
+
+  for (;;) {
+    const response = await apiClient.get<{ items: Project[]; nextCursor: string | null }>(
+      `/api/v1/projects?limit=200${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`,
+      {
+        tenantId: params.tenantId,
+        actor: toRequestActor(params.actor),
+        timeoutMs: 10000,
+      },
+    );
+    if (Array.isArray(response.data?.items)) {
+      projects.push(...response.data.items);
+    }
+    const nextCursor = typeof response.data?.nextCursor === 'string' ? response.data.nextCursor : '';
+    if (!nextCursor || seenCursors.has(nextCursor)) return projects;
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
 }
 
 function resolveClient(client?: PlatformApiClientLike): PlatformApiClientLike {


### PR DESCRIPTION
## 변경
- `/projects` 진입 시 전역 Firestore 실시간 구독을 단발 조회로 전환
- 프로젝트 목록은 BFF 페이지 조회를 우선하고 실패 시 Firestore 단발 조회로 폴백
- 관리자 화면별 Provider를 필요한 경로에만 마운트
- 리스너 제거 후 프로젝트/사용자 변경 결과를 로컬 상태에 반영

## 검증
- 관련 Vitest 47개 통과
- `npm run build` 통과
- `git diff --check` 통과

Stage 전용 배포 대상이며 Live에는 반영하지 않습니다.