### PR TITLE
fix: separate cashflow annual totals

### DIFF
--- a/server/bff/cashflow-sheet-snapshot.test.mjs
+++ b/server/bff/cashflow-sheet-snapshot.test.mjs
@@ -275,6 +275,18 @@ describe('cashflow sheet pinned snapshot', () => {
     ]);
   });
 
+  it('keeps the workbook 2,300,000 won prepayment separate by mode', () => {
+    const facts = extractCashflowSheetFacts({
+      cells: [
+        { mode: 'projection', yearMonth: '2026-01', weekNo: 3, lineId: 'MYSC_PREPAY_IN', direction: 'IN', state: 'VALUE', amount: 2_300_000 },
+        { mode: 'actual', yearMonth: '2026-01', weekNo: 3, lineId: 'MYSC_PREPAY_IN', direction: 'IN', state: 'VALUE', amount: 2_300_000 },
+      ],
+    });
+
+    expect(facts.annualCashflowTotals[0].projection.totalIn).toBe(2_300_000);
+    expect(facts.annualCashflowTotals[0].actual.totalIn).toBe(2_300_000);
+  });
+
   it('keeps annual-only values distinct from weekly coverage', () => {
     const facts = extractCashflowSheetFacts({
       annualCells: [

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -151,7 +151,7 @@ async function readCashflowSheetYearView({ db, tenantId, projectId, project, sel
     .map((row) => [row.year, row]));
   const snapshotEnabled = /^cfsnap_[a-f0-9]{32}$/.test(snapshotId);
   const snapshotDocs = snapshotEnabled
-    ? await Promise.all(availableYears.map(async (year) => {
+    ? await Promise.all(navigationYears.map(async (year) => {
       const snap = await db.doc(cashflowSheetSnapshotYearDocPath(tenantId, snapshotId, year)).get();
       return [year, snap.exists ? snap.data() || {} : null];
     }))
@@ -159,7 +159,7 @@ async function readCashflowSheetYearView({ db, tenantId, projectId, project, sel
   const snapshotTotals = new Map(snapshotDocs);
   const fallbackYears = [];
   const mismatchYears = [];
-  const years = availableYears.flatMap((year) => {
+  const years = navigationYears.flatMap((year) => {
     const mirrorTotal = mirrorTotals.get(year);
     const snapshotTotal = snapshotTotals.get(year);
     const snapshotCurrent = snapshotTotal

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -333,7 +333,7 @@ describe('cashflow sheet lab route', () => {
       fallbackYears: [],
       mismatchYears: [],
     });
-    expect(yearView.body.years).toHaveLength(4);
+    expect(yearView.body.years.map((row) => row.year)).toEqual([2025, 2026, 2027]);
     expect(yearView.body.years.every((row) => row.storage === 'SNAPSHOT')).toBe(true);
   });
 

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -193,6 +193,14 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain("end: { yearMonth: `${selectedYear}-12`, weekNo: 5 }");
   });
 
+  it('keeps Projection and Actual annual cash totals separate', () => {
+    expect(source).toContain('Projection 입금 / 출금');
+    expect(source).toContain('Actual 입금 / 출금');
+    expect(source).toContain('fmt(projection?.totalIn || 0)');
+    expect(source).toContain('fmt(actual?.totalIn || 0)');
+    expect(source).not.toContain('(projection?.totalIn || 0) + (actual?.totalIn || 0)');
+  });
+
   it('shows who explicitly loaded the sheet values in the activity timeline', () => {
     expect(source).toContain('`${event.actorName}님이`');
     expect(source).toContain('`${event.actorEmail} 계정으로`');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1787,13 +1787,14 @@ export function CashflowProjectSheet({
                 <button type="button" key={year} data-cashflow-year-view={year} onClick={() => setYearMonth(`${year}-01`)} className={`rounded-xl border px-3 py-2 text-left shadow-sm transition-colors ${year === selectedYear ? 'border-blue-200 bg-blue-50/60' : 'border-slate-200 bg-white hover:border-blue-200 hover:bg-blue-50/40'}`}>
                   <div className="flex items-center justify-between gap-2">
                     <span className="text-[11px] font-bold text-slate-900">{year}년</span>
-                    <span className="text-[9px] font-semibold text-slate-500">{annualSourceLabel(projection)} · 보기</span>
+                    <span className="text-[9px] font-semibold text-slate-500">{annualSourceLabel(projection)} · 시트 기준 · 보기</span>
                   </div>
                   {hasValues ? (
                     <div className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-[9px] text-slate-600">
                       <span>Projection 잔액</span><span className="text-right font-semibold tabular-nums text-slate-900">{fmt(projection?.net || 0)}</span>
                       <span>Actual 잔액</span><span className="text-right font-semibold tabular-nums text-slate-900">{fmt(actual?.net || 0)}</span>
-                      <span>입금 / 출금</span><span className="text-right tabular-nums">{fmt((projection?.totalIn || 0) + (actual?.totalIn || 0))} / {fmt((projection?.totalOut || 0) + (actual?.totalOut || 0))}</span>
+                      <span>Projection 입금 / 출금</span><span className="text-right tabular-nums">{fmt(projection?.totalIn || 0)} / {fmt(projection?.totalOut || 0)}</span>
+                      <span>Actual 입금 / 출금</span><span className="text-right tabular-nums">{fmt(actual?.totalIn || 0)} / {fmt(actual?.totalOut || 0)}</span>
                     </div>
                   ) : (
                     <p className="mt-2 text-[9px] leading-4 text-slate-500">시트에 입력된 값이 없습니다. 오류 없이 다음 불러오기 때 반영됩니다.</p>


### PR DESCRIPTION
## 변경 사항
- 연도 카드에서 Projection/Actual 입출금 합계를 분리해 이중 합산 제거
- 연도 카드가 시트 기준 값임을 명시
- 연도 조회를 선택 연도 ±1년으로 제한

## 검증
- 관련 테스트 91개 통과
- npm run build 통과