### PR TITLE
fix: preserve default cashflow sheet apply contract

### DIFF
--- a/server/bff/java-weekly-client.mjs
+++ b/server/bff/java-weekly-client.mjs
@@ -242,7 +242,7 @@ export function createJavaWeeklyClient({
         targetRevision,
         yearMonth,
         cells,
-        replaceAllActualSources: replaceAllActualSources === true,
+        ...(replaceAllActualSources === true ? { replaceAllActualSources: true } : {}),
       },
     });
     if (readOptionalText(result?.projectId) !== readOptionalText(projectId)) {

--- a/server/bff/java-weekly-client.test.mjs
+++ b/server/bff/java-weekly-client.test.mjs
@@ -83,6 +83,28 @@ describe('Java weekly cashflow client', () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it('forwards the explicit initial-ledger overwrite flag only when requested', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ ok: true, projectId: 'project-a' }),
+    }));
+    const client = createJavaWeeklyClient({ env: stageEnv(), fetchImpl });
+
+    await client.applyCashflowSheetLab({
+      context,
+      projectId: 'project-a',
+      idempotencyKey: 'apply-overwrite-1',
+      ...monthlyContract,
+      replaceAllActualSources: true,
+      editSession: { sessionId: 'session-a', leaseId: 'lease-a', fence: 7 },
+    });
+
+    expect(JSON.parse(fetchImpl.mock.calls[0][1].body)).toMatchObject({
+      replaceAllActualSources: true,
+    });
+  });
+
   it('rejects a JVM response for another project', async () => {
     const fetchImpl = vi.fn(async () => ({
       ok: true,


### PR DESCRIPTION
Normal sheet apply requests now omit the overwrite field; only an explicit initial-ledger overwrite sends it.

Validated with full `npm test` and `npm run build`.