### PR TITLE
fix: align cashflow sheet and ledger sources

### DIFF
--- a/docs/wiki/patch-notes/log.md
+++ b/docs/wiki/patch-notes/log.md
@@ -4,6 +4,10 @@
 - pages: [shared-portal-architecture](./pages/shared-portal-architecture.md)
 - summary: 프로젝트 등록/수정의 제출 서류와 결재선을 기획안 기준으로 정렬하고, 조직장 승인과 경영기획실 코드 부여를 분리했다. 지정 조직장 외 승인, PM self-approval, 코드 중복 부여를 BFF에서 차단하고, 경영기획실 반려는 PM 재제출 흐름으로 되돌린다.
 
+## [2026-07-20] patch-note | cashflow-source-consistency | 시트·JVM 원장 단일 기준 정렬
+- pages: [admin-cashflow-project-sheet](./pages/admin-cashflow-project-sheet.md)
+- summary: 시트값 불러오기 뒤 변경 월을 JVM 원장에 순차 반영하고 응답 금액을 재검증한다. 대시보드와 주요 관리 항목은 반영된 원장을 우선 사용하며, 인건비 3주차 외 입력·Projection 마이너스 구간·수행자 감사 이력을 함께 표시한다.
+
 ## [2026-07-14] patch-note | project-management-deck-alignment | 프로젝트 관리 기획안 정렬
 - pages: [portal-onboarding](./pages/portal-onboarding.md)
 - summary: 프로젝트 목록을 등록 프로젝트와 계약 전 상태로 구분하고 상태·정산 유형·조직·검색 조건을 결합했다. 등록·승인 CTA는 역할 권한에 맞게 제한하고, workspace 선택과 기능 검색의 `PM 포털` 표기는 기획안 기준 `실무자 포털`로 통일했다.

--- a/docs/wiki/patch-notes/pages/admin-cashflow-project-sheet.md
+++ b/docs/wiki/patch-notes/pages/admin-cashflow-project-sheet.md
@@ -3,7 +3,7 @@
 - route: `/cashflow/projects/:projectId`
 - primary users: admin, finance, 사업 운영 검토자
 - status: active
-- last updated: 2026-04-14
+- last updated: 2026-07-20
 
 ## Purpose
 
@@ -26,6 +26,7 @@
 
 ## Recent Changes
 
+- [2026-07-20] 명시적 시트값 불러오기 뒤 다월 변경분을 JVM 원장에 반영하고, 반환된 프로젝트·월·금액을 시트 고정본과 재검증하도록 보강했다. 운영 대시보드와 주요 관리 항목은 반영된 JVM 원장을 우선 사용하며, 인건비 3주차 외 입력 위치와 Projection 잔액 마이너스 구간을 간결하게 표시한다. 불러오기·원장 반영 이력에는 수행자를 함께 남긴다.
 - [2026-07-13] 화면 내부 이동 시 남은 캐시플로 입력을 개인 임시저장본에 저장한 뒤 수정 lease를 해제하도록 바꿨다. 저장에 실패하면 현재 화면에 남아 다시 시도한다.
 - [2026-04-09] admin export 흐름과 project sheet의 workbook contract를 더 밀접하게 맞췄다.
 - [2026-04-05] lazy heavy module 로딩 안정화를 넣었다.

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -1288,6 +1288,48 @@ function summarizeJavaMonthResult(result = {}) {
   });
 }
 
