### PR TITLE
fix: align cashflow and registration with PPT

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -96,9 +96,23 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('사업시트 열기');
   });
 
-  it('keeps server fallback copy intact without appending a duplicate sentence ending', () => {
-    expect(source).toContain("primaryReason?.title || '확인 항목을 확인해 주세요.'");
-    expect(source).not.toContain("primaryReason?.title || '확인 항목'}입니다");
+  it('keeps the dashboard information order from the PPT before the comparison table', () => {
+    const metadata = source.indexOf('입금 합계 (BO9)');
+    const summary = source.indexOf('{dashboardSummary}');
+    const management = source.indexOf('주요 관리 항목');
+    const comparison = source.indexOf('data-cashflow-block="comparison"');
+    expect(metadata).toBeGreaterThan(-1);
+    expect(summary).toBeGreaterThan(metadata);
+    expect(management).toBeGreaterThan(summary);
+    expect(comparison).toBeGreaterThan(management);
+  });
+
+  it('keeps the PPT summary as Projection, Actual, and monthly close only', () => {
+    expect(source).toContain("renderRateTile('Projection', opsSummary.rates.projection)");
+    expect(source).toContain("renderRateTile('Actual', opsSummary.rates.actual)");
+    expect(source).toContain("renderRateTile('결산', opsSummary.rates.confirmation)");
+    expect(source).not.toContain("renderRateTile('사람 확인', opsSummary.rates.confirmation)");
+    expect(source).not.toContain('renderOpsStatusDonut');
   });
 
   it('keeps sheet sync explicit and uses the approved action label', () => {
@@ -112,16 +126,24 @@ describe('CashflowProjectSheet monthly close shell', () => {
   });
 
   it('keeps an unlinked project usable and guides the user to sheet setup', () => {
-    expect(source).toContain('시트가 아직 연결되지 않았습니다.');
-    expect(source).toContain('시트를 연결하지 않아도 캐시플로우는 조회할 수 있습니다.');
+    expect(source).toContain('Google Sheet 연결 후 변경 후보를 검토할 수 있습니다.');
+    expect(source).toContain('처음 설정한 뒤 이 영역에서 시트값 불러오기를 직접 실행합니다.');
     expect(source).toContain('시트 연동 설정');
-    expect(source).toContain('cashflowSheetConfigLoaded && !cashflowSheetConfig');
+    expect(source).toContain('!cashflowSheetConfigLoaded || cashflowSheetConfig || !projectId');
     expect(source).toContain('myscube:cashflow-sheet-onboarding:');
     expect(source).toContain('캐시플로우 시트 연동 시작하기');
     expect(source).toContain('나중에 하기');
     expect(source).toContain('설정 후에도 자동으로 값을 가져오지 않습니다.');
     expect(source).toContain('cashflowSnapshot?.comparison?.months || []');
     expect(source).toContain('comparisonWeek?.lines?.find');
+  });
+
+  it('keeps the operations dashboard as the first visible cashflow block', () => {
+    expect(source).not.toContain('시트가 아직 연결되지 않았습니다.');
+    const operations = source.indexOf('{renderOperationsPanel()}');
+    const comparison = source.indexOf('data-cashflow-block="comparison"');
+    expect(operations).toBeGreaterThan(-1);
+    expect(operations).toBeLessThan(comparison);
   });
 
   it('shows month close only as a compact board action instead of a standalone panel', () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -35,12 +35,10 @@ import { getAuthInstance, getOrgCollectionPath, getOrgDocumentPath } from '../..
 import { resolveApiErrorMessage } from '../../platform/api-error-message';
 import {
   fetchCashflowSnapshotViaBff,
-  fetchCashflowLaborRiskViaBff,
   closeCashflowMonthViaBff,
   decideCashflowMonthReopenViaBff,
   fetchCashflowMonthCloseViaBff,
   requestCashflowMonthReopenViaBff,
-  type CashflowLaborRiskResult,
   type CashflowMonthCloseCell,
   type CashflowMonthCloseDraftInput,
   type CashflowMonthCloseResult,
@@ -359,9 +357,6 @@ export function CashflowProjectSheet({
   } | null>(null);
   const [cashflowSheetConfigLoaded, setCashflowSheetConfigLoaded] = useState(false);
   const [rangeLoadedWeeks, setRangeLoadedWeeks] = useState<CashflowWeekSheet[]>([]);
-  const [laborRisk, setLaborRisk] = useState<CashflowLaborRiskResult | null>(null);
-  const [laborRiskLoading, setLaborRiskLoading] = useState(false);
-  const [laborRiskError, setLaborRiskError] = useState<string | null>(null);
   const [cashflowSnapshot, setCashflowSnapshot] = useState<CashflowSnapshotResult | null>(null);
   const [cashflowComparisonLoading, setCashflowComparisonLoading] = useState(false);
   const [cashflowComparisonError, setCashflowComparisonError] = useState<string | null>(null);
@@ -1186,58 +1181,6 @@ export function CashflowProjectSheet({
       setMonthCloseBusy(false);
     }
   }, [canReviewReopen, isPm, loadCashflowMonthClose, monthCloseResult, orgId, projectId, reopenAction, reopenReason, resolveBffActor, yearMonth]);
-
-  const handleRefreshLaborRisk = useCallback(async (): Promise<void> => {
-    if (!projectId || !orgId || !user?.uid) {
-      setLaborRisk(null);
-      setLaborRiskError('로그인 세션이 만료되었습니다. 저장/검토 동작에서 로그인을 먼저 진행해 주세요.');
-      return;
-    }
-    setLaborRiskLoading(true);
-    setLaborRiskError(null);
-    try {
-      const resolvedActor = await resolveBffActor();
-      if (!resolvedActor?.idToken) {
-        setLaborRisk(null);
-        setLaborRiskError('로그인 세션이 만료되었습니다. 저장/검토 동작에서 로그인을 먼저 진행해 주세요.');
-        return;
-      }
-
-      let result: CashflowLaborRiskResult;
-      try {
-        result = await fetchCashflowLaborRiskViaBff({
-          tenantId: orgId,
-          actor: resolvedActor,
-          projectId,
-        });
-      } catch (error) {
-        if (!isBffAuthRejection(error)) throw error;
-        const refreshedActor = await resolveBffActor({ forceRefresh: true });
-        if (!refreshedActor?.idToken) throw error;
-        result = await fetchCashflowLaborRiskViaBff({
-          tenantId: orgId,
-          actor: refreshedActor,
-          projectId,
-        });
-      }
-      setLaborRisk(result);
-    } catch (error) {
-      setLaborRisk(null);
-      setLaborRiskError(resolveApiErrorMessage(error, '인건비/잔액 체크를 불러오지 못했습니다.'));
-    } finally {
-      setLaborRiskLoading(false);
-    }
-  }, [orgId, projectId, resolveBffActor, user?.uid]);
-
-  useEffect(() => {
-    setLaborRisk(null);
-    setLaborRiskError(null);
-    if (!projectId || !orgId || !user?.uid) {
-      setLaborRiskLoading(false);
-      return;
-    }
-    void handleRefreshLaborRisk();
-  }, [handleRefreshLaborRisk, orgId, projectId, user?.uid]);
 
   const handleRefreshSheetMirror = useCallback(async (): Promise<void> => {
     if (!cashflowSheetConfig?.value) {
@@ -2112,34 +2055,12 @@ export function CashflowProjectSheet({
     return 'text-slate-700';
   }
 
-  function renderOpsStatusDonut() {
-    const blockedCount = opsSummary.status.count;
-    const confirmationPercent = Math.min(100, Math.max(0, opsSummary.rates.confirmation.percent));
-    const actualPercent = Math.min(100, Math.max(0, opsSummary.rates.actual.percent));
-    const projectionPercent = Math.min(100, Math.max(0, opsSummary.rates.projection.percent));
-    const totalPercent = Math.max(1, projectionPercent + actualPercent + confirmationPercent);
-    const projectionEnd = (projectionPercent / totalPercent) * 360;
-    const actualEnd = projectionEnd + (actualPercent / totalPercent) * 360;
-    const confirmationEnd = actualEnd + (confirmationPercent / totalPercent) * 360;
-    const gradient = `conic-gradient(#3b82f6 0deg ${projectionEnd}deg, #fb7185 ${projectionEnd}deg ${actualEnd}deg, #f59e0b ${actualEnd}deg ${confirmationEnd}deg, #e5e7eb ${confirmationEnd}deg 360deg)`;
-
-    return (
-      <div className="flex items-center justify-center">
-        <div className="relative h-[78px] w-[78px] rounded-full" style={{ background: gradient }}>
-          <div className="absolute inset-[15px] flex flex-col items-center justify-center rounded-full bg-white text-center shadow-sm">
-            <div className={`text-[15px] font-bold leading-4 tabular-nums ${opsTextClass(opsSummary.status.tone)}`}>
-              {blockedCount > 0 ? `${blockedCount}건` : opsSummary.status.label}
-            </div>
-            <div className="mt-0.5 text-[9px] leading-3 text-slate-500">
-              {blockedCount > 0 ? '확인 필요' : '상태'}
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
   function renderRateTile(label: string, rate: { percent: number }) {
+    const summaryDescription = label === 'Projection'
+      ? '총 계약금액 기준'
+      : label === 'Actual'
+        ? '이번 주차까지 입력 기준'
+        : '사람 확인 완료 기준';
     return (
       <div className="min-w-[158px] rounded-[18px] bg-white px-3.5 py-3 shadow-[0_8px_24px_rgba(15,23,42,0.06)]" title="BFF/JVM 서버 요약값">
         <div className="flex items-center justify-between gap-2">
@@ -2155,92 +2076,75 @@ export function CashflowProjectSheet({
         <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-slate-100">
           <div className="h-full rounded-full bg-blue-500" style={{ width: `${Math.min(100, Math.max(0, rate.percent))}%` }} />
         </div>
-        <div className="mt-1.5 truncate text-[9px] leading-3 text-slate-500">월 결산 서버 응답</div>
+        <div className="mt-1.5 truncate text-[9px] leading-3 text-slate-500">{summaryDescription}</div>
       </div>
     );
   }
 
-  function renderLaborRiskCopy() {
-    if (laborRiskLoading) {
-      return (
-        <div className="flex items-center gap-2 text-[11px] text-slate-600">
-          <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          인건비/잔액 체크를 불러오는 중입니다.
-        </div>
-      );
-    }
-    if (laborRiskError) {
-      return <div className="text-[11px] font-semibold text-amber-700">인건비/잔액 체크 실패: {laborRiskError}</div>;
-    }
-    if (!laborRisk) return <div className="text-[11px] text-slate-500">페이지를 열면 인건비/잔액 체크 결과를 자동으로 계산합니다.</div>;
-
-    const missingMonths = laborRisk.labor.missingProjectionMonths;
-    const nextMonthProjectionMissing = !laborRisk.labor.nextMonthProjection.isWritten;
-    const nextLaborAmount = laborRisk.labor.nextProjection?.amount
-      ?? laborRisk.labor.nextMonthProjection.projectionAmount
-      ?? laborRisk.labor.referenceActualAmount
-      ?? 0;
-    const laborChanged = laborRisk.labor.lastMonth.actualAmount !== nextLaborAmount;
-    const minBalanceText = laborRisk.shortage.week
-      ? `${laborRisk.shortage.week.label} 예상 잔액 ${fmt(laborRisk.shortage.projectedBalance || 0)}원`
-      : '현재 Projection 기준 잔액 부족 예상 주차는 없습니다';
-
+  function renderOperationsSummary(input: {
+    hiddenInboxCount: number;
+    visibleInbox: typeof opsSummary.inbox;
+  }) {
     return (
-      <div className="space-y-1.5 text-[11px] leading-5 text-slate-700">
-        {nextMonthProjectionMissing ? (
-          <p>
-            지난달 Actual 인건비는 <span className="font-semibold tabular-nums text-blue-700">{fmt(laborRisk.labor.lastMonth.actualAmount)}원</span>,
-            오늘 기준 Actual 잔액은 <span className="font-semibold tabular-nums text-blue-700">{fmt(laborRisk.current.balance)}원</span>입니다.{' '}
-            <span className="font-semibold text-rose-700">다음 달 Projection 인건비가 미작성이라 잔액 부족 여부를 확정할 수 없습니다.</span>
-          </p>
-        ) : (
-          <div className="space-y-1">
-            <p>
-              오늘 기준 Actual 잔액은 <span className="font-semibold tabular-nums text-blue-700">{fmt(laborRisk.current.balance)}원</span>입니다.
-              다음 인건비 <span className="font-semibold tabular-nums text-blue-700">{fmt(nextLaborAmount)}원</span> 반영 후 예상 잔액은{' '}
-              <span className="font-semibold tabular-nums text-blue-700">{fmt(laborRisk.labor.balanceAfterNextLabor)}원</span>이며, {minBalanceText}.
-            </p>
-            {laborChanged && (
-              <p className="font-semibold text-amber-700">
-                지난달 인건비는 {fmt(laborRisk.labor.lastMonth.actualAmount)}원인데 이번달 인건비는 {fmt(nextLaborAmount)}원이라서 확인 필요합니다.
-              </p>
+      <div className="grid gap-2.5 xl:grid-cols-[minmax(0,1fr)_240px]">
+        <div className="grid gap-2 md:grid-cols-3">
+          {renderRateTile('Projection', opsSummary.rates.projection)}
+          {renderRateTile('Actual', opsSummary.rates.actual)}
+          {renderRateTile('결산', opsSummary.rates.confirmation)}
+        </div>
+
+        <div className="min-w-0 overflow-hidden rounded-[20px] bg-white shadow-[0_8px_24px_rgba(15,23,42,0.06)] xl:max-h-[126px]">
+          <div className="flex items-center justify-between gap-2 px-3 py-2">
+            <div className="min-w-0">
+              <div className="text-[10px] font-semibold text-slate-500">확인할 항목</div>
+              <div className={`mt-0.5 text-[10px] font-bold tabular-nums ${opsTextClass(opsSummary.status.tone)}`}>
+                {opsSummary.status.count}건
+              </div>
+            </div>
+          </div>
+          <div className="divide-y divide-slate-50">
+            {input.visibleInbox.length === 0 ? (
+              <div className="grid grid-cols-[14px_minmax(0,1fr)] gap-1.5 px-3 py-1.5">
+                <div className="flex h-4 items-center justify-center">
+                  <span className={`h-1.5 w-1.5 rounded-full ${opsDotClass('success')}`} />
+                </div>
+                <div className="min-w-0">
+                  <div className={`truncate text-[10px] font-bold leading-3 ${opsTextClass('success')}`}>확인할 항목이 없습니다.</div>
+                  <div className="mt-0.5 truncate text-[9px] leading-3 text-slate-500">서버 검증 기준으로 준비되었습니다.</div>
+                </div>
+              </div>
+            ) : input.visibleInbox.map((item) => (
+              <div key={item.id} className="grid grid-cols-[14px_minmax(0,1fr)] gap-1.5 px-3 py-1.5">
+                <div className="flex h-4 items-center justify-center">
+                  <span className={`h-1.5 w-1.5 rounded-full ${opsDotClass(item.tone)}`} />
+                </div>
+                <div className="min-w-0">
+                  <div className={`truncate text-[10px] font-bold leading-3 ${opsTextClass(item.tone)}`}>{item.title}</div>
+                  <div className="mt-0.5 truncate text-[9px] leading-3 text-slate-500">{item.detail}</div>
+                </div>
+              </div>
+            ))}
+            {input.hiddenInboxCount > 0 && (
+              <div className="px-2 py-1 text-[9px] font-semibold text-slate-500">
+                외 {input.hiddenInboxCount}건
+              </div>
             )}
           </div>
-        )}
-        <div className="flex flex-wrap gap-x-4 gap-y-1 border-t border-slate-200 pt-1.5 text-[10px] text-slate-500">
-          <span>지난달: {laborRisk.labor.lastMonth.label}</span>
-          <span>현재 주차: {laborRisk.current.week?.label || '없음'}</span>
-          <span>다음 인건비 주차: {laborRisk.labor.nextProjection?.label || '없음'}</span>
-          <span>
-            다음 달 Projection: {laborRisk.labor.nextMonthProjection.label} ·{' '}
-            <span className={laborRisk.labor.nextMonthProjection.isWritten ? 'text-slate-600' : 'font-semibold text-rose-700'}>
-              {laborRisk.labor.nextMonthProjection.isWritten ? '작성됨' : '미작성'}
-            </span>
-          </span>
         </div>
-        {missingMonths.length > 0 && (
-          <div className="text-[11px] text-amber-700">
-            MYSC 인건비 Projection 미산입 월: {missingMonths.slice(0, 6).map((month) => month.label).join(', ')}
-            {missingMonths.length > 6 ? ` 외 ${missingMonths.length - 6}개월` : ''}
-          </div>
-        )}
       </div>
     );
   }
 
   function renderOperationsPanel() {
-    const compactStatusDetail = opsSummary.status.detail
-      .replace(' 항목이 있습니다.', ' 항목');
     const visibleInbox = opsSummary.inbox.slice(0, 4);
     const hiddenInboxCount = Math.max(0, opsSummary.status.count - visibleInbox.length);
-    const primaryReason = visibleInbox.find((item) => item.id === 'projection-actual-diff') || visibleInbox[0];
-    const remainingReasonCount = Math.max(0, opsSummary.status.count - 1);
     const statusBadgeLabel = opsSummary.status.kind === 'ready'
       ? opsSummary.status.label
       : `확인 항목 ${opsSummary.status.count}건`;
-    const statusReason = opsSummary.status.kind === 'ready'
-      ? '확인할 항목이 없습니다.'
-      : `${primaryReason?.title || '확인 항목을 확인해 주세요.'}${remainingReasonCount > 0 ? ` 외 ${remainingReasonCount}건` : ''}`;
+    const dashboardSummary = renderOperationsSummary({
+      hiddenInboxCount,
+      visibleInbox,
+    });
     return (
       <Card className="overflow-hidden rounded-[24px] border-0 bg-slate-50/80 shadow-[0_16px_40px_rgba(15,23,42,0.08)]">
         <CardContent className="space-y-3 p-4">
@@ -2398,6 +2302,8 @@ export function CashflowProjectSheet({
             </div>
           ) : null}
 
+          {dashboardSummary}
+
           <div className="grid gap-3 xl:grid-cols-[minmax(0,1.2fr)_minmax(280px,0.8fr)]">
             <div className="rounded-[20px] bg-white px-3.5 py-3 shadow-[0_8px_24px_rgba(15,23,42,0.06)]">
               <div className="mb-2 flex items-center justify-between gap-2">
@@ -2495,77 +2401,6 @@ export function CashflowProjectSheet({
             </div>
           ) : null}
 
-          <div className="grid gap-2.5 xl:grid-cols-[minmax(0,1fr)_240px]">
-            <div className="grid gap-2 md:grid-cols-[210px_repeat(3,minmax(158px,1fr))]">
-              <div className="flex min-w-[190px] items-center gap-3 rounded-[20px] bg-white px-3.5 py-3 shadow-[0_8px_24px_rgba(15,23,42,0.06)]" title={opsSummary.status.detail}>
-                {renderOpsStatusDonut()}
-                <div className="min-w-0">
-                  <div className="text-[10px] font-semibold leading-3 text-slate-500">선택 월 기준</div>
-                  <div className={`mt-1 truncate text-[13px] font-bold leading-4 ${opsTextClass(opsSummary.status.tone)}`}>
-                    {statusBadgeLabel}
-                  </div>
-                  <div className="mt-1 max-h-8 overflow-hidden text-[10px] leading-4 text-slate-500">
-                    {statusReason}
-                  </div>
-                  <div className="mt-1 text-[9px] leading-3 text-slate-400">{compactStatusDetail} · 서버 검증</div>
-                </div>
-              </div>
-              {renderRateTile('Projection', opsSummary.rates.projection)}
-              {renderRateTile('Actual', opsSummary.rates.actual)}
-              {renderRateTile('사람 확인', opsSummary.rates.confirmation)}
-            </div>
-
-            <div className="min-w-0 overflow-hidden rounded-[20px] bg-white shadow-[0_8px_24px_rgba(15,23,42,0.06)] xl:max-h-[126px]">
-              <div className="flex items-center justify-between gap-2 px-3 py-2">
-                <div className="min-w-0">
-                  <div className="text-[10px] font-semibold text-slate-500">확인할 항목</div>
-                  <div className={`mt-0.5 text-[10px] font-bold tabular-nums ${opsTextClass(opsSummary.status.tone)}`}>
-                    {opsSummary.status.count}건
-                  </div>
-                </div>
-              </div>
-              <div className="divide-y divide-slate-50">
-                {visibleInbox.length === 0 ? (
-                  <div className="grid grid-cols-[14px_minmax(0,1fr)] gap-1.5 px-3 py-1.5">
-                    <div className="flex h-4 items-center justify-center">
-                      <span className={`h-1.5 w-1.5 rounded-full ${opsDotClass('success')}`} />
-                    </div>
-                    <div className="min-w-0">
-                      <div className={`truncate text-[10px] font-bold leading-3 ${opsTextClass('success')}`}>확인할 항목이 없습니다.</div>
-                      <div className="mt-0.5 truncate text-[9px] leading-3 text-slate-500">서버 검증 기준으로 준비되었습니다.</div>
-                    </div>
-                  </div>
-                ) : visibleInbox.map((item) => (
-                  <div key={item.id} className="grid grid-cols-[14px_minmax(0,1fr)] gap-1.5 px-3 py-1.5">
-                    <div className="flex h-4 items-center justify-center">
-                      <span className={`h-1.5 w-1.5 rounded-full ${opsDotClass(item.tone)}`} />
-                    </div>
-                    <div className="min-w-0">
-                      <div className={`truncate text-[10px] font-bold leading-3 ${opsTextClass(item.tone)}`}>{item.title}</div>
-                      <div className="mt-0.5 truncate text-[9px] leading-3 text-slate-500">{item.detail}</div>
-                    </div>
-                  </div>
-                ))}
-                {hiddenInboxCount > 0 && (
-                  <div className="px-2 py-1 text-[9px] font-semibold text-slate-500">
-                    외 {hiddenInboxCount}건
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-
-          <div className="rounded-[20px] bg-white px-3.5 py-3 shadow-[0_8px_24px_rgba(15,23,42,0.06)]">
-            <div className="mb-1.5 flex items-center justify-between gap-2">
-              <div className="text-[11px] font-bold text-slate-900">
-              <HoverExplain message="저장된 주차 값을 읽어 현재 잔액과 다음 인건비를 계산합니다.">
-                인건비/잔액 체크
-              </HoverExplain>
-              </div>
-              <div className="shrink-0 text-[10px] font-medium text-slate-400">페이지 새로고침 시 자동 계산</div>
-            </div>
-            {renderLaborRiskCopy()}
-          </div>
         </CardContent>
       </Card>
     );
@@ -2824,21 +2659,6 @@ export function CashflowProjectSheet({
 
   return (
     <div className="space-y-5 rounded-[28px] bg-slate-50/80 p-3">
-      {cashflowSheetConfigLoaded && !cashflowSheetConfig ? (
-        <section className="flex flex-col gap-3 rounded-[20px] border border-amber-200 bg-amber-50 px-4 py-3 text-amber-950 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex min-w-0 items-start gap-2">
-            <FileSpreadsheet className="mt-0.5 h-4 w-4 shrink-0 text-amber-700" />
-            <div>
-              <div className="text-[12px] font-bold">시트가 아직 연결되지 않았습니다.</div>
-              <div className="mt-1 text-[10px] leading-4 text-amber-800">시트를 연결하지 않아도 캐시플로우는 조회할 수 있습니다. 시트값을 가져오려면 먼저 연결 범위를 설정해 주세요.</div>
-            </div>
-          </div>
-          <Button type="button" size="sm" variant="outline" className="h-8 shrink-0 rounded-full border-amber-300 bg-white px-3 text-[10px] text-amber-900" onClick={handleOpenSheetOnboarding}>
-            시트 연동 설정
-          </Button>
-        </section>
-      ) : null}
-
       <section className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_320px]">
         {renderOperationsPanel()}
         {renderOpsTimeline()}

--- a/src/app/components/projects/ProjectEditorWizard.shell.test.ts
+++ b/src/app/components/projects/ProjectEditorWizard.shell.test.ts
@@ -186,15 +186,18 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(contractDocumentPolicySource).toContain('교체 취소');
   });
 
-  it('renders registration v2 requirements and completed-project checkout without a new route', () => {
+  it('keeps the PPT registration attachment contract and completed-project checkout without a new route', () => {
     expect(portalRegisterSource).toContain('registrationRequirementsVersion: 2');
     expect(source).toContain("'customer_business_registration'");
-    expect(source).toContain("'proposal_word_original'");
-    expect(source).toContain("'proposal_ppt_original'");
-    expect(source).toContain("'presentation_ppt_original'");
+    expect(source).toContain("'proposal'");
     expect(source).toContain("'rfp_request_evidence'");
-    expect(source).toContain('미첨부 사유 / 해당 없음 *');
-    expect(source).toContain('등록 첨부 7종');
+    expect(source).toContain('제안서 PDF *');
+    expect(source).toContain('RFP 또는 요청 메일 증빙 (제안서가 없는 경우) *');
+    expect(source).toContain("if (!draft.proposalDocument && !draft.rfpRequestEvidenceDocument)");
+    expect(source).toContain('등록 필수 첨부');
+    expect(source).not.toContain('등록 첨부 7종');
+    expect(source).not.toContain("if (draft.settlementType === 'NONE') issues.push");
+    expect(source).not.toContain("if (draft.basis === 'NONE') issues.push");
     expect(source).toContain('발주처 사업자등록증 PDF');
     expect(source).toContain('연도별 계약·재무 *');
     expect(source).toContain('계약기간 전체 연도별 재무 확인');

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -176,9 +176,6 @@ const REGISTRATION_DOCUMENT_KINDS: ProjectRequestDocumentKind[] = [
   'customer_business_registration',
   'quote',
   'proposal',
-  'proposal_word_original',
-  'proposal_ppt_original',
-  'presentation_ppt_original',
   'rfp_request_evidence',
 ];
 const CHECKOUT_DOCUMENT_KINDS: ProjectRequestDocumentKind[] = [
@@ -190,11 +187,11 @@ const PROJECT_DOCUMENT_LABELS: Record<ProjectRequestDocumentKind, string> = {
   contract: '계약서 PDF',
   customer_business_registration: '발주처 사업자등록증 PDF',
   quote: '견적서 PDF',
-  proposal: '제안서 PDF (기존 첨부, 선택)',
+  proposal: '제안서 PDF *',
   proposal_word_original: '제안서 Word 원본 (선택)',
   proposal_ppt_original: '제안서 PPT 원본 (선택)',
   presentation_ppt_original: '발표자료 PPT 원본 (선택)',
-  rfp_request_evidence: 'RFP 또는 요청 메일 증빙 *',
+  rfp_request_evidence: 'RFP 또는 요청 메일 증빙 (제안서가 없는 경우) *',
   performance_certificate: '수행확인서 PDF',
   tax_invoice: '세금계산서 PDF',
   final_settlement_report: '최종 정산보고서 PDF',
@@ -1117,20 +1114,11 @@ export function ProjectEditorWizard({
       if (!draft.groupwareName.trim()) issues.push({ step: 'basic', label: '그룹웨어 등록명' });
       if (!draft.projectPurpose.trim()) issues.push({ step: 'basic', label: '프로젝트 목적' });
       if (!draft.description.trim()) issues.push({ step: 'basic', label: '프로젝트 주요 내용' });
-      if (draft.settlementType === 'NONE') issues.push({ step: 'financial', label: '정산 유형' });
-      if (draft.basis === 'NONE') issues.push({ step: 'financial', label: '정산 기준' });
       if (!draft.contractDocument) issues.push({ step: 'financial', label: '계약서 PDF' });
       if (!draft.customerBusinessRegistrationDocument) issues.push({ step: 'financial', label: '발주처 사업자등록증 PDF' });
       if (!draft.quoteDocument) issues.push({ step: 'financial', label: '견적서 PDF' });
-      if (!draft.rfpRequestEvidenceDocument) issues.push({ step: 'financial', label: 'RFP 또는 요청 메일 증빙' });
-      if (!draft.proposalWordOriginalDocument && !draft.registrationOptionalDocumentNotes.proposalWordOriginal.trim()) {
-        issues.push({ step: 'financial', label: '제안서 Word 원본 미첨부 사유' });
-      }
-      if (!draft.proposalPptOriginalDocument && !draft.registrationOptionalDocumentNotes.proposalPptOriginal.trim()) {
-        issues.push({ step: 'financial', label: '제안서 PPT 원본 미첨부 사유' });
-      }
-      if (!draft.presentationPptOriginalDocument && !draft.registrationOptionalDocumentNotes.presentationPptOriginal.trim()) {
-        issues.push({ step: 'financial', label: '발표자료 PPT 원본 미첨부 사유' });
+      if (!draft.proposalDocument && !draft.rfpRequestEvidenceDocument) {
+        issues.push({ step: 'financial', label: '제안서 또는 RFP/요청 메일 증빙' });
       }
       const startYear = Number(draft.contractStart.slice(0, 4));
       const endYear = Number(draft.contractEnd.slice(0, 4));
@@ -1650,14 +1638,12 @@ export function ProjectEditorWizard({
         <div>
           <Label className="text-xs">정산 유형</Label>
           <Select
-            value={usesRegistrationV2 && draft.settlementType === 'NONE' ? undefined : draft.settlementType}
+            value={draft.settlementType}
             onValueChange={(value) => update('settlementType', value as SettlementType)}
           >
             <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue placeholder="정산 유형 선택" /></SelectTrigger>
             <SelectContent>
-              {(Object.entries(SETTLEMENT_TYPE_LABELS) as [SettlementType, string][])
-                .filter(([key]) => !(usesRegistrationV2 && key === 'NONE'))
-                .map(([key, value]) => (
+              {(Object.entries(SETTLEMENT_TYPE_LABELS) as [SettlementType, string][]).map(([key, value]) => (
                 <SelectItem key={key} value={key}>{value}</SelectItem>
                 ))}
             </SelectContent>
@@ -1666,14 +1652,12 @@ export function ProjectEditorWizard({
         <div>
           <Label className="text-xs">정산 기준</Label>
           <Select
-            value={usesRegistrationV2 && draft.basis === 'NONE' ? undefined : draft.basis}
+            value={draft.basis}
             onValueChange={(value) => update('basis', value as Basis)}
           >
             <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue placeholder="정산 기준 선택" /></SelectTrigger>
             <SelectContent>
-              {(Object.entries(BASIS_LABELS) as [Basis, string][])
-                .filter(([key]) => !(usesRegistrationV2 && key === 'NONE'))
-                .map(([key, value]) => (
+              {(Object.entries(BASIS_LABELS) as [Basis, string][]).map(([key, value]) => (
                 <SelectItem key={key} value={key}>{value}</SelectItem>
                 ))}
             </SelectContent>
@@ -2205,16 +2189,12 @@ export function ProjectEditorWizard({
                   )).join('\n')}
                 />
                 <ReviewRow
-                  label="등록 첨부 7종"
+                  label="등록 필수 첨부"
                   value={[
                     `1. 계약서: ${draft.contractDocument?.name || '미첨부'}`,
                     `2. 사업자등록증: ${draft.customerBusinessRegistrationDocument?.name || '미첨부'}`,
                     `3. 견적서: ${draft.quoteDocument?.name || '미첨부'}`,
-                    `4. 제안서 Word: ${draft.proposalWordOriginalDocument?.name || draft.registrationOptionalDocumentNotes.proposalWordOriginal || '사유 미입력'}`,
-                    `5. 제안서 PPT: ${draft.proposalPptOriginalDocument?.name || draft.registrationOptionalDocumentNotes.proposalPptOriginal || '사유 미입력'}`,
-                    `6. 발표자료 PPT: ${draft.presentationPptOriginalDocument?.name || draft.registrationOptionalDocumentNotes.presentationPptOriginal || '사유 미입력'}`,
-                    `7. RFP/요청 메일: ${draft.rfpRequestEvidenceDocument?.name || '미첨부'}`,
-                    ...(draft.proposalDocument ? [`기존 제안서 PDF: ${draft.proposalDocument.name}`] : []),
+                    `4. 제안서 또는 RFP/요청 메일: ${draft.proposalDocument?.name || draft.rfpRequestEvidenceDocument?.name || '미첨부'}`,
                   ].join('\n')}
                 />
               </>


### PR DESCRIPTION
## 변경\n- 캐시플로우 운영 대시보드의 PPT 순서 및 요약 구조 정렬\n- PPT 외 자동 진단/상단 배너 제거\n- 프로젝트 등록의 정산 없음, 제안서 또는 RFP 첨부 계약 반영\n\n## 검증\n- npm test\n- npm run build\n\nStage 전용 배포용 PR입니다. 라이브 배포 대상이 아닙니다.