### PR TITLE
feat: explicit cashflow ledger overwrite

### DIFF
--- a/server/bff/java-weekly-client.mjs
+++ b/server/bff/java-weekly-client.mjs
@@ -205,6 +205,7 @@ export function createJavaWeeklyClient({
     targetRevision,
     yearMonth,
     cells,
+    replaceAllActualSources = false,
   }) {
     const normalizedProjectId = encodeURIComponent(readOptionalText(projectId));
     if (!normalizedProjectId) {
@@ -241,6 +242,7 @@ export function createJavaWeeklyClient({
         targetRevision,
         yearMonth,
         cells,
+        replaceAllActualSources: replaceAllActualSources === true,
       },
     });
     if (readOptionalText(result?.projectId) !== readOptionalText(projectId)) {

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -894,7 +894,7 @@ async function readCashflowSheetStageMonth({ db, tenantId, projectId, runId, yea
   return value;
 }
 
-function buildPinnedSheetChangeCandidates({ tenantId, projectId, runId, mirror, cashflowSnapshot, context, now }) {
+function buildPinnedSheetChangeCandidates({ tenantId, projectId, runId, mirror, cashflowSnapshot, context, now, forceFullReplacement = false }) {
   const amountIndex = buildSnapshotAmountIndex(cashflowSnapshot);
   const weekIndex = new Map((cashflowSnapshot?.weeks || []).map((week) => [`${week.yearMonth}:${week.weekNo}`, week]));
   const blockedMonths = new Set((mirror?.cells || [])
@@ -931,7 +931,7 @@ function buildPinnedSheetChangeCandidates({ tenantId, projectId, runId, mirror, 
       const beforeAmount = beforeHadValue ? normalizeAppliedAmount(readIndexedSnapshotAmount(amountIndex, mapping)) : null;
       const proposedHadValue = cell.state === 'VALUE';
       const proposedAmount = proposedHadValue ? normalizeAppliedAmount(cell.amount) : null;
-      if (beforeHadValue === proposedHadValue && (!proposedHadValue || beforeAmount === proposedAmount)) return null;
+      if (!forceFullReplacement && beforeHadValue === proposedHadValue && (!proposedHadValue || beforeAmount === proposedAmount)) return null;
 
       const week = weekIndex.get(`${cell.yearMonth}:${cell.weekNo}`);
       const riskFlags = week?.adminClosed ? ['closed_week_change'] : [];
@@ -1123,7 +1123,12 @@ async function applyStagedCashflowSheetLab({
   }
 
   let stageRun = await readCashflowSheetStageRun(db, tenantId, projectId, stagedRunId);
-  const applyRequestHash = stableHash({ stagedRunId, applyRiskCandidates: Boolean(parsed.applyRiskCandidates) });
+  const replaceAllActualSources = stageRun.replaceAllActualSources === true;
+  const applyRequestHash = stableHash({
+    stagedRunId,
+    applyRiskCandidates: Boolean(parsed.applyRiskCandidates),
+    ...(replaceAllActualSources ? { replaceAllActualSources: true } : {}),
+  });
   if (readOptionalText(stageRun.status) === 'APPLIED') {
     assertApplyRequestMatches(stageRun, applyRequestHash);
     if (stageRun.applyResponse) return stageRun.applyResponse;
@@ -1242,6 +1247,7 @@ async function applyStagedCashflowSheetLab({
         targetRevision,
         yearMonth: month.yearMonth,
         cells: month.cells,
+        replaceAllActualSources,
       });
       targetRevision = assertResultingTargetRevision(javaResult);
       javaResults.push(javaResult);
@@ -1334,8 +1340,14 @@ async function stagePinnedCashflowSheetLab({
   logger('start', {
     projectId,
     expectedMirrorRevision: parsed.expectedMirrorRevision,
+    yearMonth: parsed.yearMonth || null,
+    replaceAllActualSources: Boolean(parsed.replaceAllActualSources),
   });
-  const requestHash = stableHash({ expectedMirrorRevision: parsed.expectedMirrorRevision });
+  const requestHash = stableHash({
+    expectedMirrorRevision: parsed.expectedMirrorRevision,
+    ...(parsed.yearMonth ? { yearMonth: parsed.yearMonth } : {}),
+    ...(parsed.replaceAllActualSources ? { replaceAllActualSources: true } : {}),
+  });
   const runId = `cfstage_${stableHash({ tenantId, projectId, idempotencyKey: parsed.idempotencyKey }).slice(0, 32)}`;
   const runRef = db.doc(`orgs/${tenantId}/${CASHFLOW_SHEET_STAGE_RUNS_COLLECTION_ID}/${runId}`);
   const mirror = await readCashflowSheetMirror(db, tenantId, projectId);
@@ -1358,7 +1370,10 @@ async function stagePinnedCashflowSheetLab({
     }
   }
 
-  const pinnedMonths = [...groupPinnedCellsByMonth(mirror.cells || []).keys()].sort();
+  const pinnedCells = parsed.yearMonth
+    ? (mirror.cells || []).filter((cell) => readOptionalText(cell.yearMonth) === parsed.yearMonth)
+    : (mirror.cells || []);
+  const pinnedMonths = [...groupPinnedCellsByMonth(pinnedCells).keys()].sort();
   if (pinnedMonths.length !== 1) {
     throw createHttpError(
       409,
@@ -1377,14 +1392,15 @@ async function stagePinnedCashflowSheetLab({
     tenantId,
     projectId,
     runId,
-    mirror,
+    mirror: { ...mirror, cells: pinnedCells },
     cashflowSnapshot,
     context,
     now,
+    forceFullReplacement: Boolean(parsed.replaceAllActualSources),
   });
   const projectionLineCount = candidates.filter((candidate) => candidate.mode === 'projection').length;
   const actualLineCount = candidates.filter((candidate) => candidate.mode === 'actual').length;
-  const cellsByMonth = groupPinnedCellsByMonth(mirror.cells || []);
+  const cellsByMonth = groupPinnedCellsByMonth(pinnedCells);
   const stagedMonths = [...new Set(candidates.map((candidate) => candidate.yearMonth))].sort();
   const stagedMonthDocuments = stagedMonths.map((yearMonth) => {
     const validated = validateCompletePinnedMonth(yearMonth, cellsByMonth.get(yearMonth) || []);
@@ -1416,6 +1432,7 @@ async function stagePinnedCashflowSheetLab({
     configRevision,
     sourceRevision: mirror.sourceRevision,
     targetRevisionAtFetch: mirror.targetRevisionAtFetch,
+    replaceAllActualSources: Boolean(parsed.replaceAllActualSources),
     activeWeekRange: mirror.activeWeekRange,
     runId,
     status: blockedMonths.length > 0 ? 'BLOCKED' : 'READY',
@@ -1443,6 +1460,7 @@ async function stagePinnedCashflowSheetLab({
     configRevision,
     sourceRevision: mirror.sourceRevision,
     targetRevisionAtFetch: mirror.targetRevisionAtFetch,
+    replaceAllActualSources: Boolean(parsed.replaceAllActualSources),
     status: response.status,
     stagedLineCount: candidates.length,
     blockedMonths,

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -1567,9 +1567,13 @@ describe('cashflow sheet lab route', () => {
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
       .send({
         expectedMirrorRevision: mirror.body.sourceRevision,
+        yearMonth: '2026-01',
+        replaceAllActualSources: true,
         idempotencyKey: 'stage-apply-001',
       })
       .expect(200);
+
+    expect(stage.body.replaceAllActualSources).toBe(true);
 
     const apply = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
@@ -1594,6 +1598,7 @@ describe('cashflow sheet lab route', () => {
       sourceRevision: mirror.body.sourceRevision,
       targetRevision: mirror.body.targetRevisionAtFetch,
       yearMonth: '2026-01',
+      replaceAllActualSources: true,
       cells: expect.arrayContaining([
         expect.objectContaining({
           mode: 'projection',

--- a/server/bff/schemas.mjs
+++ b/server/bff/schemas.mjs
@@ -178,6 +178,8 @@ export const cashflowSheetLabApplySchema = z.object({
 
 export const cashflowSheetLabStageSchema = z.object({
   expectedMirrorRevision: NON_EMPTY_STRING,
+  yearMonth: z.string().regex(/^20\d{2}-(0[1-9]|1[0-2])$/).optional(),
+  replaceAllActualSources: z.boolean().optional(),
   idempotencyKey: NON_EMPTY_STRING,
 }).strict();
 

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSheetLabApplyRequest.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSheetLabApplyRequest.java
@@ -23,6 +23,7 @@ public record CashflowSheetLabApplyRequest(
     @Size(min = WeeklyExpenseRequestLimits.MAX_YEAR_MONTH_LENGTH, max = WeeklyExpenseRequestLimits.MAX_YEAR_MONTH_LENGTH)
     @Pattern(regexp = "20\\d{2}-(0[1-9]|1[0-2])")
     String yearMonth,
+    boolean replaceAllActualSources,
     @Valid @NotNull @Size(min = 160, max = 160) List<Cell> cells
 ) {
     public static final int FINANCE_WEEK_COUNT = 5;

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -979,7 +979,8 @@ public class WeeklyExpenseCommandService {
             sourceSheetKey,
             request.yearMonth(),
             request.targetRevision(),
-            cells
+            cells,
+            request.replaceAllActualSources()
         );
         List<CashflowSnapshotResponse.ActualLine> actual = replacement.actual().stream()
             .map(line -> new CashflowSnapshotResponse.ActualLine(
@@ -1015,7 +1016,8 @@ public class WeeklyExpenseCommandService {
                 request.targetRevision(),
                 replacement.resultingTargetRevision(),
                 projection.size(),
-                actual.size()
+                actual.size(),
+                request.replaceAllActualSources()
             )
         ));
 
@@ -2382,7 +2384,8 @@ public class WeeklyExpenseCommandService {
         String targetRevision,
         String resultingTargetRevision,
         int projectionLineCount,
-        int actualLineCount
+        int actualLineCount,
+        boolean replaceAllActualSources
     ) {
         Map<String, Object> metadata = new LinkedHashMap<>();
         metadata.put("sourceSheetKey", sourceSheetKey);
@@ -2392,6 +2395,7 @@ public class WeeklyExpenseCommandService {
         metadata.put("resultingTargetRevision", resultingTargetRevision);
         metadata.put("projectionLineCount", projectionLineCount);
         metadata.put("actualLineCount", actualLineCount);
+        metadata.put("replaceAllActualSources", replaceAllActualSources);
         putActorMetadata(metadata, actor);
         return writeJson(metadata);
     }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowWeekActualMerge.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowWeekActualMerge.java
@@ -22,8 +22,21 @@ final class FirestoreCashflowWeekActualMerge {
         List<SaveDraftResponse.ActualDelta> sheetDeltas,
         Instant now
     ) {
+        return buildPatch(tenantId, projectId, sheetKey, existingDoc, sheetDeltas, now, false);
+    }
+
+    static Map<String, Object> buildPatch(
+        String tenantId,
+        String projectId,
+        String sheetKey,
+        Map<String, Object> existingDoc,
+        List<SaveDraftResponse.ActualDelta> sheetDeltas,
+        Instant now,
+        boolean replaceAllActualSources
+    ) {
         Map<String, Object> bySheet = nestedMap(existingDoc.get("weeklyExpenseActualBySheet"));
-        bySheet.remove(sheetKey);
+        if (replaceAllActualSources) bySheet.clear();
+        else bySheet.remove(sheetKey);
         Map<String, BigDecimal> currentSheet = new LinkedHashMap<>();
         for (SaveDraftResponse.ActualDelta delta : sheetDeltas) {
             currentSheet.merge(delta.cashflowLine(), amount(delta.amount()), BigDecimal::add);

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -680,6 +680,27 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         String targetRevision,
         List<CashflowSheetLabApplyRequest.Cell> cells
     ) {
+        return replaceCashflowSheetMonth(
+            tenantId,
+            projectId,
+            sourceSheetKey,
+            yearMonth,
+            targetRevision,
+            cells,
+            false
+        );
+    }
+
+    @Override
+    public CashflowSheetMonthReplacement replaceCashflowSheetMonth(
+        String tenantId,
+        String projectId,
+        String sourceSheetKey,
+        String yearMonth,
+        String targetRevision,
+        List<CashflowSheetLabApplyRequest.Cell> cells,
+        boolean replaceAllActualSources
+    ) {
         requireValidatedCashflowWriteScope(tenantId, projectId);
         cells = CashflowSheetLabApplyRequest.requireCompleteMonth(cells);
         requireCashflowMonthsOpen(tenantId, projectId, List.of(yearMonth));
@@ -775,7 +796,8 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                 sourceSheetKey,
                 existing,
                 actualDeltas,
-                now
+                now,
+                replaceAllActualSources
             ));
             replacements.put(docId, replacement);
         }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
@@ -223,6 +223,18 @@ public interface WeeklyExpensePersistence {
         );
     }
 
+    default CashflowSheetMonthReplacement replaceCashflowSheetMonth(
+        String tenantId,
+        String projectId,
+        String sourceSheetKey,
+        String yearMonth,
+        String targetRevision,
+        List<CashflowSheetLabApplyRequest.Cell> cells,
+        boolean replaceAllActualSources
+    ) {
+        return replaceCashflowSheetMonth(tenantId, projectId, sourceSheetKey, yearMonth, targetRevision, cells);
+    }
+
     default int countCashflowActualReplacementWrites(
         String tenantId,
         String projectId,

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowSheetMonthlyApplyServiceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowSheetMonthlyApplyServiceTest.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -51,7 +52,8 @@ class CashflowSheetMonthlyApplyServiceTest {
             eq("cashflow-sheet-lab"),
             eq("2026-07"),
             eq(TARGET_REVISION),
-            any()
+            any(),
+            anyBoolean()
         )).thenReturn(new WeeklyExpensePersistence.CashflowSheetMonthReplacement(
             List.of(),
             List.of(),
@@ -86,7 +88,27 @@ class CashflowSheetMonthlyApplyServiceTest {
             eq("cashflow-sheet-lab"),
             eq("2026-07"),
             eq(TARGET_REVISION),
-            any()
+            any(),
+            eq(false)
+        );
+    }
+
+    @Test
+    void forwardsAnExplicitInitialActualReplacementToPersistence() {
+        WeeklyExpensePersistence persistence = mock(WeeklyExpensePersistence.class);
+        when(persistence.requireCashflowWritePermission(ACTOR, "project-a")).thenReturn("pm");
+        when(persistence.findIdempotency(any(), any(), any(), any())).thenReturn(Optional.empty());
+        when(persistence.requireCashflowWriteLease(ACTOR, "project-a", SESSION)).thenReturn("pm");
+        when(persistence.replaceCashflowSheetMonth(
+            eq("tenant-a"), eq("project-a"), eq("cashflow-sheet-lab"), eq("2026-07"), eq(TARGET_REVISION), any(), eq(true)
+        )).thenReturn(new WeeklyExpensePersistence.CashflowSheetMonthReplacement(List.of(), List.of(), List.of(), TARGET_REVISION));
+        when(persistence.saveAuditEvent(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(persistence.saveIdempotency(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service(persistence).applyCashflowSheetLab(ACTOR, "project-a", SESSION, request("apply-replace-all", completeCells(5), true));
+
+        verify(persistence).replaceCashflowSheetMonth(
+            eq("tenant-a"), eq("project-a"), eq("cashflow-sheet-lab"), eq("2026-07"), eq(TARGET_REVISION), any(), eq(true)
         );
     }
 
@@ -255,11 +277,20 @@ class CashflowSheetMonthlyApplyServiceTest {
         String idempotencyKey,
         List<CashflowSheetLabApplyRequest.Cell> cells
     ) {
+        return request(idempotencyKey, cells, false);
+    }
+
+    private static CashflowSheetLabApplyRequest request(
+        String idempotencyKey,
+        List<CashflowSheetLabApplyRequest.Cell> cells,
+        boolean replaceAllActualSources
+    ) {
         return new CashflowSheetLabApplyRequest(
             idempotencyKey,
             SOURCE_REVISION,
             TARGET_REVISION,
             "2026-07",
+            replaceAllActualSources,
             cells
         );
     }

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -1614,6 +1614,7 @@ class FirestoreCashflowLeaseGuardTest {
             SOURCE_REVISION,
             targetRevision,
             yearMonth,
+            false,
             cells
         );
     }

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowWeekActualMergeTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowWeekActualMergeTest.java
@@ -83,6 +83,35 @@ class FirestoreCashflowWeekActualMergeTest {
     }
 
     @Test
+    void replacesAllActualSourcesOnlyWhenInitialLedgerOverwriteIsExplicit() {
+        Map<String, Object> existing = Map.of(
+            "weeklyExpenseActualBySheet", Map.of(
+                "bank-import", Map.of("SALES_IN", 10000),
+                "manual-entry", Map.of("DIRECT_COST_OUT", 2500)
+            )
+        );
+
+        Map<String, Object> patch = FirestoreCashflowWeekActualMerge.buildPatch(
+            "mysc",
+            "project-a",
+            "cashflow-sheet",
+            existing,
+            List.of(new SaveDraftResponse.ActualDelta("2026-06", 1, "SALES_IN", new BigDecimal("3000"))),
+            Instant.parse("2026-06-08T00:00:00Z"),
+            true
+        );
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> bySheet = (Map<String, Object>) patch.get("weeklyExpenseActualBySheet");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> actual = (Map<String, Object>) patch.get("actual");
+
+        assertThat(bySheet).containsOnlyKeys("cashflow-sheet");
+        assertThat(actual).containsExactly(Map.entry("SALES_IN", 3000L));
+        assertThat(patch.get("actualTotals")).isEqualTo(Map.of("totalIn", 3000L, "totalOut", 0L, "net", 3000L));
+    }
+
+    @Test
     void removesCurrentSheetContributionWhenSheetNoLongerHasActualDeltas() {
         Map<String, Object> existing = Map.of(
             "weeklyExpenseActualBySheet", Map.of(

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -124,6 +124,8 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('refreshCashflowSheetLabMirrorViaBff');
     expect(source).toContain('stageCashflowSheetLabViaBff');
     expect(source).toContain('시트값 불러오기');
+    expect(source).toContain('원장 덮어쓰기');
+    expect(source).toContain('replaceAllActualSources');
     expect(source).not.toContain('시트 연동하기');
     expect(source).not.toContain('최신값 다시 가져오기');
     expect(source).not.toContain('setInterval');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -399,6 +399,7 @@ export function CashflowProjectSheet({
     riskLineCount: number;
     candidates: CashflowSheetLabChangeCandidate[];
     omittedCandidateCount: number;
+    replaceAllActualSources: boolean;
   } | null>(null);
   const [sheetStageApplyLoading, setSheetStageApplyLoading] = useState(false);
   const [cashflowEvents, setCashflowEvents] = useState<CashflowEvent[]>([]);
@@ -1255,7 +1256,7 @@ export function CashflowProjectSheet({
     }
   }, [cashflowSheetConfig, orgId, projectId, resolveBffActor]);
 
-  const handleStagePinnedSheetValues = useCallback(async (): Promise<void> => {
+  const handleStagePinnedSheetValues = useCallback(async (replaceAllActualSources = false): Promise<void> => {
     if (cashflowSheetMirror?.status !== 'FRESH' || !cashflowSheetMirror.sourceRevision) {
       toast.error('먼저 시트값 불러오기를 실행해 고정해 주세요.');
       return;
@@ -1268,6 +1269,7 @@ export function CashflowProjectSheet({
         actor,
         projectId,
         expectedMirrorRevision,
+        ...(replaceAllActualSources ? { yearMonth, replaceAllActualSources: true } : {}),
         idempotencyKey: stageIdempotencyKey,
       })
     );
@@ -1287,9 +1289,10 @@ export function CashflowProjectSheet({
         riskLineCount: result.riskLineCount,
         candidates: result.candidates || [],
         omittedCandidateCount: result.omittedCandidateCount || 0,
+        replaceAllActualSources: result.replaceAllActualSources === true,
       });
       if (result.status === 'BLOCKED') toast.warning('검토가 필요한 월이 있어 바로 저장할 수 없습니다.');
-      else toast.success('고정된 시트 값과 원장 값을 비교했습니다.');
+      else toast.success(result.replaceAllActualSources ? '선택한 월의 원장 덮어쓰기 값을 준비했습니다.' : '고정된 시트 값과 원장 값을 비교했습니다.');
     };
     setSheetRefreshLoading(true);
     setSheetRefreshResult(null);
@@ -1316,7 +1319,7 @@ export function CashflowProjectSheet({
     } finally {
       setSheetRefreshLoading(false);
     }
-  }, [cashflowSheetMirror, orgId, projectId, resolveBffActor]);
+  }, [cashflowSheetMirror, orgId, projectId, resolveBffActor, yearMonth]);
 
   const handleApplyStagedSheetValues = useCallback(async (): Promise<void> => {
     if (!sheetStageDialog?.runId) {
@@ -1410,9 +1413,9 @@ export function CashflowProjectSheet({
     setSheetReviewDialogOpen(true);
   }, []);
 
-  const handleStartSheetChangeReview = useCallback(async (): Promise<void> => {
+  const handleStartSheetChangeReview = useCallback(async (replaceAllActualSources = false): Promise<void> => {
     setSheetReviewDialogOpen(false);
-    await handleStagePinnedSheetValues();
+    await handleStagePinnedSheetValues(replaceAllActualSources);
   }, [handleStagePinnedSheetValues]);
 
   const handleRevertCashflowRun = useCallback(async (_runId: string): Promise<void> => {
@@ -2959,10 +2962,16 @@ export function CashflowProjectSheet({
                 시트 연동 설정
               </AlertDialogAction>
             ) : (
-              <AlertDialogAction onClick={() => void handleStartSheetChangeReview()} disabled={sheetRefreshLoading || sheetMirrorStatus !== 'FRESH'} className="transition-transform hover:-translate-y-0.5">
-                {sheetRefreshLoading ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="mr-1.5 h-3.5 w-3.5" />}
-                고정값 비교하기
-              </AlertDialogAction>
+              <>
+                <Button type="button" variant="outline" onClick={() => void handleStartSheetChangeReview()} disabled={sheetRefreshLoading || sheetMirrorStatus !== 'FRESH'}>
+                  {sheetRefreshLoading ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="mr-1.5 h-3.5 w-3.5" />}
+                  고정값 비교하기
+                </Button>
+                <AlertDialogAction onClick={() => void handleStartSheetChangeReview(true)} disabled={sheetRefreshLoading || sheetMirrorStatus !== 'FRESH'} className="bg-rose-700 hover:bg-rose-800">
+                  {sheetRefreshLoading ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <Save className="mr-1.5 h-3.5 w-3.5" />}
+                  {yearMonth} 원장 덮어쓰기
+                </AlertDialogAction>
+              </>
             )}
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -2976,9 +2985,11 @@ export function CashflowProjectSheet({
       >
         <AlertDialogContent className="w-[calc(100vw-2rem)] max-w-[1100px]">
           <AlertDialogHeader>
-            <AlertDialogTitle>시트 값 비교 {sheetStageDialog?.stagedLineCount.toLocaleString() || 0}건</AlertDialogTitle>
+            <AlertDialogTitle>{sheetStageDialog?.replaceAllActualSources ? `${yearMonth} 원장 덮어쓰기` : `시트 값 비교 ${sheetStageDialog?.stagedLineCount.toLocaleString() || 0}건`}</AlertDialogTitle>
             <AlertDialogDescription>
-              원장은 아직 변경되지 않았습니다. 아래 변경 범위를 확인한 뒤 이 팝업에서 바로 저장합니다.
+              {sheetStageDialog?.replaceAllActualSources
+                ? '이 월의 Projection과 Actual 기존값을 모두 지우고, 고정한 시트 160개 셀로 교체합니다. 감사 이력은 유지됩니다.'
+                : '원장은 아직 변경되지 않았습니다. 아래 변경 범위를 확인한 뒤 이 팝업에서 바로 저장합니다.'}
             </AlertDialogDescription>
           </AlertDialogHeader>
           {sheetStageDialog && (
@@ -3017,10 +3028,12 @@ export function CashflowProjectSheet({
                   <div className="mt-1 text-[16px] font-bold text-amber-900">{sheetStageDialog.riskLineCount.toLocaleString()}건</div>
                 </div>
               </div>
-              <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-[11px] leading-5 text-slate-600">
-                Actual은 기존 값이 있어도 시트 값을 기준으로 덮어씁니다. 확인 필요 표시가 있는 행은 원장에 저장되지 않으니 별도로 확인해 주세요.
+              <div className={`rounded-lg border px-3 py-2 text-[11px] leading-5 ${sheetStageDialog.replaceAllActualSources ? 'border-rose-200 bg-rose-50 text-rose-900' : 'border-slate-200 bg-slate-50 text-slate-600'}`}>
+                {sheetStageDialog.replaceAllActualSources
+                  ? '기존 은행·수기 등 Actual 출처도 이 월에서는 삭제됩니다. 시트값이 이 월의 단일 기준인지 확인한 뒤 저장하세요.'
+                  : 'Actual은 시트 출처 값만 갱신하고 다른 출처 값은 유지합니다. 확인 필요 표시가 있는 행은 저장되지 않습니다.'}
               </div>
-              {renderSheetStageReviewGrid(sheetStageDialog)}
+              {!sheetStageDialog.replaceAllActualSources ? renderSheetStageReviewGrid(sheetStageDialog) : null}
               {sheetStageDialog.omittedCandidateCount > 0 ? (
                 <div className="rounded-lg border border-amber-100 bg-amber-50 px-3 py-2 text-[11px] text-amber-800">
                   표시되지 않은 변경 값 {sheetStageDialog.omittedCandidateCount.toLocaleString()}건
@@ -3038,7 +3051,9 @@ export function CashflowProjectSheet({
             >
               {sheetStageApplyLoading ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <Save className="mr-1.5 h-3.5 w-3.5" />}
               {sheetStageDialog && Math.max(0, sheetStageDialog.stagedLineCount - sheetStageDialog.riskLineCount) > 0
-                ? `검토한 값 ${Math.max(0, sheetStageDialog.stagedLineCount - sheetStageDialog.riskLineCount).toLocaleString()}건 원장에 저장`
+                ? sheetStageDialog.replaceAllActualSources
+                  ? `${yearMonth} 원장 전체 덮어쓰기`
+                  : `검토한 값 ${Math.max(0, sheetStageDialog.stagedLineCount - sheetStageDialog.riskLineCount).toLocaleString()}건 원장에 저장`
                 : '저장할 변경 없음'}
             </Button>
           </AlertDialogFooter>

--- a/src/app/lib/sheets-cashflow-readonly-client.test.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.test.ts
@@ -274,6 +274,8 @@ describe('sheets cashflow readonly client', () => {
       projectId: 'p001',
       expectedMirrorRevision: 'sha256:source-001',
       idempotencyKey: 'stage-001',
+      yearMonth: '2026-07',
+      replaceAllActualSources: true,
       client,
     });
 
@@ -285,6 +287,8 @@ describe('sheets cashflow readonly client', () => {
         body: {
           expectedMirrorRevision: 'sha256:source-001',
           idempotencyKey: 'stage-001',
+          yearMonth: '2026-07',
+          replaceAllActualSources: true,
         },
         idempotencyKey: 'stage-001',
       }),

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -297,6 +297,7 @@ export interface CashflowSheetLabStageResult {
   activeWeekRange?: CashflowSheetLabApplyResult['activeWeekRange'];
   sourceRevision?: string;
   targetRevisionAtFetch?: string;
+  replaceAllActualSources?: boolean;
   runId: string;
   status?: 'READY' | 'BLOCKED';
   stagedLineCount: number;
@@ -435,6 +436,8 @@ export async function stageCashflowSheetLabViaBff(params: {
   actor: ActorLike;
   projectId: string;
   expectedMirrorRevision: string;
+  yearMonth?: string;
+  replaceAllActualSources?: boolean;
   idempotencyKey: string;
   client?: PlatformApiClientLike;
 }): Promise<CashflowSheetLabStageResult> {
@@ -446,6 +449,8 @@ export async function stageCashflowSheetLabViaBff(params: {
       actor: toRequestActor(params.actor),
       body: {
         expectedMirrorRevision: params.expectedMirrorRevision,
+        ...(params.yearMonth ? { yearMonth: params.yearMonth } : {}),
+        ...(params.replaceAllActualSources ? { replaceAllActualSources: true } : {}),
         idempotencyKey: params.idempotencyKey,
       },
       idempotencyKey: params.idempotencyKey,


### PR DESCRIPTION
## 변경
- 선택한 월의 시트 고정값 160셀로 Projection·Actual 원장을 명시적으로 전체 덮어쓰기
- 일반 시트 불러오기/비교 경로는 비파괴로 유지
- Actual의 기존 은행·수기 출처 삭제를 2단계 경고·확정으로 제한하고 감사 메타데이터에 기록

## 검증
- npm test -- --run server/bff/routes/cashflow-sheet-lab.test.mjs src/app/lib/sheets-cashflow-readonly-client.test.ts src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
- npm run build
- mvn test -Dtest=CashflowSheetMonthlyApplyServiceTest,FirestoreCashflowWeekActualMergeTest,FirestoreCashflowLeaseGuardTest