### PR TITLE
feat: 다년도 현금흐름 시트 대조

### DIFF
--- a/server/bff/cashflow-sheet-snapshot.mjs
+++ b/server/bff/cashflow-sheet-snapshot.mjs
@@ -158,6 +158,12 @@ function controlRow({ matrix, row, weekColumns, issues }) {
     ? null
     : amounts.reduce((sum, amount) => sum + amount, 0);
   const value = readWholeWon(matrix, row.rowIndex, 66, issues, field, { allowEmpty: false });
+  const annualValues = new Map();
+  for (let index = 0; index < weekColumns.length; index += 1) {
+    const year = Number(String(weekColumns[index].yearMonth).slice(0, 4));
+    if (!Number.isSafeInteger(year)) continue;
+    annualValues.set(year, (annualValues.get(year) || 0) + (amounts[index] || 0));
+  }
   return {
     kind: row.kind,
     ...(row.lineId ? { lineId: row.lineId } : { derivedKind: row.derivedKind }),
@@ -165,7 +171,33 @@ function controlRow({ matrix, row, weekColumns, issues }) {
     value,
     computed,
     matches: value === null || computed === null ? false : value === computed,
+    annualValues: [...annualValues.entries()]
+      .sort(([left], [right]) => left - right)
+      .map(([year, annualValue]) => ({ year, value: annualValue })),
   };
+}
+
+function annualSheetFinancialTotals({ depositScheduleRows, projectionControls }) {
+  const years = new Set(depositScheduleRows.map((row) => Number(String(row.yearMonth).slice(0, 4))));
+  for (const control of projectionControls) {
+    for (const annualValue of control.annualValues || []) years.add(annualValue.year);
+  }
+  const annualValue = (lineId, year) => (
+    projectionControls.find((control) => control.lineId === lineId)?.annualValues
+      ?.find((value) => value.year === year)?.value || 0
+  );
+  return [...years]
+    .filter(Number.isSafeInteger)
+    .sort((left, right) => left - right)
+    .map((year) => ({
+      year,
+      contractAmount: depositScheduleRows
+        .filter((row) => Number(String(row.yearMonth).slice(0, 4)) === year)
+        .reduce((sum, row) => sum + (row.expectedDepositAmount || 0), 0),
+      salesVatAmount: annualValue('SALES_VAT_IN', year),
+      totalRevenueAmount: annualValue('MYSC_PROFIT_OUT', year),
+      supportAmount: annualValue('TEAM_SUPPORT_IN', year),
+    }));
 }
 
 export function extractCashflowSheetFacts({ template = {}, matrix = [] } = {}) {
@@ -226,6 +258,9 @@ export function extractCashflowSheetFacts({ template = {}, matrix = [] } = {}) {
     : depositValues.reduce((sum, amount) => sum + amount, 0);
   const depositValue = readWholeWon(matrix, 8, 66, issues, 'depositControl', { allowEmpty: false, nonNegative: true });
 
+  const projectionControls = modeControls('projection');
+  const actualControls = modeControls('actual');
+
   return {
     metadata: {
       lastUpdateText: { sourceCell: 'B1', value: matrixValue(matrix, 0, 1) },
@@ -234,6 +269,7 @@ export function extractCashflowSheetFacts({ template = {}, matrix = [] } = {}) {
       settlementStatus: { sourceCell: 'B4', value: matrixValue(matrix, 3, 1) },
     },
     depositScheduleRows,
+    annualFinancialTotals: annualSheetFinancialTotals({ depositScheduleRows, projectionControls }),
     controlTotals: {
       deposit: {
         sourceCell: 'BO9',
@@ -245,8 +281,8 @@ export function extractCashflowSheetFacts({ template = {}, matrix = [] } = {}) {
         sourceCell: 'BP9',
         value: readWholeWon(matrix, 8, 67, issues, 'unpaidControl'),
       },
-      projection: modeControls('projection'),
-      actual: modeControls('actual'),
+      projection: projectionControls,
+      actual: actualControls,
     },
     issues,
   };

--- a/server/bff/cashflow-sheet-snapshot.test.mjs
+++ b/server/bff/cashflow-sheet-snapshot.test.mjs
@@ -121,14 +121,23 @@ describe('cashflow sheet pinned snapshot', () => {
           expectedDepositAmount: `${String.fromCharCode(68 + weekIndex)}9`,
         },
       })),
+      annualFinancialTotals: [{
+        year: 2026,
+        contractAmount: 15000,
+        salesVatAmount: 0,
+        totalRevenueAmount: 0,
+        supportAmount: 0,
+      }],
       controlTotals: {
         deposit: { sourceCell: 'BO9', value: 15000, computed: 15000, matches: true },
         unpaid: { sourceCell: 'BP9', value: 85000 },
         projection: [{
           kind: 'line', lineId: 'SALES_IN', sourceCell: 'BO14', value: 150, computed: 150, matches: true,
+          annualValues: [{ year: 2026, value: 150 }],
         }],
         actual: [{
           kind: 'line', lineId: 'SALES_IN', sourceCell: 'BO37', value: 75, computed: 75, matches: true,
+          annualValues: [{ year: 2026, value: 75 }],
         }],
       },
       issues: [],
@@ -159,6 +168,50 @@ describe('cashflow sheet pinned snapshot', () => {
     expect(facts.depositScheduleRows[1].expectedDepositAmount).toBeNull();
     expect(facts.controlTotals.deposit).toMatchObject({ computed: 1000, value: 1000, matches: true });
     expect(facts.controlTotals.projection[0]).toMatchObject({ computed: 100, value: 100, matches: true });
+  });
+
+  it('groups sheet finance checks by calendar year using the registered cashflow lines', () => {
+    const matrix = Array.from({ length: 55 }, () => Array.from({ length: 68 }, () => ''));
+    const weekColumns = [
+      { yearMonth: '2025-12', weekNo: 5, columnIndex: 3 },
+      { yearMonth: '2026-01', weekNo: 1, columnIndex: 4 },
+    ];
+    matrix[8][3] = '100';
+    matrix[8][4] = '200';
+    matrix[8][66] = '300';
+    matrix[13][3] = '10';
+    matrix[13][4] = '20';
+    matrix[13][66] = '30';
+    matrix[14][3] = '30';
+    matrix[14][4] = '40';
+    matrix[14][66] = '70';
+    matrix[15][3] = '50';
+    matrix[15][4] = '60';
+    matrix[15][66] = '110';
+
+    const facts = extractCashflowSheetFacts({
+      matrix,
+      template: {
+        sections: [
+          {
+            mode: 'projection',
+            weekColumns,
+            lineRows: [
+              { rowIndex: 13, lineId: 'SALES_VAT_IN' },
+              { rowIndex: 14, lineId: 'MYSC_PROFIT_OUT' },
+              { rowIndex: 15, lineId: 'TEAM_SUPPORT_IN' },
+            ],
+            derivedRows: [],
+          },
+          { mode: 'actual', weekColumns, lineRows: [], derivedRows: [] },
+        ],
+      },
+    });
+
+    expect(facts.annualFinancialTotals).toEqual([
+      { year: 2025, contractAmount: 100, salesVatAmount: 10, totalRevenueAmount: 30, supportAmount: 50 },
+      { year: 2026, contractAmount: 200, salesVatAmount: 20, totalRevenueAmount: 40, supportAmount: 60 },
+    ]);
   });
 
   it('computes the same target revision regardless of Firestore map and week order', () => {

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -33,6 +33,65 @@ const CASHFLOW_SHEET_STAGE_MONTHS_COLLECTION_ID = 'cashflow_sheet_stage_months';
 const CASHFLOW_MODES = ['projection', 'actual'];
 const CASHFLOW_SHEET_SOURCE_KEY = 'cashflow-sheet-lab';
 const CASHFLOW_LINE_ORDER = new Map(CASHFLOW_ALL_LINES.map((lineId, index) => [lineId, index]));
+const FINANCIAL_YEAR_FIELDS = [
+  'contractAmount',
+  'salesVatAmount',
+  'totalRevenueAmount',
+  'supportAmount',
+];
+
+function wholeWon(value) {
+  return Number.isSafeInteger(value) ? value : 0;
+}
+
+function attachFinancialYearChecks(mirror, project) {
+  if (mirror?.status !== 'FRESH') return mirror;
+  const registeredYears = Array.isArray(project?.financialYears)
+    ? project.financialYears
+      .filter((row) => Number.isSafeInteger(row?.year))
+      .sort((left, right) => left.year - right.year)
+    : [];
+  if (registeredYears.length < 2) return mirror;
+
+  const sheetYears = new Map((mirror.sheetFacts?.annualFinancialTotals || [])
+    .filter((row) => Number.isSafeInteger(row?.year))
+    .map((row) => [row.year, row]));
+  const compare = (year, registered, sheet) => {
+    const mismatches = FINANCIAL_YEAR_FIELDS.filter((field) => (
+      !sheet || wholeWon(registered[field]) !== wholeWon(sheet[field])
+    ));
+    return {
+      year,
+      status: sheet ? (mismatches.length === 0 ? 'MATCH' : 'MISMATCH') : 'SHEET_YEAR_MISSING',
+      mismatches,
+      registered: Object.fromEntries(FINANCIAL_YEAR_FIELDS.map((field) => [field, wholeWon(registered[field])])),
+      sheet: Object.fromEntries(FINANCIAL_YEAR_FIELDS.map((field) => [field, wholeWon(sheet?.[field])])),
+    };
+  };
+  const years = registeredYears.map((registered) => compare(registered.year, registered, sheetYears.get(registered.year)));
+  const totalRegistered = Object.fromEntries(FINANCIAL_YEAR_FIELDS.map((field) => [field,
+    years.reduce((sum, row) => sum + row.registered[field], 0),
+  ]));
+  const totalSheet = Object.fromEntries(FINANCIAL_YEAR_FIELDS.map((field) => [field,
+    years.reduce((sum, row) => sum + row.sheet[field], 0),
+  ]));
+  const totalMismatches = FINANCIAL_YEAR_FIELDS.filter((field) => totalRegistered[field] !== totalSheet[field]);
+
+  return {
+    ...mirror,
+    financialYearChecks: {
+      years,
+      total: {
+        status: years.some((row) => row.status === 'SHEET_YEAR_MISSING')
+          ? 'SHEET_YEAR_MISSING'
+          : (totalMismatches.length === 0 ? 'MATCH' : 'MISMATCH'),
+        mismatches: totalMismatches,
+        registered: totalRegistered,
+        sheet: totalSheet,
+      },
+    },
+  };
+}
 
 function readEditSession(req) {
   const sessionId = readOptionalText(req.header('x-edit-session-id'));
@@ -1539,9 +1598,9 @@ export function mountCashflowSheetLabRoutes(app, {
     assertCashflowSheetLabAccess(req, workspaceEmailDomain);
     const { tenantId } = req.context;
     const { projectId } = req.params;
-    await readProjectDocument(db, tenantId, projectId);
+    const project = await readProjectDocument(db, tenantId, projectId);
     const mirror = await readCashflowSheetMirror(db, tenantId, projectId);
-    res.status(200).json(mirror || { projectId, status: 'EMPTY' });
+    res.status(200).json(attachFinancialYearChecks(mirror, project) || { projectId, status: 'EMPTY' });
   }));
 
   app.post('/api/v1/projects/:projectId/cashflow-sheet-lab/mirror/refresh', asyncHandler(async (req, res) => {

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -256,6 +256,42 @@ describe('cashflow sheet lab route', () => {
     expect(db.__getDocument().cashflowSheetLab.activeWeeks).toBeUndefined();
   });
 
+  it('compares a pinned multi-year sheet total with registered financial years', async () => {
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        financialYears: [
+          { year: 2025, contractAmount: 100, salesVatAmount: 10, totalRevenueAmount: 20, supportAmount: 30 },
+          { year: 2026, contractAmount: 200, salesVatAmount: 20, totalRevenueAmount: 40, supportAmount: 60 },
+        ],
+      },
+      initialDocuments: {
+        'orgs/tenant-a/cashflow_sheet_mirrors/project-a': {
+          projectId: 'project-a',
+          status: 'FRESH',
+          sheetFacts: {
+            annualFinancialTotals: [
+              { year: 2025, contractAmount: 100, salesVatAmount: 10, totalRevenueAmount: 20, supportAmount: 30 },
+              { year: 2026, contractAmount: 200, salesVatAmount: 21, totalRevenueAmount: 40, supportAmount: 60 },
+            ],
+          },
+        },
+      },
+    });
+
+    const response = await request(createApp({ db }))
+      .get('/api/v1/projects/project-a/cashflow-sheet-lab/mirror')
+      .expect(200);
+
+    expect(response.body.financialYearChecks).toMatchObject({
+      years: [
+        { year: 2025, status: 'MATCH', mismatches: [] },
+        { year: 2026, status: 'MISMATCH', mismatches: ['salesVatAmount'] },
+      ],
+      total: { status: 'MISMATCH', mismatches: ['salesVatAmount'] },
+    });
+  });
+
   it('keeps the last-good mirror as STALE when an explicit refresh fails', async () => {
     const db = createDb({
       project: {

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -152,6 +152,17 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('재오픈 요청');
   });
 
+  it('opens only the selected Projection week and keeps multi-year sheet checks visible', () => {
+    expect(source).toContain('현금흐름 관리시트');
+    expect(source).not.toContain('캐시플로 진단시트');
+    expect(source).not.toContain('수정 시작');
+    expect(source).not.toContain('서버 확정 원장 합계');
+    expect(source).toContain('openProjectionWeekEditing');
+    expect(source).toContain('financialYearChecks?.years.length');
+    expect(source).toContain('시트 연도값 없음');
+    expect(source).toContain('시트 {fmt(check.sheet[field.key])} · 등록 {fmt(check.registered[field.key])}');
+  });
+
   it('offers the exact three in-app exit choices and releases only on exit', () => {
     expect(source).toContain('임시저장 후 종료');
     expect(source).toContain('저장하지 않고 종료');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { collection, doc, getDoc, getDocs, limit, query, where } from 'firebase/firestore';
-import { ArrowDownToLine, CheckCircle2, ChevronLeft, ChevronRight, ClipboardCheck, ClipboardList, Columns2, FileSpreadsheet, Loader2, Pencil, RefreshCw, Save } from 'lucide-react';
+import { ArrowDownToLine, CheckCircle2, ChevronLeft, ChevronRight, ClipboardCheck, ClipboardList, Columns2, FileSpreadsheet, Loader2, RefreshCw, Save } from 'lucide-react';
 import { toast } from 'sonner';
 import { useBlocker, useNavigate } from 'react-router';
 import { Button } from '../ui/button';
@@ -83,6 +83,13 @@ function fmtSigned(n: number): string {
   if (n === 0) return '0';
   return `${n > 0 ? '+' : '-'}${Math.abs(n).toLocaleString('ko-KR')}`;
 }
+
+const FINANCIAL_YEAR_CHECK_FIELDS = [
+  { key: 'contractAmount', label: '입금예정' },
+  { key: 'salesVatAmount', label: '매출 부가세' },
+  { key: 'totalRevenueAmount', label: 'MYSC 수익' },
+  { key: 'supportAmount', label: '팀지원금' },
+] as const;
 
 function formatSheetAppliedAt(value?: string): string {
   if (!value) return '';
@@ -1429,6 +1436,18 @@ export function CashflowProjectSheet({
     return editingWeekModes[resolveWeekKey(params)] === true;
   }
 
+  const openProjectionWeekEditing = useCallback(async (targetYearMonth: string, weekNo: number) => {
+    if (!cashflowLease.canEdit) {
+      const started = await beginCashflowEditing();
+      if (!started) return;
+    }
+    setShowEmptyCashflowRows(true);
+    setEditingWeekModes((current) => ({
+      ...current,
+      [resolveWeekKey({ yearMonth: targetYearMonth, mode: 'projection', weekNo })]: true,
+    }));
+  }, [beginCashflowEditing, cashflowLease.canEdit]);
+
   function getWeekLabel(weekNo: number, targetYearMonth = yearMonth): string {
     return annualWeeks.find((week) => week.yearMonth === targetYearMonth && week.weekNo === weekNo)?.label
       || monthWeeks.find((week) => week.weekNo === weekNo)?.label
@@ -1610,7 +1629,15 @@ export function CashflowProjectSheet({
     return (
       <td key={`${input.lineId}-${input.targetYearMonth}-${input.weekNo}-p`} className={`min-w-[84px] border-l-[6px] border-l-white px-1 py-1 align-middle ${bgClass}`}>
         {isCollapsedEmpty ? (
-          <div className="py-0.5 text-center text-[9px] text-slate-300">-</div>
+          <button
+            type="button"
+            className="w-full py-0.5 text-center text-[9px] text-slate-300"
+            onClick={() => void openProjectionWeekEditing(input.targetYearMonth, input.weekNo)}
+            disabled={!canUseCashflowActions || cashflowLease.busy || monthCloseResult?.status !== 'OPEN'}
+            aria-label={`${input.targetYearMonth} ${input.weekNo}주차 Projection 입력`}
+          >
+            -
+          </button>
         ) : isEditing ? (
           <Input
             value={projectionValue}
@@ -1625,9 +1652,15 @@ export function CashflowProjectSheet({
             }}
           />
         ) : (
-          <div className={`h-5 rounded-md px-1 text-right text-[8px] leading-5 tabular-nums ${shouldHighlightMismatch ? 'font-semibold text-rose-700' : 'text-slate-900'}`}>
+          <button
+            type="button"
+            className={`h-5 w-full rounded-md px-1 text-right text-[8px] leading-5 tabular-nums ${shouldHighlightMismatch ? 'font-semibold text-rose-700' : 'text-slate-900'}`}
+            onClick={() => void openProjectionWeekEditing(input.targetYearMonth, input.weekNo)}
+            disabled={!canUseCashflowActions || cashflowLease.busy || monthCloseResult?.status !== 'OPEN'}
+            aria-label={`${input.targetYearMonth} ${input.weekNo}주차 Projection 입력`}
+          >
             {fmt(projection)}
-          </div>
+          </button>
         )}
       </td>
     );
@@ -1730,22 +1763,6 @@ export function CashflowProjectSheet({
     const boardIsEditing = visibleWeeks.some((week) => (
       isWeekModeEditing({ yearMonth: week.yearMonth, mode: 'projection', weekNo: week.weekNo })
     ));
-    const setBoardEditing = (editing: boolean) => {
-      setShowEmptyCashflowRows((current) => (editing ? true : current));
-      setEditingWeekModes((current) => {
-        const next = { ...current };
-        for (const week of visibleWeeks) {
-          next[resolveWeekKey({ yearMonth: week.yearMonth, mode: 'projection', weekNo: week.weekNo })] = editing;
-          next[resolveWeekKey({ yearMonth: week.yearMonth, mode: 'actual', weekNo: week.weekNo })] = false;
-        }
-        return next;
-      });
-    };
-    const startBoardEditing = () => {
-      void beginCashflowEditing().then((started) => {
-        if (started) setBoardEditing(true);
-      });
-    };
     const scrollBoard = (direction: -1 | 1) => {
       const container = cashflowBoardScrollRef.current;
       if (!container) return;
@@ -1870,8 +1887,7 @@ export function CashflowProjectSheet({
         <CardContent className="p-0">
           <div className="flex flex-wrap items-center justify-between gap-3 bg-gradient-to-b from-white to-slate-50/70 px-5 py-4">
             <div>
-              <div className="text-[15px] font-bold tracking-[-0.01em] text-slate-950">캐시플로 진단시트</div>
-              <div className="mt-1 text-[10px] text-slate-500">기준 범위 {cashflowTotalPeriodLabel} · 서버 확정 원장 합계 · Projection 입력 / Actual 조회</div>
+              <div className="text-[15px] font-bold tracking-[-0.01em] text-slate-950">현금흐름 관리시트</div>
             </div>
             <div className="flex flex-wrap items-center justify-end gap-2">
               <label className="flex items-center gap-1 text-[10px] font-semibold text-slate-600">
@@ -1886,10 +1902,6 @@ export function CashflowProjectSheet({
               <Badge className={`h-8 rounded-full border-0 px-3 text-[10px] ${monthCloseStatusClass}`}>
                 {monthCloseLoading ? '상태 확인 중' : monthCloseStatusLabel}
               </Badge>
-              <Button type="button" size="sm" variant={boardIsEditing ? 'default' : 'outline'} className="h-8 rounded-full px-3 text-[11px] shadow-sm" onClick={startBoardEditing} disabled={!canUseCashflowActions || boardIsEditing || cashflowLease.busy || !cashflowLease.sessionId}>
-                {cashflowLease.busy ? <Loader2 className="mr-1 h-3 w-3 animate-spin" /> : <Pencil className="mr-1 h-3 w-3" />}
-                수정 시작
-              </Button>
               <Button type="button" size="sm" variant="outline" className="h-8 rounded-full border-0 bg-white px-3 text-[11px] shadow-sm" onClick={() => void savePrivateCashflowDraft().then(() => toast.success('작성자 전용 임시저장본을 저장했습니다.')).catch((error) => toast.error(resolveApiErrorMessage(error, '임시저장에 실패했습니다.')))} disabled={!canEdit || cashflowLease.busy || (!boardIsEditing && dirtyBoardWeeks.length === 0)}>
                 <Save className="mr-1 h-3 w-3" />
                 임시저장
@@ -1918,6 +1930,38 @@ export function CashflowProjectSheet({
               ) : null}
             </div>
           </div>
+          {financialYearChecks?.years.length ? (
+            <div className="grid gap-2 border-t border-slate-100 bg-slate-50/70 px-5 py-3 sm:grid-cols-2 xl:grid-cols-4">
+              {[...financialYearChecks.years.map((check) => ({ ...check, label: `${check.year}년` })), { ...financialYearChecks.total, label: '전체' }].map((check) => (
+                <div key={check.label} className="rounded-xl border border-slate-200 bg-white px-3 py-2 shadow-sm">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-[11px] font-bold text-slate-900">{check.label}</span>
+                    <span className={`text-[9px] font-semibold ${check.status === 'MATCH' ? 'text-emerald-700' : 'text-amber-700'}`}>
+                      {check.status === 'MATCH' ? '등록값과 일치' : check.status === 'SHEET_YEAR_MISSING' ? '시트 연도값 없음' : '확인 필요'}
+                    </span>
+                  </div>
+                  <div className="mt-2 space-y-1">
+                    {FINANCIAL_YEAR_CHECK_FIELDS.map((field) => {
+                      const differs = check.mismatches.includes(field.key);
+                      return (
+                        <div key={field.key} className={`flex items-center justify-between gap-2 text-[9px] ${differs ? 'text-amber-700' : 'text-slate-500'}`}>
+                          <span>{field.label}</span>
+                          <span className="text-right tabular-nums">시트 {fmt(check.sheet[field.key])} · 등록 {fmt(check.registered[field.key])}</span>
+                        </div>
+                      );
+                    })}
+                  </div>
+                  {check.status === 'MISMATCH' ? (
+                    <p className="mt-2 text-[9px] leading-4 text-amber-700">
+                      {FINANCIAL_YEAR_CHECK_FIELDS.filter((field) => check.mismatches.includes(field.key)).map((field) => field.label).join(', ')} 값이 시트와 다릅니다.
+                    </p>
+                  ) : check.status === 'SHEET_YEAR_MISSING' ? (
+                    <p className="mt-2 text-[9px] leading-4 text-amber-700">이 연도의 시트 주차와 값을 확인해 주세요.</p>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          ) : null}
           <div className="relative bg-slate-50/80 px-4 pb-4">
             <Button type="button" variant="outline" size="sm" className="absolute left-2 top-1/2 z-50 h-11 w-9 -translate-y-1/2 rounded-full border-0 bg-white/95 p-0 shadow-[0_10px_28px_rgba(15,23,42,0.16)]" onClick={() => scrollBoard(-1)} aria-label="왼쪽 주차로 이동">
               <ChevronLeft className="h-4 w-4" />
@@ -2547,6 +2591,9 @@ export function CashflowProjectSheet({
       : 'bg-amber-100 text-amber-800';
   const sheetDashboardMetadata = cashflowSheetMirror?.status === 'FRESH'
     ? cashflowSheetMirror.sheetFacts?.metadata
+    : undefined;
+  const financialYearChecks = cashflowSheetMirror?.status === 'FRESH'
+    ? cashflowSheetMirror.financialYearChecks
     : undefined;
   const hasSheetDepositSchedule = (cashflowSheetMirror?.status === 'FRESH'
     ? cashflowSheetMirror.sheetFacts?.depositScheduleRows

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -259,6 +259,28 @@ export interface CashflowSheetLabMirrorResult {
         expectedDepositAmount: string;
       };
     }>;
+    annualFinancialTotals?: Array<{
+      year: number;
+      contractAmount: number;
+      salesVatAmount: number;
+      totalRevenueAmount: number;
+      supportAmount: number;
+    }>;
+  };
+  financialYearChecks?: {
+    years: Array<{
+      year: number;
+      status: 'MATCH' | 'MISMATCH' | 'SHEET_YEAR_MISSING';
+      mismatches: Array<'contractAmount' | 'salesVatAmount' | 'totalRevenueAmount' | 'supportAmount'>;
+      registered: Record<'contractAmount' | 'salesVatAmount' | 'totalRevenueAmount' | 'supportAmount', number>;
+      sheet: Record<'contractAmount' | 'salesVatAmount' | 'totalRevenueAmount' | 'supportAmount', number>;
+    }>;
+    total: {
+      status: 'MATCH' | 'MISMATCH' | 'SHEET_YEAR_MISSING';
+      mismatches: Array<'contractAmount' | 'salesVatAmount' | 'totalRevenueAmount' | 'supportAmount'>;
+      registered: Record<'contractAmount' | 'salesVatAmount' | 'totalRevenueAmount' | 'supportAmount', number>;
+      sheet: Record<'contractAmount' | 'salesVatAmount' | 'totalRevenueAmount' | 'supportAmount', number>;
+    };
   };
   activeWeekRange?: CashflowSheetLabApplyResult['activeWeekRange'] & { activeWeeks?: unknown[] };
   lastRefreshAttemptAt?: string;


### PR DESCRIPTION
## 변경\n- 현금흐름 관리시트로 명칭 변경 및 수정 시작 버튼 제거\n- Projection 셀 클릭 시 해당 주차만 수정 세션 시작\n- 고정 시트값을 연도별 합산해 프로젝트 등록 financialYears와 대조\n- 불일치는 경고 표시만 하고 저장을 차단하지 않음\n\n## 검증\n- npm test -- --run server/bff/cashflow-sheet-snapshot.test.mjs server/bff/routes/cashflow-sheet-lab.test.mjs src/app/components/cashflow/CashflowProjectSheet.shell.test.ts\n- npm run build