### PR TITLE
fix: distinguish empty and zero labor transfers

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -403,21 +403,58 @@ function canonicalCashflowWeeks(cashflow, cells, yearMonth, pinnedSheetCells) {
   ));
 }
 
+function cashflowCellKey(yearMonth, cell) {
+  return `${yearMonth}:${cell.mode}:${cell.weekNo}:${cell.cashflowLine}`;
+}
+
+function canonicalCashflowCellStates(cells, yearMonth, pinnedSheetCells) {
+  const byKey = new Map();
+  for (const sourceCell of Array.isArray(pinnedSheetCells) ? pinnedSheetCells : []) {
+    const source = objectValue(sourceCell);
+    const sourceYearMonth = readOptionalText(source?.yearMonth);
+    if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(sourceYearMonth)) continue;
+    const cell = normalizeMonthCloseCell(source, sourceYearMonth);
+    if (cell) byKey.set(cashflowCellKey(sourceYearMonth, cell), cell);
+  }
+  for (const cell of Array.isArray(cells) ? cells : []) {
+    if (cell) byKey.set(cashflowCellKey(yearMonth, cell), cell);
+  }
+  return byKey;
+}
+
 function managementCheck(id, status, title, detail) {
   return { id, status, title, detail };
 }
 
-function laborTransferCheck(weeks, yearMonth, asOfKey) {
-  const monthWeeks = weeks.filter((week) => week.yearMonth === yearMonth);
-  const week = monthWeeks.find((candidate) => candidate.weekNo === 3);
-  const projectionOk = safeAmount(week?.projection?.MYSC_LABOR_OUT) > 0;
+function laborTransferCheck(weeks, cellStates, yearMonth, asOfKey) {
   const actualDue = cashflowRangeSortKey({ yearMonth, weekNo: 3 }) <= asOfKey;
-  const actualOk = !actualDue || safeAmount(week?.actual?.MYSC_LABOR_OUT) > 0;
+  if (!actualDue) {
+    return managementCheck('labor-transfer', 'REVIEW_REQUIRED', 'MYSC 인건비 이관', '3주차 도래 전입니다. Projection 인건비 입력을 준비해 주세요.');
+  }
+  const projection = cellStates.get(`${yearMonth}:projection:3:MYSC_LABOR_OUT`);
+  if (!projection || projection.cellState === 'EMPTY') {
+    return managementCheck('labor-transfer', 'WARNING', 'MYSC 인건비 이관', `${yearMonth} 3주차 · Projection 인건비 미기입`);
+  }
+  const plannedAmount = safeAmount(projection.amount);
+  if (plannedAmount === 0) {
+    return managementCheck('labor-transfer', 'REVIEW_REQUIRED', 'MYSC 인건비 이관', `${yearMonth} 3주차 · Projection 0원 입력 · 이관 대상 없음 확인 필요`);
+  }
+  const actual = cellStates.get(`${yearMonth}:actual:3:MYSC_LABOR_OUT`);
+  if (!actual || actual.cellState === 'EMPTY') {
+    return managementCheck('labor-transfer', 'WARNING', 'MYSC 인건비 이관', `${yearMonth} 3주차 · 예정 ${plannedAmount.toLocaleString('ko-KR')}원 · Actual 인건비 미기입`);
+  }
+  const actualAmount = safeAmount(actual.amount);
+  if (actualAmount === 0) {
+    return managementCheck('labor-transfer', 'WARNING', 'MYSC 인건비 이관', `${yearMonth} 3주차 · 예정 ${plannedAmount.toLocaleString('ko-KR')}원 · 실제 0원 · 실제 미이관`);
+  }
+  if (actualAmount < plannedAmount) {
+    return managementCheck('labor-transfer', 'WARNING', 'MYSC 인건비 이관', `${yearMonth} 3주차 · 예정 ${plannedAmount.toLocaleString('ko-KR')}원 · 실제 ${actualAmount.toLocaleString('ko-KR')}원 · 일부 이관`);
+  }
   return managementCheck(
     'labor-transfer',
-    projectionOk && actualOk ? 'OK' : 'WARNING',
+    'OK',
     'MYSC 인건비 이관',
-    `3주차 Projection ${projectionOk ? '정상' : '미이관'} · Actual ${actualDue ? (actualOk ? '정상' : '미이관') : '기한 전'}`,
+    `${yearMonth} 3주차 · 예정 ${plannedAmount.toLocaleString('ko-KR')}원 · 실제 ${actualAmount.toLocaleString('ko-KR')}원 · 이관 완료`,
   );
 }
 
@@ -494,10 +531,11 @@ function futurePrepayCheck(weeks, asOfKey) {
 
 export function buildCashflowManagementChecks({ cashflow, cells, yearMonth, depositScheduleRows, comparisonBoundary, pinnedSheetCells }) {
   const weeks = canonicalCashflowWeeks(cashflow, cells, yearMonth, pinnedSheetCells);
+  const cellStates = canonicalCashflowCellStates(cells, yearMonth, pinnedSheetCells);
   const asOfKey = cashflowRangeSortKey(comparisonBoundary?.asOfWeek || { yearMonth, weekNo: 5 });
   const deposits = (Array.isArray(depositScheduleRows) ? depositScheduleRows : []).map((row) => ({ ...row, yearMonth }));
   return [
-    laborTransferCheck(weeks, yearMonth, asOfKey),
+    laborTransferCheck(weeks, cellStates, yearMonth, asOfKey),
     profitVatAfterDepositCheck(weeks, deposits, asOfKey),
     negativeProjectionCheck(weeks),
     futurePrepayCheck(weeks, asOfKey),

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -40,7 +40,7 @@ const managementConfirmations = [
 ].map((checkId) => ({ checkId, decision: 'CONFIRMED' }));
 
 const emptyManagementChecks = [
-  { id: 'labor-transfer', status: 'WARNING', title: 'MYSC 인건비 이관', detail: '3주차 Projection 미이관 · Actual 미이관' },
+  { id: 'labor-transfer', status: 'WARNING', title: 'MYSC 인건비 이관', detail: '2026-06 3주차 · Projection 인건비 미기입' },
   { id: 'profit-vat-after-deposit', status: 'REVIEW_REQUIRED', title: '입금 후 MYSC 수익·매출부가세 이관', detail: '실제 입금 확인 건이 없습니다. 해당 없음 여부를 사람이 확인해 주세요.' },
   { id: 'negative-projection-balance', status: 'OK', title: 'Projection 잔액 마이너스', detail: 'Projection 누적 잔액이 0원 이상입니다.' },
   { id: 'future-prepay-over-million', status: 'OK', title: '금주 이후 선입금 요청 100만원 초과', detail: '금주 이후 100만원 초과 요청이 없습니다.' },
@@ -453,18 +453,19 @@ describe('JVM weekly API BFF proxy', () => {
 
     expect(checks).toHaveLength(4);
     expect(checks.map((check) => [check.id, check.status])).toEqual([
-      ['labor-transfer', 'OK'],
+      ['labor-transfer', 'WARNING'],
       ['profit-vat-after-deposit', 'REVIEW_REQUIRED'],
       ['negative-projection-balance', 'WARNING'],
       ['future-prepay-over-million', 'OK'],
     ]);
+    expect(checks[0].detail).toContain('일부 이관');
   });
 
   it('flags missing labor, post-deposit transfer, negative balance, and future prepay on the server', () => {
     const { documents } = fullMonthCloseSource();
     const draft = [...documents.values()].find((value) => value?.resourceType === 'cashflow');
     const cells = draft.payload.monthClose.cells.map((cell) => (
-      cell.weekNo === 3 && cell.cashflowLine === 'MYSC_LABOR_OUT' ? { ...cell, amount: 0 } : cell
+      cell.mode === 'actual' && cell.weekNo === 3 && cell.cashflowLine === 'MYSC_LABOR_OUT' ? { ...cell, amount: 0 } : cell
     ));
     const depositScheduleRows = draft.payload.monthClose.depositScheduleRows.map((row) => (
       row.weekNo === 5
@@ -495,7 +496,32 @@ describe('JVM weekly API BFF proxy', () => {
       ['future-prepay-over-million', 'WARNING'],
     ]);
     expect(checks[1].detail).toContain('다음 주차 원장 없음');
+    expect(checks[0].detail).toContain('실제 0원 · 실제 미이관');
     expect(checks[3].detail).toContain('1,000,001원');
+  });
+
+  it('prioritizes an empty third-week Projection over an explicit zero amount', () => {
+    const { documents } = fullMonthCloseSource();
+    const draft = [...documents.values()].find((value) => value?.resourceType === 'cashflow');
+    const cells = draft.payload.monthClose.cells.map((cell) => (
+      cell.mode === 'projection' && cell.weekNo === 3 && cell.cashflowLine === 'MYSC_LABOR_OUT'
+        ? { ...cell, cellState: 'EMPTY' }
+        : cell
+    ));
+    const checks = buildCashflowManagementChecks({
+      cashflow: { readModel: { months: [] } },
+      cells,
+      yearMonth: '2026-06',
+      depositScheduleRows: [],
+      comparisonBoundary: { asOfWeek: { yearMonth: '2026-07', weekNo: 2 } },
+    });
+
+    expect(checks.find((check) => check.id === 'labor-transfer')).toEqual({
+      id: 'labor-transfer',
+      status: 'WARNING',
+      title: 'MYSC 인건비 이관',
+      detail: '2026-06 3주차 · Projection 인건비 미기입',
+    });
   });
 
   it('uses the manually pinned sheet range instead of legacy JVM months for negative Projection balance', () => {


### PR DESCRIPTION
## 변경\n- 3주차 MYSC 인건비 Projection/Actual의 EMPTY와 VALUE(0)를 구분\n- Projection 미기입, Actual 미기입, 실제 0원 미이관, 일부 이관을 별도 판정\n- 기존 시트 고정 스냅샷 상태를 그대로 사용\n\n## 검증\n- npm test -- --run server/bff/routes/jvm-weekly-api.test.mjs\n- npm run build