### PR TITLE
feat(projects): separate planning agreement from approval

### DIFF
--- a/server/bff/app.integration.test.ts
+++ b/server/bff/app.integration.test.ts
@@ -67,6 +67,9 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
   async function resetTenantData(): Promise<void> {
     const collections = [
       'projects',
+      'project_code_registry',
+      'project_requests',
+      'projectRequests',
       'ledgers',
       'transactions',
       'comments',
@@ -202,7 +205,7 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
     }));
   });
 
-  it('allows executive review reversal, appends history, and posts Slack on rejection', async () => {
+  it('records planning agreement before the designated approver rejects, and posts Slack', async () => {
     const projectRegistrationSlackService = {
       enabled: true,
       notifyMessage: vi.fn(async () => {}),
@@ -219,19 +222,17 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
       tenantId,
       name: '네팔 귀환노동자 재정착 사업',
       registrationSource: 'pm_portal',
-      executiveReviewStatus: 'APPROVED',
-      executiveReviewedAt: '2026-04-20T09:00:00.000Z',
-      executiveReviewedById: 'u-old',
-      executiveReviewedByName: '임원A',
-      executiveReviewComment: '초안 승인',
+      executiveReviewStatus: 'PENDING',
+      executiveApproverId: actorId,
+      executiveApproverName: '조직장A',
       executiveReviewHistory: [
         {
-          status: 'APPROVED',
-          previousStatus: 'PENDING',
-          reviewedAt: '2026-04-20T09:00:00.000Z',
+          status: 'PENDING',
+          previousStatus: null,
+          reviewedAt: '2026-04-20T08:00:00.000Z',
           reviewedById: 'u-old',
-          reviewedByName: '임원A',
-          reviewComment: '초안 승인',
+          reviewedByName: '변민욱',
+          reviewComment: 'PM 신규 등록',
         },
       ],
       createdAt: '2026-04-20T08:00:00.000Z',
@@ -251,20 +252,33 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
         clientOrg: 'KOICA',
         department: 'CIC1',
         managerName: '변민욱',
+        executiveApproverId: actorId,
         teamName: 'AXR팀',
       },
       createdAt: '2026-04-20T08:00:00.000Z',
       updatedAt: '2026-04-20T09:00:00.000Z',
     }, { merge: true });
 
-    const response = await reviewApi
+    const agreement = await reviewApi
       .post('/api/v1/projects/p_exec_review_001/executive-review')
       .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-executive-review-001' })
       .send({
         requestId: 'pr_exec_review_001',
+        reviewStatus: 'PLANNING_AGREED',
+        projectCode: 'PRJ-2026-001',
+        reviewerName: '무시되는 요청 본문 이름',
+      });
+    expect(agreement.status).toBe(200);
+    expect(agreement.body.reviewStatus).toBe('PLANNING_AGREED');
+
+    const response = await reviewApi
+      .post('/api/v1/projects/p_exec_review_001/executive-review')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-executive-review-001-reject' })
+      .send({
+        requestId: 'pr_exec_review_001',
         reviewStatus: 'REVISION_REJECTED',
         reviewComment: '예산 산출 근거 보완 필요',
-        reviewerName: '임원B',
+        reviewerName: '무시되는 요청 본문 이름',
       });
 
     expect(response.status).toBe(200);
@@ -280,14 +294,14 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
     expect(projectSnap.exists).toBe(true);
     expect(projectSnap.data()).toMatchObject({
       executiveReviewStatus: 'REVISION_REJECTED',
-      executiveReviewedByName: '임원B',
+      executiveReviewedByName: actorId,
       executiveReviewComment: '예산 산출 근거 보완 필요',
     });
-    expect(projectSnap.data()?.executiveReviewHistory).toHaveLength(2);
-    expect(projectSnap.data()?.executiveReviewHistory?.[1]).toMatchObject({
+    expect(projectSnap.data()?.executiveReviewHistory).toHaveLength(3);
+    expect(projectSnap.data()?.executiveReviewHistory?.[2]).toMatchObject({
       status: 'REVISION_REJECTED',
-      previousStatus: 'APPROVED',
-      reviewedByName: '임원B',
+      previousStatus: 'PLANNING_AGREED',
+      reviewedByName: actorId,
       reviewComment: '예산 산출 근거 보완 필요',
     });
 
@@ -296,7 +310,7 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
     expect(requestSnap.data()).toMatchObject({
       status: 'REJECTED',
       reviewOutcome: 'REVISION_REJECTED',
-      reviewedByName: '임원B',
+      reviewedByName: actorId,
       rejectedReason: '예산 산출 근거 보완 필요',
     });
     expect(projectRegistrationSlackService.notifyMessage).toHaveBeenCalledWith(expect.objectContaining({
@@ -333,28 +347,65 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
     expect(response.body.message).toMatch(/reviewComment/i);
   });
 
-  it('requires and persists a project code when approving a project', async () => {
+  it('requires a code for planning agreement and locks it for final approval', async () => {
     const reviewApi = request(createBffApp({ projectId, workerSecret, db }));
     await db.doc(`orgs/${tenantId}/projects/p_project_code_001`).set({
-      id: 'p_project_code_001', tenantId, name: '코드 부여 테스트', executiveReviewStatus: 'PENDING', executiveReviewHistory: [],
+      id: 'p_project_code_001', tenantId, name: '코드 부여 테스트', executiveApproverId: actorId, executiveReviewStatus: 'PENDING', executiveReviewHistory: [],
     });
 
     const missingCode = await reviewApi
       .post('/api/v1/projects/p_project_code_001/executive-review')
       .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-code-missing' })
-      .send({ reviewStatus: 'APPROVED', reviewerName: '경영기획실' });
+      .send({ reviewStatus: 'PLANNING_AGREED', reviewerName: '경영기획실' });
     expect(missingCode.status).toBe(422);
+
+    const agreed = await reviewApi
+      .post('/api/v1/projects/p_project_code_001/executive-review')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-code-approved' })
+      .send({ reviewStatus: 'PLANNING_AGREED', projectCode: 'PRJ-2026-001', reviewerName: '경영기획실' });
+    expect(agreed.status).toBe(200);
 
     const approved = await reviewApi
       .post('/api/v1/projects/p_project_code_001/executive-review')
-      .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-code-approved' })
-      .send({ reviewStatus: 'APPROVED', projectCode: 'PRJ-2026-001', reviewerName: '경영기획실' });
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-code-final-approved' })
+      .send({ reviewStatus: 'APPROVED' });
     expect(approved.status).toBe(200);
 
     expect((await db.doc(`orgs/${tenantId}/projects/p_project_code_001`).get()).data()).toMatchObject({
       executiveReviewStatus: 'APPROVED', projectCode: 'PRJ-2026-001',
-      executiveReviewHistory: [expect.objectContaining({ projectCode: 'PRJ-2026-001' })],
+      executiveReviewHistory: expect.arrayContaining([expect.objectContaining({ projectCode: 'PRJ-2026-001' })]),
     });
+    expect((await db.doc(`orgs/${tenantId}/project_code_registry/PRJ-2026-001`).get()).data()).toMatchObject({
+      projectId: 'p_project_code_001',
+    });
+  });
+
+  it('rejects duplicate codes and final decisions by someone other than the designated approver', async () => {
+    const reviewApi = request(createBffApp({ projectId, workerSecret, db }));
+    await db.doc(`orgs/${tenantId}/projects/p_code_owner_001`).set({
+      id: 'p_code_owner_001', tenantId, name: '코드 소유 프로젝트', executiveApproverId: 'u-other', executiveReviewStatus: 'PENDING', executiveReviewHistory: [],
+    });
+    await db.doc(`orgs/${tenantId}/projects/p_code_owner_002`).set({
+      id: 'p_code_owner_002', tenantId, name: '코드 중복 프로젝트', executiveApproverId: actorId, executiveReviewStatus: 'PENDING', executiveReviewHistory: [],
+    });
+
+    const agreed = await reviewApi
+      .post('/api/v1/projects/p_code_owner_001/executive-review')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-code-owner-agree' })
+      .send({ reviewStatus: 'PLANNING_AGREED', projectCode: 'PRJ-2026-009' });
+    expect(agreed.status).toBe(200);
+
+    const wrongApprover = await reviewApi
+      .post('/api/v1/projects/p_code_owner_001/executive-review')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-code-owner-final' })
+      .send({ reviewStatus: 'APPROVED' });
+    expect(wrongApprover.status).toBe(403);
+
+    const duplicate = await reviewApi
+      .post('/api/v1/projects/p_code_owner_002/executive-review')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-code-duplicate' })
+      .send({ reviewStatus: 'PLANNING_AGREED', projectCode: 'PRJ-2026-009' });
+    expect(duplicate.status).toBe(409);
   });
 
   it('atomically trashes a project with its duplicate-discard review', async () => {
@@ -366,7 +417,9 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
       name: '중복 폐기 테스트',
       version: 1,
       registrationSource: 'pm_portal',
-      executiveReviewStatus: 'PENDING',
+      executiveReviewStatus: 'PLANNING_AGREED',
+      executiveApproverId: actorId,
+      projectCode: 'PRJ-2026-002',
       createdAt: '2026-07-12T00:00:00.000Z',
       updatedAt: '2026-07-12T00:00:00.000Z',
     });

--- a/server/bff/app.integration.test.ts
+++ b/server/bff/app.integration.test.ts
@@ -333,6 +333,30 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
     expect(response.body.message).toMatch(/reviewComment/i);
   });
 
+  it('requires and persists a project code when approving a project', async () => {
+    const reviewApi = request(createBffApp({ projectId, workerSecret, db }));
+    await db.doc(`orgs/${tenantId}/projects/p_project_code_001`).set({
+      id: 'p_project_code_001', tenantId, name: '코드 부여 테스트', executiveReviewStatus: 'PENDING', executiveReviewHistory: [],
+    });
+
+    const missingCode = await reviewApi
+      .post('/api/v1/projects/p_project_code_001/executive-review')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-code-missing' })
+      .send({ reviewStatus: 'APPROVED', reviewerName: '경영기획실' });
+    expect(missingCode.status).toBe(422);
+
+    const approved = await reviewApi
+      .post('/api/v1/projects/p_project_code_001/executive-review')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-code-approved' })
+      .send({ reviewStatus: 'APPROVED', projectCode: 'PRJ-2026-001', reviewerName: '경영기획실' });
+    expect(approved.status).toBe(200);
+
+    expect((await db.doc(`orgs/${tenantId}/projects/p_project_code_001`).get()).data()).toMatchObject({
+      executiveReviewStatus: 'APPROVED', projectCode: 'PRJ-2026-001',
+      executiveReviewHistory: [expect.objectContaining({ projectCode: 'PRJ-2026-001' })],
+    });
+  });
+
   it('atomically trashes a project with its duplicate-discard review', async () => {
     const reviewApi = request(createBffApp({ projectId, workerSecret, db }));
     const projectRef = db.doc(`orgs/${tenantId}/projects/p_exec_discard_001`);

--- a/server/bff/routes/projects.mjs
+++ b/server/bff/routes/projects.mjs
@@ -2637,6 +2637,12 @@ export function mountProjectRoutes(app, {
         const reviewRequest = currentRequest || request;
         const previousStatus = readOptionalText(currentProject.executiveReviewStatus) || 'PENDING';
         const currentHistory = Array.isArray(currentProject.executiveReviewHistory) ? currentProject.executiveReviewHistory : [];
+        const projectCode = parsed.reviewStatus === 'APPROVED'
+          ? readOptionalText(parsed.projectCode) || readOptionalText(currentProject.projectCode)
+          : null;
+        if (parsed.reviewStatus === 'APPROVED' && !projectCode) {
+          throw createHttpError(422, 'projectCode is required when approving a project', 'missing_project_code');
+        }
         const isApprovedChangeRequest = parsed.reviewStatus === 'APPROVED' && isProjectChangeRequest(reviewRequest);
         const requestChanges = Array.isArray(reviewRequest?.changedFields) ? reviewRequest.changedFields : [];
         const requestPayload = resolveProjectRequestPayloadForReview(reviewRequest);
@@ -2650,6 +2656,7 @@ export function mountProjectRoutes(app, {
           executiveReviewedById: actorId,
           executiveReviewedByName: reviewerName,
           executiveReviewComment: readOptionalText(parsed.reviewComment) || null,
+          ...(projectCode ? { projectCode } : {}),
           executiveReviewHistory: [
             ...currentHistory,
             {
@@ -2659,6 +2666,7 @@ export function mountProjectRoutes(app, {
               reviewedById: actorId,
               reviewedByName: reviewerName,
               reviewComment: readOptionalText(parsed.reviewComment) || null,
+              ...(projectCode ? { projectCode } : {}),
               ...(requestChanges.length > 0 ? { changes: requestChanges } : {}),
             },
           ],

--- a/server/bff/routes/projects.mjs
+++ b/server/bff/routes/projects.mjs
@@ -77,6 +77,10 @@ function formatOptionalProjectAmount(value, explicit) {
   return Number.isFinite(value) ? formatKrw(value) : '-';
 }
 
+function normalizeProjectCode(value) {
+  return readOptionalText(value).toUpperCase().replace(/\s+/g, '');
+}
+
 export function buildProjectRegistrationSlackPayload(projectRequest) {
   const payload = projectRequest?.payload && typeof projectRequest.payload === 'object'
     ? projectRequest.payload
@@ -171,6 +175,7 @@ function buildProjectCreatedSlackPayload(project, context = {}) {
 }
 
 function formatExecutiveReviewSlackLabel(status) {
+  if (status === 'PLANNING_AGREED') return '경영기획실 합의 완료';
   if (status === 'APPROVED') return '승인 완료';
   if (status === 'REVISION_REJECTED') return '수정 요청 후 반려';
   if (status === 'DUPLICATE_DISCARDED') return '중복·폐기';
@@ -189,12 +194,14 @@ function buildProjectExecutiveReviewSlackPayload({ project, projectRequest, revi
   const requester = trimSlackText(projectRequest?.requestedByName, 120);
   const requestId = trimSlackText(projectRequest?.id, 120);
   const projectId = trimSlackText(payload.id, 120);
+  const projectCode = trimSlackText(payload.projectCode, 120);
   const decisionLabel = formatExecutiveReviewSlackLabel(reviewStatus);
   const reason = trimSlackText(reviewComment, 280);
   const reviewer = trimSlackText(reviewerName, 120);
   const lines = [
-    '*[InnerPlatform] CIC 대표 검토 결과*',
+    '*[InnerPlatform] 프로젝트 등록 처리 결과*',
     `프로젝트명: \`${projectName}\``,
+    `프로젝트 코드: ${projectCode}`,
     `공식 계약명: ${officialContractName}`,
     `계약 대상: ${clientOrg}`,
     `담당조직(CIC): ${department}`,
@@ -207,7 +214,7 @@ function buildProjectExecutiveReviewSlackPayload({ project, projectRequest, revi
   ];
 
   return {
-    text: `[InnerPlatform] CIC 대표 검토 결과: ${decisionLabel} · ${projectName}`,
+    text: `[InnerPlatform] 프로젝트 등록 처리 결과: ${decisionLabel} · ${projectName}`,
     blocks: [
       {
         type: 'section',
@@ -333,7 +340,7 @@ export async function mergeProjectAndRequestDocs({
         );
       }
     }
-    const projectPatch = buildProjectPatch(current, currentRequest, nextVersion);
+    const projectPatch = await buildProjectPatch(current, currentRequest, nextVersion, tx);
     const document = {
       ...current, ...projectPatch, tenantId, version: nextVersion,
       createdBy: current.createdBy || actorId, createdAt: current.createdAt || now,
@@ -2080,14 +2087,17 @@ export function mountProjectRoutes(app, {
       profile.projectId,
       ...(Array.isArray(profile.projectIds) ? profile.projectIds : []),
     ].map(readOptionalText).filter(Boolean));
+    const projectSnap = await db.doc(`orgs/${tenantId}/projects/${projectId}`).get();
+    if (!projectSnap.exists) throw createHttpError(404, `Project not found: ${projectId}`, 'not_found');
+    const project = projectSnap.data() || {};
     if (
-      !['admin', 'finance'].includes(storedRole) && !assignedProjectIds.has(projectId)
+      !['admin', 'finance'].includes(storedRole)
+      && !assignedProjectIds.has(projectId)
+      && readOptionalText(project.executiveApproverId) !== actorId
     ) {
       throw createHttpError(403, 'Project attachment access denied', 'forbidden');
     }
-    const projectSnap = await db.doc(`orgs/${tenantId}/projects/${projectId}`).get();
-    if (!projectSnap.exists) throw createHttpError(404, `Project not found: ${projectId}`, 'not_found');
-    const attachment = projectSnap.data()?.[field];
+    const attachment = project[field];
     const path = readOptionalText(attachment?.path);
     const expectedPrefix = `orgs/${tenantId}/project-registration-documents/${projectId}/`;
     const objectName = path.startsWith(expectedPrefix) ? path.slice(expectedPrefix.length) : '';
@@ -2611,7 +2621,7 @@ export function mountProjectRoutes(app, {
   }));
 
   app.post('/api/v1/projects/:projectId/executive-review', createMutatingRoute(idempotencyService, async (req) => {
-    const { tenantId, actorId, actorEmail } = req.context;
+    const { tenantId, actorId, actorEmail, actorName } = req.context;
     assertActorRoleAllowed(req, ROUTE_ROLES.writeCore, 'review project executive status');
     const projectId = readOptionalText(req.params.projectId);
     if (!projectId) {
@@ -2620,7 +2630,7 @@ export function mountProjectRoutes(app, {
 
     const parsed = parseWithSchema(projectExecutiveReviewSchema, req.body, 'Invalid executive review payload');
     const projectPath = `orgs/${tenantId}/projects/${projectId}`;
-    const reviewerName = readOptionalText(parsed.reviewerName) || readOptionalText(actorEmail) || actorId;
+    const reviewerName = readOptionalText(actorName) || readOptionalText(actorEmail) || actorId;
     const now = new Date().toISOString();
     await ensureDocumentExists(db, projectPath, `Project not found: ${projectId}`);
     const { request, requestId: resolvedRequestId, refs } = await resolveProjectRequestDocuments({
@@ -2633,19 +2643,58 @@ export function mountProjectRoutes(app, {
     const projectResult = await mergeProjectAndRequestDocs({
       db,
       projectPath,
-      buildProjectPatch: (currentProject, currentRequest) => {
+      buildProjectPatch: async (currentProject, currentRequest, _nextVersion, tx) => {
         const reviewRequest = currentRequest || request;
         const previousStatus = readOptionalText(currentProject.executiveReviewStatus) || 'PENDING';
         const currentHistory = Array.isArray(currentProject.executiveReviewHistory) ? currentProject.executiveReviewHistory : [];
-        const projectCode = parsed.reviewStatus === 'APPROVED'
-          ? readOptionalText(parsed.projectCode) || readOptionalText(currentProject.projectCode)
-          : null;
-        if (parsed.reviewStatus === 'APPROVED' && !projectCode) {
-          throw createHttpError(422, 'projectCode is required when approving a project', 'missing_project_code');
+        const isPlanningAgreement = parsed.reviewStatus === 'PLANNING_AGREED';
+        const requestPayload = resolveProjectRequestPayloadForReview(reviewRequest);
+        const designatedApproverId = readOptionalText(currentProject.executiveApproverId)
+          || readOptionalText(requestPayload?.executiveApproverId);
+        const projectCode = normalizeProjectCode(
+          isPlanningAgreement ? parsed.projectCode : currentProject.projectCode,
+        );
+
+        if (isPlanningAgreement) {
+          if (!projectCode) {
+            throw createHttpError(422, 'projectCode is required when agreeing a project', 'missing_project_code');
+          }
+          if (previousStatus !== 'PENDING') {
+            throw createHttpError(409, 'Only submitted projects can be agreed', 'invalid_planning_agreement_state');
+          }
+          const existingProjectCode = normalizeProjectCode(currentProject.projectCode);
+          if (existingProjectCode && existingProjectCode !== projectCode) {
+            throw createHttpError(422, 'projectCode cannot change after it is assigned', 'project_code_locked');
+          }
+          const codeRef = db.doc(`orgs/${tenantId}/project_code_registry/${encodeURIComponent(projectCode)}`);
+          const codeSnap = await tx.get(codeRef);
+          if (codeSnap.exists && readOptionalText(codeSnap.data()?.projectId) !== projectId) {
+            throw createHttpError(409, `Project code '${projectCode}' is already assigned`, 'duplicate_project_code');
+          }
+          tx.set(codeRef, {
+            code: projectCode,
+            projectId,
+            agreedAt: now,
+            agreedById: actorId,
+            agreedByName: reviewerName,
+          }, { merge: true });
+        } else {
+          if (previousStatus !== 'PLANNING_AGREED') {
+            throw createHttpError(409, 'Planning agreement is required before final approval', 'planning_agreement_required');
+          }
+          if (!designatedApproverId || designatedApproverId !== actorId) {
+            throw createHttpError(403, 'Only the designated approver can make the final decision', 'designated_approver_required');
+          }
+          if (!projectCode) {
+            throw createHttpError(422, 'projectCode is required before final approval', 'missing_project_code');
+          }
+          const submittedCode = normalizeProjectCode(parsed.projectCode);
+          if (submittedCode && submittedCode !== projectCode) {
+            throw createHttpError(422, 'projectCode cannot change after planning agreement', 'project_code_locked');
+          }
         }
         const isApprovedChangeRequest = parsed.reviewStatus === 'APPROVED' && isProjectChangeRequest(reviewRequest);
         const requestChanges = Array.isArray(reviewRequest?.changedFields) ? reviewRequest.changedFields : [];
-        const requestPayload = resolveProjectRequestPayloadForReview(reviewRequest);
         const payloadPatch = isApprovedChangeRequest
           ? buildProjectPatchFromChangeRequestPayload(requestPayload, currentProject)
           : {};
@@ -2656,7 +2705,7 @@ export function mountProjectRoutes(app, {
           executiveReviewedById: actorId,
           executiveReviewedByName: reviewerName,
           executiveReviewComment: readOptionalText(parsed.reviewComment) || null,
-          ...(projectCode ? { projectCode } : {}),
+          ...(isPlanningAgreement || projectCode ? { projectCode } : {}),
           executiveReviewHistory: [
             ...currentHistory,
             {
@@ -2666,7 +2715,7 @@ export function mountProjectRoutes(app, {
               reviewedById: actorId,
               reviewedByName: reviewerName,
               reviewComment: readOptionalText(parsed.reviewComment) || null,
-              ...(projectCode ? { projectCode } : {}),
+              ...(isPlanningAgreement || projectCode ? { projectCode } : {}),
               ...(requestChanges.length > 0 ? { changes: requestChanges } : {}),
             },
           ],
@@ -2678,7 +2727,10 @@ export function mountProjectRoutes(app, {
           } : {}),
         };
       },
-      buildRequestPatch: (_currentProject, currentRequest, nextVersion) => resolvedRequestId ? ({
+      buildRequestPatch: (_currentProject, currentRequest, nextVersion) => (
+        parsed.reviewStatus === 'PLANNING_AGREED' || !resolvedRequestId
+          ? null
+          : ({
         status: parsed.reviewStatus === 'APPROVED' ? 'APPROVED' : 'REJECTED',
         reviewOutcome: parsed.reviewStatus,
         reviewedBy: actorId,
@@ -2693,7 +2745,8 @@ export function mountProjectRoutes(app, {
           approvedProjectVersion: nextVersion,
         } : {}),
         updatedAt: now,
-      }) : null,
+          })
+      ),
       requestRefs: resolvedRequestId ? refs : [],
       enforceChangeRequestVersion: parsed.reviewStatus === 'APPROVED',
       tenantId,

--- a/server/bff/routes/projects.test.ts
+++ b/server/bff/routes/projects.test.ts
@@ -381,7 +381,7 @@ describe('project route helpers', () => {
     });
   });
 
-  it('denies an unassigned member using persisted access before reading attachment metadata', async () => {
+  it('denies an unassigned member who is not the designated approver', async () => {
     const projectGet = vi.fn(async () => ({
       exists: true,
       data: () => ({
@@ -422,8 +422,43 @@ describe('project route helpers', () => {
 
     expect(response.status).toBe(403);
     expect(response.body.error).toBe('forbidden');
-    expect(projectGet).not.toHaveBeenCalled();
+    expect(projectGet).toHaveBeenCalledTimes(1);
     expect(downloadProjectRegistrationAttachment).not.toHaveBeenCalled();
+  });
+
+  it('allows the designated approver to read the final project contract', async () => {
+    const path = 'orgs/mysc/project-registration-documents/project-a/contract.pdf';
+    const downloadProjectRegistrationAttachment = vi.fn(async () => ({
+      buffer: Buffer.from('approver-private-pdf'), contentType: 'application/pdf', size: 20,
+    }));
+    const db = {
+      doc: vi.fn((documentPath: string) => ({
+        get: vi.fn(async () => ({
+          exists: true,
+          data: () => documentPath.includes('/members/')
+            ? { uid: 'approver-a', role: 'pm', status: 'ACTIVE', projectIds: [] }
+            : { id: 'project-a', executiveApproverId: 'approver-a', contractDocument: { path, name: 'contract.pdf' } },
+        })),
+      })),
+    };
+    const app = express();
+    app.use((req: any, _res, next) => {
+      req.context = { tenantId: 'mysc', actorId: 'approver-a', actorRole: 'pm' };
+      next();
+    });
+    mountProjectRoutes(app, {
+      db,
+      now: () => '2026-07-10T00:00:00.000Z',
+      idempotencyService: {},
+      projectRequestContractStorageService: { downloadProjectRegistrationAttachment },
+    } as any);
+
+    const response = await request(app).get('/api/v1/projects/project-a/attachments/contract');
+
+    expect(response.status).toBe(200);
+    expect(downloadProjectRegistrationAttachment).toHaveBeenCalledWith({
+      tenantId: 'mysc', projectId: 'project-a', path,
+    });
   });
 
   it('denies a persisted member document whose uid does not match the authenticated actor', async () => {

--- a/server/bff/schemas.mjs
+++ b/server/bff/schemas.mjs
@@ -129,6 +129,7 @@ export const projectExecutiveReviewSchema = z.object({
   reviewStatus: z.enum(['APPROVED', 'REVISION_REJECTED', 'DUPLICATE_DISCARDED']),
   reviewComment: z.string().trim().max(2000).optional(),
   reviewerName: z.string().trim().max(200).optional(),
+  projectCode: z.string().trim().max(100).optional(),
 }).strict().superRefine((value, ctx) => {
   if (value.reviewStatus !== 'APPROVED' && !value.reviewComment) {
     ctx.addIssue({

--- a/server/bff/schemas.mjs
+++ b/server/bff/schemas.mjs
@@ -126,12 +126,12 @@ export const projectRestoreSchema = z.object({
 
 export const projectExecutiveReviewSchema = z.object({
   requestId: NON_EMPTY_STRING.optional(),
-  reviewStatus: z.enum(['APPROVED', 'REVISION_REJECTED', 'DUPLICATE_DISCARDED']),
+  reviewStatus: z.enum(['PLANNING_AGREED', 'APPROVED', 'REVISION_REJECTED', 'DUPLICATE_DISCARDED']),
   reviewComment: z.string().trim().max(2000).optional(),
   reviewerName: z.string().trim().max(200).optional(),
   projectCode: z.string().trim().max(100).optional(),
 }).strict().superRefine((value, ctx) => {
-  if (value.reviewStatus !== 'APPROVED' && !value.reviewComment) {
+  if (!['PLANNING_AGREED', 'APPROVED'].includes(value.reviewStatus) && !value.reviewComment) {
     ctx.addIssue({
       code: 'custom',
       path: ['reviewComment'],

--- a/server/bff/schemas.test.mjs
+++ b/server/bff/schemas.test.mjs
@@ -6,4 +6,8 @@ describe('projectExecutiveReviewSchema', () => {
     expect(projectExecutiveReviewSchema.safeParse({ reviewStatus: 'APPROVED', projectCode: 'PRJ-2026-001' }).success).toBe(true);
     expect(projectExecutiveReviewSchema.safeParse({ reviewStatus: 'REVISION_REJECTED', reviewComment: '계약서 보완' }).success).toBe(true);
   });
+
+  it('accepts a planning agreement with a project code', () => {
+    expect(projectExecutiveReviewSchema.safeParse({ reviewStatus: 'PLANNING_AGREED', projectCode: 'PRJ-2026-001' }).success).toBe(true);
+  });
 });

--- a/server/bff/schemas.test.mjs
+++ b/server/bff/schemas.test.mjs
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { projectExecutiveReviewSchema } from './schemas.mjs';
+
+describe('projectExecutiveReviewSchema', () => {
+  it('accepts a project code as an approval payload field', () => {
+    expect(projectExecutiveReviewSchema.safeParse({ reviewStatus: 'APPROVED', projectCode: 'PRJ-2026-001' }).success).toBe(true);
+    expect(projectExecutiveReviewSchema.safeParse({ reviewStatus: 'REVISION_REJECTED', reviewComment: '계약서 보완' }).success).toBe(true);
+  });
+});

--- a/src/app/components/cashflow/CashflowAnalyticsPage.copy.test.ts
+++ b/src/app/components/cashflow/CashflowAnalyticsPage.copy.test.ts
@@ -30,6 +30,6 @@ describe('CashflowAnalyticsPage copy', () => {
 
   it('opens the planning office project registration and approval surface', () => {
     expect(source).toContain('프로젝트 등록·승인');
-    expect(source).toContain('<ProjectMigrationAuditPage embedded defaultInboxScope="ALL" />');
+    expect(source).toContain('<ProjectMigrationAuditPage embedded defaultInboxScope="ALL" workflowStage="planning" />');
   });
 });

--- a/src/app/components/cashflow/CashflowAnalyticsPage.copy.test.ts
+++ b/src/app/components/cashflow/CashflowAnalyticsPage.copy.test.ts
@@ -27,4 +27,9 @@ describe('CashflowAnalyticsPage copy', () => {
     expect(source).toContain('<LineChart data={analytics.monthlyRows}>');
     expect(source).not.toContain('<AreaChart data={analytics.monthlyRows}>');
   });
+
+  it('opens the planning office project registration and approval surface', () => {
+    expect(source).toContain('프로젝트 등록·승인');
+    expect(source).toContain('<ProjectMigrationAuditPage embedded defaultInboxScope="ALL" />');
+  });
 });

--- a/src/app/components/cashflow/CashflowAnalyticsPage.tsx
+++ b/src/app/components/cashflow/CashflowAnalyticsPage.tsx
@@ -281,7 +281,7 @@ export function CashflowAnalyticsPage() {
             <Button variant="outline" className="rounded-none border-[#c7c7c7]" onClick={() => setActiveView('analytics')}>통합 현황으로</Button>
           </div>
         </section>
-        <ProjectMigrationAuditPage embedded defaultInboxScope="ALL" />
+        <ProjectMigrationAuditPage embedded defaultInboxScope="ALL" workflowStage="planning" />
       </div>
     );
   }

--- a/src/app/components/cashflow/CashflowAnalyticsPage.tsx
+++ b/src/app/components/cashflow/CashflowAnalyticsPage.tsx
@@ -44,6 +44,7 @@ import {
   type TransactionState,
 } from '../../data/types';
 import { buildCashflowAnalytics } from '../../platform/cashflow-analytics';
+import { ProjectMigrationAuditPage } from '../projects/ProjectMigrationAuditPage';
 
 const REPORT_TEAL = '#008c86';
 const REPORT_DARK_TEAL = '#00766f';
@@ -139,6 +140,7 @@ function FilterLabel({ label, disabled = false }: { label: string; disabled?: bo
 
 export function CashflowAnalyticsPage() {
   const { transactions, projects } = useAppStore();
+  const [activeView, setActiveView] = useState<'analytics' | 'projectApproval'>('analytics');
   const [projectFilter, setProjectFilter] = useState('ALL');
   const [typeFilter, setTypeFilter] = useState('ALL');
   const [departmentFilter, setDepartmentFilter] = useState('ALL');
@@ -266,6 +268,24 @@ export function CashflowAnalyticsPage() {
 
   const { totals } = analytics;
 
+  if (activeView === 'projectApproval') {
+    return (
+      <div className="space-y-5 bg-white px-1 pb-8 text-zinc-950">
+        <section className="border bg-white px-6 py-5" style={{ borderColor: REPORT_BORDER }}>
+          <p className="text-[13px]" style={{ color: REPORT_TEAL, fontWeight: 800 }}>경영기획실 통합 관리</p>
+          <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h1 className="text-[28px] leading-tight text-zinc-950" style={{ fontWeight: 900 }}>프로젝트 등록·승인</h1>
+              <p className="mt-2 text-[12px] text-[#6f7478]">등록 문서를 열어 프로젝트 코드를 부여하고 승인 또는 반려 사유를 처리합니다.</p>
+            </div>
+            <Button variant="outline" className="rounded-none border-[#c7c7c7]" onClick={() => setActiveView('analytics')}>통합 현황으로</Button>
+          </div>
+        </section>
+        <ProjectMigrationAuditPage embedded defaultInboxScope="ALL" />
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-5 bg-white px-1 pb-8 text-zinc-950">
       <section className="relative border bg-white px-6 py-5" style={{ borderColor: REPORT_BORDER }}>
@@ -281,8 +301,9 @@ export function CashflowAnalyticsPage() {
               사업·통장사용내역 기반 조회/필터/집계 · 현재 조건 {totals.count}건
             </p>
           </div>
-          <div className="hidden text-right sm:block">
-            <p className="text-[34px] leading-none text-[#c9c9c9]" style={{ fontWeight: 900 }}>2026</p>
+          <div className="flex flex-col items-end gap-3 text-right">
+            <p className="hidden text-[34px] leading-none text-[#c9c9c9] sm:block" style={{ fontWeight: 900 }}>2026</p>
+            <Button variant="outline" size="sm" className="rounded-none border-[#c7c7c7] text-[11px]" onClick={() => setActiveView('projectApproval')}>프로젝트 등록·승인</Button>
           </div>
         </div>
       </section>

--- a/src/app/components/projects/ProjectMigrationAuditPage.shell.test.ts
+++ b/src/app/components/projects/ProjectMigrationAuditPage.shell.test.ts
@@ -32,12 +32,12 @@ describe('ProjectMigrationAuditPage shell contract', () => {
     expect(compositeSource).toContain('프로젝트명, 등록 원문, 계약 대상, PM 검색');
     expect(compositeSource).toContain('migration-review-project-search');
     expect(compositeSource).toContain('statusChartBackground');
-    expect(compositeSource).toContain('검토대기');
+    expect(compositeSource).toContain('합의대기');
+    expect(compositeSource).toContain('경영기획실 합의');
     expect(compositeSource).toContain('승인');
     expect(compositeSource).toContain('수정 요청 후 반려');
     expect(compositeSource).toContain('중복·폐기');
-    expect(compositeSource).toContain('PM 등록 프로젝트 검토');
-    expect(compositeSource).toContain('기안·조직장 결재선과 등록 원문을 확인합니다.');
+    expect(compositeSource).toContain('경영기획실 프로젝트 합의');
     expect(compositeSource).toContain('문서 열기');
     expect(compositeSource).toContain('describeProjectRequestVersion');
     expect(compositeSource).toContain('수정 중');
@@ -72,9 +72,10 @@ describe('ProjectMigrationAuditPage shell contract', () => {
     expect(pageSource).not.toContain('setDoc(');
   });
 
-  it('requires a project code before saving an approval decision', () => {
+  it('requires a project code before saving a planning agreement', () => {
     expect(pageSource).toContain('프로젝트 코드를 입력해 주세요.');
-    expect(pageSource).toContain('projectCode: trimmedProjectCode');
+    expect(pageSource).toContain("projectCode: actionMode === 'agree' ? trimmedProjectCode : undefined");
+    expect(pageSource).toContain("reviewStatus: nextExecutiveStatus");
     expect(documentSource).toContain('프로젝트 코드');
   });
 

--- a/src/app/components/projects/ProjectMigrationAuditPage.shell.test.ts
+++ b/src/app/components/projects/ProjectMigrationAuditPage.shell.test.ts
@@ -72,6 +72,12 @@ describe('ProjectMigrationAuditPage shell contract', () => {
     expect(pageSource).not.toContain('setDoc(');
   });
 
+  it('requires a project code before saving an approval decision', () => {
+    expect(pageSource).toContain('프로젝트 코드를 입력해 주세요.');
+    expect(pageSource).toContain('projectCode: trimmedProjectCode');
+    expect(documentSource).toContain('프로젝트 코드');
+  });
+
   it('listens to both canonical and legacy project request collections', () => {
     expect(pageSource).toContain("const PROJECT_REQUEST_COLLECTIONS: ProjectRequestCollectionName[] = ['project_requests', 'projectRequests']");
     expect(pageSource).toContain('__collectionName: collectionName');

--- a/src/app/components/projects/ProjectMigrationAuditPage.tsx
+++ b/src/app/components/projects/ProjectMigrationAuditPage.tsx
@@ -13,7 +13,7 @@ import type { ProjectExecutiveReviewStatus, ProjectRequest } from '../../data/ty
 import { getOrgRootPath } from '../../lib/firebase';
 import { useFirebase } from '../../lib/firebase-context';
 import { isPlatformApiEnabled, reviewProjectExecutiveStatusViaBff } from '../../lib/platform-bff-client';
-import { downloadProjectRequestAttachmentViaBff } from '../../lib/project-request-attachment-client';
+import { downloadProjectAttachmentViaBff, downloadProjectRequestAttachmentViaBff } from '../../lib/project-request-attachment-client';
 import {
   type MigrationAuditConsoleStatus,
   buildMigrationAuditConsoleRecords,
@@ -44,7 +44,8 @@ import {
 import { Textarea } from '../ui/textarea';
 import { Input } from '../ui/input';
 
-type ReviewActionMode = 'approve' | 'reject' | 'discard';
+type ReviewActionMode = 'agree' | 'approve' | 'reject';
+type WorkflowStage = 'planning' | 'approval';
 type ProjectRequestCollectionName = 'project_requests' | 'projectRequests';
 type ProjectRequestWithSource = ProjectRequest & {
   __collectionName?: ProjectRequestCollectionName;
@@ -53,41 +54,46 @@ type ProjectRequestWithSource = ProjectRequest & {
 const PROJECT_REQUEST_COLLECTIONS: ProjectRequestCollectionName[] = ['project_requests', 'projectRequests'];
 
 function getReviewDialogTitle(mode: ReviewActionMode): string {
+  if (mode === 'agree') return '이 프로젝트에 합의할까요?';
   if (mode === 'approve') return '이 프로젝트를 승인할까요?';
   if (mode === 'reject') return '수정 요청 후 반려할까요?';
-  return '이 프로젝트를 중복·폐기할까요?';
+  return '';
 }
 
 function getReviewDialogDescription(mode: ReviewActionMode): string {
-  if (mode === 'approve') return 'PM이 올린 원문을 기준으로 이 프로젝트를 등록 대상으로 확정합니다.';
+  if (mode === 'agree') return '경영기획실 합의와 함께 프로젝트 코드를 부여하고, 지정 조직장에게 최종 승인을 요청합니다.';
+  if (mode === 'approve') return '경영기획실 합의가 끝난 문서를 최종 승인합니다.';
   if (mode === 'reject') return '수정이 필요한 이유를 반드시 남기고 PM이 다시 보완하도록 돌려보냅니다.';
-  return '중복 또는 폐기 대상으로 정리하고, 왜 그렇게 판단했는지 사유를 반드시 남깁니다.';
+  return '';
 }
 
 function getProjectRequestReviewDescription(mode: ReviewActionMode, request: ProjectRequest | null | undefined): string {
   const isChangeRequest = resolveProjectRequestKind(request) === 'CHANGE';
-  if (!isChangeRequest) return getReviewDialogDescription(mode);
+  if (!isChangeRequest || mode === 'agree') return getReviewDialogDescription(mode);
   if (mode === 'approve') return 'PM이 제출한 수정 중 값을 프로젝트 원장에 반영하고 변경 요청을 승인 완료로 닫습니다.';
   if (mode === 'reject') return '프로젝트 원장은 유지하고, 수정이 필요한 이유를 남겨 PM에게 돌려보냅니다.';
   return '프로젝트 원장은 유지하고, 중복 또는 폐기된 수정 요청으로 정리합니다.';
 }
 
 function toExecutiveStatus(mode: ReviewActionMode): ProjectExecutiveReviewStatus {
+  if (mode === 'agree') return 'PLANNING_AGREED';
   if (mode === 'approve') return 'APPROVED';
   if (mode === 'reject') return 'REVISION_REJECTED';
-  return 'DUPLICATE_DISCARDED';
+  return 'PENDING';
 }
 
 type ProjectMigrationAuditPageProps = {
   embedded?: boolean;
   reviewScope?: 'all' | 'pending';
   defaultInboxScope?: 'MINE' | 'ALL';
+  workflowStage?: WorkflowStage;
 };
 
 export function ProjectMigrationAuditPage({
   embedded = false,
   reviewScope = 'all',
   defaultInboxScope = 'MINE',
+  workflowStage = 'approval',
 }: ProjectMigrationAuditPageProps = {}) {
   const { user: authUser } = useAuth();
   const { projects, currentUser } = useAppStore();
@@ -96,7 +102,9 @@ export function ProjectMigrationAuditPage({
   const [requests, setRequests] = useState<ProjectRequest[]>([]);
   const [loadingRequests, setLoadingRequests] = useState(true);
   const [cicFilter, setCicFilter] = useState('ALL');
-  const [statusFilter, setStatusFilter] = useState<'ALL' | MigrationAuditConsoleStatus>('PENDING');
+  const [statusFilter, setStatusFilter] = useState<'ALL' | MigrationAuditConsoleStatus>(
+    workflowStage === 'planning' ? 'PENDING' : 'PLANNING_AGREED',
+  );
   const [searchQuery, setSearchQuery] = useState('');
   const [inboxScope, setInboxScope] = useState<'MINE' | 'ALL'>(defaultInboxScope);
   const [openRecordId, setOpenRecordId] = useState<string | null>(null);
@@ -169,18 +177,23 @@ export function ProjectMigrationAuditPage({
   const scopedRecords = useMemo(
     () => reviewScope === 'pending'
       ? records.filter((record) => (
-          record.status === 'PENDING'
+          workflowStage === 'planning'
+            ? record.status === 'PENDING'
+            : record.status === 'PLANNING_AGREED'
         ))
       : records,
-    [records, reviewScope],
+    [records, reviewScope, workflowStage],
   );
 
   const reviewerDepartment = String(authUser?.department || '').trim();
   const inboxRecords = useMemo(
-    () => inboxScope === 'MINE' && reviewerDepartment
-      ? scopedRecords.filter((record) => isSameMigrationAuditCic(record.cic, reviewerDepartment))
+    () => inboxScope === 'MINE'
+      ? scopedRecords.filter((record) => workflowStage === 'planning'
+        ? reviewerDepartment && isSameMigrationAuditCic(record.cic, reviewerDepartment)
+        : (resolveProjectRequestPayload(record.request)?.executiveApproverId || record.project.executiveApproverId) === authUser?.uid,
+      )
       : scopedRecords,
-    [inboxScope, reviewerDepartment, scopedRecords],
+    [authUser?.uid, inboxScope, reviewerDepartment, scopedRecords, workflowStage],
   );
 
   const summaryRecords = useMemo(
@@ -215,14 +228,14 @@ export function ProjectMigrationAuditPage({
     () => summaryRecords.find((record) => record.id === openRecordId) || null,
     [openRecordId, summaryRecords],
   );
-  const pendingContractDocument = openRecord?.request?.status === 'PENDING'
-    ? resolveProjectRequestPayload(openRecord.request)?.contractDocument
-    : null;
-  const pendingContractPath = String(pendingContractDocument?.path || '').trim();
-  const pendingContractDownloadUrl = String(pendingContractDocument?.downloadURL || '').trim();
-  const pendingRequestId = String(openRecord?.request?.id || '').trim();
-  const secureContractDocumentKey = pendingRequestId && pendingContractPath
-    ? `${pendingRequestId}:${pendingContractPath}`
+  const contractDocument = resolveProjectRequestPayload(openRecord?.request)?.contractDocument || openRecord?.project.contractDocument;
+  const contractPath = String(contractDocument?.path || '').trim();
+  const contractDownloadUrl = String(contractDocument?.downloadURL || '').trim();
+  const requestId = String(openRecord?.request?.id || '').trim();
+  const projectId = String(openRecord?.project.id || '').trim();
+  const usePendingRequestAttachment = openRecord?.request?.status === 'PENDING';
+  const secureContractDocumentKey = (usePendingRequestAttachment ? requestId : projectId) && contractPath
+    ? `${usePendingRequestAttachment ? requestId : projectId}:${contractPath}`
     : '';
   const secureContractDocumentUrl = secureContractDocument.key === secureContractDocumentKey
     ? secureContractDocument.url
@@ -236,24 +249,23 @@ export function ProjectMigrationAuditPage({
     if (
       !isPlatformApiEnabled()
       || !authUser?.uid
-      || !pendingRequestId
-      || !pendingContractPath
-      || pendingContractDownloadUrl
+      || !projectId
+      || !contractPath
+      || contractDownloadUrl
     ) return undefined;
 
     let disposed = false;
     let objectUrl = '';
-    void downloadProjectRequestAttachmentViaBff({
-      tenantId: orgId,
-      actor: {
-        uid: authUser.uid,
-        email: authUser.email,
-        role: authUser.role,
-        idToken: authUser.idToken,
-      },
-      requestId: pendingRequestId,
-      documentKind: 'contract',
-    }).then(({ blob }) => {
+    const actor = {
+      uid: authUser.uid,
+      email: authUser.email,
+      role: authUser.role,
+      idToken: authUser.idToken,
+    };
+    const download = usePendingRequestAttachment && requestId
+      ? downloadProjectRequestAttachmentViaBff({ tenantId: orgId, actor, requestId, documentKind: 'contract' })
+      : downloadProjectAttachmentViaBff({ tenantId: orgId, actor, projectId, documentKind: 'contract' });
+    void download.then(({ blob }) => {
       if (disposed) return;
       objectUrl = URL.createObjectURL(blob);
       setSecureContractDocument({ key: secureContractDocumentKey, url: objectUrl, error: '' });
@@ -277,10 +289,12 @@ export function ProjectMigrationAuditPage({
     authUser?.role,
     authUser?.uid,
     orgId,
-    pendingContractDownloadUrl,
-    pendingContractPath,
-    pendingRequestId,
+    contractDownloadUrl,
+    contractPath,
+    projectId,
+    requestId,
     secureContractDocumentKey,
+    usePendingRequestAttachment,
   ]);
 
   async function handleConfirmAction() {
@@ -290,16 +304,16 @@ export function ProjectMigrationAuditPage({
     const trimmedComment = reviewComment.trim();
     const trimmedProjectCode = projectCode.trim();
     const reviewerName = currentUser?.name || authUser?.name || currentUser?.email || authUser?.email || '관리자';
-    if (nextExecutiveStatus === 'APPROVED' && !trimmedProjectCode) {
+    if (nextExecutiveStatus === 'PLANNING_AGREED' && !trimmedProjectCode) {
       toast.error('프로젝트 코드를 입력해 주세요.');
       return;
     }
-    if (nextExecutiveStatus !== 'APPROVED' && !trimmedComment) {
-      toast.error(actionMode === 'reject' ? '반려 사유를 입력해 주세요.' : '폐기 사유를 입력해 주세요.');
+    if (nextExecutiveStatus === 'REVISION_REJECTED' && !trimmedComment) {
+      toast.error('반려 사유를 입력해 주세요.');
       return;
     }
     if (!isPlatformApiEnabled() || !authUser?.uid) {
-      toast.error('CIC 대표 검토 API가 연결되어 있지 않아 저장하지 않았습니다.');
+      toast.error('프로젝트 처리 서버가 연결되어 있지 않아 저장하지 않았습니다.');
       return;
     }
 
@@ -319,7 +333,7 @@ export function ProjectMigrationAuditPage({
           reviewStatus: nextExecutiveStatus,
           reviewComment: trimmedComment || undefined,
           reviewerName,
-          projectCode: trimmedProjectCode || undefined,
+          projectCode: actionMode === 'agree' ? trimmedProjectCode : undefined,
         },
       });
       if (response.slackDelivered === false && response.slackReason) {
@@ -327,11 +341,13 @@ export function ProjectMigrationAuditPage({
       }
 
       toast.success(
-        actionMode === 'approve'
-          ? '프로젝트를 승인했습니다.'
+        actionMode === 'agree'
+          ? '경영기획실 합의를 완료했습니다. 지정 조직장 승인 대기 상태입니다.'
+          : actionMode === 'approve'
+            ? '프로젝트를 승인했습니다.'
           : actionMode === 'reject'
             ? '수정 요청 후 반려로 처리했습니다.'
-            : '중복·폐기로 처리했습니다.',
+            : '',
         {
           description: openRecord.title,
         },
@@ -340,7 +356,7 @@ export function ProjectMigrationAuditPage({
       setReviewComment('');
       setProjectCode('');
     } catch (error) {
-      toast.error('CIC 대표 검토 결정 저장 실패', {
+      toast.error(actionMode === 'agree' ? '경영기획실 합의 저장 실패' : '조직장 결재 저장 실패', {
         description: error instanceof Error ? error.message : '다시 시도해 주세요.',
       });
     } finally {
@@ -348,7 +364,9 @@ export function ProjectMigrationAuditPage({
     }
   }
 
-  const pageDescription = '내게 배정된 프로젝트 등록 요청을 먼저 확인하고, 문서형 팝업에서 기안·조직장 결재선과 등록 내용을 검토합니다.';
+  const pageDescription = workflowStage === 'planning'
+    ? '프로젝트 코드 부여와 경영기획실 합의가 필요한 등록 문서를 확인합니다.'
+    : '경영기획실 합의가 끝난 문서를 지정 조직장이 최종 승인 또는 반려합니다.';
 
   return (
     <div className="space-y-6">
@@ -356,9 +374,9 @@ export function ProjectMigrationAuditPage({
         <PageHeader
           icon={ClipboardCheck}
           iconGradient="linear-gradient(135deg, #0f766e 0%, #0ea5e9 100%)"
-          title="PM 등록 프로젝트 검토"
+          title={workflowStage === 'planning' ? '경영기획실 프로젝트 합의' : 'PM 등록 프로젝트 승인'}
           description={pageDescription}
-          badge="대표 검토"
+          badge={workflowStage === 'planning' ? '코드 부여·합의' : '지정 조직장 결재'}
         />
       ) : null}
 
@@ -377,6 +395,7 @@ export function ProjectMigrationAuditPage({
         inboxScope={inboxScope}
         onInboxScopeChange={setInboxScope}
         reviewerDepartment={reviewerDepartment}
+        workflowStage={workflowStage}
         statusFilter={statusFilter}
         onStatusFilterChange={setStatusFilter}
         searchQuery={searchQuery}
@@ -399,14 +418,21 @@ export function ProjectMigrationAuditPage({
         open={!!openRecord}
         record={openRecord}
         reviewerName={currentUser?.name || authUser?.name || '조직장'}
+        workflowStage={workflowStage}
+        canFinalize={Boolean(authUser?.uid && (resolveProjectRequestPayload(openRecord?.request)?.executiveApproverId || openRecord?.project.executiveApproverId) === authUser.uid)}
         acting={acting}
         contractDocumentDownloadURL={secureContractDocumentUrl}
         contractDocumentError={privateAttachmentError}
         onOpenChange={(open) => { if (!open) setOpenRecordId(null); }}
+        onAgree={() => {
+          setActionMode('agree');
+          setReviewComment('');
+          setProjectCode(openRecord?.project.projectCode || '');
+        }}
         onApprove={() => {
           setActionMode('approve');
-          setReviewComment(openRecord?.project.executiveReviewComment || '');
-          setProjectCode(openRecord?.project.projectCode || '');
+          setReviewComment('');
+          setProjectCode('');
         }}
         onReject={() => {
           setActionMode('reject');
@@ -430,7 +456,7 @@ export function ProjectMigrationAuditPage({
             </AlertDialogDescription>
           </AlertDialogHeader>
           <div className="space-y-2">
-            {actionMode === 'approve' ? (
+            {actionMode === 'agree' ? (
               <label className="block text-[12px] font-medium text-slate-700">
                 프로젝트 코드
                 <Input
@@ -443,12 +469,12 @@ export function ProjectMigrationAuditPage({
               </label>
             ) : null}
             <p className="text-[12px] font-medium text-slate-700">
-              {actionMode === 'approve' ? '승인 메모' : actionMode === 'reject' ? '반려 사유' : '폐기 사유'}
+              {actionMode === 'agree' ? '합의 메모' : actionMode === 'approve' ? '승인 메모' : '반려 사유'}
             </p>
             <Textarea
               value={reviewComment}
               onChange={(event) => setReviewComment(event.target.value)}
-              placeholder={actionMode === 'approve' ? '승인 판단 근거를 남길 수 있습니다.' : 'PM이 수정하거나 폐기 판단을 이해할 수 있도록 사유를 남겨 주세요.'}
+              placeholder={actionMode === 'agree' ? '합의 근거를 남길 수 있습니다.' : actionMode === 'approve' ? '승인 판단 근거를 남길 수 있습니다.' : 'PM이 수정하거나 폐기 판단을 이해할 수 있도록 사유를 남겨 주세요.'}
               className="min-h-[120px]"
             />
           </div>
@@ -457,8 +483,8 @@ export function ProjectMigrationAuditPage({
             <AlertDialogAction onClick={(event) => {
               event.preventDefault();
               void handleConfirmAction();
-            }} disabled={acting || (actionMode === 'approve' ? !projectCode.trim() : !reviewComment.trim())}>
-              {acting ? '저장 중...' : actionMode === 'approve' ? '승인 저장' : actionMode === 'reject' ? '반려 저장' : '폐기 저장'}
+            }} disabled={acting || (actionMode === 'agree' ? !projectCode.trim() : actionMode === 'reject' ? !reviewComment.trim() : false)}>
+              {acting ? '저장 중...' : actionMode === 'agree' ? '합의 저장' : actionMode === 'approve' ? '승인 저장' : '반려 저장'}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/app/components/projects/ProjectMigrationAuditPage.tsx
+++ b/src/app/components/projects/ProjectMigrationAuditPage.tsx
@@ -42,6 +42,7 @@ import {
   AlertDialogTitle,
 } from '../ui/alert-dialog';
 import { Textarea } from '../ui/textarea';
+import { Input } from '../ui/input';
 
 type ReviewActionMode = 'approve' | 'reject' | 'discard';
 type ProjectRequestCollectionName = 'project_requests' | 'projectRequests';
@@ -80,11 +81,13 @@ function toExecutiveStatus(mode: ReviewActionMode): ProjectExecutiveReviewStatus
 type ProjectMigrationAuditPageProps = {
   embedded?: boolean;
   reviewScope?: 'all' | 'pending';
+  defaultInboxScope?: 'MINE' | 'ALL';
 };
 
 export function ProjectMigrationAuditPage({
   embedded = false,
   reviewScope = 'all',
+  defaultInboxScope = 'MINE',
 }: ProjectMigrationAuditPageProps = {}) {
   const { user: authUser } = useAuth();
   const { projects, currentUser } = useAppStore();
@@ -95,10 +98,11 @@ export function ProjectMigrationAuditPage({
   const [cicFilter, setCicFilter] = useState('ALL');
   const [statusFilter, setStatusFilter] = useState<'ALL' | MigrationAuditConsoleStatus>('PENDING');
   const [searchQuery, setSearchQuery] = useState('');
-  const [inboxScope, setInboxScope] = useState<'MINE' | 'ALL'>('MINE');
+  const [inboxScope, setInboxScope] = useState<'MINE' | 'ALL'>(defaultInboxScope);
   const [openRecordId, setOpenRecordId] = useState<string | null>(null);
   const [actionMode, setActionMode] = useState<ReviewActionMode | null>(null);
   const [reviewComment, setReviewComment] = useState('');
+  const [projectCode, setProjectCode] = useState('');
   const [acting, setActing] = useState(false);
   const [secureContractDocument, setSecureContractDocument] = useState({ key: '', url: '', error: '' });
 
@@ -284,7 +288,12 @@ export function ProjectMigrationAuditPage({
 
     const nextExecutiveStatus = toExecutiveStatus(actionMode);
     const trimmedComment = reviewComment.trim();
+    const trimmedProjectCode = projectCode.trim();
     const reviewerName = currentUser?.name || authUser?.name || currentUser?.email || authUser?.email || '관리자';
+    if (nextExecutiveStatus === 'APPROVED' && !trimmedProjectCode) {
+      toast.error('프로젝트 코드를 입력해 주세요.');
+      return;
+    }
     if (nextExecutiveStatus !== 'APPROVED' && !trimmedComment) {
       toast.error(actionMode === 'reject' ? '반려 사유를 입력해 주세요.' : '폐기 사유를 입력해 주세요.');
       return;
@@ -310,6 +319,7 @@ export function ProjectMigrationAuditPage({
           reviewStatus: nextExecutiveStatus,
           reviewComment: trimmedComment || undefined,
           reviewerName,
+          projectCode: trimmedProjectCode || undefined,
         },
       });
       if (response.slackDelivered === false && response.slackReason) {
@@ -328,6 +338,7 @@ export function ProjectMigrationAuditPage({
       );
       setActionMode(null);
       setReviewComment('');
+      setProjectCode('');
     } catch (error) {
       toast.error('CIC 대표 검토 결정 저장 실패', {
         description: error instanceof Error ? error.message : '다시 시도해 주세요.',
@@ -395,10 +406,12 @@ export function ProjectMigrationAuditPage({
         onApprove={() => {
           setActionMode('approve');
           setReviewComment(openRecord?.project.executiveReviewComment || '');
+          setProjectCode(openRecord?.project.projectCode || '');
         }}
         onReject={() => {
           setActionMode('reject');
           setReviewComment(openRecord?.project.executiveReviewComment || '');
+          setProjectCode('');
         }}
       />
 
@@ -406,6 +419,7 @@ export function ProjectMigrationAuditPage({
         if (!open) {
           setActionMode(null);
           setReviewComment('');
+          setProjectCode('');
         }
       }}>
         <AlertDialogContent>
@@ -416,6 +430,18 @@ export function ProjectMigrationAuditPage({
             </AlertDialogDescription>
           </AlertDialogHeader>
           <div className="space-y-2">
+            {actionMode === 'approve' ? (
+              <label className="block text-[12px] font-medium text-slate-700">
+                프로젝트 코드
+                <Input
+                  value={projectCode}
+                  onChange={(event) => setProjectCode(event.target.value)}
+                  placeholder="예: PRJ-2026-001"
+                  className="mt-2 h-10 rounded-none"
+                  aria-label="프로젝트 코드"
+                />
+              </label>
+            ) : null}
             <p className="text-[12px] font-medium text-slate-700">
               {actionMode === 'approve' ? '승인 메모' : actionMode === 'reject' ? '반려 사유' : '폐기 사유'}
             </p>
@@ -431,7 +457,7 @@ export function ProjectMigrationAuditPage({
             <AlertDialogAction onClick={(event) => {
               event.preventDefault();
               void handleConfirmAction();
-            }} disabled={acting || (actionMode !== 'approve' && !reviewComment.trim())}>
+            }} disabled={acting || (actionMode === 'approve' ? !projectCode.trim() : !reviewComment.trim())}>
               {acting ? '저장 중...' : actionMode === 'approve' ? '승인 저장' : actionMode === 'reject' ? '반려 저장' : '폐기 저장'}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/src/app/components/projects/migration-audit/MigrationAuditControlBar.tsx
+++ b/src/app/components/projects/migration-audit/MigrationAuditControlBar.tsx
@@ -20,6 +20,7 @@ interface MigrationAuditControlBarProps {
   inboxScope: 'MINE' | 'ALL';
   onInboxScopeChange: (value: 'MINE' | 'ALL') => void;
   reviewerDepartment: string;
+  workflowStage: 'planning' | 'approval';
   statusFilter: 'ALL' | MigrationAuditConsoleStatus;
   onStatusFilterChange: (value: 'ALL' | MigrationAuditConsoleStatus) => void;
   searchQuery: string;
@@ -34,17 +35,20 @@ export function MigrationAuditControlBar({
   inboxScope,
   onInboxScopeChange,
   reviewerDepartment,
+  workflowStage,
   statusFilter,
   onStatusFilterChange,
   searchQuery,
   onSearchQueryChange,
   summary,
 }: MigrationAuditControlBarProps) {
-  const reviewTotal = summary.pending + summary.approved + summary.rejected;
+  const reviewTotal = summary.pending + summary.agreed + summary.approved + summary.rejected;
+  const pendingCount = workflowStage === 'planning' ? summary.pending : summary.agreed;
   const pendingEnd = reviewTotal ? (summary.pending / reviewTotal) * 100 : 0;
-  const approvedEnd = pendingEnd + (reviewTotal ? (summary.approved / reviewTotal) * 100 : 0);
+  const agreedEnd = pendingEnd + (reviewTotal ? (summary.agreed / reviewTotal) * 100 : 0);
+  const approvedEnd = agreedEnd + (reviewTotal ? (summary.approved / reviewTotal) * 100 : 0);
   const statusChartBackground = reviewTotal
-    ? `conic-gradient(#174a7c 0 ${pendingEnd}%, #15803d ${pendingEnd}% ${approvedEnd}%, #b42318 ${approvedEnd}% 100%)`
+    ? `conic-gradient(#174a7c 0 ${pendingEnd}%, #2563eb ${pendingEnd}% ${agreedEnd}%, #15803d ${agreedEnd}% ${approvedEnd}%, #b42318 ${approvedEnd}% 100%)`
     : '#e2e8f0';
 
   return (
@@ -52,20 +56,22 @@ export function MigrationAuditControlBar({
       <CardContent className="space-y-4 p-4">
         <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
           <div>
-            <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500">조직장 결재</p>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500">{workflowStage === 'planning' ? '경영기획실 합의' : '조직장 결재'}</p>
             <h2 className="mt-1 text-[22px] font-semibold tracking-[-0.03em] text-slate-950">
-              프로젝트 등록/승인
+              {workflowStage === 'planning' ? '프로젝트 코드 부여·합의' : '프로젝트 최종 승인'}
             </h2>
             <p className="mt-1 text-[12px] leading-6 text-slate-600">
-              검토할 문서를 먼저 좁힌 뒤, 문서 열기에서 기안·조직장 결재선과 등록 원문을 확인합니다.
+              {workflowStage === 'planning'
+                ? '등록 원문을 확인한 뒤 프로젝트 코드를 부여하고 경영기획실 합의를 남깁니다.'
+                : '경영기획실 합의가 끝난 문서를 열어 최종 승인 또는 반려합니다.'}
             </p>
           </div>
           <div className="flex items-center gap-4 border-l border-slate-200 pl-4">
-            <div className="grid h-[78px] w-[78px] place-items-center rounded-full" role="img" aria-label={`검토 대기 ${summary.pending}건, 승인 완료 ${summary.approved}건, 반려 ${summary.rejected}건`} style={{ background: statusChartBackground }}>
+            <div className="grid h-[78px] w-[78px] place-items-center rounded-full" role="img" aria-label={`합의 대기 ${summary.pending}건, 승인 대기 ${summary.agreed}건, 승인 완료 ${summary.approved}건, 반려 ${summary.rejected}건`} style={{ background: statusChartBackground }}>
               <span className="grid h-[54px] w-[54px] place-items-center rounded-full bg-white text-center text-[11px] font-semibold text-slate-700">{reviewTotal}<small className="block text-[9px] font-normal">건</small></span>
             </div>
             <dl className="grid grid-cols-3 divide-x divide-slate-200 text-center">
-              <div className="px-3"><dt className="text-[10px] text-slate-500">검토대기</dt><dd className="mt-1 text-[15px] font-bold text-[#174a7c]">{summary.pending}</dd></div>
+              <div className="px-3"><dt className="text-[10px] text-slate-500">{workflowStage === 'planning' ? '합의대기' : '승인대기'}</dt><dd className="mt-1 text-[15px] font-bold text-[#174a7c]">{pendingCount}</dd></div>
               <div className="px-3"><dt className="text-[10px] text-slate-500">승인완료</dt><dd className="mt-1 text-[15px] font-bold text-[#15803d]">{summary.approved}</dd></div>
               <div className="px-3"><dt className="text-[10px] text-slate-500">반려</dt><dd className="mt-1 text-[15px] font-bold text-[#b42318]">{summary.rejected}</dd></div>
             </dl>
@@ -108,7 +114,8 @@ export function MigrationAuditControlBar({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="ALL">전체 상태</SelectItem>
-                <SelectItem value="PENDING">검토 대기</SelectItem>
+                <SelectItem value="PENDING">합의 대기</SelectItem>
+                <SelectItem value="PLANNING_AGREED">합의 완료·승인 대기</SelectItem>
                 <SelectItem value="APPROVED">승인 완료</SelectItem>
                 <SelectItem value="REVISION_REJECTED">수정 요청 후 반려</SelectItem>
                 <SelectItem value="DUPLICATE_DISCARDED">중복·폐기</SelectItem>

--- a/src/app/components/projects/migration-audit/MigrationAuditDocumentDialog.tsx
+++ b/src/app/components/projects/migration-audit/MigrationAuditDocumentDialog.tsx
@@ -143,6 +143,7 @@ export function MigrationAuditDocumentDialog({
 
           <section className="mt-6 border border-slate-400">
             <DocumentCell label="문서 번호" value={record.request?.id || record.id} />
+            <DocumentCell label="프로젝트 코드" value={record.project.projectCode || ''} />
             <DocumentCell label="작성 일자" value={formatDateTime(record.requestedAt)} />
             <DocumentCell label="기안 부서" value={record.cic} />
             <DocumentCell label="기안자" value={dossier.audit.requestedByName} />

--- a/src/app/components/projects/migration-audit/MigrationAuditDocumentDialog.tsx
+++ b/src/app/components/projects/migration-audit/MigrationAuditDocumentDialog.tsx
@@ -18,9 +18,12 @@ interface MigrationAuditDocumentDialogProps {
   record: MigrationAuditConsoleRecord | null;
   reviewerName: string;
   acting: boolean;
+  workflowStage: 'planning' | 'approval';
+  canFinalize: boolean;
   contractDocumentDownloadURL?: string;
   contractDocumentError?: string;
   onOpenChange: (open: boolean) => void;
+  onAgree: () => void;
   onApprove: () => void;
   onReject: () => void;
 }
@@ -66,9 +69,12 @@ export function MigrationAuditDocumentDialog({
   record,
   reviewerName,
   acting,
+  workflowStage,
+  canFinalize,
   contractDocumentDownloadURL = '',
   contractDocumentError = '',
   onOpenChange,
+  onAgree,
   onApprove,
   onReject,
 }: MigrationAuditDocumentDialogProps) {
@@ -79,12 +85,16 @@ export function MigrationAuditDocumentDialog({
   const designatedApproverName = requestPayload?.executiveApproverName
     || record.project.executiveApproverName
     || '';
-  const latestReview = record.project.executiveReviewHistory?.at(-1);
-  const reviewedByName = latestReview?.reviewedByName
+  const history = record.project.executiveReviewHistory || [];
+  const planningAgreement = [...history].reverse().find((entry) => entry.status === 'PLANNING_AGREED');
+  const finalReview = [...history].reverse().find((entry) => (
+    entry.status === 'APPROVED' || entry.status === 'REVISION_REJECTED' || entry.status === 'DUPLICATE_DISCARDED'
+  ));
+  const reviewedByName = finalReview?.reviewedByName
     || record.project.executiveReviewedByName
     || record.request?.reviewedByName
     || reviewerName;
-  const reviewedAt = latestReview?.reviewedAt
+  const reviewedAt = finalReview?.reviewedAt
     || record.project.executiveReviewedAt
     || record.request?.reviewedAt;
   const approvalState = record.status === 'APPROVED'
@@ -115,13 +125,21 @@ export function MigrationAuditDocumentDialog({
                 <h2 className="mt-3 text-center text-[25px] font-bold tracking-[0.08em]">프로젝트 등록 및 승인서</h2>
               </div>
               <div className="border border-slate-400">
-                <div className="grid grid-cols-[48px_repeat(2,minmax(0,1fr))]">
+                  <div className="grid grid-cols-[48px_repeat(3,minmax(0,1fr))]">
                   <div className="flex items-center justify-center border-r border-b border-slate-400 bg-slate-50 text-[11px] font-semibold">결재</div>
                   <div className="border-r border-b border-slate-400 px-2 py-1.5 text-center text-[11px] font-semibold">기안</div>
+                  <div className="border-r border-b border-slate-400 px-2 py-1.5 text-center text-[11px] font-semibold">경영기획실 합의</div>
                   <div className="border-b border-slate-400 px-2 py-1.5 text-center text-[11px] font-semibold">조직장 승인</div>
                   <div className="flex items-center justify-center border-r border-slate-400 bg-slate-50 text-[10px] text-slate-600">인</div>
                   <div className="flex min-h-[70px] flex-col items-center justify-center gap-1 border-r border-slate-400 px-2 py-2">
                     <ApprovalSeal name={dossier.audit.requestedByName} state="submitted" />
+                  </div>
+                  <div className="flex min-h-[70px] flex-col items-center justify-center gap-1 border-r border-slate-400 px-2 py-2">
+                    {planningAgreement ? (
+                      <ApprovalSeal name={planningAgreement.reviewedByName} state="approved" />
+                    ) : (
+                      <span className="text-center text-[10px] text-slate-500">합의 대기</span>
+                    )}
                   </div>
                   <div className="flex min-h-[70px] flex-col items-center justify-center gap-1 px-2 py-2">
                     {approvalState === 'pending' ? (
@@ -135,6 +153,7 @@ export function MigrationAuditDocumentDialog({
                   </div>
                   <div className="flex items-center justify-center border-r border-t border-slate-400 bg-slate-50 text-[10px] text-slate-600">일자</div>
                   <div className="border-r border-t border-slate-400 px-2 py-2 text-center text-[10px] text-slate-700">{formatDateTime(record.requestedAt)}</div>
+                  <div className="border-r border-t border-slate-400 px-2 py-2 text-center text-[10px] text-slate-700">{planningAgreement ? formatDateTime(planningAgreement.reviewedAt) : '합의 대기'}</div>
                   <div className="border-t border-slate-400 px-2 py-2 text-center text-[10px] text-slate-700">{reviewedAt ? formatDateTime(reviewedAt) : '검토 대기'}</div>
                 </div>
               </div>
@@ -148,6 +167,21 @@ export function MigrationAuditDocumentDialog({
             <DocumentCell label="기안 부서" value={record.cic} />
             <DocumentCell label="기안자" value={dossier.audit.requestedByName} />
             <DocumentCell label="결재 상태" value={getMigrationAuditStatusLabel(record.status)} />
+          </section>
+
+          <section className="mt-6">
+            <h3 className="border-b-2 border-slate-700 pb-2 text-[14px] font-bold">처리 의견</h3>
+            <div className="border border-t-0 border-slate-400">
+              {history.map((entry, index) => (
+                <div key={`${entry.reviewedAt}-${index}`} className="border-b border-slate-300 px-4 py-3 last:border-b-0">
+                  <p className="text-[11px] font-semibold text-slate-800">
+                    {entry.status === 'PLANNING_AGREED' ? '경영기획실 합의' : getMigrationAuditStatusLabel(entry.status)} · {entry.reviewedByName} · {formatDateTime(entry.reviewedAt)}
+                    {entry.projectCode ? ` · ${entry.projectCode}` : ''}
+                  </p>
+                  <p className="mt-1 whitespace-pre-wrap text-[12px] leading-5 text-slate-700">{entry.reviewComment || '-'}</p>
+                </div>
+              ))}
+            </div>
           </section>
 
           <section className="mt-6">
@@ -190,14 +224,25 @@ export function MigrationAuditDocumentDialog({
                 <a className="ml-3 font-semibold text-[#174a7c] underline underline-offset-2" href={contractDocumentUrl} target="_blank" rel="noreferrer">계약서 원문 열기</a>
               ) : null}
               {contractDocumentError ? <p className="mt-1 text-[11px] text-rose-700">{contractDocumentError}</p> : null}
+              {contractDocumentUrl ? (
+                <iframe title="계약서 미리보기" src={contractDocumentUrl} className="mt-3 h-[520px] w-full border border-slate-300 bg-slate-50" />
+              ) : null}
             </div>
           </section>
 
-          {record.status === 'PENDING' ? (
+          {workflowStage === 'planning' && record.status === 'PENDING' ? (
+            <footer className="mt-7 flex justify-end gap-2 border-t border-slate-300 pt-4">
+              <Button type="button" className="rounded-none bg-[#174a7c] hover:bg-[#103a63]" onClick={onAgree} disabled={acting}>합의</Button>
+            </footer>
+          ) : null}
+          {workflowStage === 'approval' && record.status === 'PLANNING_AGREED' && canFinalize ? (
             <footer className="mt-7 flex justify-end gap-2 border-t border-slate-300 pt-4">
               <Button type="button" variant="outline" className="rounded-none border-slate-500" onClick={onReject} disabled={acting}>반려</Button>
               <Button type="button" className="rounded-none bg-[#174a7c] hover:bg-[#103a63]" onClick={onApprove} disabled={acting}>승인</Button>
             </footer>
+          ) : null}
+          {workflowStage === 'approval' && record.status === 'PLANNING_AGREED' && !canFinalize ? (
+            <p className="mt-7 border-t border-slate-300 pt-4 text-right text-[11px] text-slate-500">지정된 조직장만 최종 승인 또는 반려할 수 있습니다.</p>
           ) : null}
         </article>
       </DialogContent>

--- a/src/app/components/projects/migration-audit/MigrationAuditRecordList.tsx
+++ b/src/app/components/projects/migration-audit/MigrationAuditRecordList.tsx
@@ -10,6 +10,7 @@ interface MigrationAuditRecordListProps {
 }
 
 function statusClass(status: MigrationAuditConsoleRecord['status']) {
+  if (status === 'PLANNING_AGREED') return 'border-blue-300 text-blue-800';
   if (status === 'APPROVED') return 'border-emerald-300 text-emerald-800';
   if (status === 'REVISION_REJECTED') return 'border-rose-300 text-rose-800';
   if (status === 'DUPLICATE_DISCARDED') return 'border-slate-400 text-slate-700';

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -610,6 +610,7 @@ export interface Project {
   executiveApproverId?: string;
   executiveApproverName?: string;
   executiveApproverEmail?: string;
+  projectCode?: string;
   registeredAt?: string;
   executiveReviewStatus?: ProjectExecutiveReviewStatus;
   executiveReviewedAt?: string;
@@ -727,6 +728,7 @@ export interface ProjectExecutiveReviewHistoryEntry {
   reviewedById: string;
   reviewedByName: string;
   reviewComment?: string;
+  projectCode?: string;
   changes?: ProjectReviewFieldChange[];
 }
 

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -710,7 +710,7 @@ export interface Project {
 }
 
 export type ProjectRequestStatus = 'PENDING' | 'APPROVED' | 'REJECTED';
-export type ProjectExecutiveReviewStatus = 'PENDING' | 'APPROVED' | 'REVISION_REJECTED' | 'DUPLICATE_DISCARDED';
+export type ProjectExecutiveReviewStatus = 'PENDING' | 'PLANNING_AGREED' | 'APPROVED' | 'REVISION_REJECTED' | 'DUPLICATE_DISCARDED';
 export type ProjectRequestReviewOutcome = 'APPROVED' | 'REVISION_REJECTED' | 'DUPLICATE_DISCARDED';
 export type ProjectRequestKind = 'REGISTRATION' | 'CHANGE';
 

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -963,6 +963,26 @@ describe('platform-bff-client', () => {
     }));
   });
 
+  it('sends the assigned project code with an approval decision', async () => {
+    const client = asMockClient({
+      post: vi.fn(async () => ({ data: { ok: true, projectId: 'p-123', requestId: null, reviewStatus: 'APPROVED' } })),
+      get: vi.fn(),
+      request: vi.fn(),
+    });
+
+    await reviewProjectExecutiveStatusViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'u-admin', role: 'admin', idToken: 'token-abc' },
+      projectId: 'p-123',
+      review: { reviewStatus: 'APPROVED', projectCode: '  PRJ-2026-001  ' },
+      client,
+    });
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/projects/p-123/executive-review', expect.objectContaining({
+      body: { reviewStatus: 'APPROVED', projectCode: 'PRJ-2026-001' },
+    }));
+  });
+
   it('calls project executive review resubmission endpoint', async () => {
     const client = asMockClient({
       post: vi.fn(async () => ({

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -258,6 +258,7 @@ export interface ProjectExecutiveReviewPayload {
   reviewStatus: ProjectExecutiveReviewStatus;
   reviewComment?: string;
   reviewerName?: string;
+  projectCode?: string;
 }
 
 export interface ProjectExecutiveReviewResult {
@@ -362,11 +363,13 @@ function normalizeProjectExecutiveReviewPayload(
   const requestId = normalizeOptionalText(payload.requestId);
   const reviewComment = normalizeOptionalText(payload.reviewComment);
   const reviewerName = normalizeOptionalText(payload.reviewerName);
+  const projectCode = normalizeOptionalText(payload.projectCode);
   return {
     ...(requestId ? { requestId } : {}),
     reviewStatus: payload.reviewStatus,
     ...(reviewComment ? { reviewComment } : {}),
     ...(reviewerName ? { reviewerName } : {}),
+    ...(projectCode ? { projectCode } : {}),
   };
 }
 

--- a/src/app/lib/project-request-attachment-client.test.ts
+++ b/src/app/lib/project-request-attachment-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { downloadProjectRequestAttachmentViaBff } from './project-request-attachment-client';
+import { downloadProjectAttachmentViaBff, downloadProjectRequestAttachmentViaBff } from './project-request-attachment-client';
 
 describe('project request attachment client', () => {
   it('downloads a pending attachment with authorization headers and no token in the URL', async () => {
@@ -30,5 +30,21 @@ describe('project request attachment client', () => {
     expect(headers.get('x-tenant-id')).toBe('mysc');
     expect(result.blob.type).toBe('application/pdf');
     expect(result.fileName).toBe('pending-contract.pdf');
+  });
+
+  it('downloads a project attachment after final approval', async () => {
+    const fetchImpl = vi.fn(async () => new Response(new Blob(['private-pdf']), {
+      status: 200,
+      headers: { 'content-disposition': "attachment; filename*=UTF-8''contract.pdf" },
+    }));
+
+    await downloadProjectAttachmentViaBff({
+      tenantId: 'mysc', actor: { uid: 'approver-a', role: 'admin' }, projectId: 'project-a', documentKind: 'contract', fetchImpl,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/v1\/projects\/project-a\/attachments\/contract$/),
+      expect.objectContaining({ method: 'GET' }),
+    );
   });
 });

--- a/src/app/lib/project-request-attachment-client.ts
+++ b/src/app/lib/project-request-attachment-client.ts
@@ -45,3 +45,33 @@ export async function downloadProjectRequestAttachmentViaBff(params: {
     fileName: contentDispositionFileName(response.headers.get('content-disposition')) || 'attachment',
   };
 }
+
+export async function downloadProjectAttachmentViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectId: string;
+  documentKind: ProjectRequestDocumentKind;
+  fetchImpl?: typeof fetch;
+}): Promise<{ blob: Blob; fileName: string }> {
+  const projectId = params.projectId.trim();
+  if (!projectId || projectId.includes('/')) throw new Error('project ID is invalid');
+  const response = await (params.fetchImpl || globalThis.fetch)(
+    `${readPlatformApiRuntimeConfig().baseUrl}/api/v1/projects/${encodeURIComponent(projectId)}/attachments/${params.documentKind}`,
+    {
+      method: 'GET',
+      headers: buildStandardHeaders({
+        tenantId: params.tenantId,
+        actor: toRequestActor(params.actor),
+        method: 'GET',
+      }),
+    },
+  );
+  if (!response.ok) {
+    const message = (await response.text()).trim();
+    throw new Error(message || '첨부 파일을 불러오지 못했습니다.');
+  }
+  return {
+    blob: await response.blob(),
+    fileName: contentDispositionFileName(response.headers.get('content-disposition')) || 'attachment',
+  };
+}

--- a/src/app/platform/project-migration-console.test.ts
+++ b/src/app/platform/project-migration-console.test.ts
@@ -4,6 +4,7 @@ import {
   buildMigrationAuditConsoleRecords,
   collectMigrationAuditCicOptions,
   describeMigrationAuditActionState,
+  deriveMigrationAuditStatus,
   filterMigrationAuditConsoleRecords,
   findMigrationAuditRecord,
   isMigrationAuditPmRegistration,
@@ -96,6 +97,10 @@ function makeRequest(overrides: Partial<ProjectRequest> = {}): ProjectRequest {
 }
 
 describe('project-migration-console', () => {
+  it('keeps planning-agreed registrations out of the unreviewed queue', () => {
+    expect(deriveMigrationAuditStatus(makeProject({ executiveReviewStatus: 'PLANNING_AGREED' }))).toBe('PLANNING_AGREED');
+  });
+
   it('normalizes empty cic to 미지정', () => {
     expect(normalizeCicLabel('')).toBe('미지정');
     expect(normalizeCicLabel(undefined)).toBe('미지정');

--- a/src/app/platform/project-migration-console.ts
+++ b/src/app/platform/project-migration-console.ts
@@ -22,6 +22,7 @@ export interface MigrationAuditConsoleRecord {
 export interface MigrationAuditConsoleSummary {
   total: number;
   pending: number;
+  agreed: number;
   approved: number;
   rejected: number;
   discarded: number;
@@ -71,6 +72,8 @@ export function deriveMigrationAuditStatus(
   request?: ProjectRequest | null,
 ): MigrationAuditConsoleStatus {
   if (
+    project.executiveReviewStatus === 'PLANNING_AGREED'
+    ||
     project.executiveReviewStatus === 'REVISION_REJECTED'
     || project.executiveReviewStatus === 'DUPLICATE_DISCARDED'
   ) {
@@ -84,6 +87,7 @@ export function deriveMigrationAuditStatus(
 }
 
 export function getMigrationAuditStatusLabel(status: MigrationAuditConsoleStatus): string {
+  if (status === 'PLANNING_AGREED') return '경영기획실 합의 완료';
   if (status === 'APPROVED') return '승인 완료';
   if (status === 'REVISION_REJECTED') return '수정 요청 후 반려';
   if (status === 'DUPLICATE_DISCARDED') return '중복·폐기';
@@ -187,6 +191,7 @@ export function summarizeMigrationAuditConsole(
   return {
     total: records.length,
     pending: records.filter((record) => record.status === 'PENDING').length,
+    agreed: records.filter((record) => record.status === 'PLANNING_AGREED').length,
     approved: records.filter((record) => record.status === 'APPROVED').length,
     rejected: records.filter((record) => record.status === 'REVISION_REJECTED').length,
     discarded: records.filter((record) => record.status === 'DUPLICATE_DISCARDED').length,
@@ -214,6 +219,13 @@ export function describeMigrationAuditActionState(
       tone: 'success',
       label: '승인 완료',
       helper: 'CIC 대표 검토가 끝났고 이 프로젝트 등록 요청은 확정되었습니다. 필요하면 다시 반려 또는 중복·폐기로 조정할 수 있습니다.',
+    };
+  }
+  if (record.status === 'PLANNING_AGREED') {
+    return {
+      tone: 'neutral',
+      label: '경영기획실 합의 완료',
+      helper: '프로젝트 코드가 부여됐습니다. 지정 조직장의 최종 승인 또는 반려가 필요합니다.',
     };
   }
   if (record.status === 'REVISION_REJECTED') {

--- a/src/app/platform/project-terminology.shell.test.ts
+++ b/src/app/platform/project-terminology.shell.test.ts
@@ -122,7 +122,7 @@ describe('project terminology contract', () => {
     [
       '프로젝트 등록 요청',
       '프로젝트 등록 검토',
-      'PM 등록 프로젝트 검토',
+      'PM 등록 프로젝트 승인',
       'CIC 대표 검토',
       '프로젝트명',
       '계약 대상',


### PR DESCRIPTION
## 변경 사항
- 경영기획실의 프로젝트 코드 부여 및 합의를 최종 승인과 분리
- 지정 조직장만 합의 완료 건을 승인 또는 반려하도록 서버와 화면에서 검증
- 결재 문서에 기안·경영기획실 합의·조직장 승인 및 메모·계약서 미리보기 표시

## 검증
- 프로젝트 관련 Vitest 68건 통과
- npm run build 통과