### PR TITLE
feat: navigate cashflow annual summaries

### DIFF
--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -220,6 +220,31 @@
       "indexes": []
     },
     {
+      "collectionGroup": "monthly_close_versions",
+      "fieldPath": "snapshot",
+      "indexes": []
+    },
+    {
+      "collectionGroup": "cashflow_sheet_snapshot_months",
+      "fieldPath": "cells",
+      "indexes": []
+    },
+    {
+      "collectionGroup": "cashflow_sheet_snapshot_years",
+      "fieldPath": "annualCells",
+      "indexes": []
+    },
+    {
+      "collectionGroup": "cashflow_sheet_snapshot_years",
+      "fieldPath": "projection",
+      "indexes": []
+    },
+    {
+      "collectionGroup": "cashflow_sheet_snapshot_years",
+      "fieldPath": "actual",
+      "indexes": []
+    },
+    {
       "collectionGroup": "weekly_api_idempotency",
       "fieldPath": "responseJson",
       "indexes": []

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -110,11 +110,17 @@ service cloud.firestore {
         || collection in ['cashflow_edit_locks']
         || collection in ['editLeases']
         || collection in ['cashflow_sheet_mirrors']
+        || collection in ['cashflow_sheet_snapshots']
+        || collection in ['cashflow_sheet_snapshot_months']
+        || collection in ['cashflow_sheet_snapshot_years']
+        || collection in ['cashflow_sheet_week_values']
+        || collection in ['cashflow_sheet_year_totals']
         || collection in ['cashflow_sheet_refresh_runs']
         || collection in ['cashflow_sheet_stage_runs']
         || collection in ['cashflow_sheet_stage_months']
         || collection in ['cashflow_change_candidates']
         || collection in ['monthly_closes']
+        || collection in ['monthly_close_versions']
         || collection in ['weekly_api_idempotency']
         || collection in ['weekly_api_audit_events']
         || collection in ['weekly_api_audit_exports']
@@ -251,6 +257,26 @@ service cloud.firestore {
       allow read, write: if false;
     }
 
+    match /orgs/{orgId}/cashflow_sheet_snapshots/{snapshotId} {
+      allow read, write: if false;
+    }
+
+    match /orgs/{orgId}/cashflow_sheet_snapshot_months/{monthId} {
+      allow read, write: if false;
+    }
+
+    match /orgs/{orgId}/cashflow_sheet_snapshot_years/{yearId} {
+      allow read, write: if false;
+    }
+
+    match /orgs/{orgId}/cashflow_sheet_week_values/{monthId} {
+      allow read, write: if false;
+    }
+
+    match /orgs/{orgId}/cashflow_sheet_year_totals/{yearId} {
+      allow read, write: if false;
+    }
+
     match /orgs/{orgId}/cashflow_sheet_refresh_runs/{runId} {
       allow read, write: if false;
     }
@@ -290,6 +316,10 @@ service cloud.firestore {
     }
 
     match /orgs/{orgId}/monthly_closes/{closeId} {
+      allow read, write: if false;
+    }
+
+    match /orgs/{orgId}/monthly_close_versions/{versionId} {
       allow read, write: if false;
     }
 

--- a/server/bff/cashflow-sheet-snapshot.mjs
+++ b/server/bff/cashflow-sheet-snapshot.mjs
@@ -187,6 +187,20 @@ function summarizeAnnualMode(cells, source) {
   };
 }
 
+function reconcileAnnualMode(weekly, annual) {
+  if (weekly.source !== 'WEEKLY' || annual.source !== 'ANNUAL') {
+    return { status: 'NOT_APPLICABLE', mismatchedLineIds: [] };
+  }
+  if (weekly.coverage.status !== 'COMPLETE') {
+    return { status: 'PARTIAL_WEEKLY', mismatchedLineIds: [] };
+  }
+  const lineIds = new Set([...Object.keys(weekly.lineAmounts), ...Object.keys(annual.lineAmounts)]);
+  const mismatchedLineIds = [...lineIds]
+    .filter((lineId) => (weekly.lineAmounts[lineId] || 0) !== (annual.lineAmounts[lineId] || 0))
+    .sort(compareCodeUnits);
+  return { status: mismatchedLineIds.length > 0 ? 'MISMATCH' : 'MATCH', mismatchedLineIds };
+}
+
 function buildAnnualCashflowTotals({ cells, annualCells }) {
   const years = new Set([
     ...cells.map((cell) => Number(String(cell.yearMonth).slice(0, 4))),
@@ -199,10 +213,12 @@ function buildAnnualCashflowTotals({ cells, annualCells }) {
       for (const mode of ['projection', 'actual']) {
         const weeklyCells = cells.filter((cell) => cell.mode === mode && Number(String(cell.yearMonth).slice(0, 4)) === year);
         const annualCellsForMode = annualCells.filter((cell) => cell.mode === mode && cell.year === year);
-        modeTotals[mode] = summarizeAnnualMode(
-          weeklyCells.length > 0 ? weeklyCells : annualCellsForMode,
-          weeklyCells.length > 0 ? 'WEEKLY' : annualCellsForMode.length > 0 ? 'ANNUAL' : 'NONE',
-        );
+        const weekly = summarizeAnnualMode(weeklyCells, weeklyCells.length > 0 ? 'WEEKLY' : 'NONE');
+        const annual = summarizeAnnualMode(annualCellsForMode, annualCellsForMode.length > 0 ? 'ANNUAL' : 'NONE');
+        modeTotals[mode] = {
+          ...(weeklyCells.length > 0 ? weekly : annual),
+          reconciliation: reconcileAnnualMode(weekly, annual),
+        };
       }
       return { year, ...modeTotals };
     });

--- a/server/bff/cashflow-sheet-snapshot.mjs
+++ b/server/bff/cashflow-sheet-snapshot.mjs
@@ -121,6 +121,33 @@ function compareAnnualCells(left, right) {
     || String(left.lineId).localeCompare(String(right.lineId));
 }
 
+function annualCoverage(cells, source) {
+  const weeks = new Set();
+  const months = new Set();
+  for (const cell of cells) {
+    const yearMonth = normalizedText(cell?.yearMonth);
+    const weekNo = Number(cell?.weekNo);
+    if (!yearMonth || !Number.isSafeInteger(weekNo)) continue;
+    months.add(yearMonth);
+    weeks.add(`${yearMonth}:${weekNo}`);
+  }
+  return {
+    status: source === 'WEEKLY'
+      ? (weeks.size === 60 && months.size === 12 ? 'COMPLETE' : 'PARTIAL')
+      : source === 'ANNUAL' ? 'ANNUAL_ONLY' : 'NONE',
+    weekCount: weeks.size,
+    expectedWeekCount: 60,
+    monthCount: months.size,
+    expectedMonthCount: 12,
+  };
+}
+
+function addWholeWon(left, right) {
+  const sum = left + right;
+  if (!Number.isSafeInteger(sum)) throw new RangeError('Cashflow annual total exceeds the safe whole-won range.');
+  return sum;
+}
+
 function summarizeAnnualMode(cells, source) {
   const lineAmounts = {};
   let totalIn = 0;
@@ -137,21 +164,26 @@ function summarizeAnnualMode(cells, source) {
       invalidCellCount += 1;
       continue;
     }
+    const amount = Number(cell.amount);
+    if (!Number.isSafeInteger(amount)) {
+      invalidCellCount += 1;
+      continue;
+    }
     valueCellCount += 1;
-    const amount = Number(cell.amount) || 0;
-    lineAmounts[cell.lineId] = amount;
-    if (cell.direction === 'IN') totalIn += amount;
-    if (cell.direction === 'OUT') totalOut += amount;
+    lineAmounts[cell.lineId] = addWholeWon(lineAmounts[cell.lineId] || 0, amount);
+    if (cell.direction === 'IN') totalIn = addWholeWon(totalIn, amount);
+    if (cell.direction === 'OUT') totalOut = addWholeWon(totalOut, amount);
   }
   return {
     source,
+    coverage: annualCoverage(cells, source),
     valueCellCount,
     emptyCellCount,
     invalidCellCount,
     lineAmounts,
     totalIn,
     totalOut,
-    net: totalIn - totalOut,
+    net: addWholeWon(totalIn, -totalOut),
   };
 }
 

--- a/server/bff/cashflow-sheet-snapshot.test.mjs
+++ b/server/bff/cashflow-sheet-snapshot.test.mjs
@@ -295,6 +295,30 @@ describe('cashflow sheet pinned snapshot', () => {
     });
   });
 
