### PR TITLE
fix: stabilize cashflow dashboard loading

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -483,8 +483,8 @@ function canonicalCashflowCellStates(cells, yearMonth, pinnedSheetCells) {
   return byKey;
 }
 
-function managementCheck(id, status, title, detail) {
-  return { id, status, title, detail };
+function managementCheck(id, status, title, detail, findings = []) {
+  return findings.length > 0 ? { id, status, title, detail, findings } : { id, status, title, detail };
 }
 
 function laborTransferCheck(weeks, cellStates, yearMonth, asOfKey) {
@@ -521,6 +521,7 @@ function laborTransferCheck(weeks, cellStates, yearMonth, asOfKey) {
     warnings.length > 0 ? 'WARNING' : reviews.length > 0 ? 'REVIEW_REQUIRED' : 'OK',
     'MYSC 인건비 이관',
     findings.length > 0 ? findings.join(', ') : '기준일까지 모든 3주차 인건비 이관을 확인했습니다.',
+    findings,
   );
 }
 
@@ -558,25 +559,31 @@ function profitVatAfterDepositCheck(weeks, deposits, asOfKey) {
     due.length > 0 ? 'WARNING' : 'OK',
     '입금 후 MYSC 수익·매출부가세 이관',
     due.length > 0 ? `다음 주차까지 미이관: ${due.join(', ')}` : '실제 입금 건의 다음 주차 이관을 확인했습니다.',
+    due,
   );
 }
 
 function negativeProjectionCheck(weeks) {
   let balance = 0;
   let prepay = 0;
+  const findings = [];
   for (const week of weeks) {
     const totalIn = sumSafe(CASHFLOW_IN_LINES.map((lineId) => week.projection?.[lineId])) || 0;
     const totalOut = sumSafe(CASHFLOW_OUT_LINES.map((lineId) => week.projection?.[lineId])) || 0;
     balance += totalIn - totalOut;
     prepay += safeAmount(week.projection?.MYSC_PREPAY_IN);
     if (balance < 0) {
-      return managementCheck(
-        'negative-projection-balance',
-        'WARNING',
-        'Projection 잔액 마이너스',
-        `${week.yearMonth} ${week.weekNo}주차부터 ${balance.toLocaleString('ko-KR')}원${prepay > 0 ? '' : ' · MYSC 선입금 Projection 없음'}`,
-      );
+      findings.push(`${week.yearMonth} ${week.weekNo}주차 · ${balance.toLocaleString('ko-KR')}원${prepay > 0 ? '' : ' · MYSC 선입금 Projection 없음'}`);
     }
+  }
+  if (findings.length > 0) {
+    return managementCheck(
+      'negative-projection-balance',
+      'WARNING',
+      'Projection 잔액 마이너스',
+      `${findings.length}개 주차에서 마이너스 · 최초 ${findings[0]}`,
+      findings,
+    );
   }
   return managementCheck('negative-projection-balance', 'OK', 'Projection 잔액 마이너스', 'Projection 누적 잔액이 0원 이상입니다.');
 }
@@ -592,6 +599,7 @@ function futurePrepayCheck(weeks, asOfKey) {
     occurrences.length > 0
       ? occurrences.map((week) => `${week.yearMonth} ${week.weekNo}주차 ${safeAmount(week.projection?.MYSC_PREPAY_IN).toLocaleString('ko-KR')}원`).join(', ')
       : '금주 이후 100만원 초과 요청이 없습니다.',
+    occurrences.map((week) => `${week.yearMonth} ${week.weekNo}주차 · ${safeAmount(week.projection?.MYSC_PREPAY_IN).toLocaleString('ko-KR')}원`),
   );
 }
 