+function javaAppliedLineIndex(lines, { mode, yearMonth }) {
+  const index = new Map();
+  for (const line of Array.isArray(lines) ? lines : []) {
+    if (readOptionalText(line?.yearMonth) !== yearMonth) continue;
+    if (mode === 'actual' && readOptionalText(line?.sheetKey) !== CASHFLOW_SHEET_SOURCE_KEY) continue;
+    const weekNo = Number(line?.weekNo);
+    const lineId = readOptionalText(line?.cashflowLine);
+    const amount = Number(line?.amount);
+    const key = `${weekNo}:${lineId}`;
+    if (!Number.isInteger(weekNo) || !CASHFLOW_LINE_ORDER.has(lineId) || !Number.isSafeInteger(amount) || index.has(key)) {
+      throw createHttpError(502, 'JVM 캐시플로 저장 검증값이 올바르지 않습니다.', 'cashflow_jvm_apply_verification_failed');
+    }
+    index.set(key, amount);
+  }
+  return index;
+}
+
+function verifyJavaMonthAppliedCells(result, month, projectId) {
+  if (
+    readOptionalText(result?.projectId) !== projectId
+    || readOptionalText(result?.yearMonth) !== month.yearMonth
+    || readOptionalText(result?.sourceSheetKey) !== CASHFLOW_SHEET_SOURCE_KEY
+  ) {
+    throw createHttpError(502, 'JVM 캐시플로 저장 범위가 요청과 다릅니다.', 'cashflow_jvm_apply_verification_failed');
+  }
+  let verifiedLineCount = 0;
+  for (const mode of CASHFLOW_MODES) {
+    const index = javaAppliedLineIndex(result?.[mode], { mode, yearMonth: month.yearMonth });
+    const expected = month.cells.filter((cell) => cell.mode === mode && cell.cellState === 'VALUE');
+    if (index.size !== expected.length) {
+      throw createHttpError(502, 'JVM 캐시플로 저장 건수가 시트 고정본과 다릅니다.', 'cashflow_jvm_apply_verification_failed');
+    }
+    for (const cell of expected) {
+      if (index.get(`${cell.weekNo}:${cell.cashflowLine}`) !== Number(cell.amount)) {
+        throw createHttpError(502, 'JVM 캐시플로 저장 금액이 시트 고정본과 다릅니다.', 'cashflow_jvm_apply_verification_failed');
+      }
+      verifiedLineCount += 1;
+    }
+  }
+  return verifiedLineCount;
+}
+
 async function applyStagedCashflowSheetLab({
   db,
   tenantId,
@@ -1335,13 +1377,6 @@ async function applyStagedCashflowSheetLab({
 
   const riskCandidates = candidates.filter((candidate) => Array.isArray(candidate.riskFlags) && candidate.riskFlags.length > 0);
   const candidateMonths = [...new Set(candidates.map((candidate) => readOptionalText(candidate.yearMonth)).filter(Boolean))].sort();
-  if (candidateMonths.length !== 1) {
-    throw createHttpError(
-      409,
-      '최종 반영은 한 달 단위입니다. 한 달의 1~5주차만 다시 연동해 주세요.',
-      'cashflow_sheet_stage_single_month_required',
-    );
-  }
   if (riskCandidates.length > 0) {
     throw createHttpError(409, '결산된 월은 다시 열기 전까지 수정할 수 없습니다.', 'cashflow_sheet_stage_closed_month');
   }
@@ -1412,6 +1447,7 @@ async function applyStagedCashflowSheetLab({
   }
 
   const javaResults = [];
+  let verifiedLineCount = 0;
   let targetRevision = readOptionalText(stageRun.targetRevisionAtFetch);
   try {
     const resolvedEditSession = typeof resolveEditSession === 'function'
@@ -1439,6 +1475,7 @@ async function applyStagedCashflowSheetLab({
         replaceAllActualSources,
       });
       targetRevision = assertResultingTargetRevision(javaResult);
+      verifiedLineCount += verifyJavaMonthAppliedCells(javaResult, month, projectId);
       javaResults.push(javaResult);
     }
   } catch (error) {
@@ -1481,6 +1518,7 @@ async function applyStagedCashflowSheetLab({
       email: readOptionalText(context?.actorEmail),
       role: readOptionalText(context?.actorRole) || 'workspace_user',
     },
+    verifiedLineCount,
     firebaseResult: {
       ok: true,
       commandName: 'weeklyExpense.cashflowSheetLab.apply',
@@ -1489,7 +1527,7 @@ async function applyStagedCashflowSheetLab({
       targetRevisionAtStart: stageRun.targetRevisionAtFetch,
       resultingTargetRevision: targetRevision,
       monthResults: javaResults.map(summarizeJavaMonthResult),
-      verifiedLineCount: appliedCells.length,
+      verifiedLineCount,
     },
   };
   await reservation.runRef.set({
@@ -1500,6 +1538,12 @@ async function applyStagedCashflowSheetLab({
     applyResponse: response,
     appliedBy: response.lastAppliedBy,
   }, { merge: true });
+  await db.doc(cashflowSheetMirrorDocPath(tenantId, projectId)).set(stripUndefinedDeep({
+    appliedSourceRevision: stageRun.sourceRevision,
+    appliedTargetRevision: targetRevision,
+    lastAppliedAt: now,
+    lastAppliedBy: response.lastAppliedBy,
+  }), { merge: true });
   try {
     await markCashflowChangeCandidatesStatus({
       db,
@@ -1563,11 +1607,11 @@ async function stagePinnedCashflowSheetLab({
     ? (mirror.cells || []).filter((cell) => readOptionalText(cell.yearMonth) === parsed.yearMonth)
     : (mirror.cells || []);
   const pinnedMonths = [...groupPinnedCellsByMonth(pinnedCells).keys()].sort();
-  if (pinnedMonths.length !== 1) {
+  if (pinnedMonths.length === 0) {
     throw createHttpError(
       409,
-      '최종 반영은 한 달 단위입니다. 한 달의 1~5주차만 다시 연동해 주세요.',
-      'cashflow_sheet_stage_single_month_required',
+      '고정한 시트에서 반영할 월을 찾을 수 없습니다.',
+      'cashflow_sheet_stage_month_required',
     );
   }
 
@@ -2088,7 +2132,6 @@ export function mountCashflowSheetLabRoutes(app, {
 
     let editSession = clientEditSession;
     let temporaryLeaseAcquired = false;
-    let applyCompleted = false;
     try {
       const stagedRunId = readOptionalText(parsed.stageRunId);
       if (!stagedRunId) {
@@ -2123,7 +2166,6 @@ export function mountCashflowSheetLabRoutes(app, {
           logCashflowSheetLab(`apply.${event}`, req, details, level);
         },
       });
-      applyCompleted = true;
       res.status(200).json(result);
     } catch (error) {
       logCashflowSheetLab('apply.error', req, {
@@ -2134,7 +2176,7 @@ export function mountCashflowSheetLabRoutes(app, {
       }, 'warn');
       throw normalizeRouteError(error);
     } finally {
-      if (temporaryLeaseAcquired && !applyCompleted) {
+      if (temporaryLeaseAcquired) {
         await releaseSheetLabApplyLease({
           editLeaseService,
           req,

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -41,6 +41,37 @@ const ACTUAL_OUT_LABELS = [
 
 const JANUARY_FINANCE_WEEKS = ['26-1-1', '26-1-2', '26-1-3', '26-1-4', '26-1-5'];
 
+function javaApplyResponse(request, resultingTargetRevision) {
+  const lines = (request.cells || []).filter((cell) => cell.cellState === 'VALUE');
+  return {
+    ok: true,
+    commandName: 'weeklyExpense.cashflowSheetLab.apply',
+    projectId: request.projectId,
+    sourceSheetKey: 'cashflow-sheet-lab',
+    yearMonth: request.yearMonth,
+    sourceRevision: request.sourceRevision,
+    targetRevision: request.targetRevision,
+    resultingTargetRevision,
+    projection: lines
+      .filter((cell) => cell.mode === 'projection')
+      .map((cell) => ({
+        yearMonth: request.yearMonth,
+        weekNo: cell.weekNo,
+        cashflowLine: cell.cashflowLine,
+        amount: cell.amount,
+      })),
+    actual: lines
+      .filter((cell) => cell.mode === 'actual')
+      .map((cell) => ({
+        sheetKey: 'cashflow-sheet-lab',
+        yearMonth: request.yearMonth,
+        weekNo: cell.weekNo,
+        cashflowLine: cell.cashflowLine,
+        amount: cell.amount,
+      })),
+  };
+}
+
 function buildSection(actual = false, weekLabels = ['26-1-1', '26-1-2', '26-1-3'], annualYears = [], annualValue = '') {
   const firstWeekColumn = annualYears.length > 0 ? 2 + annualYears.length : 3;
   const header = [actual ? 'ACTUAL' : 'Projection'];
@@ -79,6 +110,46 @@ function buildMatrixWithWeekLabels(weekLabels) {
     [],
     ...buildSection(true, weekLabels),
   ];
+}
+
+function buildWorkbook260701MockMatrix() {
+  const weekLabels = Array.from({ length: 12 }, (_, monthIndex) => (
+    Array.from({ length: 5 }, (_unused, weekIndex) => `26-${monthIndex + 1}-${weekIndex + 1}`)
+  )).flat();
+  const valueMap = new Map([
+    ['IN:0:26-1-3', '2300000'],
+    ['IN:1:26-1-3', '2000000'],
+    ['IN:2:26-2-1', '300000'],
+    ['IN:3:26-2-1', '5000000'],
+    ['IN:4:26-2-1', '500000'],
+    ['IN:5:26-2-1', '1000000'],
+    ['IN:6:26-3-1', '0'],
+    ['OUT:0:26-2-2', '2300000'],
+    ['OUT:1:26-1-4', '2000000'],
+    ['OUT:2:26-1-3', '1000000'],
+    ['OUT:2:26-1-4', '2000000'],
+    ['OUT:3:26-1-3', '100000'],
+    ['OUT:3:26-1-4', '200000'],
+    ['OUT:4:26-2-3', '2000000'],
+    ['OUT:5:26-2-2', '2000000'],
+    ['OUT:6:26-2-2', '500000'],
+    ['OUT:7:26-1-5', '1000000'],
+  ]);
+  const section = (actual) => {
+    const inLabels = actual ? ACTUAL_IN_LABELS : PROJECTION_IN_LABELS;
+    const outLabels = actual ? ACTUAL_OUT_LABELS : PROJECTION_OUT_LABELS;
+    const values = (direction, lineIndex) => weekLabels.map((week) => valueMap.get(`${direction}:${lineIndex}:${week}`) || '');
+    return [
+      [actual ? 'ACTUAL' : 'Projection'],
+      ['', '', '', ...weekLabels],
+      ...inLabels.map((label, index) => [label, '', '', ...values('IN', index)]),
+      ['입금 합계'],
+      ...outLabels.map((label, index) => [label, '', '', ...values('OUT', index)]),
+      ['출금 합계'],
+      [actual ? '잔액' : '잔액 (※ 중요)'],
+    ];
+  };
+  return [['260701 cashflow mock'], ...section(false), [], ...section(true)];
 }
 
 function buildMultiYearMatrix() {
@@ -826,14 +897,7 @@ describe('cashflow sheet lab route', () => {
     });
     const resultingTargetRevision = `sha256:${'5'.repeat(64)}`;
     const javaWeeklyClient = {
-      applyCashflowSheetLab: vi.fn(async ({ projectId, yearMonth, sourceRevision, targetRevision }) => ({
-        ok: true,
-        projectId,
-        yearMonth,
-        sourceRevision,
-        targetRevision,
-        resultingTargetRevision,
-      })),
+      applyCashflowSheetLab: vi.fn(async (input) => javaApplyResponse(input, resultingTargetRevision)),
     };
     const app = createApp({
       db,
@@ -1649,17 +1713,7 @@ describe('cashflow sheet lab route', () => {
     };
     const resultingTargetRevision = `sha256:${'1'.repeat(64)}`;
     const javaWeeklyClient = {
-      applyCashflowSheetLab: vi.fn(async ({ projectId, yearMonth, cells, sourceRevision, targetRevision }) => ({
-        ok: true,
-        projectId,
-        commandName: 'weeklyExpense.cashflowSheetLab.apply',
-        yearMonth,
-        sourceRevision,
-        targetRevision,
-        resultingTargetRevision,
-        savedProjectionLineCount: cells.filter((cell) => cell.mode === 'projection').length,
-        savedActualLineCount: cells.filter((cell) => cell.mode === 'actual').length,
-      })),
+      applyCashflowSheetLab: vi.fn(async (input) => javaApplyResponse(input, resultingTargetRevision)),
     };
     const editLeaseService = {
       acquire: vi.fn(async () => ({ body: { leaseId: 'sheet-lab-lease', fence: 8 } })),
@@ -1735,7 +1789,7 @@ describe('cashflow sheet lab route', () => {
       }),
     }));
     expect(editLeaseService.acquire).toHaveBeenCalledTimes(1);
-    expect(editLeaseService.release).not.toHaveBeenCalled();
+    expect(editLeaseService.release).toHaveBeenCalledTimes(1);
     expect(javaWeeklyClient.applyCashflowSheetLab.mock.calls[0][0].cells).toHaveLength(160);
     expect(db.__getQueries()).toContainEqual({
       path: 'orgs/tenant-a/cashflow_change_candidates',
@@ -1755,7 +1809,7 @@ describe('cashflow sheet lab route', () => {
     });
   });
 
-  it('rejects a multi-month mirror before staging any authoritative write', async () => {
+  it('stages every complete month from a multi-month mirror for one explicit apply', async () => {
     const db = createDb({
       project: {
         id: 'project-a',
@@ -1780,29 +1834,192 @@ describe('cashflow sheet lab route', () => {
         matrix: buildMatrixWithWeekLabels(twoFullMonths),
       })),
     };
-    const javaWeeklyClient = { applyCashflowSheetLab: vi.fn() };
+    let applyIndex = 0;
+    const javaWeeklyClient = {
+      applyCashflowSheetLab: vi.fn(async (input) => {
+        applyIndex += 1;
+        return javaApplyResponse(input, `sha256:${String(applyIndex).repeat(64)}`);
+      }),
+    };
+    const editLeaseService = {
+      acquire: vi.fn(async () => ({ body: { leaseId: 'sheet-lab-lease', fence: 8 } })),
+      release: vi.fn(),
+    };
     const app = createApp({
       db,
       googleSheetsService,
-      routeOptions: { editLeasesEnabled: true, javaWeeklyClient },
+      routeOptions: { editLeasesEnabled: true, editLeaseService, javaWeeklyClient },
     });
 
     const mirror = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
       .send({ idempotencyKey: 'refresh-two-months' })
       .expect(200);
-    await request(app)
+    const stage = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
       .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-two-months' })
-      .expect(409)
-      .expect((response) => {
-        expect(response.body.code).toBe('cashflow_sheet_stage_single_month_required');
-      });
+      .expect(200);
 
-    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_change_candidates/')).toHaveLength(0);
-    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_stage_runs/')).toHaveLength(0);
-    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_stage_months/')).toHaveLength(0);
-    expect(javaWeeklyClient.applyCashflowSheetLab).not.toHaveBeenCalled();
+    expect(stage.body.stagedMonths).toEqual(['2026-01', '2026-02']);
+    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_change_candidates/').length).toBeGreaterThan(0);
+    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_stage_runs/')).toHaveLength(1);
+    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_stage_months/')).toHaveLength(2);
+    const apply = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
+      .send({ stageRunId: stage.body.runId, idempotencyKey: 'apply-two-months' })
+      .expect(200);
+
+    expect(apply.body).toMatchObject({
+      appliedMonths: ['2026-01', '2026-02'],
+      appliedLineCount: 320,
+      verifiedLineCount: 320,
+    });
+    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(2);
+    expect(javaWeeklyClient.applyCashflowSheetLab.mock.calls.map(([input]) => input.yearMonth))
+      .toEqual(['2026-01', '2026-02']);
+    expect(editLeaseService.release).toHaveBeenCalledTimes(1);
+  });
+
+  it('imports the sanitized 260701 workbook shape across the full year and verifies exact ledger totals', async () => {
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        cashflowSheetLab: {
+          value: 'saved-spreadsheet-a',
+          sheetName: 'cashflow(사용내역 연동)',
+          startWeek: '26-1-1',
+          endWeek: '26-12-5',
+        },
+      },
+    });
+    const googleSheetsService = {
+      previewSpreadsheet: vi.fn(async () => ({
+        spreadsheetId: 'spreadsheet-a',
+        spreadsheetTitle: '260701 cashflow mock',
+        selectedSheetName: 'cashflow(사용내역 연동)',
+        availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
+        matrix: buildWorkbook260701MockMatrix(),
+      })),
+    };
+    const revisions = '123456789abc';
+    let applyIndex = 0;
+    const javaWeeklyClient = {
+      applyCashflowSheetLab: vi.fn(async (input) => {
+        const revision = `sha256:${revisions[applyIndex].repeat(64)}`;
+        applyIndex += 1;
+        return javaApplyResponse(input, revision);
+      }),
+    };
+    const editLeaseService = {
+      acquire: vi.fn(async () => ({ body: { leaseId: 'sheet-lab-lease', fence: 8 } })),
+      release: vi.fn(),
+    };
+    const app = createApp({
+      db,
+      googleSheetsService,
+      routeOptions: { editLeasesEnabled: true, editLeaseService, javaWeeklyClient },
+    });
+
+    const mirror = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'refresh-260701-mock' })
+      .expect(200);
+
+    const sum = (mode, direction) => mirror.body.cells
+      .filter((cell) => cell.mode === mode && cell.direction === direction && cell.state === 'VALUE')
+      .reduce((total, cell) => total + cell.amount, 0);
+    expect(mirror.body.summary).toMatchObject({ cellCount: 1920, invalidCount: 0 });
+    expect({
+      projectionIn: sum('projection', 'IN'),
+      projectionOut: sum('projection', 'OUT'),
+      actualIn: sum('actual', 'IN'),
+      actualOut: sum('actual', 'OUT'),
+    }).toEqual({
+      projectionIn: 11_100_000,
+      projectionOut: 13_100_000,
+      actualIn: 11_100_000,
+      actualOut: 13_100_000,
+    });
+
+    const stage = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-260701-mock' })
+      .expect(200);
+    expect(stage.body.stagedMonths).toEqual(['2026-01', '2026-02', '2026-03']);
+
+    const apply = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
+      .send({ stageRunId: stage.body.runId, idempotencyKey: 'apply-260701-mock' })
+      .expect(200);
+
+    expect(apply.body).toMatchObject({
+      appliedLineCount: 480,
+      projectionLineCount: 240,
+      actualLineCount: 240,
+      verifiedLineCount: 34,
+      resultingTargetRevision: `sha256:${'3'.repeat(64)}`,
+    });
+    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(3);
+    expect(editLeaseService.release).toHaveBeenCalledTimes(1);
+    expect(db.__getDocument('orgs/tenant-a/cashflow_sheet_mirrors/project-a')).toMatchObject({
+      appliedSourceRevision: mirror.body.sourceRevision,
+      appliedTargetRevision: `sha256:${'3'.repeat(64)}`,
+    });
+  });
+
+  it('fails closed when the JVM reports a different amount than the staged sheet value', async () => {
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        cashflowSheetLab: {
+          value: 'saved-spreadsheet-a',
+          sheetName: 'cashflow(사용내역 연동)',
+          startWeek: '26-1-1',
+          endWeek: '26-1-5',
+        },
+      },
+    });
+    const javaWeeklyClient = {
+      applyCashflowSheetLab: vi.fn(async (input) => {
+        const response = javaApplyResponse(input, `sha256:${'7'.repeat(64)}`);
+        response.projection[0] = { ...response.projection[0], amount: response.projection[0].amount + 1 };
+        return response;
+      }),
+    };
+    const editLeaseService = {
+      acquire: vi.fn(async () => ({ body: { leaseId: 'sheet-lab-lease', fence: 8 } })),
+      release: vi.fn(),
+    };
+    const app = createApp({
+      db,
+      googleSheetsService: {
+        previewSpreadsheet: vi.fn(async () => ({
+          spreadsheetId: 'spreadsheet-a',
+          selectedSheetName: 'cashflow(사용내역 연동)',
+          availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
+          matrix: buildMatrixWithWeekLabels(JANUARY_FINANCE_WEEKS),
+        })),
+      },
+      routeOptions: { editLeasesEnabled: true, editLeaseService, javaWeeklyClient },
+    });
+    const mirror = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'refresh-jvm-mismatch' })
+      .expect(200);
+    const stage = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-jvm-mismatch' })
+      .expect(200);
+
+    await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
+      .send({ stageRunId: stage.body.runId, idempotencyKey: 'apply-jvm-mismatch' })
+      .expect(502)
+      .expect((response) => {
+        expect(response.body.code).toBe('cashflow_jvm_apply_verification_failed');
+      });
+    expect(db.__getDocument(`orgs/tenant-a/cashflow_sheet_stage_runs/${stage.body.runId}`).status).toBe('APPLYING');
+    expect(editLeaseService.release).toHaveBeenCalledTimes(1);
   });
 
   it('resumes an uncertain single-month apply with the server-pinned idempotency key', async () => {
@@ -1826,21 +2043,14 @@ describe('cashflow sheet lab route', () => {
     const resultingTargetRevision = `sha256:${'3'.repeat(64)}`;
     let attempts = 0;
     const javaWeeklyClient = {
-      applyCashflowSheetLab: vi.fn(async ({ projectId, yearMonth, sourceRevision, targetRevision }) => {
+      applyCashflowSheetLab: vi.fn(async (input) => {
         if (attempts++ === 0) {
           throw Object.assign(new Error('temporary JVM failure'), {
             statusCode: 503,
             code: 'weekly_api_unavailable',
           });
         }
-        return {
-          ok: true,
-          projectId,
-          yearMonth,
-          sourceRevision,
-          targetRevision,
-          resultingTargetRevision,
-        };
+        return javaApplyResponse(input, resultingTargetRevision);
       }),
     };
     const app = createApp({
@@ -1908,21 +2118,14 @@ describe('cashflow sheet lab route', () => {
     const resultingTargetRevision = `sha256:${'4'.repeat(64)}`;
     let attempts = 0;
     const javaWeeklyClient = {
-      applyCashflowSheetLab: vi.fn(async ({ projectId, yearMonth, sourceRevision, targetRevision }) => {
+      applyCashflowSheetLab: vi.fn(async (input) => {
         if (attempts++ === 0) {
           throw Object.assign(new Error('validation rejected'), {
             statusCode: 422,
             code: 'cashflow_sheet_validation_failed',
           });
         }
-        return {
-          ok: true,
-          projectId,
-          yearMonth,
-          sourceRevision,
-          targetRevision,
-          resultingTargetRevision,
-        };
+        return javaApplyResponse(input, resultingTargetRevision);
       }),
     };
     const app = createApp({

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -301,7 +301,29 @@ async function readCashflowActivity(db, tenantId, projectId) {
         createdAt: readOptionalText(audit.createdAt),
       };
     });
-  return [...legacyEvents, ...refreshEvents, ...closeEvents]
+  const sheetApplyEvents = monthlyAudits
+    .filter((audit) => readOptionalText(audit.commandName) === 'weeklyExpense.cashflowSheetLab.apply')
+    .map((audit) => {
+      const metadata = parseAuditMetadata(audit.metadataJson);
+      const projectionLineCount = safeAmount(metadata.projectionLineCount);
+      const actualLineCount = safeAmount(metadata.actualLineCount);
+      return {
+        id: `sheet-apply:${audit.id}`,
+        projectId,
+        runId: readOptionalText(audit.idempotencyKey) || audit.id,
+        type: 'sheet_apply',
+        source: 'google_sheet_apply',
+        yearMonth: readOptionalText(metadata.yearMonth),
+        projectionLineCount,
+        actualLineCount,
+        appliedLineCount: projectionLineCount + actualLineCount,
+        actorUid: readOptionalText(audit.actorId),
+        actorEmail: readOptionalText(metadata.actorEmail),
+        actorName: readOptionalText(metadata.actorName),
+        createdAt: readOptionalText(audit.createdAt),
+      };
+    });
+  return [...legacyEvents, ...refreshEvents, ...sheetApplyEvents, ...closeEvents]
     .filter((event) => readOptionalText(event.createdAt))
     .sort((left, right) => readOptionalText(right.createdAt).localeCompare(readOptionalText(left.createdAt)))
     .slice(0, 200);
@@ -432,13 +454,6 @@ function canonicalPinnedSheetWeeks(pinnedSheetCells) {
 
 function canonicalCashflowWeeks(cashflow, cells, yearMonth, pinnedSheetCells) {
   const pinnedWeeks = canonicalPinnedSheetWeeks(pinnedSheetCells);
-  if (pinnedWeeks.length > 0) {
-    const byKey = new Map(pinnedWeeks.map((week) => [`${week.yearMonth}:${week.weekNo}`, week]));
-    if (completeMonthCloseCells(cells)) {
-      for (const week of monthWeeksFromCells(cells, yearMonth)) byKey.set(`${yearMonth}:${week.weekNo}`, week);
-    }
-    return [...byKey.values()].sort((left, right) => cashflowRangeSortKey(left) - cashflowRangeSortKey(right));
-  }
   const byKey = new Map();
   for (const month of Array.isArray(cashflow?.readModel?.months) ? cashflow.readModel.months : []) {
     const monthKey = readOptionalText(month?.yearMonth);
@@ -456,6 +471,20 @@ function canonicalCashflowWeeks(cashflow, cells, yearMonth, pinnedSheetCells) {
       });
     }
   }
+  if (byKey.size > 0) {
+    for (const pinnedWeek of pinnedWeeks) {
+      const key = `${pinnedWeek.yearMonth}:${pinnedWeek.weekNo}`;
+      if (!byKey.has(key)) byKey.set(key, { ...pinnedWeek, projection: {}, actual: {} });
+    }
+    return [...byKey.values()].sort((left, right) => cashflowRangeSortKey(left) - cashflowRangeSortKey(right));
+  }
+  if (pinnedWeeks.length > 0) {
+    const pinnedByKey = new Map(pinnedWeeks.map((week) => [`${week.yearMonth}:${week.weekNo}`, week]));
+    if (completeMonthCloseCells(cells)) {
+      for (const week of monthWeeksFromCells(cells, yearMonth)) pinnedByKey.set(`${yearMonth}:${week.weekNo}`, week);
+    }
+    return [...pinnedByKey.values()].sort((left, right) => cashflowRangeSortKey(left) - cashflowRangeSortKey(right));
+  }
   if (completeMonthCloseCells(cells)) {
     for (const week of monthWeeksFromCells(cells, yearMonth)) byKey.set(`${yearMonth}:${week.weekNo}`, week);
   }
@@ -468,7 +497,33 @@ function cashflowCellKey(yearMonth, cell) {
   return `${yearMonth}:${cell.mode}:${cell.weekNo}:${cell.cashflowLine}`;
 }
 
-function canonicalCashflowCellStates(cells, yearMonth, pinnedSheetCells) {
+function canonicalCashflowCellStates(cashflow, cells, yearMonth, pinnedSheetCells) {
+  const canonicalMonths = Array.isArray(cashflow?.readModel?.months) ? cashflow.readModel.months : [];
+  if (canonicalMonths.length > 0) {
+    const canonical = new Map();
+    for (const month of canonicalMonths) {
+      const monthKey = readOptionalText(month?.yearMonth);
+      if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(monthKey)) continue;
+      for (const mode of ['projection', 'actual']) {
+        for (const week of Array.isArray(month?.[mode]?.weeks) ? month[mode].weeks : []) {
+          const weekNo = Number(week?.weekNo);
+          const amounts = objectValue(week?.amounts);
+          if (!Number.isInteger(weekNo) || weekNo < 1 || weekNo > 5) continue;
+          for (const lineId of CASHFLOW_ALL_LINES) {
+            if (!Object.prototype.hasOwnProperty.call(amounts, lineId)) continue;
+            canonical.set(`${monthKey}:${mode}:${weekNo}:${lineId}`, {
+              mode,
+              weekNo,
+              cashflowLine: lineId,
+              cellState: 'VALUE',
+              amount: safeAmount(amounts[lineId]),
+            });
+          }
+        }
+      }
+    }
+    return canonical;
+  }
   const byKey = new Map();
   for (const sourceCell of Array.isArray(pinnedSheetCells) ? pinnedSheetCells : []) {
     const source = objectValue(sourceCell);
@@ -495,7 +550,13 @@ function laborTransferCheck(weeks, cellStates, yearMonth, asOfKey) {
     if (cashflowRangeSortKey({ yearMonth, weekNo: 3 }) > asOfKey) continue;
     const projection = cellStates.get(`${yearMonth}:projection:3:MYSC_LABOR_OUT`);
     if (!projection || projection.cellState === 'EMPTY') {
-      warnings.push(`${yearMonth} 3주차 · Projection 인건비 미기입`);
+      const otherWeeks = weeks
+        .filter((week) => week.yearMonth === yearMonth && week.weekNo !== 3)
+        .map((week) => ({ weekNo: week.weekNo, amount: safeAmount(week.projection?.MYSC_LABOR_OUT) }))
+        .filter((week) => week.amount !== 0);
+      warnings.push(otherWeeks.length > 0
+        ? `${yearMonth} 3주차 · Projection 인건비 미기입 · ${otherWeeks.map((week) => `${week.weekNo}주차 ${week.amount.toLocaleString('ko-KR')}원`).join(', ')} 입력됨`
+        : `${yearMonth} 3주차 · Projection 인건비 미기입`);
       continue;
     }
     const plannedAmount = safeAmount(projection.amount);
@@ -567,21 +628,39 @@ function negativeProjectionCheck(weeks) {
   let balance = 0;
   let prepay = 0;
   const findings = [];
+  let episode = null;
+  const closeEpisode = () => {
+    if (!episode) return;
+    const range = episode.startKey === episode.endKey
+      ? episode.startKey
+      : `${episode.startKey}부터 ${episode.endKey}까지`;
+    findings.push(`${range} · 최저 ${episode.minimum.toLocaleString('ko-KR')}원${episode.prepaySeen ? '' : ' · MYSC 선입금 Projection 없음'}`);
+    episode = null;
+  };
   for (const week of weeks) {
     const totalIn = sumSafe(CASHFLOW_IN_LINES.map((lineId) => week.projection?.[lineId])) || 0;
     const totalOut = sumSafe(CASHFLOW_OUT_LINES.map((lineId) => week.projection?.[lineId])) || 0;
     balance += totalIn - totalOut;
     prepay += safeAmount(week.projection?.MYSC_PREPAY_IN);
     if (balance < 0) {
-      findings.push(`${week.yearMonth} ${week.weekNo}주차 · ${balance.toLocaleString('ko-KR')}원${prepay > 0 ? '' : ' · MYSC 선입금 Projection 없음'}`);
+      const key = `${week.yearMonth} ${week.weekNo}주차`;
+      if (!episode) episode = { startKey: key, endKey: key, minimum: balance, prepaySeen: prepay > 0 };
+      else {
+        episode.endKey = key;
+        episode.minimum = Math.min(episode.minimum, balance);
+        episode.prepaySeen ||= prepay > 0;
+      }
+    } else {
+      closeEpisode();
     }
   }
+  closeEpisode();
   if (findings.length > 0) {
     return managementCheck(
       'negative-projection-balance',
       'WARNING',
       'Projection 잔액 마이너스',
-      `${findings.length}개 주차에서 마이너스 · 최초 ${findings[0]}`,
+      `${findings.length}개 구간에서 마이너스 · 최초 ${findings[0]}`,
       findings,
     );
   }
@@ -605,7 +684,7 @@ function futurePrepayCheck(weeks, asOfKey) {
 
 export function buildCashflowManagementChecks({ cashflow, cells, yearMonth, depositScheduleRows, comparisonBoundary, pinnedSheetCells }) {
   const weeks = canonicalCashflowWeeks(cashflow, cells, yearMonth, pinnedSheetCells);
-  const cellStates = canonicalCashflowCellStates(cells, yearMonth, pinnedSheetCells);
+  const cellStates = canonicalCashflowCellStates(cashflow, cells, yearMonth, pinnedSheetCells);
   const asOfKey = cashflowRangeSortKey(comparisonBoundary?.asOfWeek || { yearMonth, weekNo: 5 });
   const deposits = (Array.isArray(depositScheduleRows) ? depositScheduleRows : []).map((row) => ({
     ...row,
@@ -798,6 +877,16 @@ function dashboardTotals(mode) {
     rowTotals: mode?.rowTotals || {},
     weeks: mode?.weeks || [],
   };
+}
+
+function canonicalProjectionTotalIn(cashflow, fallback) {
+  const months = Array.isArray(cashflow?.readModel?.months) ? cashflow.readModel.months : [];
+  const boundaries = cashflowReadModelBoundaries(months);
+  if (boundaries.length === 0) return fallback;
+  return buildCashflowRangeTotals(months, 'projection', {
+    start: boundaries[0],
+    end: boundaries.at(-1),
+  }).totalIn;
 }
 
 function validConfirmationKeys(confirmations) {
@@ -1114,6 +1203,8 @@ async function composeCashflowMonthDashboard({ db, req, projectId, yearMonth, cl
     else if (mirror.status !== 'FRESH') blockers.push({ code: 'SHEET_SOURCE_STALE', message: '시트값을 다시 불러와 주세요.' });
     else if ((mirror.projectId && mirror.projectId !== projectId) || !mirror.yearMonths?.includes(yearMonth)) {
       blockers.push({ code: 'SHEET_SOURCE_SCOPE_MISMATCH', message: '고정한 시트값의 프로젝트 또는 월이 다릅니다.' });
+    } else if (readOptionalText(mirror.appliedSourceRevision) !== readOptionalText(mirror.sourceRevision)) {
+      blockers.push({ code: 'SHEET_SOURCE_NOT_APPLIED', message: '불러온 시트값을 원장에 반영해 주세요.' });
     }
     blockers.push(...sheetControlBlockers(sheetFacts));
     if (!completeMonthCloseCells(cells)) blockers.push({ code: 'SHEET_MONTH_INCOMPLETE', message: '선택한 월의 160개 캐시플로우 값을 다시 불러와 주세요.' });
@@ -1131,9 +1222,10 @@ async function composeCashflowMonthDashboard({ db, req, projectId, yearMonth, cl
     }
   }
   const contractAmount = safeAmount(project?.contractAmount);
+  const projectionTotalIn = canonicalProjectionTotalIn(cashflow, projection.totalIn);
   const rawProjectionProgressPercent = contractAmount === 0
     ? 100
-    : Math.round((projection.totalIn / contractAmount) * 10_000) / 100;
+    : Math.round((projectionTotalIn / contractAmount) * 10_000) / 100;
   const projectionProgressPercent = Math.max(0, Math.min(100, rawProjectionProgressPercent));
   const requiredCellConfirmationCount = CASHFLOW_ALL_LINES.length * 2 * 5;
   const requiredManagementConfirmationCount = CASHFLOW_MANAGEMENT_CHECK_IDS.length;
@@ -1155,6 +1247,8 @@ async function composeCashflowMonthDashboard({ db, req, projectId, yearMonth, cl
     status: readOptionalText(mirror?.status) || 'EMPTY',
     sourceRevision: readOptionalText(mirror?.sourceRevision),
     targetRevision: readOptionalText(mirror?.targetRevisionAtFetch),
+    appliedSourceRevision: readOptionalText(mirror?.appliedSourceRevision),
+    appliedTargetRevision: readOptionalText(mirror?.appliedTargetRevision),
     capturedAt: readOptionalText(mirror?.capturedAt),
   };
   return {

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -120,7 +120,7 @@ function fullMonthCloseSource({ mirrorStatus = 'FRESH', controlMatches = true, c
       } },
     }],
     ['orgs/tenant-a/cashflow_sheet_mirrors/project-a', {
-      projectId: 'project-a', status: mirrorStatus, sourceRevision, targetRevisionAtFetch: targetRevision,
+      projectId: 'project-a', status: mirrorStatus, sourceRevision, appliedSourceRevision: sourceRevision, targetRevisionAtFetch: targetRevision,
       yearMonths: ['2026-06'], capturedAt: '2026-07-01T00:00:00.000Z', configRevision: `sha256:${'e'.repeat(64)}`,
       cells, sheetFacts,
     }],
@@ -164,7 +164,7 @@ function createMonthCloseDb() {
       } },
     }],
     ['orgs/tenant-a/cashflow_sheet_mirrors/project-a', {
-      projectId: 'project-a', status: 'FRESH', sourceRevision, targetRevisionAtFetch: targetRevision,
+      projectId: 'project-a', status: 'FRESH', sourceRevision, appliedSourceRevision: sourceRevision, targetRevisionAtFetch: targetRevision,
       yearMonths: ['2026-06'], capturedAt: '2026-07-01T00:00:00.000Z',
       sheetFacts: {
         metadata: {},
@@ -404,11 +404,21 @@ describe('JVM weekly API BFF proxy', () => {
         createdBy: { uid: 'pm-1', name: '변민욱(보람)', email: 'pm@example.com' },
         response: { status: 'FRESH', selectedSheetName: 'cashflow(사용내역 연동)' },
       }],
-      weekly_api_audit_events: [{
-        id: 'close-1', projectId: 'project-a', idempotencyKey: 'close-key', commandName: 'cashflowMonth.close',
-        actorId: 'pm-1', createdAt: '2026-07-02T00:00:00.000Z',
-        metadataJson: JSON.stringify({ yearMonth: '2026-06', status: 'CLOSED', actorEmail: 'pm@example.com' }),
-      }],
+      weekly_api_audit_events: [
+        {
+          id: 'close-1', projectId: 'project-a', idempotencyKey: 'close-key', commandName: 'cashflowMonth.close',
+          actorId: 'pm-1', createdAt: '2026-07-02T00:00:00.000Z',
+          metadataJson: JSON.stringify({ yearMonth: '2026-06', status: 'CLOSED', actorEmail: 'pm@example.com' }),
+        },
+        {
+          id: 'apply-1', projectId: 'project-a', idempotencyKey: 'apply-key', commandName: 'weeklyExpense.cashflowSheetLab.apply',
+          actorId: 'pm-1', createdAt: '2026-07-01T12:00:00.000Z',
+          metadataJson: JSON.stringify({
+            yearMonth: '2026-06', projectionLineCount: 8, actualLineCount: 7,
+            actorName: '변민욱(보람)', actorEmail: 'pm@example.com',
+          }),
+        },
+      ],
       cashflow_events: [],
     };
     const db = {
@@ -428,6 +438,10 @@ describe('JVM weekly API BFF proxy', () => {
       .expect((response) => {
         expect(response.body.events).toMatchObject([
           { type: 'month_close', yearMonth: '2026-06', status: 'CLOSED' },
+          {
+            type: 'sheet_apply', yearMonth: '2026-06', appliedLineCount: 15,
+            actorName: '변민욱(보람)', actorEmail: 'pm@example.com',
+          },
           { type: 'sheet_refresh', sheetName: 'cashflow(사용내역 연동)', actorName: '변민욱(보람)', actorEmail: 'pm@example.com' },
         ]);
       });
@@ -511,11 +525,30 @@ describe('JVM weekly API BFF proxy', () => {
         ? { ...row, actualDepositDate: '2026-06-30', actualDepositAmount: 1_000_000, actualSource: 'SHEET' }
         : row
     ));
+    const juneMonth = {
+      yearMonth: '2026-06',
+      projection: {
+        weeks: Array.from({ length: 5 }, (_, index) => ({
+          weekNo: index + 1,
+          amounts: Object.fromEntries(cells
+            .filter((cell) => cell.mode === 'projection' && cell.weekNo === index + 1)
+            .map((cell) => [cell.cashflowLine, cell.amount])),
+        })),
+      },
+      actual: {
+        weeks: Array.from({ length: 5 }, (_, index) => ({
+          weekNo: index + 1,
+          amounts: Object.fromEntries(cells
+            .filter((cell) => cell.mode === 'actual' && cell.weekNo === index + 1)
+            .map((cell) => [cell.cashflowLine, cell.amount])),
+        })),
+      },
+    };
     const checks = buildCashflowManagementChecks({
       project: {},
       cashflow: {
         readModel: {
-          months: [{
+          months: [juneMonth, {
             yearMonth: '2026-08',
             projection: { weeks: [{ weekNo: 1, amounts: { MYSC_PREPAY_IN: 1_000_001 } }] },
             actual: { weeks: [] },
@@ -537,8 +570,9 @@ describe('JVM weekly API BFF proxy', () => {
     expect(checks[1].detail).toContain('다음 주차 원장 없음');
     expect(checks[0].detail).toContain('실제 0원 · 실제 미이관');
     expect(checks[0].findings).toContain('2026-06 3주차 · 예정 10원 · 실제 0원 · 실제 미이관');
-    expect(checks[2].findings).toHaveLength(5);
+    expect(checks[2].findings).toHaveLength(1);
     expect(checks[2].findings[0]).toContain('2026-06 1주차');
+    expect(checks[2].findings[0]).toContain('2026-06 5주차까지');
     expect(checks[3].detail).toContain('1,000,001원');
   });
 
@@ -562,8 +596,8 @@ describe('JVM weekly API BFF proxy', () => {
       id: 'labor-transfer',
       status: 'WARNING',
       title: 'MYSC 인건비 이관',
-      detail: '2026-06 3주차 · Projection 인건비 미기입',
-      findings: ['2026-06 3주차 · Projection 인건비 미기입'],
+      detail: '2026-06 3주차 · Projection 인건비 미기입 · 1주차 10원, 2주차 10원, 4주차 10원, 5주차 10원 입력됨',
+      findings: ['2026-06 3주차 · Projection 인건비 미기입 · 1주차 10원, 2주차 10원, 4주차 10원, 5주차 10원 입력됨'],
     });
   });
 
@@ -599,7 +633,7 @@ describe('JVM weekly API BFF proxy', () => {
     expect(checks.find((check) => check.id === 'profit-vat-after-deposit')?.detail).toContain('2026-07 2주차 MYSC 수익·매출부가세');
   });
 
-  it('uses the manually pinned sheet range instead of legacy JVM months for negative Projection balance', () => {
+  it('uses the canonical JVM ledger instead of an unapplied pinned sheet for negative Projection balance', () => {
     const { documents } = fullMonthCloseSource();
     const mirror = documents.get('orgs/tenant-a/cashflow_sheet_mirrors/project-a');
     const pinnedSheetCells = mirror.cells.map((cell) => ({
@@ -629,11 +663,11 @@ describe('JVM weekly API BFF proxy', () => {
       comparisonBoundary: { asOfWeek: { yearMonth: '2026-06', weekNo: 5 } },
     });
 
-    expect(checks.find((check) => check.id === 'negative-projection-balance')).toEqual({
+    expect(checks.find((check) => check.id === 'negative-projection-balance')).toMatchObject({
       id: 'negative-projection-balance',
-      status: 'OK',
+      status: 'WARNING',
       title: 'Projection 잔액 마이너스',
-      detail: 'Projection 누적 잔액이 0원 이상입니다.',
+      findings: [expect.stringContaining('2024-09 2주차')],
     });
   });
 

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -123,6 +123,7 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('handleRefreshSheetMirror');
     expect(source).toContain('refreshCashflowSheetLabMirrorViaBff');
     expect(source).toContain('stageCashflowSheetLabViaBff');
+    expect(source).toContain('handleStagePinnedSheetValues(false, cashflowSheetMirror)');
     expect(source).toContain('시트값 불러오기');
     expect(source).toContain('시트 값 불러오기');
     expect(source).toContain('fetchCashflowActivityViaBff');
@@ -192,7 +193,7 @@ describe('CashflowProjectSheet monthly close shell', () => {
   it('shows who explicitly loaded the sheet values in the activity timeline', () => {
     expect(source).toContain('`${event.actorName}님이`');
     expect(source).toContain('`${event.actorEmail} 계정으로`');
-    expect(source).toContain('시트의 최신 값을 불러와 기준값으로 저장했습니다.');
+    expect(source).toContain('시트의 최신 값을 불러와 원장 반영 전 검증본으로 보관했습니다.');
     expect(source).toContain('누가 언제 시트 값을 불러오고 월 결산했는지 확인할 수 있습니다.');
   });
 
@@ -209,6 +210,10 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('setMonthCloseResult((current) => current?.yearMonth === yearMonth ? current : null)');
     expect(source).toContain('check.findings?.length');
     expect(source).toContain('check.findings.map((finding)');
+  });
+
+  it('reloads both the canonical ledger and management checks after sheet apply', () => {
+    expect(source).toMatch(/loadCashflowComparison\(\)[\s\S]*loadCashflowMonthClose\(\)/);
   });
 
   it('offers the exact three in-app exit choices and releases only on exit', () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -286,12 +286,14 @@ export function CashflowProjectSheet({
   const [reopenAction, setReopenAction] = useState<'request' | 'approve' | 'reject' | null>(null);
   const [reopenReason, setReopenReason] = useState('');
   const [sheetRefreshLoading, setSheetRefreshLoading] = useState(false);
+  const [pendingAutoStageRevision, setPendingAutoStageRevision] = useState('');
   const [sheetRefreshResult, setSheetRefreshResult] = useState<{
     runId: string;
     stagedLineCount: number;
     projectionLineCount: number;
     actualLineCount: number;
     riskLineCount: number;
+    stagedMonths: string[];
   } | null>(null);
   const [sheetReviewDialogOpen, setSheetReviewDialogOpen] = useState(false);
   const [sheetStageDialog, setSheetStageDialog] = useState<{
@@ -300,6 +302,7 @@ export function CashflowProjectSheet({
     projectionLineCount: number;
     actualLineCount: number;
     riskLineCount: number;
+    stagedMonths: string[];
     candidates: CashflowSheetLabChangeCandidate[];
     omittedCandidateCount: number;
     replaceAllActualSources: boolean;
@@ -585,6 +588,7 @@ export function CashflowProjectSheet({
   useEffect(() => {
     let cancelled = false;
     setCashflowSheetMirror(null);
+    setPendingAutoStageRevision('');
     if (!projectId || !orgId || !user?.uid) return () => { cancelled = true; };
 
     const readMirror = (actor: NonNullable<Awaited<ReturnType<typeof resolveBffActor>>>) => (
@@ -985,8 +989,9 @@ export function CashflowProjectSheet({
       setSheetRefreshResult(null);
       setSheetStageDialog(null);
       if (mirror.status === 'FRESH' && mirror.sourceRevision) {
+        setPendingAutoStageRevision(mirror.sourceRevision);
         void loadCashflowEvents();
-        toast.success('시트값을 고정했습니다. 저장할 값을 확인해 주세요.');
+        toast.success('시트값을 불러왔습니다. 원장 반영 전 금액을 확인합니다.');
       } else if (mirror.status === 'STALE') {
         toast.warning('최신 시트 조회에 실패해 마지막 정상 고정값을 유지했습니다.');
       } else {
@@ -1019,12 +1024,16 @@ export function CashflowProjectSheet({
     }
   }, [cashflowSheetConfig, loadCashflowEvents, orgId, projectId, resolveBffActor]);
 
-  const handleStagePinnedSheetValues = useCallback(async (replaceAllActualSources = false): Promise<void> => {
-    if (cashflowSheetMirror?.status !== 'FRESH' || !cashflowSheetMirror.sourceRevision) {
+  const handleStagePinnedSheetValues = useCallback(async (
+    replaceAllActualSources = false,
+    mirrorOverride?: CashflowSheetLabMirrorResult,
+  ): Promise<void> => {
+    const sourceMirror = mirrorOverride || cashflowSheetMirror;
+    if (sourceMirror?.status !== 'FRESH' || !sourceMirror.sourceRevision) {
       toast.error('먼저 시트값 불러오기를 실행해 고정해 주세요.');
       return;
     }
-    const expectedMirrorRevision = cashflowSheetMirror.sourceRevision;
+    const expectedMirrorRevision = sourceMirror.sourceRevision;
     const stageIdempotencyKey = `cashflow-sheet-stage:${projectId}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
     const stageMirror = (actor: NonNullable<Awaited<ReturnType<typeof resolveBffActor>>>) => (
       stageCashflowSheetLabViaBff({
@@ -1043,6 +1052,7 @@ export function CashflowProjectSheet({
         projectionLineCount: result.projectionLineCount,
         actualLineCount: result.actualLineCount,
         riskLineCount: result.riskLineCount,
+        stagedMonths: result.stagedMonths || [],
       });
       setSheetStageDialog({
         runId: result.runId,
@@ -1050,6 +1060,7 @@ export function CashflowProjectSheet({
         projectionLineCount: result.projectionLineCount,
         actualLineCount: result.actualLineCount,
         riskLineCount: result.riskLineCount,
+        stagedMonths: result.stagedMonths || [],
         candidates: result.candidates || [],
         omittedCandidateCount: result.omittedCandidateCount || 0,
         replaceAllActualSources: result.replaceAllActualSources === true,
@@ -1084,6 +1095,12 @@ export function CashflowProjectSheet({
     }
   }, [cashflowSheetMirror, orgId, projectId, resolveBffActor, yearMonth]);
 
+  useEffect(() => {
+    if (!pendingAutoStageRevision || cashflowSheetMirror?.sourceRevision !== pendingAutoStageRevision) return;
+    setPendingAutoStageRevision('');
+    void handleStagePinnedSheetValues(false, cashflowSheetMirror);
+  }, [cashflowSheetMirror, handleStagePinnedSheetValues, pendingAutoStageRevision]);
+
   const handleApplyStagedSheetValues = useCallback(async (): Promise<void> => {
     if (!sheetStageDialog?.runId) {
       toast.error('저장할 검토 값이 없습니다.');
@@ -1095,10 +1112,7 @@ export function CashflowProjectSheet({
       return;
     }
     const applyIdempotencyKey = `cashflow-sheet-apply-stage:${projectId}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
-    let finalMutationLease: Awaited<ReturnType<typeof cashflowLease.checkBeforeMutation>> | null = null;
     const apply = async (actor: NonNullable<Awaited<ReturnType<typeof resolveBffActor>>>) => {
-      const mutationLease = finalMutationLease || await cashflowLease.checkBeforeMutation();
-      finalMutationLease = mutationLease;
       return applyCashflowSheetLabViaBff({
         tenantId: orgId,
         actor,
@@ -1106,14 +1120,13 @@ export function CashflowProjectSheet({
         stageRunId: sheetStageDialog.runId,
         applyRiskCandidates: false,
         idempotencyKey: applyIdempotencyKey,
-        lease: mutationLease,
-        finalize: true,
       });
     };
     const rememberApplyResult = async (result: Awaited<ReturnType<typeof apply>>) => {
       await Promise.all([
         loadCashflowEvents(),
         loadCashflowComparison(),
+        loadCashflowMonthClose(),
       ]);
       setCashflowSheetConfig((current) => current ? {
         ...current,
@@ -1125,14 +1138,7 @@ export function CashflowProjectSheet({
       } : current);
       setSheetStageDialog(null);
       setSheetRefreshResult(null);
-      if (cashflowPrivateDraftClient && privateDraftRevision !== null && finalMutationLease) {
-        await cashflowPrivateDraftClient.complete(finalMutationLease, {
-          expectedDraftRevision: privateDraftRevision,
-        });
-        setPrivateDraftRevision(null);
-      }
-      await cashflowLease.checkStatus();
-      toast.success(`검토한 값 ${result.appliedLineCount.toLocaleString()}건을 캐시플로우 원장에 저장했습니다.`);
+      toast.success(`시트 값 ${result.appliedLineCount.toLocaleString()}건을 검증하고 원장에 반영했습니다.`);
     };
 
     setSheetStageApplyLoading(true);
@@ -1161,7 +1167,7 @@ export function CashflowProjectSheet({
     } finally {
       setSheetStageApplyLoading(false);
     }
-  }, [cashflowLease.checkBeforeMutation, cashflowLease.checkStatus, cashflowPrivateDraftClient, loadCashflowComparison, loadCashflowEvents, orgId, privateDraftRevision, projectId, resolveBffActor, sheetStageDialog]);
+  }, [loadCashflowComparison, loadCashflowEvents, loadCashflowMonthClose, orgId, projectId, resolveBffActor, sheetStageDialog]);
 
   const handleOpenSheetReviewDialog = useCallback(() => {
     if (cashflowSheetMirror?.status !== 'FRESH' || !cashflowSheetMirror.sourceRevision) {
@@ -2096,11 +2102,12 @@ export function CashflowProjectSheet({
       const actor = event.actorName
         ? `${event.actorName}님이`
         : event.actorEmail ? `${event.actorEmail} 계정으로` : '담당자가';
-      const action = `${actor} 시트의 최신 값을 불러와 기준값으로 저장했습니다.`;
+      const action = `${actor} 시트의 최신 값을 불러와 원장 반영 전 검증본으로 보관했습니다.`;
       return [event.sheetName, action].filter(Boolean).join(' · ');
     }
     if (event.type === 'sheet_apply') {
-      return `Google Sheet 반영 ${event.appliedLineCount || 0}건 · Projection ${event.projectionLineCount || 0}건 · Actual ${event.actualLineCount || 0}건`;
+      const actor = event.actorName || event.actorEmail || '담당자';
+      return `${actor} · ${event.yearMonth || ''} 원장 반영 ${event.appliedLineCount || 0}건 · Projection ${event.projectionLineCount || 0}건 · Actual ${event.actualLineCount || 0}건`;
     }
     if (event.type === 'month_close') return [`${event.yearMonth || ''} 월`, event.status || '결산 완료', event.actorName || event.actorEmail || '사용자'].filter(Boolean).join(' · ');
     if (event.type === 'projection_amount_change' || event.type === 'actual_amount_change') {
@@ -2742,11 +2749,11 @@ export function CashflowProjectSheet({
       >
         <AlertDialogContent className="w-[calc(100vw-2rem)] max-w-[1100px]">
           <AlertDialogHeader>
-            <AlertDialogTitle>{sheetStageDialog?.replaceAllActualSources ? `${yearMonth} 원장 덮어쓰기` : `시트 값 비교 ${sheetStageDialog?.stagedLineCount.toLocaleString() || 0}건`}</AlertDialogTitle>
+            <AlertDialogTitle>{sheetStageDialog?.replaceAllActualSources ? `${yearMonth} 원장 덮어쓰기` : `시트 값 원장 반영 ${sheetStageDialog?.stagedLineCount.toLocaleString() || 0}건`}</AlertDialogTitle>
             <AlertDialogDescription>
               {sheetStageDialog?.replaceAllActualSources
                 ? '이 월의 Projection과 Actual 기존값을 모두 지우고, 고정한 시트 160개 셀로 교체합니다. 감사 이력은 유지됩니다.'
-                : '원장은 아직 변경되지 않았습니다. 아래 변경 범위를 확인한 뒤 이 팝업에서 바로 저장합니다.'}
+                : `원장은 아직 변경되지 않았습니다. ${sheetStageDialog?.stagedMonths.length || 0}개월의 시트값과 원장 차이를 확인한 뒤 한 번에 반영합니다.`}
             </AlertDialogDescription>
           </AlertDialogHeader>
           {sheetStageDialog && (
@@ -2810,7 +2817,7 @@ export function CashflowProjectSheet({
               {sheetStageDialog && Math.max(0, sheetStageDialog.stagedLineCount - sheetStageDialog.riskLineCount) > 0
                 ? sheetStageDialog.replaceAllActualSources
                   ? `${yearMonth} 원장 전체 덮어쓰기`
-                  : `검토한 값 ${Math.max(0, sheetStageDialog.stagedLineCount - sheetStageDialog.riskLineCount).toLocaleString()}건 원장에 저장`
+                  : `검증한 값 ${Math.max(0, sheetStageDialog.stagedLineCount - sheetStageDialog.riskLineCount).toLocaleString()}건 원장에 반영`
                 : '저장할 변경 없음'}
             </Button>
           </AlertDialogFooter>

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -172,6 +172,7 @@ export interface CashflowSheetLabApplyResult {
   lastAppliedAt?: string;
   runId?: string;
   stagedRunId?: string;
+  appliedMonths?: string[];
   lastAppliedBy?: {
     uid?: string;
     email?: string;
@@ -258,6 +259,8 @@ export interface CashflowSheetLabMirrorResult {
   selectedSheetName?: string;
   sourceRevision?: string;
   targetRevisionAtFetch?: string;
+  appliedSourceRevision?: string;
+  appliedTargetRevision?: string;
   capturedAt?: string;
   capturedBy?: { uid?: string; email?: string; role?: string };
   yearMonths?: string[];
@@ -381,6 +384,7 @@ export interface CashflowSheetLabStageResult {
   skippedInvalidWeekCount?: number;
   skippedInvalidWeeks?: string[];
   blockedMonths?: string[];
+  stagedMonths?: string[];
   candidates?: CashflowSheetLabChangeCandidate[];
   omittedCandidateCount?: number;
   lastStagedAt?: string;


### PR DESCRIPTION
## 변경
- 명시적 시트값 불러오기 후 변경 월 전체를 JVM 원장 반영 대상으로 준비
- JVM 응답의 프로젝트/월/항목/금액을 시트 고정본과 재검증하고 불일치 시 fail-closed
- 운영 대시보드와 주요 관리 항목이 반영된 JVM 원장을 우선 사용
- 인건비 3주차 외 입력 위치와 Projection 마이너스 연속 구간을 표시
- 시트 불러오기/원장 반영 감사 이력에 수행자 표시

## 검증
- cashflow BFF/frontend targeted: 146 passed
- JVM Maven: 157 passed
- Vite production build: passed
- 전체 Vitest: 2128 passed, 92 skipped; 로컬에 @firebase/rules-unit-testing 패키지가 없어 기존 Firestore Rules integration suite 1개만 collection 실패
- 제공된 260701 엑셀 구조를 비식별 목업으로 재현: 1920 cells, Projection/Actual IN 11,100,000 / OUT 13,100,000 일치