### PR TITLE
fix: allow project members to import cashflow sheets

### DIFF
--- a/server/bff/edit-lease.mjs
+++ b/server/bff/edit-lease.mjs
@@ -379,10 +379,6 @@ export function createEditLeaseService({
       rbacPolicy,
     });
 
-    if (current.resourceType === 'cashflow' && readOptionalText(member.role).toLowerCase() !== 'pm') {
-      throw createHttpError(403, 'Only the project PM can acquire the cashflow edit session', 'forbidden');
-    }
-
     if (current.resourceType === 'project-registration') {
       const draftRef = db.doc(`orgs/${current.tenantId}/projectRequestDrafts/${current.resourceId}`);
       const draftSnap = await tx.get(draftRef);

--- a/server/bff/edit-lease.test.mjs
+++ b/server/bff/edit-lease.test.mjs
@@ -88,6 +88,9 @@ function createHarness({ createLeaseId } = {}) {
     'orgs/tenant-a/members/actor-admin': {
       uid: 'actor-admin', role: 'admin', status: 'ACTIVE', projectIds: [],
     },
+    'orgs/tenant-a/members/actor-viewer': {
+      uid: 'actor-viewer', role: 'viewer', status: 'ACTIVE', projectIds: ['project-a'],
+    },
     'orgs/tenant-a/projects/project-a': { id: 'project-a' },
   });
   const auditChainService = createAuditChainService(db, { now: () => new Date(serverNow).toISOString() });