@@ -1588,21 +1596,19 @@ export function mountJvmWeeklyApiRoutes(app, {
       throw createHttpError(400, 'Cashflow month close yearMonth must use YYYY-MM.', 'cashflow_month_close_request_invalid');
     }
     const comparisonBoundary = resolveCashflowComparisonAsOf('', now());
-    const result = await proxyJavaWeeklyRequest({
+    const source = await proxyJavaWeeklyRequest({
       context: req.context,
       method: 'GET',
-      path: `/api/v1/cashflow/${projectId}/month-close?yearMonth=${encodeURIComponent(yearMonth)}`,
+      path: `/api/v1/cashflow/${projectId}/month-close/dashboard-source?yearMonth=${encodeURIComponent(yearMonth)}`,
     });
+    const result = objectValue(source?.monthClose);
+    const cashflow = objectValue(source?.cashflow);
     if (readOptionalText(result?.projectId) !== rawProjectId || readOptionalText(result?.yearMonth) !== yearMonth) {
       throw createHttpError(502, 'JVM cashflow month response scope does not match the request.', 'jvm_weekly_project_mismatch');
     }
-    const cashflow = db?.doc && readOptionalText(result?.status) === 'OPEN'
-      ? await proxyJavaWeeklyRequest({
-        context: req.context,
-        method: 'GET',
-        path: `/api/v1/cashflow/${projectId}`,
-      })
-      : null;
+    if (db?.doc && readOptionalText(result?.status) === 'OPEN' && !cashflow) {
+      throw createHttpError(502, 'JVM cashflow month source is incomplete.', 'jvm_weekly_response_invalid');
+    }
     if (cashflow && readOptionalText(cashflow?.projectId) !== rawProjectId) {
       throw createHttpError(502, 'JVM cashflow response project does not match the request.', 'jvm_weekly_project_mismatch');
     }

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -46,6 +46,10 @@ const emptyManagementChecks = [
   { id: 'future-prepay-over-million', status: 'OK', title: '금주 이후 선입금 요청 100만원 초과', detail: '금주 이후 100만원 초과 요청이 없습니다.' },
 ];
 
+function monthDashboardSource(monthClose, cashflow = { projectId: 'project-a', projection: [], actual: [], readModel: { months: [] } }) {
+  return { monthClose, cashflow: monthClose.status === 'OPEN' ? cashflow : null };
+}
+
 function matchingControlRows(startRow, matches = true) {
   return Array.from({ length: 19 }, (_, index) => ({
     sourceCell: `BO${startRow + index}`, value: 0, computed: 0, matches,
@@ -361,12 +365,12 @@ describe('JVM weekly API BFF proxy', () => {
     const fetchImpl = vi.fn(async () => ({
       ok: true,
       status: 200,
-      text: async () => JSON.stringify({
+      text: async () => JSON.stringify(monthDashboardSource({
         ok: true,
         projectId: 'project-a',
         yearMonth: '2026-06',
         status: 'CLOSED',
-      }),
+      })),
     }));
     const { app } = createApp(fetchImpl, createIdempotencyService(), {
       actorId: 'auditor-1',
@@ -386,7 +390,7 @@ describe('JVM weekly API BFF proxy', () => {
 
     expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(fetchImpl.mock.calls[0][0]).toBe(
-      'http://jvm-weekly.local/api/v1/cashflow/project-a/month-close?yearMonth=2026-06',
+      'http://jvm-weekly.local/api/v1/cashflow/project-a/month-close/dashboard-source?yearMonth=2026-06',
     );
     expect(fetchImpl.mock.calls[0][1].method).toBe('GET');
     expect(fetchImpl.mock.calls[0][1].body).toBeUndefined();
@@ -431,15 +435,13 @@ describe('JVM weekly API BFF proxy', () => {
 
   it('composes the open-month dashboard from the pinned sheet, private draft, project, and JVM state', async () => {
     const { db, sourceRevision, targetRevision } = fullMonthCloseSource();
-    const fetchImpl = vi.fn(async (url) => ({
+    const fetchImpl = vi.fn(async () => ({
       ok: true,
       status: 200,
-      text: async () => JSON.stringify(url.endsWith('/month-close?yearMonth=2026-06') ? {
+      text: async () => JSON.stringify(monthDashboardSource({
         ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0,
         reopenCount: 0, projectWarningCount: 0, snapshot: {},
-      } : {
-        projectId: 'project-a', projection: [], actual: [], readModel: { months: [] },
-      }),
+      })),
     }));
     const { app } = createApp(fetchImpl, createIdempotencyService(), {}, {
       env: stageEnv,
@@ -472,7 +474,7 @@ describe('JVM weekly API BFF proxy', () => {
         expect(response.body.dashboard.depositScheduleRows).toHaveLength(5);
       });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
   it('returns the four PPT 38 management checks from canonical server values', () => {
@@ -534,6 +536,9 @@ describe('JVM weekly API BFF proxy', () => {
     ]);
     expect(checks[1].detail).toContain('다음 주차 원장 없음');
     expect(checks[0].detail).toContain('실제 0원 · 실제 미이관');
+    expect(checks[0].findings).toContain('2026-06 3주차 · 예정 10원 · 실제 0원 · 실제 미이관');
+    expect(checks[2].findings).toHaveLength(5);
+    expect(checks[2].findings[0]).toContain('2026-06 1주차');
     expect(checks[3].detail).toContain('1,000,001원');
   });
 
@@ -558,6 +563,7 @@ describe('JVM weekly API BFF proxy', () => {
       status: 'WARNING',
       title: 'MYSC 인건비 이관',
       detail: '2026-06 3주차 · Projection 인건비 미기입',
+      findings: ['2026-06 3주차 · Projection 인건비 미기입'],
     });
   });
 
@@ -643,15 +649,13 @@ describe('JVM weekly API BFF proxy', () => {
         },
       }),
     };
-    const fetchImpl = vi.fn(async (url) => ({
+    const fetchImpl = vi.fn(async () => ({
       ok: true,
       status: 200,
-      text: async () => JSON.stringify(url.endsWith('/month-close?yearMonth=2026-06') ? {
+      text: async () => JSON.stringify(monthDashboardSource({
         ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0,
         reopenCount: 0, projectWarningCount: 0, snapshot: {},
-      } : {
-        projectId: 'project-a', projection: [], actual: [], readModel: { months: [] },
-      }),
+      })),
     }));
     const { app } = createApp(fetchImpl, createIdempotencyService(), {}, {
       env: stageEnv,
@@ -684,15 +688,13 @@ describe('JVM weekly API BFF proxy', () => {
     const draft = [...documents.values()].find((value) => value?.resourceType === 'cashflow');
     const confirmations = draft.payload.monthClose.confirmations;
     confirmations[confirmations.length - 1] = { ...confirmations[0] };
-    const fetchImpl = vi.fn(async (url) => ({
+    const fetchImpl = vi.fn(async () => ({
       ok: true,
       status: 200,
-      text: async () => JSON.stringify(url.endsWith('/month-close?yearMonth=2026-06') ? {
+      text: async () => JSON.stringify(monthDashboardSource({
         ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0,
         reopenCount: 0, projectWarningCount: 0, snapshot: {},
-      } : {
-        projectId: 'project-a', projection: [], actual: [], readModel: { months: [] },
-      }),
+      })),
     }));
     const { app } = createApp(fetchImpl, createIdempotencyService(), {}, {
       env: stageEnv,
@@ -715,15 +717,13 @@ describe('JVM weekly API BFF proxy', () => {
   it('caps Projection progress at 100 percent and keeps the zero-contract rule', async () => {
     for (const contractAmount of [100, 0]) {
       const { db } = fullMonthCloseSource({ contractAmount });
-      const fetchImpl = vi.fn(async (url) => ({
+      const fetchImpl = vi.fn(async () => ({
         ok: true,
         status: 200,
-        text: async () => JSON.stringify(url.endsWith('/month-close?yearMonth=2026-06') ? {
+        text: async () => JSON.stringify(monthDashboardSource({
           ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0,
           reopenCount: 0, projectWarningCount: 0, snapshot: {},
-        } : {
-          projectId: 'project-a', projection: [], actual: [], readModel: { months: [] },
-        }),
+        })),
       }));
       const { app } = createApp(fetchImpl, createIdempotencyService(), {}, {
         env: stageEnv,
@@ -754,7 +754,7 @@ describe('JVM weekly API BFF proxy', () => {
     const fetchImpl = vi.fn(async () => ({
       ok: true,
       status: 200,
-      text: async () => JSON.stringify({
+      text: async () => JSON.stringify(monthDashboardSource({
         ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'CLOSED', revision: 1,
         reopenCount: 0, projectWarningCount: 0,
         previousSnapshot: { weeklyTotals: previousWeeklyTotals },
@@ -768,7 +768,7 @@ describe('JVM weekly API BFF proxy', () => {
           depositScheduleRows: [], confirmations: [],
           sheetFacts: { metadata: { businessType: { value: 'snapshot metadata' } }, depositScheduleRows: [] },
         },
-      }),
+      })),
     }));
     const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { env: stageEnv, db: current.db });
 
@@ -804,10 +804,10 @@ describe('JVM weekly API BFF proxy', () => {
       const fetchImpl = vi.fn(async (url) => ({
         ok: true,
         status: 200,
-        text: async () => JSON.stringify(url.includes('/month-close') ? {
+        text: async () => JSON.stringify(url.includes('/dashboard-source') ? monthDashboardSource({
           ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0,
           reopenCount: 0, projectWarningCount: 0, snapshot: {},
-        } : { projectId: 'project-a', projection: [], actual: [], readModel: { months: [] } }),
+        }) : { ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'CLOSED' }),
       }));
       const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { env: stageEnv, db: source.db });
 

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowMonthDashboardSourceResponse.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowMonthDashboardSourceResponse.java
@@ -1,0 +1,7 @@
+package dev.merryai.innerplatform.weekly.api;
+
+public record CashflowMonthDashboardSourceResponse(
+    CashflowMonthCloseResponse monthClose,
+    CashflowSnapshotResponse cashflow
+) {
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CloseCashflowMonthRequest.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CloseCashflowMonthRequest.java
@@ -76,8 +76,16 @@ public record CloseCashflowMonthRequest(
         @NotBlank @Pattern(regexp = "labor-transfer|profit-vat-after-deposit|negative-projection-balance|future-prepay-over-million") String id,
         @NotBlank @Pattern(regexp = "OK|WARNING|REVIEW_REQUIRED") String status,
         @NotBlank @Size(max = 200) String title,
-        @NotBlank @Size(max = 2000) String detail
+        @NotBlank @Size(max = 2000) String detail,
+        @Size(max = 500) List<@NotBlank @Size(max = 2000) String> findings
     ) {
+        public ManagementCheck {
+            findings = findings == null ? List.of() : List.copyOf(findings);
+        }
+
+        public ManagementCheck(String id, String status, String title, String detail) {
+            this(id, status, title, detail, List.of());
+        }
     }
 
     public record ManagementConfirmation(
@@ -234,7 +242,7 @@ public record CloseCashflowMonthRequest(
             if (!List.of("OK", "WARNING", "REVIEW_REQUIRED").contains(status) || title.isBlank() || detail.isBlank()) {
                 throw new IllegalArgumentException("Cashflow management check status, title, and detail are required.");
             }
-            ManagementCheck canonical = new ManagementCheck(check.id(), status, title, detail);
+            ManagementCheck canonical = new ManagementCheck(check.id(), status, title, detail, check.findings());
             if (byId.putIfAbsent(check.id(), canonical) != null) {
                 throw new IllegalArgumentException("Cashflow month close contains duplicate management checks.");
             }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -358,6 +358,26 @@ public class WeeklyExpenseController {
         );
     }
 
+    @GetMapping("/cashflow/{projectId}/month-close/dashboard-source")
+    public CashflowMonthDashboardSourceResponse readCashflowMonthDashboardSource(
+        @PathVariable String projectId,
+        @RequestParam("yearMonth") String yearMonth,
+        @RequestHeader("x-tenant-id") String tenantId,
+        @RequestHeader("x-actor-id") String actorId,
+        @RequestHeader("x-actor-role") String actorRole,
+        @RequestHeader(value = "x-actor-email", required = false) String actorEmail
+    ) {
+        CashflowMonthCloseResponse monthClose = commandService.readCashflowMonthClose(
+            actorContext(tenantId, actorId, actorRole, actorEmail),
+            projectId,
+            yearMonth
+        );
+        CashflowSnapshotResponse cashflow = "OPEN".equals(monthClose.status())
+            ? cashflowSnapshot(projectId, tenantId, actorId, actorRole, actorEmail)
+            : null;
+        return new CashflowMonthDashboardSourceResponse(monthClose, cashflow);
+    }
+
     @PostMapping("/cashflow/{projectId}/month-close")
     public CashflowMonthCloseResponse closeCashflowMonth(
         @PathVariable String projectId,

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
@@ -10,7 +10,9 @@ import dev.merryai.innerplatform.weekly.repository.WeeklyExpenseBankImportLineRe
 import dev.merryai.innerplatform.weekly.repository.WeeklyExpenseIdempotencyRepository;
 import dev.merryai.innerplatform.weekly.repository.WeeklyExpenseProjectionRepository;
 import dev.merryai.innerplatform.weekly.repository.WeeklyExpenseSheetRepository;
+import dev.merryai.innerplatform.weekly.service.WeeklyExpenseCommandService;
 import dev.merryai.innerplatform.weekly.storage.JpaWeeklyExpensePersistence;
+import dev.merryai.innerplatform.weekly.storage.WeeklyExpensePersistence;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -35,7 +37,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -1432,6 +1436,40 @@ class WeeklyExpenseControllerTest {
                 "viewer"
             ))
             .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void cashflowMonthDashboardSourceReturnsCloseAndCashflowInOneResponse() {
+        WeeklyExpenseCommandService dashboardCommandService = mock(WeeklyExpenseCommandService.class);
+        WeeklyExpensePersistence dashboardPersistence = mock(WeeklyExpensePersistence.class);
+        when(dashboardCommandService.readCashflowMonthClose(any(), eq("project-month-dashboard"), eq("2026-06")))
+            .thenReturn(new CashflowMonthCloseResponse(
+            true, "cashflowMonth.read", "project-month-dashboard", "2026-06", "OPEN",
+            0, 0, 0, null, null, Map.of(), Map.of(), false,
+            "2026-07-20", "2026-07-10", true,
+            null, null, null, null, null, null, null, null, null, null, null
+        ));
+        when(dashboardPersistence.findProjectionLines("tenant-month-dashboard", "project-month-dashboard"))
+            .thenReturn(List.of());
+        when(dashboardPersistence.findActualLines("tenant-month-dashboard", "project-month-dashboard"))
+            .thenReturn(List.of());
+
+        CashflowMonthDashboardSourceResponse response = new WeeklyExpenseController(
+            dashboardCommandService,
+            dashboardPersistence,
+            false
+        ).readCashflowMonthDashboardSource(
+            "project-month-dashboard",
+            "2026-06",
+            "tenant-month-dashboard",
+            "viewer-month-dashboard",
+            "viewer",
+            "viewer@example.com"
+        );
+
+        assertThat(response.monthClose().status()).isEqualTo("OPEN");
+        assertThat(response.cashflow().projectId()).isEqualTo("project-month-dashboard");
+        assertThat(response.cashflow().readModel().months()).isEmpty();
     }
 
     @Test

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -162,43 +162,31 @@ describe('CashflowProjectSheet monthly close shell', () => {
   });
 
   it('keeps the board action next to the settlement status without a manual temporary-save button', () => {
-    const boardHeader = source.slice(source.indexOf('현금흐름 관리시트'), source.indexOf('{financialYearChecks?.years.length'));
+    const boardHeader = source.slice(source.indexOf('현금흐름 관리시트'), source.indexOf('data-cashflow-block="multi-year-view"'));
     expect(boardHeader).toContain('월 결산');
     expect(boardHeader).not.toContain('작성자 전용 임시저장본을 저장했습니다.');
   });
 
-  it('opens only the selected Projection week and keeps multi-year sheet checks visible', () => {
+  it('opens only the selected Projection week without annual amount cards', () => {
     expect(source).toContain('현금흐름 관리시트');
     expect(source).not.toContain('캐시플로 진단시트');
     expect(source).not.toContain('수정 시작');
     expect(source).not.toContain('서버 확정 원장 합계');
     expect(source).toContain('openProjectionWeekEditing');
-    expect(source).toContain('financialYearChecks?.years.length');
-    expect(source).toContain('시트 연도값 없음');
-    expect(source).toContain('시트 {fmt(check.sheet[field.key])} · 등록 {fmt(check.registered[field.key])}');
+    expect(source).not.toContain('financialYearChecks?.years.length');
+    expect(source).not.toContain('시트 {fmt(check.sheet[field.key])} · 등록 {fmt(check.registered[field.key])}');
   });
 
-  it('keeps the detailed board on one year while showing the adjacent annual source values', () => {
-    expect(source).toContain('getCashflowSheetLabYearViewViaBff');
-    expect(source).toContain('cashflowYearView?.navigationYears');
-    expect(source).toContain('cashflowSheetMirror?.sheetFacts?.annualCashflowTotals');
+  it('keeps the detailed board on one year with navigation-only adjacent years', () => {
+    expect(source).not.toContain('getCashflowSheetLabYearViewViaBff');
+    expect(source).not.toContain('cashflowYearView');
+    expect(source).not.toContain('data-cashflow-annual-summary="true"');
     expect(source).toContain('[selectedYear - 1, selectedYear, selectedYear + 1]');
     expect(source).toContain('data-cashflow-block="multi-year-view"');
-    expect(source).toContain("'주차값 집계'");
-    expect(source).toContain("'일부 주차 합계'");
-    expect(source).toContain("'연간 합계'");
-    expect(source).toContain("'합계 불일치'");
-    expect(source).toContain('오류 없이 다음 불러오기 때 반영됩니다.');
+    expect(source).toContain('data-cashflow-year-view={year}');
+    expect(source).toContain('{String(year).slice(-2)}년');
     expect(source).toContain("start: { yearMonth: `${selectedYear}-01`, weekNo: 1 }");
     expect(source).toContain("end: { yearMonth: `${selectedYear}-12`, weekNo: 5 }");
-  });
-
-  it('keeps Projection and Actual annual cash totals separate', () => {
-    expect(source).toContain('Projection 입금 / 출금');
-    expect(source).toContain('Actual 입금 / 출금');
-    expect(source).toContain('fmt(projection?.totalIn || 0)');
-    expect(source).toContain('fmt(actual?.totalIn || 0)');
-    expect(source).not.toContain('(projection?.totalIn || 0) + (actual?.totalIn || 0)');
   });
 
   it('shows who explicitly loaded the sheet values in the activity timeline', () => {
@@ -208,13 +196,19 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('누가 언제 시트 값을 불러오고 월 결산했는지 확인할 수 있습니다.');
   });
 
-  it('places adjacent annual totals around weekly columns and lets users open each year view', () => {
-    expect(source).toContain('data-cashflow-annual-summary="true"');
+  it('lets users open each adjacent year without annual amount columns', () => {
     expect(source).toContain('`${year}-01`');
     expect(source).toContain('data-cashflow-year-view={year}');
-    expect(source).toContain('annualSourceLabel(total?.[mode])} · 보기');
+    expect(source).not.toContain('annualSourceLabel');
+    expect(source).not.toContain('renderAnnualSummaryCell');
     expect(source).not.toContain("'서버 값'");
     expect(source).not.toContain("'값 없음'");
+  });
+
+  it('keeps the last good month result during a same-month retry and lists every management finding', () => {
+    expect(source).toContain('setMonthCloseResult((current) => current?.yearMonth === yearMonth ? current : null)');
+    expect(source).toContain('check.findings?.length');
+    expect(source).toContain('check.findings.map((finding)');
   });
 
   it('offers the exact three in-app exit choices and releases only on exit', () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -52,14 +52,11 @@ import {
   applyCashflowSheetLabViaBff,
   getCashflowSheetLabMirrorViaBff,
   getCashflowSheetLabShareAccountViaBff,
-  getCashflowSheetLabYearViewViaBff,
   refreshCashflowSheetLabMirrorViaBff,
   stageCashflowSheetLabViaBff,
   type CashflowSheetLabChangeCandidate,
-  type CashflowSheetLabAnnualModeTotal,
   type CashflowSheetLabMirrorResult,
   type CashflowSheetLabShareAccountResult,
-  type CashflowSheetLabYearViewResult,
 } from '../../lib/sheets-cashflow-readonly-client';
 import { EditLeaseDialogs } from '../editing/EditLeaseDialogs';
 import { useCashflowEditLease } from './useCashflowEditLease';
@@ -87,13 +84,6 @@ function fmtSigned(n: number): string {
   if (n === 0) return '0';
   return `${n > 0 ? '+' : '-'}${Math.abs(n).toLocaleString('ko-KR')}`;
 }
-
-const FINANCIAL_YEAR_CHECK_FIELDS = [
-  { key: 'contractAmount', label: '입금예정' },
-  { key: 'salesVatAmount', label: '매출 부가세' },
-  { key: 'totalRevenueAmount', label: 'MYSC 수익' },
-  { key: 'supportAmount', label: '팀지원금' },
-] as const;
 
 function formatSheetAppliedAt(value?: string): string {
   if (!value) return '';
@@ -282,7 +272,6 @@ export function CashflowProjectSheet({
   const [cashflowComparisonLoading, setCashflowComparisonLoading] = useState(false);
   const [cashflowComparisonError, setCashflowComparisonError] = useState<string | null>(null);
   const [cashflowSheetMirror, setCashflowSheetMirror] = useState<CashflowSheetLabMirrorResult | null>(null);
-  const [cashflowYearView, setCashflowYearView] = useState<CashflowSheetLabYearViewResult | null>(null);
   const [monthCloseResult, setMonthCloseResult] = useState<CashflowMonthCloseResult | null>(null);
   const [monthCloseLoading, setMonthCloseLoading] = useState(false);
   const [monthCloseError, setMonthCloseError] = useState<string | null>(null);
@@ -623,33 +612,6 @@ export function CashflowProjectSheet({
     return () => { cancelled = true; };
   }, [orgId, projectId, resolveBffActor, user?.uid]);
 
-  useEffect(() => {
-    let cancelled = false;
-    setCashflowYearView(null);
-    if (!cashflowSheetMirror || !projectId || !orgId || !user?.uid) return () => { cancelled = true; };
-
-    const loadYearView = async (): Promise<void> => {
-      try {
-        let actor = await resolveBffActor();
-        if (!actor?.idToken) return;
-        try {
-          const result = await getCashflowSheetLabYearViewViaBff({ tenantId: orgId, actor, projectId, selectedYear });
-          if (!cancelled) setCashflowYearView(result);
-        } catch (error) {
-          if (!isBffAuthRejection(error)) throw error;
-          actor = await resolveBffActor({ forceRefresh: true });
-          if (!actor?.idToken) throw error;
-          const result = await getCashflowSheetLabYearViewViaBff({ tenantId: orgId, actor, projectId, selectedYear });
-          if (!cancelled) setCashflowYearView(result);
-        }
-      } catch {
-        if (!cancelled) setCashflowYearView(null);
-      }
-    };
-    void loadYearView();
-    return () => { cancelled = true; };
-  }, [cashflowSheetMirror, orgId, projectId, resolveBffActor, selectedYear, user?.uid]);
-
   const loadCashflowComparison = useCallback(async (): Promise<void> => {
     if (!projectId || !orgId || !user?.uid) {
       setCashflowSnapshot(null);
@@ -697,6 +659,7 @@ export function CashflowProjectSheet({
       setMonthCloseError('로그인 세션이 만료되었습니다.');
       return;
     }
+    setMonthCloseResult((current) => current?.yearMonth === yearMonth ? current : null);
     setMonthCloseLoading(true);
     setMonthCloseError(null);
     try {
@@ -721,7 +684,6 @@ export function CashflowProjectSheet({
         }));
       }
     } catch (error) {
-      setMonthCloseResult(null);
       setMonthCloseError(resolveApiErrorMessage(error, '월 결산 상태를 불러오지 못했습니다.'));
     } finally {
       setMonthCloseLoading(false);
@@ -1297,19 +1259,7 @@ export function CashflowProjectSheet({
   }, [annualWeeks, cashflowSnapshot, monthCloseResult?.dashboard?.comparison, yearMonth]);
 
   const cashflowTotalPeriodLabel = `${selectedYear}년`;
-  const multiYearCashflowTotals = useMemo(() => {
-    const totalsByYear = new Map((cashflowYearView?.years?.length
-      ? cashflowYearView.years
-      : cashflowSheetMirror?.sheetFacts?.annualCashflowTotals || [])
-      .map((total) => [total.year, total]));
-    const navigationYears = cashflowYearView?.navigationYears?.length === 3
-      ? cashflowYearView.navigationYears
-      : [selectedYear - 1, selectedYear, selectedYear + 1];
-    return navigationYears.map((year) => ({
-      year,
-      total: totalsByYear.get(year),
-    }));
-  }, [cashflowSheetMirror?.sheetFacts?.annualCashflowTotals, cashflowYearView, selectedYear]);
+  const navigationYears = [selectedYear - 1, selectedYear, selectedYear + 1];
   const sheetRangeLabel = cashflowSheetConfig
     ? `${cashflowSheetConfig.sheetName || '시트 탭'} · ${cashflowSheetConfig.startWeek || '전체'} ~ ${cashflowSheetConfig.endWeek || '전체'}`
     : '연결된 Google Sheet가 없습니다.';
@@ -1573,37 +1523,6 @@ export function CashflowProjectSheet({
       projection: readServerSummary('projection'),
       actual: readServerSummary('actual'),
     };
-    const adjacentYearSummaries = [selectedYear - 1, selectedYear + 1].map((year) => (
-      multiYearCashflowTotals.find((item) => item.year === year) || { year, total: undefined }
-    ));
-    const annualSourceLabel = (summary?: CashflowSheetLabAnnualModeTotal) => (
-      summary?.reconciliation?.status === 'MISMATCH'
-        ? '합계 불일치'
-        : summary?.coverage?.status === 'PARTIAL'
-        ? '일부 주차 합계'
-        : summary?.source === 'WEEKLY' ? '주차값 집계' : summary?.source === 'ANNUAL' ? '연간 합계' : '미입력'
-    );
-    const renderAnnualSummaryCell = (input: {
-      year: number;
-      summary?: CashflowSheetLabAnnualModeTotal;
-      mode: 'projection' | 'actual';
-      lineId?: CashflowSheetLineId;
-      kind?: 'totalIn' | 'totalOut' | 'net';
-    }) => {
-      const hasValues = Boolean(input.summary?.valueCellCount);
-      const value = input.lineId
-        ? input.summary?.lineAmounts[input.lineId] || 0
-        : input.kind === 'totalIn'
-          ? input.summary?.totalIn || 0
-          : input.kind === 'totalOut'
-            ? input.summary?.totalOut || 0
-            : input.summary?.net || 0;
-      return (
-        <td key={`${input.mode}-${input.year}-${input.lineId || input.kind}`} className="min-w-[96px] border-l-[6px] border-l-white bg-amber-50/70 px-2 py-1 align-middle">
-          <div className="text-right text-[8px] font-semibold tabular-nums text-slate-800">{hasValues ? fmt(value) : '-'}</div>
-        </td>
-      );
-    };
     const scrollBoard = (direction: -1 | 1) => {
       const container = cashflowBoardScrollRef.current;
       if (!container) return;
@@ -1631,14 +1550,12 @@ export function CashflowProjectSheet({
           <td className={`sticky left-0 z-20 w-[192px] min-w-[192px] border-r-[6px] border-r-white px-3 py-1.5 text-[9px] leading-4 text-slate-900 ${rowTone === 'income' ? 'border-l-[3px] border-l-emerald-400 bg-emerald-50/80' : 'border-l-[3px] border-l-rose-400 bg-rose-50/80'} ${emphasized ? 'font-bold' : 'font-medium'}`}>
             {renderCashflowLineLabel(getCashflowModeLineLabel(lineId, mode))}
           </td>
-          {adjacentYearSummaries.map(({ year, total }) => year < selectedYear ? renderAnnualSummaryCell({ year, summary: total?.[mode], mode, lineId }) : null)}
           {visibleWeeks.map((week) => {
             const isThisWeek = todayYearMonth === week.yearMonth && todayIso >= week.weekStart && todayIso <= week.weekEnd;
             return mode === 'projection'
               ? renderProjectionCell({ targetYearMonth: week.yearMonth, weekNo: week.weekNo, lineId, isThisWeek })
               : renderActualCell({ targetYearMonth: week.yearMonth, weekNo: week.weekNo, lineId, isThisWeek });
           })}
-          {adjacentYearSummaries.map(({ year, total }) => year > selectedYear ? renderAnnualSummaryCell({ year, summary: total?.[mode], mode, lineId }) : null)}
           {renderSummaryCell({
             keyName: `${mode}-${lineId}-range`,
             value: derived[mode].rowTotals[lineId] || 0,
@@ -1662,7 +1579,6 @@ export function CashflowProjectSheet({
           <td className={`sticky left-0 z-20 w-[192px] min-w-[192px] border-r-[6px] border-r-white px-3 py-2 text-[9px] font-bold ${isIncome ? 'bg-emerald-50 text-emerald-950' : isExpense ? 'bg-rose-50 text-rose-950' : 'bg-slate-100 text-slate-950'}`}>
             {label}
           </td>
-          {adjacentYearSummaries.map(({ year, total }) => year < selectedYear ? renderAnnualSummaryCell({ year, summary: total?.[mode], mode, kind }) : null)}
           {visibleWeeks.map((week, index) => renderSummaryCell({
             keyName: `${mode}-${kind}-${week.yearMonth}-${week.weekNo}`,
             value: derived[mode].weekTotals[index]?.[kind] || 0,
@@ -1671,7 +1587,6 @@ export function CashflowProjectSheet({
             emphasis,
             rowTone,
           }))}
-          {adjacentYearSummaries.map(({ year, total }) => year > selectedYear ? renderAnnualSummaryCell({ year, summary: total?.[mode], mode, kind }) : null)}
           {renderSummaryCell({
             keyName: `${mode}-${kind}-range`,
             value: derived[mode].monthTotals[kind],
@@ -1684,20 +1599,12 @@ export function CashflowProjectSheet({
       );
     };
     const renderModeTable = (mode: 'projection' | 'actual') => (
-      <table className="w-full border-separate border-spacing-0 text-[8px]" style={{ minWidth: `${192 + visibleWeeks.length * 84 + 84 * 3}px` }}>
+      <table className="w-full border-separate border-spacing-0 text-[8px]" style={{ minWidth: `${192 + visibleWeeks.length * 84 + 84}px` }}>
         <thead className="sticky top-0 z-40 bg-white/95 text-slate-600 backdrop-blur shadow-[0_10px_24px_rgba(15,23,42,0.06)]">
           <tr>
             <th className="sticky left-0 z-50 w-[192px] min-w-[192px] border-r-[6px] border-r-white bg-white px-3 py-2 text-left text-[11px] font-bold text-slate-800">
               항목
             </th>
-            {adjacentYearSummaries.filter(({ year }) => year < selectedYear).map(({ year, total }) => (
-              <th key={`annual-before-${mode}-${year}`} data-cashflow-annual-summary="true" className="min-w-[96px] border-l-[6px] border-l-white bg-amber-50 px-1 py-2 text-center align-top">
-                <button type="button" className="w-full rounded-md px-1 py-0.5 text-left hover:bg-amber-100" onClick={() => setYearMonth(`${year}-01`)}>
-                  <span className="block text-[10px] font-bold text-slate-800">{year}년 합계</span>
-                  <span className="block text-[8px] font-normal text-slate-500">{annualSourceLabel(total?.[mode])} · 보기</span>
-                </button>
-              </th>
-            ))}
             {visibleWeeks.map((week) => {
               const saveState = weekSaveState[resolveWeekKey({ yearMonth: week.yearMonth, mode, weekNo: week.weekNo })];
               const isThisWeek = todayYearMonth === week.yearMonth && todayIso >= week.weekStart && todayIso <= week.weekEnd;
@@ -1711,14 +1618,6 @@ export function CashflowProjectSheet({
                 </th>
               );
             })}
-            {adjacentYearSummaries.filter(({ year }) => year > selectedYear).map(({ year, total }) => (
-              <th key={`annual-after-${mode}-${year}`} data-cashflow-annual-summary="true" className="min-w-[96px] border-l-[6px] border-l-white bg-amber-50 px-1 py-2 text-center align-top">
-                <button type="button" className="w-full rounded-md px-1 py-0.5 text-left hover:bg-amber-100" onClick={() => setYearMonth(`${year}-01`)}>
-                  <span className="block text-[10px] font-bold text-slate-800">{year}년 합계</span>
-                  <span className="block text-[8px] font-normal text-slate-500">{annualSourceLabel(total?.[mode])} · 보기</span>
-                </button>
-              </th>
-            ))}
             <th className="sticky right-0 z-50 min-w-[84px] border-l-[6px] border-l-white bg-white px-1 py-2 text-left text-[11px] font-bold text-slate-800 shadow-[-12px_0_24px_rgba(15,23,42,0.08)]">
               범위 합계
             </th>
@@ -1778,63 +1677,13 @@ export function CashflowProjectSheet({
               ) : null}
             </div>
           </div>
-          <div data-cashflow-block="multi-year-view" className="grid gap-2 border-t border-slate-100 bg-slate-50/70 px-5 py-3 sm:grid-cols-3">
-            {multiYearCashflowTotals.map(({ year, total }) => {
-              const projection = total?.projection;
-              const actual = total?.actual;
-              const hasValues = Boolean((projection?.valueCellCount || 0) + (actual?.valueCellCount || 0));
-              return (
-                <button type="button" key={year} data-cashflow-year-view={year} onClick={() => setYearMonth(`${year}-01`)} className={`rounded-xl border px-3 py-2 text-left shadow-sm transition-colors ${year === selectedYear ? 'border-blue-200 bg-blue-50/60' : 'border-slate-200 bg-white hover:border-blue-200 hover:bg-blue-50/40'}`}>
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="text-[11px] font-bold text-slate-900">{year}년</span>
-                    <span className="text-[9px] font-semibold text-slate-500">{annualSourceLabel(projection)} · 시트 기준 · 보기</span>
-                  </div>
-                  {hasValues ? (
-                    <div className="mt-2 grid grid-cols-2 gap-x-3 gap-y-1 text-[9px] text-slate-600">
-                      <span>Projection 잔액</span><span className="text-right font-semibold tabular-nums text-slate-900">{fmt(projection?.net || 0)}</span>
-                      <span>Actual 잔액</span><span className="text-right font-semibold tabular-nums text-slate-900">{fmt(actual?.net || 0)}</span>
-                      <span>Projection 입금 / 출금</span><span className="text-right tabular-nums">{fmt(projection?.totalIn || 0)} / {fmt(projection?.totalOut || 0)}</span>
-                      <span>Actual 입금 / 출금</span><span className="text-right tabular-nums">{fmt(actual?.totalIn || 0)} / {fmt(actual?.totalOut || 0)}</span>
-                    </div>
-                  ) : (
-                    <p className="mt-2 text-[9px] leading-4 text-slate-500">시트에 입력된 값이 없습니다. 오류 없이 다음 불러오기 때 반영됩니다.</p>
-                  )}
-                </button>
-              );
-            })}
+          <div data-cashflow-block="multi-year-view" className="flex items-center gap-2 border-t border-slate-100 bg-slate-50/70 px-5 py-3">
+            {navigationYears.map((year) => (
+              <button type="button" key={year} data-cashflow-year-view={year} aria-current={year === selectedYear ? 'page' : undefined} aria-label={`${year}년 현금흐름 보기`} onClick={() => setYearMonth(`${year}-01`)} className={`rounded-full px-4 py-2 text-[11px] font-bold transition-colors ${year === selectedYear ? 'bg-blue-600 text-white' : 'bg-white text-slate-700 shadow-sm hover:bg-blue-50'}`}>
+                {String(year).slice(-2)}년
+              </button>
+            ))}
           </div>
-          {financialYearChecks?.years.length ? (
-            <div className="grid gap-2 border-t border-slate-100 bg-slate-50/70 px-5 py-3 sm:grid-cols-2 xl:grid-cols-4">
-              {[...financialYearChecks.years.map((check) => ({ ...check, label: `${check.year}년` })), { ...financialYearChecks.total, label: '전체' }].map((check) => (
-                <div key={check.label} className="rounded-xl border border-slate-200 bg-white px-3 py-2 shadow-sm">
-                  <div className="flex items-center justify-between gap-2">
-                    <span className="text-[11px] font-bold text-slate-900">{check.label}</span>
-                    <span className={`text-[9px] font-semibold ${check.status === 'MATCH' ? 'text-emerald-700' : 'text-amber-700'}`}>
-                      {check.status === 'MATCH' ? '등록값과 일치' : check.status === 'SHEET_YEAR_MISSING' ? '시트 연도값 없음' : '확인 필요'}
-                    </span>
-                  </div>
-                  <div className="mt-2 space-y-1">
-                    {FINANCIAL_YEAR_CHECK_FIELDS.map((field) => {
-                      const differs = check.mismatches.includes(field.key);
-                      return (
-                        <div key={field.key} className={`flex items-center justify-between gap-2 text-[9px] ${differs ? 'text-amber-700' : 'text-slate-500'}`}>
-                          <span>{field.label}</span>
-                          <span className="text-right tabular-nums">시트 {fmt(check.sheet[field.key])} · 등록 {fmt(check.registered[field.key])}</span>
-                        </div>
-                      );
-                    })}
-                  </div>
-                  {check.status === 'MISMATCH' ? (
-                    <p className="mt-2 text-[9px] leading-4 text-amber-700">
-                      {FINANCIAL_YEAR_CHECK_FIELDS.filter((field) => check.mismatches.includes(field.key)).map((field) => field.label).join(', ')} 값이 시트와 다릅니다.
-                    </p>
-                  ) : check.status === 'SHEET_YEAR_MISSING' ? (
-                    <p className="mt-2 text-[9px] leading-4 text-amber-700">이 연도의 시트 주차와 값을 확인해 주세요.</p>
-                  ) : null}
-                </div>
-              ))}
-            </div>
-          ) : null}
           <div className="relative bg-slate-50/80 px-4 pb-4">
             <Button type="button" variant="outline" size="sm" className="absolute left-2 top-1/2 z-50 h-11 w-9 -translate-y-1/2 rounded-full border-0 bg-white/95 p-0 shadow-[0_10px_28px_rgba(15,23,42,0.16)]" onClick={() => scrollBoard(-1)} aria-label="왼쪽 주차로 이동">
               <ChevronLeft className="h-4 w-4" />
@@ -2151,7 +2000,13 @@ export function CashflowProjectSheet({
                             <span className={`h-2 w-2 rounded-full ${opsDotClass(tone)}`} />
                             <span className="text-[10px] font-bold text-slate-900">{check.title}</span>
                           </div>
-                          <div className="mt-1 text-[9px] leading-4 text-slate-500">{check.detail}</div>
+                          {check.findings?.length ? (
+                            <ul className="mt-1 space-y-0.5 text-[9px] leading-4 text-slate-500">
+                              {check.findings.map((finding) => <li key={finding}>· {finding}</li>)}
+                            </ul>
+                          ) : (
+                            <div className="mt-1 text-[9px] leading-4 text-slate-500">{check.detail}</div>
+                          )}
                         </div>
                         <div className="flex shrink-0 gap-1">
                           <Button
@@ -2477,9 +2332,6 @@ export function CashflowProjectSheet({
       : 'bg-amber-100 text-amber-800';
   const sheetDashboardMetadata = cashflowSheetMirror?.status === 'FRESH'
     ? cashflowSheetMirror.sheetFacts?.metadata
-    : undefined;
-  const financialYearChecks = cashflowSheetMirror?.status === 'FRESH'
-    ? cashflowSheetMirror.financialYearChecks
     : undefined;
   const dashboardTitle = `${projectName?.trim() || '이 프로젝트'} 현금흐름 대시보드`;
 

--- a/src/app/components/cashflow/useCashflowEditLease.ts
+++ b/src/app/components/cashflow/useCashflowEditLease.ts
@@ -54,7 +54,7 @@ export function useCashflowEditLease(options: {
     [validProjectId],
   );
   const client = useMemo(() => {
-    if (!session || !validProjectId) return UNAVAILABLE_CLIENT;
+    if (!session || !validProjectId || !options.actor.idToken) return UNAVAILABLE_CLIENT;
     return createEditLeaseClient({
       tenantId: options.tenantId,
       actor: options.actor,

--- a/src/app/components/editing/useEditLease.test.ts
+++ b/src/app/components/editing/useEditLease.test.ts
@@ -85,7 +85,7 @@ describe('createEditLeaseController', () => {
     controller.dispose();
   });
 
-  it('checks status on visible visibilitychange, focus, and pageshow without extending', async () => {
+  it('coalesces simultaneous visibility, focus, and pageshow status checks without extending', async () => {
     const windowTarget = new FakeEventTarget();
     const documentTarget = new FakeDocumentTarget();
     const client = mockClient();
@@ -100,7 +100,7 @@ describe('createEditLeaseController', () => {
     windowTarget.dispatch('pageshow');
     await flush();
 
-    expect(client.getStatus).toHaveBeenCalledTimes(3);
+    expect(client.getStatus).toHaveBeenCalledOnce();
     expect(client.extend).not.toHaveBeenCalled();
     expect(client.acquire).not.toHaveBeenCalled();
     controller.dispose();

--- a/src/app/components/editing/useEditLease.ts
+++ b/src/app/components/editing/useEditLease.ts
@@ -106,6 +106,7 @@ export function createEditLeaseController(options: EditLeaseControllerOptions): 
   let heldAcknowledgedKey: string | null = null;
   let interval: ReturnType<typeof setInterval> | undefined;
   let started = false;
+  let statusPromise: Promise<EditLeaseViewState> | null = null;
 
   const update = (next: EditLeaseViewState) => {
     state = next;
@@ -289,13 +290,17 @@ export function createEditLeaseController(options: EditLeaseControllerOptions): 
     }
   };
 
-  const checkStatus = async (): Promise<EditLeaseViewState> => {
-    try {
-      applyStatus(await options.client.getStatus());
-    } catch (error) {
-      await failClosed(error);
-    }
-    return state;
+  const checkStatus = (): Promise<EditLeaseViewState> => {
+    if (statusPromise) return statusPromise;
+    statusPromise = (async () => {
+      try {
+        applyStatus(await options.client.getStatus());
+      } catch (error) {
+        await failClosed(error);
+      }
+      return state;
+    })().finally(() => { statusPromise = null; });
+    return statusPromise;
   };
   const onVisibilityChange = () => {
     if (documentTarget?.visibilityState === 'visible') void checkStatus();

--- a/src/app/components/portal/PortalCashflowPage.tsx
+++ b/src/app/components/portal/PortalCashflowPage.tsx
@@ -1,5 +1,4 @@
-import { useEffect } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router';
+import { Navigate, useLocation, useParams } from 'react-router';
 import { CashflowProjectSheet } from '../cashflow/CashflowProjectSheet';
 import { usePortalStore } from '../../data/portal-store';
 import {
@@ -10,7 +9,6 @@ import {
 export function PortalCashflowPage() {
   const { projectId: routeProjectId } = useParams<{ projectId: string }>();
   const location = useLocation();
-  const navigate = useNavigate();
   const {
     activeProjectId,
     portalUser,
@@ -21,17 +19,16 @@ export function PortalCashflowPage() {
   const projectId = resolvePortalProjectResourceId(routeProjectId, activeProjectId, myProject?.id);
   const currentPath = `${location.pathname}${location.search}${location.hash}`;
 
-  useEffect(() => {
-    if (routeProjectId || !projectId) return;
-    navigate(resolvePortalProjectResourcePath(currentPath, projectId), { replace: true });
-  }, [currentPath, navigate, projectId, routeProjectId]);
-
   if (!projectId) {
     return (
       <div className="p-6 text-[12px] text-muted-foreground">
         배정된 사업이 없습니다. 관리자에게 사업 배정을 요청하세요.
       </div>
     );
+  }
+
+  if (!routeProjectId) {
+    return <Navigate to={resolvePortalProjectResourcePath(currentPath, projectId)} replace />;
   }
 
   return (

--- a/src/app/data/auth-store.first-login.test.ts
+++ b/src/app/data/auth-store.first-login.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { buildSafeFirstLoginMember } from './auth-store';
+
+const authStoreSource = readFileSync(resolve(import.meta.dirname, 'auth-store.tsx'), 'utf8');
 
 describe('first-login member bootstrap', () => {
   it('creates only an unassigned PM profile that cannot self-elevate', () => {
@@ -23,5 +27,12 @@ describe('first-login member bootstrap', () => {
     expect(member).not.toHaveProperty('portalProfile');
     expect(member).not.toHaveProperty('projectNames');
     expect(member).not.toHaveProperty('department');
+  });
+
+  it('attaches a Firebase token before publishing the optimistic user', () => {
+    const tokenRead = authStoreSource.indexOf('const optimisticIdToken = await firebaseUser.getIdToken()');
+    const optimisticPublish = authStoreSource.indexOf('setUser(optimisticUser);', tokenRead);
+    expect(tokenRead).toBeGreaterThan(-1);
+    expect(optimisticPublish).toBeGreaterThan(tokenRead);
   });
 });

--- a/src/app/data/auth-store.tsx
+++ b/src/app/data/auth-store.tsx
@@ -455,7 +455,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         envTenantId: DEFAULT_ORG_ID,
         strict: false,
       });
-      const optimisticUser = mapFirebaseUserToAuthUser(firebaseUser, cachedMember, cachedTenantId);
+      const optimisticIdToken = await firebaseUser.getIdToken().catch(() => undefined);
+      const optimisticUser = mapFirebaseUserToAuthUser(firebaseUser, cachedMember, cachedTenantId, optimisticIdToken);
       optimisticUser.source = 'firebase';
       setUser(optimisticUser);
       saveUser(optimisticUser);

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -789,6 +789,7 @@ export interface CashflowManagementCheck {
   status: 'OK' | 'WARNING' | 'REVIEW_REQUIRED';
   title: string;
   detail: string;
+  findings?: string[];
 }
 
 export interface CashflowManagementConfirmation {

--- a/src/app/routes.portal-canonical.shell.test.ts
+++ b/src/app/routes.portal-canonical.shell.test.ts
@@ -26,7 +26,7 @@ describe('portal canonical edit resource routes', () => {
   it('lets the route project win and replaces ID-less cashflow URLs in the SPA', () => {
     expect(cashflowSource).toContain('useParams');
     expect(cashflowSource).toContain('resolvePortalProjectResourceId(routeProjectId');
-    expect(cashflowSource).toContain("navigate(resolvePortalProjectResourcePath(currentPath, projectId), { replace: true })");
+    expect(cashflowSource).toContain('<Navigate to={resolvePortalProjectResourcePath(currentPath, projectId)} replace />');
     expect(sheetLabSource).toContain('useParams');
     expect(sheetLabSource).toContain('routeProjectId');
     expect(sheetLabSource).toContain("navigate(resolvePortalProjectResourcePath(currentPath, projectId), { replace: true })");


### PR DESCRIPTION
## 변경
- 캐시플로우 진입 중복 마운트와 토큰 없는 lease 요청 차단
- 월 결산 JVM 조회를 단일 복합 계약으로 통합
- 주요 관리 항목 전체 발견 내역 표시 및 결산 계약 보존
- 연도별 금액 카드를 제거하고 이전/현재/다음 연도 네비게이션만 유지

## 검증
- Vitest 106건 통과
- JVM 전체 테스트 157건 통과
- npm run build 통과