+  it('reports an item-level mismatch when a complete weekly year differs from its annual column', () => {
+    const cells = Array.from({ length: 60 }, (_, index) => ({
+      mode: 'projection',
+      yearMonth: `2026-${String(Math.floor(index / 5) + 1).padStart(2, '0')}`,
+      weekNo: (index % 5) + 1,
+      lineId: 'SALES_IN',
+      direction: 'IN',
+      state: 'VALUE',
+      amount: 10,
+    }));
+    const facts = extractCashflowSheetFacts({
+      cells,
+      annualCells: [
+        { mode: 'projection', year: 2026, lineId: 'SALES_IN', direction: 'IN', state: 'VALUE', amount: 599 },
+      ],
+    });
+
+    expect(facts.annualCashflowTotals[0].projection).toMatchObject({
+      source: 'WEEKLY',
+      totalIn: 600,
+      reconciliation: { status: 'MISMATCH', mismatchedLineIds: ['SALES_IN'] },
+    });
+  });
+
   it('computes the same target revision regardless of Firestore map and week order', () => {
     const first = computeCashflowTargetRevision({
       weeks: [

--- a/server/bff/cashflow-sheet-snapshot.test.mjs
+++ b/server/bff/cashflow-sheet-snapshot.test.mjs
@@ -245,6 +245,56 @@ describe('cashflow sheet pinned snapshot', () => {
     ]);
   });
 
+  it('sums repeated weekly line values and marks an incomplete year as partial', () => {
+    const facts = extractCashflowSheetFacts({
+      cells: [
+        { mode: 'projection', yearMonth: '2026-01', weekNo: 1, lineId: 'SALES_IN', direction: 'IN', state: 'VALUE', amount: 100 },
+        { mode: 'projection', yearMonth: '2026-01', weekNo: 2, lineId: 'SALES_IN', direction: 'IN', state: 'VALUE', amount: 200 },
+        { mode: 'projection', yearMonth: '2026-01', weekNo: 2, lineId: 'DIRECT_COST_OUT', direction: 'OUT', state: 'VALUE', amount: 40 },
+      ],
+    });
+
+    expect(facts.annualCashflowTotals).toEqual([
+      expect.objectContaining({
+        year: 2026,
+        projection: expect.objectContaining({
+          source: 'WEEKLY',
+          lineAmounts: { SALES_IN: 300, DIRECT_COST_OUT: 40 },
+          totalIn: 300,
+          totalOut: 40,
+          net: 260,
+          coverage: {
+            status: 'PARTIAL',
+            weekCount: 2,
+            expectedWeekCount: 60,
+            monthCount: 1,
+            expectedMonthCount: 12,
+          },
+        }),
+      }),
+    ]);
+  });
+
+  it('keeps annual-only values distinct from weekly coverage', () => {
+    const facts = extractCashflowSheetFacts({
+      annualCells: [
+        { mode: 'actual', year: 2025, lineId: 'SALES_IN', direction: 'IN', state: 'VALUE', amount: 500 },
+      ],
+    });
+
+    expect(facts.annualCashflowTotals[0].actual).toMatchObject({
+      source: 'ANNUAL',
+      lineAmounts: { SALES_IN: 500 },
+      coverage: {
+        status: 'ANNUAL_ONLY',
+        weekCount: 0,
+        expectedWeekCount: 60,
+        monthCount: 0,
+        expectedMonthCount: 12,
+      },
+    });
+  });
+
   it('computes the same target revision regardless of Firestore map and week order', () => {
     const first = computeCashflowTargetRevision({
       weeks: [

--- a/server/bff/cashflow-sheet-template.mjs
+++ b/server/bff/cashflow-sheet-template.mjs
@@ -159,13 +159,16 @@ function detectSectionCandidates(rows) {
 
 function resolveModeFromRow(row) {
   const searchLimit = Math.min(6, row?.length || 0);
+  let hasProjection = false;
+  let hasActual = false;
   for (let index = 0; index < searchLimit; index += 1) {
     const normalized = normalizeLabelKey(row[index]).toLowerCase();
     if (!normalized) continue;
-    if (normalized.includes('projection')) return 'projection';
-    if (normalized.includes('actual')) return 'actual';
+    hasProjection ||= normalized.includes('projection');
+    hasActual ||= normalized.includes('actual');
   }
-  return null;
+  if (hasProjection === hasActual) return null;
+  return hasProjection ? 'projection' : 'actual';
 }
 
 function detectCashflowSectionCandidates(rows) {

--- a/server/bff/cashflow-sheet-template.test.mjs
+++ b/server/bff/cashflow-sheet-template.test.mjs
@@ -214,6 +214,21 @@ describe('cashflow sheet template mapping', () => {
     expect(result.sections[1].lineRows).toHaveLength(16);
   });
 
+  it('does not mistake the Projection - Actual difference heading for the Projection section', () => {
+    const matrix = buildTemplateMatrix({ weekCount: 4 });
+    const projectionHeaderIndex = matrix.findIndex((row) => row[0] === 'Projection');
+    matrix.splice(projectionHeaderIndex, 0, ['Projection - Actual 차이']);
+    const projectionHeader = matrix.find((row) => row[0] === 'Projection');
+    projectionHeader[1] = '2024년';
+    projectionHeader[2] = '2025년';
+
+    const result = analyzeCashflowSheetTemplate(matrix);
+
+    expect(result.supported).toBe(true);
+    expect(result.sections[0].headerRowIndex).toBe(matrix.indexOf(projectionHeader));
+    expect(result.sections[0].annualColumns.map((column) => column.year)).toEqual([2024, 2025]);
+  });
+
   it('scans weekly columns dynamically when the last column is not BK', () => {
     const result = analyzeCashflowSheetTemplate(buildTemplateMatrix({ weekCount: 8, firstWeekColumn: 5 }));
 

--- a/server/bff/firestore-rules.edit-leases.integration.test.ts
+++ b/server/bff/firestore-rules.edit-leases.integration.test.ts
@@ -34,10 +34,16 @@ const protectedCollections = [
   'cashflowEditLocks',
   'cashflow_edit_locks',
   'cashflow_sheet_mirrors',
+  'cashflow_sheet_snapshots',
+  'cashflow_sheet_snapshot_months',
+  'cashflow_sheet_snapshot_years',
+  'cashflow_sheet_week_values',
+  'cashflow_sheet_year_totals',
   'cashflow_sheet_refresh_runs',
   'cashflow_sheet_stage_runs',
   'cashflow_sheet_stage_months',
   'cashflow_change_candidates',
+  'monthly_close_versions',
 ] as const;
 const canonicalRootCollections = [
   'projects',

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -808,6 +808,7 @@ async function beginCashflowSheetRefreshRun({
       createdAt: attemptedAt,
       createdBy: {
         uid: readOptionalText(context?.actorId),
+        name: readOptionalText(context?.actorName),
         email: readOptionalText(context?.actorEmail),
         role: readOptionalText(context?.actorRole) || 'workspace_user',
       },

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -96,6 +96,117 @@ function attachFinancialYearChecks(mirror, project) {
   };
 }
 
+function readSelectedYear(value) {
+  const text = readOptionalText(value);
+  const year = /^\d{4}$/.test(text) ? Number(text) : Number.NaN;
+  if (!Number.isSafeInteger(year)) {
+    throw createHttpError(400, 'selectedYear must be a four-digit year.', 'cashflow_selected_year_invalid');
+  }
+  return year;
+}
+
+function cashflowAvailableYears(mirror, project, selectedYear) {
+  return [...new Set([
+    selectedYear - 1,
+    selectedYear,
+    selectedYear + 1,
+    ...(Array.isArray(project?.financialYears) ? project.financialYears.map((row) => Number(row?.year)) : []),
+    ...(Array.isArray(mirror?.years) ? mirror.years.map(Number) : []),
+    ...(mirror?.sheetFacts?.annualCashflowTotals || []).map((row) => Number(row?.year)),
+  ].filter(Number.isSafeInteger))].sort((left, right) => left - right);
+}
+
+function cashflowReadModelHash(value) {
+  const canonicalize = (item) => {
+    if (Array.isArray(item)) return item.map(canonicalize);
+    if (!item || typeof item !== 'object') return item;
+    return Object.fromEntries(Object.keys(item)
+      .sort()
+      .map((key) => [key, canonicalize(item[key])]));
+  };
+  return stableHash(canonicalize(value));
+}
+
+async function readCashflowSheetYearView({ db, tenantId, projectId, project, selectedYear }) {
+  const mirror = await readCashflowSheetMirror(db, tenantId, projectId);
+  const availableYears = cashflowAvailableYears(mirror, project, selectedYear);
+  const navigationYears = [selectedYear - 1, selectedYear, selectedYear + 1];
+  if (!mirror?.sourceRevision) {
+    return {
+      projectId,
+      status: 'EMPTY',
+      selectedYear,
+      availableYears,
+      navigationYears,
+      years: [],
+      readModelStatus: 'EMPTY',
+      fallbackYears: [],
+      mismatchYears: [],
+    };
+  }
+
+  const snapshotId = readOptionalText(mirror.snapshotId);
+  const mirrorTotals = new Map((mirror.sheetFacts?.annualCashflowTotals || [])
+    .filter((row) => Number.isSafeInteger(row?.year))
+    .map((row) => [row.year, row]));
+  const snapshotEnabled = /^cfsnap_[a-f0-9]{32}$/.test(snapshotId);
+  const snapshotDocs = snapshotEnabled
+    ? await Promise.all(availableYears.map(async (year) => {
+      const snap = await db.doc(cashflowSheetSnapshotYearDocPath(tenantId, snapshotId, year)).get();
+      return [year, snap.exists ? snap.data() || {} : null];
+    }))
+    : [];
+  const snapshotTotals = new Map(snapshotDocs);
+  const fallbackYears = [];
+  const mismatchYears = [];
+  const years = availableYears.flatMap((year) => {
+    const mirrorTotal = mirrorTotals.get(year);
+    const snapshotTotal = snapshotTotals.get(year);
+    const snapshotCurrent = snapshotTotal
+      && readOptionalText(snapshotTotal.snapshotId) === snapshotId
+      && readOptionalText(snapshotTotal.projectId) === projectId
+      && readOptionalText(snapshotTotal.sourceRevision) === readOptionalText(mirror.sourceRevision)
+      && Number(snapshotTotal.year) === year;
+    if (snapshotCurrent) {
+      if (mirrorTotal && cashflowReadModelHash({ projection: snapshotTotal.projection, actual: snapshotTotal.actual })
+        !== cashflowReadModelHash({ projection: mirrorTotal.projection, actual: mirrorTotal.actual })) {
+        mismatchYears.push(year);
+      }
+      return [{
+        year,
+        projection: snapshotTotal.projection,
+        actual: snapshotTotal.actual,
+        sourceRevision: snapshotTotal.sourceRevision,
+        capturedAt: snapshotTotal.capturedAt,
+        storage: 'SNAPSHOT',
+      }];
+    }
+    if (!mirrorTotal) return [];
+    fallbackYears.push(year);
+    return [{
+      ...mirrorTotal,
+      sourceRevision: mirror.sourceRevision,
+      capturedAt: mirror.capturedAt,
+      storage: 'MIRROR_FALLBACK',
+    }];
+  });
+
+  return {
+    projectId,
+    status: readOptionalText(mirror.status) || 'FRESH',
+    selectedYear,
+    availableYears,
+    navigationYears,
+    snapshotId: snapshotEnabled ? snapshotId : undefined,
+    sourceRevision: mirror.sourceRevision,
+    capturedAt: mirror.capturedAt,
+    years,
+    readModelStatus: mismatchYears.length > 0 ? 'MISMATCH' : fallbackYears.length > 0 ? 'FALLBACK' : 'CURRENT',
+    fallbackYears,
+    mismatchYears,
+  };
+}
+
 function readEditSession(req) {
   const sessionId = readOptionalText(req.header('x-edit-session-id'));
   const leaseId = readOptionalText(req.header('x-edit-lease-id'));
@@ -1696,6 +1807,21 @@ export function mountCashflowSheetLabRoutes(app, {
     const project = await readProjectDocument(db, tenantId, projectId);
     const mirror = await readCashflowSheetMirror(db, tenantId, projectId);
     res.status(200).json(attachFinancialYearChecks(mirror, project) || { projectId, status: 'EMPTY' });
+  }));
+
+  app.get('/api/v1/projects/:projectId/cashflow-sheet-lab/years', asyncHandler(async (req, res) => {
+    assertCashflowSheetLabAccess(req, workspaceEmailDomain);
+    const { tenantId } = req.context;
+    const { projectId } = req.params;
+    const selectedYear = readSelectedYear(req.query.selectedYear);
+    const project = await readProjectDocument(db, tenantId, projectId);
+    res.status(200).json(await readCashflowSheetYearView({
+      db,
+      tenantId,
+      projectId,
+      project,
+      selectedYear,
+    }));
   }));
 
   app.post('/api/v1/projects/:projectId/cashflow-sheet-lab/mirror/refresh', asyncHandler(async (req, res) => {

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -27,8 +27,9 @@ const CASHFLOW_WEEK_BASIS = 'sheet_range';
 const CASHFLOW_WEEKS_COLLECTION_ID = 'cashflow_weeks';
 const CASHFLOW_CHANGE_CANDIDATES_COLLECTION_ID = 'cashflow_change_candidates';
 const CASHFLOW_SHEET_MIRRORS_COLLECTION_ID = 'cashflow_sheet_mirrors';
-const CASHFLOW_SHEET_WEEK_VALUES_COLLECTION_ID = 'cashflow_sheet_week_values';
-const CASHFLOW_SHEET_YEAR_TOTALS_COLLECTION_ID = 'cashflow_sheet_year_totals';
+const CASHFLOW_SHEET_SNAPSHOTS_COLLECTION_ID = 'cashflow_sheet_snapshots';
+const CASHFLOW_SHEET_SNAPSHOT_MONTHS_COLLECTION_ID = 'cashflow_sheet_snapshot_months';
+const CASHFLOW_SHEET_SNAPSHOT_YEARS_COLLECTION_ID = 'cashflow_sheet_snapshot_years';
 const CASHFLOW_SHEET_REFRESH_RUNS_COLLECTION_ID = 'cashflow_sheet_refresh_runs';
 const CASHFLOW_SHEET_STAGE_RUNS_COLLECTION_ID = 'cashflow_sheet_stage_runs';
 const CASHFLOW_SHEET_STAGE_MONTHS_COLLECTION_ID = 'cashflow_sheet_stage_months';
@@ -246,12 +247,16 @@ function cashflowSheetMirrorDocPath(tenantId, projectId) {
   return `orgs/${tenantId}/${CASHFLOW_SHEET_MIRRORS_COLLECTION_ID}/${projectId}`;
 }
 
-function cashflowSheetWeekValueDocPath(tenantId, projectId, yearMonth) {
-  return `orgs/${tenantId}/${CASHFLOW_SHEET_WEEK_VALUES_COLLECTION_ID}/${projectId}_${readOptionalText(yearMonth).replace('-', '_')}`;
+function cashflowSheetSnapshotDocPath(tenantId, snapshotId) {
+  return `orgs/${tenantId}/${CASHFLOW_SHEET_SNAPSHOTS_COLLECTION_ID}/${snapshotId}`;
 }
 
-function cashflowSheetYearTotalDocPath(tenantId, projectId, year) {
-  return `orgs/${tenantId}/${CASHFLOW_SHEET_YEAR_TOTALS_COLLECTION_ID}/${projectId}_${Number(year)}`;
+function cashflowSheetSnapshotMonthDocPath(tenantId, snapshotId, yearMonth) {
+  return `orgs/${tenantId}/${CASHFLOW_SHEET_SNAPSHOT_MONTHS_COLLECTION_ID}/${snapshotId}_${readOptionalText(yearMonth).replace('-', '_')}`;
+}
+
+function cashflowSheetSnapshotYearDocPath(tenantId, snapshotId, year) {
+  return `orgs/${tenantId}/${CASHFLOW_SHEET_SNAPSHOT_YEARS_COLLECTION_ID}/${snapshotId}_${Number(year)}`;
 }
 
 function cashflowSheetRefreshRunDocPath(tenantId, projectId, idempotencyKey) {
@@ -730,13 +735,15 @@ async function completeCashflowSheetRefreshRun({
     const currentMirror = mirrorSnap.exists ? mirrorSnap.data() || {} : {};
     const currentGeneration = Math.max(0, Number(currentMirror.latestRefreshGeneration) || 0);
     const superseded = currentGeneration > runGeneration;
-    const installedResponse = superseded
-      ? currentMirror
-      : stripUndefinedDeep({
-        ...response,
-        latestRefreshGeneration: runGeneration,
-        pendingRefreshConfigRevision: null,
-      });
+    const runId = readOptionalText(runRef?.id) || readOptionalText(runRef?.path).split('/').pop();
+    const snapshotId = `cfsnap_${stableHash({ tenantId, projectId, runId, sourceRevision: response?.sourceRevision }).slice(0, 32)}`;
+    const installedResponse = superseded ? currentMirror : stripUndefinedDeep({
+      ...response,
+      snapshotId,
+      snapshotSchemaVersion: 2,
+      latestRefreshGeneration: runGeneration,
+      pendingRefreshConfigRevision: null,
+    });
     if (!superseded) {
       transaction.set(mirrorRef, installedResponse);
       writeCashflowSheetReadModels({ transaction, db, tenantId, projectId, mirror: installedResponse });
@@ -753,11 +760,34 @@ async function completeCashflowSheetRefreshRun({
 
 function writeCashflowSheetReadModels({ transaction, db, tenantId, projectId, mirror }) {
   if (readOptionalText(mirror?.status) !== 'FRESH') return;
+  const snapshotId = readOptionalText(mirror?.snapshotId);
+  if (!/^cfsnap_[a-f0-9]{32}$/.test(snapshotId)) return;
   const capturedAt = readOptionalText(mirror?.capturedAt);
   const sourceRevision = readOptionalText(mirror?.sourceRevision);
+  transaction.set(db.doc(cashflowSheetSnapshotDocPath(tenantId, snapshotId)), stripUndefinedDeep({
+    schemaVersion: 2,
+    snapshotId,
+    tenantId,
+    projectId,
+    status: 'INSTALLED',
+    spreadsheetId: readOptionalText(mirror?.spreadsheetId),
+    spreadsheetTitle: readOptionalText(mirror?.spreadsheetTitle),
+    selectedSheetName: readOptionalText(mirror?.selectedSheetName),
+    configRevision: readOptionalText(mirror?.configRevision),
+    sourceRevision,
+    targetRevisionAtFetch: readOptionalText(mirror?.targetRevisionAtFetch),
+    capturedAt,
+    capturedBy: mirror?.capturedBy || {},
+    yearMonths: mirror?.yearMonths || [],
+    years: mirror?.years || [],
+    summary: mirror?.summary || {},
+    activeWeekRange: mirror?.activeWeekRange || {},
+  }));
   const cellsByMonth = groupPinnedCellsByMonth(mirror?.cells || []);
   for (const [yearMonth, cells] of cellsByMonth) {
-    transaction.set(db.doc(cashflowSheetWeekValueDocPath(tenantId, projectId, yearMonth)), stripUndefinedDeep({
+    transaction.set(db.doc(cashflowSheetSnapshotMonthDocPath(tenantId, snapshotId, yearMonth)), stripUndefinedDeep({
+      schemaVersion: 2,
+      snapshotId,
       tenantId,
       projectId,
       yearMonth,
@@ -769,7 +799,9 @@ function writeCashflowSheetReadModels({ transaction, db, tenantId, projectId, mi
   }
   for (const total of mirror?.sheetFacts?.annualCashflowTotals || []) {
     if (!Number.isSafeInteger(total?.year)) continue;
-    transaction.set(db.doc(cashflowSheetYearTotalDocPath(tenantId, projectId, total.year)), stripUndefinedDeep({
+    transaction.set(db.doc(cashflowSheetSnapshotYearDocPath(tenantId, snapshotId, total.year)), stripUndefinedDeep({
+      schemaVersion: 2,
+      snapshotId,
       tenantId,
       projectId,
       year: total.year,
@@ -778,10 +810,9 @@ function writeCashflowSheetReadModels({ transaction, db, tenantId, projectId, mi
       capturedAt,
       projection: total.projection,
       actual: total.actual,
+      annualCells: (mirror?.annualCells || []).filter((cell) => Number(cell?.year) === total.year),
     }));
   }
-  // ponytail: the existing mirror still keeps all cells for the review/apply flow.
-  // Split its reads by month before a project needs more than three detailed years.
 }
 
 function setFiniteAmount(index, mapping, amount) {

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -307,8 +307,13 @@ describe('cashflow sheet lab route', () => {
       expect.objectContaining({ year: 2026, projection: expect.objectContaining({ source: 'WEEKLY' }) }),
       expect.objectContaining({ year: 2027, projection: expect.objectContaining({ source: 'ANNUAL', valueCellCount: 0 }) }),
     ]));
-    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_week_values/')).toHaveLength(1);
-    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_year_totals/')).toHaveLength(4);
+    const mirror = db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_mirrors/');
+    const snapshots = db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_snapshots/');
+    expect(mirror[0].data).toMatchObject({ projectId: 'project-a', status: 'FRESH', snapshotSchemaVersion: 2 });
+    expect(mirror[0].data.snapshotId).toMatch(/^cfsnap_[a-f0-9]{32}$/);
+    expect(snapshots).toHaveLength(1);
+    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_snapshot_months/')).toHaveLength(1);
+    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_snapshot_years/')).toHaveLength(4);
   });
 
   it('compares a pinned multi-year sheet total with registered financial years', async () => {

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -313,7 +313,60 @@ describe('cashflow sheet lab route', () => {
     expect(mirror[0].data.snapshotId).toMatch(/^cfsnap_[a-f0-9]{32}$/);
     expect(snapshots).toHaveLength(1);
     expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_snapshot_months/')).toHaveLength(1);
-    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_snapshot_years/')).toHaveLength(4);
+    const yearSnapshots = db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_snapshot_years/');
+    expect(yearSnapshots).toHaveLength(4);
+    const reordered = yearSnapshots.find(({ data }) => data.year === 2025);
+    reordered.data.projection.lineAmounts = Object.fromEntries(
+      Object.entries(reordered.data.projection.lineAmounts).reverse(),
+    );
+    await db.doc(reordered.path).set(reordered.data);
+
+    const yearView = await request(app)
+      .get('/api/v1/projects/project-a/cashflow-sheet-lab/years?selectedYear=2026')
+      .expect(200);
+
+    expect(yearView.body).toMatchObject({
+      selectedYear: 2026,
+      availableYears: [2024, 2025, 2026, 2027],
+      navigationYears: [2025, 2026, 2027],
+      readModelStatus: 'CURRENT',
+      fallbackYears: [],
+      mismatchYears: [],
+    });
+    expect(yearView.body.years).toHaveLength(4);
+    expect(yearView.body.years.every((row) => row.storage === 'SNAPSHOT')).toBe(true);
+  });
+
+  it('keeps legacy mirrors readable until the next explicit sheet refresh rebuilds year snapshots', async () => {
+    const db = createDb({
+      initialDocuments: {
+        'orgs/tenant-a/cashflow_sheet_mirrors/project-a': {
+          projectId: 'project-a',
+          status: 'FRESH',
+          sourceRevision: 'sha256:legacy',
+          years: [2025],
+          sheetFacts: {
+            annualCashflowTotals: [{
+              year: 2025,
+              projection: { source: 'ANNUAL', totalIn: 100, totalOut: 20, net: 80, lineAmounts: {} },
+              actual: { source: 'ANNUAL', totalIn: 90, totalOut: 10, net: 80, lineAmounts: {} },
+            }],
+          },
+        },
+      },
+    });
+
+    const response = await request(createApp({ db }))
+      .get('/api/v1/projects/project-a/cashflow-sheet-lab/years?selectedYear=2026')
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      availableYears: [2025, 2026, 2027],
+      navigationYears: [2025, 2026, 2027],
+      readModelStatus: 'FALLBACK',
+      fallbackYears: [2025],
+      years: [{ year: 2025, storage: 'MIRROR_FALLBACK' }],
+    });
   });
 
   it('compares a pinned multi-year sheet total with registered financial years', async () => {

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -278,6 +278,7 @@ async function readCashflowActivity(db, tenantId, projectId) {
       type: 'sheet_refresh',
       source: 'google_sheet_refresh',
       actorUid: readOptionalText(run.createdBy?.uid),
+      actorName: readOptionalText(run.createdBy?.name),
       actorEmail: readOptionalText(run.createdBy?.email),
       createdAt: readOptionalText(run.completedAt) || readOptionalText(run.createdAt),
       sheetName: readOptionalText(run.response?.selectedSheetName),

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -397,7 +397,7 @@ describe('JVM weekly API BFF proxy', () => {
       cashflow_sheet_refresh_runs: [{
         id: 'refresh-1', projectId: 'project-a', idempotencyKey: 'refresh-key', status: 'COMPLETED',
         createdAt: '2026-07-01T00:00:00.000Z', completedAt: '2026-07-01T00:01:00.000Z',
-        createdBy: { uid: 'pm-1', email: 'pm@example.com' },
+        createdBy: { uid: 'pm-1', name: '변민욱(보람)', email: 'pm@example.com' },
         response: { status: 'FRESH', selectedSheetName: 'cashflow(사용내역 연동)' },
       }],
       weekly_api_audit_events: [{
@@ -424,7 +424,7 @@ describe('JVM weekly API BFF proxy', () => {
       .expect((response) => {
         expect(response.body.events).toMatchObject([
           { type: 'month_close', yearMonth: '2026-06', status: 'CLOSED' },
-          { type: 'sheet_refresh', sheetName: 'cashflow(사용내역 연동)' },
+          { type: 'sheet_refresh', sheetName: 'cashflow(사용내역 연동)', actorName: '변민욱(보람)', actorEmail: 'pm@example.com' },
         ]);
       });
   });

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -508,6 +508,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         String snapshotHash = hashCanonicalJson(snapshot);
         String previousSnapshotHash = text(current.get("snapshotHash"), "");
         boolean late = today.isAfter(targetMonth.plusMonths(1).atDay(10));
+        String versionId = projectId + "-" + request.yearMonth() + "-r" + revision;
         Map<String, Object> patch = new LinkedHashMap<>();
         patch.put("id", projectId + "-" + request.yearMonth());
         patch.put("contractVersion", CASHFLOW_MONTH_CLOSE_CONTRACT_VERSION);
@@ -521,6 +522,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         patch.put("previousSnapshot", nestedMap(current.get("snapshot")));
         patch.put("snapshotHash", snapshotHash);
         patch.put("previousSnapshotHash", previousSnapshotHash);
+        patch.put("latestVersionId", versionId);
         patch.put("late", late);
         patch.put("closedAt", now.toString());
         patch.put("closedByUid", actor.id());
@@ -530,6 +532,26 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         patch.put("createdAt", text(current.get("createdAt"), now.toString()));
         patch.put("updatedAt", now.toString());
         set(closeRef, patch);
+        Map<String, Object> version = new LinkedHashMap<>();
+        version.put("id", versionId);
+        version.put("contractVersion", CASHFLOW_MONTH_CLOSE_CONTRACT_VERSION);
+        version.put("schemaVersion", 1);
+        version.put("tenantId", actor.tenantId());
+        version.put("projectId", projectId);
+        version.put("yearMonth", request.yearMonth());
+        version.put("status", "CLOSED");
+        version.put("revision", revision);
+        version.put("reopenCount", reopenCount);
+        version.put("snapshot", snapshot);
+        version.put("snapshotHash", snapshotHash);
+        version.put("previousSnapshotHash", previousSnapshotHash);
+        version.put("sourceRevision", request.sourceRevision());
+        version.put("targetRevision", request.targetRevision());
+        version.put("late", late);
+        version.put("closedAt", now.toString());
+        version.put("closedByUid", actor.id());
+        version.put("closedByName", actor.name());
+        set(db.document(monthlyCloseVersionPath(actor.tenantId(), versionId)), version);
         submitValidatedPrivateDraft(actor, projectId, request, source, now);
         currentCashflowMonthStates.get().put(
             monthStateKey(actor.tenantId(), projectId, request.yearMonth()),
@@ -1047,6 +1069,10 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
 
     private String monthlyClosePath(String tenantId, String projectId, String yearMonth) {
         return "orgs/" + tenantId + "/monthly_closes/" + projectId + "-" + yearMonth;
+    }
+
+    private String monthlyCloseVersionPath(String tenantId, String versionId) {
+        return "orgs/" + tenantId + "/monthly_close_versions/" + versionId;
     }
 
     private String monthStateKey(String tenantId, String projectId, String yearMonth) {

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -844,6 +844,7 @@ class FirestoreCashflowLeaseGuardTest {
         ));
 
         Map<String, Object> close = fixture.documents.get(monthClosePath("project-a", "2026-06"));
+        Map<String, Object> closeVersion = fixture.documents.get(monthCloseVersionPath("project-a", "2026-06", 1));
         assertThat(response.status()).isEqualTo("CLOSED");
         assertThat(response.revision()).isEqualTo(1);
         assertThat(response.reopenCount()).isZero();
@@ -868,6 +869,12 @@ class FirestoreCashflowLeaseGuardTest {
                 "managementChecks", "managementConfirmations", "deadlineSummary",
                 "weeklyTotals", "projectionTotal", "actualTotal"
             );
+        assertThat(closeVersion)
+            .containsEntry("projectId", "project-a")
+            .containsEntry("yearMonth", "2026-06")
+            .containsEntry("revision", 1L)
+            .containsEntry("snapshotHash", response.snapshotHash())
+            .containsKeys("snapshot", "closedAt", "closedByUid");
         assertThat(response.previousSnapshot()).isEmpty();
         assertThat((List<?>) ((Map<String, Object>) close.get("snapshot")).get("depositScheduleRows"))
             .hasSize(5);
@@ -1972,6 +1979,10 @@ class FirestoreCashflowLeaseGuardTest {
 
     private static String monthClosePath(String projectId, String yearMonth) {
         return "orgs/tenant-a/monthly_closes/" + projectId + "-" + yearMonth;
+    }
+
+    private static String monthCloseVersionPath(String projectId, String yearMonth, long revision) {
+        return "orgs/tenant-a/monthly_close_versions/" + projectId + "-" + yearMonth + "-r" + revision;
     }
 
     private static Map<String, Object> closedMonth(String yearMonth, long revision, long reopenCount) {

--- a/src/app/components/cashflow/CashflowAnalyticsPage.copy.test.ts
+++ b/src/app/components/cashflow/CashflowAnalyticsPage.copy.test.ts
@@ -30,6 +30,6 @@ describe('CashflowAnalyticsPage copy', () => {
 
   it('opens the planning office project registration and approval surface', () => {
     expect(source).toContain('프로젝트 등록·승인');
-    expect(source).toContain('<ProjectMigrationAuditPage embedded defaultInboxScope="ALL" workflowStage="planning" />');
+    expect(source).toContain('<ProjectMigrationAuditPage embedded reviewStage="managementPlanning" />');
   });
 });

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -183,7 +183,8 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('[selectedYear - 1, selectedYear, selectedYear + 1]');
     expect(source).toContain('data-cashflow-block="multi-year-view"');
     expect(source).toContain("'주차값 집계'");
-    expect(source).toContain("'연간 합산값'");
+    expect(source).toContain("'일부 주차 합계'");
+    expect(source).toContain("'연간 합계'");
     expect(source).toContain('오류 없이 다음 불러오기 때 반영됩니다.');
     expect(source).toContain("start: { yearMonth: `${selectedYear}-01`, weekNo: 1 }");
     expect(source).toContain("end: { yearMonth: `${selectedYear}-12`, weekNo: 5 }");
@@ -193,7 +194,7 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('data-cashflow-annual-summary="true"');
     expect(source).toContain('`${year}-01`');
     expect(source).toContain('data-cashflow-year-view={year}');
-    expect(source).toContain('annualSourceLabel(total?.[mode]?.source)} · 보기');
+    expect(source).toContain('annualSourceLabel(total?.[mode])} · 보기');
     expect(source).not.toContain("'서버 값'");
     expect(source).not.toContain("'값 없음'");
   });

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -189,6 +189,15 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain("end: { yearMonth: `${selectedYear}-12`, weekNo: 5 }");
   });
 
+  it('places adjacent annual totals around weekly columns and lets users open each year view', () => {
+    expect(source).toContain('data-cashflow-annual-summary="true"');
+    expect(source).toContain('`${year}-01`');
+    expect(source).toContain('data-cashflow-year-view={year}');
+    expect(source).toContain('annualSourceLabel(total?.[mode]?.source)} · 보기');
+    expect(source).not.toContain("'서버 값'");
+    expect(source).not.toContain("'값 없음'");
+  });
+
   it('offers the exact three in-app exit choices and releases only on exit', () => {
     expect(source).toContain('임시저장 후 종료');
     expect(source).toContain('저장하지 않고 종료');

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -193,6 +193,13 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain("end: { yearMonth: `${selectedYear}-12`, weekNo: 5 }");
   });
 
+  it('shows who explicitly loaded the sheet values in the activity timeline', () => {
+    expect(source).toContain('`${event.actorName}님이`');
+    expect(source).toContain('`${event.actorEmail} 계정으로`');
+    expect(source).toContain('시트의 최신 값을 불러와 기준값으로 저장했습니다.');
+    expect(source).toContain('누가 언제 시트 값을 불러오고 월 결산했는지 확인할 수 있습니다.');
+  });
+
   it('places adjacent annual totals around weekly columns and lets users open each year view', () => {
     expect(source).toContain('data-cashflow-annual-summary="true"');
     expect(source).toContain('`${year}-01`');

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -179,12 +179,15 @@ describe('CashflowProjectSheet monthly close shell', () => {
   });
 
   it('keeps the detailed board on one year while showing the adjacent annual source values', () => {
+    expect(source).toContain('getCashflowSheetLabYearViewViaBff');
+    expect(source).toContain('cashflowYearView?.navigationYears');
     expect(source).toContain('cashflowSheetMirror?.sheetFacts?.annualCashflowTotals');
     expect(source).toContain('[selectedYear - 1, selectedYear, selectedYear + 1]');
     expect(source).toContain('data-cashflow-block="multi-year-view"');
     expect(source).toContain("'주차값 집계'");
     expect(source).toContain("'일부 주차 합계'");
     expect(source).toContain("'연간 합계'");
+    expect(source).toContain("'합계 불일치'");
     expect(source).toContain('오류 없이 다음 불러오기 때 반영됩니다.');
     expect(source).toContain("start: { yearMonth: `${selectedYear}-01`, weekNo: 1 }");
     expect(source).toContain("end: { yearMonth: `${selectedYear}-12`, weekNo: 5 }");

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1683,8 +1683,10 @@ export function CashflowProjectSheet({
     const adjacentYearSummaries = [selectedYear - 1, selectedYear + 1].map((year) => (
       multiYearCashflowTotals.find((item) => item.year === year) || { year, total: undefined }
     ));
-    const annualSourceLabel = (source?: 'WEEKLY' | 'ANNUAL' | 'NONE') => (
-      source === 'WEEKLY' ? '주차값 집계' : source === 'ANNUAL' ? '연간 합계' : '미입력'
+    const annualSourceLabel = (summary?: CashflowSheetLabAnnualModeTotal) => (
+      summary?.coverage?.status === 'PARTIAL'
+        ? '일부 주차 합계'
+        : summary?.source === 'WEEKLY' ? '주차값 집계' : summary?.source === 'ANNUAL' ? '연간 합계' : '미입력'
     );
     const renderAnnualSummaryCell = (input: {
       year: number;
@@ -1797,7 +1799,7 @@ export function CashflowProjectSheet({
               <th key={`annual-before-${mode}-${year}`} data-cashflow-annual-summary="true" className="min-w-[96px] border-l-[6px] border-l-white bg-amber-50 px-1 py-2 text-center align-top">
                 <button type="button" className="w-full rounded-md px-1 py-0.5 text-left hover:bg-amber-100" onClick={() => setYearMonth(`${year}-01`)}>
                   <span className="block text-[10px] font-bold text-slate-800">{year}년 합계</span>
-                  <span className="block text-[8px] font-normal text-slate-500">{annualSourceLabel(total?.[mode]?.source)} · 보기</span>
+                  <span className="block text-[8px] font-normal text-slate-500">{annualSourceLabel(total?.[mode])} · 보기</span>
                 </button>
               </th>
             ))}
@@ -1818,7 +1820,7 @@ export function CashflowProjectSheet({
               <th key={`annual-after-${mode}-${year}`} data-cashflow-annual-summary="true" className="min-w-[96px] border-l-[6px] border-l-white bg-amber-50 px-1 py-2 text-center align-top">
                 <button type="button" className="w-full rounded-md px-1 py-0.5 text-left hover:bg-amber-100" onClick={() => setYearMonth(`${year}-01`)}>
                   <span className="block text-[10px] font-bold text-slate-800">{year}년 합계</span>
-                  <span className="block text-[8px] font-normal text-slate-500">{annualSourceLabel(total?.[mode]?.source)} · 보기</span>
+                  <span className="block text-[8px] font-normal text-slate-500">{annualSourceLabel(total?.[mode])} · 보기</span>
                 </button>
               </th>
             ))}
@@ -1886,14 +1888,11 @@ export function CashflowProjectSheet({
               const projection = total?.projection;
               const actual = total?.actual;
               const hasValues = Boolean((projection?.valueCellCount || 0) + (actual?.valueCellCount || 0));
-              const sourceLabel = (source?: 'WEEKLY' | 'ANNUAL' | 'NONE') => (
-                source === 'WEEKLY' ? '주차값 집계' : source === 'ANNUAL' ? '연간 합산값' : '미입력'
-              );
               return (
                 <button type="button" key={year} data-cashflow-year-view={year} onClick={() => setYearMonth(`${year}-01`)} className={`rounded-xl border px-3 py-2 text-left shadow-sm transition-colors ${year === selectedYear ? 'border-blue-200 bg-blue-50/60' : 'border-slate-200 bg-white hover:border-blue-200 hover:bg-blue-50/40'}`}>
                   <div className="flex items-center justify-between gap-2">
                     <span className="text-[11px] font-bold text-slate-900">{year}년</span>
-                    <span className="text-[9px] font-semibold text-slate-500">{sourceLabel(projection?.source)} · 보기</span>
+                    <span className="text-[9px] font-semibold text-slate-500">{annualSourceLabel(projection)} · 보기</span>
                   </div>
                   {hasValues ? (
                     <div className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-[9px] text-slate-600">

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -56,6 +56,7 @@ import {
   refreshCashflowSheetLabMirrorViaBff,
   stageCashflowSheetLabViaBff,
   type CashflowSheetLabChangeCandidate,
+  type CashflowSheetLabAnnualModeTotal,
   type CashflowSheetLabMirrorResult,
 } from '../../lib/sheets-cashflow-readonly-client';
 import { recordDevtoolsLog } from '../../platform/devtools-transaction-log';
@@ -1679,6 +1680,33 @@ export function CashflowProjectSheet({
       projection: readServerSummary('projection'),
       actual: readServerSummary('actual'),
     };
+    const adjacentYearSummaries = [selectedYear - 1, selectedYear + 1].map((year) => (
+      multiYearCashflowTotals.find((item) => item.year === year) || { year, total: undefined }
+    ));
+    const annualSourceLabel = (source?: 'WEEKLY' | 'ANNUAL' | 'NONE') => (
+      source === 'WEEKLY' ? '주차값 집계' : source === 'ANNUAL' ? '연간 합계' : '미입력'
+    );
+    const renderAnnualSummaryCell = (input: {
+      year: number;
+      summary?: CashflowSheetLabAnnualModeTotal;
+      mode: 'projection' | 'actual';
+      lineId?: CashflowSheetLineId;
+      kind?: 'totalIn' | 'totalOut' | 'net';
+    }) => {
+      const hasValues = Boolean(input.summary?.valueCellCount);
+      const value = input.lineId
+        ? input.summary?.lineAmounts[input.lineId] || 0
+        : input.kind === 'totalIn'
+          ? input.summary?.totalIn || 0
+          : input.kind === 'totalOut'
+            ? input.summary?.totalOut || 0
+            : input.summary?.net || 0;
+      return (
+        <td key={`${input.mode}-${input.year}-${input.lineId || input.kind}`} className="min-w-[96px] border-l-[6px] border-l-white bg-amber-50/70 px-2 py-1 align-middle">
+          <div className="text-right text-[8px] font-semibold tabular-nums text-slate-800">{hasValues ? fmt(value) : '-'}</div>
+        </td>
+      );
+    };
     const scrollBoard = (direction: -1 | 1) => {
       const container = cashflowBoardScrollRef.current;
       if (!container) return;
@@ -1706,12 +1734,14 @@ export function CashflowProjectSheet({
           <td className={`sticky left-0 z-20 w-[192px] min-w-[192px] border-r-[6px] border-r-white px-3 py-1.5 text-[9px] leading-4 text-slate-900 ${rowTone === 'income' ? 'border-l-[3px] border-l-emerald-400 bg-emerald-50/80' : 'border-l-[3px] border-l-rose-400 bg-rose-50/80'} ${emphasized ? 'font-bold' : 'font-medium'}`}>
             {renderCashflowLineLabel(getCashflowModeLineLabel(lineId, mode))}
           </td>
+          {adjacentYearSummaries.map(({ year, total }) => year < selectedYear ? renderAnnualSummaryCell({ year, summary: total?.[mode], mode, lineId }) : null)}
           {visibleWeeks.map((week) => {
             const isThisWeek = todayYearMonth === week.yearMonth && todayIso >= week.weekStart && todayIso <= week.weekEnd;
             return mode === 'projection'
               ? renderProjectionCell({ targetYearMonth: week.yearMonth, weekNo: week.weekNo, lineId, isThisWeek })
               : renderActualCell({ targetYearMonth: week.yearMonth, weekNo: week.weekNo, lineId, isThisWeek });
           })}
+          {adjacentYearSummaries.map(({ year, total }) => year > selectedYear ? renderAnnualSummaryCell({ year, summary: total?.[mode], mode, lineId }) : null)}
           {renderSummaryCell({
             keyName: `${mode}-${lineId}-range`,
             value: derived[mode].rowTotals[lineId] || 0,
@@ -1735,6 +1765,7 @@ export function CashflowProjectSheet({
           <td className={`sticky left-0 z-20 w-[192px] min-w-[192px] border-r-[6px] border-r-white px-3 py-2 text-[9px] font-bold ${isIncome ? 'bg-emerald-50 text-emerald-950' : isExpense ? 'bg-rose-50 text-rose-950' : 'bg-slate-100 text-slate-950'}`}>
             {label}
           </td>
+          {adjacentYearSummaries.map(({ year, total }) => year < selectedYear ? renderAnnualSummaryCell({ year, summary: total?.[mode], mode, kind }) : null)}
           {visibleWeeks.map((week, index) => renderSummaryCell({
             keyName: `${mode}-${kind}-${week.yearMonth}-${week.weekNo}`,
             value: derived[mode].weekTotals[index]?.[kind] || 0,
@@ -1743,6 +1774,7 @@ export function CashflowProjectSheet({
             emphasis,
             rowTone,
           }))}
+          {adjacentYearSummaries.map(({ year, total }) => year > selectedYear ? renderAnnualSummaryCell({ year, summary: total?.[mode], mode, kind }) : null)}
           {renderSummaryCell({
             keyName: `${mode}-${kind}-range`,
             value: derived[mode].monthTotals[kind],
@@ -1755,34 +1787,41 @@ export function CashflowProjectSheet({
       );
     };
     const renderModeTable = (mode: 'projection' | 'actual') => (
-      <table className="w-full border-separate border-spacing-0 text-[8px]" style={{ minWidth: `${192 + visibleWeeks.length * 84 + 84}px` }}>
+      <table className="w-full border-separate border-spacing-0 text-[8px]" style={{ minWidth: `${192 + visibleWeeks.length * 84 + 84 * 3}px` }}>
         <thead className="sticky top-0 z-40 bg-white/95 text-slate-600 backdrop-blur shadow-[0_10px_24px_rgba(15,23,42,0.06)]">
           <tr>
             <th className="sticky left-0 z-50 w-[192px] min-w-[192px] border-r-[6px] border-r-white bg-white px-3 py-2 text-left text-[11px] font-bold text-slate-800">
               항목
             </th>
+            {adjacentYearSummaries.filter(({ year }) => year < selectedYear).map(({ year, total }) => (
+              <th key={`annual-before-${mode}-${year}`} data-cashflow-annual-summary="true" className="min-w-[96px] border-l-[6px] border-l-white bg-amber-50 px-1 py-2 text-center align-top">
+                <button type="button" className="w-full rounded-md px-1 py-0.5 text-left hover:bg-amber-100" onClick={() => setYearMonth(`${year}-01`)}>
+                  <span className="block text-[10px] font-bold text-slate-800">{year}년 합계</span>
+                  <span className="block text-[8px] font-normal text-slate-500">{annualSourceLabel(total?.[mode]?.source)} · 보기</span>
+                </button>
+              </th>
+            ))}
             {visibleWeeks.map((week) => {
               const saveState = weekSaveState[resolveWeekKey({ yearMonth: week.yearMonth, mode, weekNo: week.weekNo })];
               const isThisWeek = todayYearMonth === week.yearMonth && todayIso >= week.weekStart && todayIso <= week.weekEnd;
-              const hasServerValues = CASHFLOW_ALL_LINES.some((lineId) => getServerReadCell({
-                targetYearMonth: week.yearMonth,
-                mode,
-                weekNo: week.weekNo,
-                lineId,
-              }).hasValue);
               return (
                 <th key={`${mode}-${week.yearMonth}-${week.weekNo}`} data-cashflow-week-column="true" className={`min-w-[84px] border-l-[6px] border-l-white px-1 py-2 text-center align-top font-semibold ${isThisWeek ? 'bg-blue-50/90' : 'bg-slate-50/80'}`}>
                   <div className="min-h-5">
                     <span className="block truncate text-[10px] font-bold leading-5 text-slate-800">{week.label}</span>
                   </div>
                   <div className="truncate text-[8px] font-normal text-slate-400">{week.weekStart && week.weekEnd ? `${week.weekStart.slice(5)}~${week.weekEnd.slice(5)}` : '-'}</div>
-                  <Badge className={`mt-1 h-3.5 w-full justify-center rounded-full border-0 px-1 text-[7px] ${hasServerValues ? 'bg-white text-slate-700' : 'bg-rose-100 text-rose-700'}`}>
-                    {hasServerValues ? '서버 값' : '값 없음'}
-                  </Badge>
                   {saveState === 'dirty' ? <Badge className="mt-0.5 h-3.5 rounded-full border-0 bg-sky-100 px-1 text-[7px] text-sky-700">미저장</Badge> : null}
                 </th>
               );
             })}
+            {adjacentYearSummaries.filter(({ year }) => year > selectedYear).map(({ year, total }) => (
+              <th key={`annual-after-${mode}-${year}`} data-cashflow-annual-summary="true" className="min-w-[96px] border-l-[6px] border-l-white bg-amber-50 px-1 py-2 text-center align-top">
+                <button type="button" className="w-full rounded-md px-1 py-0.5 text-left hover:bg-amber-100" onClick={() => setYearMonth(`${year}-01`)}>
+                  <span className="block text-[10px] font-bold text-slate-800">{year}년 합계</span>
+                  <span className="block text-[8px] font-normal text-slate-500">{annualSourceLabel(total?.[mode]?.source)} · 보기</span>
+                </button>
+              </th>
+            ))}
             <th className="sticky right-0 z-50 min-w-[84px] border-l-[6px] border-l-white bg-white px-1 py-2 text-left text-[11px] font-bold text-slate-800 shadow-[-12px_0_24px_rgba(15,23,42,0.08)]">
               범위 합계
             </th>
@@ -1851,10 +1890,10 @@ export function CashflowProjectSheet({
                 source === 'WEEKLY' ? '주차값 집계' : source === 'ANNUAL' ? '연간 합산값' : '미입력'
               );
               return (
-                <div key={year} className={`rounded-xl border px-3 py-2 shadow-sm ${year === selectedYear ? 'border-blue-200 bg-blue-50/60' : 'border-slate-200 bg-white'}`}>
+                <button type="button" key={year} data-cashflow-year-view={year} onClick={() => setYearMonth(`${year}-01`)} className={`rounded-xl border px-3 py-2 text-left shadow-sm transition-colors ${year === selectedYear ? 'border-blue-200 bg-blue-50/60' : 'border-slate-200 bg-white hover:border-blue-200 hover:bg-blue-50/40'}`}>
                   <div className="flex items-center justify-between gap-2">
                     <span className="text-[11px] font-bold text-slate-900">{year}년</span>
-                    <span className="text-[9px] font-semibold text-slate-500">{sourceLabel(projection?.source)}</span>
+                    <span className="text-[9px] font-semibold text-slate-500">{sourceLabel(projection?.source)} · 보기</span>
                   </div>
                   {hasValues ? (
                     <div className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-[9px] text-slate-600">
@@ -1865,7 +1904,7 @@ export function CashflowProjectSheet({
                   ) : (
                     <p className="mt-2 text-[9px] leading-4 text-slate-500">시트에 입력된 값이 없습니다. 오류 없이 다음 불러오기 때 반영됩니다.</p>
                   )}
-                </div>
+                </button>
               );
             })}
           </div>

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { collection, doc, getDoc, getDocs, limit, query, where } from 'firebase/firestore';
 import { ArrowDownToLine, CheckCircle2, ChevronLeft, ChevronRight, ClipboardCheck, ClipboardList, Columns2, FileSpreadsheet, Loader2, RefreshCw, Save } from 'lucide-react';
 import { toast } from 'sonner';
 import { useBlocker, useNavigate } from 'react-router';
@@ -22,7 +21,6 @@ import { useCashflowWeeks } from '../../data/cashflow-weeks-store';
 import {
   CASHFLOW_SHEET_LINE_LABELS,
   type CashflowSheetLineId,
-  type CashflowWeekSheet,
   type UserRole,
 } from '../../data/types';
 import { getSeoulTodayIso } from '../../platform/business-days';
@@ -31,7 +29,7 @@ import { getMonthMondayWeeks, getYearMondayWeeks, type MonthMondayWeek } from '.
 import { useAuth } from '../../data/auth-store';
 import { hasUnsavedChanges } from './cashflow-unsaved';
 import { useFirebase } from '../../lib/firebase-context';
-import { getAuthInstance, getOrgCollectionPath, getOrgDocumentPath } from '../../lib/firebase';
+import { getAuthInstance } from '../../lib/firebase';
 import { resolveApiErrorMessage } from '../../platform/api-error-message';
 import {
   fetchCashflowSnapshotViaBff,
@@ -53,13 +51,16 @@ import type { CashflowOpsTone } from './cashflow-ops-summary';
 import {
   applyCashflowSheetLabViaBff,
   getCashflowSheetLabMirrorViaBff,
+  getCashflowSheetLabShareAccountViaBff,
+  getCashflowSheetLabYearViewViaBff,
   refreshCashflowSheetLabMirrorViaBff,
   stageCashflowSheetLabViaBff,
   type CashflowSheetLabChangeCandidate,
   type CashflowSheetLabAnnualModeTotal,
   type CashflowSheetLabMirrorResult,
+  type CashflowSheetLabShareAccountResult,
+  type CashflowSheetLabYearViewResult,
 } from '../../lib/sheets-cashflow-readonly-client';
-import { recordDevtoolsLog } from '../../platform/devtools-transaction-log';
 import { EditLeaseDialogs } from '../editing/EditLeaseDialogs';
 import { useCashflowEditLease } from './useCashflowEditLease';
 import { createCashflowPrivateDraftClient } from '../../lib/cashflow-private-draft-client';
@@ -180,27 +181,6 @@ function renderCashflowLineLabel(label: string): ReactNode {
   );
 }
 
-function pad2(value: number): string {
-  return String(value).padStart(2, '0');
-}
-
-function parseCashflowSheetWeekLabel(value: unknown): { year: number; month: number; yearMonth: string; weekNo: number; sortKey: number } | null {
-  const match = /^(\d{2})-(\d{1,2})-(\d{1,2})$/.exec(String(value || '').trim());
-  if (!match) return null;
-  const year = 2000 + Number.parseInt(match[1], 10);
-  const month = Number.parseInt(match[2], 10);
-  const weekNo = Number.parseInt(match[3], 10);
-  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(weekNo)) return null;
-  if (month < 1 || month > 12 || weekNo < 1 || weekNo > 5) return null;
-  return {
-    year,
-    month,
-    yearMonth: `${year}-${pad2(month)}`,
-    weekNo,
-    sortKey: year * 10000 + month * 100 + weekNo,
-  };
-}
-
 function isBffAuthRejection(error: unknown): boolean {
   const source = error as { status?: number; body?: { code?: string; error?: string } };
   const code = source.body?.code || source.body?.error || '';
@@ -230,7 +210,7 @@ export function CashflowProjectSheet({
   }) => Promise<void>;
 }) {
   const { user } = useAuth();
-  const { db, orgId } = useFirebase();
+  const { orgId } = useFirebase();
   const navigate = useNavigate();
   const role = (roleOverride || user?.role || '').toString().toLowerCase() as UserRole | '';
   const isPm = role === 'pm';
@@ -282,14 +262,8 @@ export function CashflowProjectSheet({
   const {
     yearMonth,
     setYearMonth,
-    weeks,
-    isLoading,
   } = useCashflowWeeks();
 
-  const [cashflowSheetRange, setCashflowSheetRange] = useState<{
-    startWeek: string;
-    endWeek: string;
-  } | null>(null);
   const [cashflowSheetConfig, setCashflowSheetConfig] = useState<{
     value?: string;
     sheetName?: string;
@@ -304,11 +278,11 @@ export function CashflowProjectSheet({
     lastActualLineCount?: number;
   } | null>(null);
   const [cashflowSheetConfigLoaded, setCashflowSheetConfigLoaded] = useState(false);
-  const [rangeLoadedWeeks, setRangeLoadedWeeks] = useState<CashflowWeekSheet[]>([]);
   const [cashflowSnapshot, setCashflowSnapshot] = useState<CashflowSnapshotResult | null>(null);
   const [cashflowComparisonLoading, setCashflowComparisonLoading] = useState(false);
   const [cashflowComparisonError, setCashflowComparisonError] = useState<string | null>(null);
   const [cashflowSheetMirror, setCashflowSheetMirror] = useState<CashflowSheetLabMirrorResult | null>(null);
+  const [cashflowYearView, setCashflowYearView] = useState<CashflowSheetLabYearViewResult | null>(null);
   const [monthCloseResult, setMonthCloseResult] = useState<CashflowMonthCloseResult | null>(null);
   const [monthCloseLoading, setMonthCloseLoading] = useState(false);
   const [monthCloseError, setMonthCloseError] = useState<string | null>(null);
@@ -358,39 +332,10 @@ export function CashflowProjectSheet({
     };
   }, [selectedYear]);
   const yearWeeks = useMemo(() => getYearMondayWeeks(selectedYear), [selectedYear]);
-  const allProjectCashflowWeeks = useMemo(() => {
-    const byKey = new Map<string, CashflowWeekSheet>();
-    for (const week of [...weeks, ...rangeLoadedWeeks]) {
-      if (week.projectId !== projectId) continue;
-      byKey.set(`${week.yearMonth}:${week.weekNo}`, week);
-    }
-    return Array.from(byKey.values());
-  }, [projectId, rangeLoadedWeeks, weeks]);
-  const annualWeeks = useMemo<MonthMondayWeek[]>(() => {
-    const byKey = new Map<string, MonthMondayWeek>();
-    for (const week of yearWeeks) {
-      byKey.set(`${week.yearMonth}:${week.weekNo}`, hydrateWeekDates(week));
-    }
-    for (const week of allProjectCashflowWeeks) {
-      if (week.projectId !== projectId) continue;
-      const weekNo = Number(week.weekNo);
-      if (!Number.isFinite(weekNo)) continue;
-      if (!week.yearMonth?.startsWith(`${selectedYear}-`)) {
-        continue;
-      }
-      const key = `${week.yearMonth}:${weekNo}`;
-      if (byKey.has(key)) continue;
-      byKey.set(key, hydrateWeekDates({
-        yearMonth: week.yearMonth,
-        weekNo,
-        weekStart: week.weekStart || '',
-        weekEnd: week.weekEnd || '',
-        label: formatSheetWeekLabel(week.yearMonth, weekNo),
-      }));
-    }
-    return Array.from(byKey.values())
-      .sort((a, b) => a.yearMonth.localeCompare(b.yearMonth) || a.weekNo - b.weekNo);
-  }, [allProjectCashflowWeeks, projectId, selectedYear, yearWeeks]);
+  const annualWeeks = useMemo<MonthMondayWeek[]>(
+    () => yearWeeks.map(hydrateWeekDates),
+    [yearWeeks],
+  );
   const [showEmptyCashflowRows, setShowEmptyCashflowRows] = useState(false);
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [editingWeekModes, setEditingWeekModes] = useState<Record<string, boolean>>({});
@@ -603,89 +548,38 @@ export function CashflowProjectSheet({
   }, [blocker, cashflowLease.release]);
 
   useEffect(() => {
-    setCashflowSheetConfigLoaded(false);
-    setCashflowSheetRange(null);
-    setCashflowSheetConfig(null);
-    if (!db || !projectId) {
-      setCashflowSheetConfigLoaded(true);
-      return;
-    }
-    const documentPath = getOrgDocumentPath(orgId, 'projects', projectId);
     let cancelled = false;
-    getDoc(doc(db, documentPath))
-      .then((snap) => {
-        if (cancelled) return;
-        const config = snap.exists()
-          ? (snap.data() as { cashflowSheetLab?: { value?: string; sheetName?: string; spreadsheetId?: string; spreadsheetTitle?: string; startWeek?: string; endWeek?: string; lastAppliedAt?: string; lastAppliedBy?: { uid?: string; email?: string; role?: string } | null; lastAppliedLineCount?: number; lastProjectionLineCount?: number; lastActualLineCount?: number } }).cashflowSheetLab
-          : null;
-        recordDevtoolsLog({
-          kind: 'cashflow_transaction',
-          phase: 'info',
-          operation: 'cashflow.sheet_config.dashboard.read',
-          transport: 'firestore',
-          projectId,
-          summary: {
-            orgId,
-            documentPath,
-            projectExists: snap.exists(),
-            hasCashflowSheetLab: Boolean(config),
-            hasValue: Boolean(config?.value),
-            spreadsheetId: config?.spreadsheetId || null,
-            spreadsheetTitle: config?.spreadsheetTitle || null,
-            sheetName: config?.sheetName || null,
-            startWeek: config?.startWeek || null,
-            endWeek: config?.endWeek || null,
-            updatedAt: (config as { updatedAt?: string } | null)?.updatedAt || null,
-            lastAppliedAt: config?.lastAppliedAt || null,
-          },
-        });
-        setCashflowSheetConfig(config?.value ? {
-          value: config.value,
-          sheetName: config.sheetName,
-          spreadsheetId: config.spreadsheetId,
-          spreadsheetTitle: config.spreadsheetTitle,
-          startWeek: config.startWeek,
-          endWeek: config.endWeek,
-          lastAppliedAt: config.lastAppliedAt,
-          lastAppliedBy: config.lastAppliedBy,
-          lastAppliedLineCount: config.lastAppliedLineCount,
-          lastProjectionLineCount: config.lastProjectionLineCount,
-          lastActualLineCount: config.lastActualLineCount,
-        } : null);
-        const start = parseCashflowSheetWeekLabel(config?.startWeek);
-        const end = parseCashflowSheetWeekLabel(config?.endWeek);
-        if (!start || !end || start.sortKey > end.sortKey) {
-          setCashflowSheetRange(null);
-          return;
+    setCashflowSheetConfigLoaded(false);
+    setCashflowSheetConfig(null);
+    if (!projectId || !orgId || !user?.uid) {
+      setCashflowSheetConfigLoaded(true);
+      return () => { cancelled = true; };
+    }
+    const loadConfig = async (): Promise<void> => {
+      try {
+        let actor = await resolveBffActor();
+        if (!actor?.idToken) return;
+        let response: CashflowSheetLabShareAccountResult;
+        try {
+          response = await getCashflowSheetLabShareAccountViaBff({ tenantId: orgId, actor, projectId });
+        } catch (error) {
+          if (!isBffAuthRejection(error)) throw error;
+          actor = await resolveBffActor({ forceRefresh: true });
+          if (!actor?.idToken) throw error;
+          response = await getCashflowSheetLabShareAccountViaBff({ tenantId: orgId, actor, projectId });
         }
-        setCashflowSheetRange({
-          startWeek: config?.startWeek || '',
-          endWeek: config?.endWeek || '',
-        });
-      })
-      .catch(() => {
-        if (cancelled) return;
-        recordDevtoolsLog({
-          kind: 'cashflow_transaction',
-          phase: 'error',
-          operation: 'cashflow.sheet_config.dashboard.read.error',
-          transport: 'firestore',
-          projectId,
-          summary: {
-            orgId,
-            documentPath,
-          },
-        });
-        setCashflowSheetRange(null);
-        setCashflowSheetConfig(null);
-      })
-      .finally(() => {
+        if (!cancelled) setCashflowSheetConfig(response.config?.value ? response.config : null);
+      } catch {
+        if (!cancelled) setCashflowSheetConfig(null);
+      } finally {
         if (!cancelled) setCashflowSheetConfigLoaded(true);
-      });
+      }
+    };
+    void loadConfig();
     return () => {
       cancelled = true;
     };
-  }, [db, orgId, projectId]);
+  }, [orgId, projectId, resolveBffActor, user?.uid]);
 
   useEffect(() => {
     if (!cashflowSheetConfigLoaded || cashflowSheetConfig || !projectId || typeof window === 'undefined') return;
@@ -728,6 +622,33 @@ export function CashflowProjectSheet({
     void loadPinnedMirror();
     return () => { cancelled = true; };
   }, [orgId, projectId, resolveBffActor, user?.uid]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setCashflowYearView(null);
+    if (!cashflowSheetMirror || !projectId || !orgId || !user?.uid) return () => { cancelled = true; };
+
+    const loadYearView = async (): Promise<void> => {
+      try {
+        let actor = await resolveBffActor();
+        if (!actor?.idToken) return;
+        try {
+          const result = await getCashflowSheetLabYearViewViaBff({ tenantId: orgId, actor, projectId, selectedYear });
+          if (!cancelled) setCashflowYearView(result);
+        } catch (error) {
+          if (!isBffAuthRejection(error)) throw error;
+          actor = await resolveBffActor({ forceRefresh: true });
+          if (!actor?.idToken) throw error;
+          const result = await getCashflowSheetLabYearViewViaBff({ tenantId: orgId, actor, projectId, selectedYear });
+          if (!cancelled) setCashflowYearView(result);
+        }
+      } catch {
+        if (!cancelled) setCashflowYearView(null);
+      }
+    };
+    void loadYearView();
+    return () => { cancelled = true; };
+  }, [cashflowSheetMirror, orgId, projectId, resolveBffActor, selectedYear, user?.uid]);
 
   const loadCashflowComparison = useCallback(async (): Promise<void> => {
     if (!projectId || !orgId || !user?.uid) {
@@ -810,36 +731,6 @@ export function CashflowProjectSheet({
   useEffect(() => {
     void loadCashflowMonthClose();
   }, [loadCashflowMonthClose]);
-
-  const loadCashflowSheetRangeWeeks = useCallback(async (): Promise<void> => {
-    if (!db || !cashflowSheetRange) {
-      setRangeLoadedWeeks([]);
-      return;
-    }
-    const base = collection(db, getOrgCollectionPath(orgId, 'cashflowWeeks'));
-    const q = query(
-      base,
-      where('yearMonth', '>=', `${selectedYear}-01`),
-      where('yearMonth', '<=', `${selectedYear}-12`),
-      limit(5000),
-    );
-    const snap = await getDocs(q);
-    setRangeLoadedWeeks(
-      snap.docs
-        .map((d) => d.data() as CashflowWeekSheet)
-        .filter((week) => week.projectId === projectId),
-    );
-  }, [cashflowSheetRange, db, orgId, projectId, selectedYear]);
-
-  useEffect(() => {
-    let cancelled = false;
-    loadCashflowSheetRangeWeeks().catch(() => {
-      if (!cancelled) setRangeLoadedWeeks([]);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [loadCashflowSheetRangeWeeks]);
 
   const loadCashflowEvents = useCallback(async (): Promise<void> => {
     if (!projectId || !orgId || !user?.uid) {
@@ -1016,7 +907,6 @@ export function CashflowProjectSheet({
       await Promise.all([
         loadCashflowComparison(),
         loadCashflowEvents(),
-        loadCashflowSheetRangeWeeks(),
       ]);
       toast.success(`${yearMonth} 월 결산을 완료했습니다. 이제 수정할 수 없습니다.`);
     } catch (error) {
@@ -1034,7 +924,6 @@ export function CashflowProjectSheet({
     loadCashflowComparison,
     loadCashflowEvents,
     loadCashflowMonthClose,
-    loadCashflowSheetRangeWeeks,
     monthCloseDecisions,
     monthCloseDepositRows,
     managementDecisions,
@@ -1261,7 +1150,6 @@ export function CashflowProjectSheet({
     };
     const rememberApplyResult = async (result: Awaited<ReturnType<typeof apply>>) => {
       await Promise.all([
-        loadCashflowSheetRangeWeeks(),
         loadCashflowEvents(),
         loadCashflowComparison(),
       ]);
@@ -1311,7 +1199,7 @@ export function CashflowProjectSheet({
     } finally {
       setSheetStageApplyLoading(false);
     }
-  }, [cashflowLease.checkBeforeMutation, cashflowLease.checkStatus, cashflowPrivateDraftClient, loadCashflowComparison, loadCashflowEvents, loadCashflowSheetRangeWeeks, orgId, privateDraftRevision, projectId, resolveBffActor, sheetStageDialog]);
+  }, [cashflowLease.checkBeforeMutation, cashflowLease.checkStatus, cashflowPrivateDraftClient, loadCashflowComparison, loadCashflowEvents, orgId, privateDraftRevision, projectId, resolveBffActor, sheetStageDialog]);
 
   const handleOpenSheetReviewDialog = useCallback(() => {
     if (cashflowSheetMirror?.status !== 'FRESH' || !cashflowSheetMirror.sourceRevision) {
@@ -1410,13 +1298,18 @@ export function CashflowProjectSheet({
 
   const cashflowTotalPeriodLabel = `${selectedYear}년`;
   const multiYearCashflowTotals = useMemo(() => {
-    const totalsByYear = new Map((cashflowSheetMirror?.sheetFacts?.annualCashflowTotals || [])
+    const totalsByYear = new Map((cashflowYearView?.years?.length
+      ? cashflowYearView.years
+      : cashflowSheetMirror?.sheetFacts?.annualCashflowTotals || [])
       .map((total) => [total.year, total]));
-    return [selectedYear - 1, selectedYear, selectedYear + 1].map((year) => ({
+    const navigationYears = cashflowYearView?.navigationYears?.length === 3
+      ? cashflowYearView.navigationYears
+      : [selectedYear - 1, selectedYear, selectedYear + 1];
+    return navigationYears.map((year) => ({
       year,
       total: totalsByYear.get(year),
     }));
-  }, [cashflowSheetMirror?.sheetFacts?.annualCashflowTotals, selectedYear]);
+  }, [cashflowSheetMirror?.sheetFacts?.annualCashflowTotals, cashflowYearView, selectedYear]);
   const sheetRangeLabel = cashflowSheetConfig
     ? `${cashflowSheetConfig.sheetName || '시트 탭'} · ${cashflowSheetConfig.startWeek || '전체'} ~ ${cashflowSheetConfig.endWeek || '전체'}`
     : '연결된 Google Sheet가 없습니다.';
@@ -1684,7 +1577,9 @@ export function CashflowProjectSheet({
       multiYearCashflowTotals.find((item) => item.year === year) || { year, total: undefined }
     ));
     const annualSourceLabel = (summary?: CashflowSheetLabAnnualModeTotal) => (
-      summary?.coverage?.status === 'PARTIAL'
+      summary?.reconciliation?.status === 'MISMATCH'
+        ? '합계 불일치'
+        : summary?.coverage?.status === 'PARTIAL'
         ? '일부 주차 합계'
         : summary?.source === 'WEEKLY' ? '주차값 집계' : summary?.source === 'ANNUAL' ? '연간 합계' : '미입력'
     );
@@ -1957,7 +1852,7 @@ export function CashflowProjectSheet({
               </section>
             </div>
           </div>
-          {isLoading ? <div className="px-3 py-2 text-[11px] text-slate-500">불러오는 중...</div> : null}
+          {cashflowComparisonLoading ? <div className="px-3 py-2 text-[11px] text-slate-500">불러오는 중...</div> : null}
         </CardContent>
       </Card>
     );

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -2236,7 +2236,13 @@ export function CashflowProjectSheet({
   }
 
   function cashflowEventDetail(event: CashflowEvent): string {
-    if (event.type === 'sheet_refresh') return [event.sheetName, '시트값을 고정했습니다.'].filter(Boolean).join(' · ');
+    if (event.type === 'sheet_refresh') {
+      const actor = event.actorName
+        ? `${event.actorName}님이`
+        : event.actorEmail ? `${event.actorEmail} 계정으로` : '담당자가';
+      const action = `${actor} 시트의 최신 값을 불러와 기준값으로 저장했습니다.`;
+      return [event.sheetName, action].filter(Boolean).join(' · ');
+    }
     if (event.type === 'sheet_apply') {
       return `Google Sheet 반영 ${event.appliedLineCount || 0}건 · Projection ${event.projectionLineCount || 0}건 · Actual ${event.actualLineCount || 0}건`;
     }
@@ -2380,7 +2386,7 @@ export function CashflowProjectSheet({
           <div className="flex items-start justify-between gap-2 pb-3">
             <div>
               <div className="text-[15px] font-bold tracking-[-0.01em] text-slate-950">변경 이력</div>
-              <div className="text-[10px] text-slate-500">명시적 시트 불러오기와 월 결산 이력입니다.</div>
+              <div className="text-[10px] text-slate-500">누가 언제 시트 값을 불러오고 월 결산했는지 확인할 수 있습니다.</div>
             </div>
             <div className="flex shrink-0 flex-wrap justify-end gap-1">
               {countBadges.map((badge) => (
@@ -2404,7 +2410,7 @@ export function CashflowProjectSheet({
               <div className="px-2 py-8 text-center text-[10px] leading-4 text-slate-500">
                 아직 표시할 변경 기록이 없습니다.
                 <br />
-                시트값 불러오기와 월 결산 이력이 여기에 기록됩니다.
+                시트 값을 불러오거나 월 결산하면 담당자와 시간이 여기에 남습니다.
               </div>
             ) : cashflowEvents.map((event, index) => {
               const canRevert = event.type === 'sheet_apply'

--- a/src/app/lib/sheets-cashflow-readonly-client.test.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.test.ts
@@ -6,6 +6,7 @@ import {
   extractSpreadsheetIdFromSheetInput,
   getCashflowSheetLabMirrorViaBff,
   getCashflowSheetLabShareAccountViaBff,
+  getCashflowSheetLabYearViewViaBff,
   refreshCashflowSheetLabMirrorViaBff,
   saveCashflowSheetLabConfigViaBff,
   stageCashflowSheetLabViaBff,
@@ -196,6 +197,38 @@ describe('sheets cashflow readonly client', () => {
       expect.objectContaining({ tenantId: 'mysc' }),
     );
     expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('reads the server-owned annual view for the selected year', async () => {
+    const client = asMockClient({
+      get: vi.fn(async () => ({
+        data: {
+          projectId: 'p001',
+          status: 'FRESH',
+          selectedYear: 2026,
+          availableYears: [2025, 2026, 2027],
+          navigationYears: [2025, 2026, 2027],
+          years: [],
+          readModelStatus: 'CURRENT',
+          fallbackYears: [],
+          mismatchYears: [],
+        },
+      })),
+    });
+
+    const result = await getCashflowSheetLabYearViewViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'user-1', role: 'workspace_user', email: 'user@mysc.co.kr' },
+      projectId: 'p001',
+      selectedYear: 2026,
+      client,
+    });
+
+    expect(result.navigationYears).toEqual([2025, 2026, 2027]);
+    expect(client.get).toHaveBeenCalledWith(
+      '/api/v1/projects/p001/cashflow-sheet-lab/years?selectedYear=2026',
+      expect.objectContaining({ tenantId: 'mysc' }),
+    );
   });
 
   it('refreshes the mirror only on an explicit request and retains a stale last-good snapshot', async () => {

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -319,6 +319,13 @@ export interface CashflowSheetLabMirrorResult {
 
 export interface CashflowSheetLabAnnualModeTotal {
   source: 'WEEKLY' | 'ANNUAL' | 'NONE';
+  coverage: {
+    status: 'COMPLETE' | 'PARTIAL' | 'ANNUAL_ONLY' | 'NONE';
+    weekCount: number;
+    expectedWeekCount: number;
+    monthCount: number;
+    expectedMonthCount: number;
+  };
   valueCellCount: number;
   emptyCellCount: number;
   invalidCellCount: number;

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -333,6 +333,32 @@ export interface CashflowSheetLabAnnualModeTotal {
   totalIn: number;
   totalOut: number;
   net: number;
+  reconciliation: {
+    status: 'NOT_APPLICABLE' | 'PARTIAL_WEEKLY' | 'MATCH' | 'MISMATCH';
+    mismatchedLineIds: string[];
+  };
+}
+
+export interface CashflowSheetLabYearViewResult {
+  projectId: string;
+  status: 'EMPTY' | 'FRESH' | 'STALE';
+  selectedYear: number;
+  availableYears: number[];
+  navigationYears: number[];
+  snapshotId?: string;
+  sourceRevision?: string;
+  capturedAt?: string;
+  years: Array<{
+    year: number;
+    projection: CashflowSheetLabAnnualModeTotal;
+    actual: CashflowSheetLabAnnualModeTotal;
+    sourceRevision: string;
+    capturedAt?: string;
+    storage: 'SNAPSHOT' | 'MIRROR_FALLBACK';
+  }>;
+  readModelStatus: 'EMPTY' | 'CURRENT' | 'FALLBACK' | 'MISMATCH';
+  fallbackYears: number[];
+  mismatchYears: number[];
 }
 
 export interface CashflowSheetLabStageResult {
@@ -518,6 +544,26 @@ export async function getCashflowSheetLabMirrorViaBff(params: {
   const apiClient = params.client || createSameOriginBffClient();
   const response = await apiClient.get<CashflowSheetLabMirrorResult>(
     `/api/v1/projects/${encodeURIComponent(params.projectId)}/cashflow-sheet-lab/mirror`,
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      timeoutMs: 15000,
+      retries: 0,
+    },
+  );
+  return response.data;
+}
+
+export async function getCashflowSheetLabYearViewViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectId: string;
+  selectedYear: number;
+  client?: PlatformApiClientLike;
+}): Promise<CashflowSheetLabYearViewResult> {
+  const apiClient = params.client || createSameOriginBffClient();
+  const response = await apiClient.get<CashflowSheetLabYearViewResult>(
+    `/api/v1/projects/${encodeURIComponent(params.projectId)}/cashflow-sheet-lab/years?selectedYear=${params.selectedYear}`,
     {
       tenantId: params.tenantId,
       actor: toRequestActor(params.actor),

--- a/src/app/platform/firestore-rules-policy.test.ts
+++ b/src/app/platform/firestore-rules-policy.test.ts
@@ -198,11 +198,17 @@ describe('firestore rules policy alignment', () => {
       'cashflowEditLocks',
       'cashflow_edit_locks',
       'cashflow_sheet_mirrors',
+      'cashflow_sheet_snapshots',
+      'cashflow_sheet_snapshot_months',
+      'cashflow_sheet_snapshot_years',
+      'cashflow_sheet_week_values',
+      'cashflow_sheet_year_totals',
       'cashflow_sheet_refresh_runs',
       'cashflow_sheet_stage_runs',
       'cashflow_sheet_stage_months',
       'cashflow_change_candidates',
       'monthly_closes',
+      'monthly_close_versions',
     ]) {
       expect(firestoreRulesText).toContain(`collection in ['${collection}']`);
       expect(firestoreRulesText).toMatch(

--- a/src/app/platform/project-terminology.shell.test.ts
+++ b/src/app/platform/project-terminology.shell.test.ts
@@ -122,7 +122,7 @@ describe('project terminology contract', () => {
     [
       '프로젝트 등록 요청',
       '프로젝트 등록 검토',
-      'PM 등록 프로젝트 승인',
+      'PM 등록 프로젝트 검토',
       'CIC 대표 검토',
       '프로젝트명',
       '계약 대상',


### PR DESCRIPTION
## Summary
- replace weekly server-value badges with adjacent annual sheet summary columns
- render the detailed table as previous-year total, selected-year weeks, next-year total, and range total
- make 25/26/27 year summaries open the selected year view

## Validation
- npm test -- --run src/app/components/cashflow/CashflowProjectSheet.shell.test.ts --reporter=dot
- npm run build