### PR TITLE
feat: 현금흐름 시트 불러오기·월 결산 변경 이력

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -246,6 +246,66 @@ function objectValue(value) {
   return value && typeof value === 'object' && !Array.isArray(value) ? value : null;
 }
 
+function parseAuditMetadata(value) {
+  try {
+    return objectValue(JSON.parse(readOptionalText(value) || '{}')) || {};
+  } catch {
+    return {};
+  }
+}
+
+async function readCashflowActivityDocuments(db, tenantId, collectionId, projectId) {
+  if (!db?.collection) return [];
+  const snap = await db.collection(`orgs/${tenantId}/${collectionId}`)
+    .where('projectId', '==', projectId)
+    .limit(200)
+    .get();
+  return snap.docs.map((doc) => ({ id: doc.id, ...(doc.data() || {}) }));
+}
+
+async function readCashflowActivity(db, tenantId, projectId) {
+  const [refreshRuns, monthlyAudits, legacyEvents] = await Promise.all([
+    readCashflowActivityDocuments(db, tenantId, 'cashflow_sheet_refresh_runs', projectId),
+    readCashflowActivityDocuments(db, tenantId, 'weekly_api_audit_events', projectId),
+    readCashflowActivityDocuments(db, tenantId, 'cashflow_events', projectId),
+  ]);
+  const refreshEvents = refreshRuns
+    .filter((run) => readOptionalText(run.status) === 'COMPLETED' && readOptionalText(run.response?.status) === 'FRESH')
+    .map((run) => ({
+      id: `sheet-refresh:${run.id}`,
+      projectId,
+      runId: readOptionalText(run.idempotencyKey) || run.id,
+      type: 'sheet_refresh',
+      source: 'google_sheet_refresh',
+      actorUid: readOptionalText(run.createdBy?.uid),
+      actorEmail: readOptionalText(run.createdBy?.email),
+      createdAt: readOptionalText(run.completedAt) || readOptionalText(run.createdAt),
+      sheetName: readOptionalText(run.response?.selectedSheetName),
+    }));
+  const closeEvents = monthlyAudits
+    .filter((audit) => readOptionalText(audit.commandName).startsWith('cashflowMonth.'))
+    .map((audit) => {
+      const metadata = parseAuditMetadata(audit.metadataJson);
+      return {
+        id: `month-close:${audit.id}`,
+        projectId,
+        runId: readOptionalText(audit.idempotencyKey) || audit.id,
+        type: 'month_close',
+        source: 'month_close',
+        yearMonth: readOptionalText(metadata.yearMonth),
+        status: readOptionalText(metadata.status),
+        actorUid: readOptionalText(audit.actorId),
+        actorEmail: readOptionalText(metadata.actorEmail),
+        actorName: readOptionalText(metadata.actorName),
+        createdAt: readOptionalText(audit.createdAt),
+      };
+    });
+  return [...legacyEvents, ...refreshEvents, ...closeEvents]
+    .filter((event) => readOptionalText(event.createdAt))
+    .sort((left, right) => readOptionalText(right.createdAt).localeCompare(readOptionalText(left.createdAt)))
+    .slice(0, 200);
+}
+
 function safeAmount(value) {
   const amount = Number(value);
   return Number.isSafeInteger(amount) ? amount : 0;
@@ -1505,6 +1565,15 @@ export function mountJvmWeeklyApiRoutes(app, {
       { cashflowWrite: true },
     );
     return { status: 200, body: result };
+  }));
+
+  app.get('/api/v1/cashflow/:projectId/activity', asyncHandler(async (req, res) => {
+    assertWeeklyWorkspaceOrRoleAllowed(req, ROUTE_ROLES.readCore, 'read cashflow activity', authMode, workspaceEmailDomain);
+    const projectId = readOptionalText(req.params.projectId);
+    res.status(200).json({
+      projectId,
+      events: await readCashflowActivity(db, readOptionalText(req.context?.tenantId), projectId),
+    });
   }));
 
   app.get('/api/v1/cashflow/:projectId/month-close', asyncHandler(async (req, res) => {

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -392,6 +392,43 @@ describe('JVM weekly API BFF proxy', () => {
     expect(fetchImpl.mock.calls[0][1].body).toBeUndefined();
   });
 
+  it('combines explicit sheet refresh and JVM month-close audit records for the activity timeline', async () => {
+    const eventsByCollection = {
+      cashflow_sheet_refresh_runs: [{
+        id: 'refresh-1', projectId: 'project-a', idempotencyKey: 'refresh-key', status: 'COMPLETED',
+        createdAt: '2026-07-01T00:00:00.000Z', completedAt: '2026-07-01T00:01:00.000Z',
+        createdBy: { uid: 'pm-1', email: 'pm@example.com' },
+        response: { status: 'FRESH', selectedSheetName: 'cashflow(사용내역 연동)' },
+      }],
+      weekly_api_audit_events: [{
+        id: 'close-1', projectId: 'project-a', idempotencyKey: 'close-key', commandName: 'cashflowMonth.close',
+        actorId: 'pm-1', createdAt: '2026-07-02T00:00:00.000Z',
+        metadataJson: JSON.stringify({ yearMonth: '2026-06', status: 'CLOSED', actorEmail: 'pm@example.com' }),
+      }],
+      cashflow_events: [],
+    };
+    const db = {
+      collection: (path) => ({
+        where: () => ({
+          limit: () => ({
+            get: async () => ({ docs: (eventsByCollection[path.split('/').at(-1)] || []).map((data) => ({ id: data.id, data: () => data })) }),
+          }),
+        }),
+      }),
+    };
+    const { app } = createApp(vi.fn(), createIdempotencyService(), {}, { env: stageEnv, db });
+
+    await request(app)
+      .get('/api/v1/cashflow/project-a/activity')
+      .expect(200)
+      .expect((response) => {
+        expect(response.body.events).toMatchObject([
+          { type: 'month_close', yearMonth: '2026-06', status: 'CLOSED' },
+          { type: 'sheet_refresh', sheetName: 'cashflow(사용내역 연동)' },
+        ]);
+      });
+  });
+
   it('composes the open-month dashboard from the pinned sheet, private draft, project, and JVM state', async () => {
     const { db, sourceRevision, targetRevision } = fullMonthCloseSource();
     const fetchImpl = vi.fn(async (url) => ({

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -124,6 +124,8 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('refreshCashflowSheetLabMirrorViaBff');
     expect(source).toContain('stageCashflowSheetLabViaBff');
     expect(source).toContain('시트값 불러오기');
+    expect(source).toContain('시트 값 불러오기');
+    expect(source).toContain('fetchCashflowActivityViaBff');
     expect(source).toContain('원장 덮어쓰기');
     expect(source).toContain('replaceAllActualSources');
     expect(source).not.toContain('시트 연동하기');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -35,6 +35,7 @@ import { getAuthInstance, getOrgCollectionPath, getOrgDocumentPath } from '../..
 import { resolveApiErrorMessage } from '../../platform/api-error-message';
 import {
   fetchCashflowSnapshotViaBff,
+  fetchCashflowActivityViaBff,
   closeCashflowMonthViaBff,
   decideCashflowMonthReopenViaBff,
   fetchCashflowMonthCloseViaBff,
@@ -44,6 +45,7 @@ import {
   type CashflowMonthCloseResult,
   type CashflowDeadlineSummary,
   type CashflowSnapshotResult,
+  type CashflowActivityEvent,
 } from '../../lib/platform-bff-client';
 import { getCashflowModeLineLabel } from '../../platform/policies/cashflow-policy';
 import { getSnappedWeekScrollLeft } from './cashflow-board-scroll';
@@ -101,40 +103,7 @@ function formatSheetAppliedAt(value?: string): string {
   }).format(date);
 }
 
-type CashflowEventType =
-  | 'sheet_apply'
-  | 'projection_amount_change'
-  | 'actual_amount_change'
-  | 'projection_completed'
-  | 'actual_completed'
-  | 'admin_closed'
-  | 'sheet_apply_reverted';
-
-type CashflowEvent = {
-  id?: string;
-  tenantId?: string;
-  projectId: string;
-  runId: string;
-  type: CashflowEventType;
-  source?: 'manual' | 'google_sheet_apply' | 'revert';
-  yearMonth?: string;
-  weekNo?: number;
-  mode?: 'projection' | 'actual';
-  lineId?: CashflowSheetLineId;
-  beforeAmount?: number;
-  afterAmount?: number;
-  beforeHadValue?: boolean;
-  afterHadValue?: boolean;
-  appliedLineCount?: number;
-  projectionLineCount?: number;
-  actualLineCount?: number;
-  revertedRunId?: string;
-  actorUid?: string;
-  actorName?: string;
-  actorEmail?: string;
-  createdAt: string;
-  revertedAt?: string;
-};
+type CashflowEvent = CashflowActivityEvent & { revertedAt?: string };
 
 function diffColorExplanation(section: '입금' | '출금', diff: number): string {
   if (diff === 0) return '차이가 없습니다.';
@@ -921,40 +890,30 @@ export function CashflowProjectSheet({
   }, [loadCashflowSheetRangeWeeks]);
 
   const loadCashflowEvents = useCallback(async (): Promise<void> => {
-    if (!db || !projectId) {
+    if (!projectId || !orgId || !user?.uid) {
       setCashflowEvents([]);
       setCashflowEventsError(null);
       return;
     }
-    const base = collection(db, getOrgCollectionPath(orgId, 'cashflowEvents'));
-    const targetProjectId = String(projectId || '').trim();
-    const readCashflowEventsSnapshot = async (filterByProject: boolean): Promise<CashflowEvent[]> => {
-      const snap = await getDocs(filterByProject
-        ? query(base, where('projectId', '==', projectId), limit(200))
-        : query(base, limit(500)));
-      return snap.docs
-        .map((d) => ({ id: d.id, ...(d.data() as Omit<CashflowEvent, 'id'>) }))
-        .filter((event) => String(event.projectId || '').trim() === targetProjectId)
-        .sort((a, b) => String(b.createdAt || '').localeCompare(String(a.createdAt || '')))
-        .slice(0, 200);
-    };
-
     try {
-      let events = await readCashflowEventsSnapshot(true);
-      if (events.length === 0) events = await readCashflowEventsSnapshot(false);
-      setCashflowEvents(events);
+      let actor = await resolveBffActor();
+      if (!actor?.idToken) throw new Error('로그인 세션이 만료되었습니다.');
+      try {
+        const response = await fetchCashflowActivityViaBff({ tenantId: orgId, actor, projectId });
+        setCashflowEvents(response.events);
+      } catch (error) {
+        if (!isBffAuthRejection(error)) throw error;
+        actor = await resolveBffActor({ forceRefresh: true });
+        if (!actor?.idToken) throw error;
+        const response = await fetchCashflowActivityViaBff({ tenantId: orgId, actor, projectId });
+        setCashflowEvents(response.events);
+      }
       setCashflowEventsError(null);
     } catch (error) {
-      try {
-        const events = await readCashflowEventsSnapshot(false);
-        setCashflowEvents(events);
-        setCashflowEventsError(null);
-      } catch {
-        setCashflowEvents([]);
-        setCashflowEventsError(resolveApiErrorMessage(error, '변경 이력을 불러오지 못했습니다.'));
-      }
+      setCashflowEvents([]);
+      setCashflowEventsError(resolveApiErrorMessage(error, '변경 이력을 불러오지 못했습니다.'));
     }
-  }, [db, orgId, projectId]);
+  }, [orgId, projectId, resolveBffActor, user?.uid]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1223,6 +1182,7 @@ export function CashflowProjectSheet({
       setSheetRefreshResult(null);
       setSheetStageDialog(null);
       if (mirror.status === 'FRESH' && mirror.sourceRevision) {
+        void loadCashflowEvents();
         toast.success('시트값을 고정했습니다. 저장할 값을 확인해 주세요.');
       } else if (mirror.status === 'STALE') {
         toast.warning('최신 시트 조회에 실패해 마지막 정상 고정값을 유지했습니다.');
@@ -1254,7 +1214,7 @@ export function CashflowProjectSheet({
     } finally {
       setSheetRefreshLoading(false);
     }
-  }, [cashflowSheetConfig, orgId, projectId, resolveBffActor]);
+  }, [cashflowSheetConfig, loadCashflowEvents, orgId, projectId, resolveBffActor]);
 
   const handleStagePinnedSheetValues = useCallback(async (replaceAllActualSources = false): Promise<void> => {
     if (cashflowSheetMirror?.status !== 'FRESH' || !cashflowSheetMirror.sourceRevision) {
@@ -2197,6 +2157,19 @@ export function CashflowProjectSheet({
               >
                 {cashflowSheetConfig ? '시트 설정' : '시트 연결'}
               </Button>
+              {cashflowSheetConfig ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="h-7 shrink-0 rounded-full border-emerald-200 bg-white px-2.5 text-[10px] font-semibold text-emerald-700"
+                  disabled={sheetRefreshLoading}
+                  onClick={() => void handleRefreshSheetMirror()}
+                >
+                  {sheetRefreshLoading ? <Loader2 className="mr-1 h-3 w-3 animate-spin" /> : <RefreshCw className="mr-1 h-3 w-3" />}
+                  시트 값 불러오기
+                </Button>
+              ) : null}
             </div>
             <div className="flex shrink-0 items-center gap-2">
               <span className="hidden text-[10px] text-slate-400 sm:inline">기준일 {todayIso}</span>
@@ -2331,7 +2304,9 @@ export function CashflowProjectSheet({
   }
 
   function cashflowEventLabel(event: CashflowEvent): string {
+    if (event.type === 'sheet_refresh') return '시트 값 불러오기';
     if (event.type === 'sheet_apply') return '시트 값 반영';
+    if (event.type === 'month_close') return '월 결산';
     if (event.type === 'projection_amount_change') return 'Projection 값 변경';
     if (event.type === 'actual_amount_change') return 'Actual 값 변경';
     if (event.type === 'projection_completed') return '과거 Projection 완료 기록';
@@ -2342,12 +2317,14 @@ export function CashflowProjectSheet({
   }
 
   function cashflowEventDetail(event: CashflowEvent): string {
+    if (event.type === 'sheet_refresh') return [event.sheetName, '시트값을 고정했습니다.'].filter(Boolean).join(' · ');
     if (event.type === 'sheet_apply') {
       return `Google Sheet 반영 ${event.appliedLineCount || 0}건 · Projection ${event.projectionLineCount || 0}건 · Actual ${event.actualLineCount || 0}건`;
     }
+    if (event.type === 'month_close') return [`${event.yearMonth || ''} 월`, event.status || '결산 완료', event.actorName || event.actorEmail || '사용자'].filter(Boolean).join(' · ');
     if (event.type === 'projection_amount_change' || event.type === 'actual_amount_change') {
       const weekLabel = event.weekNo ? getWeekLabel(event.weekNo, event.yearMonth) : '';
-      const lineLabel = event.lineId ? CASHFLOW_SHEET_LINE_LABELS[event.lineId] || event.lineId : '';
+      const lineLabel = event.lineId ? CASHFLOW_SHEET_LINE_LABELS[event.lineId as CashflowSheetLineId] || event.lineId : '';
       const before = event.beforeHadValue ? `${fmt(Number(event.beforeAmount || 0))}원` : '미작성';
       const after = `${fmt(Number(event.afterAmount || 0))}원`;
       return `${weekLabel} ${lineLabel} ${before} → ${after}`;
@@ -2358,7 +2335,9 @@ export function CashflowProjectSheet({
   }
 
   function cashflowEventSourceClass(source: CashflowEvent['source']): string {
+    if (source === 'google_sheet_refresh') return 'bg-emerald-50 text-emerald-700';
     if (source === 'google_sheet_apply') return 'bg-blue-50 text-blue-700';
+    if (source === 'month_close') return 'bg-violet-50 text-violet-700';
     if (source === 'revert') return 'bg-amber-50 text-amber-700';
     return 'bg-slate-100 text-slate-700';
   }
@@ -2471,9 +2450,9 @@ export function CashflowProjectSheet({
 
   function renderOpsTimeline() {
     const countBadges = [
-      { key: 'sheet', label: '시트 반영', value: cashflowEvents.filter((event) => event.type === 'sheet_apply').length },
+      { key: 'sheet', label: '시트 불러오기', value: cashflowEvents.filter((event) => event.type === 'sheet_refresh').length },
       { key: 'amount', label: '금액 변경', value: cashflowEvents.filter((event) => event.type === 'projection_amount_change' || event.type === 'actual_amount_change').length },
-      { key: 'status', label: '완료', value: cashflowEvents.filter((event) => ['projection_completed', 'actual_completed', 'admin_closed'].includes(event.type)).length },
+      { key: 'status', label: '월 결산', value: cashflowEvents.filter((event) => event.type === 'month_close').length },
     ].filter((item) => item.value > 0);
 
     return (
@@ -2482,7 +2461,7 @@ export function CashflowProjectSheet({
           <div className="flex items-start justify-between gap-2 pb-3">
             <div>
               <div className="text-[15px] font-bold tracking-[-0.01em] text-slate-950">변경 이력</div>
-              <div className="text-[10px] text-slate-500">시트 반영, 임시저장, 월 결산과 과거 기록입니다.</div>
+              <div className="text-[10px] text-slate-500">명시적 시트 불러오기와 월 결산 이력입니다.</div>
             </div>
             <div className="flex shrink-0 flex-wrap justify-end gap-1">
               {countBadges.map((badge) => (
@@ -2506,7 +2485,7 @@ export function CashflowProjectSheet({
               <div className="px-2 py-8 text-center text-[10px] leading-4 text-slate-500">
                 아직 표시할 변경 기록이 없습니다.
                 <br />
-                시트값 반영과 월 결산 이력이 여기에 기록됩니다.
+                시트값 불러오기와 월 결산 이력이 여기에 기록됩니다.
               </div>
             ) : cashflowEvents.map((event, index) => {
               const canRevert = event.type === 'sheet_apply'
@@ -2528,7 +2507,7 @@ export function CashflowProjectSheet({
                     <div className="min-w-0">
                       <div className="flex min-w-0 items-center gap-1.5">
                         <span className={`shrink-0 rounded-full border-0 px-1.5 py-0.5 text-[9px] font-semibold leading-3 ${cashflowEventSourceClass(event.source)}`}>
-                          {event.source === 'google_sheet_apply' ? '시트' : event.source === 'revert' ? '되돌림' : '기록'}
+                          {event.source === 'google_sheet_refresh' ? '불러오기' : event.source === 'google_sheet_apply' ? '시트' : event.source === 'month_close' ? '결산' : event.source === 'revert' ? '되돌림' : '기록'}
                         </span>
                         <span className="truncate text-[11px] font-bold text-slate-900">{cashflowEventLabel(event)}</span>
                       </div>

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -705,6 +705,32 @@ export interface CashflowSnapshotResult {
 export type CashflowMonthCloseStatus = 'OPEN' | 'CLOSED' | 'REOPEN_REQUESTED';
 export type CashflowMonthReopenDecision = 'APPROVE' | 'REJECT';
 
+export interface CashflowActivityEvent {
+  id: string;
+  projectId: string;
+  runId: string;
+  type: 'sheet_refresh' | 'sheet_apply' | 'projection_amount_change' | 'actual_amount_change' | 'projection_completed' | 'actual_completed' | 'admin_closed' | 'sheet_apply_reverted' | 'month_close';
+  source?: 'google_sheet_refresh' | 'google_sheet_apply' | 'month_close' | 'manual' | 'revert';
+  yearMonth?: string;
+  weekNo?: number;
+  mode?: 'projection' | 'actual';
+  lineId?: string;
+  beforeAmount?: number;
+  afterAmount?: number;
+  beforeHadValue?: boolean;
+  afterHadValue?: boolean;
+  appliedLineCount?: number;
+  projectionLineCount?: number;
+  actualLineCount?: number;
+  revertedRunId?: string;
+  actorUid?: string;
+  actorName?: string;
+  actorEmail?: string;
+  status?: string;
+  sheetName?: string;
+  createdAt: string;
+}
+
 export interface CashflowMonthCloseCell {
   mode: 'projection' | 'actual';
   weekNo: number;
@@ -2197,6 +2223,24 @@ export async function fetchCashflowMonthCloseViaBff(params: {
 }): Promise<CashflowMonthCloseResult> {
   const response = await resolveClient(params.client).get<CashflowMonthCloseResult>(
     `/api/v1/cashflow/${encodeURIComponent(params.projectId)}/month-close?yearMonth=${encodeURIComponent(params.yearMonth)}`,
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      retries: 0,
+      timeoutMs: 12000,
+    },
+  );
+  return response.data;
+}
+
+export async function fetchCashflowActivityViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectId: string;
+  client?: PlatformApiClientLike;
+}): Promise<{ projectId: string; events: CashflowActivityEvent[] }> {
+  const response = await resolveClient(params.client).get<{ projectId: string; events: CashflowActivityEvent[] }>(
+    `/api/v1/cashflow/${encodeURIComponent(params.projectId)}/activity`,
     {
       tenantId: params.tenantId,
       actor: toRequestActor(params.actor),


### PR DESCRIPTION
변경 사항: 시트 설정 옆에 명시적 시트 값 불러오기 버튼을 추가했습니다. 성공한 시트 불러오기 기록과 JVM 월 결산 감사 기록을 BFF에서 합쳐 변경 이력으로 표시합니다. 기존 변경 이력도 유지하며, 화면에서 임의 이력을 만들지 않습니다. 검증: 대상 테스트 92건 통과 및 프로덕션 빌드 통과. Stage 전용 변경이며 Live 배포는 포함하지 않습니다.