### PR TITLE
feat: multi-year cashflow sheet storage

### DIFF
--- a/server/bff/cashflow-sheet-snapshot.mjs
+++ b/server/bff/cashflow-sheet-snapshot.mjs
@@ -95,11 +95,85 @@ function snapshotCell(mapping, matrix) {
   };
 }
 
+function snapshotAnnualCell(mapping, matrix) {
+  const classified = classifyCashflowSheetCell(matrix?.[mapping.rowIndex]?.[mapping.columnIndex]);
+  return {
+    mode: mapping.mode,
+    year: Number(mapping.year),
+    lineId: mapping.lineId,
+    direction: mapping.direction,
+    sourceCell: mapping.a1,
+    sourceLabel: mapping.label || mapping.canonicalLabel || mapping.lineId,
+    ...classified,
+  };
+}
+
 function compareCells(left, right) {
   return String(left.mode).localeCompare(String(right.mode))
     || String(left.yearMonth).localeCompare(String(right.yearMonth))
     || Number(left.weekNo) - Number(right.weekNo)
     || String(left.lineId).localeCompare(String(right.lineId));
+}
+
+function compareAnnualCells(left, right) {
+  return Number(left.year) - Number(right.year)
+    || String(left.mode).localeCompare(String(right.mode))
+    || String(left.lineId).localeCompare(String(right.lineId));
+}
+
+function summarizeAnnualMode(cells, source) {
+  const lineAmounts = {};
+  let totalIn = 0;
+  let totalOut = 0;
+  let valueCellCount = 0;
+  let emptyCellCount = 0;
+  let invalidCellCount = 0;
+  for (const cell of cells) {
+    if (cell.state === 'EMPTY') {
+      emptyCellCount += 1;
+      continue;
+    }
+    if (cell.state === 'INVALID') {
+      invalidCellCount += 1;
+      continue;
+    }
+    valueCellCount += 1;
+    const amount = Number(cell.amount) || 0;
+    lineAmounts[cell.lineId] = amount;
+    if (cell.direction === 'IN') totalIn += amount;
+    if (cell.direction === 'OUT') totalOut += amount;
+  }
+  return {
+    source,
+    valueCellCount,
+    emptyCellCount,
+    invalidCellCount,
+    lineAmounts,
+    totalIn,
+    totalOut,
+    net: totalIn - totalOut,
+  };
+}
+
+function buildAnnualCashflowTotals({ cells, annualCells }) {
+  const years = new Set([
+    ...cells.map((cell) => Number(String(cell.yearMonth).slice(0, 4))),
+    ...annualCells.map((cell) => Number(cell.year)),
+  ].filter(Number.isSafeInteger));
+  return [...years]
+    .sort((left, right) => left - right)
+    .map((year) => {
+      const modeTotals = {};
+      for (const mode of ['projection', 'actual']) {
+        const weeklyCells = cells.filter((cell) => cell.mode === mode && Number(String(cell.yearMonth).slice(0, 4)) === year);
+        const annualCellsForMode = annualCells.filter((cell) => cell.mode === mode && cell.year === year);
+        modeTotals[mode] = summarizeAnnualMode(
+          weeklyCells.length > 0 ? weeklyCells : annualCellsForMode,
+          weeklyCells.length > 0 ? 'WEEKLY' : annualCellsForMode.length > 0 ? 'ANNUAL' : 'NONE',
+        );
+      }
+      return { year, ...modeTotals };
+    });
 }
 
 function matrixValue(matrix, rowIndex, columnIndex) {
@@ -144,7 +218,16 @@ function readWholeWon(
   return classified.amount;
 }
 
-function controlRow({ matrix, row, weekColumns, issues }) {
+function findControlColumnIndex(template, matrix, headerText, legacyColumnIndex) {
+  const projectionSection = template?.sections?.find((section) => section.mode === 'projection');
+  if (!Number.isInteger(projectionSection?.headerRowIndex)) return legacyColumnIndex;
+  const header = matrix?.[projectionSection.headerRowIndex] || [];
+  const normalizedTarget = normalizedText(headerText).replace(/\s+/g, '').toLowerCase();
+  const found = header.findIndex((value) => normalizedText(value).replace(/\s+/g, '').toLowerCase() === normalizedTarget);
+  return found >= 0 ? found : null;
+}
+
+function controlRow({ matrix, row, weekColumns, issues, controlColumnIndex }) {
   const field = `${row.kind}:${row.lineId || row.derivedKind}`;
   const amounts = weekColumns.map((week) => readWholeWon(
     matrix,
@@ -157,7 +240,9 @@ function controlRow({ matrix, row, weekColumns, issues }) {
   const computed = amounts.some((amount) => amount === null)
     ? null
     : amounts.reduce((sum, amount) => sum + amount, 0);
-  const value = readWholeWon(matrix, row.rowIndex, 66, issues, field, { allowEmpty: false });
+  const value = controlColumnIndex === null
+    ? null
+    : readWholeWon(matrix, row.rowIndex, controlColumnIndex, issues, field, { allowEmpty: false });
   const annualValues = new Map();
   for (let index = 0; index < weekColumns.length; index += 1) {
     const year = Number(String(weekColumns[index].yearMonth).slice(0, 4));
@@ -167,10 +252,10 @@ function controlRow({ matrix, row, weekColumns, issues }) {
   return {
     kind: row.kind,
     ...(row.lineId ? { lineId: row.lineId } : { derivedKind: row.derivedKind }),
-    sourceCell: toA1(row.rowIndex, 66),
+    sourceCell: controlColumnIndex === null ? '' : toA1(row.rowIndex, controlColumnIndex),
     value,
     computed,
-    matches: value === null || computed === null ? false : value === computed,
+    matches: value === null || computed === null ? null : value === computed,
     annualValues: [...annualValues.entries()]
       .sort(([left], [right]) => left - right)
       .map(([year, annualValue]) => ({ year, value: annualValue })),
@@ -200,12 +285,13 @@ function annualSheetFinancialTotals({ depositScheduleRows, projectionControls })
     }));
 }
 
-export function extractCashflowSheetFacts({ template = {}, matrix = [] } = {}) {
+export function extractCashflowSheetFacts({ template = {}, matrix = [], cells = [], annualCells = [] } = {}) {
   const issues = [];
   const projectionSection = template?.sections?.find((section) => section.mode === 'projection');
   const weekColumns = (projectionSection?.weekColumns || [])
-    .filter((week) => week.columnIndex >= 3 && week.columnIndex <= 62)
     .sort((left, right) => left.yearMonth.localeCompare(right.yearMonth) || left.weekNo - right.weekNo);
+  const depositControlColumnIndex = findControlColumnIndex(template, matrix, '입금Total', 66);
+  const unpaidControlColumnIndex = findControlColumnIndex(template, matrix, '미지급Total', 67);
   const depositScheduleRows = weekColumns.map((week) => {
     const taxInvoiceIssuedDate = normalizeDateCell(matrix?.[6]?.[week.columnIndex]);
     const expectedDepositDate = normalizeDateCell(matrix?.[7]?.[week.columnIndex]);
@@ -242,8 +328,14 @@ export function extractCashflowSheetFacts({ template = {}, matrix = [] } = {}) {
   ].sort((left, right) => left.rowIndex - right.rowIndex);
   const modeControls = (mode) => {
     const section = template?.sections?.find((candidate) => candidate.mode === mode);
-    const columns = (section?.weekColumns || []).filter((week) => week.columnIndex >= 3 && week.columnIndex <= 62);
-    return controlRows(section).map((row) => controlRow({ matrix, row, weekColumns: columns, issues }));
+    const columns = section?.weekColumns || [];
+    return controlRows(section).map((row) => controlRow({
+      matrix,
+      row,
+      weekColumns: columns,
+      issues,
+      controlColumnIndex: depositControlColumnIndex,
+    }));
   };
   const depositValues = weekColumns.map((week) => readWholeWon(
     matrix,
@@ -256,7 +348,9 @@ export function extractCashflowSheetFacts({ template = {}, matrix = [] } = {}) {
   const depositComputed = depositValues.some((amount) => amount === null)
     ? null
     : depositValues.reduce((sum, amount) => sum + amount, 0);
-  const depositValue = readWholeWon(matrix, 8, 66, issues, 'depositControl', { allowEmpty: false, nonNegative: true });
+  const depositValue = depositControlColumnIndex === null
+    ? null
+    : readWholeWon(matrix, 8, depositControlColumnIndex, issues, 'depositControl', { allowEmpty: false, nonNegative: true });
 
   const projectionControls = modeControls('projection');
   const actualControls = modeControls('actual');
@@ -270,16 +364,17 @@ export function extractCashflowSheetFacts({ template = {}, matrix = [] } = {}) {
     },
     depositScheduleRows,
     annualFinancialTotals: annualSheetFinancialTotals({ depositScheduleRows, projectionControls }),
+    annualCashflowTotals: buildAnnualCashflowTotals({ cells, annualCells }),
     controlTotals: {
       deposit: {
-        sourceCell: 'BO9',
+        sourceCell: depositControlColumnIndex === null ? '' : toA1(8, depositControlColumnIndex),
         value: depositValue,
         computed: depositComputed,
-        matches: depositValue === null || depositComputed === null ? false : depositValue === depositComputed,
+        matches: depositValue === null || depositComputed === null ? null : depositValue === depositComputed,
       },
       unpaid: {
-        sourceCell: 'BP9',
-        value: readWholeWon(matrix, 8, 67, issues, 'unpaidControl'),
+        sourceCell: unpaidControlColumnIndex === null ? '' : toA1(8, unpaidControlColumnIndex),
+        value: unpaidControlColumnIndex === null ? null : readWholeWon(matrix, 8, unpaidControlColumnIndex, issues, 'unpaidControl'),
       },
       projection: projectionControls,
       actual: actualControls,
@@ -301,8 +396,12 @@ export function createCashflowPinnedSnapshot({
   capturedBy = {},
 } = {}) {
   const cells = mappings.map((mapping) => snapshotCell(mapping, matrix)).sort(compareCells);
-  const sheetFacts = extractCashflowSheetFacts({ template, matrix });
-  const sourceRevision = revisionOf({ spreadsheetId, selectedSheetName, cells, sheetFacts });
+  const annualCells = (template?.sections || [])
+    .flatMap((section) => section.annualMappings || [])
+    .map((mapping) => snapshotAnnualCell(mapping, matrix))
+    .sort(compareAnnualCells);
+  const sheetFacts = extractCashflowSheetFacts({ template, matrix, cells, annualCells });
+  const sourceRevision = revisionOf({ spreadsheetId, selectedSheetName, cells, annualCells, sheetFacts });
   const summary = cells.reduce((counts, cell) => {
     counts.cellCount += 1;
     if (cell.state === 'VALUE') counts.valueCount += 1;
@@ -327,8 +426,13 @@ export function createCashflowPinnedSnapshot({
       role: String(capturedBy?.role || ''),
     },
     yearMonths: [...new Set(cells.map((cell) => cell.yearMonth))].sort(),
+    years: [...new Set([
+      ...cells.map((cell) => Number(String(cell.yearMonth).slice(0, 4))),
+      ...annualCells.map((cell) => cell.year),
+    ].filter(Number.isSafeInteger))].sort((left, right) => left - right),
     summary,
     cells,
+    annualCells,
     sheetFacts,
   };
 }

--- a/server/bff/cashflow-sheet-snapshot.test.mjs
+++ b/server/bff/cashflow-sheet-snapshot.test.mjs
@@ -128,6 +128,7 @@ describe('cashflow sheet pinned snapshot', () => {
         totalRevenueAmount: 0,
         supportAmount: 0,
       }],
+      annualCashflowTotals: [],
       controlTotals: {
         deposit: { sourceCell: 'BO9', value: 15000, computed: 15000, matches: true },
         unpaid: { sourceCell: 'BP9', value: 85000 },
@@ -168,6 +169,36 @@ describe('cashflow sheet pinned snapshot', () => {
     expect(facts.depositScheduleRows[1].expectedDepositAmount).toBeNull();
     expect(facts.controlTotals.deposit).toMatchObject({ computed: 1000, value: 1000, matches: true });
     expect(facts.controlTotals.projection[0]).toMatchObject({ computed: 100, value: 100, matches: true });
+  });
+
+  it('finds the moving Total columns and keeps week values beyond the 2026 layout', () => {
+    const matrix = Array.from({ length: 55 }, () => Array.from({ length: 72 }, () => ''));
+    matrix[0][68] = '입금\nTotal';
+    matrix[0][69] = '미지급 Total';
+    const weekColumns = [
+      { yearMonth: '2027-01', weekNo: 4, columnIndex: 63 },
+      { yearMonth: '2027-01', weekNo: 5, columnIndex: 64 },
+    ];
+    matrix[8][63] = '1000';
+    matrix[8][64] = '2000';
+    matrix[8][68] = '3000';
+    matrix[13][63] = '100';
+    matrix[13][64] = '200';
+    matrix[13][68] = '300';
+
+    const facts = extractCashflowSheetFacts({
+      matrix,
+      template: {
+        sections: [
+          { mode: 'projection', headerRowIndex: 0, weekColumns, lineRows: [{ rowIndex: 13, lineId: 'SALES_IN' }], derivedRows: [] },
+          { mode: 'actual', headerRowIndex: 0, weekColumns, lineRows: [], derivedRows: [] },
+        ],
+      },
+    });
+
+    expect(facts.depositScheduleRows).toHaveLength(2);
+    expect(facts.controlTotals.deposit).toMatchObject({ sourceCell: 'BQ9', value: 3000, computed: 3000, matches: true });
+    expect(facts.controlTotals.projection[0]).toMatchObject({ sourceCell: 'BQ14', value: 300, computed: 300, matches: true });
   });
 
   it('groups sheet finance checks by calendar year using the registered cashflow lines', () => {

--- a/server/bff/cashflow-sheet-template.mjs
+++ b/server/bff/cashflow-sheet-template.mjs
@@ -1,6 +1,7 @@
 import cashflowPolicyData from '../../src/app/policies/cashflow-policy.json' with { type: 'json' };
 
 const WEEK_LABEL_RE = /^(\d{2})-(\d{1,2})-(\d{1,2})$/;
+const ANNUAL_YEAR_LABEL_RE = /^(\d{4})년$/;
 const SUPPORTED_MODES = ['projection', 'actual'];
 const MIN_WEEK_LABELS_PER_SECTION = 2;
 const LINE_ENTRIES = Array.isArray(cashflowPolicyData.lineEntries) ? cashflowPolicyData.lineEntries : [];
@@ -103,6 +104,20 @@ function detectWeekColumns(row) {
     .filter(Boolean);
 }
 
+function detectAnnualYearColumns(row) {
+  return (row || [])
+    .map((cell, columnIndex) => {
+      const match = ANNUAL_YEAR_LABEL_RE.exec(normalizeText(cell));
+      if (!match) return null;
+      return {
+        year: Number.parseInt(match[1], 10),
+        columnIndex,
+        a1: toA1(0, columnIndex).replace(/\d+$/, ''),
+      };
+    })
+    .filter((column) => Number.isSafeInteger(column?.year));
+}
+
 function readRowLabel(row) {
   const searchLimit = Math.min(4, row?.length || 0);
   for (let index = 0; index < searchLimit; index += 1) {
@@ -189,6 +204,10 @@ function analyzeSection({ rows, candidate, nextCandidate, mode }) {
   const duplicateLineIds = new Set();
   const seenLineIds = new Set();
   const endRowIndex = nextCandidate?.headerRowIndex ?? rows.length;
+  const annualColumns = detectAnnualYearColumns(rows[candidate.headerRowIndex]).map((column) => ({
+    ...column,
+    a1: toA1(candidate.headerRowIndex, column.columnIndex),
+  }));
   let direction = 'IN';
 
   for (let rowIndex = candidate.rowIndex + 1; rowIndex < endRowIndex; rowIndex += 1) {
@@ -235,6 +254,7 @@ function analyzeSection({ rows, candidate, nextCandidate, mode }) {
   }
 
   const mappings = [];
+  const annualMappings = [];
   for (const lineRow of lineRows) {
     for (const week of candidate.weekColumns) {
       mappings.push({
@@ -251,6 +271,20 @@ function analyzeSection({ rows, candidate, nextCandidate, mode }) {
         source: 'sheet_layout',
       });
     }
+    for (const column of annualColumns) {
+      annualMappings.push({
+        mode,
+        lineId: lineRow.lineId,
+        label: lineRow.label,
+        canonicalLabel: lineRow.canonicalLabel,
+        direction: lineRow.direction,
+        year: column.year,
+        rowIndex: lineRow.rowIndex,
+        columnIndex: column.columnIndex,
+        a1: toA1(lineRow.rowIndex, column.columnIndex),
+        source: 'sheet_annual_total',
+      });
+    }
   }
 
   const missingLineIds = EXPECTED_LINE_IDS.filter((lineId) => !seenLineIds.has(lineId));
@@ -260,10 +294,12 @@ function analyzeSection({ rows, candidate, nextCandidate, mode }) {
     headerRowIndex: Math.max(0, candidate.rowIndex - 1),
     weekRowIndex: candidate.rowIndex,
     weekColumns: candidate.weekColumns,
+    annualColumns,
     lineRows,
     derivedRows,
     ignoredRows,
     mappings,
+    annualMappings,
     missingLineIds,
     duplicateLineIds: Array.from(duplicateLineIds),
   };

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -27,6 +27,8 @@ const CASHFLOW_WEEK_BASIS = 'sheet_range';
 const CASHFLOW_WEEKS_COLLECTION_ID = 'cashflow_weeks';
 const CASHFLOW_CHANGE_CANDIDATES_COLLECTION_ID = 'cashflow_change_candidates';
 const CASHFLOW_SHEET_MIRRORS_COLLECTION_ID = 'cashflow_sheet_mirrors';
+const CASHFLOW_SHEET_WEEK_VALUES_COLLECTION_ID = 'cashflow_sheet_week_values';
+const CASHFLOW_SHEET_YEAR_TOTALS_COLLECTION_ID = 'cashflow_sheet_year_totals';
 const CASHFLOW_SHEET_REFRESH_RUNS_COLLECTION_ID = 'cashflow_sheet_refresh_runs';
 const CASHFLOW_SHEET_STAGE_RUNS_COLLECTION_ID = 'cashflow_sheet_stage_runs';
 const CASHFLOW_SHEET_STAGE_MONTHS_COLLECTION_ID = 'cashflow_sheet_stage_months';
@@ -242,6 +244,14 @@ function projectDocPath(tenantId, projectId) {
 
 function cashflowSheetMirrorDocPath(tenantId, projectId) {
   return `orgs/${tenantId}/${CASHFLOW_SHEET_MIRRORS_COLLECTION_ID}/${projectId}`;
+}
+
+function cashflowSheetWeekValueDocPath(tenantId, projectId, yearMonth) {
+  return `orgs/${tenantId}/${CASHFLOW_SHEET_WEEK_VALUES_COLLECTION_ID}/${projectId}_${readOptionalText(yearMonth).replace('-', '_')}`;
+}
+
+function cashflowSheetYearTotalDocPath(tenantId, projectId, year) {
+  return `orgs/${tenantId}/${CASHFLOW_SHEET_YEAR_TOTALS_COLLECTION_ID}/${projectId}_${Number(year)}`;
 }
 
 function cashflowSheetRefreshRunDocPath(tenantId, projectId, idempotencyKey) {
@@ -727,7 +737,10 @@ async function completeCashflowSheetRefreshRun({
         latestRefreshGeneration: runGeneration,
         pendingRefreshConfigRevision: null,
       });
-    if (!superseded) transaction.set(mirrorRef, installedResponse);
+    if (!superseded) {
+      transaction.set(mirrorRef, installedResponse);
+      writeCashflowSheetReadModels({ transaction, db, tenantId, projectId, mirror: installedResponse });
+    }
     transaction.set(runRef, stripUndefinedDeep({
       status: 'COMPLETED',
       completedAt,
@@ -736,6 +749,39 @@ async function completeCashflowSheetRefreshRun({
     }), { merge: true });
     return installedResponse;
   });
+}
+
+function writeCashflowSheetReadModels({ transaction, db, tenantId, projectId, mirror }) {
+  if (readOptionalText(mirror?.status) !== 'FRESH') return;
+  const capturedAt = readOptionalText(mirror?.capturedAt);
+  const sourceRevision = readOptionalText(mirror?.sourceRevision);
+  const cellsByMonth = groupPinnedCellsByMonth(mirror?.cells || []);
+  for (const [yearMonth, cells] of cellsByMonth) {
+    transaction.set(db.doc(cashflowSheetWeekValueDocPath(tenantId, projectId, yearMonth)), stripUndefinedDeep({
+      tenantId,
+      projectId,
+      yearMonth,
+      source: 'cashflow_sheet_refresh',
+      sourceRevision,
+      capturedAt,
+      cells,
+    }));
+  }
+  for (const total of mirror?.sheetFacts?.annualCashflowTotals || []) {
+    if (!Number.isSafeInteger(total?.year)) continue;
+    transaction.set(db.doc(cashflowSheetYearTotalDocPath(tenantId, projectId, total.year)), stripUndefinedDeep({
+      tenantId,
+      projectId,
+      year: total.year,
+      source: 'cashflow_sheet_refresh',
+      sourceRevision,
+      capturedAt,
+      projection: total.projection,
+      actual: total.actual,
+    }));
+  }
+  // ponytail: the existing mirror still keeps all cells for the review/apply flow.
+  // Split its reads by month before a project needs more than three detailed years.
 }
 
 function setFiniteAmount(index, mapping, amount) {

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -41,19 +41,25 @@ const ACTUAL_OUT_LABELS = [
 
 const JANUARY_FINANCE_WEEKS = ['26-1-1', '26-1-2', '26-1-3', '26-1-4', '26-1-5'];
 
-function buildSection(actual = false, weekLabels = ['26-1-1', '26-1-2', '26-1-3']) {
-  const weekRow = ['', '', '', ...weekLabels];
+function buildSection(actual = false, weekLabels = ['26-1-1', '26-1-2', '26-1-3'], annualYears = [], annualValue = '') {
+  const firstWeekColumn = annualYears.length > 0 ? 2 + annualYears.length : 3;
+  const header = [actual ? 'ACTUAL' : 'Projection'];
+  annualYears.forEach((year, index) => {
+    header[2 + index] = `${year}년`;
+  });
+  const weekRow = [...Array(firstWeekColumn).fill(''), ...weekLabels];
   const valueCells = weekLabels.map(() => '999');
+  const annualValueCells = annualYears.map((year) => (year === 2027 ? '' : annualValue));
   const inLabels = actual ? ACTUAL_IN_LABELS : PROJECTION_IN_LABELS;
   const outLabels = actual ? ACTUAL_OUT_LABELS : PROJECTION_OUT_LABELS;
   return [
-    [actual ? 'ACTUAL' : 'Projection'],
+    header,
     weekRow,
-    ...inLabels.map((label) => [label, '', '', ...valueCells]),
-    ['입금 합계', '', '', ...valueCells],
-    ...outLabels.map((label) => [label, '', '', ...valueCells]),
-    ['출금 합계', '', '', ...valueCells],
-    [actual ? '잔액' : '잔액 (※ 중요)', '', '', ...valueCells],
+    ...inLabels.map((label) => [label, '', ...(annualYears.length > 0 ? annualValueCells : ['']), ...valueCells]),
+    ['입금 합계', '', ...(annualYears.length > 0 ? annualValueCells : ['']), ...valueCells],
+    ...outLabels.map((label) => [label, '', ...(annualYears.length > 0 ? annualValueCells : ['']), ...valueCells]),
+    ['출금 합계', '', ...(annualYears.length > 0 ? annualValueCells : ['']), ...valueCells],
+    [actual ? '잔액' : '잔액 (※ 중요)', '', ...(annualYears.length > 0 ? annualValueCells : ['']), ...valueCells],
   ];
 }
 
@@ -72,6 +78,15 @@ function buildMatrixWithWeekLabels(weekLabels) {
     ...buildSection(false, weekLabels),
     [],
     ...buildSection(true, weekLabels),
+  ];
+}
+
+function buildMultiYearMatrix() {
+  return [
+    ['title'],
+    ...buildSection(false, JANUARY_FINANCE_WEEKS, [2024, 2025, 2027], '100'),
+    [],
+    ...buildSection(true, JANUARY_FINANCE_WEEKS, [2024, 2025, 2027], '50'),
   ];
 }
 
@@ -254,6 +269,46 @@ describe('cashflow sheet lab route', () => {
     expect(pinned.body.cells).toHaveLength(32);
     expect(previewSpreadsheet).toHaveBeenCalledTimes(1);
     expect(db.__getDocument().cashflowSheetLab.activeWeeks).toBeUndefined();
+  });
+
+  it('stores weekly values and annual totals without requiring a missing future year', async () => {
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        cashflowSheetLab: {
+          value: 'https://docs.google.com/spreadsheets/d/spreadsheet-a/edit',
+          sheetName: 'cashflow(사용내역 연동)',
+          startWeek: '26-1-1',
+          endWeek: '26-1-5',
+        },
+      },
+    });
+    const app = createApp({
+      db,
+      googleSheetsService: {
+        previewSpreadsheet: vi.fn(async () => ({
+          spreadsheetId: 'spreadsheet-a',
+          spreadsheetTitle: 'Cashflow workbook',
+          selectedSheetName: 'cashflow(사용내역 연동)',
+          availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
+          matrix: buildMultiYearMatrix(),
+        })),
+      },
+    });
+
+    const refreshed = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'multi-year-refresh-001' })
+      .expect(200);
+
+    expect(refreshed.body.sheetFacts.annualCashflowTotals).toEqual(expect.arrayContaining([
+      expect.objectContaining({ year: 2024, projection: expect.objectContaining({ source: 'ANNUAL' }) }),
+      expect.objectContaining({ year: 2025, actual: expect.objectContaining({ source: 'ANNUAL' }) }),
+      expect.objectContaining({ year: 2026, projection: expect.objectContaining({ source: 'WEEKLY' }) }),
+      expect.objectContaining({ year: 2027, projection: expect.objectContaining({ source: 'ANNUAL', valueCellCount: 0 }) }),
+    ]));
+    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_week_values/')).toHaveLength(1);
+    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_year_totals/')).toHaveLength(4);
   });
 
   it('compares a pinned multi-year sheet total with registered financial years', async () => {

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -969,7 +969,9 @@ function sheetControlBlockers(sheetFacts) {
       message: 'Projection/Actual BO control total이 불완전합니다. 시트값을 다시 불러와 주세요.',
     });
   }
-  if (controls?.deposit?.matches !== true || rows.some((row) => row?.matches !== true)) {
+  const comparableRows = rows.filter((row) => typeof row?.matches === 'boolean');
+  const depositComparable = typeof controls?.deposit?.matches === 'boolean';
+  if ((depositComparable && controls.deposit.matches !== true) || comparableRows.some((row) => row.matches !== true)) {
     blockers.push({
       code: 'SHEET_CONTROL_TOTAL_MISMATCH',
       message: '전체 주차 합계와 시트 BO control total이 다릅니다.',

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -178,6 +178,17 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('시트 {fmt(check.sheet[field.key])} · 등록 {fmt(check.registered[field.key])}');
   });
 
+  it('keeps the detailed board on one year while showing the adjacent annual source values', () => {
+    expect(source).toContain('cashflowSheetMirror?.sheetFacts?.annualCashflowTotals');
+    expect(source).toContain('[selectedYear - 1, selectedYear, selectedYear + 1]');
+    expect(source).toContain('data-cashflow-block="multi-year-view"');
+    expect(source).toContain("'주차값 집계'");
+    expect(source).toContain("'연간 합산값'");
+    expect(source).toContain('오류 없이 다음 불러오기 때 반영됩니다.');
+    expect(source).toContain("start: { yearMonth: `${selectedYear}-01`, weekNo: 1 }");
+    expect(source).toContain("end: { yearMonth: `${selectedYear}-12`, weekNo: 5 }");
+  });
+
   it('offers the exact three in-app exit choices and releases only on exit', () => {
     expect(source).toContain('임시저장 후 종료');
     expect(source).toContain('저장하지 않고 종료');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -200,32 +200,6 @@ function parseCashflowSheetWeekLabel(value: unknown): { year: number; month: num
   };
 }
 
-function normalizeActiveSheetWeeks(raw: unknown): MonthMondayWeek[] {
-  if (!Array.isArray(raw)) return [];
-  const weeks: MonthMondayWeek[] = [];
-  const seen = new Set<string>();
-  for (const item of raw) {
-    if (!item || typeof item !== 'object') continue;
-    const source = item as { label?: unknown; yearMonth?: unknown; weekNo?: unknown; weekStart?: unknown; weekEnd?: unknown };
-    const label = String(source.label || '').trim();
-    const parsedLabel = parseCashflowSheetWeekLabel(label);
-    const yearMonth = String(source.yearMonth || parsedLabel?.yearMonth || '').trim();
-    const weekNo = Number(source.weekNo ?? parsedLabel?.weekNo);
-    if (!/^\d{4}-\d{2}$/.test(yearMonth) || !Number.isFinite(weekNo)) continue;
-    const key = `${yearMonth}:${weekNo}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    weeks.push({
-      yearMonth,
-      weekNo,
-      weekStart: String(source.weekStart || ''),
-      weekEnd: String(source.weekEnd || ''),
-      label: label || formatSheetWeekLabel(yearMonth, weekNo),
-    });
-  }
-  return weeks.sort((a, b) => a.yearMonth.localeCompare(b.yearMonth) || a.weekNo - b.weekNo);
-}
-
 function isBffAuthRejection(error: unknown): boolean {
   const source = error as { status?: number; body?: { code?: string; error?: string } };
   const code = source.body?.code || source.body?.error || '';
@@ -314,10 +288,6 @@ export function CashflowProjectSheet({
   const [cashflowSheetRange, setCashflowSheetRange] = useState<{
     startWeek: string;
     endWeek: string;
-    startYearMonth: string;
-    endYearMonth: string;
-    label: string;
-    activeWeeks: MonthMondayWeek[];
   } | null>(null);
   const [cashflowSheetConfig, setCashflowSheetConfig] = useState<{
     value?: string;
@@ -381,19 +351,12 @@ export function CashflowProjectSheet({
     return Number.isFinite(parsed) ? parsed : new Date().getFullYear();
   }, [yearMonth]);
   const cashflowSnapshotRange = useMemo(() => {
-    const configuredStart = parseCashflowSheetWeekLabel(cashflowSheetRange?.startWeek);
-    const configuredEnd = parseCashflowSheetWeekLabel(cashflowSheetRange?.endWeek);
     return {
-      start: configuredStart
-        ? { yearMonth: configuredStart.yearMonth, weekNo: configuredStart.weekNo }
-        : { yearMonth: `${selectedYear}-01`, weekNo: 1 },
-      end: configuredEnd
-        ? { yearMonth: configuredEnd.yearMonth, weekNo: configuredEnd.weekNo }
-        : { yearMonth: `${selectedYear}-12`, weekNo: 5 },
+      start: { yearMonth: `${selectedYear}-01`, weekNo: 1 },
+      end: { yearMonth: `${selectedYear}-12`, weekNo: 5 },
     };
-  }, [cashflowSheetRange?.endWeek, cashflowSheetRange?.startWeek, selectedYear]);
+  }, [selectedYear]);
   const yearWeeks = useMemo(() => getYearMondayWeeks(selectedYear), [selectedYear]);
-  const sheetRangeWeeks = cashflowSheetRange?.activeWeeks || [];
   const allProjectCashflowWeeks = useMemo(() => {
     const byKey = new Map<string, CashflowWeekSheet>();
     for (const week of [...weeks, ...rangeLoadedWeeks]) {
@@ -404,20 +367,14 @@ export function CashflowProjectSheet({
   }, [projectId, rangeLoadedWeeks, weeks]);
   const annualWeeks = useMemo<MonthMondayWeek[]>(() => {
     const byKey = new Map<string, MonthMondayWeek>();
-    const baseWeeks = sheetRangeWeeks.length > 0 ? sheetRangeWeeks : yearWeeks;
-    const rangeStart = cashflowSheetRange ? parseCashflowSheetWeekLabel(cashflowSheetRange.startWeek) : null;
-    const rangeEnd = cashflowSheetRange ? parseCashflowSheetWeekLabel(cashflowSheetRange.endWeek) : null;
-    for (const week of baseWeeks) {
+    for (const week of yearWeeks) {
       byKey.set(`${week.yearMonth}:${week.weekNo}`, hydrateWeekDates(week));
     }
     for (const week of allProjectCashflowWeeks) {
       if (week.projectId !== projectId) continue;
       const weekNo = Number(week.weekNo);
       if (!Number.isFinite(weekNo)) continue;
-      const parsedWeek = parseCashflowSheetWeekLabel(formatSheetWeekLabel(week.yearMonth, weekNo));
-      if (rangeStart && rangeEnd) {
-        if (!parsedWeek || parsedWeek.sortKey < rangeStart.sortKey || parsedWeek.sortKey > rangeEnd.sortKey) continue;
-      } else if (!week.yearMonth?.startsWith(`${selectedYear}-`)) {
+      if (!week.yearMonth?.startsWith(`${selectedYear}-`)) {
         continue;
       }
       const key = `${week.yearMonth}:${weekNo}`;
@@ -432,7 +389,7 @@ export function CashflowProjectSheet({
     }
     return Array.from(byKey.values())
       .sort((a, b) => a.yearMonth.localeCompare(b.yearMonth) || a.weekNo - b.weekNo);
-  }, [allProjectCashflowWeeks, cashflowSheetRange, projectId, selectedYear, sheetRangeWeeks, yearWeeks]);
+  }, [allProjectCashflowWeeks, projectId, selectedYear, yearWeeks]);
   const [showEmptyCashflowRows, setShowEmptyCashflowRows] = useState(false);
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [editingWeekModes, setEditingWeekModes] = useState<Record<string, boolean>>({});
@@ -658,9 +615,8 @@ export function CashflowProjectSheet({
       .then((snap) => {
         if (cancelled) return;
         const config = snap.exists()
-          ? (snap.data() as { cashflowSheetLab?: { value?: string; sheetName?: string; spreadsheetId?: string; spreadsheetTitle?: string; startWeek?: string; endWeek?: string; activeWeeks?: unknown; lastAppliedAt?: string; lastAppliedBy?: { uid?: string; email?: string; role?: string } | null; lastAppliedLineCount?: number; lastProjectionLineCount?: number; lastActualLineCount?: number } }).cashflowSheetLab
+          ? (snap.data() as { cashflowSheetLab?: { value?: string; sheetName?: string; spreadsheetId?: string; spreadsheetTitle?: string; startWeek?: string; endWeek?: string; lastAppliedAt?: string; lastAppliedBy?: { uid?: string; email?: string; role?: string } | null; lastAppliedLineCount?: number; lastProjectionLineCount?: number; lastActualLineCount?: number } }).cashflowSheetLab
           : null;
-        const activeWeeks = normalizeActiveSheetWeeks(config?.activeWeeks);
         recordDevtoolsLog({
           kind: 'cashflow_transaction',
           phase: 'info',
@@ -678,7 +634,6 @@ export function CashflowProjectSheet({
             sheetName: config?.sheetName || null,
             startWeek: config?.startWeek || null,
             endWeek: config?.endWeek || null,
-            activeWeekCount: activeWeeks.length,
             updatedAt: (config as { updatedAt?: string } | null)?.updatedAt || null,
             lastAppliedAt: config?.lastAppliedAt || null,
           },
@@ -698,17 +653,13 @@ export function CashflowProjectSheet({
         } : null);
         const start = parseCashflowSheetWeekLabel(config?.startWeek);
         const end = parseCashflowSheetWeekLabel(config?.endWeek);
-        if (!start || !end || start.sortKey > end.sortKey || activeWeeks.length === 0) {
+        if (!start || !end || start.sortKey > end.sortKey) {
           setCashflowSheetRange(null);
           return;
         }
         setCashflowSheetRange({
           startWeek: config?.startWeek || '',
           endWeek: config?.endWeek || '',
-          startYearMonth: start.yearMonth,
-          endYearMonth: end.yearMonth,
-          label: `${config?.startWeek} ~ ${config?.endWeek}`,
-          activeWeeks,
         });
       })
       .catch(() => {
@@ -867,8 +818,8 @@ export function CashflowProjectSheet({
     const base = collection(db, getOrgCollectionPath(orgId, 'cashflowWeeks'));
     const q = query(
       base,
-      where('yearMonth', '>=', cashflowSheetRange.startYearMonth),
-      where('yearMonth', '<=', cashflowSheetRange.endYearMonth),
+      where('yearMonth', '>=', `${selectedYear}-01`),
+      where('yearMonth', '<=', `${selectedYear}-12`),
       limit(5000),
     );
     const snap = await getDocs(q);
@@ -877,7 +828,7 @@ export function CashflowProjectSheet({
         .map((d) => d.data() as CashflowWeekSheet)
         .filter((week) => week.projectId === projectId),
     );
-  }, [cashflowSheetRange, db, orgId, projectId]);
+  }, [cashflowSheetRange, db, orgId, projectId, selectedYear]);
 
   useEffect(() => {
     let cancelled = false;
@@ -1456,7 +1407,15 @@ export function CashflowProjectSheet({
     };
   }, [annualWeeks, cashflowSnapshot, monthCloseResult?.dashboard?.comparison, yearMonth]);
 
-  const cashflowTotalPeriodLabel = cashflowSheetRange?.label || `${selectedYear}년`;
+  const cashflowTotalPeriodLabel = `${selectedYear}년`;
+  const multiYearCashflowTotals = useMemo(() => {
+    const totalsByYear = new Map((cashflowSheetMirror?.sheetFacts?.annualCashflowTotals || [])
+      .map((total) => [total.year, total]));
+    return [selectedYear - 1, selectedYear, selectedYear + 1].map((year) => ({
+      year,
+      total: totalsByYear.get(year),
+    }));
+  }, [cashflowSheetMirror?.sheetFacts?.annualCashflowTotals, selectedYear]);
   const sheetRangeLabel = cashflowSheetConfig
     ? `${cashflowSheetConfig.sheetName || '시트 탭'} · ${cashflowSheetConfig.startWeek || '전체'} ~ ${cashflowSheetConfig.endWeek || '전체'}`
     : '연결된 Google Sheet가 없습니다.';
@@ -1882,6 +1841,33 @@ export function CashflowProjectSheet({
                 </Button>
               ) : null}
             </div>
+          </div>
+          <div data-cashflow-block="multi-year-view" className="grid gap-2 border-t border-slate-100 bg-slate-50/70 px-5 py-3 sm:grid-cols-3">
+            {multiYearCashflowTotals.map(({ year, total }) => {
+              const projection = total?.projection;
+              const actual = total?.actual;
+              const hasValues = Boolean((projection?.valueCellCount || 0) + (actual?.valueCellCount || 0));
+              const sourceLabel = (source?: 'WEEKLY' | 'ANNUAL' | 'NONE') => (
+                source === 'WEEKLY' ? '주차값 집계' : source === 'ANNUAL' ? '연간 합산값' : '미입력'
+              );
+              return (
+                <div key={year} className={`rounded-xl border px-3 py-2 shadow-sm ${year === selectedYear ? 'border-blue-200 bg-blue-50/60' : 'border-slate-200 bg-white'}`}>
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-[11px] font-bold text-slate-900">{year}년</span>
+                    <span className="text-[9px] font-semibold text-slate-500">{sourceLabel(projection?.source)}</span>
+                  </div>
+                  {hasValues ? (
+                    <div className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-[9px] text-slate-600">
+                      <span>Projection 잔액</span><span className="text-right font-semibold tabular-nums text-slate-900">{fmt(projection?.net || 0)}</span>
+                      <span>Actual 잔액</span><span className="text-right font-semibold tabular-nums text-slate-900">{fmt(actual?.net || 0)}</span>
+                      <span>입금 / 출금</span><span className="text-right tabular-nums">{fmt((projection?.totalIn || 0) + (actual?.totalIn || 0))} / {fmt((projection?.totalOut || 0) + (actual?.totalOut || 0))}</span>
+                    </div>
+                  ) : (
+                    <p className="mt-2 text-[9px] leading-4 text-slate-500">시트에 입력된 값이 없습니다. 오류 없이 다음 불러오기 때 반영됩니다.</p>
+                  )}
+                </div>
+              );
+            })}
           </div>
           {financialYearChecks?.years.length ? (
             <div className="grid gap-2 border-t border-slate-100 bg-slate-50/70 px-5 py-3 sm:grid-cols-2 xl:grid-cols-4">

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -22,6 +22,12 @@ export interface CashflowSheetLabWeekColumn {
   a1: string;
 }
 
+export interface CashflowSheetLabAnnualColumn {
+  year: number;
+  columnIndex: number;
+  a1: string;
+}
+
 export interface CashflowSheetLabLineRow {
   rowIndex: number;
   label: string;
@@ -57,6 +63,7 @@ export interface CashflowSheetLabTemplateSection {
   headerRowIndex: number;
   weekRowIndex: number;
   weekColumns: CashflowSheetLabWeekColumn[];
+  annualColumns: CashflowSheetLabAnnualColumn[];
   lineRows: CashflowSheetLabLineRow[];
   derivedRows: Array<{
     rowIndex: number;
@@ -73,6 +80,10 @@ export interface CashflowSheetLabTemplateSection {
     reason: string;
   }>;
   mappings: CashflowSheetLabMappingCandidate[];
+  annualMappings: Array<Omit<CashflowSheetLabMappingCandidate, 'yearMonth' | 'weekNo' | 'source'> & {
+    year: number;
+    source: 'sheet_annual_total';
+  }>;
   missingLineIds: string[];
   duplicateLineIds: string[];
 }
@@ -226,6 +237,18 @@ export interface CashflowSheetLabMirrorCell {
   rawValue?: string;
 }
 
+export interface CashflowSheetLabAnnualCell {
+  mode: 'projection' | 'actual';
+  year: number;
+  lineId: string;
+  direction: 'IN' | 'OUT';
+  sourceCell: string;
+  sourceLabel: string;
+  state: 'VALUE' | 'EMPTY' | 'INVALID';
+  amount?: number;
+  rawValue?: string;
+}
+
 export interface CashflowSheetLabMirrorResult {
   schemaVersion?: number;
   projectId: string;
@@ -238,8 +261,10 @@ export interface CashflowSheetLabMirrorResult {
   capturedAt?: string;
   capturedBy?: { uid?: string; email?: string; role?: string };
   yearMonths?: string[];
+  years?: number[];
   summary?: { cellCount: number; valueCount: number; emptyCount: number; invalidCount: number };
   cells?: CashflowSheetLabMirrorCell[];
+  annualCells?: CashflowSheetLabAnnualCell[];
   sheetFacts?: {
     metadata?: {
       lastUpdateText?: { sourceCell: string; value: string };
@@ -266,6 +291,11 @@ export interface CashflowSheetLabMirrorResult {
       totalRevenueAmount: number;
       supportAmount: number;
     }>;
+    annualCashflowTotals?: Array<{
+      year: number;
+      projection: CashflowSheetLabAnnualModeTotal;
+      actual: CashflowSheetLabAnnualModeTotal;
+    }>;
   };
   financialYearChecks?: {
     years: Array<{
@@ -285,6 +315,17 @@ export interface CashflowSheetLabMirrorResult {
   activeWeekRange?: CashflowSheetLabApplyResult['activeWeekRange'] & { activeWeeks?: unknown[] };
   lastRefreshAttemptAt?: string;
   lastRefreshError?: { code: string; message: string; statusCode?: number; at?: string } | null;
+}
+
+export interface CashflowSheetLabAnnualModeTotal {
+  source: 'WEEKLY' | 'ANNUAL' | 'NONE';
+  valueCellCount: number;
+  emptyCellCount: number;
+  invalidCellCount: number;
+  lineAmounts: Record<string, number>;
+  totalIn: number;
+  totalOut: number;
+  net: number;
 }
 
 export interface CashflowSheetLabStageResult {


### PR DESCRIPTION
## Summary
- store explicit sheet refresh data in separate weekly-value and annual-total collections
- interpret annual sheet columns (for example 2024년, 2025년) alongside current-year weekly columns
- show a selected-year ±1 annual cashflow view without treating blank future years as errors
- keep the existing monthly review and JVM authoritative apply path unchanged

## Validation
- npm test -- --run server/bff/routes/cashflow-sheet-lab.test.mjs server/bff/cashflow-sheet-snapshot.test.mjs server/bff/cashflow-sheet-template.test.mjs server/bff/routes/jvm-weekly-api.test.mjs src/app/components/cashflow/CashflowProjectSheet.shell.test.ts --reporter=dot
- npm run build