@@ -136,15 +139,35 @@ async function expectHttpError(promise, statusCode, code) {
 }
 
 describe('edit lease service', () => {
-  it('allows only the project PM to acquire a cashflow edit session', async () => {
+  it('allows active project writers to acquire a cashflow edit session regardless of role', async () => {
     const { service, base } = createHarness();
-    await expectHttpError(service.acquire({
+    const adminLease = await command(service.acquire({
       ...base,
       resourceType: 'cashflow',
       actorId: 'actor-admin',
       sessionId: 'admin-session',
       idempotencyKey: 'admin-cashflow-acquire',
-    }), 403, 'forbidden');
+    }));
+    expect(adminLease).toMatchObject({ state: 'ACTIVE', canEdit: true });
+
+    await command(service.release({
+      ...base,
+      resourceType: 'cashflow',
+      actorId: 'actor-admin',
+      sessionId: 'admin-session',
+      leaseId: adminLease.leaseId,
+      fence: adminLease.fence,
+      idempotencyKey: 'admin-cashflow-release',
+    }));
+
+    const viewerLease = await command(service.acquire({
+      ...base,
+      resourceType: 'cashflow',
+      actorId: 'actor-viewer',
+      sessionId: 'viewer-session',
+      idempotencyKey: 'viewer-cashflow-acquire',
+    }));
+    expect(viewerLease).toMatchObject({ state: 'ACTIVE', canEdit: true });
   });
 
   it('reuses one acquire ID when Firestore retries the transaction', async () => {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseAuthorizationService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseAuthorizationService.java
@@ -51,7 +51,7 @@ public class WeeklyExpenseAuthorizationService {
         Map.entry(WeeklyExpenseCommandService.BANK_IMPORT_LIST_LINES_COMMAND, Set.of("admin", "finance", "pm", "auditor", "viewer", "tenant_admin", "support", "security")),
         Map.entry(WeeklyExpenseCommandService.BANK_IMPORT_APPLY_ITEMS_COMMAND, Set.of("admin", "finance", "pm")),
         Map.entry(WeeklyExpenseCommandService.UPSERT_PROJECTION_COMMAND, Set.of("admin", "finance", "pm")),
-        Map.entry(WeeklyExpenseCommandService.CASHFLOW_SHEET_LAB_APPLY_COMMAND, Set.of("admin", "finance", "pm")),
+        Map.entry(WeeklyExpenseCommandService.CASHFLOW_SHEET_LAB_APPLY_COMMAND, Set.of("admin", "finance", "pm", "viewer")),
         Map.entry(WeeklyExpenseCommandService.SUBMIT_WEEK_COMMAND, Set.of("admin", "finance", "pm")),
         Map.entry(WeeklyExpenseCommandService.WEEKLY_STATUS_READ_COMMAND, Set.of("admin", "finance", "pm", "auditor", "viewer", "tenant_admin", "support", "security")),
         Map.entry(WeeklyExpenseCommandService.CELL_PATCH_COMMAND, Set.of("admin", "finance", "pm")),

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -65,7 +65,7 @@ import java.util.concurrent.Callable;
 @ConditionalOnProperty(name = "weekly.storage-backend", havingValue = "firestore")
 public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpensePersistence {
     private static final ObjectMapper JSON = new ObjectMapper();
-    private static final Set<String> CASHFLOW_WRITE_ROLES = Set.of("admin", "finance", "pm", "tenant_admin");
+    private static final Set<String> CASHFLOW_WRITE_ROLES = Set.of("admin", "finance", "pm", "viewer", "tenant_admin");
     private static final Set<String> CASHFLOW_CROSS_PROJECT_ROLES = Set.of("admin", "finance", "tenant_admin");
     private static final String CASHFLOW_MONTH_CLOSE_CONTRACT_VERSION = "cashflow-month-close-v1";
     private static final long MAX_SAFE_INTEGER = 9_007_199_254_740_991L;

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseAuthorizationServiceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseAuthorizationServiceTest.java
@@ -56,6 +56,28 @@ class WeeklyExpenseAuthorizationServiceTest {
     }
 
     @Test
+    void assignedViewerCanApplyCashflowSheetWithoutReceivingOtherCashflowWritePermissions() {
+        WeeklyExpenseAuthorizationService service = new WeeklyExpenseAuthorizationService(
+            (actor, projectId) -> "project-allowed".equals(projectId),
+            new SplitProjectExistenceRepository(true, true),
+            "strict"
+        );
+        TrustedActorContext viewer = new TrustedActorContext("tenant-a", "viewer-1", "viewer@example.com", "viewer");
+
+        assertThatCode(() -> service.requireProjectAllowed(
+            WeeklyExpenseCommandService.CASHFLOW_SHEET_LAB_APPLY_COMMAND,
+            viewer,
+            "project-allowed"
+        )).doesNotThrowAnyException();
+
+        assertThatThrownBy(() -> service.requireProjectAllowed(
+            WeeklyExpenseCommandService.UPSERT_PROJECTION_COMMAND,
+            viewer,
+            "project-allowed"
+        )).isInstanceOf(WeeklyExpenseForbiddenException.class);
+    }
+
+    @Test
     void tenantWideRolesStillRespectCommandRoleGate() {
         WeeklyExpenseAuthorizationService service = new WeeklyExpenseAuthorizationService(
             (actor, projectId) -> false,

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -343,6 +343,18 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
+    void allowsAssignedViewerToUseCashflowLeaseForSheetApplyAuthorization() {
+        Fixture fixture = fixture(
+            member(Map.of("role", "viewer", "projectIds", List.of("project-a"))),
+            activeLease()
+        );
+
+        assertThat(fixture.persistence.runCommandTransaction(() ->
+            fixture.persistence.requireCashflowWriteLease(ACTOR, "project-a", SESSION)
+        )).isEqualTo("viewer");
+    }
+
+    @Test
     void usesStoredRoleForCrossProjectAccessAndRequiresCanonicalProjectInTransaction() {
         Fixture finance = fixture(member(Map.of("role", "finance", "projectIds", List.of())), activeLease());
         assertThatCode(() -> finance.persistence.runCommandTransaction(() -> {


### PR DESCRIPTION
## 변경\n- 캐시플로 수정 세션의 PM 전용 제한 제거\n- 활성 프로젝트 구성원(viewer 포함)의 시트 값 저장 허용\n- 월 결산 및 다른 캐시플로 쓰기 권한은 유지\n\n## 검증\n- npm test -- server/bff/edit-lease.test.mjs\n- mvn -q -Dtest=WeeklyExpenseAuthorizationServiceTest,FirestoreCashflowLeaseGuardTest test