### PR TITLE
fix: use pinned sheet for cashflow checks

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -351,7 +351,33 @@ function monthWeeksFromCells(cells, yearMonth) {
   });
 }
 
-function canonicalCashflowWeeks(cashflow, cells, yearMonth) {
+function canonicalPinnedSheetWeeks(pinnedSheetCells) {
+  const cellsByMonth = new Map();
+  for (const sourceCell of Array.isArray(pinnedSheetCells) ? pinnedSheetCells : []) {
+    const source = objectValue(sourceCell);
+    const yearMonth = readOptionalText(source?.yearMonth);
+    if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(yearMonth)) continue;
+    const cell = normalizeMonthCloseCell(source, yearMonth);
+    if (!cell) continue;
+    const monthCells = cellsByMonth.get(yearMonth) || [];
+    monthCells.push(cell);
+    cellsByMonth.set(yearMonth, monthCells);
+  }
+  return [...cellsByMonth.entries()]
+    .filter(([, monthCells]) => completeMonthCloseCells(monthCells))
+    .flatMap(([yearMonth, monthCells]) => monthWeeksFromCells(monthCells, yearMonth))
+    .sort((left, right) => cashflowRangeSortKey(left) - cashflowRangeSortKey(right));
+}
+
+function canonicalCashflowWeeks(cashflow, cells, yearMonth, pinnedSheetCells) {
+  const pinnedWeeks = canonicalPinnedSheetWeeks(pinnedSheetCells);
+  if (pinnedWeeks.length > 0) {
+    const byKey = new Map(pinnedWeeks.map((week) => [`${week.yearMonth}:${week.weekNo}`, week]));
+    if (completeMonthCloseCells(cells)) {
+      for (const week of monthWeeksFromCells(cells, yearMonth)) byKey.set(`${yearMonth}:${week.weekNo}`, week);
+    }
+    return [...byKey.values()].sort((left, right) => cashflowRangeSortKey(left) - cashflowRangeSortKey(right));
+  }
   const byKey = new Map();
   for (const month of Array.isArray(cashflow?.readModel?.months) ? cashflow.readModel.months : []) {
     const monthKey = readOptionalText(month?.yearMonth);
@@ -381,42 +407,18 @@ function managementCheck(id, status, title, detail) {
   return { id, status, title, detail };
 }
 
-function laborTransferCheck(project, weeks, yearMonth, asOfKey) {
-  const plan = objectValue(project?.laborTransferPlan) || {};
+function laborTransferCheck(weeks, yearMonth, asOfKey) {
   const monthWeeks = weeks.filter((week) => week.yearMonth === yearMonth);
-  const projectionTotal = monthWeeks.reduce((sum, week) => sum + safeAmount(week.projection?.MYSC_LABOR_OUT), 0);
-  const actualTotal = monthWeeks.reduce((sum, week) => sum + safeAmount(week.actual?.MYSC_LABOR_OUT), 0);
-  if (plan.mode === 'MONTHLY_WEEK_3') {
-    const week = monthWeeks.find((candidate) => candidate.weekNo === 3);
-    const projectionOk = safeAmount(week?.projection?.MYSC_LABOR_OUT) > 0;
-    const actualDue = cashflowRangeSortKey({ yearMonth, weekNo: 3 }) <= asOfKey;
-    const actualOk = !actualDue || safeAmount(week?.actual?.MYSC_LABOR_OUT) > 0;
-    return managementCheck(
-      'labor-transfer',
-      projectionOk && actualOk ? 'OK' : 'WARNING',
-      'MYSC 인건비 이관',
-      `3주차 Projection ${projectionOk ? '정상' : '미이관'} · Actual ${actualDue ? (actualOk ? '정상' : '미이관') : '기한 전'}`,
-    );
-  }
-  if (plan.mode === 'PAYMENT_MILESTONE') {
-    const amounts = objectValue(plan.milestoneAmounts) || {};
-    const expectedMonths = objectValue(project?.paymentExpectedMonths) || {};
-    const expected = ['contract', 'interim', 'final'].reduce((sum, key) => (
-      readOptionalText(expectedMonths[key]) === yearMonth ? sum + safeAmount(amounts[key]) : sum
-    ), 0);
-    if (expected <= 0) {
-      return managementCheck('labor-transfer', 'REVIEW_REQUIRED', 'MYSC 인건비 이관', '선금·중도금·잔금별 인건비 할당액을 프로젝트 등록에서 확인해 주세요.');
-    }
-    const projectionOk = projectionTotal >= expected;
-    const actualOk = actualTotal >= expected;
-    return managementCheck(
-      'labor-transfer',
-      projectionOk && actualOk ? 'OK' : 'WARNING',
-      'MYSC 인건비 이관',
-      `할당 ${expected.toLocaleString('ko-KR')}원 · Projection ${projectionTotal.toLocaleString('ko-KR')}원 · Actual ${actualTotal.toLocaleString('ko-KR')}원`,
-    );
-  }
-  return managementCheck('labor-transfer', 'REVIEW_REQUIRED', 'MYSC 인건비 이관', '프로젝트 등록에서 인건비 이관 방식을 선택해 주세요.');
+  const week = monthWeeks.find((candidate) => candidate.weekNo === 3);
+  const projectionOk = safeAmount(week?.projection?.MYSC_LABOR_OUT) > 0;
+  const actualDue = cashflowRangeSortKey({ yearMonth, weekNo: 3 }) <= asOfKey;
+  const actualOk = !actualDue || safeAmount(week?.actual?.MYSC_LABOR_OUT) > 0;
+  return managementCheck(
+    'labor-transfer',
+    projectionOk && actualOk ? 'OK' : 'WARNING',
+    'MYSC 인건비 이관',
+    `3주차 Projection ${projectionOk ? '정상' : '미이관'} · Actual ${actualDue ? (actualOk ? '정상' : '미이관') : '기한 전'}`,
+  );
 }
 
 function profitVatAfterDepositCheck(weeks, deposits, asOfKey) {
@@ -490,12 +492,12 @@ function futurePrepayCheck(weeks, asOfKey) {
   );
 }
 
-export function buildCashflowManagementChecks({ project, cashflow, cells, yearMonth, depositScheduleRows, comparisonBoundary }) {
-  const weeks = canonicalCashflowWeeks(cashflow, cells, yearMonth);
+export function buildCashflowManagementChecks({ cashflow, cells, yearMonth, depositScheduleRows, comparisonBoundary, pinnedSheetCells }) {
+  const weeks = canonicalCashflowWeeks(cashflow, cells, yearMonth, pinnedSheetCells);
   const asOfKey = cashflowRangeSortKey(comparisonBoundary?.asOfWeek || { yearMonth, weekNo: 5 });
   const deposits = (Array.isArray(depositScheduleRows) ? depositScheduleRows : []).map((row) => ({ ...row, yearMonth }));
   return [
-    laborTransferCheck(project, weeks, yearMonth, asOfKey),
+    laborTransferCheck(weeks, yearMonth, asOfKey),
     profitVatAfterDepositCheck(weeks, deposits, asOfKey),
     negativeProjectionCheck(weeks),
     futurePrepayCheck(weeks, asOfKey),
@@ -975,6 +977,7 @@ async function composeCashflowMonthDashboard({ db, req, projectId, yearMonth, cl
       yearMonth,
       depositScheduleRows,
       comparisonBoundary,
+      pinnedSheetCells: mirror?.cells,
     });
   const deadlineSummary = closedSnapshot?.deadlineSummary || await readCashflowDeadlineSummary({
     db,
@@ -1174,6 +1177,7 @@ async function composeCashflowMonthCloseBody({ db, req, projectId, cashflow, com
     yearMonth,
     depositScheduleRows: closeInput.depositScheduleRows,
     comparisonBoundary,
+    pinnedSheetCells: mirror.cells,
   });
   if (!matchingManagementChecks(managementChecks, closeInput.managementChecks)) {
     throw createHttpError(409, '주요 관리 항목 판정이 변경되었습니다. 다시 확인해 주세요.', 'cashflow_management_checks_stale');

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -40,7 +40,7 @@ const managementConfirmations = [
 ].map((checkId) => ({ checkId, decision: 'CONFIRMED' }));
 
 const emptyManagementChecks = [
-  { id: 'labor-transfer', status: 'REVIEW_REQUIRED', title: 'MYSC 인건비 이관', detail: '프로젝트 등록에서 인건비 이관 방식을 선택해 주세요.' },
+  { id: 'labor-transfer', status: 'WARNING', title: 'MYSC 인건비 이관', detail: '3주차 Projection 미이관 · Actual 미이관' },
   { id: 'profit-vat-after-deposit', status: 'REVIEW_REQUIRED', title: '입금 후 MYSC 수익·매출부가세 이관', detail: '실제 입금 확인 건이 없습니다. 해당 없음 여부를 사람이 확인해 주세요.' },
   { id: 'negative-projection-balance', status: 'OK', title: 'Projection 잔액 마이너스', detail: 'Projection 누적 잔액이 0원 이상입니다.' },
   { id: 'future-prepay-over-million', status: 'OK', title: '금주 이후 선입금 요청 100만원 초과', detail: '금주 이후 100만원 초과 요청이 없습니다.' },
@@ -453,7 +453,7 @@ describe('JVM weekly API BFF proxy', () => {
 
     expect(checks).toHaveLength(4);
     expect(checks.map((check) => [check.id, check.status])).toEqual([
-      ['labor-transfer', 'REVIEW_REQUIRED'],
+      ['labor-transfer', 'OK'],
       ['profit-vat-after-deposit', 'REVIEW_REQUIRED'],
       ['negative-projection-balance', 'WARNING'],
       ['future-prepay-over-million', 'OK'],
@@ -472,7 +472,7 @@ describe('JVM weekly API BFF proxy', () => {
         : row
     ));
     const checks = buildCashflowManagementChecks({
-      project: { laborTransferPlan: { mode: 'MONTHLY_WEEK_3', milestoneAmounts: {} } },
+      project: {},
       cashflow: {
         readModel: {
           months: [{
@@ -496,6 +496,44 @@ describe('JVM weekly API BFF proxy', () => {
     ]);
     expect(checks[1].detail).toContain('다음 주차 원장 없음');
     expect(checks[3].detail).toContain('1,000,001원');
+  });
+
+  it('uses the manually pinned sheet range instead of legacy JVM months for negative Projection balance', () => {
+    const { documents } = fullMonthCloseSource();
+    const mirror = documents.get('orgs/tenant-a/cashflow_sheet_mirrors/project-a');
+    const pinnedSheetCells = mirror.cells.map((cell) => ({
+      ...cell,
+      amount: cell.lineId === 'MYSC_PREPAY_IN' || cell.lineId === 'DIRECT_COST_OUT' ? 100 : 0,
+    }));
+    const cells = pinnedSheetCells.map(({ lineId, state, yearMonth: _yearMonth, direction: _direction, ...cell }) => ({
+      ...cell,
+      cashflowLine: lineId,
+      cellState: state,
+    }));
+    const checks = buildCashflowManagementChecks({
+      project: {},
+      cashflow: {
+        readModel: {
+          months: [{
+            yearMonth: '2024-09',
+            projection: { weeks: [{ weekNo: 2, amounts: { DIRECT_COST_OUT: 1_293_296 } }] },
+            actual: { weeks: [] },
+          }],
+        },
+      },
+      cells,
+      yearMonth: '2026-06',
+      pinnedSheetCells,
+      depositScheduleRows: [],
+      comparisonBoundary: { asOfWeek: { yearMonth: '2026-06', weekNo: 5 } },
+    });
+
+    expect(checks.find((check) => check.id === 'negative-projection-balance')).toEqual({
+      id: 'negative-projection-balance',
+      status: 'OK',
+      title: 'Projection 잔액 마이너스',
+      detail: 'Projection 누적 잔액이 0원 이상입니다.',
+    });
   });
 
   it('returns an empty usable dashboard when the project has no linked sheet', async () => {

--- a/server/bff/routes/projects.mjs
+++ b/server/bff/routes/projects.mjs
@@ -631,17 +631,13 @@ function normalizePaymentExpectedMonths(value) {
   };
 }
 
-function normalizeLaborTransferPlan(value) {
-  const source = value && typeof value === 'object' && !Array.isArray(value) ? value : {};
-  const mode = ['MONTHLY_WEEK_3', 'PAYMENT_MILESTONE'].includes(readOptionalText(source.mode))
-    ? readOptionalText(source.mode)
-    : 'UNDECIDED';
+function normalizeLaborTransferPlan(_value) {
   return {
-    mode,
+    mode: 'MONTHLY_WEEK_3',
     milestoneAmounts: {
-      contract: registrationAmount(source.milestoneAmounts?.contract),
-      interim: registrationAmount(source.milestoneAmounts?.interim),
-      final: registrationAmount(source.milestoneAmounts?.final),
+      contract: 0,
+      interim: 0,
+      final: 0,
     },
   };
 }

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -157,6 +157,12 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('재오픈 요청');
   });
 
+  it('keeps the board action next to the settlement status without a manual temporary-save button', () => {
+    const boardHeader = source.slice(source.indexOf('현금흐름 관리시트'), source.indexOf('{financialYearChecks?.years.length'));
+    expect(boardHeader).toContain('월 결산');
+    expect(boardHeader).not.toContain('작성자 전용 임시저장본을 저장했습니다.');
+  });
+
   it('opens only the selected Projection week and keeps multi-year sheet checks visible', () => {
     expect(source).toContain('현금흐름 관리시트');
     expect(source).not.toContain('캐시플로 진단시트');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1757,12 +1757,6 @@ export function CashflowProjectSheet({
       projection: readServerSummary('projection'),
       actual: readServerSummary('actual'),
     };
-    const dirtyBoardWeeks = visibleWeeks.filter((week) => (
-      weekSaveState[resolveWeekKey({ yearMonth: week.yearMonth, mode: 'projection', weekNo: week.weekNo })] === 'dirty'
-    ));
-    const boardIsEditing = visibleWeeks.some((week) => (
-      isWeekModeEditing({ yearMonth: week.yearMonth, mode: 'projection', weekNo: week.weekNo })
-    ));
     const scrollBoard = (direction: -1 | 1) => {
       const container = cashflowBoardScrollRef.current;
       if (!container) return;
@@ -1902,14 +1896,10 @@ export function CashflowProjectSheet({
               <Badge className={`h-8 rounded-full border-0 px-3 text-[10px] ${monthCloseStatusClass}`}>
                 {monthCloseLoading ? '상태 확인 중' : monthCloseStatusLabel}
               </Badge>
-              <Button type="button" size="sm" variant="outline" className="h-8 rounded-full border-0 bg-white px-3 text-[11px] shadow-sm" onClick={() => void savePrivateCashflowDraft().then(() => toast.success('작성자 전용 임시저장본을 저장했습니다.')).catch((error) => toast.error(resolveApiErrorMessage(error, '임시저장에 실패했습니다.')))} disabled={!canEdit || cashflowLease.busy || (!boardIsEditing && dirtyBoardWeeks.length === 0)}>
-                <Save className="mr-1 h-3 w-3" />
-                임시저장
-              </Button>
               {isPm && monthCloseResult?.status === 'OPEN' ? (
                 <Button type="button" size="sm" variant="outline" className="h-8 rounded-full border-0 bg-white px-3 text-[11px] shadow-sm" onClick={() => setMonthCloseReviewOpen(true)} disabled={!canEdit || cashflowLease.busy || monthCloseBusy}>
                   <CheckCircle2 className="mr-1 h-3 w-3" />
-                  최종저장 · 월 결산
+                  월 결산
                 </Button>
               ) : null}
               {isPm && monthCloseResult?.status === 'CLOSED' ? (

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -1915,45 +1915,6 @@ export function ProjectEditorWizard({
           <Input type="month" value={draft.paymentExpectedMonths.final} onChange={(event) => update('paymentExpectedMonths', { ...draft.paymentExpectedMonths, final: event.target.value })} className="mt-1 h-9 text-sm" />
         </div>
       </div>
-      <div className="space-y-3 rounded-xl border border-slate-200 bg-slate-50/70 p-4">
-        <div>
-          <Label className="text-xs font-semibold">MYSC 인건비 이관 방식</Label>
-          <Select
-            value={draft.laborTransferPlan.mode}
-            onValueChange={(mode) => update('laborTransferPlan', {
-              ...draft.laborTransferPlan,
-              mode: mode as typeof draft.laborTransferPlan.mode,
-            })}
-          >
-            <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue /></SelectTrigger>
-            <SelectContent>
-              <SelectItem value="UNDECIDED">미정</SelectItem>
-              <SelectItem value="MONTHLY_WEEK_3">매월 3주차 이관</SelectItem>
-              <SelectItem value="PAYMENT_MILESTONE">선금·중도금·잔금별 일괄 이관</SelectItem>
-            </SelectContent>
-          </Select>
-        </div>
-        {draft.laborTransferPlan.mode === 'PAYMENT_MILESTONE' ? (
-          <div className="grid gap-3 lg:grid-cols-3">
-            {(['contract', 'interim', 'final'] as const).map((key) => (
-              <div key={key}>
-                <Label className="text-xs">{key === 'contract' ? '선금' : key === 'interim' ? '중도금' : '잔금'} 인건비 할당액</Label>
-                <Input
-                  value={formatProjectAmountInput(draft.laborTransferPlan.milestoneAmounts[key], true)}
-                  onChange={(event) => update('laborTransferPlan', {
-                    ...draft.laborTransferPlan,
-                    milestoneAmounts: {
-                      ...draft.laborTransferPlan.milestoneAmounts,
-                      [key]: parseProjectAmountInput(event.target.value),
-                    },
-                  })}
-                  className="mt-1 h-9 text-sm"
-                />
-              </div>
-            ))}
-          </div>
-        ) : null}
-      </div>
       {advanceInterimRatio !== null && paymentPlanTotal > 0 ? (
         <div className={`rounded-lg border px-3 py-2 text-[12px] ${requiresAdvanceInterimReason ? 'border-amber-300 bg-amber-50 text-amber-900' : 'border-slate-200 bg-slate-50 text-slate-700'}`}>
           선금+중도금 비율 {(advanceInterimRatio * 100).toFixed(1)}%
@@ -2211,14 +2172,6 @@ export function ProjectEditorWizard({
             <ReviewRow label="중도금 예상월" value={draft.paymentExpectedMonths.interim} />
             <ReviewRow label="잔금" value={formatPaymentPlanAmount(draft.paymentPlan.final, draft.contractAmount)} />
             <ReviewRow label="잔금 예상월" value={draft.paymentExpectedMonths.final} />
-            <ReviewRow
-              label="MYSC 인건비 이관"
-              value={draft.laborTransferPlan.mode === 'MONTHLY_WEEK_3'
-                ? '매월 3주차'
-                : draft.laborTransferPlan.mode === 'PAYMENT_MILESTONE'
-                  ? `선금 ${fmtKRW(draft.laborTransferPlan.milestoneAmounts.contract)}원 · 중도금 ${fmtKRW(draft.laborTransferPlan.milestoneAmounts.interim)}원 · 잔금 ${fmtKRW(draft.laborTransferPlan.milestoneAmounts.final)}원`
-                  : '미정'}
-            />
             <ReviewRow label="선금+중도금 비율" value={advanceInterimRatio === null ? '-' : `${(advanceInterimRatio * 100).toFixed(1)}%`} />
             {requiresAdvanceInterimReason ? <ReviewRow label="70% 미만 사유" value={draft.advanceInterimBelow70Reason} /> : null}
             <ReviewRow label="입금 계획" value={draft.paymentPlanDesc} />

--- a/src/app/platform/project-editor.test.ts
+++ b/src/app/platform/project-editor.test.ts
@@ -106,6 +106,10 @@ describe('project editor draft mapping', () => {
     expect(draft.teamMembersDetailed).toEqual([
       { memberName: '김다은', memberNickname: '데이나', role: 'PM', participationRate: 60 },
     ]);
+    expect(draft.laborTransferPlan).toEqual({
+      mode: 'MONTHLY_WEEK_3',
+      milestoneAmounts: { contract: 0, interim: 0, final: 0 },
+    });
   });
 
   it('uses selected registeredBy member as the project owner source of truth', () => {

--- a/src/app/platform/project-editor.ts
+++ b/src/app/platform/project-editor.ts
@@ -201,7 +201,7 @@ const DEFAULT_DRAFT: ProjectEditorDraft = {
   groupwareName: '',
   paymentPlan: { contract: 0, interim: 0, final: 0 },
   paymentExpectedMonths: { contract: '', interim: '', final: '' },
-  laborTransferPlan: { mode: 'UNDECIDED', milestoneAmounts: { contract: 0, interim: 0, final: 0 } },
+  laborTransferPlan: { mode: 'MONTHLY_WEEK_3', milestoneAmounts: { contract: 0, interim: 0, final: 0 } },
   advanceInterimBelow70Reason: '',
   finalPaymentNote: '',
   budgetCurrentYear: 0,
@@ -344,13 +344,10 @@ function normalizePaymentExpectedMonths(
   };
 }
 
-function normalizeLaborTransferPlan(value: Partial<ProjectLaborTransferPlan> | null | undefined): ProjectLaborTransferPlan {
-  const mode = ['MONTHLY_WEEK_3', 'PAYMENT_MILESTONE'].includes(String(value?.mode || ''))
-    ? value?.mode as ProjectLaborTransferPlan['mode']
-    : 'UNDECIDED';
+function normalizeLaborTransferPlan(_value: Partial<ProjectLaborTransferPlan> | null | undefined): ProjectLaborTransferPlan {
   return {
-    mode,
-    milestoneAmounts: normalizePaymentPlan(value?.milestoneAmounts),
+    mode: 'MONTHLY_WEEK_3',
+    milestoneAmounts: { contract: 0, interim: 0, final: 0 },
   };
 }
 


### PR DESCRIPTION
## 변경\n- 주요 관리 항목의 누적 Projection 잔액을 수동으로 고정한 전체 시트 스냅샷 기준으로 계산\n- JVM의 과거 원장 월이 시트 범위 밖에서 경고를 만드는 문제 수정\n- 현금흐름 관리시트 헤더의 임시저장 버튼 제거 및 결산 전 옆 월 결산 버튼 유지\n- MYSC 인건비 이관을 프로젝트 설정과 무관하게 매월 3주차 원칙으로 통일\n\n## 검증\n- npm test -- --run server/bff/routes/jvm-weekly-api.test.mjs server/bff/routes/projects.test.ts src/app/components/cashflow/CashflowProjectSheet.shell.test.ts src/app/components/projects/ProjectEditorWizard.shell.test.ts src/app/platform/project-editor.test.ts\n- npm run build