### PR TITLE
feat(projects): add management planning approval flow

### DIFF
--- a/policies/nav-policy.json
+++ b/policies/nav-policy.json
@@ -14,6 +14,7 @@
       "/budget-summary",
       "/expense-management",
       "/approvals",
+      "/management-planning/project-codes",
       "/claude-sdk-help",
       "/portal"
     ],

--- a/server/bff/app.integration.test.ts
+++ b/server/bff/app.integration.test.ts
@@ -205,18 +205,27 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
     }));
   });
 
-  it('records planning agreement before the designated approver rejects, and posts Slack', async () => {
-    const projectRegistrationSlackService = {
-      enabled: true,
-      notifyMessage: vi.fn(async () => {}),
-    };
-    const reviewApi = request(createBffApp({
-      projectId,
-      workerSecret,
-      db,
-      projectRegistrationSlackService,
-    }));
+  it('requires organization-head approval before management planning can agree', async () => {
+    const reviewApi = request(createBffApp({ projectId, workerSecret, db }));
+    await db.doc(`orgs/${tenantId}/projects/p_management_gate_001`).set({
+      id: 'p_management_gate_001',
+      tenantId,
+      name: '경영기획실 승인 게이트',
+      executiveReviewStatus: 'PENDING',
+      executiveReviewHistory: [],
+    });
 
+    const response = await reviewApi
+      .post('/api/v1/projects/p_management_gate_001/management-planning-review')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-management-gate-001' })
+      .send({ reviewStatus: 'AGREED', projectCode: 'PRJ-2026-100' });
+
+    expect(response.status).toBe(409);
+    expect(response.body.error).toBe('executive_review_required');
+  });
+
+  it('lets management planning issue a code only after organization-head approval', async () => {
+    const reviewApi = request(createBffApp({ projectId, workerSecret, db }));
     await db.doc(`orgs/${tenantId}/projects/p_exec_review_001`).set({
       id: 'p_exec_review_001',
       tenantId,
@@ -225,97 +234,54 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
       executiveReviewStatus: 'PENDING',
       executiveApproverId: actorId,
       executiveApproverName: '조직장A',
-      executiveReviewHistory: [
-        {
-          status: 'PENDING',
-          previousStatus: null,
-          reviewedAt: '2026-04-20T08:00:00.000Z',
-          reviewedById: 'u-old',
-          reviewedByName: '변민욱',
-          reviewComment: 'PM 신규 등록',
-        },
-      ],
+      executiveReviewHistory: [{
+        status: 'PENDING',
+        previousStatus: null,
+        reviewedAt: '2026-04-20T08:00:00.000Z',
+        reviewedById: 'u-old',
+        reviewedByName: '변민욱',
+        reviewComment: 'PM 신규 등록',
+      }],
       createdAt: '2026-04-20T08:00:00.000Z',
       updatedAt: '2026-04-20T09:00:00.000Z',
     }, { merge: true });
-
     await db.doc(`orgs/${tenantId}/project_requests/pr_exec_review_001`).set({
       id: 'pr_exec_review_001',
       tenantId,
-      status: 'APPROVED',
+      status: 'PENDING',
       approvedProjectId: 'p_exec_review_001',
-      requestedByName: '변민욱',
-      requestedByEmail: 'boram@example.com',
-      payload: {
-        name: '네팔 귀환노동자 재정착 사업',
-        officialContractName: '네팔 귀환노동자 재정착 사업',
-        clientOrg: 'KOICA',
-        department: 'CIC1',
-        managerName: '변민욱',
-        executiveApproverId: actorId,
-        teamName: 'AXR팀',
-      },
-      createdAt: '2026-04-20T08:00:00.000Z',
-      updatedAt: '2026-04-20T09:00:00.000Z',
+      payload: { executiveApproverId: actorId },
     }, { merge: true });
 
-    const agreement = await reviewApi
+    const approved = await reviewApi
       .post('/api/v1/projects/p_exec_review_001/executive-review')
       .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-executive-review-001' })
-      .send({
-        requestId: 'pr_exec_review_001',
-        reviewStatus: 'PLANNING_AGREED',
-        projectCode: 'PRJ-2026-001',
-        reviewerName: '무시되는 요청 본문 이름',
-      });
+      .send({ requestId: 'pr_exec_review_001', reviewStatus: 'APPROVED' });
+    expect(approved.status).toBe(200);
+
+    const agreement = await reviewApi
+      .post('/api/v1/projects/p_exec_review_001/management-planning-review')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-management-review-001' })
+      .send({ requestId: 'pr_exec_review_001', reviewStatus: 'AGREED', projectCode: ' prj-2026-001 ' });
     expect(agreement.status).toBe(200);
-    expect(agreement.body.reviewStatus).toBe('PLANNING_AGREED');
+    expect(agreement.body.reviewStatus).toBe('AGREED');
 
-    const response = await reviewApi
-      .post('/api/v1/projects/p_exec_review_001/executive-review')
-      .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-executive-review-001-reject' })
-      .send({
-        requestId: 'pr_exec_review_001',
-        reviewStatus: 'REVISION_REJECTED',
-        reviewComment: '예산 산출 근거 보완 필요',
-        reviewerName: '무시되는 요청 본문 이름',
-      });
-
-    expect(response.status).toBe(200);
-    expect(response.body).toMatchObject({
-      ok: true,
+    const project = (await db.doc(`orgs/${tenantId}/projects/p_exec_review_001`).get()).data();
+    expect(project).toMatchObject({
+      executiveReviewStatus: 'APPROVED',
+      projectCode: 'PRJ-2026-001',
+      projectCodeKey: 'PRJ-2026-001',
+      managementPlanningReviewStatus: 'AGREED',
+    });
+    expect(project?.executiveReviewHistory).toHaveLength(2);
+    expect(project?.managementPlanningReviewHistory).toEqual([expect.objectContaining({
+      status: 'AGREED',
+      previousStatus: 'PENDING',
+      projectCode: 'PRJ-2026-001',
+    })]);
+    expect((await db.doc(`orgs/${tenantId}/project_code_registry/PRJ-2026-001`).get()).data()).toMatchObject({
       projectId: 'p_exec_review_001',
-      requestId: 'pr_exec_review_001',
-      reviewStatus: 'REVISION_REJECTED',
-      slackDelivered: true,
     });
-
-    const projectSnap = await db.doc(`orgs/${tenantId}/projects/p_exec_review_001`).get();
-    expect(projectSnap.exists).toBe(true);
-    expect(projectSnap.data()).toMatchObject({
-      executiveReviewStatus: 'REVISION_REJECTED',
-      executiveReviewedByName: actorId,
-      executiveReviewComment: '예산 산출 근거 보완 필요',
-    });
-    expect(projectSnap.data()?.executiveReviewHistory).toHaveLength(3);
-    expect(projectSnap.data()?.executiveReviewHistory?.[2]).toMatchObject({
-      status: 'REVISION_REJECTED',
-      previousStatus: 'PLANNING_AGREED',
-      reviewedByName: actorId,
-      reviewComment: '예산 산출 근거 보완 필요',
-    });
-
-    const requestSnap = await db.doc(`orgs/${tenantId}/project_requests/pr_exec_review_001`).get();
-    expect(requestSnap.exists).toBe(true);
-    expect(requestSnap.data()).toMatchObject({
-      status: 'REJECTED',
-      reviewOutcome: 'REVISION_REJECTED',
-      reviewedByName: actorId,
-      rejectedReason: '예산 산출 근거 보완 필요',
-    });
-    expect(projectRegistrationSlackService.notifyMessage).toHaveBeenCalledWith(expect.objectContaining({
-      text: expect.stringContaining('수정 요청 후 반려'),
-    }));
   });
 
   it('requires a rejection reason for executive rejection and discard', async () => {
@@ -347,65 +313,134 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
     expect(response.body.message).toMatch(/reviewComment/i);
   });
 
-  it('requires a code for planning agreement and locks it for final approval', async () => {
+  it('rejects new planning-before-exec but lets organization heads finalise existing planning agreements', async () => {
     const reviewApi = request(createBffApp({ projectId, workerSecret, db }));
-    await db.doc(`orgs/${tenantId}/projects/p_project_code_001`).set({
-      id: 'p_project_code_001', tenantId, name: '코드 부여 테스트', executiveApproverId: actorId, executiveReviewStatus: 'PENDING', executiveReviewHistory: [],
+    await db.doc(`orgs/${tenantId}/projects/p_new_planning_001`).set({
+      id: 'p_new_planning_001', tenantId, name: '신규 역순 차단', executiveApproverId: actorId, executiveReviewStatus: 'PENDING', executiveReviewHistory: [],
     });
+    const newAgreement = await reviewApi
+      .post('/api/v1/projects/p_new_planning_001/executive-review')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-new-planning-before-exec' })
+      .send({ reviewStatus: 'PLANNING_AGREED', projectCode: 'PRJ-2026-legacy' });
+    expect(newAgreement.status).toBe(409);
+    expect(newAgreement.body.error).toBe('legacy_planning_agreement_read_only');
 
-    const missingCode = await reviewApi
-      .post('/api/v1/projects/p_project_code_001/executive-review')
-      .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-code-missing' })
-      .send({ reviewStatus: 'PLANNING_AGREED', reviewerName: '경영기획실' });
-    expect(missingCode.status).toBe(422);
-
-    const agreed = await reviewApi
-      .post('/api/v1/projects/p_project_code_001/executive-review')
-      .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-code-approved' })
-      .send({ reviewStatus: 'PLANNING_AGREED', projectCode: 'PRJ-2026-001', reviewerName: '경영기획실' });
-    expect(agreed.status).toBe(200);
-
+    await db.doc(`orgs/${tenantId}/projects/p_legacy_planning_001`).set({
+      id: 'p_legacy_planning_001',
+      tenantId,
+      name: '기존 경영기획실 합의',
+      executiveApproverId: actorId,
+      executiveReviewStatus: 'PLANNING_AGREED',
+      executiveReviewHistory: [{ status: 'PLANNING_AGREED', projectCode: 'PRJ-2026-LEGACY' }],
+      projectCode: 'PRJ-2026-LEGACY',
+    });
     const approved = await reviewApi
-      .post('/api/v1/projects/p_project_code_001/executive-review')
-      .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-code-final-approved' })
+      .post('/api/v1/projects/p_legacy_planning_001/executive-review')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-legacy-planning-final-approved' })
       .send({ reviewStatus: 'APPROVED' });
     expect(approved.status).toBe(200);
-
-    expect((await db.doc(`orgs/${tenantId}/projects/p_project_code_001`).get()).data()).toMatchObject({
-      executiveReviewStatus: 'APPROVED', projectCode: 'PRJ-2026-001',
-      executiveReviewHistory: expect.arrayContaining([expect.objectContaining({ projectCode: 'PRJ-2026-001' })]),
+    expect((await db.doc(`orgs/${tenantId}/projects/p_legacy_planning_001`).get()).data()).toMatchObject({
+      executiveReviewStatus: 'APPROVED',
+      projectCode: 'PRJ-2026-LEGACY',
     });
-    expect((await db.doc(`orgs/${tenantId}/project_code_registry/PRJ-2026-001`).get()).data()).toMatchObject({
-      projectId: 'p_project_code_001',
-    });
+    const alreadyAgreed = await reviewApi
+      .post('/api/v1/projects/p_legacy_planning_001/management-planning-review')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-legacy-planning-management-repeat' })
+      .send({ reviewStatus: 'AGREED', projectCode: 'PRJ-2026-LEGACY' });
+    expect(alreadyAgreed.status).toBe(409);
+    expect(alreadyAgreed.body.error).toBe('legacy_planning_agreement_already_finalized');
   });
 
-  it('rejects duplicate codes and final decisions by someone other than the designated approver', async () => {
+  it('rejects duplicate project codes from management planning', async () => {
     const reviewApi = request(createBffApp({ projectId, workerSecret, db }));
     await db.doc(`orgs/${tenantId}/projects/p_code_owner_001`).set({
-      id: 'p_code_owner_001', tenantId, name: '코드 소유 프로젝트', executiveApproverId: 'u-other', executiveReviewStatus: 'PENDING', executiveReviewHistory: [],
+      id: 'p_code_owner_001', tenantId, name: '코드 소유 프로젝트', executiveApproverId: actorId, executiveReviewStatus: 'PENDING', executiveReviewHistory: [],
     });
     await db.doc(`orgs/${tenantId}/projects/p_code_owner_002`).set({
       id: 'p_code_owner_002', tenantId, name: '코드 중복 프로젝트', executiveApproverId: actorId, executiveReviewStatus: 'PENDING', executiveReviewHistory: [],
     });
 
-    const agreed = await reviewApi
+    const firstApproval = await reviewApi
       .post('/api/v1/projects/p_code_owner_001/executive-review')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-code-owner-exec-001' })
+      .send({ reviewStatus: 'APPROVED' });
+    expect(firstApproval.status).toBe(200);
+    const secondApproval = await reviewApi
+      .post('/api/v1/projects/p_code_owner_002/executive-review')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-code-owner-exec-002' })
+      .send({ reviewStatus: 'APPROVED' });
+    expect(secondApproval.status).toBe(200);
+
+    const agreed = await reviewApi
+      .post('/api/v1/projects/p_code_owner_001/management-planning-review')
       .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-code-owner-agree' })
-      .send({ reviewStatus: 'PLANNING_AGREED', projectCode: 'PRJ-2026-009' });
+      .send({ reviewStatus: 'AGREED', projectCode: 'PRJ-2026-009' });
     expect(agreed.status).toBe(200);
 
-    const wrongApprover = await reviewApi
-      .post('/api/v1/projects/p_code_owner_001/executive-review')
-      .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-code-owner-final' })
-      .send({ reviewStatus: 'APPROVED' });
-    expect(wrongApprover.status).toBe(403);
-
     const duplicate = await reviewApi
-      .post('/api/v1/projects/p_code_owner_002/executive-review')
+      .post('/api/v1/projects/p_code_owner_002/management-planning-review')
       .set({ ...defaultHeaders, 'idempotency-key': 'idem-project-code-duplicate' })
-      .send({ reviewStatus: 'PLANNING_AGREED', projectCode: 'PRJ-2026-009' });
+      .send({ reviewStatus: 'AGREED', projectCode: 'PRJ-2026-009' });
     expect(duplicate.status).toBe(409);
+  });
+
+  it('requires the designated organization head for new executive decisions', async () => {
+    const reviewApi = request(createBffApp({ projectId, workerSecret, db }));
+    await db.doc(`orgs/${tenantId}/projects/p_designated_exec_001`).set({
+      id: 'p_designated_exec_001',
+      tenantId,
+      name: '조직장 지정 검증',
+      executiveApproverId: 'u-other',
+      executiveReviewStatus: 'PENDING',
+      executiveReviewHistory: [],
+    });
+
+    const response = await reviewApi
+      .post('/api/v1/projects/p_designated_exec_001/executive-review')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-designated-exec-001' })
+      .send({ reviewStatus: 'APPROVED' });
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe('designated_approver_required');
+  });
+
+  it('uses the resubmitted change request approver instead of a stale project approver', async () => {
+    const reviewApi = request(createBffApp({ projectId, workerSecret, db }));
+    await db.doc(`orgs/${tenantId}/projects/p_reassigned_exec_001`).set({
+      id: 'p_reassigned_exec_001',
+      tenantId,
+      name: '조직장 재지정',
+      version: 2,
+      executiveApproverId: 'u-previous-head',
+      executiveApproverName: '이전 조직장',
+      executiveReviewStatus: 'PENDING',
+      executiveReviewHistory: [],
+    });
+    await db.doc(`orgs/${tenantId}/project_requests/pr_reassigned_exec_001`).set({
+      id: 'pr_reassigned_exec_001',
+      tenantId,
+      requestKind: 'CHANGE',
+      status: 'PENDING',
+      targetProjectId: 'p_reassigned_exec_001',
+      approvedProjectId: 'p_reassigned_exec_001',
+      baseProjectVersion: 1,
+      targetProjectVersion: 2,
+      proposedSnapshot: {
+        executiveApproverId: actorId,
+        executiveApproverName: '새 조직장',
+      },
+    });
+
+    const response = await reviewApi
+      .post('/api/v1/projects/p_reassigned_exec_001/executive-review')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-reassigned-exec-001' })
+      .send({ requestId: 'pr_reassigned_exec_001', reviewStatus: 'APPROVED' });
+
+    expect(response.status).toBe(200);
+    expect((await db.doc(`orgs/${tenantId}/projects/p_reassigned_exec_001`).get()).data()).toMatchObject({
+      executiveApproverId: actorId,
+      executiveApproverName: '새 조직장',
+      executiveReviewStatus: 'APPROVED',
+    });
   });
 
   it('atomically trashes a project with its duplicate-discard review', async () => {
@@ -560,6 +595,66 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
     expect(requestSnap.data()?.proposedSnapshot?.contractDocument).toMatchObject({
       name: '보완_계약서.pdf',
       path: 'orgs/mysc/project-request-documents/u-new/contract.pdf',
+    });
+  });
+
+  it('resubmits a management-planning rejection without reopening organization-head review', async () => {
+    const reviewApi = request(createBffApp({ projectId, workerSecret, db }));
+    const executiveHistory = [{
+      status: 'APPROVED',
+      previousStatus: 'PENDING',
+      reviewedAt: '2026-07-12T00:00:00.000Z',
+      reviewedById: actorId,
+      reviewedByName: '조직장A',
+      reviewComment: null,
+    }];
+    const managementHistory = [{
+      status: 'REVISION_REJECTED',
+      previousStatus: 'PENDING',
+      reviewedAt: '2026-07-12T01:00:00.000Z',
+      reviewedById: 'finance-a',
+      reviewedByName: '경영기획실A',
+      reviewComment: '프로젝트 코드 기준을 보완해 주세요',
+    }];
+    await db.doc(`orgs/${tenantId}/projects/p_management_resubmit_001`).set({
+      id: 'p_management_resubmit_001',
+      tenantId,
+      name: '경영기획실 반려 재제출',
+      executiveReviewStatus: 'APPROVED',
+      executiveReviewHistory: executiveHistory,
+      managementPlanningReviewStatus: 'REVISION_REJECTED',
+      managementPlanningReviewedAt: '2026-07-12T01:00:00.000Z',
+      managementPlanningReviewedById: 'finance-a',
+      managementPlanningReviewedByName: '경영기획실A',
+      managementPlanningReviewComment: '프로젝트 코드 기준을 보완해 주세요',
+      managementPlanningReviewHistory: managementHistory,
+    });
+    await db.doc(`orgs/${tenantId}/project_requests/pr_management_resubmit_001`).set({
+      id: 'pr_management_resubmit_001',
+      tenantId,
+      status: 'PENDING',
+      reviewOutcome: 'REVISION_REJECTED',
+      approvedProjectId: 'p_management_resubmit_001',
+      rejectedReason: '프로젝트 코드 기준을 보완해 주세요',
+      payload: { name: '경영기획실 반려 재제출' },
+    });
+
+    const response = await reviewApi
+      .post('/api/v1/projects/p_management_resubmit_001/executive-review/resubmit')
+      .set({ ...defaultHeaders, 'idempotency-key': 'idem-management-resubmit-001' })
+      .send({ requestId: 'pr_management_resubmit_001', reviewComment: '보완 후 재제출' });
+    expect(response.status).toBe(200);
+
+    const project = (await db.doc(`orgs/${tenantId}/projects/p_management_resubmit_001`).get()).data();
+    expect(project?.executiveReviewStatus).toBe('APPROVED');
+    expect(project?.executiveReviewHistory).toEqual(executiveHistory);
+    expect(project).toMatchObject({
+      managementPlanningReviewStatus: 'PENDING',
+      managementPlanningReviewedAt: null,
+      managementPlanningReviewedById: null,
+      managementPlanningReviewedByName: null,
+      managementPlanningReviewComment: null,
+      managementPlanningReviewHistory: managementHistory,
     });
   });
 

--- a/server/bff/routes/project-info-drafts.test.mjs
+++ b/server/bff/routes/project-info-drafts.test.mjs
@@ -239,6 +239,10 @@ describe('project information private drafts', () => {
 
   it('submits request, metadata-only draft, canonical version, lease, audit, idempotency and outbox atomically', async () => {
     const h = harness();
+    h.db.documents.set('orgs/tenant-a/projects/project-a', {
+      ...h.db.documents.get('orgs/tenant-a/projects/project-a'),
+      executiveReviewStatus: 'REVISION_REJECTED',
+    });
     await openedDraft(h);
     await h.service.update({
       ...h.base, idempotencyKey: 'save-a', expectedDraftRevision: 0,
@@ -283,6 +287,97 @@ describe('project information private drafts', () => {
     expect([...h.db.documents.keys()].some((path) => path.includes('/idempotency_keys/'))).toBe(true);
     expect(h.auditChainService.appendManyInTransaction).toHaveBeenCalled();
     expect(replay).toEqual({ ...submitted, replayed: true });
+  });
+
+  it('does not reopen organization-head review while management planning is still pending', async () => {
+    const h = harness();
+    h.db.documents.set('orgs/tenant-a/projects/project-a', {
+      ...h.db.documents.get('orgs/tenant-a/projects/project-a'),
+      executiveReviewStatus: 'APPROVED',
+      managementPlanningReviewStatus: 'PENDING',
+    });
+    await openedDraft(h);
+    await h.service.update({
+      ...h.base,
+      idempotencyKey: 'management-pending-save',
+      expectedDraftRevision: 0,
+      payload: validPayload({ name: 'Must not reopen review' }),
+    });
+
+    await expect(h.service.submit({
+      ...h.base,
+      idempotencyKey: 'management-pending-resubmit',
+      expectedDraftRevision: 1,
+      expectedVersion: 3,
+      resubmit: true,
+      reviewComment: '잘못된 재제출',
+    })).rejects.toMatchObject({ statusCode: 409, code: 'invalid_resubmit_state' });
+    expect(h.db.documents.get('orgs/tenant-a/projects/project-a')).toMatchObject({
+      executiveReviewStatus: 'APPROVED',
+      managementPlanningReviewStatus: 'PENDING',
+    });
+  });
+
+  it('resubmits a management-planning rejection without reopening executive review', async () => {
+    const h = harness();
+    const projectPath = 'orgs/tenant-a/projects/project-a';
+    const executiveHistory = [{
+      status: 'APPROVED',
+      previousStatus: 'PENDING',
+      reviewedAt: '2026-07-11T00:00:00.000Z',
+      reviewedById: 'head-a',
+      reviewedByName: 'Head A',
+      reviewComment: null,
+    }];
+    h.db.documents.set(projectPath, {
+      ...h.db.documents.get(projectPath),
+      executiveReviewStatus: 'APPROVED',
+      executiveReviewHistory: executiveHistory,
+      managementPlanningReviewStatus: 'REVISION_REJECTED',
+      managementPlanningReviewHistory: [{
+        status: 'REVISION_REJECTED',
+        previousStatus: 'PENDING',
+        reviewedAt: '2026-07-11T01:00:00.000Z',
+        reviewedById: 'finance-a',
+        reviewedByName: 'Finance A',
+        reviewComment: '코드 기준을 보완해 주세요',
+      }],
+    });
+
+    await openedDraft(h);
+    await h.service.update({
+      ...h.base,
+      idempotencyKey: 'management-reject-save',
+      expectedDraftRevision: 0,
+      payload: validPayload({ name: 'Management resubmission' }),
+    });
+    await h.service.submit({
+      ...h.base,
+      idempotencyKey: 'management-reject-submit',
+      expectedDraftRevision: 1,
+      expectedVersion: 3,
+      resubmit: true,
+      reviewComment: '기획실 보완사항 반영',
+    });
+
+    const project = h.db.documents.get(projectPath);
+    expect(project.executiveReviewStatus).toBe('APPROVED');
+    expect(project.executiveReviewHistory).toEqual(executiveHistory);
+    expect(project).toMatchObject({
+      managementPlanningReviewStatus: 'PENDING',
+      managementPlanningReviewedAt: null,
+      managementPlanningReviewedById: null,
+      managementPlanningReviewedByName: null,
+      managementPlanningReviewComment: null,
+    });
+    expect(project.managementPlanningReviewHistory).toEqual([{
+      status: 'REVISION_REJECTED',
+      previousStatus: 'PENDING',
+      reviewedAt: '2026-07-11T01:00:00.000Z',
+      reviewedById: 'finance-a',
+      reviewedByName: 'Finance A',
+      reviewComment: '코드 기준을 보완해 주세요',
+    }]);
   });
 
   it('preserves completed-project checkout and three private evidence PDFs in the change request', async () => {

--- a/server/bff/routes/projects.mjs
+++ b/server/bff/routes/projects.mjs
@@ -32,6 +32,7 @@ import {
   projectTrashSchema,
   projectExecutiveReviewSchema,
   projectExecutiveResubmitSchema,
+  projectManagementPlanningReviewSchema,
 } from '../schemas.mjs';
 
 function trimSlackText(value, maxLength = 200) {
@@ -79,6 +80,42 @@ function formatOptionalProjectAmount(value, explicit) {
 
 function normalizeProjectCode(value) {
   return readOptionalText(value).toUpperCase().replace(/\s+/g, '');
+}
+
+function requireProjectCode(value) {
+  const projectCode = normalizeProjectCode(value);
+  if (!projectCode) {
+    throw createHttpError(422, 'projectCode is required when agreeing a project', 'missing_project_code');
+  }
+  if (projectCode.length > 64 || !/^[A-Z0-9_-]+$/.test(projectCode)) {
+    throw createHttpError(422, 'projectCode must use letters, numbers, hyphens, or underscores', 'invalid_project_code');
+  }
+  return projectCode;
+}
+
+function hasLegacyPlanningAgreement(project) {
+  return Array.isArray(project?.executiveReviewHistory)
+    && project.executiveReviewHistory.some((entry) => readOptionalText(entry?.status) === 'PLANNING_AGREED');
+}
+
+function isManagementPlanningRevisionRejected(project) {
+  return readOptionalText(project?.executiveReviewStatus) === 'APPROVED'
+    && readOptionalText(project?.managementPlanningReviewStatus) === 'REVISION_REJECTED';
+}
+
+function isExecutiveRevisionRejected(project) {
+  const status = readOptionalText(project?.executiveReviewStatus);
+  return status === 'REVISION_REJECTED' || status === 'DUPLICATE_DISCARDED';
+}
+
+function buildManagementPlanningResubmissionPatch() {
+  return {
+    managementPlanningReviewStatus: 'PENDING',
+    managementPlanningReviewedAt: null,
+    managementPlanningReviewedById: null,
+    managementPlanningReviewedByName: null,
+    managementPlanningReviewComment: null,
+  };
 }
 
 export function buildProjectRegistrationSlackPayload(projectRequest) {
@@ -1078,6 +1115,8 @@ export function buildProjectRegistrationCanonicalDocuments({
       reviewedByName: actorName,
       reviewComment: 'PM 신규 등록',
     }],
+    managementPlanningReviewStatus: 'PENDING',
+    managementPlanningReviewHistory: [],
     registeredAt: timestamp,
     ...projectPatch,
     quoteDocument: documents.quoteDocument,
@@ -1506,25 +1545,33 @@ export function buildProjectInfoChangeSubmission({
   const requestVersion = Number.isInteger(previousRequest?.requestVersion) && previousRequest.requestVersion > 0
     ? previousRequest.requestVersion + 1
     : 1;
-  const projectPatch = resubmit ? {
-    executiveReviewStatus: 'PENDING',
-    executiveReviewedAt: timestamp,
-    executiveReviewedById: actorId,
-    executiveReviewedByName: actorName,
-    executiveReviewComment: readOptionalText(reviewComment) || null,
-    executiveReviewHistory: [
-      ...(Array.isArray(project.executiveReviewHistory) ? project.executiveReviewHistory : []),
-      {
-        status: 'PENDING',
-        previousStatus: readOptionalText(project.executiveReviewStatus) || 'PENDING',
-        reviewedAt: timestamp,
-        reviewedById: actorId,
-        reviewedByName: actorName,
-        reviewComment: readOptionalText(reviewComment) || null,
-        ...(changedFields.length ? { changes: changedFields } : {}),
-      },
-    ],
-  } : {};
+  const managementPlanningResubmission = isManagementPlanningRevisionRejected(project);
+  if (resubmit && !managementPlanningResubmission && !isExecutiveRevisionRejected(project)) {
+    throw createHttpError(409, 'Project is not awaiting resubmission', 'invalid_resubmit_state');
+  }
+  const projectPatch = resubmit
+    ? (managementPlanningResubmission
+      ? buildManagementPlanningResubmissionPatch()
+      : {
+        executiveReviewStatus: 'PENDING',
+        executiveReviewedAt: timestamp,
+        executiveReviewedById: actorId,
+        executiveReviewedByName: actorName,
+        executiveReviewComment: readOptionalText(reviewComment) || null,
+        executiveReviewHistory: [
+          ...(Array.isArray(project.executiveReviewHistory) ? project.executiveReviewHistory : []),
+          {
+            status: 'PENDING',
+            previousStatus: readOptionalText(project.executiveReviewStatus) || 'PENDING',
+            reviewedAt: timestamp,
+            reviewedById: actorId,
+            reviewedByName: actorName,
+            reviewComment: readOptionalText(reviewComment) || null,
+            ...(changedFields.length ? { changes: changedFields } : {}),
+          },
+        ],
+      })
+    : {};
   const projectRequestId = `change-${readOptionalText(project.id)}`;
   const projectRequest = stripUndefinedDeep({
     id: projectRequestId,
@@ -2629,6 +2676,13 @@ export function mountProjectRoutes(app, {
     }
 
     const parsed = parseWithSchema(projectExecutiveReviewSchema, req.body, 'Invalid executive review payload');
+    if (parsed.reviewStatus === 'PLANNING_AGREED') {
+      throw createHttpError(
+        409,
+        'New planning agreements must be completed after organization-head approval',
+        'legacy_planning_agreement_read_only',
+      );
+    }
     const projectPath = `orgs/${tenantId}/projects/${projectId}`;
     const reviewerName = readOptionalText(actorName) || readOptionalText(actorEmail) || actorId;
     const now = new Date().toISOString();
@@ -2647,51 +2701,25 @@ export function mountProjectRoutes(app, {
         const reviewRequest = currentRequest || request;
         const previousStatus = readOptionalText(currentProject.executiveReviewStatus) || 'PENDING';
         const currentHistory = Array.isArray(currentProject.executiveReviewHistory) ? currentProject.executiveReviewHistory : [];
-        const isPlanningAgreement = parsed.reviewStatus === 'PLANNING_AGREED';
+        const isLegacyPlanningAgreement = previousStatus === 'PLANNING_AGREED';
         const requestPayload = resolveProjectRequestPayloadForReview(reviewRequest);
-        const designatedApproverId = readOptionalText(currentProject.executiveApproverId)
-          || readOptionalText(requestPayload?.executiveApproverId);
-        const projectCode = normalizeProjectCode(
-          isPlanningAgreement ? parsed.projectCode : currentProject.projectCode,
-        );
-
-        if (isPlanningAgreement) {
-          if (!projectCode) {
-            throw createHttpError(422, 'projectCode is required when agreeing a project', 'missing_project_code');
-          }
-          if (previousStatus !== 'PENDING') {
-            throw createHttpError(409, 'Only submitted projects can be agreed', 'invalid_planning_agreement_state');
-          }
-          const existingProjectCode = normalizeProjectCode(currentProject.projectCode);
-          if (existingProjectCode && existingProjectCode !== projectCode) {
-            throw createHttpError(422, 'projectCode cannot change after it is assigned', 'project_code_locked');
-          }
-          const codeRef = db.doc(`orgs/${tenantId}/project_code_registry/${encodeURIComponent(projectCode)}`);
-          const codeSnap = await tx.get(codeRef);
-          if (codeSnap.exists && readOptionalText(codeSnap.data()?.projectId) !== projectId) {
-            throw createHttpError(409, `Project code '${projectCode}' is already assigned`, 'duplicate_project_code');
-          }
-          tx.set(codeRef, {
-            code: projectCode,
-            projectId,
-            agreedAt: now,
-            agreedById: actorId,
-            agreedByName: reviewerName,
-          }, { merge: true });
-        } else {
-          if (previousStatus !== 'PLANNING_AGREED') {
-            throw createHttpError(409, 'Planning agreement is required before final approval', 'planning_agreement_required');
-          }
-          if (!designatedApproverId || designatedApproverId !== actorId) {
-            throw createHttpError(403, 'Only the designated approver can make the final decision', 'designated_approver_required');
-          }
-          if (!projectCode) {
-            throw createHttpError(422, 'projectCode is required before final approval', 'missing_project_code');
-          }
-          const submittedCode = normalizeProjectCode(parsed.projectCode);
-          if (submittedCode && submittedCode !== projectCode) {
-            throw createHttpError(422, 'projectCode cannot change after planning agreement', 'project_code_locked');
-          }
+        const requestApproverId = readOptionalText(requestPayload?.executiveApproverId);
+        const designatedApproverId = !isLegacyPlanningAgreement && requestApproverId
+          ? requestApproverId
+          : readOptionalText(currentProject.executiveApproverId);
+        if (!['PENDING', 'PLANNING_AGREED'].includes(previousStatus)) {
+          throw createHttpError(409, 'Project is not awaiting an organization-head decision', 'invalid_executive_review_state');
+        }
+        if (!designatedApproverId || designatedApproverId !== actorId) {
+          throw createHttpError(403, 'Only the designated approver can make the final decision', 'designated_approver_required');
+        }
+        const legacyProjectCode = isLegacyPlanningAgreement ? requireProjectCode(currentProject.projectCode) : null;
+        const submittedCode = normalizeProjectCode(parsed.projectCode);
+        if (isLegacyPlanningAgreement && submittedCode && requireProjectCode(submittedCode) !== legacyProjectCode) {
+          throw createHttpError(422, 'projectCode cannot change after planning agreement', 'project_code_locked');
+        }
+        if (!isLegacyPlanningAgreement && submittedCode) {
+          throw createHttpError(422, 'projectCode is issued by management planning after approval', 'project_code_management_only');
         }
         const isApprovedChangeRequest = parsed.reviewStatus === 'APPROVED' && isProjectChangeRequest(reviewRequest);
         const requestChanges = Array.isArray(reviewRequest?.changedFields) ? reviewRequest.changedFields : [];
@@ -2705,7 +2733,13 @@ export function mountProjectRoutes(app, {
           executiveReviewedById: actorId,
           executiveReviewedByName: reviewerName,
           executiveReviewComment: readOptionalText(parsed.reviewComment) || null,
-          ...(isPlanningAgreement || projectCode ? { projectCode } : {}),
+          ...(legacyProjectCode ? { projectCode: legacyProjectCode, projectCodeKey: legacyProjectCode } : {}),
+          ...(parsed.reviewStatus === 'APPROVED' && !isLegacyPlanningAgreement && !readOptionalText(currentProject.managementPlanningReviewStatus) ? {
+            managementPlanningReviewStatus: 'PENDING',
+            managementPlanningReviewHistory: Array.isArray(currentProject.managementPlanningReviewHistory)
+              ? currentProject.managementPlanningReviewHistory
+              : [],
+          } : {}),
           executiveReviewHistory: [
             ...currentHistory,
             {
@@ -2715,7 +2749,7 @@ export function mountProjectRoutes(app, {
               reviewedById: actorId,
               reviewedByName: reviewerName,
               reviewComment: readOptionalText(parsed.reviewComment) || null,
-              ...(isPlanningAgreement || projectCode ? { projectCode } : {}),
+              ...(legacyProjectCode ? { projectCode: legacyProjectCode } : {}),
               ...(requestChanges.length > 0 ? { changes: requestChanges } : {}),
             },
           ],
@@ -2728,7 +2762,7 @@ export function mountProjectRoutes(app, {
         };
       },
       buildRequestPatch: (_currentProject, currentRequest, nextVersion) => (
-        parsed.reviewStatus === 'PLANNING_AGREED' || !resolvedRequestId
+        !resolvedRequestId
           ? null
           : ({
         status: parsed.reviewStatus === 'APPROVED' ? 'APPROVED' : 'REJECTED',
@@ -2789,6 +2823,128 @@ export function mountProjectRoutes(app, {
     };
   }));
 
+  app.post('/api/v1/projects/:projectId/management-planning-review', createMutatingRoute(idempotencyService, async (req) => {
+    const { tenantId, actorId, actorEmail, actorName } = req.context;
+    assertActorRoleAllowed(req, ['admin', 'finance'], 'review project management planning status');
+    const projectId = readOptionalText(req.params.projectId);
+    if (!projectId) {
+      throw createHttpError(400, 'project id is required', 'missing_project_id');
+    }
+
+    const parsed = parseWithSchema(
+      projectManagementPlanningReviewSchema,
+      req.body,
+      'Invalid management planning review payload',
+    );
+    const projectPath = `orgs/${tenantId}/projects/${projectId}`;
+    const reviewerName = readOptionalText(actorName) || readOptionalText(actorEmail) || actorId;
+    const now = new Date().toISOString();
+    await ensureDocumentExists(db, projectPath, `Project not found: ${projectId}`);
+    const { request, requestId: resolvedRequestId, refs } = await resolveProjectRequestDocuments({
+      db,
+      tenantId,
+      requestId: parsed.requestId,
+      projectId,
+    });
+
+    await mergeProjectAndRequestDocs({
+      db,
+      projectPath,
+      buildProjectPatch: async (currentProject, _currentRequest, _nextVersion, tx) => {
+        if (readOptionalText(currentProject.executiveReviewStatus) !== 'APPROVED') {
+          throw createHttpError(409, 'Organization-head approval is required before management planning review', 'executive_review_required');
+        }
+        if (hasLegacyPlanningAgreement(currentProject)) {
+          throw createHttpError(
+            409,
+            'Legacy planning agreements are already finalised and cannot be reviewed again',
+            'legacy_planning_agreement_already_finalized',
+          );
+        }
+        const previousStatus = readOptionalText(currentProject.managementPlanningReviewStatus) || 'PENDING';
+        if (previousStatus !== 'PENDING') {
+          throw createHttpError(409, 'Project is not awaiting management planning review', 'invalid_management_planning_review_state');
+        }
+        const currentHistory = Array.isArray(currentProject.managementPlanningReviewHistory)
+          ? currentProject.managementPlanningReviewHistory
+          : [];
+        const isAgreed = parsed.reviewStatus === 'AGREED';
+        const projectCode = isAgreed ? requireProjectCode(parsed.projectCode) : null;
+        if (projectCode) {
+          const existingProjectCode = normalizeProjectCode(currentProject.projectCode);
+          if (existingProjectCode && existingProjectCode !== projectCode) {
+            throw createHttpError(422, 'projectCode cannot change after it is assigned', 'project_code_locked');
+          }
+          const codeRef = db.doc(`orgs/${tenantId}/project_code_registry/${encodeURIComponent(projectCode)}`);
+          const codeSnap = await tx.get(codeRef);
+          if (codeSnap.exists && readOptionalText(codeSnap.data()?.projectId) !== projectId) {
+            throw createHttpError(409, `Project code '${projectCode}' is already assigned`, 'duplicate_project_code');
+          }
+          tx.set(codeRef, {
+            code: projectCode,
+            projectId,
+            agreedAt: now,
+            agreedById: actorId,
+            agreedByName: reviewerName,
+          }, { merge: true });
+        }
+
+        return {
+          managementPlanningReviewStatus: parsed.reviewStatus,
+          managementPlanningReviewedAt: now,
+          managementPlanningReviewedById: actorId,
+          managementPlanningReviewedByName: reviewerName,
+          managementPlanningReviewComment: readOptionalText(parsed.reviewComment) || null,
+          ...(projectCode ? { projectCode, projectCodeKey: projectCode } : {}),
+          managementPlanningReviewHistory: [
+            ...currentHistory,
+            {
+              status: parsed.reviewStatus,
+              previousStatus,
+              reviewedAt: now,
+              reviewedById: actorId,
+              reviewedByName: reviewerName,
+              reviewComment: readOptionalText(parsed.reviewComment) || null,
+              ...(projectCode ? { projectCode } : {}),
+            },
+          ],
+        };
+      },
+      buildRequestPatch: () => {
+        if (!resolvedRequestId) return null;
+        const isAgreed = parsed.reviewStatus === 'AGREED';
+        return {
+          status: isAgreed ? 'APPROVED' : 'PENDING',
+          reviewOutcome: parsed.reviewStatus,
+          reviewedBy: actorId,
+          reviewedByName: reviewerName,
+          reviewedAt: now,
+          reviewComment: readOptionalText(parsed.reviewComment) || null,
+          rejectedReason: isAgreed ? null : readOptionalText(parsed.reviewComment),
+          approvedProjectId: projectId,
+          targetProjectId: projectId,
+          updatedAt: now,
+        };
+      },
+      requestRefs: resolvedRequestId ? refs : [],
+      tenantId,
+      actorId,
+      now,
+      notFoundMessage: `Project not found: ${projectId}`,
+    });
+
+    return {
+      status: 200,
+      body: {
+        ok: true,
+        projectId,
+        requestId: resolvedRequestId || null,
+        reviewStatus: parsed.reviewStatus,
+        reviewedAt: now,
+      },
+    };
+  }));
+
   app.post('/api/v1/projects/:projectId/executive-review/resubmit', createMutatingRoute(idempotencyService, async (req) => {
     const { tenantId, actorId, actorEmail } = req.context;
     assertActorRoleAllowed(req, ROUTE_ROLES.writeCore, 'resubmit project for executive review');
@@ -2814,6 +2970,12 @@ export function mountProjectRoutes(app, {
       projectPath,
       buildProjectPatch: (currentProject) => {
         const previousStatus = readOptionalText(currentProject.executiveReviewStatus) || 'PENDING';
+        if (isManagementPlanningRevisionRejected(currentProject)) {
+          return buildManagementPlanningResubmissionPatch();
+        }
+        if (previousStatus !== 'REVISION_REJECTED') {
+          throw createHttpError(409, 'Project is not awaiting resubmission', 'invalid_resubmit_state');
+        }
         const currentHistory = Array.isArray(currentProject.executiveReviewHistory) ? currentProject.executiveReviewHistory : [];
         return {
           executiveReviewStatus: 'PENDING',

--- a/server/bff/schemas.mjs
+++ b/server/bff/schemas.mjs
@@ -146,6 +146,29 @@ export const projectExecutiveResubmitSchema = z.object({
   reviewerName: z.string().trim().max(200).optional(),
 }).strict();
 
+export const projectManagementPlanningReviewSchema = z.object({
+  requestId: NON_EMPTY_STRING.optional(),
+  reviewStatus: z.enum(['AGREED', 'REVISION_REJECTED']),
+  reviewComment: z.string().trim().max(2000).optional(),
+  reviewerName: z.string().trim().max(200).optional(),
+  projectCode: z.string().trim().max(100).optional(),
+}).strict().superRefine((value, ctx) => {
+  if (value.reviewStatus === 'AGREED' && !value.projectCode) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['projectCode'],
+      message: 'projectCode is required when management planning agrees a project',
+    });
+  }
+  if (value.reviewStatus === 'REVISION_REJECTED' && !value.reviewComment) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['reviewComment'],
+      message: 'reviewComment is required when management planning rejects a project',
+    });
+  }
+});
+
 export const googleSheetImportPreviewSchema = z.object({
   value: NON_EMPTY_STRING,
   sheetName: NON_EMPTY_STRING.optional(),

--- a/server/bff/schemas.test.mjs
+++ b/server/bff/schemas.test.mjs
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { projectExecutiveReviewSchema } from './schemas.mjs';
+import {
+  projectExecutiveReviewSchema,
+  projectManagementPlanningReviewSchema,
+} from './schemas.mjs';
 
 describe('projectExecutiveReviewSchema', () => {
   it('accepts a project code as an approval payload field', () => {
@@ -9,5 +12,16 @@ describe('projectExecutiveReviewSchema', () => {
 
   it('accepts a planning agreement with a project code', () => {
     expect(projectExecutiveReviewSchema.safeParse({ reviewStatus: 'PLANNING_AGREED', projectCode: 'PRJ-2026-001' }).success).toBe(true);
+  });
+
+  it('requires a code to agree and a reason to reject in management planning', () => {
+    expect(projectManagementPlanningReviewSchema.safeParse({
+      reviewStatus: 'AGREED', projectCode: 'PRJ-2026-001',
+    }).success).toBe(true);
+    expect(projectManagementPlanningReviewSchema.safeParse({ reviewStatus: 'AGREED' }).success).toBe(false);
+    expect(projectManagementPlanningReviewSchema.safeParse({ reviewStatus: 'REVISION_REJECTED' }).success).toBe(false);
+    expect(projectManagementPlanningReviewSchema.safeParse({
+      reviewStatus: 'REVISION_REJECTED', reviewComment: '계약 기준 보완',
+    }).success).toBe(true);
   });
 });

--- a/src/app/components/cashflow/CashflowAnalyticsPage.tsx
+++ b/src/app/components/cashflow/CashflowAnalyticsPage.tsx
@@ -281,7 +281,7 @@ export function CashflowAnalyticsPage() {
             <Button variant="outline" className="rounded-none border-[#c7c7c7]" onClick={() => setActiveView('analytics')}>통합 현황으로</Button>
           </div>
         </section>
-        <ProjectMigrationAuditPage embedded defaultInboxScope="ALL" workflowStage="planning" />
+        <ProjectMigrationAuditPage embedded reviewStage="managementPlanning" />
       </div>
     );
   }

--- a/src/app/components/portal/PortalProjectEdit.persist-shell.test.ts
+++ b/src/app/components/portal/PortalProjectEdit.persist-shell.test.ts
@@ -19,6 +19,11 @@ describe('PortalProjectEdit persistence shell', () => {
     expect(source).not.toContain('resubmitProjectExecutiveReviewViaBff');
   });
 
+  it('reads canonical and legacy project request collections so reviewer feedback is retained', () => {
+    expect(source).toContain("['project_requests', 'projectRequests']");
+    expect(source).toContain('const sourceRows = new Map<string, ProjectRequest>()');
+  });
+
   it('keeps the project edit draft key stable across request listener updates', () => {
     expect(source).toContain('const autosaveKey = `portal-edit-${orgId}-${project.id}-${actor.uid}`');
     expect(source).toContain('draftKey={autosaveKey}');

--- a/src/app/components/portal/PortalProjectEdit.tsx
+++ b/src/app/components/portal/PortalProjectEdit.tsx
@@ -6,6 +6,7 @@ import {
   Clock3,
   Loader2,
   LockKeyhole,
+  MessageSquareText,
   Pencil,
   Save,
   SendHorizontal,
@@ -37,6 +38,11 @@ import {
   resolveProjectRequestKind,
   resolveProjectRequestPayload,
 } from '../../platform/project-change-request';
+import {
+  buildPortalProjectReviewFeedback,
+  hasManagementPlanningReview,
+} from '../../platform/portal-project-review-feedback';
+import { getManagementPlanningReview } from '../../platform/project-management-planning-review';
 import type { ProjectRequestDocumentKind } from '../../platform/project-contract-upload';
 import { resolvePortalProjectResourcePath } from '../../platform/portal-project-selection';
 import { EditLeaseDialogs } from '../editing/EditLeaseDialogs';
@@ -63,7 +69,7 @@ function resolveExecutiveBanner(project: Project) {
   const reason = project.executiveReviewComment || '';
   if (status === 'APPROVED') return {
     tone: 'success', title: '승인 완료',
-    description: 'CIC 대표 검토가 승인된 프로젝트입니다. PM이 수정 저장하면 다시 검토 대기로 전환됩니다.',
+    description: '조직장 검토가 승인되었습니다. 경영기획실 합의가 완료될 때까지 조직장 승인 이력은 유지됩니다.',
   };
   if (status === 'REVISION_REJECTED') return {
     tone: 'danger', title: '수정 요청 후 반려',
@@ -84,6 +90,27 @@ function bannerClassName(tone: string) {
   if (tone === 'neutral') return 'border-slate-200 bg-slate-50 text-slate-900';
   if (tone === 'warning') return 'border-slate-200 bg-white text-red-700';
   return 'border-slate-200 bg-white text-slate-900';
+}
+
+function resolveManagementPlanningBanner(
+  status: ReturnType<typeof getManagementPlanningReview>['status'],
+  comment: string,
+) {
+  if (status === 'AGREED') return {
+    tone: 'success', title: '경영기획실 합의 완료', description: comment || '경영기획실 합의가 완료되었습니다.',
+  };
+  if (status === 'REVISION_REJECTED') return {
+    tone: 'danger', title: '경영기획실 반려', description: comment || '보완 요청을 확인한 뒤 수정 후 다시 제출해 주세요.',
+  };
+  return {
+    tone: 'warning', title: '경영기획실 합의 대기', description: comment || '조직장 승인 후 경영기획실 합의를 기다리고 있습니다.',
+  };
+}
+
+function managementPlanningBannerClassName(tone: string) {
+  if (tone === 'danger') return 'border-rose-200 bg-rose-50 text-rose-900';
+  if (tone === 'success') return 'border-emerald-200 bg-emerald-50 text-emerald-900';
+  return 'border-amber-200 bg-amber-50 text-amber-900';
 }
 
 function attachmentDocument(attachment: ProjectInfoAttachment): FileAttachment {
@@ -137,6 +164,7 @@ function ProjectInfoEditor({
   draftClient,
   members,
   project,
+  requestDoc,
   session,
 }: {
   actor: ActorLike;
@@ -145,6 +173,7 @@ function ProjectInfoEditor({
   draftClient: DraftClient;
   members: ReturnType<typeof usePortalStore>['members'];
   project: Project;
+  requestDoc: ProjectRequest | null;
   session: EditSession;
 }) {
   const navigate = useNavigate();
@@ -164,9 +193,20 @@ function ProjectInfoEditor({
     resourceId: project.id,
   }), [actor, orgId, project.id, session.sessionId]);
   const lease = useEditLease({ client: leaseClient });
-  const canResubmit = project.executiveReviewStatus === 'REVISION_REJECTED'
+  const canExecutiveResubmit = project.executiveReviewStatus === 'REVISION_REJECTED'
     || project.executiveReviewStatus === 'DUPLICATE_DISCARDED';
+  const managementPlanningReview = useMemo(() => getManagementPlanningReview(project), [project]);
+  const hasExplicitManagementPlanningReview = useMemo(() => hasManagementPlanningReview(project), [project]);
+  const managementPlanningBanner = useMemo(
+    () => hasExplicitManagementPlanningReview
+      ? resolveManagementPlanningBanner(managementPlanningReview.status, managementPlanningReview.reviewComment)
+      : null,
+    [hasExplicitManagementPlanningReview, managementPlanningReview.reviewComment, managementPlanningReview.status],
+  );
+  const canManagementPlanningResubmit = managementPlanningReview.status === 'REVISION_REJECTED';
+  const canResubmit = canExecutiveResubmit || canManagementPlanningResubmit;
   const executiveBanner = useMemo(() => resolveExecutiveBanner(project), [project]);
+  const reviewFeedback = useMemo(() => buildPortalProjectReviewFeedback(project, requestDoc), [project, requestDoc]);
   const initialDraft = useMemo(
     () => (record ? editorDraftFromPrivate(record) : canonicalDraft),
     [canonicalDraft, record],
@@ -311,6 +351,19 @@ function ProjectInfoEditor({
     </div>
   );
 
+  const resubmitCommentField = (
+    <div className="mt-4">
+      <Label className="text-[11px] font-semibold uppercase tracking-[0.16em]">다시 제출 메모</Label>
+      <Textarea
+        value={resubmitComment}
+        onChange={(event) => setResubmitComment(event.target.value)}
+        placeholder="보완한 내용을 짧게 남길 수 있습니다."
+        className="mt-2 min-h-[88px] border-white/70 bg-white/85 text-sm text-slate-900"
+        disabled={!editorCanEdit}
+      />
+    </div>
+  );
+
   const topSlot = (
     <div className="space-y-3">
       {leaseBar}
@@ -318,27 +371,42 @@ function ProjectInfoEditor({
         <div className="flex items-start gap-3">
           <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
           <div className="min-w-0 flex-1">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.16em]">
-              {canResubmit ? '반려 사유' : '검토 상태'}
-            </p>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.16em]">{canExecutiveResubmit ? '반려 사유' : '검토 상태'}</p>
             <h2 className="mt-1 text-base font-semibold">{executiveBanner.title}</h2>
             <p className="mt-2 whitespace-pre-wrap text-sm leading-6">{executiveBanner.description}</p>
-            {canResubmit ? (
-              <div className="mt-4">
-                <Label className="text-[11px] font-semibold uppercase tracking-[0.16em]">다시 제출 메모</Label>
-                <Textarea
-                  value={resubmitComment}
-                  onChange={(event) => setResubmitComment(event.target.value)}
-                  placeholder="보완한 내용을 짧게 남길 수 있습니다."
-                  className="mt-2 min-h-[88px] border-white/70 bg-white/85 text-sm text-slate-900"
-                  disabled={!editorCanEdit}
-                />
-              </div>
-            ) : null}
+            {canExecutiveResubmit ? resubmitCommentField : null}
           </div>
           {busyActionId ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
         </div>
       </div>
+      {managementPlanningBanner ? (
+        <div className={`rounded-2xl border px-4 py-4 ${managementPlanningBannerClassName(managementPlanningBanner.tone)}`} data-testid="portal-management-planning-review">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
+            <div className="min-w-0 flex-1">
+              <p className="text-[11px] font-semibold uppercase tracking-[0.16em]">경영기획실 검토</p>
+              <h2 className="mt-1 text-base font-semibold">{managementPlanningBanner.title}</h2>
+              <p className="mt-2 whitespace-pre-wrap text-sm leading-6">{managementPlanningBanner.description}</p>
+              {canManagementPlanningResubmit ? resubmitCommentField : null}
+            </div>
+          </div>
+        </div>
+      ) : null}
+      {reviewFeedback.length > 0 ? (
+        <section className="rounded-xl border border-slate-200 bg-white px-4 py-3" data-testid="portal-project-review-feedback">
+          <div className="flex items-center gap-2 text-slate-900"><MessageSquareText className="h-4 w-4" /><h2 className="text-sm font-semibold">제출·처리 메모</h2></div>
+          <ol className="mt-3 space-y-3 border-l border-slate-200 pl-4">
+            {reviewFeedback.map((entry) => (
+              <li key={entry.id} className="relative">
+                <span className="absolute -left-[1.1rem] top-1.5 h-2 w-2 rounded-full border border-slate-300 bg-white" />
+                <p className="text-xs font-semibold text-slate-800">{entry.label}</p>
+                <p className="mt-1 whitespace-pre-wrap text-sm leading-6 text-slate-700">{entry.comment}</p>
+                {entry.reviewerName || entry.reviewedAt ? <p className="mt-1 text-xs text-slate-500">{[entry.reviewerName, entry.reviewedAt].filter(Boolean).join(' · ')}</p> : null}
+              </li>
+            ))}
+          </ol>
+        </section>
+      ) : null}
     </div>
   );
 
@@ -438,15 +506,30 @@ export function PortalProjectEdit() {
       setRequestDoc(null);
       return undefined;
     }
-    const requestQuery = query(
-      collection(db, getOrgCollectionPath(orgId, 'projectRequests')),
-      where('approvedProjectId', '==', project.id),
-      orderBy('requestedAt', 'desc'),
-      limit(1),
-    );
-    return onSnapshot(requestQuery, (snapshot) => {
-      setRequestDoc(snapshot.docs[0]?.data() as ProjectRequest || null);
-    }, () => setRequestDoc(null));
+    const sourceRows = new Map<string, ProjectRequest>();
+    const publish = () => {
+      const latest = Array.from(sourceRows.values())
+        .sort((left, right) => String(right.requestedAt || '').localeCompare(String(left.requestedAt || '')))[0] || null;
+      setRequestDoc(latest);
+    };
+    const unsubscribers = (['project_requests', 'projectRequests'] as const).map((collectionName) => {
+      const requestQuery = query(
+        collection(db, getOrgCollectionPath(orgId, collectionName)),
+        where('approvedProjectId', '==', project.id),
+        orderBy('requestedAt', 'desc'),
+        limit(1),
+      );
+      return onSnapshot(requestQuery, (snapshot) => {
+        const request = snapshot.docs[0]?.data() as ProjectRequest | undefined;
+        if (request) sourceRows.set(collectionName, request);
+        else sourceRows.delete(collectionName);
+        publish();
+      }, () => {
+        sourceRows.delete(collectionName);
+        publish();
+      });
+    });
+    return () => unsubscribers.forEach((unsubscribe) => unsubscribe());
   }, [db, isOnline, orgId, project?.id]);
 
   useEffect(() => {
@@ -530,6 +613,7 @@ export function PortalProjectEdit() {
       draftClient={bootstrap.draftClient}
       members={members}
       project={project}
+      requestDoc={requestDoc}
       session={bootstrap.session}
     />
   );

--- a/src/app/components/projects/ProjectCodeIssuancePage.shell.test.ts
+++ b/src/app/components/projects/ProjectCodeIssuancePage.shell.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(import.meta.dirname, 'ProjectCodeIssuancePage.tsx'), 'utf8');
+
+describe('ProjectCodeIssuancePage', () => {
+  it('reuses the formal registration review surface in management-planning mode', () => {
+    expect(source).toContain('ProjectMigrationAuditPage');
+    expect(source).toContain('reviewStage="managementPlanning"');
+  });
+});

--- a/src/app/components/projects/ProjectCodeIssuancePage.tsx
+++ b/src/app/components/projects/ProjectCodeIssuancePage.tsx
@@ -1,0 +1,5 @@
+import { ProjectMigrationAuditPage } from './ProjectMigrationAuditPage';
+
+export function ProjectCodeIssuancePage() {
+  return <ProjectMigrationAuditPage reviewStage="managementPlanning" />;
+}

--- a/src/app/components/projects/ProjectMigrationAuditPage.shell.test.ts
+++ b/src/app/components/projects/ProjectMigrationAuditPage.shell.test.ts
@@ -4,127 +4,56 @@ import { describe, expect, it } from 'vitest';
 
 const pageSource = readFileSync(resolve(import.meta.dirname, 'ProjectMigrationAuditPage.tsx'), 'utf8');
 const controlBarSource = readFileSync(resolve(import.meta.dirname, 'migration-audit/MigrationAuditControlBar.tsx'), 'utf8');
-const queueSource = readFileSync(resolve(import.meta.dirname, 'migration-audit/MigrationAuditQueueRail.tsx'), 'utf8');
-const detailSource = readFileSync(resolve(import.meta.dirname, 'migration-audit/MigrationAuditDetailPanel.tsx'), 'utf8');
 const documentSource = readFileSync(resolve(import.meta.dirname, 'migration-audit/MigrationAuditDocumentDialog.tsx'), 'utf8');
 const recordListSource = readFileSync(resolve(import.meta.dirname, 'migration-audit/MigrationAuditRecordList.tsx'), 'utf8');
 const previewSource = readFileSync(resolve(import.meta.dirname, 'ContractDocumentPreview.tsx'), 'utf8');
-const compositeSource = [pageSource, controlBarSource, queueSource, detailSource, documentSource, recordListSource, previewSource].join('\n');
+const compositeSource = [pageSource, controlBarSource, documentSource, recordListSource, previewSource].join('\n');
 
-describe('ProjectMigrationAuditPage shell contract', () => {
-  it('presents a filtered review inbox and opens the registration as an approval document', () => {
-    expect(pageSource).toContain('MigrationAuditRecordList');
-    expect(pageSource).toContain('MigrationAuditDocumentDialog');
-    expect(pageSource).toContain('isSameMigrationAuditCic');
-    expect(pageSource).not.toContain('MigrationAuditQueueRail');
+describe('ProjectMigrationAuditPage review flow', () => {
+  it('keeps a filter-first inbox and opens a formal three-line approval document', () => {
     expect(compositeSource).toContain('data-testid="migration-review-search-bar"');
     expect(compositeSource).toContain('data-testid="migration-review-record-list"');
     expect(compositeSource).toContain('data-testid="migration-review-document"');
     expect(compositeSource).toContain('프로젝트 등록 및 승인서');
+    expect(compositeSource).toContain('기안');
     expect(compositeSource).toContain('조직장 승인');
+    expect(compositeSource).toContain('경영기획실 합의');
+    expect(compositeSource).toContain('실무자 제출/재제출 메모');
+    expect(compositeSource).toContain("entry.status === 'PENDING' ? '실무자 제출/재제출 메모'");
     expect(compositeSource).toContain('ApprovalSeal');
-    expect(documentSource).toContain('executiveApproverName');
-    expect(documentSource).toContain("const designatedApproverName = requestPayload?.executiveApproverName\n    || record.project.executiveApproverName");
-    expect(compositeSource).toContain('내 검토함');
     expect(compositeSource).toContain('CIC 필터');
     expect(compositeSource).toContain('상태 필터');
     expect(compositeSource).toContain('프로젝트 검색');
-    expect(compositeSource).toContain('프로젝트명, 등록 원문, 계약 대상, PM 검색');
-    expect(compositeSource).toContain('migration-review-project-search');
-    expect(compositeSource).toContain('statusChartBackground');
-    expect(compositeSource).toContain('합의대기');
-    expect(compositeSource).toContain('경영기획실 합의');
-    expect(compositeSource).toContain('승인');
-    expect(compositeSource).toContain('수정 요청 후 반려');
-    expect(compositeSource).toContain('중복·폐기');
-    expect(compositeSource).toContain('경영기획실 프로젝트 합의');
     expect(compositeSource).toContain('문서 열기');
-    expect(compositeSource).toContain('describeProjectRequestVersion');
-    expect(compositeSource).toContain('수정 중');
-    expect(compositeSource).toContain('PM 수정 요청');
-    expect(compositeSource).not.toContain('사업명으로 검색');
-    expect(compositeSource).not.toContain('우리 사업으로 승인');
-    expect(compositeSource).not.toContain('연결 필요');
-    expect(compositeSource).not.toContain('연결 완료');
-    expect(compositeSource).not.toContain('기존 시스템에만 있는 프로젝트');
-    expect(compositeSource).not.toContain('PM 등록 없음');
-    expect(compositeSource).not.toContain('검토 후보');
-    expect(compositeSource).not.toContain('비교할 다른 프로젝트 후보');
-    expect(compositeSource).not.toContain('빠른 등록 시작');
-    expect(compositeSource).not.toContain('기준 다시 적재');
-    expect(compositeSource).not.toContain('운영 포커스');
   });
 
-  it('does not describe approved records as read-only and removes review summary labels', () => {
-    expect(compositeSource).not.toContain('기존 등록 프로젝트는 읽기 전용 참고 화면입니다. 별도 승인 액션은 보여주지 않습니다.');
-    expect(compositeSource).not.toContain('읽기 전용');
-    expect(detailSource).not.toContain('DetailFact label="검토자"');
-    expect(detailSource).not.toContain('DetailFact label="검토일"');
-    expect(detailSource).not.toContain('DetailFact label="검토 메모"');
-    expect(detailSource).not.toContain("{isPmPortalProject ? 'PM 등록' : '기존 등록'}");
+  it('keeps the designated organization-head guard in the UI as defense in depth', () => {
+    expect(pageSource).toContain('const designatedApproverId');
+    expect(pageSource).toContain('designatedApproverId === authUser.uid');
+    expect(pageSource).toContain('if (!canFinalize)');
+    expect(pageSource).not.toContain('isSameMigrationAuditCic');
+    expect(documentSource).toContain('canFinalize: boolean');
+    expect(documentSource).toContain('지정된 조직장만 승인 또는 반려할 수 있습니다.');
   });
 
-  it('routes every decision through one fail-closed BFF command', () => {
-    expect(pageSource).toContain('reviewProjectExecutiveStatusViaBff');
-    expect(pageSource).toContain('if (!isPlatformApiEnabled() || !authUser?.uid)');
-    expect(pageSource).not.toContain('trashProject');
-    expect(pageSource).not.toContain('updateProject');
-    expect(pageSource).not.toContain('setDoc(');
-  });
-
-  it('requires a project code before saving a planning agreement', () => {
+  it('uses a separate management-planning command only after organization approval', () => {
+    expect(pageSource).toContain("reviewStage = 'executive'");
+    expect(pageSource).toContain("reviewStage === 'managementPlanning'");
+    expect(pageSource).toContain("record.project.executiveReviewStatus === 'APPROVED'");
+    expect(pageSource).toContain('reviewProjectManagementPlanningStatusViaBff');
+    expect(pageSource).toContain("reviewStatus: actionMode === 'approve' ? 'AGREED' : 'REVISION_REJECTED'");
     expect(pageSource).toContain('프로젝트 코드를 입력해 주세요.');
-    expect(pageSource).toContain("projectCode: actionMode === 'agree' ? trimmedProjectCode : undefined");
-    expect(pageSource).toContain("reviewStatus: nextExecutiveStatus");
-    expect(documentSource).toContain('프로젝트 코드');
+    expect(pageSource).not.toContain("reviewStatus: 'PLANNING_AGREED'");
+    expect(recordListSource).toContain('프로젝트 코드');
   });
 
-  it('listens to both canonical and legacy project request collections', () => {
-    expect(pageSource).toContain("const PROJECT_REQUEST_COLLECTIONS: ProjectRequestCollectionName[] = ['project_requests', 'projectRequests']");
-    expect(pageSource).toContain('__collectionName: collectionName');
-    expect(compositeSource).toContain('isMigrationAuditPmRegistration');
-  });
-
-  it('shows the uploaded contract PDF next to analysis notes', () => {
-    expect(detailSource).toContain('계약 분석 보조 정보');
-    expect(detailSource).toContain('ContractDocumentPreview');
-    expect(detailSource).toContain('계약서 PDF 원문');
-    expect(detailSource).toContain('계약서 요약');
-    expect(detailSource).not.toContain('AI/휴리스틱 요약');
-    expect(previewSource).toContain('data-testid="contract-document-preview"');
-    expect(previewSource).toContain('<iframe');
-    expect(previewSource).toContain('PDF 미리보기');
-    expect(previewSource).toContain('첨부 파일 원문을 불러올 수 없습니다.');
-  });
-
-  it('highlights attachment changes and previews the pending request document', () => {
-    expect(detailSource).toContain('ATTACHMENT_CHANGE_KEYS');
-    expect(detailSource).toContain('첨부파일 변경');
-    expect(detailSource).toContain('수정사항');
-    expect(detailSource).toContain('border border-amber-200 bg-amber-50');
-    expect(detailSource).toContain('useRequestPayloadAsCurrent');
-    expect(detailSource).toContain('resolveProjectRequestPayload');
-    expect(detailSource).toContain('requestPayload?.contractDocument || record.project.contractDocument || null');
-  });
-
-  it('loads private pending request attachments through the authenticated BFF for the document popup', () => {
+  it('keeps the contract in the document popup and fetches private originals through the BFF', () => {
+    expect(pageSource).toContain('resolveMigrationReviewContractDocument');
     expect(pageSource).toContain('downloadProjectRequestAttachmentViaBff');
     expect(pageSource).toContain('URL.createObjectURL');
     expect(pageSource).toContain('URL.revokeObjectURL');
-    expect(pageSource).toContain('secureContractDocumentUrl');
-    expect(pageSource).toContain('secureContractDocumentKey');
-    expect(pageSource).toContain('privateAttachmentError');
-    expect(documentSource).toContain('contractDocumentDownloadURL');
-    expect(documentSource).toContain('contractDocumentError');
-    expect(documentSource).toContain('계약서 원문 열기');
-  });
-
-  it('keeps CIC registration review read-only while improving scan hierarchy', () => {
-    expect(detailSource).toContain('ReviewSection');
-    expect(detailSource).toContain('ReviewFactGrid');
-    expect(detailSource).toContain('sticky bottom-0');
-    expect(detailSource).toContain('requestVersionDescription');
-    expect(detailSource).not.toContain('ProjectEditorWizard');
-    expect(detailSource).not.toContain('수정 저장');
+    expect(documentSource).toContain('ContractDocumentPreview');
+    expect(previewSource).toContain('data-testid="contract-document-preview"');
+    expect(previewSource).toContain('<iframe');
   });
 });

--- a/src/app/components/projects/ProjectMigrationAuditPage.tsx
+++ b/src/app/components/projects/ProjectMigrationAuditPage.tsx
@@ -1,31 +1,29 @@
 import { useEffect, useMemo, useState } from 'react';
 import { ClipboardCheck, Loader2 } from 'lucide-react';
-import {
-  collection,
-  onSnapshot,
-  orderBy,
-  query,
-} from 'firebase/firestore';
+import { collection, onSnapshot, orderBy, query } from 'firebase/firestore';
 import { toast } from 'sonner';
 import { useAuth } from '../../data/auth-store';
 import { useAppStore } from '../../data/store';
-import type { ProjectExecutiveReviewStatus, ProjectRequest } from '../../data/types';
+import type { Project, ProjectExecutiveReviewStatus, ProjectRequest } from '../../data/types';
 import { getOrgRootPath } from '../../lib/firebase';
 import { useFirebase } from '../../lib/firebase-context';
-import { isPlatformApiEnabled, reviewProjectExecutiveStatusViaBff } from '../../lib/platform-bff-client';
+import {
+  isPlatformApiEnabled,
+  reviewProjectExecutiveStatusViaBff,
+  reviewProjectManagementPlanningStatusViaBff,
+} from '../../lib/platform-bff-client';
 import { downloadProjectAttachmentViaBff, downloadProjectRequestAttachmentViaBff } from '../../lib/project-request-attachment-client';
 import {
+  type MigrationAuditConsoleRecord,
   type MigrationAuditConsoleStatus,
   buildMigrationAuditConsoleRecords,
   collectMigrationAuditCicOptions,
   filterMigrationAuditConsoleRecords,
-  isSameMigrationAuditCic,
   summarizeMigrationAuditConsole,
 } from '../../platform/project-migration-console';
-import {
-  resolveProjectRequestKind,
-  resolveProjectRequestPayload,
-} from '../../platform/project-change-request';
+import { getManagementPlanningReview } from '../../platform/project-management-planning-review';
+import { resolveProjectRequestKind, resolveProjectRequestPayload } from '../../platform/project-change-request';
+import { resolveMigrationReviewContractDocument } from '../../platform/project-migration-review-dossier';
 import { PageHeader } from '../layout/PageHeader';
 import { Card, CardContent } from '../ui/card';
 import { MigrationAuditControlBar } from './migration-audit/MigrationAuditControlBar';
@@ -44,75 +42,90 @@ import {
 import { Textarea } from '../ui/textarea';
 import { Input } from '../ui/input';
 
-type ReviewActionMode = 'agree' | 'approve' | 'reject';
-type WorkflowStage = 'planning' | 'approval';
+type ReviewActionMode = 'approve' | 'reject' | 'discard';
+export type ProjectRegistrationReviewStage = 'executive' | 'managementPlanning';
 type ProjectRequestCollectionName = 'project_requests' | 'projectRequests';
-type ProjectRequestWithSource = ProjectRequest & {
-  __collectionName?: ProjectRequestCollectionName;
-};
+type ProjectRequestWithSource = ProjectRequest & { __collectionName?: ProjectRequestCollectionName };
 
 const PROJECT_REQUEST_COLLECTIONS: ProjectRequestCollectionName[] = ['project_requests', 'projectRequests'];
 
-function getReviewDialogTitle(mode: ReviewActionMode): string {
-  if (mode === 'agree') return '이 프로젝트에 합의할까요?';
+function getReviewDialogTitle(mode: ReviewActionMode, reviewStage: ProjectRegistrationReviewStage): string {
+  if (reviewStage === 'managementPlanning') return mode === 'approve' ? '프로젝트 코드 부여에 합의할까요?' : '프로젝트 코드를 반려할까요?';
   if (mode === 'approve') return '이 프로젝트를 승인할까요?';
   if (mode === 'reject') return '수정 요청 후 반려할까요?';
-  return '';
+  return '이 프로젝트를 중복·폐기할까요?';
 }
 
-function getReviewDialogDescription(mode: ReviewActionMode): string {
-  if (mode === 'agree') return '경영기획실 합의와 함께 프로젝트 코드를 부여하고, 지정 조직장에게 최종 승인을 요청합니다.';
-  if (mode === 'approve') return '경영기획실 합의가 끝난 문서를 최종 승인합니다.';
+function getReviewDialogDescription(mode: ReviewActionMode, reviewStage: ProjectRegistrationReviewStage): string {
+  if (reviewStage === 'managementPlanning') {
+    return mode === 'approve'
+      ? '조직장 승인이 끝난 프로젝트에 코드를 부여하고 경영기획실 합의로 기록합니다.'
+      : '반려 사유를 남기면 PM에게 다시 전달되어 보완 후 재제출할 수 있습니다.';
+  }
+  if (mode === 'approve') return 'PM이 올린 원문을 기준으로 이 프로젝트를 등록 대상으로 확정합니다.';
   if (mode === 'reject') return '수정이 필요한 이유를 반드시 남기고 PM이 다시 보완하도록 돌려보냅니다.';
-  return '';
+  return '중복 또는 폐기 대상으로 정리하고, 판단 근거를 반드시 남깁니다.';
 }
 
-function getProjectRequestReviewDescription(mode: ReviewActionMode, request: ProjectRequest | null | undefined): string {
-  const isChangeRequest = resolveProjectRequestKind(request) === 'CHANGE';
-  if (!isChangeRequest || mode === 'agree') return getReviewDialogDescription(mode);
-  if (mode === 'approve') return 'PM이 제출한 수정 중 값을 프로젝트 원장에 반영하고 변경 요청을 승인 완료로 닫습니다.';
+function getProjectRequestReviewDescription(mode: ReviewActionMode, request: ProjectRequest | null | undefined, reviewStage: ProjectRegistrationReviewStage): string {
+  if (reviewStage === 'managementPlanning' || resolveProjectRequestKind(request) !== 'CHANGE') return getReviewDialogDescription(mode, reviewStage);
+  if (mode === 'approve') return 'PM이 제출한 수정 값을 프로젝트 원장에 반영하고 변경 요청을 승인 완료로 닫습니다.';
   if (mode === 'reject') return '프로젝트 원장은 유지하고, 수정이 필요한 이유를 남겨 PM에게 돌려보냅니다.';
   return '프로젝트 원장은 유지하고, 중복 또는 폐기된 수정 요청으로 정리합니다.';
 }
 
 function toExecutiveStatus(mode: ReviewActionMode): ProjectExecutiveReviewStatus {
-  if (mode === 'agree') return 'PLANNING_AGREED';
   if (mode === 'approve') return 'APPROVED';
   if (mode === 'reject') return 'REVISION_REJECTED';
+  return 'DUPLICATE_DISCARDED';
+}
+
+function buildExecutiveRecords(records: MigrationAuditConsoleRecord[]): MigrationAuditConsoleRecord[] {
+  // Legacy planning agreements were made before the management-planning state split.
+  // They remain eligible for the designated organization head's decision, but are shown as pending.
+  return records.map((record) => record.status === 'PLANNING_AGREED' ? { ...record, status: 'PENDING' } : record);
+}
+
+function toManagementPlanningConsoleStatus(project: Project): MigrationAuditConsoleStatus {
+  const status = getManagementPlanningReview(project).status;
+  if (status === 'AGREED') return 'APPROVED';
+  if (status === 'REVISION_REJECTED') return 'REVISION_REJECTED';
   return 'PENDING';
+}
+
+function buildManagementPlanningRecords(records: MigrationAuditConsoleRecord[]): MigrationAuditConsoleRecord[] {
+  return records
+    .filter((record) => record.project.executiveReviewStatus === 'APPROVED')
+    .map((record) => ({ ...record, status: toManagementPlanningConsoleStatus(record.project) }));
 }
 
 type ProjectMigrationAuditPageProps = {
   embedded?: boolean;
   reviewScope?: 'all' | 'pending';
-  defaultInboxScope?: 'MINE' | 'ALL';
-  workflowStage?: WorkflowStage;
+  reviewStage?: ProjectRegistrationReviewStage;
 };
 
 export function ProjectMigrationAuditPage({
   embedded = false,
   reviewScope = 'all',
-  defaultInboxScope = 'MINE',
-  workflowStage = 'approval',
+  reviewStage = 'executive',
 }: ProjectMigrationAuditPageProps = {}) {
   const { user: authUser } = useAuth();
   const { projects, currentUser } = useAppStore();
   const { db, isOnline, orgId } = useFirebase();
-
   const [requests, setRequests] = useState<ProjectRequest[]>([]);
   const [loadingRequests, setLoadingRequests] = useState(true);
   const [cicFilter, setCicFilter] = useState('ALL');
-  const [statusFilter, setStatusFilter] = useState<'ALL' | MigrationAuditConsoleStatus>(
-    workflowStage === 'planning' ? 'PENDING' : 'PLANNING_AGREED',
-  );
+  const [statusFilter, setStatusFilter] = useState<'ALL' | MigrationAuditConsoleStatus>('PENDING');
   const [searchQuery, setSearchQuery] = useState('');
-  const [inboxScope, setInboxScope] = useState<'MINE' | 'ALL'>(defaultInboxScope);
+  const [inboxScope, setInboxScope] = useState<'MINE' | 'ALL'>('MINE');
   const [openRecordId, setOpenRecordId] = useState<string | null>(null);
   const [actionMode, setActionMode] = useState<ReviewActionMode | null>(null);
   const [reviewComment, setReviewComment] = useState('');
   const [projectCode, setProjectCode] = useState('');
   const [acting, setActing] = useState(false);
   const [secureContractDocument, setSecureContractDocument] = useState({ key: '', url: '', error: '' });
+  const isManagementPlanning = reviewStage === 'managementPlanning';
 
   useEffect(() => {
     if (!db || !isOnline) {
@@ -125,144 +138,80 @@ export function ProjectMigrationAuditPage({
     const sourceRows = new Map<ProjectRequestCollectionName, ProjectRequestWithSource[]>();
     const initializedSources = new Set<ProjectRequestCollectionName>();
     let disposed = false;
-
     const publish = () => {
       if (disposed) return;
       setRequests(Array.from(sourceRows.values()).flat());
-      if (initializedSources.size === PROJECT_REQUEST_COLLECTIONS.length) {
-        setLoadingRequests(false);
-      }
+      if (initializedSources.size === PROJECT_REQUEST_COLLECTIONS.length) setLoadingRequests(false);
     };
-
-    const unsubscribers = PROJECT_REQUEST_COLLECTIONS.map((collectionName) => {
-      const requestQuery = query(
-        collection(db, `${getOrgRootPath(orgId)}/${collectionName}`),
-        orderBy('requestedAt', 'desc'),
-      );
-
-      return onSnapshot(
-        requestQuery,
-        (snapshot) => {
-          sourceRows.set(
-            collectionName,
-            snapshot.docs.map((docSnap) => ({
-              ...(docSnap.data() as ProjectRequest),
-              id: String((docSnap.data() as ProjectRequest).id || docSnap.id),
-              __collectionName: collectionName,
-            })),
-          );
-          initializedSources.add(collectionName);
-          publish();
-        },
-        (error) => {
-          console.error(`[ProjectMigrationAuditPage] ${collectionName} listen error:`, error);
-          sourceRows.set(collectionName, []);
-          initializedSources.add(collectionName);
-          publish();
-        },
-      );
-    });
-
+    const unsubscribers = PROJECT_REQUEST_COLLECTIONS.map((collectionName) => onSnapshot(
+      query(collection(db, `${getOrgRootPath(orgId)}/${collectionName}`), orderBy('requestedAt', 'desc')),
+      (snapshot) => {
+        sourceRows.set(collectionName, snapshot.docs.map((docSnap) => ({
+          ...(docSnap.data() as ProjectRequest),
+          id: String((docSnap.data() as ProjectRequest).id || docSnap.id),
+          __collectionName: collectionName,
+        })));
+        initializedSources.add(collectionName);
+        publish();
+      },
+      (error) => {
+        console.error(`[ProjectMigrationAuditPage] ${collectionName} listen error:`, error);
+        sourceRows.set(collectionName, []);
+        initializedSources.add(collectionName);
+        publish();
+      },
+    ));
     return () => {
       disposed = true;
       unsubscribers.forEach((unsubscribe) => unsubscribe());
     };
   }, [db, isOnline, orgId]);
 
-  const records = useMemo(
-    () => buildMigrationAuditConsoleRecords(projects, requests),
-    [projects, requests],
-  );
-
-  const scopedRecords = useMemo(
-    () => reviewScope === 'pending'
-      ? records.filter((record) => (
-          workflowStage === 'planning'
-            ? record.status === 'PENDING'
-            : record.status === 'PLANNING_AGREED'
-        ))
-      : records,
-    [records, reviewScope, workflowStage],
-  );
-
+  const records = useMemo(() => buildMigrationAuditConsoleRecords(projects, requests), [projects, requests]);
+  const stageRecords = useMemo(() => {
+    if (isManagementPlanning) return buildManagementPlanningRecords(records);
+    return buildExecutiveRecords(records);
+  }, [isManagementPlanning, records]);
+  const scopedRecords = useMemo(() => reviewScope === 'pending'
+    ? stageRecords.filter((record) => record.status === 'PENDING')
+    : stageRecords, [reviewScope, stageRecords]);
   const reviewerDepartment = String(authUser?.department || '').trim();
-  const inboxRecords = useMemo(
-    () => inboxScope === 'MINE'
-      ? scopedRecords.filter((record) => workflowStage === 'planning'
-        ? reviewerDepartment && isSameMigrationAuditCic(record.cic, reviewerDepartment)
-        : (resolveProjectRequestPayload(record.request)?.executiveApproverId || record.project.executiveApproverId) === authUser?.uid,
-      )
-      : scopedRecords,
-    [authUser?.uid, inboxScope, reviewerDepartment, scopedRecords, workflowStage],
-  );
-
-  const summaryRecords = useMemo(
-    () => filterMigrationAuditConsoleRecords(inboxRecords, {
-      cic: cicFilter,
-      status: 'ALL',
-      searchQuery,
-    }),
-    [cicFilter, inboxRecords, searchQuery],
-  );
-
-  const filteredRecords = useMemo(
-    () => filterMigrationAuditConsoleRecords(summaryRecords, {
-      cic: cicFilter,
-      status: statusFilter,
-      searchQuery,
-    }),
-    [cicFilter, searchQuery, statusFilter, summaryRecords],
-  );
-
-  const summary = useMemo(
-    () => summarizeMigrationAuditConsole(summaryRecords),
-    [summaryRecords],
-  );
-
-  const cicOptions = useMemo(
-    () => collectMigrationAuditCicOptions(inboxRecords),
-    [inboxRecords],
-  );
-
-  const openRecord = useMemo(
-    () => summaryRecords.find((record) => record.id === openRecordId) || null,
-    [openRecordId, summaryRecords],
-  );
-  const contractDocument = resolveProjectRequestPayload(openRecord?.request)?.contractDocument || openRecord?.project.contractDocument;
-  const contractPath = String(contractDocument?.path || '').trim();
+  const inboxRecords = useMemo(() => {
+    if (isManagementPlanning || inboxScope === 'ALL') return scopedRecords;
+    return scopedRecords.filter((record) => {
+      const approverId = resolveProjectRequestPayload(record.request)?.executiveApproverId || record.project.executiveApproverId;
+      return Boolean(authUser?.uid && approverId === authUser.uid);
+    });
+  }, [authUser?.uid, inboxScope, isManagementPlanning, scopedRecords]);
+  const summaryRecords = useMemo(() => filterMigrationAuditConsoleRecords(inboxRecords, { cic: cicFilter, status: 'ALL', searchQuery }), [cicFilter, inboxRecords, searchQuery]);
+  const filteredRecords = useMemo(() => filterMigrationAuditConsoleRecords(summaryRecords, { cic: cicFilter, status: statusFilter, searchQuery }), [cicFilter, searchQuery, statusFilter, summaryRecords]);
+  const summary = useMemo(() => summarizeMigrationAuditConsole(summaryRecords), [summaryRecords]);
+  const cicOptions = useMemo(() => collectMigrationAuditCicOptions(inboxRecords), [inboxRecords]);
+  const openRecord = useMemo(() => summaryRecords.find((record) => record.id === openRecordId) || null, [openRecordId, summaryRecords]);
+  const contractDocument = openRecord ? resolveMigrationReviewContractDocument(openRecord.project, openRecord.request) : null;
+  const contractDocumentPath = String(contractDocument?.path || '').trim();
   const contractDownloadUrl = String(contractDocument?.downloadURL || '').trim();
+  const requestContractPath = String(resolveProjectRequestPayload(openRecord?.request)?.contractDocument?.path || '').trim();
   const requestId = String(openRecord?.request?.id || '').trim();
   const projectId = String(openRecord?.project.id || '').trim();
-  const usePendingRequestAttachment = openRecord?.request?.status === 'PENDING';
-  const secureContractDocumentKey = (usePendingRequestAttachment ? requestId : projectId) && contractPath
-    ? `${usePendingRequestAttachment ? requestId : projectId}:${contractPath}`
-    : '';
-  const secureContractDocumentUrl = secureContractDocument.key === secureContractDocumentKey
-    ? secureContractDocument.url
-    : '';
-  const privateAttachmentError = secureContractDocument.key === secureContractDocumentKey
-    ? secureContractDocument.error
-    : '';
+  const contractAttachmentSource = requestId && contractDocumentPath === requestContractPath ? 'request' : projectId && contractDocumentPath ? 'project' : '';
+  const contractAttachmentId = contractAttachmentSource === 'request' ? requestId : projectId;
+  const secureContractDocumentKey = contractAttachmentSource && contractAttachmentId && contractDocumentPath ? `${contractAttachmentSource}:${contractAttachmentId}:${contractDocumentPath}` : '';
+  const secureContractDocumentUrl = secureContractDocument.key === secureContractDocumentKey ? secureContractDocument.url : '';
+  const privateAttachmentError = secureContractDocument.key === secureContractDocumentKey ? secureContractDocument.error : '';
+  const designatedApproverId = resolveProjectRequestPayload(openRecord?.request)?.executiveApproverId || openRecord?.project.executiveApproverId;
+  const canExecutiveFinalize = Boolean(authUser?.uid && designatedApproverId === authUser.uid);
+  const role = String(authUser?.role || '').trim().toLowerCase();
+  const canManagementPlanningFinalize = role === 'admin' || role === 'finance';
+  const canFinalize = isManagementPlanning ? canManagementPlanningFinalize : canExecutiveFinalize;
 
   useEffect(() => {
     setSecureContractDocument({ key: secureContractDocumentKey, url: '', error: '' });
-    if (
-      !isPlatformApiEnabled()
-      || !authUser?.uid
-      || !projectId
-      || !contractPath
-      || contractDownloadUrl
-    ) return undefined;
-
+    if (!isPlatformApiEnabled() || !authUser?.uid || !contractAttachmentSource || !contractAttachmentId || !contractDocumentPath || contractDownloadUrl) return undefined;
     let disposed = false;
     let objectUrl = '';
-    const actor = {
-      uid: authUser.uid,
-      email: authUser.email,
-      role: authUser.role,
-      idToken: authUser.idToken,
-    };
-    const download = usePendingRequestAttachment && requestId
+    const actor = { uid: authUser.uid, email: authUser.email, role: authUser.role, idToken: authUser.idToken };
+    const download = contractAttachmentSource === 'request'
       ? downloadProjectRequestAttachmentViaBff({ tenantId: orgId, actor, requestId, documentKind: 'contract' })
       : downloadProjectAttachmentViaBff({ tenantId: orgId, actor, projectId, documentKind: 'contract' });
     void download.then(({ blob }) => {
@@ -272,221 +221,108 @@ export function ProjectMigrationAuditPage({
     }).catch((error) => {
       if (disposed) return;
       console.error('[ProjectMigrationAuditPage] private attachment download failed:', error);
-      setSecureContractDocument({
-        key: secureContractDocumentKey,
-        url: '',
-        error: '보안 원문을 불러오지 못했습니다. 권한 또는 파일 처리 상태를 확인해 주세요.',
-      });
+      setSecureContractDocument({ key: secureContractDocumentKey, url: '', error: '보안 원문을 불러오지 못했습니다. 권한 또는 파일 처리 상태를 확인해 주세요.' });
     });
-
     return () => {
       disposed = true;
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
-  }, [
-    authUser?.email,
-    authUser?.idToken,
-    authUser?.role,
-    authUser?.uid,
-    orgId,
-    contractDownloadUrl,
-    contractPath,
-    projectId,
-    requestId,
-    secureContractDocumentKey,
-    usePendingRequestAttachment,
-  ]);
+  }, [authUser?.email, authUser?.idToken, authUser?.role, authUser?.uid, contractAttachmentId, contractAttachmentSource, contractDocumentPath, contractDownloadUrl, orgId, projectId, requestId, secureContractDocumentKey]);
 
   async function handleConfirmAction() {
     if (!openRecord || !actionMode) return;
-
-    const nextExecutiveStatus = toExecutiveStatus(actionMode);
+    if (!canFinalize) {
+      toast.error(isManagementPlanning ? '경영기획실 담당자만 처리할 수 있습니다.' : '지정된 조직장만 처리할 수 있습니다.');
+      return;
+    }
     const trimmedComment = reviewComment.trim();
     const trimmedProjectCode = projectCode.trim();
     const reviewerName = currentUser?.name || authUser?.name || currentUser?.email || authUser?.email || '관리자';
-    if (nextExecutiveStatus === 'PLANNING_AGREED' && !trimmedProjectCode) {
-      toast.error('프로젝트 코드를 입력해 주세요.');
-      return;
-    }
-    if (nextExecutiveStatus === 'REVISION_REJECTED' && !trimmedComment) {
-      toast.error('반려 사유를 입력해 주세요.');
-      return;
-    }
     if (!isPlatformApiEnabled() || !authUser?.uid) {
       toast.error('프로젝트 처리 서버가 연결되어 있지 않아 저장하지 않았습니다.');
       return;
     }
 
+    if (isManagementPlanning) {
+      if (actionMode === 'discard') return;
+      if (actionMode === 'approve' && !trimmedProjectCode) {
+        toast.error('프로젝트 코드를 입력해 주세요.');
+        return;
+      }
+      if (actionMode === 'reject' && !trimmedComment) {
+        toast.error('반려 사유를 입력해 주세요.');
+        return;
+      }
+      setActing(true);
+      try {
+        await reviewProjectManagementPlanningStatusViaBff({
+          tenantId: orgId,
+          actor: { uid: authUser.uid, email: authUser.email, role: authUser.role, idToken: authUser.idToken },
+          projectId: openRecord.project.id,
+          review: {
+            requestId: openRecord.request?.id,
+            reviewStatus: actionMode === 'approve' ? 'AGREED' : 'REVISION_REJECTED',
+            projectCode: actionMode === 'approve' ? trimmedProjectCode : undefined,
+            reviewComment: trimmedComment || undefined,
+            reviewerName,
+          },
+        });
+        toast.success(actionMode === 'approve' ? '프로젝트 코드를 부여하고 합의했습니다.' : '반려 사유를 PM에게 전달했습니다.', { description: openRecord.title });
+        setActionMode(null);
+        setReviewComment('');
+        setProjectCode('');
+      } catch (error) {
+        toast.error('경영기획실 합의 저장 실패', { description: error instanceof Error ? error.message : '다시 시도해 주세요.' });
+      } finally {
+        setActing(false);
+      }
+      return;
+    }
+
+    const nextExecutiveStatus = toExecutiveStatus(actionMode);
+    if (nextExecutiveStatus !== 'APPROVED' && !trimmedComment) {
+      toast.error(actionMode === 'reject' ? '반려 사유를 입력해 주세요.' : '폐기 사유를 입력해 주세요.');
+      return;
+    }
     setActing(true);
     try {
-      const response = await reviewProjectExecutiveStatusViaBff({
+      await reviewProjectExecutiveStatusViaBff({
         tenantId: orgId,
-        actor: {
-          uid: authUser.uid,
-          email: authUser.email,
-          role: authUser.role,
-          idToken: authUser.idToken,
-        },
+        actor: { uid: authUser.uid, email: authUser.email, role: authUser.role, idToken: authUser.idToken },
         projectId: openRecord.project.id,
-        review: {
-          requestId: openRecord.request?.id,
-          reviewStatus: nextExecutiveStatus,
-          reviewComment: trimmedComment || undefined,
-          reviewerName,
-          projectCode: actionMode === 'agree' ? trimmedProjectCode : undefined,
-        },
+        review: { requestId: openRecord.request?.id, reviewStatus: nextExecutiveStatus, reviewComment: trimmedComment || undefined, reviewerName },
       });
-      if (response.slackDelivered === false && response.slackReason) {
-        console.warn('[ProjectMigrationAuditPage] executive review slack not delivered:', response.slackReason);
-      }
-
-      toast.success(
-        actionMode === 'agree'
-          ? '경영기획실 합의를 완료했습니다. 지정 조직장 승인 대기 상태입니다.'
-          : actionMode === 'approve'
-            ? '프로젝트를 승인했습니다.'
-          : actionMode === 'reject'
-            ? '수정 요청 후 반려로 처리했습니다.'
-            : '',
-        {
-          description: openRecord.title,
-        },
-      );
+      toast.success(actionMode === 'approve' ? '프로젝트를 승인했습니다.' : actionMode === 'reject' ? '수정 요청 후 반려로 처리했습니다.' : '중복·폐기로 처리했습니다.', { description: openRecord.title });
       setActionMode(null);
       setReviewComment('');
-      setProjectCode('');
     } catch (error) {
-      toast.error(actionMode === 'agree' ? '경영기획실 합의 저장 실패' : '조직장 결재 저장 실패', {
-        description: error instanceof Error ? error.message : '다시 시도해 주세요.',
-      });
+      toast.error('조직장 결재 저장 실패', { description: error instanceof Error ? error.message : '다시 시도해 주세요.' });
     } finally {
       setActing(false);
     }
   }
 
-  const pageDescription = workflowStage === 'planning'
-    ? '프로젝트 코드 부여와 경영기획실 합의가 필요한 등록 문서를 확인합니다.'
-    : '경영기획실 합의가 끝난 문서를 지정 조직장이 최종 승인 또는 반려합니다.';
+  const pageTitle = isManagementPlanning ? '프로젝트 코드 부여' : 'PM 등록 프로젝트 검토';
+  const pageDescription = isManagementPlanning
+    ? '조직장 승인이 끝난 프로젝트를 확인하고, 경영기획실 합의와 함께 프로젝트 코드를 부여합니다.'
+    : '내게 배정된 프로젝트 등록 요청을 먼저 확인하고, 문서형 팝업에서 기안·조직장 결재선과 등록 내용을 검토합니다.';
 
   return (
     <div className="space-y-6">
-      {!embedded ? (
-        <PageHeader
-          icon={ClipboardCheck}
-          iconGradient="linear-gradient(135deg, #0f766e 0%, #0ea5e9 100%)"
-          title={workflowStage === 'planning' ? '경영기획실 프로젝트 합의' : 'PM 등록 프로젝트 승인'}
-          description={pageDescription}
-          badge={workflowStage === 'planning' ? '코드 부여·합의' : '지정 조직장 결재'}
-        />
-      ) : null}
-
-      {!db || !isOnline ? (
-        <Card>
-          <CardContent className="p-4 text-[12px] text-muted-foreground">
-            Firebase 연결이 없어서 PM 등록 프로젝트와 접수 이력을 읽지 못했습니다. Firestore 연결 후 다시 확인해 주세요.
-          </CardContent>
-        </Card>
-      ) : null}
-
-      <MigrationAuditControlBar
-        cicOptions={cicOptions}
-        cicFilter={cicFilter}
-        onCicFilterChange={setCicFilter}
-        inboxScope={inboxScope}
-        onInboxScopeChange={setInboxScope}
-        reviewerDepartment={reviewerDepartment}
-        workflowStage={workflowStage}
-        statusFilter={statusFilter}
-        onStatusFilterChange={setStatusFilter}
-        searchQuery={searchQuery}
-        onSearchQueryChange={setSearchQuery}
-        summary={summary}
-      />
-
-      {loadingRequests ? (
-        <Card>
-          <CardContent className="flex items-center justify-center gap-2 py-16 text-[12px] text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            PM 등록 프로젝트와 접수 이력을 불러오는 중입니다…
-          </CardContent>
-        </Card>
-      ) : (
-        <MigrationAuditRecordList records={filteredRecords} onOpen={(record) => setOpenRecordId(record.id)} />
-      )}
-
-      <MigrationAuditDocumentDialog
-        open={!!openRecord}
-        record={openRecord}
-        reviewerName={currentUser?.name || authUser?.name || '조직장'}
-        workflowStage={workflowStage}
-        canFinalize={Boolean(authUser?.uid && (resolveProjectRequestPayload(openRecord?.request)?.executiveApproverId || openRecord?.project.executiveApproverId) === authUser.uid)}
-        acting={acting}
-        contractDocumentDownloadURL={secureContractDocumentUrl}
-        contractDocumentError={privateAttachmentError}
-        onOpenChange={(open) => { if (!open) setOpenRecordId(null); }}
-        onAgree={() => {
-          setActionMode('agree');
-          setReviewComment('');
-          setProjectCode(openRecord?.project.projectCode || '');
-        }}
-        onApprove={() => {
-          setActionMode('approve');
-          setReviewComment('');
-          setProjectCode('');
-        }}
-        onReject={() => {
-          setActionMode('reject');
-          setReviewComment(openRecord?.project.executiveReviewComment || '');
-          setProjectCode('');
-        }}
-      />
-
-      <AlertDialog open={!!actionMode} onOpenChange={(open) => {
-        if (!open) {
-          setActionMode(null);
-          setReviewComment('');
-          setProjectCode('');
-        }
-      }}>
+      {!embedded ? <PageHeader icon={ClipboardCheck} iconGradient={isManagementPlanning ? 'linear-gradient(135deg, #0f2f57 0%, #174a7c 100%)' : 'linear-gradient(135deg, #0f766e 0%, #0ea5e9 100%)'} title={pageTitle} description={pageDescription} badge={isManagementPlanning ? '경영기획실 합의' : '대표 검토'} /> : null}
+      {!db || !isOnline ? <Card><CardContent className="p-4 text-[12px] text-muted-foreground">Firebase 연결이 없어서 PM 등록 프로젝트와 접수 이력을 읽지 못했습니다. Firestore 연결 후 다시 확인해 주세요.</CardContent></Card> : null}
+      <MigrationAuditControlBar cicOptions={cicOptions} cicFilter={cicFilter} onCicFilterChange={setCicFilter} inboxScope={inboxScope} onInboxScopeChange={setInboxScope} reviewerDepartment={reviewerDepartment} statusFilter={statusFilter} onStatusFilterChange={setStatusFilter} searchQuery={searchQuery} onSearchQueryChange={setSearchQuery} summary={summary} reviewStage={reviewStage} />
+      {loadingRequests ? <Card><CardContent className="flex items-center justify-center gap-2 py-16 text-[12px] text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" />PM 등록 프로젝트와 접수 이력을 불러오는 중입니다…</CardContent></Card> : <MigrationAuditRecordList records={filteredRecords} onOpen={(record) => setOpenRecordId(record.id)} reviewStage={reviewStage} />}
+      <MigrationAuditDocumentDialog open={!!openRecord} record={openRecord} acting={acting} canFinalize={canFinalize} contractDocumentDownloadURL={secureContractDocumentUrl || contractDownloadUrl} contractDocumentError={privateAttachmentError} reviewStage={reviewStage} onOpenChange={(open) => { if (!open) setOpenRecordId(null); }} onApprove={() => { setActionMode('approve'); setReviewComment(''); setProjectCode(''); }} onReject={() => { setActionMode('reject'); setReviewComment(isManagementPlanning ? '' : (openRecord?.project.executiveReviewComment || '')); setProjectCode(''); }} />
+      <AlertDialog open={!!actionMode} onOpenChange={(open) => { if (!open) { setActionMode(null); setReviewComment(''); setProjectCode(''); } }}>
         <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{getReviewDialogTitle(actionMode || 'approve')}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {getProjectRequestReviewDescription(actionMode || 'approve', openRecord?.request)}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
+          <AlertDialogHeader><AlertDialogTitle>{getReviewDialogTitle(actionMode || 'approve', reviewStage)}</AlertDialogTitle><AlertDialogDescription>{getProjectRequestReviewDescription(actionMode || 'approve', openRecord?.request, reviewStage)}</AlertDialogDescription></AlertDialogHeader>
           <div className="space-y-2">
-            {actionMode === 'agree' ? (
-              <label className="block text-[12px] font-medium text-slate-700">
-                프로젝트 코드
-                <Input
-                  value={projectCode}
-                  onChange={(event) => setProjectCode(event.target.value)}
-                  placeholder="예: PRJ-2026-001"
-                  className="mt-2 h-10 rounded-none"
-                  aria-label="프로젝트 코드"
-                />
-              </label>
-            ) : null}
-            <p className="text-[12px] font-medium text-slate-700">
-              {actionMode === 'agree' ? '합의 메모' : actionMode === 'approve' ? '승인 메모' : '반려 사유'}
-            </p>
-            <Textarea
-              value={reviewComment}
-              onChange={(event) => setReviewComment(event.target.value)}
-              placeholder={actionMode === 'agree' ? '합의 근거를 남길 수 있습니다.' : actionMode === 'approve' ? '승인 판단 근거를 남길 수 있습니다.' : 'PM이 수정하거나 폐기 판단을 이해할 수 있도록 사유를 남겨 주세요.'}
-              className="min-h-[120px]"
-            />
+            {isManagementPlanning && actionMode === 'approve' ? <div className="space-y-2"><label htmlFor="management-planning-project-code" className="text-[12px] font-medium text-slate-700">프로젝트 코드</label><Input id="management-planning-project-code" value={projectCode} onChange={(event) => setProjectCode(event.target.value)} placeholder="예: MYSC-2026-001" className="rounded-none border-slate-400" autoComplete="off" /><p className="text-[11px] leading-5 text-slate-500">합의 저장과 함께 프로젝트 원장에 저장되며, 이후 운영 화면의 기준 코드로 사용됩니다.</p></div> : null}
+            <p className="text-[12px] font-medium text-slate-700">{actionMode === 'approve' ? (isManagementPlanning ? '합의 메모' : '승인 메모') : actionMode === 'reject' ? '반려 사유' : '폐기 사유'}</p>
+            <Textarea value={reviewComment} onChange={(event) => setReviewComment(event.target.value)} placeholder={actionMode === 'approve' ? (isManagementPlanning ? '합의 판단 근거를 남길 수 있습니다.' : '승인 판단 근거를 남길 수 있습니다.') : 'PM이 보완 내용을 이해할 수 있도록 반려 사유를 남겨 주세요.'} className="min-h-[120px]" />
           </div>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={acting}>취소</AlertDialogCancel>
-            <AlertDialogAction onClick={(event) => {
-              event.preventDefault();
-              void handleConfirmAction();
-            }} disabled={acting || (actionMode === 'agree' ? !projectCode.trim() : actionMode === 'reject' ? !reviewComment.trim() : false)}>
-              {acting ? '저장 중...' : actionMode === 'agree' ? '합의 저장' : actionMode === 'approve' ? '승인 저장' : '반려 저장'}
-            </AlertDialogAction>
-          </AlertDialogFooter>
+          <AlertDialogFooter><AlertDialogCancel disabled={acting}>취소</AlertDialogCancel><AlertDialogAction onClick={(event) => { event.preventDefault(); void handleConfirmAction(); }} disabled={acting || (isManagementPlanning && actionMode === 'approve' && !projectCode.trim()) || (actionMode !== 'approve' && !reviewComment.trim())}>{acting ? '저장 중...' : actionMode === 'approve' ? (isManagementPlanning ? '합의 및 코드 저장' : '승인 저장') : actionMode === 'reject' ? '반려 저장' : '폐기 저장'}</AlertDialogAction></AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
     </div>

--- a/src/app/components/projects/migration-audit/MigrationAuditControlBar.tsx
+++ b/src/app/components/projects/migration-audit/MigrationAuditControlBar.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '../../ui/badge';
 import { Card, CardContent } from '../../ui/card';
 import { Input } from '../../ui/input';
 import {
@@ -13,6 +12,8 @@ import type {
   MigrationAuditConsoleSummary,
 } from '../../../platform/project-migration-console';
 
+export type MigrationAuditReviewStage = 'executive' | 'managementPlanning';
+
 interface MigrationAuditControlBarProps {
   cicOptions: string[];
   cicFilter: string;
@@ -20,12 +21,12 @@ interface MigrationAuditControlBarProps {
   inboxScope: 'MINE' | 'ALL';
   onInboxScopeChange: (value: 'MINE' | 'ALL') => void;
   reviewerDepartment: string;
-  workflowStage: 'planning' | 'approval';
   statusFilter: 'ALL' | MigrationAuditConsoleStatus;
   onStatusFilterChange: (value: 'ALL' | MigrationAuditConsoleStatus) => void;
   searchQuery: string;
   onSearchQueryChange: (value: string) => void;
   summary: MigrationAuditConsoleSummary;
+  reviewStage?: MigrationAuditReviewStage;
 }
 
 export function MigrationAuditControlBar({
@@ -35,20 +36,22 @@ export function MigrationAuditControlBar({
   inboxScope,
   onInboxScopeChange,
   reviewerDepartment,
-  workflowStage,
   statusFilter,
   onStatusFilterChange,
   searchQuery,
   onSearchQueryChange,
   summary,
+  reviewStage = 'executive',
 }: MigrationAuditControlBarProps) {
-  const reviewTotal = summary.pending + summary.agreed + summary.approved + summary.rejected;
-  const pendingCount = workflowStage === 'planning' ? summary.pending : summary.agreed;
+  const isManagementPlanning = reviewStage === 'managementPlanning';
+  const reviewLabel = isManagementPlanning ? '경영기획실 합의' : '조직장 결재';
+  const pageTitle = isManagementPlanning ? '프로젝트 코드 부여' : '프로젝트 등록/승인';
+  const approvedLabel = isManagementPlanning ? '합의 완료' : '승인 완료';
+  const reviewTotal = summary.pending + summary.approved + summary.rejected;
   const pendingEnd = reviewTotal ? (summary.pending / reviewTotal) * 100 : 0;
-  const agreedEnd = pendingEnd + (reviewTotal ? (summary.agreed / reviewTotal) * 100 : 0);
-  const approvedEnd = agreedEnd + (reviewTotal ? (summary.approved / reviewTotal) * 100 : 0);
+  const approvedEnd = pendingEnd + (reviewTotal ? (summary.approved / reviewTotal) * 100 : 0);
   const statusChartBackground = reviewTotal
-    ? `conic-gradient(#174a7c 0 ${pendingEnd}%, #2563eb ${pendingEnd}% ${agreedEnd}%, #15803d ${agreedEnd}% ${approvedEnd}%, #b42318 ${approvedEnd}% 100%)`
+    ? `conic-gradient(#174a7c 0 ${pendingEnd}%, #15803d ${pendingEnd}% ${approvedEnd}%, #b42318 ${approvedEnd}% 100%)`
     : '#e2e8f0';
 
   return (
@@ -56,73 +59,69 @@ export function MigrationAuditControlBar({
       <CardContent className="space-y-4 p-4">
         <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
           <div>
-            <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500">{workflowStage === 'planning' ? '경영기획실 합의' : '조직장 결재'}</p>
-            <h2 className="mt-1 text-[22px] font-semibold tracking-[-0.03em] text-slate-950">
-              {workflowStage === 'planning' ? '프로젝트 코드 부여·합의' : '프로젝트 최종 승인'}
-            </h2>
+            <p className="text-[11px] font-semibold uppercase tracking-[0.12em] text-slate-500">{reviewLabel}</p>
+            <h2 className="mt-1 text-[22px] font-semibold tracking-[-0.03em] text-slate-950">{pageTitle}</h2>
             <p className="mt-1 text-[12px] leading-6 text-slate-600">
-              {workflowStage === 'planning'
-                ? '등록 원문을 확인한 뒤 프로젝트 코드를 부여하고 경영기획실 합의를 남깁니다.'
-                : '경영기획실 합의가 끝난 문서를 열어 최종 승인 또는 반려합니다.'}
+              {isManagementPlanning
+                ? '조직장 승인이 끝난 문서를 확인하고, 합의와 함께 프로젝트 코드를 부여합니다.'
+                : '검토할 문서를 먼저 좁힌 뒤, 문서 열기에서 기안·조직장 결재선과 등록 원문을 확인합니다.'}
             </p>
           </div>
           <div className="flex items-center gap-4 border-l border-slate-200 pl-4">
-            <div className="grid h-[78px] w-[78px] place-items-center rounded-full" role="img" aria-label={`합의 대기 ${summary.pending}건, 승인 대기 ${summary.agreed}건, 승인 완료 ${summary.approved}건, 반려 ${summary.rejected}건`} style={{ background: statusChartBackground }}>
-              <span className="grid h-[54px] w-[54px] place-items-center rounded-full bg-white text-center text-[11px] font-semibold text-slate-700">{reviewTotal}<small className="block text-[9px] font-normal">건</small></span>
+            <div
+              className="grid h-[78px] w-[78px] place-items-center rounded-full"
+              role="img"
+              aria-label={`검토 대기 ${summary.pending}건, ${approvedLabel} ${summary.approved}건, 반려 ${summary.rejected}건`}
+              style={{ background: statusChartBackground }}
+            >
+              <span className="grid h-[54px] w-[54px] place-items-center rounded-full bg-white text-center text-[11px] font-semibold text-slate-700">
+                {reviewTotal}<small className="block text-[9px] font-normal">건</small>
+              </span>
             </div>
             <dl className="grid grid-cols-3 divide-x divide-slate-200 text-center">
-              <div className="px-3"><dt className="text-[10px] text-slate-500">{workflowStage === 'planning' ? '합의대기' : '승인대기'}</dt><dd className="mt-1 text-[15px] font-bold text-[#174a7c]">{pendingCount}</dd></div>
-              <div className="px-3"><dt className="text-[10px] text-slate-500">승인완료</dt><dd className="mt-1 text-[15px] font-bold text-[#15803d]">{summary.approved}</dd></div>
+              <div className="px-3"><dt className="text-[10px] text-slate-500">검토대기</dt><dd className="mt-1 text-[15px] font-bold text-[#174a7c]">{summary.pending}</dd></div>
+              <div className="px-3"><dt className="text-[10px] text-slate-500">{approvedLabel.replace(' ', '')}</dt><dd className="mt-1 text-[15px] font-bold text-[#15803d]">{summary.approved}</dd></div>
               <div className="px-3"><dt className="text-[10px] text-slate-500">반려</dt><dd className="mt-1 text-[15px] font-bold text-[#b42318]">{summary.rejected}</dd></div>
             </dl>
           </div>
         </div>
 
-        <div className="grid gap-4 xl:grid-cols-[minmax(180px,230px)_minmax(180px,230px)_minmax(180px,230px)_minmax(260px,1fr)]">
-          <div className="space-y-1.5">
-            <p className="text-[12px] font-semibold text-slate-600">검토함</p>
-            <Select value={inboxScope} onValueChange={(value) => onInboxScopeChange(value as 'MINE' | 'ALL')}>
-              <SelectTrigger className="h-11 rounded-none border-slate-300 bg-white px-3 text-[13px] font-medium">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="MINE">내 검토함{reviewerDepartment ? ` · ${reviewerDepartment}` : ''}</SelectItem>
-                <SelectItem value="ALL">전체 검토 문서</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+        <div className={`grid gap-4 ${isManagementPlanning ? 'xl:grid-cols-[minmax(180px,230px)_minmax(180px,230px)_minmax(260px,1fr)]' : 'xl:grid-cols-[minmax(180px,230px)_minmax(180px,230px)_minmax(180px,230px)_minmax(260px,1fr)]'}`}>
+          {!isManagementPlanning ? (
+            <div className="space-y-1.5">
+              <p className="text-[12px] font-semibold text-slate-600">검토함</p>
+              <Select value={inboxScope} onValueChange={(value) => onInboxScopeChange(value as 'MINE' | 'ALL')}>
+                <SelectTrigger className="h-11 rounded-none border-slate-300 bg-white px-3 text-[13px] font-medium"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="MINE">내 검토함{reviewerDepartment ? ` · ${reviewerDepartment}` : ''}</SelectItem>
+                  <SelectItem value="ALL">전체 검토 문서</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          ) : null}
           <div className="space-y-1.5">
             <p className="text-[12px] font-semibold text-slate-600">CIC 필터</p>
             <Select value={cicFilter} onValueChange={onCicFilterChange}>
-              <SelectTrigger className="h-11 rounded-none border-slate-300 bg-white px-3 text-[13px] font-medium">
-                <SelectValue placeholder="전체 CIC" />
-              </SelectTrigger>
+              <SelectTrigger className="h-11 rounded-none border-slate-300 bg-white px-3 text-[13px] font-medium"><SelectValue placeholder="전체 CIC" /></SelectTrigger>
               <SelectContent>
                 <SelectItem value="ALL">전체 CIC</SelectItem>
-                {cicOptions.map((cic) => (
-                  <SelectItem key={cic} value={cic}>{cic}</SelectItem>
-                ))}
+                {cicOptions.map((cic) => <SelectItem key={cic} value={cic}>{cic}</SelectItem>)}
               </SelectContent>
             </Select>
           </div>
-
           <div className="space-y-1.5">
             <p className="text-[12px] font-semibold text-slate-600">상태 필터</p>
             <Select value={statusFilter} onValueChange={(value) => onStatusFilterChange(value as 'ALL' | MigrationAuditConsoleStatus)}>
-              <SelectTrigger className="h-11 rounded-none border-slate-300 bg-white px-3 text-[13px] font-medium">
-                <SelectValue placeholder="전체 상태" />
-              </SelectTrigger>
+              <SelectTrigger className="h-11 rounded-none border-slate-300 bg-white px-3 text-[13px] font-medium"><SelectValue placeholder="전체 상태" /></SelectTrigger>
               <SelectContent>
                 <SelectItem value="ALL">전체 상태</SelectItem>
-                <SelectItem value="PENDING">합의 대기</SelectItem>
-                <SelectItem value="PLANNING_AGREED">합의 완료·승인 대기</SelectItem>
-                <SelectItem value="APPROVED">승인 완료</SelectItem>
-                <SelectItem value="REVISION_REJECTED">수정 요청 후 반려</SelectItem>
-                <SelectItem value="DUPLICATE_DISCARDED">중복·폐기</SelectItem>
+                <SelectItem value="PENDING">{isManagementPlanning ? '합의 대기' : '검토 대기'}</SelectItem>
+                <SelectItem value="APPROVED">{approvedLabel}</SelectItem>
+                <SelectItem value="REVISION_REJECTED">{isManagementPlanning ? '반려' : '수정 요청 후 반려'}</SelectItem>
+                {!isManagementPlanning ? <SelectItem value="DUPLICATE_DISCARDED">중복·폐기</SelectItem> : null}
               </SelectContent>
             </Select>
           </div>
-
           <div className="space-y-1.5">
             <p className="text-[12px] font-semibold text-slate-600">프로젝트 검색</p>
             <Input

--- a/src/app/components/projects/migration-audit/MigrationAuditDocumentDialog.tsx
+++ b/src/app/components/projects/migration-audit/MigrationAuditDocumentDialog.tsx
@@ -1,9 +1,15 @@
 import type { MigrationAuditConsoleRecord } from '../../../platform/project-migration-console';
-import {
-  getMigrationAuditStatusLabel,
-} from '../../../platform/project-migration-console';
+import { getMigrationAuditStatusLabel } from '../../../platform/project-migration-console';
 import { resolveProjectRequestPayload } from '../../../platform/project-change-request';
-import { buildMigrationReviewDossier } from '../../../platform/project-migration-review-dossier';
+import {
+  buildMigrationReviewDossier,
+  resolveMigrationReviewContractDocument,
+} from '../../../platform/project-migration-review-dossier';
+import {
+  getManagementPlanningReview,
+  getManagementPlanningReviewLabel,
+} from '../../../platform/project-management-planning-review';
+import { ContractDocumentPreview } from '../ContractDocumentPreview';
 import {
   Dialog,
   DialogContent,
@@ -16,14 +22,12 @@ import { Button } from '../../ui/button';
 interface MigrationAuditDocumentDialogProps {
   open: boolean;
   record: MigrationAuditConsoleRecord | null;
-  reviewerName: string;
   acting: boolean;
-  workflowStage: 'planning' | 'approval';
   canFinalize: boolean;
   contractDocumentDownloadURL?: string;
   contractDocumentError?: string;
+  reviewStage?: 'executive' | 'managementPlanning';
   onOpenChange: (open: boolean) => void;
-  onAgree: () => void;
   onApprove: () => void;
   onReject: () => void;
 }
@@ -33,26 +37,17 @@ function formatDateTime(value?: string) {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value.slice(0, 10).replace(/-/g, '.');
   return new Intl.DateTimeFormat('ko-KR', {
-    timeZone: 'Asia/Seoul',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
+    timeZone: 'Asia/Seoul', year: 'numeric', month: '2-digit', day: '2-digit',
   }).format(date);
 }
 
-function ApprovalSeal({ name, state }: { name: string; state: 'submitted' | 'pending' | 'approved' | 'rejected' }) {
+function ApprovalSeal({ name, state }: { name: string; state: 'submitted' | 'approved' | 'rejected' }) {
   const tone = state === 'approved'
     ? 'border-[#174a7c] text-[#174a7c]'
     : state === 'rejected'
       ? 'border-[#b42318] text-[#b42318]'
-      : state === 'pending'
-        ? 'border-slate-400 text-slate-500'
-        : 'border-slate-500 text-slate-700';
-  return (
-    <div className={`grid h-12 w-12 place-items-center rounded-full border-2 bg-white text-center text-[10px] font-semibold leading-3 ${tone}`}>
-      {name || '-'}
-    </div>
-  );
+      : 'border-slate-500 text-slate-700';
+  return <div className={`grid h-12 w-12 place-items-center rounded-full border-2 bg-white text-center text-[10px] font-semibold leading-3 ${tone}`}>{name || '-'}</div>;
 }
 
 function DocumentCell({ label, value, className = '' }: { label: string; value: string; className?: string }) {
@@ -64,17 +59,25 @@ function DocumentCell({ label, value, className = '' }: { label: string; value: 
   );
 }
 
+function ReviewMessage({ label, by, at, message }: { label: string; by: string; at: string; message: string }) {
+  return (
+    <div className="grid border-b border-slate-300 last:border-b-0 md:grid-cols-[150px_150px_minmax(0,1fr)]">
+      <div className="bg-slate-50 px-3 py-3 font-semibold text-slate-700">{label}</div>
+      <div className="border-y border-slate-300 px-3 py-3 text-slate-600 md:border-y-0 md:border-r">{by} · {at}</div>
+      <p className="whitespace-pre-wrap break-words px-3 py-3 leading-5 text-slate-900">{message}</p>
+    </div>
+  );
+}
+
 export function MigrationAuditDocumentDialog({
   open,
   record,
-  reviewerName,
   acting,
-  workflowStage,
   canFinalize,
   contractDocumentDownloadURL = '',
   contractDocumentError = '',
+  reviewStage = 'executive',
   onOpenChange,
-  onAgree,
   onApprove,
   onReject,
 }: MigrationAuditDocumentDialogProps) {
@@ -82,41 +85,53 @@ export function MigrationAuditDocumentDialog({
 
   const dossier = buildMigrationReviewDossier(record.project, record.request);
   const requestPayload = resolveProjectRequestPayload(record.request);
-  const designatedApproverName = requestPayload?.executiveApproverName
-    || record.project.executiveApproverName
-    || '';
-  const history = record.project.executiveReviewHistory || [];
-  const planningAgreement = [...history].reverse().find((entry) => entry.status === 'PLANNING_AGREED');
-  const finalReview = [...history].reverse().find((entry) => (
-    entry.status === 'APPROVED' || entry.status === 'REVISION_REJECTED' || entry.status === 'DUPLICATE_DISCARDED'
-  ));
-  const reviewedByName = finalReview?.reviewedByName
-    || record.project.executiveReviewedByName
-    || record.request?.reviewedByName
-    || reviewerName;
-  const reviewedAt = finalReview?.reviewedAt
-    || record.project.executiveReviewedAt
-    || record.request?.reviewedAt;
-  const approvalState = record.status === 'APPROVED'
+  const designatedApproverName = record.project.executiveApproverName || requestPayload?.executiveApproverName || '';
+  const isManagementPlanning = reviewStage === 'managementPlanning';
+  const organizationReviewStatus = record.project.executiveReviewStatus;
+  const organizationDecisionState = organizationReviewStatus === 'APPROVED'
     ? 'approved'
-    : record.status === 'REVISION_REJECTED'
+    : organizationReviewStatus === 'REVISION_REJECTED' || organizationReviewStatus === 'DUPLICATE_DISCARDED'
       ? 'rejected'
-      : 'pending';
-  const attachmentNames = [
-    requestPayload?.contractDocument?.name,
-    requestPayload?.quoteDocument?.name,
-    requestPayload?.proposalDocument?.name,
-  ].filter((name): name is string => !!name?.trim());
-  const contractDocumentUrl = contractDocumentDownloadURL || requestPayload?.contractDocument?.downloadURL || '';
+      : null;
+  const latestOrganizationDecision = organizationDecisionState
+    ? [...(record.project.executiveReviewHistory || [])].reverse().find((entry) => entry.status === organizationReviewStatus)
+    : undefined;
+  const organizationReviewedByName = latestOrganizationDecision?.reviewedByName || record.project.executiveReviewedByName || '';
+  const organizationReviewedAt = latestOrganizationDecision?.reviewedAt || record.project.executiveReviewedAt || '';
+  const managementReview = getManagementPlanningReview(record.project);
+  const managementDecisionState = managementReview.status === 'AGREED'
+    ? 'approved'
+    : managementReview.status === 'REVISION_REJECTED'
+      ? 'rejected'
+      : null;
+  const latestManagementDecision = managementDecisionState
+    ? [...managementReview.history].reverse().find((entry) => entry.status === managementReview.status)
+    : undefined;
+  const managementReviewedByName = latestManagementDecision?.reviewedByName || managementReview.reviewedByName;
+  const managementReviewedAt = latestManagementDecision?.reviewedAt || managementReview.reviewedAt;
+  const contractDocument = resolveMigrationReviewContractDocument(record.project, record.request);
+  const contractDocumentUrl = contractDocumentDownloadURL || contractDocument?.downloadURL || '';
+  const attachmentNames = [contractDocument?.name, requestPayload?.quoteDocument?.name, requestPayload?.proposalDocument?.name]
+    .filter((name): name is string => Boolean(name?.trim()));
+  const reviewMessages = dossier.audit.history.filter((entry) => entry.reviewComment !== '-' && entry.reviewComment !== 'PM 신규 등록');
+  const managementMessages = managementReview.history.filter((entry) => Boolean(entry.reviewComment?.trim()));
+  const requestReviewComment = String(record.request?.reviewComment || '').trim();
+  const hasDistinctRequestReviewComment = Boolean(
+    requestReviewComment
+    && requestReviewComment !== 'PM 신규 등록'
+    && ![...reviewMessages, ...managementMessages].some((entry) => String(entry.reviewComment || '').trim() === requestReviewComment),
+  );
+  const isActionPending = isManagementPlanning
+    ? organizationReviewStatus === 'APPROVED' && managementReview.status === 'PENDING'
+    : record.status === 'PENDING';
+  const documentStatus = isManagementPlanning
+    ? getManagementPlanningReviewLabel(managementReview.status)
+    : getMigrationAuditStatusLabel(record.status);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[calc(100dvh-2rem)] max-w-[1180px] overflow-y-auto rounded-none border border-slate-500 bg-slate-100 p-5 shadow-2xl sm:max-w-[1180px]">
-        <DialogHeader className="sr-only">
-          <DialogTitle>프로젝트 등록 및 승인서</DialogTitle>
-          <DialogDescription>프로젝트 등록 내용을 결재 문서 형식으로 확인합니다.</DialogDescription>
-        </DialogHeader>
-
+        <DialogHeader className="sr-only"><DialogTitle>프로젝트 등록 및 승인서</DialogTitle><DialogDescription>프로젝트 등록 내용을 결재 문서 형식으로 확인합니다.</DialogDescription></DialogHeader>
         <article className="mx-auto w-full max-w-[1020px] border border-slate-400 bg-white px-8 py-9 text-slate-900" data-testid="migration-review-document">
           <header className="border-b-2 border-slate-700 pb-5">
             <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_410px]">
@@ -125,125 +140,64 @@ export function MigrationAuditDocumentDialog({
                 <h2 className="mt-3 text-center text-[25px] font-bold tracking-[0.08em]">프로젝트 등록 및 승인서</h2>
               </div>
               <div className="border border-slate-400">
-                  <div className="grid grid-cols-[48px_repeat(3,minmax(0,1fr))]">
+                <div className="grid grid-cols-[48px_repeat(3,minmax(0,1fr))]">
                   <div className="flex items-center justify-center border-r border-b border-slate-400 bg-slate-50 text-[11px] font-semibold">결재</div>
                   <div className="border-r border-b border-slate-400 px-2 py-1.5 text-center text-[11px] font-semibold">기안</div>
-                  <div className="border-r border-b border-slate-400 px-2 py-1.5 text-center text-[11px] font-semibold">경영기획실 합의</div>
-                  <div className="border-b border-slate-400 px-2 py-1.5 text-center text-[11px] font-semibold">조직장 승인</div>
-                  <div className="flex items-center justify-center border-r border-slate-400 bg-slate-50 text-[10px] text-slate-600">인</div>
-                  <div className="flex min-h-[70px] flex-col items-center justify-center gap-1 border-r border-slate-400 px-2 py-2">
-                    <ApprovalSeal name={dossier.audit.requestedByName} state="submitted" />
+                  <div className="border-r border-b border-slate-400 px-2 py-1.5 text-center text-[11px] font-semibold">조직장 승인</div>
+                  <div className="border-b border-slate-400 px-2 py-1.5 text-center text-[11px] font-semibold">경영기획실 합의</div>
+                  <div className="flex items-center justify-center border-r border-b border-slate-400 bg-slate-50 text-[10px] text-slate-600">인</div>
+                  <div className="flex min-h-[70px] items-center justify-center border-r border-b border-slate-400 px-2 py-2"><ApprovalSeal name={dossier.audit.requestedByName} state="submitted" /></div>
+                  <div className="flex min-h-[70px] items-center justify-center border-r border-b border-slate-400 px-2 py-2">
+                    {organizationDecisionState ? <ApprovalSeal name={organizationReviewedByName || '미상'} state={organizationDecisionState} /> : <span data-testid="organization-head-approval-pending" className="text-center"><span className="block text-[11px] font-medium text-slate-800">{designatedApproverName || '결재자 미지정'}</span><span className="mt-1 block text-[10px] text-slate-500">검토 대기</span></span>}
                   </div>
-                  <div className="flex min-h-[70px] flex-col items-center justify-center gap-1 border-r border-slate-400 px-2 py-2">
-                    {planningAgreement ? (
-                      <ApprovalSeal name={planningAgreement.reviewedByName} state="approved" />
-                    ) : (
-                      <span className="text-center text-[10px] text-slate-500">합의 대기</span>
-                    )}
-                  </div>
-                  <div className="flex min-h-[70px] flex-col items-center justify-center gap-1 px-2 py-2">
-                    {approvalState === 'pending' ? (
-                      <span className="text-center" aria-label="조직장 승인 대기">
-                        <span className="block text-[11px] font-medium text-slate-800">{designatedApproverName || '결재자 미지정'}</span>
-                        <span className="mt-1 block text-[10px] text-slate-500">검토 대기</span>
-                      </span>
-                    ) : (
-                      <ApprovalSeal name={reviewedByName} state={approvalState} />
-                    )}
+                  <div className="flex min-h-[70px] items-center justify-center border-b border-slate-400 px-2 py-2">
+                    {managementDecisionState ? <ApprovalSeal name={managementReviewedByName || '미상'} state={managementDecisionState} /> : <span data-testid="management-planning-approval-pending" aria-label="경영기획실 합의 대기" className="text-[10px] text-slate-500">합의 대기</span>}
                   </div>
                   <div className="flex items-center justify-center border-r border-t border-slate-400 bg-slate-50 text-[10px] text-slate-600">일자</div>
                   <div className="border-r border-t border-slate-400 px-2 py-2 text-center text-[10px] text-slate-700">{formatDateTime(record.requestedAt)}</div>
-                  <div className="border-r border-t border-slate-400 px-2 py-2 text-center text-[10px] text-slate-700">{planningAgreement ? formatDateTime(planningAgreement.reviewedAt) : '합의 대기'}</div>
-                  <div className="border-t border-slate-400 px-2 py-2 text-center text-[10px] text-slate-700">{reviewedAt ? formatDateTime(reviewedAt) : '검토 대기'}</div>
+                  <div className="border-r border-t border-slate-400 px-2 py-2 text-center text-[10px] text-slate-700">{organizationReviewedAt ? formatDateTime(organizationReviewedAt) : '검토 대기'}</div>
+                  <div className="border-t border-slate-400 px-2 py-2 text-center text-[10px] text-slate-700">{managementReviewedAt ? formatDateTime(managementReviewedAt) : '합의 대기'}</div>
                 </div>
               </div>
             </div>
           </header>
 
+          <section className="mt-5">
+            <h3 className="border-b-2 border-slate-700 pb-2 text-[14px] font-bold">의견 및 처리 이력</h3>
+            <div className="border border-t-0 border-slate-400 text-[12px]">
+              {dossier.audit.requestSummary !== '-' ? <ReviewMessage label="요청 요약" by={dossier.audit.requestedByName} at={dossier.audit.requestedAt} message={dossier.audit.requestSummary} /> : null}
+              {dossier.notes.note !== '-' ? <ReviewMessage label="실무자 기안 메모" by={dossier.audit.requestedByName} at={dossier.audit.requestUpdatedAt} message={dossier.notes.note} /> : null}
+              {hasDistinctRequestReviewComment ? <ReviewMessage label="실무자 제출/재제출 메모" by={record.request?.requestedByName || dossier.audit.requestedByName} at={record.request?.requestedAt || dossier.audit.requestUpdatedAt} message={requestReviewComment} /> : null}
+              {reviewMessages.map((entry, index) => <ReviewMessage key={`${entry.status}-${entry.reviewedAt}-${index}`} label={entry.status === 'PENDING' ? '실무자 제출/재제출 메모' : entry.status === 'APPROVED' ? '조직장 승인 메모' : entry.status === 'REVISION_REJECTED' ? '조직장 반려 메모' : '조직장 폐기 메모'} by={entry.reviewedByName} at={entry.reviewedAt} message={entry.reviewComment} />)}
+              {managementMessages.map((entry, index) => <ReviewMessage key={`management-${entry.status}-${entry.reviewedAt}-${index}`} label={entry.status === 'AGREED' ? '경영기획실 합의 메모' : '경영기획실 반려 메모'} by={entry.reviewedByName} at={formatDateTime(entry.reviewedAt)} message={String(entry.reviewComment || '-')} />)}
+              {dossier.audit.requestSummary === '-' && dossier.notes.note === '-' && !hasDistinctRequestReviewComment && reviewMessages.length === 0 && managementMessages.length === 0 ? <p className="px-3 py-4 text-slate-500">등록된 의견 또는 처리 메모가 없습니다.</p> : null}
+            </div>
+          </section>
+
           <section className="mt-6 border border-slate-400">
             <DocumentCell label="문서 번호" value={record.request?.id || record.id} />
-            <DocumentCell label="프로젝트 코드" value={record.project.projectCode || ''} />
             <DocumentCell label="작성 일자" value={formatDateTime(record.requestedAt)} />
             <DocumentCell label="기안 부서" value={record.cic} />
             <DocumentCell label="기안자" value={dossier.audit.requestedByName} />
-            <DocumentCell label="결재 상태" value={getMigrationAuditStatusLabel(record.status)} />
+            <DocumentCell label="결재 상태" value={documentStatus} />
           </section>
 
-          <section className="mt-6">
-            <h3 className="border-b-2 border-slate-700 pb-2 text-[14px] font-bold">처리 의견</h3>
-            <div className="border border-t-0 border-slate-400">
-              {history.map((entry, index) => (
-                <div key={`${entry.reviewedAt}-${index}`} className="border-b border-slate-300 px-4 py-3 last:border-b-0">
-                  <p className="text-[11px] font-semibold text-slate-800">
-                    {entry.status === 'PLANNING_AGREED' ? '경영기획실 합의' : getMigrationAuditStatusLabel(entry.status)} · {entry.reviewedByName} · {formatDateTime(entry.reviewedAt)}
-                    {entry.projectCode ? ` · ${entry.projectCode}` : ''}
-                  </p>
-                  <p className="mt-1 whitespace-pre-wrap text-[12px] leading-5 text-slate-700">{entry.reviewComment || '-'}</p>
-                </div>
-              ))}
-            </div>
+          <section className="mt-6"><h3 className="border-b-2 border-slate-700 pb-2 text-[14px] font-bold">기본정보</h3><dl className="border border-t-0 border-slate-400">
+            <DocumentCell label="프로젝트명" value={dossier.headerTitle} /><DocumentCell label="공식 계약명" value={dossier.identity.officialContractName} /><DocumentCell label="계약 대상" value={dossier.identity.clientOrg} /><DocumentCell label="담당조직(CIC)" value={dossier.identity.cic} /><DocumentCell label="사업 담당자" value={dossier.identity.pmName} /><DocumentCell label="프로젝트 코드" value={managementReview.projectCode || '부여 대기'} />
+          </dl></section>
+          <section className="mt-6"><h3 className="border-b-2 border-slate-700 pb-2 text-[14px] font-bold">계약 및 정산 정보</h3><dl className="grid border border-t-0 border-slate-400 md:grid-cols-2">
+            <DocumentCell label="계약 기간" value={dossier.contract.periodLabel} className="md:border-r md:border-slate-400" /><DocumentCell label="정산 유형" value={dossier.contract.settlementTypeLabel} /><DocumentCell label="계약금액" value={dossier.budget.contractAmountLabel} className="md:border-r md:border-slate-400" /><DocumentCell label="총수익" value={dossier.budget.totalRevenueAmountLabel} /><DocumentCell label="입금 계획" value={dossier.budget.paymentPlanDesc} className="md:col-span-2" />
+          </dl></section>
+          <section className="mt-6"><h3 className="border-b-2 border-slate-700 pb-2 text-[14px] font-bold">등록 내용</h3><dl className="border border-t-0 border-slate-400">
+            <DocumentCell label="프로젝트 목적" value={dossier.notes.projectPurpose} /><DocumentCell label="상세 설명" value={dossier.notes.description} /><DocumentCell label="참여 조건" value={dossier.notes.participantCondition} /><DocumentCell label="비고" value={dossier.notes.note} />
+          </dl></section>
+          <section className="mt-6"><h3 className="border-b-2 border-slate-700 pb-2 text-[14px] font-bold">첨부자료</h3>
+            <div className="border border-t-0 border-slate-400 px-4 py-3 text-[12px] leading-6 text-slate-800">{attachmentNames.length > 0 ? attachmentNames.join(' · ') : '등록된 첨부자료가 없습니다.'}{contractDocumentError ? <p className="mt-1 text-[11px] text-rose-700">{contractDocumentError}</p> : null}</div>
+            <ContractDocumentPreview document={contractDocument ? { ...contractDocument, downloadURL: contractDocumentUrl } : null} title="계약서 PDF 원문" description="등록 요청에 첨부된 계약서 원문을 문서 안에서 확인합니다." className="rounded-none border-t-0 border-slate-400" />
           </section>
 
-          <section className="mt-6">
-            <h3 className="border-b-2 border-slate-700 pb-2 text-[14px] font-bold">기본정보</h3>
-            <dl className="border border-t-0 border-slate-400">
-              <DocumentCell label="프로젝트명" value={dossier.headerTitle} />
-              <DocumentCell label="공식 계약명" value={dossier.identity.officialContractName} />
-              <DocumentCell label="계약 대상" value={dossier.identity.clientOrg} />
-              <DocumentCell label="담당조직(CIC)" value={dossier.identity.cic} />
-              <DocumentCell label="사업 담당자" value={dossier.identity.pmName} />
-            </dl>
-          </section>
-
-          <section className="mt-6">
-            <h3 className="border-b-2 border-slate-700 pb-2 text-[14px] font-bold">계약 및 정산 정보</h3>
-            <dl className="grid border border-t-0 border-slate-400 md:grid-cols-2">
-              <DocumentCell label="계약 기간" value={dossier.contract.periodLabel} className="md:border-r md:border-slate-400" />
-              <DocumentCell label="정산 유형" value={dossier.contract.settlementTypeLabel} />
-              <DocumentCell label="계약금액" value={dossier.budget.contractAmountLabel} className="md:border-r md:border-slate-400" />
-              <DocumentCell label="총수익" value={dossier.budget.totalRevenueAmountLabel} />
-              <DocumentCell label="입금 계획" value={dossier.budget.paymentPlanDesc} className="md:col-span-2" />
-            </dl>
-          </section>
-
-          <section className="mt-6">
-            <h3 className="border-b-2 border-slate-700 pb-2 text-[14px] font-bold">등록 내용</h3>
-            <dl className="border border-t-0 border-slate-400">
-              <DocumentCell label="프로젝트 목적" value={dossier.notes.projectPurpose} />
-              <DocumentCell label="상세 설명" value={dossier.notes.description} />
-              <DocumentCell label="참여 조건" value={dossier.notes.participantCondition} />
-              <DocumentCell label="비고" value={dossier.notes.note} />
-            </dl>
-          </section>
-
-          <section className="mt-6">
-            <h3 className="border-b-2 border-slate-700 pb-2 text-[14px] font-bold">첨부자료</h3>
-            <div className="border border-t-0 border-slate-400 px-4 py-3 text-[12px] leading-6 text-slate-800">
-              {attachmentNames.length > 0 ? attachmentNames.join(' · ') : '등록된 첨부자료가 없습니다.'}
-              {contractDocumentUrl ? (
-                <a className="ml-3 font-semibold text-[#174a7c] underline underline-offset-2" href={contractDocumentUrl} target="_blank" rel="noreferrer">계약서 원문 열기</a>
-              ) : null}
-              {contractDocumentError ? <p className="mt-1 text-[11px] text-rose-700">{contractDocumentError}</p> : null}
-              {contractDocumentUrl ? (
-                <iframe title="계약서 미리보기" src={contractDocumentUrl} className="mt-3 h-[520px] w-full border border-slate-300 bg-slate-50" />
-              ) : null}
-            </div>
-          </section>
-
-          {workflowStage === 'planning' && record.status === 'PENDING' ? (
-            <footer className="mt-7 flex justify-end gap-2 border-t border-slate-300 pt-4">
-              <Button type="button" className="rounded-none bg-[#174a7c] hover:bg-[#103a63]" onClick={onAgree} disabled={acting}>합의</Button>
-            </footer>
-          ) : null}
-          {workflowStage === 'approval' && record.status === 'PLANNING_AGREED' && canFinalize ? (
-            <footer className="mt-7 flex justify-end gap-2 border-t border-slate-300 pt-4">
-              <Button type="button" variant="outline" className="rounded-none border-slate-500" onClick={onReject} disabled={acting}>반려</Button>
-              <Button type="button" className="rounded-none bg-[#174a7c] hover:bg-[#103a63]" onClick={onApprove} disabled={acting}>승인</Button>
-            </footer>
-          ) : null}
-          {workflowStage === 'approval' && record.status === 'PLANNING_AGREED' && !canFinalize ? (
-            <p className="mt-7 border-t border-slate-300 pt-4 text-right text-[11px] text-slate-500">지정된 조직장만 최종 승인 또는 반려할 수 있습니다.</p>
-          ) : null}
+          {isActionPending && canFinalize ? <footer className="mt-7 flex justify-end gap-2 border-t border-slate-300 pt-4"><Button type="button" variant="outline" className="rounded-none border-slate-500" onClick={onReject} disabled={acting}>반려</Button><Button type="button" className="rounded-none bg-[#174a7c] hover:bg-[#103a63]" onClick={onApprove} disabled={acting}>{isManagementPlanning ? '합의' : '승인'}</Button></footer> : null}
+          {isActionPending && !canFinalize ? <p className="mt-7 border-t border-slate-300 pt-4 text-right text-[11px] text-slate-500">{isManagementPlanning ? '경영기획실 담당자만 합의 또는 반려할 수 있습니다.' : '지정된 조직장만 승인 또는 반려할 수 있습니다.'}</p> : null}
         </article>
       </DialogContent>
     </Dialog>

--- a/src/app/components/projects/migration-audit/MigrationAuditRecordList.tsx
+++ b/src/app/components/projects/migration-audit/MigrationAuditRecordList.tsx
@@ -1,16 +1,17 @@
 import { FileText } from 'lucide-react';
 import type { MigrationAuditConsoleRecord } from '../../../platform/project-migration-console';
 import { getMigrationAuditStatusLabel } from '../../../platform/project-migration-console';
+import { getManagementPlanningReview } from '../../../platform/project-management-planning-review';
 import { Card, CardContent } from '../../ui/card';
 import { Button } from '../../ui/button';
 
 interface MigrationAuditRecordListProps {
   records: MigrationAuditConsoleRecord[];
   onOpen: (record: MigrationAuditConsoleRecord) => void;
+  reviewStage?: 'executive' | 'managementPlanning';
 }
 
 function statusClass(status: MigrationAuditConsoleRecord['status']) {
-  if (status === 'PLANNING_AGREED') return 'border-blue-300 text-blue-800';
   if (status === 'APPROVED') return 'border-emerald-300 text-emerald-800';
   if (status === 'REVISION_REJECTED') return 'border-rose-300 text-rose-800';
   if (status === 'DUPLICATE_DISCARDED') return 'border-slate-400 text-slate-700';
@@ -21,7 +22,15 @@ function formatDate(value: string) {
   return value ? value.slice(0, 10).replace(/-/g, '.') : '-';
 }
 
-export function MigrationAuditRecordList({ records, onOpen }: MigrationAuditRecordListProps) {
+export function MigrationAuditRecordList({ records, onOpen, reviewStage = 'executive' }: MigrationAuditRecordListProps) {
+  const isManagementPlanning = reviewStage === 'managementPlanning';
+  const statusLabel = (status: MigrationAuditConsoleRecord['status']) => {
+    if (!isManagementPlanning) return getMigrationAuditStatusLabel(status);
+    if (status === 'APPROVED') return '합의 완료';
+    if (status === 'REVISION_REJECTED') return '반려';
+    return '합의 대기';
+  };
+
   return (
     <Card className="overflow-hidden border-slate-300 bg-white shadow-sm" data-testid="migration-review-record-list">
       <CardContent className="p-0">
@@ -34,15 +43,14 @@ export function MigrationAuditRecordList({ records, onOpen }: MigrationAuditReco
                 <th className="px-4 py-3">프로젝트명</th>
                 <th className="px-4 py-3">등록자</th>
                 <th className="px-4 py-3">접수일</th>
+                {isManagementPlanning ? <th className="px-4 py-3">프로젝트 코드</th> : null}
                 <th className="px-4 py-3 text-right">문서</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-200">
               {records.map((record) => (
                 <tr key={record.id} className="hover:bg-slate-50">
-                  <td className="px-4 py-3">
-                    <span className={`inline-flex border px-2 py-1 text-[11px] font-semibold ${statusClass(record.status)}`}>{getMigrationAuditStatusLabel(record.status)}</span>
-                  </td>
+                  <td className="px-4 py-3"><span className={`inline-flex border px-2 py-1 text-[11px] font-semibold ${statusClass(record.status)}`}>{statusLabel(record.status)}</span></td>
                   <td className="px-4 py-3 text-[12px] text-slate-700">{record.cic}</td>
                   <td className="max-w-[330px] px-4 py-3">
                     <p className="truncate text-[13px] font-semibold text-slate-950">{record.title}</p>
@@ -50,6 +58,7 @@ export function MigrationAuditRecordList({ records, onOpen }: MigrationAuditReco
                   </td>
                   <td className="px-4 py-3 text-[12px] text-slate-700">{record.managerName || '-'}</td>
                   <td className="px-4 py-3 text-[12px] text-slate-600">{formatDate(record.requestedAt)}</td>
+                  {isManagementPlanning ? <td className="px-4 py-3 text-[12px] font-medium text-slate-700">{getManagementPlanningReview(record.project).projectCode || '부여 대기'}</td> : null}
                   <td className="px-4 py-3 text-right">
                     <Button type="button" variant="outline" size="sm" className="h-8 rounded-none border-slate-400 text-[11px]" onClick={() => onOpen(record)}>
                       <FileText className="mr-1 h-3.5 w-3.5" />문서 열기
@@ -57,11 +66,7 @@ export function MigrationAuditRecordList({ records, onOpen }: MigrationAuditReco
                   </td>
                 </tr>
               ))}
-              {records.length === 0 ? (
-                <tr>
-                  <td colSpan={6} className="px-4 py-14 text-center text-[12px] text-slate-500">현재 조건에 맞는 검토 문서가 없습니다.</td>
-                </tr>
-              ) : null}
+              {records.length === 0 ? <tr><td colSpan={isManagementPlanning ? 7 : 6} className="px-4 py-14 text-center text-[12px] text-slate-500">현재 조건에 맞는 검토 문서가 없습니다.</td></tr> : null}
             </tbody>
           </table>
         </div>

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -618,6 +618,13 @@ export interface Project {
   executiveReviewedByName?: string;
   executiveReviewComment?: string | null;
   executiveReviewHistory?: ProjectExecutiveReviewHistoryEntry[];
+  managementPlanningReviewStatus?: ProjectManagementPlanningReviewStatus;
+  managementPlanningReviewedAt?: string | null;
+  managementPlanningReviewedById?: string | null;
+  managementPlanningReviewedByName?: string | null;
+  managementPlanningReviewComment?: string | null;
+  managementPlanningReviewHistory?: ProjectManagementPlanningReviewHistoryEntry[];
+  projectCodeKey?: string | null;
   trashedAt?: string | null;
   trashedById?: string | null;
   trashedByEmail?: string | null;
@@ -730,6 +737,18 @@ export interface ProjectExecutiveReviewHistoryEntry {
   reviewComment?: string;
   projectCode?: string;
   changes?: ProjectReviewFieldChange[];
+}
+
+export type ProjectManagementPlanningReviewStatus = 'PENDING' | 'AGREED' | 'REVISION_REJECTED';
+
+export interface ProjectManagementPlanningReviewHistoryEntry {
+  status: ProjectManagementPlanningReviewStatus;
+  previousStatus?: ProjectManagementPlanningReviewStatus | null;
+  reviewedAt: string;
+  reviewedById: string;
+  reviewedByName: string;
+  reviewComment?: string | null;
+  projectCode?: string | null;
 }
 
 export interface FileAttachment {

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -10,6 +10,7 @@ import {
   fetchProjectsViaBff,
   linkProjectEvidenceDriveRootViaBff,
   notifyProjectRequestRegistrationViaBff,
+  reviewProjectManagementPlanningStatusViaBff,
   reviewProjectExecutiveStatusViaBff,
   overrideTransactionEvidenceDriveCategoriesViaBff,
   previewGoogleSheetImportViaBff,
@@ -1019,6 +1020,47 @@ describe('platform-bff-client', () => {
       },
     }));
     expect(result.reviewStatus).toBe('PENDING');
+  });
+
+  it('calls the management-planning review endpoint with normalized code metadata', async () => {
+    const client = asMockClient({
+      post: vi.fn(async () => ({
+        data: {
+          ok: true,
+          projectId: 'p-123',
+          requestId: 'pr-123',
+          reviewStatus: 'AGREED',
+        },
+      })),
+      get: vi.fn(),
+      request: vi.fn(),
+    });
+
+    const result = await reviewProjectManagementPlanningStatusViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'u-finance', role: 'finance', idToken: 'token-abc' },
+      projectId: 'p-123',
+      review: {
+        requestId: '  pr-123  ',
+        reviewStatus: 'AGREED',
+        projectCode: '  PRJ-2026-001  ',
+        reviewComment: '  코드 부여 완료  ',
+        reviewerName: '  경영기획실  ',
+      },
+      client,
+    });
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/projects/p-123/management-planning-review', expect.objectContaining({
+      tenantId: 'mysc',
+      body: {
+        requestId: 'pr-123',
+        reviewStatus: 'AGREED',
+        projectCode: 'PRJ-2026-001',
+        reviewComment: '코드 부여 완료',
+        reviewerName: '경영기획실',
+      },
+    }));
+    expect(result.reviewStatus).toBe('AGREED');
   });
 
   it('omits blank optional text fields from project executive review resubmission requests', async () => {

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -3,6 +3,7 @@ import type {
   AccountType,
   Project,
   ProjectExecutiveReviewStatus,
+  ProjectManagementPlanningReviewStatus,
   ProjectSheetSourceSnapshot,
   ProjectSheetSourceType,
   ProjectRequestContractAnalysis,
@@ -285,6 +286,22 @@ export interface ProjectExecutiveReviewResubmitResult {
   reviewedAt?: string;
 }
 
+export interface ProjectManagementPlanningReviewPayload {
+  requestId?: string;
+  reviewStatus: Exclude<ProjectManagementPlanningReviewStatus, 'PENDING'>;
+  reviewComment?: string;
+  reviewerName?: string;
+  projectCode?: string;
+}
+
+export interface ProjectManagementPlanningReviewResult {
+  ok: boolean;
+  projectId: string;
+  requestId: string | null;
+  reviewStatus: Exclude<ProjectManagementPlanningReviewStatus, 'PENDING'>;
+  reviewedAt?: string;
+}
+
 export type AuthGovernanceDriftFlag =
   | 'missing_auth'
   | 'missing_canonical_member'
@@ -383,6 +400,22 @@ function normalizeProjectExecutiveReviewResubmitPayload(
     ...(requestId ? { requestId } : {}),
     ...(reviewComment ? { reviewComment } : {}),
     ...(reviewerName ? { reviewerName } : {}),
+  };
+}
+
+function normalizeProjectManagementPlanningReviewPayload(
+  payload: ProjectManagementPlanningReviewPayload,
+): ProjectManagementPlanningReviewPayload {
+  const requestId = normalizeOptionalText(payload.requestId);
+  const reviewComment = normalizeOptionalText(payload.reviewComment);
+  const reviewerName = normalizeOptionalText(payload.reviewerName);
+  const projectCode = normalizeOptionalText(payload.projectCode);
+  return {
+    ...(requestId ? { requestId } : {}),
+    reviewStatus: payload.reviewStatus,
+    ...(reviewComment ? { reviewComment } : {}),
+    ...(reviewerName ? { reviewerName } : {}),
+    ...(projectCode ? { projectCode } : {}),
   };
 }
 
@@ -1831,6 +1864,27 @@ export async function resubmitProjectExecutiveReviewViaBff(params: {
       tenantId: params.tenantId,
       actor: toRequestActor(params.actor),
       body: normalizeProjectExecutiveReviewResubmitPayload(params.payload),
+      timeoutMs: 10000,
+      retries: 0,
+    },
+  );
+  return response.data;
+}
+
+export async function reviewProjectManagementPlanningStatusViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectId: string;
+  review: ProjectManagementPlanningReviewPayload;
+  client?: PlatformApiClientLike;
+}): Promise<ProjectManagementPlanningReviewResult> {
+  const apiClient = resolveClient(params.client);
+  const response = await apiClient.post<ProjectManagementPlanningReviewResult>(
+    `/api/v1/projects/${encodeURIComponent(params.projectId)}/management-planning-review`,
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      body: normalizeProjectManagementPlanningReviewPayload(params.review),
       timeoutMs: 10000,
       retries: 0,
     },

--- a/src/app/platform/admin-foundation.shell.test.ts
+++ b/src/app/platform/admin-foundation.shell.test.ts
@@ -18,6 +18,8 @@ describe('admin monitoring foundation shell contract', () => {
     expect(navConfigSource).toContain("to: '/dashboard'");
     expect(navConfigSource).toContain("label: '캐시플로 모니터링'");
     expect(navConfigSource).toContain("label: '프로젝트 등록/승인'");
+    expect(navConfigSource).toContain("to: '/management-planning/project-codes'");
+    expect(navConfigSource).toContain("label: '프로젝트 코드 부여'");
     expect(navConfigSource).toContain("to: '/users'");
     expect(navConfigSource).toContain("label: '권한 관리'");
     expect(navConfigSource).not.toContain("to: '/settings?tab=org'");
@@ -39,5 +41,6 @@ describe('admin monitoring foundation shell contract', () => {
     expect(routesSource).toContain("{ path: 'cashflow/export', element: <S C={CashflowExportPage} /> }");
     expect(routesSource).toContain("{ path: 'cashflow/weekly', element: <S C={CashflowWeeklyPage} /> }");
     expect(routesSource).toContain("{ path: 'cashflow/analytics', element: <S C={CashflowAnalyticsPage} /> }");
+    expect(routesSource).toContain("{ path: 'management-planning/project-codes', element: <S C={ProjectCodeIssuancePage} /> }");
   });
 });

--- a/src/app/platform/admin-nav.test.ts
+++ b/src/app/platform/admin-nav.test.ts
@@ -56,6 +56,15 @@ describe('admin nav access control', () => {
     expect(canAccessAdminPath('finance', '/projects/migration-audit')).toBe(false);
   });
 
+  it('shows management-planning project code issuance only to finance and admin', () => {
+    expect(canShowAdminNavItem('admin', '/management-planning/project-codes')).toBe(true);
+    expect(canShowAdminNavItem('finance', '/management-planning/project-codes')).toBe(true);
+    expect(canShowAdminNavItem('pm', '/management-planning/project-codes')).toBe(false);
+    expect(canShowAdminNavItem('viewer', '/management-planning/project-codes')).toBe(false);
+    expect(canAccessAdminPath('finance', '/management-planning/project-codes')).toBe(true);
+    expect(canAccessAdminPath('pm', '/management-planning/project-codes')).toBe(false);
+  });
+
   it('exposes user management only to admins in the visible nav', () => {
     expect(canShowAdminNavItem('admin', '/users')).toBe(true);
     expect(canShowAdminNavItem('finance', '/users')).toBe(false);

--- a/src/app/platform/admin-nav.ts
+++ b/src/app/platform/admin-nav.ts
@@ -42,6 +42,9 @@ function canonicalizeAdminPath(pathname: string): string | undefined {
   if (pathname === '/projects/migration-audit' || pathname.startsWith('/projects/migration-audit/')) {
     return '/projects/migration-audit';
   }
+  if (pathname === '/management-planning/project-codes' || pathname.startsWith('/management-planning/project-codes/')) {
+    return '/management-planning/project-codes';
+  }
   if (pathname.startsWith('/projects/new')) return '/projects/new';
   if (pathname.startsWith('/projects/') && pathname.endsWith('/edit')) return '/projects/new';
   if (pathname === '/projects' || pathname.startsWith('/projects/')) return '/projects';

--- a/src/app/platform/nav-config.ts
+++ b/src/app/platform/nav-config.ts
@@ -2,7 +2,7 @@ import type { LucideIcon } from 'lucide-react';
 import {
   LayoutDashboard, FolderKanban, BarChart3,
   Building2, Shield, UserCog,
-  ListChecks, ArrowLeftRight,
+  ListChecks, ArrowLeftRight, Hash,
 } from 'lucide-react';
 
 export interface NavItem {
@@ -38,6 +38,7 @@ export const NAV_GROUPS: NavGroup[] = [
     items: [
       { to: '/cashflow/analytics', icon: BarChart3, label: '통합 관리' },
       { to: '/approvals', icon: ListChecks, label: '등록/승인', accent: true },
+      { to: '/management-planning/project-codes', icon: Hash, label: '프로젝트 코드 부여', accent: true },
     ],
   },
   {

--- a/src/app/platform/portal-project-review-feedback.test.ts
+++ b/src/app/platform/portal-project-review-feedback.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import type { Project, ProjectRequest } from '../data/types';
+import { buildPortalProjectReviewFeedback } from './portal-project-review-feedback';
+
+const project = {
+  id: 'project-1', slug: 'project-1', orgId: 'mysc', name: '프로젝트',
+  executiveReviewStatus: 'APPROVED',
+  executiveReviewHistory: [{ status: 'APPROVED', reviewedAt: '2026-07-10T01:00:00.000Z', reviewedById: 'head-1', reviewedByName: '조직장', reviewComment: '계약 조건 확인했습니다.' }],
+  managementPlanningReviewStatus: 'REVISION_REJECTED',
+  managementPlanningReviewHistory: [{ status: 'REVISION_REJECTED', reviewedAt: '2026-07-11T01:00:00.000Z', reviewedById: 'planning-1', reviewedByName: '경영기획실', reviewComment: '프로젝트 코드를 다시 확인해 주세요.' }],
+} as Project;
+
+describe('portal project review feedback', () => {
+  it('keeps the organization approval and exposes the distinct management-planning rejection', () => {
+    const request = {
+      id: 'request-1', status: 'REJECTED', payload: { note: '계약 범위를 보완해 제출합니다.' },
+      requestedByName: '실무자', requestedAt: '2026-07-09T01:00:00.000Z',
+      reviewedByName: '경영기획실', reviewedAt: '2026-07-11T01:00:00.000Z', reviewComment: '프로젝트 코드를 다시 확인해 주세요.',
+    } as ProjectRequest;
+
+    expect(buildPortalProjectReviewFeedback(project, request)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: '경영기획실 반려 메모', reviewerName: '경영기획실' }),
+      expect.objectContaining({ label: '조직장 승인 메모', reviewerName: '조직장' }),
+      expect.objectContaining({ label: '실무자 제출 메모', reviewerName: '실무자' }),
+    ]));
+  });
+});

--- a/src/app/platform/portal-project-review-feedback.ts
+++ b/src/app/platform/portal-project-review-feedback.ts
@@ -1,0 +1,101 @@
+import type { Project, ProjectRequest } from '../data/types';
+import { getManagementPlanningReview, type ManagementPlanningReviewStatus } from './project-management-planning-review';
+
+export interface PortalProjectReviewFeedback {
+  id: string;
+  label: string;
+  reviewerName: string;
+  reviewedAt: string;
+  comment: string;
+}
+
+function text(value: unknown): string {
+  return String(value || '').trim();
+}
+
+function isVisibleComment(value: unknown): boolean {
+  const comment = text(value);
+  return Boolean(comment && comment !== 'PM 신규 등록');
+}
+
+function executiveLabel(status: string): string {
+  if (status === 'APPROVED') return '조직장 승인 메모';
+  if (status === 'REVISION_REJECTED') return '조직장 반려 메모';
+  if (status === 'DUPLICATE_DISCARDED') return '조직장 폐기 메모';
+  return '실무자 제출 메모';
+}
+
+function planningLabel(status: ManagementPlanningReviewStatus): string {
+  if (status === 'AGREED') return '경영기획실 합의 메모';
+  if (status === 'REVISION_REJECTED') return '경영기획실 반려 메모';
+  return '경영기획실 검토 메모';
+}
+
+export function hasManagementPlanningReview(project: Project): boolean {
+  return Boolean(
+    project.managementPlanningReviewStatus
+    || project.managementPlanningReviewedAt
+    || project.managementPlanningReviewedById
+    || project.managementPlanningReviewedByName
+    || project.managementPlanningReviewComment
+    || project.managementPlanningReviewHistory?.length
+    || project.projectCode,
+  );
+}
+
+export function buildPortalProjectReviewFeedback(project: Project, request: ProjectRequest | null): PortalProjectReviewFeedback[] {
+  const feedback: PortalProjectReviewFeedback[] = [];
+  const seen = new Set<string>();
+  const add = (entry: Omit<PortalProjectReviewFeedback, 'id'>) => {
+    if (!isVisibleComment(entry.comment)) return;
+    const key = [entry.label, entry.reviewerName, entry.reviewedAt, entry.comment].join('|');
+    if (seen.has(key)) return;
+    seen.add(key);
+    feedback.push({ ...entry, id: `feedback-${feedback.length}-${key}` });
+  };
+
+  (project.executiveReviewHistory || []).forEach((entry) => add({
+    label: executiveLabel(entry.status),
+    reviewerName: text(entry.reviewedByName),
+    reviewedAt: text(entry.reviewedAt),
+    comment: text(entry.reviewComment),
+  }));
+
+  const managementReview = getManagementPlanningReview(project);
+  managementReview.history.forEach((entry) => add({
+    label: planningLabel(entry.status),
+    reviewerName: text(entry.reviewedByName),
+    reviewedAt: text(entry.reviewedAt),
+    comment: text(entry.reviewComment),
+  }));
+  const managementCommentInHistory = managementReview.history.some((entry) => text(entry.reviewComment) === managementReview.reviewComment);
+  if (!managementCommentInHistory) add({
+    label: planningLabel(managementReview.status),
+    reviewerName: text(managementReview.reviewedByName),
+    reviewedAt: text(managementReview.reviewedAt),
+    comment: managementReview.reviewComment,
+  });
+
+  add({
+    label: '실무자 제출 메모',
+    reviewerName: text(request?.requestedByName),
+    reviewedAt: text(request?.requestedAt),
+    comment: text(request?.payload?.note),
+  });
+  if (request?.status === 'PENDING' && project.executiveReviewStatus === 'APPROVED' && managementReview.status === 'PENDING') add({
+    label: '실무자 재제출 메모',
+    reviewerName: text(request.requestedByName),
+    reviewedAt: text(request.requestedAt),
+    comment: text(request.reviewComment),
+  });
+  if (request?.status === 'REJECTED') {
+    const comment = text(request.reviewComment || request.rejectedReason);
+    if (!feedback.some((entry) => entry.comment === comment && entry.label.includes('반려 메모'))) add({
+      label: managementReview.status === 'REVISION_REJECTED' ? '경영기획실 반려 메모' : '검토 반려 메모',
+      reviewerName: text(request.reviewedByName),
+      reviewedAt: text(request.reviewedAt),
+      comment,
+    });
+  }
+  return feedback.sort((left, right) => right.reviewedAt.localeCompare(left.reviewedAt));
+}

--- a/src/app/platform/project-management-planning-review.test.ts
+++ b/src/app/platform/project-management-planning-review.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import type { Project } from '../data/types';
+import {
+  getManagementPlanningReview,
+  getManagementPlanningReviewLabel,
+} from './project-management-planning-review';
+
+const project = {
+  id: 'project-1',
+  slug: 'project-1',
+  orgId: 'mysc',
+  name: '테스트 프로젝트',
+} as Project;
+
+describe('management planning project review', () => {
+  it('keeps executive approval separate while reading management-planning status and code', () => {
+    const review = getManagementPlanningReview({
+      ...project,
+      executiveReviewStatus: 'APPROVED',
+      managementPlanningReviewStatus: 'AGREED',
+      managementPlanningReviewedByName: '경영기획실',
+      managementPlanningReviewComment: '코드 부여 완료',
+      projectCode: 'MYSC-2026-001',
+    } as Project);
+
+    expect(review).toMatchObject({
+      status: 'AGREED',
+      reviewedByName: '경영기획실',
+      projectCode: 'MYSC-2026-001',
+    });
+    expect(getManagementPlanningReviewLabel(review.status)).toBe('합의 완료');
+  });
+
+  it('adapts legacy planning agreements to read-only agreed records', () => {
+    const review = getManagementPlanningReview({
+      ...project,
+      executiveReviewStatus: 'APPROVED',
+      projectCode: 'OLD-2026-001',
+      executiveReviewHistory: [{
+        status: 'PLANNING_AGREED',
+        reviewedAt: '2026-07-20T09:00:00.000Z',
+        reviewedById: 'u-planning',
+        reviewedByName: '경영기획실',
+        projectCode: 'OLD-2026-001',
+      }],
+    } as Project);
+
+    expect(review).toMatchObject({
+      status: 'AGREED',
+      projectCode: 'OLD-2026-001',
+      history: [{ status: 'AGREED', reviewedByName: '경영기획실' }],
+    });
+  });
+
+  it('treats unreviewed projects as awaiting management-planning review', () => {
+    expect(getManagementPlanningReview(project).status).toBe('PENDING');
+  });
+});

--- a/src/app/platform/project-management-planning-review.ts
+++ b/src/app/platform/project-management-planning-review.ts
@@ -1,0 +1,46 @@
+import type {
+  Project,
+  ProjectManagementPlanningReviewStatus,
+} from '../data/types';
+
+export type ManagementPlanningReviewStatus = ProjectManagementPlanningReviewStatus;
+
+function text(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function readStatus(value: unknown): ManagementPlanningReviewStatus {
+  return value === 'AGREED' || value === 'REVISION_REJECTED' ? value : 'PENDING';
+}
+
+export function getManagementPlanningReview(project: Project) {
+  const managementHistory = Array.isArray(project.managementPlanningReviewHistory)
+    ? project.managementPlanningReviewHistory
+    : [];
+  const legacyAgreement = project.managementPlanningReviewStatus == null
+    ? [...(project.executiveReviewHistory || [])].reverse().find((entry) => entry.status === 'PLANNING_AGREED')
+    : undefined;
+  const legacyHistory = legacyAgreement ? [{
+    status: 'AGREED' as const,
+    previousStatus: null,
+    reviewedAt: text(legacyAgreement.reviewedAt),
+    reviewedById: text(legacyAgreement.reviewedById),
+    reviewedByName: text(legacyAgreement.reviewedByName),
+    reviewComment: text(legacyAgreement.reviewComment),
+    projectCode: text(legacyAgreement.projectCode || project.projectCode),
+  }] : [];
+  return {
+    status: legacyAgreement ? 'AGREED' as const : readStatus(project.managementPlanningReviewStatus),
+    reviewedAt: text(project.managementPlanningReviewedAt || legacyAgreement?.reviewedAt),
+    reviewedByName: text(project.managementPlanningReviewedByName || legacyAgreement?.reviewedByName),
+    reviewComment: text(project.managementPlanningReviewComment || legacyAgreement?.reviewComment),
+    projectCode: text(project.projectCode),
+    history: managementHistory.length > 0 ? managementHistory : legacyHistory,
+  };
+}
+
+export function getManagementPlanningReviewLabel(status: ManagementPlanningReviewStatus): string {
+  if (status === 'AGREED') return '합의 완료';
+  if (status === 'REVISION_REJECTED') return '반려';
+  return '합의 대기';
+}

--- a/src/app/platform/project-migration-console.ts
+++ b/src/app/platform/project-migration-console.ts
@@ -3,6 +3,7 @@ import type {
   ProjectExecutiveReviewStatus,
   ProjectRequest,
 } from '../data/types';
+import { normalizeProjectDepartment } from './project-cic';
 import { resolveProjectRequestPayload } from './project-change-request';
 
 export type MigrationAuditConsoleStatus = ProjectExecutiveReviewStatus;
@@ -39,7 +40,7 @@ function normalizeText(value: unknown): string {
 }
 
 export function normalizeCicLabel(value: unknown): string {
-  const normalized = normalizeText(value);
+  const normalized = normalizeProjectDepartment(value);
   return normalized || '미지정';
 }
 
@@ -79,6 +80,8 @@ export function deriveMigrationAuditStatus(
   ) {
     return project.executiveReviewStatus;
   }
+  // A management-planning return reopens only that stage. The executive seal remains authoritative.
+  if (project.executiveReviewStatus === 'APPROVED') return 'APPROVED';
   if (request?.status === 'PENDING') return 'PENDING';
   if (project.executiveReviewStatus) return project.executiveReviewStatus;
   if (request?.status === 'REJECTED') return 'REVISION_REJECTED';

--- a/src/app/platform/project-migration-review-dossier.test.ts
+++ b/src/app/platform/project-migration-review-dossier.test.ts
@@ -226,11 +226,13 @@ describe('buildMigrationReviewDossier', () => {
     expect(dossier.audit.reviewComment).toBe('예산 근거 보완 필요');
     expect(dossier.audit.history).toHaveLength(2);
     expect(dossier.audit.history[0]).toMatchObject({
+      status: 'REVISION_REJECTED',
       statusLabel: '수정 요청 후 반려',
       reviewedByName: '임원B',
       reviewComment: '예산 근거 보완 필요',
     });
     expect(dossier.audit.history[1]).toMatchObject({
+      status: 'APPROVED',
       statusLabel: '승인 완료',
       reviewedByName: '임원A',
       reviewComment: '초안 승인',

--- a/src/app/platform/project-migration-review-dossier.ts
+++ b/src/app/platform/project-migration-review-dossier.ts
@@ -11,6 +11,7 @@ import {
   PROJECT_FUND_INPUT_MODE_LABELS,
   PROJECT_CURRENCY_LABELS,
   PROJECT_TYPE_LABELS,
+  type ProjectExecutiveReviewStatus,
   type ProjectExecutiveReviewHistoryEntry,
   SETTLEMENT_TYPE_LABELS,
   type Project,
@@ -72,6 +73,7 @@ export interface MigrationReviewDossier {
     reviewedAt: string;
     reviewComment: string;
     history: Array<{
+      status: ProjectExecutiveReviewStatus;
       statusLabel: string;
       reviewedByName: string;
       reviewedAt: string;
@@ -166,6 +168,7 @@ function buildAuditHistory(project: Project, request: ProjectRequest | null) {
     return [...history]
       .sort((left, right) => String(right.reviewedAt || '').localeCompare(String(left.reviewedAt || '')))
       .map((entry: ProjectExecutiveReviewHistoryEntry) => ({
+        status: entry.status,
         statusLabel: getMigrationAuditStatusLabel(entry.status),
         reviewedByName: readable(entry.reviewedByName),
         reviewedAt: formatDate(entry.reviewedAt),
@@ -182,8 +185,10 @@ function buildAuditHistory(project: Project, request: ProjectRequest | null) {
     return [];
   }
 
+  const status = (fallbackStatus || 'PENDING') as ProjectExecutiveReviewStatus;
   return [{
-    statusLabel: getMigrationAuditStatusLabel((fallbackStatus || 'PENDING') as any),
+    status,
+    statusLabel: getMigrationAuditStatusLabel(status),
     reviewedByName: readable(fallbackReviewedByName),
     reviewedAt: formatDate(fallbackReviewedAt),
     reviewComment: readable(fallbackReviewComment),
@@ -220,15 +225,28 @@ function preferRequestPayloadForChange<T>(
     : (projectValue ?? payloadValue);
 }
 
+/**
+ * A pending change request is the source of truth while it is being reviewed;
+ * otherwise keep the registered project's contract as the primary preview.
+ */
+export function resolveMigrationReviewContractDocument(
+  project: Project,
+  request: ProjectRequest | null,
+) {
+  const payload = resolveProjectRequestPayload(request);
+  const useRequestDocument = resolveProjectRequestKind(request) === 'CHANGE' && request?.status === 'PENDING';
+  return useRequestDocument
+    ? (payload?.contractDocument || project.contractDocument || null)
+    : (project.contractDocument || payload?.contractDocument || null);
+}
+
 export function buildMigrationReviewDossier(
   project: Project,
   request: ProjectRequest | null,
 ): MigrationReviewDossier {
   const payload = resolveProjectRequestPayload(request);
   const usePayloadAsCurrent = resolveProjectRequestKind(request) === 'CHANGE' && request?.status === 'PENDING';
-  const contractDocument = usePayloadAsCurrent
-    ? (payload?.contractDocument || project.contractDocument || null)
-    : (project.contractDocument || payload?.contractDocument || null);
+  const contractDocument = resolveMigrationReviewContractDocument(project, request);
   const contractAnalysis = usePayloadAsCurrent
     ? (payload?.contractAnalysis || project.contractAnalysis || null)
     : (project.contractAnalysis || payload?.contractAnalysis || null);

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -47,6 +47,7 @@ const BoardFeedPage = lazyRoute(() => import('./components/board/BoardFeedPage')
 const BoardPostPage = lazyRoute(() => import('./components/board/BoardPostPage'), 'BoardPostPage');
 const ProjectListPage = lazyRoute(() => import('./components/projects/ProjectListPage'), 'ProjectListPage');
 const ProjectMigrationAuditPage = lazyRoute(() => import('./components/projects/ProjectMigrationAuditPage'), 'ProjectMigrationAuditPage');
+const ProjectCodeIssuancePage = lazyRoute(() => import('./components/projects/ProjectCodeIssuancePage'), 'ProjectCodeIssuancePage');
 const ProjectDetailPage = lazyRoute(() => import('./components/projects/ProjectDetailPage'), 'ProjectDetailPage');
 const ProjectWizardPage = lazyRoute(() => import('./components/projects/ProjectWizardPage'), 'ProjectWizardPage');
 const ProjectRegisterRedirectPage = lazyRoute(() => import('./components/projects/ProjectRegisterRedirectPage'), 'ProjectRegisterRedirectPage');
@@ -145,6 +146,7 @@ export const router = createBrowserRouter([
       },
       { path: 'projects', element: <S C={ProjectListPage} /> },
       { path: 'projects/migration-audit', element: <S C={ProjectMigrationAuditPage} /> },
+      { path: 'management-planning/project-codes', element: <S C={ProjectCodeIssuancePage} /> },
       { path: 'projects/new', element: <S C={ProjectRegisterRedirectPage} /> },
       { path: 'projects/:projectId', element: <S C={ProjectDetailPage} /> },
       { path: 'projects/:projectId/edit', element: <S C={ProjectWizardPage} /> },


### PR DESCRIPTION
## Scope\n- Enforce organization-head approval before management-planning agreement\n- Add project-code issuance with transactional uniqueness\n- Preserve review seals, comments, contract preview, and legacy compatibility\n\n## Verification\n- npm run bff:test:integration\n- npm run build\n- tsc --noEmit\n- focused UI and dossier tests