### PR TITLE
fix: monitor cashflow checks across project period

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -427,34 +427,39 @@ function managementCheck(id, status, title, detail) {
 }
 
 function laborTransferCheck(weeks, cellStates, yearMonth, asOfKey) {
-  const actualDue = cashflowRangeSortKey({ yearMonth, weekNo: 3 }) <= asOfKey;
-  if (!actualDue) {
-    return managementCheck('labor-transfer', 'REVIEW_REQUIRED', 'MYSC 인건비 이관', '3주차 도래 전입니다. Projection 인건비 입력을 준비해 주세요.');
+  const yearMonths = [...new Set([yearMonth, ...weeks.map((week) => readOptionalText(week.yearMonth))])].sort();
+  const warnings = [];
+  const reviews = [];
+  for (const yearMonth of yearMonths) {
+    if (cashflowRangeSortKey({ yearMonth, weekNo: 3 }) > asOfKey) continue;
+    const projection = cellStates.get(`${yearMonth}:projection:3:MYSC_LABOR_OUT`);
+    if (!projection || projection.cellState === 'EMPTY') {
+      warnings.push(`${yearMonth} 3주차 · Projection 인건비 미기입`);
+      continue;
+    }
+    const plannedAmount = safeAmount(projection.amount);
+    if (plannedAmount === 0) {
+      reviews.push(`${yearMonth} 3주차 · Projection 0원 입력 · 이관 대상 없음 확인 필요`);
+      continue;
+    }
+    const actual = cellStates.get(`${yearMonth}:actual:3:MYSC_LABOR_OUT`);
+    if (!actual || actual.cellState === 'EMPTY') {
+      warnings.push(`${yearMonth} 3주차 · 예정 ${plannedAmount.toLocaleString('ko-KR')}원 · Actual 인건비 미기입`);
+      continue;
+    }
+    const actualAmount = safeAmount(actual.amount);
+    if (actualAmount === 0) {
+      warnings.push(`${yearMonth} 3주차 · 예정 ${plannedAmount.toLocaleString('ko-KR')}원 · 실제 0원 · 실제 미이관`);
+    } else if (actualAmount < plannedAmount) {
+      warnings.push(`${yearMonth} 3주차 · 예정 ${plannedAmount.toLocaleString('ko-KR')}원 · 실제 ${actualAmount.toLocaleString('ko-KR')}원 · 일부 이관`);
+    }
   }
-  const projection = cellStates.get(`${yearMonth}:projection:3:MYSC_LABOR_OUT`);
-  if (!projection || projection.cellState === 'EMPTY') {
-    return managementCheck('labor-transfer', 'WARNING', 'MYSC 인건비 이관', `${yearMonth} 3주차 · Projection 인건비 미기입`);
-  }
-  const plannedAmount = safeAmount(projection.amount);
-  if (plannedAmount === 0) {
-    return managementCheck('labor-transfer', 'REVIEW_REQUIRED', 'MYSC 인건비 이관', `${yearMonth} 3주차 · Projection 0원 입력 · 이관 대상 없음 확인 필요`);
-  }
-  const actual = cellStates.get(`${yearMonth}:actual:3:MYSC_LABOR_OUT`);
-  if (!actual || actual.cellState === 'EMPTY') {
-    return managementCheck('labor-transfer', 'WARNING', 'MYSC 인건비 이관', `${yearMonth} 3주차 · 예정 ${plannedAmount.toLocaleString('ko-KR')}원 · Actual 인건비 미기입`);
-  }
-  const actualAmount = safeAmount(actual.amount);
-  if (actualAmount === 0) {
-    return managementCheck('labor-transfer', 'WARNING', 'MYSC 인건비 이관', `${yearMonth} 3주차 · 예정 ${plannedAmount.toLocaleString('ko-KR')}원 · 실제 0원 · 실제 미이관`);
-  }
-  if (actualAmount < plannedAmount) {
-    return managementCheck('labor-transfer', 'WARNING', 'MYSC 인건비 이관', `${yearMonth} 3주차 · 예정 ${plannedAmount.toLocaleString('ko-KR')}원 · 실제 ${actualAmount.toLocaleString('ko-KR')}원 · 일부 이관`);
-  }
+  const findings = warnings.length > 0 ? warnings : reviews;
   return managementCheck(
     'labor-transfer',
-    'OK',
+    warnings.length > 0 ? 'WARNING' : reviews.length > 0 ? 'REVIEW_REQUIRED' : 'OK',
     'MYSC 인건비 이관',
-    `${yearMonth} 3주차 · 예정 ${plannedAmount.toLocaleString('ko-KR')}원 · 실제 ${actualAmount.toLocaleString('ko-KR')}원 · 이관 완료`,
+    findings.length > 0 ? findings.join(', ') : '기준일까지 모든 3주차 인건비 이관을 확인했습니다.',
   );
 }
 
@@ -533,7 +538,10 @@ export function buildCashflowManagementChecks({ cashflow, cells, yearMonth, depo
   const weeks = canonicalCashflowWeeks(cashflow, cells, yearMonth, pinnedSheetCells);
   const cellStates = canonicalCashflowCellStates(cells, yearMonth, pinnedSheetCells);
   const asOfKey = cashflowRangeSortKey(comparisonBoundary?.asOfWeek || { yearMonth, weekNo: 5 });
-  const deposits = (Array.isArray(depositScheduleRows) ? depositScheduleRows : []).map((row) => ({ ...row, yearMonth }));
+  const deposits = (Array.isArray(depositScheduleRows) ? depositScheduleRows : []).map((row) => ({
+    ...row,
+    yearMonth: /^20\d{2}-(0[1-9]|1[0-2])$/.test(readOptionalText(row?.yearMonth)) ? row.yearMonth : yearMonth,
+  }));
   return [
     laborTransferCheck(weeks, cellStates, yearMonth, asOfKey),
     profitVatAfterDepositCheck(weeks, deposits, asOfKey),
@@ -1013,7 +1021,7 @@ async function composeCashflowMonthDashboard({ db, req, projectId, yearMonth, cl
       cashflow,
       cells,
       yearMonth,
-      depositScheduleRows,
+      depositScheduleRows: sheetFacts?.depositScheduleRows || depositScheduleRows,
       comparisonBoundary,
       pinnedSheetCells: mirror?.cells,
     });

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -524,6 +524,38 @@ describe('JVM weekly API BFF proxy', () => {
     });
   });
 
+  it('monitors labor and post-deposit transfers across the full pinned project period', () => {
+    const { documents } = fullMonthCloseSource();
+    const mirror = documents.get('orgs/tenant-a/cashflow_sheet_mirrors/project-a');
+    const juneCells = mirror.cells.map((cell) => (
+      cell.mode === 'actual' && cell.weekNo === 3 && cell.lineId === 'MYSC_LABOR_OUT'
+        ? { ...cell, amount: 10 }
+        : cell
+    ));
+    const julyCells = juneCells.map((cell) => ({
+      ...cell,
+      yearMonth: '2026-07',
+      state: cell.mode === 'projection' && cell.weekNo === 3 && cell.lineId === 'MYSC_LABOR_OUT' ? 'EMPTY' : cell.state,
+      amount: cell.mode === 'actual' && cell.weekNo === 2 && ['MYSC_PROFIT_OUT', 'SALES_VAT_OUT'].includes(cell.lineId) ? 0 : cell.amount,
+    }));
+    const currentCells = juneCells.map(({ lineId, state, yearMonth: _yearMonth, direction: _direction, ...cell }) => ({
+      ...cell, cashflowLine: lineId, cellState: state,
+    }));
+    const checks = buildCashflowManagementChecks({
+      cashflow: { readModel: { months: [] } },
+      cells: currentCells,
+      yearMonth: '2026-06',
+      pinnedSheetCells: [...juneCells, ...julyCells],
+      depositScheduleRows: [{
+        yearMonth: '2026-07', weekNo: 1, actualDepositDate: '2026-07-01', actualDepositAmount: 1_000_000,
+      }],
+      comparisonBoundary: { asOfWeek: { yearMonth: '2026-08', weekNo: 3 } },
+    });
+
+    expect(checks.find((check) => check.id === 'labor-transfer')?.detail).toContain('2026-07 3주차 · Projection 인건비 미기입');
+    expect(checks.find((check) => check.id === 'profit-vat-after-deposit')?.detail).toContain('2026-07 2주차 MYSC 수익·매출부가세');
+  });
+
   it('uses the manually pinned sheet range instead of legacy JVM months for negative Projection balance', () => {
     const { documents } = fullMonthCloseSource();
     const mirror = documents.get('orgs/tenant-a/cashflow_sheet_mirrors/project-a');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -2244,7 +2244,7 @@ export function CashflowProjectSheet({
             <div className="rounded-[20px] bg-white px-3.5 py-3 shadow-[0_8px_24px_rgba(15,23,42,0.06)]">
               <div className="mb-2 flex items-center justify-between gap-2">
                 <div className="text-[11px] font-bold text-slate-900">주요 관리 항목</div>
-                <span className="text-[9px] text-slate-400">BFF/JVM 서버 판정</span>
+                <span className="text-[9px] text-slate-400">프로젝트 전체 기간 · BFF/JVM 서버 판정</span>
               </div>
               <div className="space-y-2">
                 {(monthCloseResult?.dashboard?.managementChecks || []).map((check) => {


### PR DESCRIPTION
Makes the four management checks inspect the full pinned sheet range for open-month operations. Closed-month snapshots remain immutable.

Validated: `npm test -- --run server/bff/routes/jvm-weekly-api.test.mjs`; `npm run build`.