### PR TITLE
feat(projects): align registration and approval contract

### DIFF
--- a/docs/wiki/patch-notes/log.md
+++ b/docs/wiki/patch-notes/log.md
@@ -266,3 +266,7 @@
 ## [2026-05-21] patch-note | portal-onboarding-feature-search | 로그인 후 검색 엔트리 정리
 - pages: [portal-onboarding](./pages/portal-onboarding.md)
 - summary: 로그인 성공 후 빈 화면 대신 짧은 전환 화면을 거쳐 기능 검색 엔트리로 이동하게 하고, 업무 화면 진입 후에는 `기능 검색` 자기 참조 메뉴를 제거했으며, 프로젝트 등록 검색은 기능 결과만 노출되도록 정리했다.
+
+## [2026-07-21] patch-note | portal-project-registration | 사업관리 폴더와 다년도 재무 입력 복구
+- pages: [shared-portal-architecture](./pages/shared-portal-architecture.md)
+- summary: 프로젝트 등록·수정의 계약 대상 아래에 사업관리 Google Drive 폴더 링크를 추가하고, 다년도 사업은 연도별 계약금액·매출부가세·수익·지원금의 합계만 상단에 반영하도록 정리했다. 계약기간의 한 해라도 빠지거나 확인하지 않으면 BFF가 저장을 거절한다.

--- a/docs/wiki/patch-notes/pages/shared-portal-architecture.md
+++ b/docs/wiki/patch-notes/pages/shared-portal-architecture.md
@@ -32,11 +32,14 @@
 - [x] Cashflow Sheet Lab의 Google Sheets 연동은 서버 서비스 계정 전용으로 고정하고 사용자 OAuth token pass-through를 제거함
 - [x] `/portal/cashflow`는 route-scoped provider만 로딩하고, catalog 권한 오류가 있어도 배정 프로젝트 선택을 유지함
 - [x] 프로젝트 등록/수정은 지정 결재자, 조직장 승인, 경영기획실 코드 부여를 분리한 승인 흐름으로 정렬됨
+- [x] 다년도 프로젝트의 연도별 재무 입력과 BFF 합계 검증이 같은 계약으로 동작함
+- [x] 프로젝트 등록/수정에서 사업관리 Google Drive 폴더 링크를 프로젝트·검토 요청에 함께 보존함
 - [ ] admin summary surface cutover까지 완료됨
 - [ ] 포털의 broad Firestore direct read가 완전히 제거됨
 
 ## Recent Changes
 
+- [2026-07-21] 프로젝트 등록·수정 기본 정보의 계약 대상 아래에 사업관리 Google Drive 폴더 링크를 추가했다. 다년도 사업은 연도별 계약금액·매출부가세·수익·지원금을 입력·확인한 값만 상단 총계로 반영하며, 연도 누락·미확인·합계 불일치는 BFF가 저장 전에 거절한다. 단년도 사업은 총계 직접 입력을 유지한다.
 - [2026-07-20] 프로젝트 등록/수정 승인 흐름을 기획안 기준으로 재정렬했다. 실무자 제출 문서는 지정 조직장 승인 전 도장을 찍지 않고, 경영기획실은 조직장 승인 또는 레거시 승인 request가 있는 프로젝트만 코드 부여 대상으로 본다. 프로젝트 코드는 중복 claim을 통해 선점하고, 반려 메모는 PM 재제출 흐름으로 돌려보낸다.
 - [2026-07-13] 프로젝트 등록·수정과 cashflow의 canonical browser write를 Firestore rules에서 차단하고, BFF/JVM command만 lease·revision·audit 경계를 통과하도록 Stage 전용 리팩터링을 추가했다. 오류 복구는 강제 새로고침 없이 SPA 상태 복구로 바꿨다.
 - [2026-06-19] Cashflow Sheet Lab의 Google Sheets 접근을 서버 서비스 계정으로 고정하고, 설정 저장과 시트 검증/반영 액션을 분리했다. `/portal/cashflow`에서는 HR/Payroll/Board/Training/Career provider 로딩을 제외하고, projects catalog 권한 오류가 배정 프로젝트 선택을 지우지 않도록 했으며, labor risk 배경 요청 키를 사용자/프로젝트/날짜 기준으로 안정화했다.

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -106,6 +106,9 @@ service cloud.firestore {
         || collection in ['members']
         || collection in ['projectRequestDrafts']
         || collection in ['privateEditDrafts']
+        || collection in ['project_requests']
+        || collection in ['projectRequests']
+        || collection in ['projectCodeClaims']
         || collection in ['cashflowEditLocks']
         || collection in ['cashflow_edit_locks']
         || collection in ['editLeases']
@@ -317,6 +320,18 @@ service cloud.firestore {
     }
 
     match /orgs/{orgId}/privateEditDrafts/{draftId} {
+      allow read, write: if false;
+    }
+
+    match /orgs/{orgId}/project_requests/{requestId} {
+      allow read, write: if false;
+    }
+
+    match /orgs/{orgId}/projectRequests/{requestId} {
+      allow read, write: if false;
+    }
+
+    match /orgs/{orgId}/projectCodeClaims/{claimId} {
       allow read, write: if false;
     }
 

--- a/server/bff/app.integration.test.ts
+++ b/server/bff/app.integration.test.ts
@@ -100,6 +100,12 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
 
   beforeEach(async () => {
     await resetTenantData();
+    await db.doc(`orgs/${tenantId}/members/${actorId}`).set({
+      uid: actorId,
+      email: 'u001@example.com',
+      role: 'admin',
+      status: 'ACTIVE',
+    });
   });
 
   afterAll(async () => {
@@ -2224,6 +2230,9 @@ describeIfEmulator('BFF integration (Firestore emulator)', () => {
   });
 
   it('blocks demoting the last remaining admin (lockout protection)', async () => {
+    // This scenario predates the shared ACTIVE actor fixture above and must begin
+    // with exactly one persisted admin to exercise the lockout invariant.
+    await db.doc(`orgs/${tenantId}/members/${actorId}`).delete();
     await db.doc(`orgs/${tenantId}/members/u-admin-1`).set({
       uid: 'u-admin-1',
       tenantId,

--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -12,6 +12,7 @@ import { createIdempotencyService } from './idempotency.mjs';
 import { createAuditChainService } from './audit-chain.mjs';
 import { createEditLeaseService } from './edit-lease.mjs';
 import {
+  DRAFT_ATTACHMENT_CLEANUP_EVENT_TYPE,
   createOutboxEvent,
   enqueueOutboxEventInTransaction,
   processOutboxBatch,
@@ -77,7 +78,10 @@ import {
 } from './google-sheets.mjs';
 import { createGoogleSheetMigrationAiService } from './google-sheet-migration-ai.mjs';
 import { createProjectRequestContractAiService } from './project-request-contract-ai.mjs';
-import { createProjectRequestContractStorageService } from './project-request-contract-storage.mjs';
+import {
+  createDraftAttachmentCleanupOutboxHandler,
+  createProjectRequestContractStorageService,
+} from './project-request-contract-storage.mjs';
 import { createProjectSheetSourceStorageService } from './project-sheet-source-storage.mjs';
 import { createBusinessCardGeminiAiService } from './business-card-gemini-ai.mjs';
 import { createBusinessCardStorageService } from './business-card-storage.mjs';
@@ -566,7 +570,7 @@ export async function resolveApiRequestContext(req, {
 
   let actorRole = identity.actorRole;
   let actorEmail = identity.actorEmail;
-  const actorName = identity.actorName;
+  let actorName = identity.actorName;
 
   if (identity.source === 'firebase' && typeof resolveMemberIdentity === 'function') {
     const memberIdentity = await resolveMemberIdentity({
@@ -575,6 +579,7 @@ export async function resolveApiRequestContext(req, {
     });
     actorRole = normalizeRole(memberIdentity?.role) || actorRole || undefined;
     actorEmail = actorEmail || readOptionalText(memberIdentity?.email).toLowerCase() || undefined;
+    actorName = actorName || readOptionalText(memberIdentity?.name) || undefined;
   }
 
   return {
@@ -791,6 +796,10 @@ export function createBffApp(options = {}) {
       draftStorageService: projectRegistrationDraftStorageService,
       now,
     });
+  const draftAttachmentCleanupOutboxHandler = options.draftAttachmentCleanupOutboxHandler
+    || createDraftAttachmentCleanupOutboxHandler({
+      draftStorageService: projectRegistrationDraftStorageService,
+    });
 
   async function resolveMemberIdentity({ tenantId, actorId }) {
     const normalizedTenantId = readOptionalText(tenantId);
@@ -804,6 +813,7 @@ export function createBffApp(options = {}) {
     return {
       role: normalizeRole(data.role),
       email: readOptionalText(data.email).toLowerCase() || undefined,
+      name: readOptionalText(data.name) || undefined,
     };
   }
 
@@ -925,6 +935,7 @@ export function createBffApp(options = {}) {
       eventHandlers: {
         'project.registration.submitted': projectRegistrationOutboxHandler,
         'project.info.submitted': projectInfoOutboxHandler,
+        [DRAFT_ATTACHMENT_CLEANUP_EVENT_TYPE]: draftAttachmentCleanupOutboxHandler,
       },
     });
 

--- a/server/bff/firestore-rules.edit-leases.integration.test.ts
+++ b/server/bff/firestore-rules.edit-leases.integration.test.ts
@@ -31,6 +31,9 @@ const protectedCollections = [
   'weekly_api_audit_exports',
   'projectRequestDrafts',
   'privateEditDrafts',
+  'project_requests',
+  'projectRequests',
+  'projectCodeClaims',
   'cashflowEditLocks',
   'cashflow_edit_locks',
   'cashflow_sheet_mirrors',
@@ -48,8 +51,6 @@ const protectedCollections = [
 ] as const;
 const canonicalRootCollections = [
   'projects',
-  'project_requests',
-  'projectRequests',
   'cashflow_weeks',
   'weekly_submission_status',
   'transactions',
@@ -97,7 +98,13 @@ describeIfEmulator('BFF-only Firestore collection rules (Firestore emulator)', (
         ...actors.map((actor) => setDoc(doc(db, `orgs/${tenantId}/members/${actor.uid}`), {
           uid: actor.uid,
           role: actor.role,
+          status: 'ACTIVE',
         })),
+        setDoc(doc(db, `orgs/${tenantId}/members/inactive-member`), {
+          uid: 'inactive-member',
+          role: 'admin',
+          status: 'INACTIVE',
+        }),
         setDoc(doc(db, `orgs/${tenantId}/members/self-member`), {
           uid: 'self-member',
           name: 'Self Member',
@@ -165,6 +172,7 @@ describeIfEmulator('BFF-only Firestore collection rules (Firestore emulator)', (
       });
     }
   }
+
 
   for (const collection of canonicalProjectSubcollections) {
     for (const actor of actors.filter(({ role }) => role !== 'viewer')) {

--- a/server/bff/outbox-worker.mjs
+++ b/server/bff/outbox-worker.mjs
@@ -1,5 +1,9 @@
 import { createFirestoreDb, resolveProjectId } from './firestore.mjs';
-import { processOutboxBatch } from './outbox.mjs';
+import { DRAFT_ATTACHMENT_CLEANUP_EVENT_TYPE, processOutboxBatch } from './outbox.mjs';
+import {
+  createDraftAttachmentCleanupOutboxHandler,
+  createProjectRequestContractStorageService,
+} from './project-request-contract-storage.mjs';
 import {
   assertBffStandaloneWorkerExecutionAllowed,
   parseBffAllowedOrigins,
@@ -12,6 +16,9 @@ assertBffStandaloneWorkerExecutionAllowed(resolveBffRuntimeSafetyConfig({
   allowedOrigins: parseBffAllowedOrigins(process.env.BFF_ALLOWED_ORIGINS),
 }), 'outbox worker');
 const db = createFirestoreDb({ projectId });
+const draftAttachmentCleanupOutboxHandler = createDraftAttachmentCleanupOutboxHandler({
+  draftStorageService: createProjectRequestContractStorageService({ projectId }),
+});
 
 const batchSize = Number.parseInt(process.env.BFF_OUTBOX_BATCH || '50', 10);
 const maxAttempts = Number.parseInt(process.env.BFF_OUTBOX_MAX_ATTEMPTS || '8', 10);
@@ -22,6 +29,9 @@ async function runOnce() {
   const result = await processOutboxBatch(db, {
     limit: batchSize,
     maxAttempts,
+    eventHandlers: {
+      [DRAFT_ATTACHMENT_CLEANUP_EVENT_TYPE]: draftAttachmentCleanupOutboxHandler,
+    },
   });
   // eslint-disable-next-line no-console
   console.log(`[bff-outbox] project=${projectId} processed=${result.processed} succeeded=${result.succeeded} failed=${result.failed} dead=${result.dead}`);

--- a/server/bff/outbox.integration.test.ts
+++ b/server/bff/outbox.integration.test.ts
@@ -1,6 +1,11 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createFirestoreDb } from './firestore.mjs';
-import { createOutboxEvent, enqueueOutboxEvent, processOutboxBatch } from './outbox.mjs';
+import {
+  DRAFT_ATTACHMENT_CLEANUP_EVENT_TYPE,
+  createOutboxEvent,
+  enqueueOutboxEvent,
+  processOutboxBatch,
+} from './outbox.mjs';
 import { buildNotificationId } from './notifications.mjs';
 import { createProjectRegistrationSubmittedOutboxHandler } from './routes/projects.mjs';
 
@@ -429,7 +434,11 @@ describeIfEmulator('outbox worker integration (Firestore emulator)', () => {
     });
   });
 
-  it.each(['project.registration.submitted', 'project.info.submitted'])(
+  it.each([
+    'project.registration.submitted',
+    'project.info.submitted',
+    DRAFT_ATTACHMENT_CLEANUP_EVENT_TYPE,
+  ])(
     'does not mark %s side effects done without an event handler', async (eventType) => {
     const event = createOutboxEvent({
       tenantId,

--- a/server/bff/outbox.mjs
+++ b/server/bff/outbox.mjs
@@ -1,7 +1,13 @@
 import { randomUUID } from 'node:crypto';
 import { createNotificationsForOutboxEvent } from './notifications.mjs';
 
-const HANDLER_REQUIRED_EVENT_TYPES = new Set(['project.registration.submitted', 'project.info.submitted']);
+export const DRAFT_ATTACHMENT_CLEANUP_EVENT_TYPE = 'draft.attachments.cleanup';
+
+const HANDLER_REQUIRED_EVENT_TYPES = new Set([
+  'project.registration.submitted',
+  'project.info.submitted',
+  DRAFT_ATTACHMENT_CLEANUP_EVENT_TYPE,
+]);
 const DEFAULT_PROCESSING_TIMEOUT_MS = 5 * 60 * 1000;
 
 function toIso(value = new Date()) {

--- a/server/bff/pdf-text.mjs
+++ b/server/bff/pdf-text.mjs
@@ -1,6 +1,12 @@
+export function toPdfJsData(buffer) {
+  return new Uint8Array(buffer);
+}
+
 export async function extractTextFromPdfBuffer(buffer) {
   const pdfjsLib = await import('pdfjs-dist/legacy/build/pdf.mjs');
-  const data = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  // Node.js Buffer extends Uint8Array, but pdfjs explicitly rejects Buffer.
+  // Always create a plain Uint8Array copy before handing binary data to pdfjs.
+  const data = toPdfJsData(buffer);
   const pdf = await pdfjsLib.getDocument({ data }).promise;
 
   const pages = [];

--- a/server/bff/pdf-text.test.mjs
+++ b/server/bff/pdf-text.test.mjs
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { toPdfJsData } from './pdf-text.mjs';
+
+describe('pdf text input normalization', () => {
+  it('copies a Node.js Buffer into a plain Uint8Array accepted by pdfjs', () => {
+    const source = Buffer.from([0x25, 0x50, 0x44, 0x46]);
+
+    const normalized = toPdfJsData(source);
+
+    expect(normalized.constructor).toBe(Uint8Array);
+    expect(Buffer.isBuffer(normalized)).toBe(false);
+    expect(Array.from(normalized)).toEqual([0x25, 0x50, 0x44, 0x46]);
+    expect(normalized).not.toBe(source);
+  });
+});

--- a/server/bff/project-info-drafts.integration.test.ts
+++ b/server/bff/project-info-drafts.integration.test.ts
@@ -106,6 +106,9 @@ describeIfEmulator('project information private drafts (Firestore emulator)', ()
       teamName: 'AXR', teamMembers: '', teamMembersDetailed: [{
         memberName: 'actor-a', memberNickname: 'Actor', role: '운영매니저',
         participationRate: 100, isDocumentOnly: false,
+      }, {
+        memberName: 'Executive A', memberNickname: 'Executive', role: '사업 최종 책임자',
+        participationRate: 0, isDocumentOnly: false,
       }], participantCondition: '', note: '',
       contractDocument: {
         path: `orgs/${tenantId}/project-registration-documents/project-a/contract.pdf`,

--- a/server/bff/project-info-drafts.integration.test.ts
+++ b/server/bff/project-info-drafts.integration.test.ts
@@ -73,14 +73,57 @@ describeIfEmulator('project information private drafts (Firestore emulator)', ()
       status: 'IN_PROGRESS', phase: 'CONFIRMED', description: 'Before', clientOrg: 'Client',
       department: 'AXR', currency: 'KRW', contractAmount: 100000, salesVatAmount: 10000,
       totalRevenueAmount: 40000, supportAmount: 0, financialInputFlags: { contractAmount: true },
+      registrationRequirementsVersion: 2,
+      financialYears: [{
+        year: 2026,
+        contractAmount: 100000,
+        salesVatAmount: 10000,
+        totalRevenueAmount: 40000,
+        supportAmount: 0,
+        profitRate: 0.4,
+        confirmed: true,
+      }],
+      registrationConfirmations: {
+        laborIncludesFourInsurance: true,
+        laborIncludesRetirementPay: true,
+        customerSettlementBasisConfirmed: true,
+        modusignContractUsed: true,
+        originalContractSubmitted: null,
+      },
+      registrationOptionalDocumentNotes: {
+        proposalWordOriginal: '고객사 미제공',
+        proposalPptOriginal: '해당 없음',
+        presentationPptOriginal: '해당 없음',
+      },
       contractStart: '2026-07-01', contractEnd: '2026-12-31', contractType: '계약서(날인)',
       settlementType: 'TYPE1', basis: '공급가액', accountType: 'OPERATING', fundInputMode: 'BANK_UPLOAD',
       paymentPlan: { contract: 100000, interim: 0, final: 0 }, paymentPlanDesc: '선금 100%',
+      paymentExpectedMonths: { contract: '2026-07', interim: '', final: '' },
+      advanceInterimBelow70Reason: '',
       settlementGuide: '', finalPaymentNote: '', projectPurpose: 'Purpose',
       registeredById: 'actor-a', registeredByName: 'actor-a', managerId: 'actor-a', managerName: 'actor-a',
       executiveApproverId: 'executive-a', executiveApproverName: 'Executive A', executiveApproverEmail: 'executive-a@example.com',
-      teamName: 'AXR', teamMembers: '', teamMembersDetailed: [], participantCondition: '', note: '',
-      contractDocument: null, quoteDocument: null, proposalDocument: null, contractAnalysis: null,
+      teamName: 'AXR', teamMembers: '', teamMembersDetailed: [{
+        memberName: 'actor-a', memberNickname: 'Actor', role: '운영매니저',
+        participationRate: 100, isDocumentOnly: false,
+      }], participantCondition: '', note: '',
+      contractDocument: {
+        path: `orgs/${tenantId}/project-registration-documents/project-a/contract.pdf`,
+      },
+      customerBusinessRegistrationDocument: {
+        path: `orgs/${tenantId}/project-registration-documents/project-a/customer-business-registration.pdf`,
+      },
+      quoteDocument: {
+        path: `orgs/${tenantId}/project-registration-documents/project-a/quote.pdf`,
+      },
+      proposalDocument: {
+        path: `orgs/${tenantId}/project-registration-documents/project-a/proposal.pdf`,
+      },
+      proposalWordOriginalDocument: null,
+      proposalPptOriginalDocument: null,
+      presentationPptOriginalDocument: null,
+      rfpRequestEvidenceDocument: null,
+      contractAnalysis: null,
       ...overrides,
     };
   }
@@ -122,10 +165,10 @@ describeIfEmulator('project information private drafts (Firestore emulator)', ()
     vi.clearAllMocks();
   }
 
-  async function acquire() {
+  async function acquire(idempotencyKey = 'lease-acquire-a') {
     return api
       .post('/api/v1/edit-leases/project-info/project-a/acquire')
-      .set({ ...actorHeaders(), 'x-edit-session-id': 'session-a', 'idempotency-key': 'lease-acquire-a' })
+      .set({ ...actorHeaders(), 'x-edit-session-id': 'session-a', 'idempotency-key': idempotencyKey })
       .send({});
   }
 
@@ -171,12 +214,27 @@ describeIfEmulator('project information private drafts (Firestore emulator)', ()
     expect(project.data()).toMatchObject({
       name: 'Project A',
       version: 4,
-      executiveReviewStatus: 'APPROVED',
-      executiveReviewedAt: '2026-07-01T09:00:00.000Z',
-      executiveReviewedById: 'organization-head',
-      executiveReviewedByName: '조직장',
-      executiveReviewComment: '기존 승인 메모',
+      executiveReviewStatus: 'PENDING',
+      executiveReviewedAt: null,
+      executiveReviewedById: null,
+      executiveReviewedByName: null,
+      executiveReviewComment: null,
     });
+    expect(project.data()?.executiveReviewHistory).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        status: 'APPROVED',
+        reviewedAt: '2026-07-01T09:00:00.000Z',
+        reviewedById: 'organization-head',
+        reviewedByName: '조직장',
+        reviewComment: '기존 승인 메모',
+      }),
+      expect.objectContaining({
+        status: 'PENDING',
+        previousStatus: 'APPROVED',
+        reviewedAt: '2026-07-12T00:00:00.000Z',
+        reviewedById: 'actor-a',
+      }),
+    ]));
     expect(changeRequest.data()).toMatchObject({ status: 'PENDING', proposedSnapshot: { name: 'Private name' } });
     expect((await db.doc(`orgs/${tenantId}/projectRequests/change-project-a`).get()).exists).toBe(false);
     expect(drafts.docs[0].data()).not.toHaveProperty('payload');
@@ -216,6 +274,57 @@ describeIfEmulator('project information private drafts (Firestore emulator)', ()
     expect(relocated).toHaveLength(1);
     expect((await db.doc(`orgs/${tenantId}/project_requests/change-project-a`).get()).data())
       .toMatchObject({ proposedSnapshot: { contractDocument: { path: relocated[0] } } });
+  });
+
+  it('publishes inherited private attachments from the newest submission when the older outbox event is stale', async () => {
+    const firstLease = await acquire('lease-acquire-race-v1');
+    const firstHeaders = mutationHeaders(firstLease.body, 'draft-open-race-v1');
+    const firstDraft = await api.post('/api/v1/project-info-drafts/project-a/open').set(firstHeaders).send({});
+    const uploaded = await api.post('/api/v1/project-info-drafts/project-a/attachments')
+      .set({ ...firstHeaders, 'idempotency-key': 'draft-upload-race-v1' })
+      .send({
+        expectedDraftRevision: firstDraft.body.draft.draftRevision,
+        documentKind: 'contract', fileName: 'race-contract.pdf', mimeType: 'application/pdf',
+        fileSize: VALID_PDF.byteLength, contentBase64: VALID_PDF.toString('base64'),
+      });
+    expect(uploaded.status).toBe(200);
+    const firstSubmit = await api.post('/api/v1/project-info-drafts/project-a/submit')
+      .set({ ...firstHeaders, 'idempotency-key': 'draft-submit-race-v1' })
+      .send({ expectedDraftRevision: 1, expectedVersion: 3 });
+    expect(firstSubmit.status).toBe(200);
+
+    const secondLease = await acquire('lease-acquire-race-v2');
+    expect(secondLease.status).toBe(200);
+    const secondHeaders = mutationHeaders(secondLease.body, 'draft-open-race-v2');
+    const secondDraft = await api.post('/api/v1/project-info-drafts/project-a/open').set(secondHeaders).send({});
+    expect(secondDraft.status).toBe(200);
+    const secondSubmit = await api.post('/api/v1/project-info-drafts/project-a/submit')
+      .set({ ...secondHeaders, 'idempotency-key': 'draft-submit-race-v2' })
+      .send({ expectedDraftRevision: 0, expectedVersion: 4 });
+    expect(secondSubmit.status).toBe(200);
+
+    const secondOutbox = await db.doc('outbox/project-info-outbox-2').get();
+    expect(secondOutbox.data()?.payload?.attachmentRefs).toEqual([
+      expect.objectContaining({
+        documentKind: 'contract',
+        path: uploaded.body.attachment.path,
+      }),
+    ]);
+    const worker = await api.post('/api/internal/workers/outbox/run')
+      .set({ 'x-worker-secret': 'project-info-worker-secret' })
+      .send({ limit: 10 });
+
+    expect(worker.status).toBe(200);
+    expect(worker.body).toMatchObject({ succeeded: 2, failed: 0 });
+    expect(storage.relocateDraftAttachments).toHaveBeenCalledOnce();
+    expect(relocated).toHaveLength(1);
+    expect((await db.doc(`orgs/${tenantId}/project_requests/change-project-a`).get()).data())
+      .toMatchObject({
+        requestVersion: 2,
+        submittedOutboxId: 'project-info-outbox-2',
+        proposedSnapshot: { contractDocument: { path: relocated[0] } },
+        attachmentsPublishedAt: expect.any(String),
+      });
   });
 
   it('lets the persisted project owner acquire without a duplicated member assignment', async () => {

--- a/server/bff/project-registration-drafts.integration.test.ts
+++ b/server/bff/project-registration-drafts.integration.test.ts
@@ -195,6 +195,11 @@ describeIfEmulator('private project registration drafts (Firestore emulator)', (
         role: '운영매니저',
         participationRate: 100,
         isDocumentOnly: false,
+      }, {
+        memberName: 'Executive A',
+        role: '사업 최종 책임자',
+        participationRate: 0,
+        isDocumentOnly: false,
       }],
       projectPurpose: 'Purpose',
       arbitraryBrowserField: 'must-not-persist',

--- a/server/bff/project-registration-drafts.integration.test.ts
+++ b/server/bff/project-registration-drafts.integration.test.ts
@@ -610,7 +610,7 @@ describeIfEmulator('private project registration drafts (Firestore emulator)', (
       .toMatchObject({ path: expect.stringContaining('/project-registration-documents/'), visibility: 'PRIVATE' });
     expect((await db.doc(`orgs/${tenantId}/project_requests/${first.body.projectRequestId}`).get()).data()?.payload?.contractDocument)
       .toMatchObject({ path: expect.stringContaining('/project-registration-documents/'), visibility: 'PRIVATE' });
-    expect(await count(`orgs/${tenantId}/partEntries`)).toBe(1);
+    expect(await count(`orgs/${tenantId}/partEntries`)).toBe(2);
     expect((await db.doc(`outbox/${first.body.outbox.id}`).get()).data()?.status).toBe('DONE');
     expect((await db.doc(`orgs/${tenantId}/outbox_deliveries/${first.body.outbox.id}`).get()).exists).toBe(true);
   }, 60_000);

--- a/server/bff/project-registration-drafts.integration.test.ts
+++ b/server/bff/project-registration-drafts.integration.test.ts
@@ -192,7 +192,7 @@ describeIfEmulator('private project registration drafts (Firestore emulator)', (
       teamName: 'AXR',
       teamMembersDetailed: [{
         memberName: 'Actor A',
-        role: '실무책임자',
+        role: '운영매니저',
         participationRate: 100,
         isDocumentOnly: false,
       }],

--- a/server/bff/project-request-contract-ai.mjs
+++ b/server/bff/project-request-contract-ai.mjs
@@ -41,7 +41,7 @@ function sanitizeProjectName(value) {
     .replace(/\s+/g, ' ')
     .trim();
   if (!normalized) return '';
-  return normalized.replace(/\s+/g, '').slice(0, 10);
+  return normalized.replace(/\s+/g, '');
 }
 
 function sanitizeOfficialContractName(value) {
@@ -185,7 +185,7 @@ function buildFallbackProjectRequestContractAnalysis(input, timestamp = nowIso()
   }
 
   nextActions.push('계약서 초안을 확인한 뒤, 담당팀·정산유형·통장 유형은 사람이 직접 선택해 주세요.');
-  nextActions.push('등록 프로젝트명은 10자 이내 별칭이라서 공식 계약명과 다를 수 있습니다. 팀에서 쓰는 짧은 이름으로 조정해 주세요.');
+  nextActions.push('등록 프로젝트명은 공식 계약명과 다를 수 있습니다. 팀에서 사용하는 이름으로 조정해 주세요.');
 
   return {
     provider: 'heuristic',
@@ -335,7 +335,7 @@ function buildPrompt(input, fallback) {
     '<field_rules>',
     '<rule>officialContractName은 계약서 상의 공식 명칭입니다.</rule>',
     '<rule>officialContractName에서는 협약서, 계약서, 제안서처럼 문서 형식/종류를 나타내는 단어를 제외합니다.</rule>',
-    '<rule>suggestedProjectName은 내부 등록용 10자 이내 짧은 이름입니다.</rule>',
+    '<rule>suggestedProjectName은 내부에서 사용하는 프로젝트명이며 글자 수를 임의로 줄이지 않습니다.</rule>',
     '<rule>department, settlementType, accountType은 추측하지 않습니다.</rule>',
     '<rule>날짜는 YYYY-MM-DD 형식입니다.</rule>',
     '<rule>금액은 숫자만 반환합니다.</rule>',

--- a/server/bff/project-request-contract-ai.test.ts
+++ b/server/bff/project-request-contract-ai.test.ts
@@ -11,6 +11,11 @@ describe('project-request-contract-ai', () => {
     expect(sanitizeProjectName('뷰티풀 커넥트 운영 계약서')).toBe('뷰티풀커넥트');
   });
 
+  it('does not truncate a suggested project name to ten characters', () => {
+    expect(sanitizeProjectName('2026 지역사회 문제해결 프로젝트 운영 계약서'))
+      .toBe('2026지역사회문제해결프로젝트');
+  });
+
   it('strips document form words from official contract name', () => {
     expect(sanitizeOfficialContractName('뷰티풀 커넥트 운영 협약서')).toBe('뷰티풀 커넥트 운영');
     expect(sanitizeOfficialContractName('청년 창업 지원 사업 계약서 최종본')).toBe('청년 창업 지원 사업');

--- a/server/bff/project-request-contract-storage.mjs
+++ b/server/bff/project-request-contract-storage.mjs
@@ -51,6 +51,24 @@ function objectNameWithinPrefix(path, prefix, errorMessage) {
   return { path: normalized, objectName };
 }
 
+export function createDraftAttachmentCleanupOutboxHandler({ draftStorageService } = {}) {
+  return async (event) => {
+    if (typeof draftStorageService?.deleteDraftAttachment !== 'function') {
+      throw new Error('Draft attachment storage service is required');
+    }
+    const draftId = readOptionalText(event?.payload?.draftId);
+    const paths = event?.payload?.paths;
+    if (!draftId || !Array.isArray(paths) || paths.length < 1 || paths.length > 100) {
+      throw new Error('Draft attachment cleanup payload is invalid');
+    }
+    await Promise.all(paths.map((path) => draftStorageService.deleteDraftAttachment({
+      tenantId: event?.tenantId,
+      draftId,
+      path,
+    })));
+  };
+}
+
 export function createProjectRequestContractStorageService(options = {}) {
   const bucketName = options.bucketName || resolveBucketName(options.env || process.env);
   const adminApp = options.adminApp || getOrInitAdminApp({ projectId: options.projectId });
@@ -140,6 +158,22 @@ export function createProjectRequestContractStorageService(options = {}) {
         'draft attachment path is outside its draft prefix',
       );
       await bucket.file(path).delete({ ignoreNotFound: true });
+    },
+
+    async downloadDraftAttachment(input) {
+      const prefix = draftAttachmentPrefix(input?.tenantId, input?.draftId);
+      const { path } = objectNameWithinPrefix(
+        input?.path,
+        prefix,
+        'draft attachment path is outside its draft prefix',
+      );
+      const file = bucket.file(path);
+      const [[buffer], [metadata]] = await Promise.all([file.download(), file.getMetadata()]);
+      return {
+        buffer,
+        contentType: readOptionalText(metadata?.contentType) || 'application/octet-stream',
+        size: Number.parseInt(String(metadata?.size || buffer.byteLength), 10) || buffer.byteLength,
+      };
     },
 
     async relocateDraftAttachments(input) {

--- a/server/bff/project-request-contract-storage.test.ts
+++ b/server/bff/project-request-contract-storage.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  createDraftAttachmentCleanupOutboxHandler,
   createProjectRequestContractStorageService,
   normalizeSafeFileName,
 } from './project-request-contract-storage.mjs';
@@ -96,6 +97,58 @@ describe('project-request-contract-storage', () => {
 
     expect(bucket.file).toHaveBeenCalledWith(path);
     expect(deleteFile).toHaveBeenCalledWith({ ignoreNotFound: true });
+  });
+
+  it('deletes every path in a validated cleanup outbox payload', async () => {
+    const deleteDraftAttachment = vi.fn(async () => undefined);
+    const handler = createDraftAttachmentCleanupOutboxHandler({
+      draftStorageService: { deleteDraftAttachment },
+    });
+
+    await handler({
+      tenantId: 'tenant-a',
+      payload: {
+        draftId: 'draft-a',
+        paths: [
+          'orgs/tenant-a/project-registration-drafts/draft-a/contract.pdf',
+          'orgs/tenant-a/project-registration-drafts/draft-a/quote.pdf',
+        ],
+      },
+    });
+
+    expect(deleteDraftAttachment).toHaveBeenCalledTimes(2);
+    expect(deleteDraftAttachment).toHaveBeenNthCalledWith(1, {
+      tenantId: 'tenant-a',
+      draftId: 'draft-a',
+      path: 'orgs/tenant-a/project-registration-drafts/draft-a/contract.pdf',
+    });
+    await expect(handler({ tenantId: 'tenant-a', payload: { draftId: 'draft-a', paths: [] } }))
+      .rejects.toThrow('Draft attachment cleanup payload is invalid');
+  });
+
+  it('downloads only an attachment within the exact tenant and draft prefix', async () => {
+    const download = vi.fn(async () => [Buffer.from('private-draft-pdf')]);
+    const getMetadata = vi.fn(async () => [{ contentType: 'application/pdf', size: '17' }]);
+    const bucket = { file: vi.fn(() => ({ download, getMetadata })) };
+    const service = createProjectRequestContractStorageService({
+      projectId: 'demo-bff-it',
+      bucketName: 'demo-bff-it.firebasestorage.app',
+      storage: { bucket: vi.fn(() => bucket) },
+    });
+    const path = 'orgs/tenant-a/project-registration-drafts/draft-a/attachment-a-contract.pdf';
+
+    await expect(service.downloadDraftAttachment({
+      tenantId: 'tenant-a', draftId: 'draft-a', path,
+    })).resolves.toMatchObject({
+      buffer: Buffer.from('private-draft-pdf'),
+      contentType: 'application/pdf',
+      size: 17,
+    });
+    await expect(service.downloadDraftAttachment({
+      tenantId: 'tenant-a',
+      draftId: 'draft-a',
+      path: 'orgs/tenant-a/project-registration-drafts/draft-b/attachment-a-contract.pdf',
+    })).rejects.toThrow('draft attachment path is outside its draft prefix');
   });
 
   it('refuses to delete an object outside the owned draft prefix', async () => {

--- a/server/bff/request-context.test.ts
+++ b/server/bff/request-context.test.ts
@@ -40,4 +40,30 @@ describe('resolveApiRequestContext', () => {
     expect(context.actorRole).toBe('admin');
     expect(context.actorEmail).toBe('member@mysc.co.kr');
   });
+
+  it('uses the persisted member name when the firebase token has no display name', async () => {
+    const req = createReq({
+      authorization: 'Bearer token',
+      'x-tenant-id': 'mysc',
+      'x-actor-id': 'u-member',
+      'idempotency-key': 'idem-request-context-name',
+    });
+
+    const context = await resolveApiRequestContext(req as any, {
+      authMode: 'firebase_required',
+      verifyToken: vi.fn(async () => ({
+        uid: 'u-member',
+        tenantId: 'mysc',
+        role: 'viewer',
+        email: 'member@mysc.co.kr',
+      })),
+      resolveMemberIdentity: vi.fn(async () => ({
+        role: 'viewer',
+        email: 'member@mysc.co.kr',
+        name: '인증된 조직장 A',
+      })),
+    });
+
+    expect(context.actorName).toBe('인증된 조직장 A');
+  });
 });

--- a/server/bff/routes/management-planning-review.test.mjs
+++ b/server/bff/routes/management-planning-review.test.mjs
@@ -21,14 +21,25 @@ function createDb(seed = {}) {
       documents.set(path, options.merge && current ? { ...current, ...clone(value) } : clone(value));
     },
   });
+  const collection = (path) => ({ path, kind: 'query' });
+  const querySnapshot = (path) => {
+    const prefix = `${path}/`;
+    const docs = [...documents.entries()].flatMap(([documentPath, value]) => {
+      const relativePath = documentPath.startsWith(prefix) ? documentPath.slice(prefix.length) : '';
+      if (!relativePath || relativePath.includes('/')) return [];
+      return [{ id: relativePath, data: () => clone(value) }];
+    });
+    return { docs, empty: docs.length === 0, size: docs.length };
+  };
 
   return {
     documents,
     doc,
+    collection,
     async runTransaction(callback) {
       const writes = [];
       const tx = {
-        get: async (ref) => snapshot(ref.path),
+        get: async (ref) => ref.kind === 'query' ? querySnapshot(ref.path) : snapshot(ref.path),
         set: (ref, value, options = {}) => writes.push({ ref, value: clone(value), options }),
       };
       const result = await callback(tx);
@@ -44,8 +55,13 @@ function createDb(seed = {}) {
   };
 }
 
-function createRouteApp({ actorRole = 'finance', seed = {} } = {}) {
-  const db = createDb(seed);
+function createRouteApp({ actorRole = 'finance', memberStatus = 'ACTIVE', seed = {} } = {}) {
+  const db = createDb({
+    'orgs/tenant-a/members/finance-a': {
+      uid: 'finance-a', role: actorRole, status: memberStatus,
+    },
+    ...seed,
+  });
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
@@ -171,14 +187,34 @@ describe('management planning project review route', () => {
   });
 
   it('closes a resubmitted management-planning change request when it agrees', async () => {
+    const executiveHistory = [{
+      status: 'APPROVED',
+      previousStatus: 'PENDING',
+      reviewedAt: '2026-07-10T00:00:00.000Z',
+      reviewedById: 'executive-a',
+      reviewedByName: '조직장A',
+      reviewComment: '조직장 승인',
+    }];
     const { app, db } = createRouteApp({
       seed: reviewSeed(
-        approvedProject({ managementPlanningReviewStatus: 'REVISION_REJECTED' }),
+        approvedProject({
+          name: '보완 전 프로젝트 A',
+          managementPlanningReviewStatus: 'REVISION_REJECTED',
+          executiveReviewHistory: executiveHistory,
+        }),
         approvedRequest({
           requestKind: 'CHANGE',
           status: 'PENDING',
           reviewOutcome: null,
           rejectedReason: null,
+          baseProjectVersion: 3,
+          targetProjectVersion: 4,
+          proposedSnapshot: {
+            name: '보완 후 프로젝트 A',
+            registrationRequirementsVersion: 2,
+            settlementType: 'NONE',
+            financialYears: [],
+          },
         }),
       ),
     });
@@ -195,6 +231,10 @@ describe('management planning project review route', () => {
 
     expect(response.status).toBe(200);
     expect(db.documents.get('orgs/tenant-a/projects/project-a')).toMatchObject({
+      name: '보완 후 프로젝트 A',
+      version: 5,
+      executiveReviewStatus: 'APPROVED',
+      executiveReviewHistory: executiveHistory,
       managementPlanningReviewStatus: 'AGREED',
       projectCode: 'AXR-2026-002',
     });
@@ -205,7 +245,49 @@ describe('management planning project review route', () => {
       reviewedByName: 'finance-a@example.com',
       reviewComment: '보완 확인',
       rejectedReason: null,
+      approvedProjectVersion: 5,
+      approvedSnapshot: expect.objectContaining({ name: '보완 후 프로젝트 A' }),
     });
+  });
+
+  it('does not agree to a resubmitted change while its attachments are still private draft files', async () => {
+    const { app, db } = createRouteApp({
+      seed: reviewSeed(
+        approvedProject({ managementPlanningReviewStatus: 'REVISION_REJECTED' }),
+        approvedRequest({
+          requestKind: 'CHANGE',
+          status: 'PENDING',
+          reviewOutcome: null,
+          baseProjectVersion: 3,
+          targetProjectVersion: 4,
+          proposedSnapshot: {
+            name: '보완 후 프로젝트 A',
+            registrationRequirementsVersion: 2,
+            settlementType: 'NONE',
+            financialYears: [],
+            contractDocument: {
+              name: 'private-contract.pdf',
+              path: 'orgs/tenant-a/project-registration-drafts/draft-a/private-contract.pdf',
+            },
+          },
+        }),
+      ),
+    });
+
+    const response = await request(app)
+      .post('/api/v1/projects/project-a/management-planning-review')
+      .set('idempotency-key', 'planning-private-attachment')
+      .send({
+        requestId: 'request-a',
+        reviewStatus: 'AGREED',
+        projectCode: 'AXR-2026-PRIVATE',
+      });
+
+    expect(response.status).toBe(409);
+    expect(response.body.error).toBe('project_attachments_processing');
+    expect(db.documents.get('orgs/tenant-a/projects/project-a')?.managementPlanningReviewStatus)
+      .toBe('REVISION_REJECTED');
+    expect(db.documents.get('orgs/tenant-a/projectCodeClaims/AXR-2026-PRIVATE')).toBeUndefined();
   });
 
   it('accepts a legacy approved request as organization-head approval for code issuance', async () => {
@@ -305,12 +387,49 @@ describe('management planning project review route', () => {
     expect(db.documents.get('orgs/tenant-a/projects/project-a')?.managementPlanningReviewStatus).toBe('PENDING');
   });
 
+  it('rejects a code already stored on a legacy project even when no claim document exists', async () => {
+    const { app, db } = createRouteApp({
+      seed: {
+        ...reviewSeed(),
+        'orgs/tenant-a/projects/project-legacy': approvedProject({
+          id: 'project-legacy',
+          projectCode: ' axr-2026-legacy ',
+          projectCodeKey: undefined,
+          managementPlanningReviewStatus: 'AGREED',
+        }),
+      },
+    });
+
+    const response = await request(app)
+      .post('/api/v1/projects/project-a/management-planning-review')
+      .set('idempotency-key', 'planning-legacy-duplicate-code')
+      .send({ requestId: 'request-a', reviewStatus: 'AGREED', projectCode: 'AXR-2026-LEGACY' });
+
+    expect(response.status).toBe(409);
+    expect(response.body.error).toBe('project_code_conflict');
+    expect(db.documents.get('orgs/tenant-a/projectCodeClaims/AXR-2026-LEGACY')).toBeUndefined();
+    expect(db.documents.get('orgs/tenant-a/projects/project-a')?.managementPlanningReviewStatus).toBe('PENDING');
+  });
+
   it('allows only admin or finance to decide management-planning review', async () => {
     const { app, db } = createRouteApp({ actorRole: 'pm', seed: reviewSeed() });
 
     const response = await request(app)
       .post('/api/v1/projects/project-a/management-planning-review')
       .set('idempotency-key', 'planning-pm-denied')
+      .send({ requestId: 'request-a', reviewStatus: 'AGREED', projectCode: 'AXR-2026-001' });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe('forbidden');
+    expect(db.documents.get('orgs/tenant-a/projects/project-a')?.managementPlanningReviewStatus).toBe('PENDING');
+  });
+
+  it('rejects management-planning review from an inactive member', async () => {
+    const { app, db } = createRouteApp({ memberStatus: 'INACTIVE', seed: reviewSeed() });
+
+    const response = await request(app)
+      .post('/api/v1/projects/project-a/management-planning-review')
+      .set('idempotency-key', 'planning-inactive-denied')
       .send({ requestId: 'request-a', reviewStatus: 'AGREED', projectCode: 'AXR-2026-001' });
 
     expect(response.status).toBe(403);

--- a/server/bff/routes/project-info-drafts.mjs
+++ b/server/bff/routes/project-info-drafts.mjs
@@ -15,13 +15,17 @@ import {
 } from '../edit-lease.mjs';
 import {
   parseWithSchema,
+  projectDraftAttachmentDeleteSchema,
   projectInfoDraftAttachmentSchema,
   projectInfoDraftOpenSchema,
   projectInfoDraftPatchSchema,
   projectInfoDraftSubmitSchema,
 } from '../schemas.mjs';
 import { buildRequestFingerprint, sha256 } from '../utils.mjs';
-import { createOutboxEvent as createOutboxEventRecord } from '../outbox.mjs';
+import {
+  DRAFT_ATTACHMENT_CLEANUP_EVENT_TYPE,
+  createOutboxEvent as createOutboxEventRecord,
+} from '../outbox.mjs';
 import {
   buildProjectInfoChangeSubmission,
   buildProjectInfoDraftSeed,
@@ -34,6 +38,19 @@ import {
 const RESOURCE_TYPE = 'project-info';
 const CROSS_PROJECT_ROLES = new Set(['admin', 'finance']);
 const DOCUMENT_KINDS = PROJECT_INFO_DOCUMENT_KINDS;
+const DOCUMENT_FIELD_BY_KIND = {
+  contract: 'contractDocument',
+  customer_business_registration: 'customerBusinessRegistrationDocument',
+  quote: 'quoteDocument',
+  proposal: 'proposalDocument',
+  proposal_word_original: 'proposalWordOriginalDocument',
+  proposal_ppt_original: 'proposalPptOriginalDocument',
+  presentation_ppt_original: 'presentationPptOriginalDocument',
+  rfp_request_evidence: 'rfpRequestEvidenceDocument',
+  performance_certificate: 'performanceCertificateDocument',
+  tax_invoice: 'taxInvoiceDocument',
+  final_settlement_report: 'finalSettlementReportDocument',
+};
 const MAX_DRAFT_BYTES = 900 * 1024;
 const MAX_ATTACHMENT_REFS = 100;
 const MAX_PAYLOAD_DEPTH = 20;
@@ -84,6 +101,22 @@ function draftDocumentId(projectId, actorId) {
   return id;
 }
 
+function draftIdFromTrustedAttachmentPath(tenantId, path) {
+  const normalizedPath = readOptionalText(path);
+  const prefix = `orgs/${tenantId}/project-registration-drafts/`;
+  const relative = normalizedPath.startsWith(prefix) ? normalizedPath.slice(prefix.length) : '';
+  const [draftId, objectName, ...extra] = relative.split('/');
+  if (
+    extra.length
+    || !draftId
+    || !objectName
+    || draftId === '.'
+    || draftId === '..'
+    || !/^[A-Za-z0-9._-]+$/.test(draftId)
+  ) return '';
+  return draftId;
+}
+
 function memberProjectIds(member = {}) {
   const profile = member.portalProfile && typeof member.portalProfile === 'object'
     ? member.portalProfile
@@ -104,6 +137,56 @@ function draftAttachments(draft = {}) {
   return Array.isArray(draft.attachmentRefs) ? draft.attachmentRefs : [];
 }
 
+function publicAttachmentRefs(draft = {}) {
+  return draftAttachments(draft).map((attachment) => Object.fromEntries(
+    Object.entries(attachment || {}).filter(([key]) => key !== 'inheritedFromProjectRequest'),
+  ));
+}
+
+function resumableDraftAttachments(tenantId, draftId, request = {}) {
+  if (
+    readOptionalText(request.requestKind) !== 'CHANGE'
+    || !['PENDING', 'REJECTED'].includes(readOptionalText(request.status))
+  ) return [];
+  const source = request.proposedSnapshot && typeof request.proposedSnapshot === 'object'
+    ? request.proposedSnapshot
+    : request.payload;
+  if (!source || typeof source !== 'object' || Array.isArray(source)) return [];
+  return Object.entries(DOCUMENT_FIELD_BY_KIND).flatMap(([documentKind, field]) => {
+    const document = source[field];
+    const path = readOptionalText(document?.path);
+    if (!path || draftIdFromTrustedAttachmentPath(tenantId, path) !== draftId) return [];
+    const attachmentId = readOptionalText(document?.attachmentId);
+    return [{
+      ...(attachmentId ? { attachmentId } : {}),
+      documentKind,
+      path,
+      name: readOptionalText(document?.name),
+      size: Number.isSafeInteger(document?.size) && document.size >= 0 ? document.size : 0,
+      contentType: readOptionalText(document?.contentType) || 'application/octet-stream',
+      ...(readOptionalText(document?.uploadedAt) ? { uploadedAt: readOptionalText(document.uploadedAt) } : {}),
+      inheritedFromProjectRequest: true,
+    }];
+  });
+}
+
+function replacementDocumentKinds(documentKind) {
+  return ['proposal', 'rfp_request_evidence'].includes(documentKind)
+    ? ['proposal', 'rfp_request_evidence']
+    : [documentKind];
+}
+
+function payloadWithoutAttachment(payload, documentKind, removedAttachments) {
+  const next = { ...(payload || {}) };
+  const field = DOCUMENT_FIELD_BY_KIND[documentKind];
+  const removedPaths = new Set(removedAttachments.map((attachment) => readOptionalText(attachment?.path)).filter(Boolean));
+  if (field && removedPaths.has(readOptionalText(next[field]?.path))) {
+    next[field] = null;
+  }
+  if (documentKind === 'contract') next.contractAnalysis = null;
+  return next;
+}
+
 function draftContract(draft = {}) {
   return {
     projectId: readOptionalText(draft.resourceId),
@@ -114,7 +197,7 @@ function draftContract(draft = {}) {
     payload: draft.payload && typeof draft.payload === 'object' && !Array.isArray(draft.payload)
       ? draft.payload
       : {},
-    attachmentRefs: draftAttachments(draft),
+    attachmentRefs: publicAttachmentRefs(draft),
     stepIndex: Number.isInteger(draft.stepIndex) && draft.stepIndex >= 0 ? draft.stepIndex : 0,
     status: readOptionalText(draft.status) || 'ACTIVE',
     createdAt: draft.createdAt,
@@ -253,6 +336,20 @@ function auditEntry(current, actorRole, action, revision, timestamp, metadata = 
   };
 }
 
+function attachmentCleanupEvent(createEvent, current, paths, timestamp) {
+  const uniquePaths = [...new Set(paths.map(readOptionalText).filter(Boolean))];
+  if (uniquePaths.length === 0) return null;
+  return createEvent({
+    tenantId: current.tenantId,
+    requestId: current.requestId,
+    eventType: DRAFT_ATTACHMENT_CLEANUP_EVENT_TYPE,
+    entityType: 'project_info_draft',
+    entityId: current.draftDocumentId,
+    payload: { draftId: current.draftDocumentId, paths: uniquePaths },
+    createdAt: timestamp,
+  });
+}
+
 export function createProjectInfoSubmittedOutboxHandler({
   db,
   draftStorageService,
@@ -331,6 +428,7 @@ export function createProjectInfoDraftService({
   now = () => new Date().toISOString(),
   createAttachmentId = () => `att_${randomUUID().replace(/-/g, '')}`,
   createOutboxEvent = createOutboxEventRecord,
+  createAttachmentCleanupOutboxEvent = createOutboxEventRecord,
   auditChainService,
   idempotencyService,
   draftStorageService,
@@ -461,6 +559,7 @@ export function createProjectInfoDraftService({
         if (lockError) throw lockError;
         await assertLease(tx, current, nowDate);
         const existing = draftSnap.exists ? (draftSnap.data() || {}) : null;
+        const previousRequest = requestSnap.exists ? (requestSnap.data() || {}) : {};
         const draft = existing?.status === 'ACTIVE' && readOptionalText(existing.ownerUid) === current.actorId
           ? existing
           : {
@@ -470,8 +569,12 @@ export function createProjectInfoDraftService({
               resourceId: current.projectId,
               draftRevision: 0,
               baseCanonicalVersion: Number.isInteger(project.version) && project.version > 0 ? project.version : 1,
-              payload: buildProjectInfoDraftSeed(project, requestSnap.exists ? (requestSnap.data() || {}) : null),
-              attachmentRefs: [],
+              payload: buildProjectInfoDraftSeed(project, previousRequest),
+              attachmentRefs: resumableDraftAttachments(
+                current.tenantId,
+                current.draftDocumentId,
+                previousRequest,
+              ),
               stepIndex: 0,
               status: 'ACTIVE',
               createdAt: timestamp,
@@ -496,6 +599,60 @@ export function createProjectInfoDraftService({
         const { draft } = await ownedDraft(tx, current);
         return { draft: draftContract(draft) };
       });
+    },
+
+    async readAttachment(input) {
+      if (!draftStorageService) {
+        throw new Error('Draft attachment storage service is required');
+      }
+      const current = context(input, { ownership: false, idempotency: false });
+      const documentKind = requiredText(input?.documentKind, 'documentKind');
+      if (!DOCUMENT_KINDS.includes(documentKind)) {
+        throw createHttpError(400, 'documentKind is invalid', 'draft_attachment_invalid');
+      }
+      const field = DOCUMENT_FIELD_BY_KIND[documentKind];
+      const stored = await db.runTransaction(async (tx) => {
+        const { draft, project } = await ownedDraft(tx, current);
+        const match = draftAttachments(draft).findLast((item) => item?.documentKind === documentKind);
+        if (match && readOptionalText(match.path)) {
+          return { source: 'draft', attachment: match };
+        }
+
+        const payloadDocument = draft.payload?.[field];
+        const payloadPath = readOptionalText(payloadDocument?.path);
+        const canonicalDocument = project?.[field];
+        if (payloadPath && payloadPath === readOptionalText(canonicalDocument?.path)) {
+          return { source: 'project', attachment: canonicalDocument };
+        }
+
+        const requestSnap = await tx.get(refs(current).request);
+        const previousRequest = requestSnap.exists ? (requestSnap.data() || {}) : {};
+        const resumableChange = readOptionalText(previousRequest.requestKind) === 'CHANGE'
+          && ['PENDING', 'REJECTED'].includes(readOptionalText(previousRequest.status));
+        const requestDocument = resumableChange
+          ? (previousRequest.proposedSnapshot?.[field] || previousRequest.payload?.[field])
+          : null;
+        if (payloadPath && payloadPath === readOptionalText(requestDocument?.path)) {
+          const sourceDraftId = draftIdFromTrustedAttachmentPath(current.tenantId, payloadPath);
+          return sourceDraftId
+            ? { source: 'draft', draftId: sourceDraftId, attachment: requestDocument }
+            : { source: 'project', attachment: requestDocument };
+        }
+
+        throw createHttpError(404, 'Project information draft attachment not found', 'not_found');
+      });
+      const downloaded = stored.source === 'draft'
+        ? await draftStorageService.downloadDraftAttachment({
+          tenantId: current.tenantId,
+          draftId: stored.draftId || current.draftDocumentId,
+          path: stored.attachment.path,
+        })
+        : await draftStorageService.downloadProjectRegistrationAttachment({
+          tenantId: current.tenantId,
+          projectId: current.projectId,
+          path: stored.attachment.path,
+        });
+      return { ...downloaded, name: readOptionalText(stored.attachment.name) || 'attachment.pdf' };
     },
 
     async update(input) {
@@ -564,6 +721,7 @@ export function createProjectInfoDraftService({
       if (!DOCUMENT_KINDS.includes(documentKind)) {
         throw createHttpError(400, 'documentKind is invalid', 'draft_attachment_invalid');
       }
+      const replacedDocumentKinds = replacementDocumentKinds(documentKind);
       const fileName = requiredText(input?.fileName, 'fileName');
       const mimeType = requiredText(input?.mimeType, 'mimeType');
       assertProjectAttachment(buffer, mimeType, fileName, documentKind);
@@ -588,9 +746,9 @@ export function createProjectInfoDraftService({
         assertActive(draft);
         await assertLease(tx, current, nowDate);
         assertRevision(draft, expectedDraftRevision);
-        const replacesSameKind = draftAttachments(draft)
-          .some((attachment) => attachment.documentKind === documentKind);
-        if (draftAttachments(draft).length >= MAX_ATTACHMENT_REFS && !replacesSameKind) {
+        const replacesExistingKind = draftAttachments(draft)
+          .some((attachment) => replacedDocumentKinds.includes(attachment.documentKind));
+        if (draftAttachments(draft).length >= MAX_ATTACHMENT_REFS && !replacesExistingKind) {
           throw createHttpError(422, 'Draft attachment limit exceeded', 'draft_attachment_limit_exceeded');
         }
         return null;
@@ -641,11 +799,12 @@ export function createProjectInfoDraftService({
           await assertLease(tx, current, nowDate);
           const revision = assertRevision(draft, expectedDraftRevision) + 1;
           replacedAttachments = draftAttachments(draft)
-            .filter((currentAttachment) => currentAttachment.documentKind === documentKind);
+            .filter((currentAttachment) => replacedDocumentKinds.includes(currentAttachment.documentKind));
           const next = {
             ...draft,
+            payload: payloadWithoutAttachment(draft.payload, documentKind, replacedAttachments),
             attachmentRefs: [
-              ...draftAttachments(draft).filter((currentAttachment) => currentAttachment.documentKind !== documentKind),
+              ...draftAttachments(draft).filter((currentAttachment) => !replacedDocumentKinds.includes(currentAttachment.documentKind)),
               attachment,
             ],
             draftRevision: revision,
@@ -660,12 +819,31 @@ export function createProjectInfoDraftService({
           ]);
           tx.set(draftRef, next);
           completeIdempotency(tx, current, lock, { method, path, status: 200, body }, nowDate);
+          const cleanupEvent = attachmentCleanupEvent(
+            createAttachmentCleanupOutboxEvent,
+            current,
+            replacedAttachments
+              .filter((replaced) => (
+                replaced?.inheritedFromProjectRequest !== true
+                && readOptionalText(replaced?.path)
+                && replaced.path !== attachment.path
+              ))
+              .map((replaced) => replaced.path),
+            timestamp,
+          );
+          if (cleanupEvent) {
+            tx.create(db.doc(`outbox/${documentId(cleanupEvent.id, 'outboxId')}`), cleanupEvent);
+          }
           return { status: 200, body, replayed: false };
         });
         if (outcome.replayed) await cleanup();
         else {
           await Promise.all(replacedAttachments.map(async (replaced) => {
-            if (!readOptionalText(replaced?.path) || replaced.path === attachment.path) return;
+            if (
+              replaced?.inheritedFromProjectRequest === true
+              || !readOptionalText(replaced?.path)
+              || replaced.path === attachment.path
+            ) return;
             try {
               await draftStorageService.deleteDraftAttachment({
                 tenantId: current.tenantId,
@@ -684,6 +862,102 @@ export function createProjectInfoDraftService({
         await cleanup();
         throw error;
       }
+    },
+
+    async removeAttachment(input) {
+      if (!draftStorageService?.deleteDraftAttachment) {
+        throw new Error('Draft attachment storage service is required');
+      }
+      const current = context(input);
+      const expectedDraftRevision = Number(input?.expectedDraftRevision);
+      if (!Number.isInteger(expectedDraftRevision) || expectedDraftRevision < 0) {
+        throw createHttpError(400, 'expectedDraftRevision is invalid', 'draft_request_invalid');
+      }
+      const documentKind = requiredText(input?.documentKind, 'documentKind');
+      if (!DOCUMENT_KINDS.includes(documentKind)) {
+        throw createHttpError(400, 'documentKind is invalid', 'draft_attachment_invalid');
+      }
+      const method = 'DELETE';
+      const path = `/api/v1/project-info-drafts/${current.projectId}/attachments/${documentKind}`;
+      const fingerprint = buildRequestFingerprint({
+        method,
+        path,
+        body: {
+          actorId: current.actorId,
+          sessionId: current.sessionId,
+          leaseId: current.leaseId,
+          fence: current.fence,
+          expectedDraftRevision,
+          documentKind,
+        },
+      });
+
+      const result = await db.runTransaction(async (tx) => {
+        const nowDate = clockDate(now);
+        const timestamp = nowDate.toISOString();
+        const { actorRole, draftRef, draft } = await ownedDraft(tx, current);
+        const lock = await checkIdempotency(tx, current, fingerprint, nowDate);
+        if (lock.mode === 'replay') {
+          return { outcome: { status: lock.status, body: lock.body, replayed: true }, removedAttachments: [] };
+        }
+        const lockError = idempotencyError(lock);
+        if (lockError) throw lockError;
+        assertActive(draft);
+        await assertLease(tx, current, nowDate);
+        const revision = assertRevision(draft, expectedDraftRevision) + 1;
+        const removedAttachments = draftAttachments(draft)
+          .filter((attachment) => attachment?.documentKind === documentKind && readOptionalText(attachment?.path));
+        if (removedAttachments.length === 0) {
+          throw createHttpError(404, 'Project information draft attachment not found', 'not_found');
+        }
+        const next = {
+          ...draft,
+          payload: payloadWithoutAttachment(draft.payload, documentKind, removedAttachments),
+          attachmentRefs: draftAttachments(draft).filter((attachment) => attachment?.documentKind !== documentKind),
+          draftRevision: revision,
+          updatedAt: timestamp,
+        };
+        assertDraftSize(next);
+        const body = { draft: draftContract(next) };
+        await auditChainService.appendManyInTransaction(tx, [
+          auditEntry(current, actorRole, 'PROJECT_INFO_DRAFT_ATTACHMENT_REMOVE', revision, timestamp, {
+            fence: current.fence,
+            documentKind,
+            attachmentIds: removedAttachments.map((attachment) => readOptionalText(attachment?.attachmentId)).filter(Boolean),
+          }),
+        ]);
+        tx.set(draftRef, next);
+        completeIdempotency(tx, current, lock, { method, path, status: 200, body }, nowDate);
+        const cleanupEvent = attachmentCleanupEvent(
+          createAttachmentCleanupOutboxEvent,
+          current,
+          removedAttachments
+            .filter((attachment) => attachment?.inheritedFromProjectRequest !== true)
+            .map((attachment) => attachment.path),
+          timestamp,
+        );
+        if (cleanupEvent) {
+          tx.create(db.doc(`outbox/${documentId(cleanupEvent.id, 'outboxId')}`), cleanupEvent);
+        }
+        return { outcome: { status: 200, body, replayed: false }, removedAttachments };
+      });
+
+      await Promise.all(result.removedAttachments.map(async (attachment) => {
+        if (attachment?.inheritedFromProjectRequest === true) return;
+        try {
+          await draftStorageService.deleteDraftAttachment({
+            tenantId: current.tenantId,
+            draftId: current.draftDocumentId,
+            path: attachment.path,
+          });
+        } catch {
+          console.warn('[bff] removed project info draft attachment cleanup failed', {
+            requestId: current.requestId,
+            errorCode: 'draft_attachment_remove_cleanup_failed',
+          });
+        }
+      }));
+      return result.outcome;
     },
 
     async submit(input) {
@@ -795,7 +1069,7 @@ export function createProjectInfoDraftService({
             draftId: current.draftDocumentId,
             requestVersion: submittedProjectRequest.requestVersion,
             targetProjectVersion: submittedProjectRequest.targetProjectVersion,
-            attachmentRefs: draftAttachments(draft),
+            attachmentRefs: publicAttachmentRefs(draft),
           },
           createdAt: timestamp,
           nextAttemptAt: timestamp,
@@ -865,6 +1139,21 @@ function sendOutcome(res, outcome) {
   res.status(outcome.status).json(outcome.body);
 }
 
+function sendPrivateDraftAttachment(res, attachment) {
+  const buffer = Buffer.isBuffer(attachment?.buffer)
+    ? attachment.buffer
+    : Buffer.from(attachment?.buffer || []);
+  const contentType = readOptionalText(attachment?.contentType);
+  res.setHeader('content-type', /^[A-Za-z0-9!#$&^_.+-]+\/[A-Za-z0-9!#$&^_.+-]+$/.test(contentType)
+    ? contentType
+    : 'application/octet-stream');
+  res.setHeader('content-length', String(buffer.byteLength));
+  res.setHeader('cache-control', 'private, no-store');
+  res.setHeader('x-content-type-options', 'nosniff');
+  res.setHeader('content-disposition', `inline; filename*=UTF-8''${encodeURIComponent(readOptionalText(attachment?.name) || 'attachment.pdf')}`);
+  res.status(200).send(buffer);
+}
+
 function decodeBase64(value, expectedSize) {
   if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
     throw createHttpError(400, 'contentBase64 is invalid', 'draft_attachment_invalid');
@@ -891,6 +1180,15 @@ export function mountProjectInfoDraftRoutes(app, {
     }));
   }));
 
+  app.get('/api/v1/project-info-drafts/:projectId/attachments/:documentKind', asyncHandler(async (req, res) => {
+    assertActorRoleAllowed(req, PROJECT_REQUEST_ROUTE_ROLES, 'read a project information draft attachment');
+    sendPrivateDraftAttachment(res, await projectInfoDraftService.readAttachment({
+      ...await routeContext(req, piiProtector),
+      projectId: routeProjectId(req),
+      documentKind: requiredText(req.params?.documentKind, 'documentKind'),
+    }));
+  }));
+
   app.post('/api/v1/project-info-drafts/:projectId/open', asyncHandler(async (req, res) => {
     assertActorRoleAllowed(req, PROJECT_REQUEST_ROUTE_ROLES, 'open a project information draft');
     parseWithSchema(projectInfoDraftOpenSchema, req.body);
@@ -913,6 +1211,18 @@ export function mountProjectInfoDraftRoutes(app, {
     sendOutcome(res, await projectInfoDraftService.addAttachment({
       ...await routeContext(req, piiProtector), ...routeOwnership(req), projectId: routeProjectId(req),
       ...parsed, buffer: decodeBase64(parsed.contentBase64, parsed.fileSize),
+    }));
+  }));
+
+  app.delete('/api/v1/project-info-drafts/:projectId/attachments/:documentKind', asyncHandler(async (req, res) => {
+    assertActorRoleAllowed(req, PROJECT_REQUEST_ROUTE_ROLES, 'remove a project information draft file');
+    const parsed = parseWithSchema(projectDraftAttachmentDeleteSchema, req.body);
+    sendOutcome(res, await projectInfoDraftService.removeAttachment({
+      ...await routeContext(req, piiProtector),
+      ...routeOwnership(req),
+      projectId: routeProjectId(req),
+      documentKind: requiredText(req.params?.documentKind, 'documentKind'),
+      ...parsed,
     }));
   }));
 

--- a/server/bff/routes/project-info-drafts.test.mjs
+++ b/server/bff/routes/project-info-drafts.test.mjs
@@ -1,3 +1,5 @@
+import express from 'express';
+import request from 'supertest';
 import { describe, expect, it, vi } from 'vitest';
 import { createIdempotencyService } from '../idempotency.mjs';
 import { buildActiveEditLeaseDocument, resolveEditLeaseDocumentId } from '../edit-lease.mjs';
@@ -5,6 +7,7 @@ import { loadRbacPolicy } from '../rbac-policy.mjs';
 import {
   createProjectInfoDraftService,
   createProjectInfoSubmittedOutboxHandler,
+  mountProjectInfoDraftRoutes,
 } from './project-info-drafts.mjs';
 
 const VALID_PDF = Buffer.from('%PDF-1.4\n');
@@ -100,8 +103,69 @@ function validPayload(overrides = {}) {
   };
 }
 
-function harness({ storageService } = {}) {
+function validV2Payload(overrides = {}) {
+  return validPayload({
+    registrationRequirementsVersion: 2,
+    financialYears: [{
+      year: 2026,
+      contractAmount: 100000,
+      salesVatAmount: 10000,
+      totalRevenueAmount: 40000,
+      supportAmount: 0,
+      profitRate: 0.4,
+      confirmed: true,
+    }],
+    paymentExpectedMonths: { contract: '2026-07', interim: '', final: '' },
+    advanceInterimBelow70Reason: '',
+    registrationConfirmations: {
+      laborIncludesFourInsurance: true,
+      laborIncludesRetirementPay: true,
+      customerSettlementBasisConfirmed: true,
+      modusignContractUsed: true,
+      originalContractSubmitted: null,
+    },
+    registrationOptionalDocumentNotes: {
+      proposalWordOriginal: '고객사 미제공',
+      proposalPptOriginal: '해당 없음',
+      presentationPptOriginal: '해당 없음',
+    },
+    teamMembersDetailed: [
+      {
+        memberName: 'Head A',
+        memberNickname: 'Head',
+        role: '사업 최종 책임자',
+        participationRate: 100,
+        isDocumentOnly: false,
+      },
+      {
+        memberName: 'Actor A',
+        memberNickname: 'Actor',
+        role: '실무책임자',
+        participationRate: 100,
+        isDocumentOnly: false,
+      },
+      {
+        memberName: 'Operator A',
+        memberNickname: 'Operator',
+        role: '운영매니저',
+        participationRate: 100,
+        isDocumentOnly: false,
+      },
+    ],
+    contractDocument: { path: 'orgs/tenant-a/project-registration-documents/project-a/contract.pdf' },
+    customerBusinessRegistrationDocument: {
+      path: 'orgs/tenant-a/project-registration-documents/project-a/customer-business-registration.pdf',
+    },
+    quoteDocument: { path: 'orgs/tenant-a/project-registration-documents/project-a/quote.pdf' },
+    proposalDocument: { path: 'orgs/tenant-a/project-registration-documents/project-a/proposal.pdf' },
+    rfpRequestEvidenceDocument: null,
+    ...overrides,
+  });
+}
+
+function harness({ storageService, outboxEventFactory, cleanupOutboxEventFactory } = {}) {
   let nowMs = Date.parse('2026-07-12T00:00:00.000Z');
+  let cleanupOutboxSequence = 0;
   const lease = buildActiveEditLeaseDocument({
     tenantId: 'tenant-a', resourceType: 'project-info', resourceId: 'project-a',
     actorId: 'actor-a', actorDisplayName: 'Actor A', sessionId: 'session-a',
@@ -116,7 +180,7 @@ function harness({ storageService } = {}) {
     },
     'orgs/tenant-a/projects/project-a': {
       id: 'project-a', tenantId: 'tenant-a', version: 3, executiveReviewStatus: 'APPROVED',
-      executiveReviewHistory: [], ...validPayload(),
+      executiveReviewHistory: [], ...validV2Payload(),
     },
     [`orgs/tenant-a/editLeases/${resolveEditLeaseDocumentId('project-info', 'project-a')}`]: lease,
   });
@@ -126,10 +190,18 @@ function harness({ storageService } = {}) {
     db,
     now: () => new Date(nowMs).toISOString(),
     createAttachmentId: () => 'attachment-a',
-    createOutboxEvent: (input) => ({
+    createOutboxEvent: outboxEventFactory || ((input) => ({
       id: 'outbox-a', ...input, status: 'PENDING', attempts: 0,
       nextAttemptAt: input.createdAt, updatedAt: input.createdAt,
-    }),
+    })),
+    createAttachmentCleanupOutboxEvent: cleanupOutboxEventFactory || ((input) => ({
+      id: `cleanup-outbox-${++cleanupOutboxSequence}`,
+      ...input,
+      status: 'PENDING',
+      attempts: 0,
+      nextAttemptAt: input.createdAt,
+      updatedAt: input.createdAt,
+    })),
     auditChainService,
     idempotencyService,
     draftStorageService: storageService,
@@ -196,6 +268,219 @@ describe('project information private drafts', () => {
     });
   });
 
+  it('carries unpublished attachments into a newer submission after the older delivery becomes stale', async () => {
+    let outboxSequence = 0;
+    const relocateDraftAttachments = vi.fn(async ({ tenantId, projectId, attachmentRefs }) => (
+      attachmentRefs.map((attachment) => ({
+        ...attachment,
+        path: `orgs/${tenantId}/project-registration-documents/${projectId}/${attachment.path.split('/').at(-1)}`,
+        visibility: 'PRIVATE',
+      }))
+    ));
+    const storageService = {
+      uploadDraftAttachment: vi.fn(async (input) => ({
+        path: `orgs/${input.tenantId}/project-registration-drafts/${input.draftId}/${input.attachmentId}-${input.fileName}`,
+        name: input.fileName,
+        size: input.buffer.byteLength,
+        contentType: input.mimeType,
+        uploadedAt: '2026-07-12T00:01:00.000Z',
+      })),
+      deleteDraftAttachment: vi.fn(async () => undefined),
+      relocateDraftAttachments,
+    };
+    const h = harness({
+      storageService,
+      outboxEventFactory: (input) => ({
+        id: `outbox-${++outboxSequence}`,
+        ...input,
+        status: 'PENDING',
+        attempts: 0,
+        nextAttemptAt: input.createdAt,
+        updatedAt: input.createdAt,
+      }),
+    });
+    await openedDraft(h, 'open-v1');
+    const uploaded = await h.service.addAttachment({
+      ...h.base,
+      idempotencyKey: 'upload-v1',
+      expectedDraftRevision: 0,
+      documentKind: 'contract',
+      fileName: 'contract-v1.pdf',
+      mimeType: 'application/pdf',
+      fileSize: VALID_PDF.byteLength,
+      buffer: VALID_PDF,
+    });
+    await h.service.submit({
+      ...h.base,
+      idempotencyKey: 'submit-v1',
+      expectedDraftRevision: 1,
+      expectedVersion: 3,
+    });
+    const oldEvent = clone(h.db.documents.get('outbox/outbox-1'));
+
+    h.db.documents.set(
+      `orgs/tenant-a/editLeases/${resolveEditLeaseDocumentId('project-info', 'project-a')}`,
+      buildActiveEditLeaseDocument({
+        tenantId: 'tenant-a', resourceType: 'project-info', resourceId: 'project-a',
+        actorId: 'actor-a', actorDisplayName: 'Actor A', sessionId: 'session-a',
+        leaseId: 'lease-a', serverNow: Date.parse('2026-07-12T00:00:00.000Z'),
+      }),
+    );
+    await openedDraft(h, 'open-v2');
+    await h.service.submit({
+      ...h.base,
+      idempotencyKey: 'submit-v2',
+      expectedDraftRevision: 0,
+      expectedVersion: 4,
+    });
+    const newEvent = clone(h.db.documents.get('outbox/outbox-2'));
+
+    expect(newEvent.payload.attachmentRefs).toEqual([
+      expect.objectContaining({ documentKind: 'contract', path: uploaded.body.attachment.path }),
+    ]);
+    const handler = createProjectInfoSubmittedOutboxHandler({
+      db: h.db,
+      draftStorageService: storageService,
+      now: () => '2026-07-12T00:05:00.000Z',
+    });
+    await handler(oldEvent);
+    expect(relocateDraftAttachments).not.toHaveBeenCalled();
+    await handler(newEvent);
+
+    expect(relocateDraftAttachments).toHaveBeenCalledOnce();
+    expect(h.db.documents.get('orgs/tenant-a/project_requests/change-project-a')).toMatchObject({
+      requestVersion: 2,
+      submittedOutboxId: 'outbox-2',
+      proposedSnapshot: {
+        contractDocument: {
+          path: expect.stringContaining('/project-registration-documents/project-a/'),
+        },
+      },
+      attachmentsPublishedAt: '2026-07-12T00:05:00.000Z',
+    });
+  });
+
+  it('keeps an inherited unpublished attachment immutable when the next draft removes it', async () => {
+    const storageService = {
+      uploadDraftAttachment: vi.fn(async (input) => ({
+        path: `orgs/${input.tenantId}/project-registration-drafts/${input.draftId}/${input.attachmentId}-${input.fileName}`,
+        name: input.fileName,
+        size: input.buffer.byteLength,
+        contentType: input.mimeType,
+        uploadedAt: '2026-07-12T00:01:00.000Z',
+      })),
+      deleteDraftAttachment: vi.fn(async () => undefined),
+    };
+    const h = harness({ storageService });
+    await openedDraft(h, 'immutable-open-v1');
+    await h.service.addAttachment({
+      ...h.base,
+      idempotencyKey: 'immutable-upload-v1',
+      expectedDraftRevision: 0,
+      documentKind: 'contract',
+      fileName: 'contract-v1.pdf',
+      mimeType: 'application/pdf',
+      fileSize: VALID_PDF.byteLength,
+      buffer: VALID_PDF,
+    });
+    await h.service.submit({
+      ...h.base,
+      idempotencyKey: 'immutable-submit-v1',
+      expectedDraftRevision: 1,
+      expectedVersion: 3,
+    });
+    h.db.documents.set(
+      `orgs/tenant-a/editLeases/${resolveEditLeaseDocumentId('project-info', 'project-a')}`,
+      buildActiveEditLeaseDocument({
+        tenantId: 'tenant-a', resourceType: 'project-info', resourceId: 'project-a',
+        actorId: 'actor-a', actorDisplayName: 'Actor A', sessionId: 'session-a',
+        leaseId: 'lease-a', serverNow: Date.parse('2026-07-12T00:00:00.000Z'),
+      }),
+    );
+
+    const reopened = await openedDraft(h, 'immutable-open-v2');
+    expect(reopened.body.draft.attachmentRefs[0]).not.toHaveProperty('inheritedFromProjectRequest');
+    const rawDraft = [...h.db.documents.values()].find((value) => value?.resourceType === 'project-info' && value?.status === 'ACTIVE');
+    expect(rawDraft.attachmentRefs[0]).toMatchObject({
+      documentKind: 'contract',
+      inheritedFromProjectRequest: true,
+    });
+
+    const removed = await h.service.removeAttachment({
+      ...h.base,
+      idempotencyKey: 'immutable-remove-v2',
+      expectedDraftRevision: 0,
+      documentKind: 'contract',
+    });
+
+    expect(removed.body.draft).toMatchObject({
+      draftRevision: 1,
+      attachmentRefs: [],
+      payload: { contractDocument: null },
+    });
+    expect(storageService.deleteDraftAttachment).not.toHaveBeenCalled();
+    expect([...h.db.documents.values()].some((value) => value?.eventType === 'draft.attachments.cleanup'))
+      .toBe(false);
+  });
+
+  it('replaces an inherited proposal without deleting the prior request blob', async () => {
+    const storageService = {
+      uploadDraftAttachment: vi.fn(async (input) => ({
+        path: `orgs/${input.tenantId}/project-registration-drafts/${input.draftId}/${input.attachmentId}-${input.fileName}`,
+        name: input.fileName,
+        size: input.buffer.byteLength,
+        contentType: input.mimeType,
+        uploadedAt: '2026-07-12T00:01:00.000Z',
+      })),
+      deleteDraftAttachment: vi.fn(async () => undefined),
+    };
+    const h = harness({ storageService });
+    await openedDraft(h, 'inherited-proposal-open-v1');
+    await h.service.addAttachment({
+      ...h.base,
+      idempotencyKey: 'inherited-proposal-upload-v1',
+      expectedDraftRevision: 0,
+      documentKind: 'proposal',
+      fileName: 'proposal-v1.pdf',
+      mimeType: 'application/pdf',
+      fileSize: VALID_PDF.byteLength,
+      buffer: VALID_PDF,
+    });
+    await h.service.submit({
+      ...h.base,
+      idempotencyKey: 'inherited-proposal-submit-v1',
+      expectedDraftRevision: 1,
+      expectedVersion: 3,
+    });
+    h.db.documents.set(
+      `orgs/tenant-a/editLeases/${resolveEditLeaseDocumentId('project-info', 'project-a')}`,
+      buildActiveEditLeaseDocument({
+        tenantId: 'tenant-a', resourceType: 'project-info', resourceId: 'project-a',
+        actorId: 'actor-a', actorDisplayName: 'Actor A', sessionId: 'session-a',
+        leaseId: 'lease-a', serverNow: Date.parse('2026-07-12T00:00:00.000Z'),
+      }),
+    );
+    await openedDraft(h, 'inherited-proposal-open-v2');
+
+    const replacement = await h.service.addAttachment({
+      ...h.base,
+      idempotencyKey: 'inherited-rfp-upload-v2',
+      expectedDraftRevision: 0,
+      documentKind: 'rfp_request_evidence',
+      fileName: 'rfp-v2.pdf',
+      mimeType: 'application/pdf',
+      fileSize: VALID_PDF.byteLength,
+      buffer: VALID_PDF,
+    });
+
+    expect(replacement.body.draft.attachmentRefs).toEqual([
+      expect.objectContaining({ documentKind: 'rfp_request_evidence', name: 'rfp-v2.pdf' }),
+    ]);
+    expect(storageService.deleteDraftAttachment).not.toHaveBeenCalled();
+    expect([...h.db.documents.values()].some((value) => value?.eventType === 'draft.attachments.cleanup'))
+      .toBe(false);
+  });
+
   it('opens an owner-only draft from canonical data and hides it from admins', async () => {
     const h = harness();
     h.db.documents.set('orgs/tenant-a/members/actor-a', {
@@ -213,6 +498,146 @@ describe('project information private drafts', () => {
     await expect(h.service.get({
       tenantId: 'tenant-a', actorId: 'actor-admin', projectId: 'project-a',
     })).rejects.toMatchObject({ statusCode: 404, code: 'not_found' });
+  });
+
+  it('downloads a stored edit-draft attachment only for its owner and exact document kind', async () => {
+    const downloadDraftAttachment = vi.fn(async () => ({
+      buffer: Buffer.from('private-edit-pdf'), contentType: 'application/pdf', size: 16,
+    }));
+    const h = harness({ storageService: { downloadDraftAttachment } });
+    await openedDraft(h);
+    const [draftPath] = [...h.db.documents.keys()].filter((path) => path.includes('/privateEditDrafts/'));
+    const draft = h.db.documents.get(draftPath);
+    const path = `orgs/tenant-a/project-registration-drafts/${draftPath.split('/').at(-1)}/attachment-a-contract.pdf`;
+    h.db.documents.set(draftPath, {
+      ...draft,
+      attachmentRefs: [{
+        attachmentId: 'attachment-a', documentKind: 'contract', path,
+        name: 'contract.pdf', size: 16, contentType: 'application/pdf',
+      }],
+    });
+
+    await expect(h.service.readAttachment({
+      tenantId: 'tenant-a', actorId: 'actor-a', projectId: 'project-a', documentKind: 'contract',
+    })).resolves.toMatchObject({
+      buffer: Buffer.from('private-edit-pdf'), name: 'contract.pdf', contentType: 'application/pdf',
+    });
+    await expect(h.service.readAttachment({
+      tenantId: 'tenant-a', actorId: 'actor-admin', projectId: 'project-a', documentKind: 'contract',
+    })).rejects.toMatchObject({ statusCode: 404, code: 'not_found' });
+    await expect(h.service.readAttachment({
+      tenantId: 'tenant-a', actorId: 'actor-a', projectId: 'project-a', documentKind: 'performance_certificate',
+    })).rejects.toMatchObject({ statusCode: 404, code: 'not_found' });
+    await expect(h.service.readAttachment({
+      tenantId: 'tenant-a', actorId: 'actor-a', projectId: 'project-a', documentKind: 'browser-controlled',
+    })).rejects.toMatchObject({ statusCode: 400, code: 'draft_attachment_invalid' });
+    expect(downloadDraftAttachment).toHaveBeenCalledOnce();
+    expect(downloadDraftAttachment).toHaveBeenCalledWith({
+      tenantId: 'tenant-a', draftId: draftPath.split('/').at(-1), path,
+    });
+  });
+
+  it('previews only exact canonical or resumable-request documents when no private replacement exists', async () => {
+    const downloadProjectRegistrationAttachment = vi.fn(async () => ({
+      buffer: Buffer.from('stored-project-pdf'), contentType: 'application/pdf', size: 18,
+    }));
+    const h = harness({ storageService: {
+      downloadDraftAttachment: vi.fn(),
+      downloadProjectRegistrationAttachment,
+    } });
+    const canonicalPath = 'orgs/tenant-a/project-registration-documents/project-a/contract.pdf';
+    h.db.documents.set('orgs/tenant-a/projects/project-a', {
+      ...h.db.documents.get('orgs/tenant-a/projects/project-a'),
+      contractDocument: { path: canonicalPath, name: 'canonical-contract.pdf' },
+    });
+    await openedDraft(h);
+
+    await expect(h.service.readAttachment({
+      tenantId: 'tenant-a', actorId: 'actor-a', projectId: 'project-a', documentKind: 'contract',
+    })).resolves.toMatchObject({
+      buffer: Buffer.from('stored-project-pdf'), name: 'canonical-contract.pdf',
+    });
+    expect(downloadProjectRegistrationAttachment).toHaveBeenLastCalledWith({
+      tenantId: 'tenant-a', projectId: 'project-a', path: canonicalPath,
+    });
+
+    const [draftPath] = [...h.db.documents.keys()].filter((path) => path.includes('/privateEditDrafts/'));
+    const draft = h.db.documents.get(draftPath);
+    h.db.documents.set(draftPath, {
+      ...draft,
+      payload: {
+        ...draft.payload,
+        quoteDocument: {
+          path: 'orgs/tenant-a/project-registration-documents/project-a/browser-forged.pdf',
+          name: 'browser-forged.pdf',
+        },
+      },
+    });
+    await expect(h.service.readAttachment({
+      tenantId: 'tenant-a', actorId: 'actor-a', projectId: 'project-a', documentKind: 'quote',
+    })).rejects.toMatchObject({ statusCode: 404, code: 'not_found' });
+    expect(downloadProjectRegistrationAttachment).toHaveBeenCalledTimes(1);
+  });
+
+  it('previews a server-stored pending change document without trusting browser metadata', async () => {
+    const downloadProjectRegistrationAttachment = vi.fn(async () => ({
+      buffer: Buffer.from('pending-rfp'), contentType: 'application/pdf', size: 11,
+    }));
+    const h = harness({ storageService: {
+      downloadDraftAttachment: vi.fn(),
+      downloadProjectRegistrationAttachment,
+    } });
+    const rfpPath = 'orgs/tenant-a/project-registration-documents/project-a/pending-rfp.pdf';
+    h.db.documents.set('orgs/tenant-a/project_requests/change-project-a', {
+      requestKind: 'CHANGE',
+      status: 'PENDING',
+      payload: { rfpRequestEvidenceDocument: { path: rfpPath, name: 'pending-rfp.pdf' } },
+      proposedSnapshot: { rfpRequestEvidenceDocument: { path: rfpPath, name: 'pending-rfp.pdf' } },
+    });
+    await openedDraft(h);
+
+    await expect(h.service.readAttachment({
+      tenantId: 'tenant-a', actorId: 'actor-a', projectId: 'project-a', documentKind: 'rfp_request_evidence',
+    })).resolves.toMatchObject({ buffer: Buffer.from('pending-rfp'), name: 'pending-rfp.pdf' });
+    expect(downloadProjectRegistrationAttachment).toHaveBeenCalledWith({
+      tenantId: 'tenant-a', projectId: 'project-a', path: rfpPath,
+    });
+  });
+
+  it('previews a trusted pending-change document from private draft storage before outbox relocation', async () => {
+    const downloadDraftAttachment = vi.fn(async () => ({
+      buffer: Buffer.from('pending-private-rfp'), contentType: 'application/pdf', size: 19,
+    }));
+    const h = harness({ storageService: {
+      downloadDraftAttachment,
+      downloadProjectRegistrationAttachment: vi.fn(),
+    } });
+    await openedDraft(h);
+    const [draftPath] = [...h.db.documents.keys()].filter((path) => path.includes('/privateEditDrafts/'));
+    const draftId = draftPath.split('/').at(-1);
+    const rfpPath = `orgs/tenant-a/project-registration-drafts/${draftId}/pending-rfp.pdf`;
+    const draft = h.db.documents.get(draftPath);
+    h.db.documents.set(draftPath, {
+      ...draft,
+      payload: {
+        ...draft.payload,
+        proposalDocument: null,
+        rfpRequestEvidenceDocument: { path: rfpPath, name: 'pending-rfp.pdf' },
+      },
+    });
+    h.db.documents.set('orgs/tenant-a/project_requests/change-project-a', {
+      requestKind: 'CHANGE',
+      status: 'PENDING',
+      payload: { rfpRequestEvidenceDocument: { path: rfpPath, name: 'pending-rfp.pdf' } },
+      proposedSnapshot: { rfpRequestEvidenceDocument: { path: rfpPath, name: 'pending-rfp.pdf' } },
+    });
+
+    await expect(h.service.readAttachment({
+      tenantId: 'tenant-a', actorId: 'actor-a', projectId: 'project-a', documentKind: 'rfp_request_evidence',
+    })).resolves.toMatchObject({ buffer: Buffer.from('pending-private-rfp'), name: 'pending-rfp.pdf' });
+    expect(downloadDraftAttachment).toHaveBeenCalledWith({
+      tenantId: 'tenant-a', draftId, path: rfpPath,
+    });
   });
 
   it('temporary save changes only the private draft and rejects stale revisions', async () => {
@@ -246,7 +671,7 @@ describe('project information private drafts', () => {
     await openedDraft(h);
     await h.service.update({
       ...h.base, idempotencyKey: 'save-a', expectedDraftRevision: 0,
-      payload: validPayload({ name: 'Submitted name', browserOnlyField: 'must not persist' }), stepIndex: 4,
+      payload: validV2Payload({ name: 'Submitted name', browserOnlyField: 'must not persist' }), stepIndex: 4,
     });
     const submitInput = {
       ...h.base,
@@ -268,7 +693,15 @@ describe('project information private drafts', () => {
       projectVersion: 4, draftRevision: 2, lease: { state: 'RELEASED', canEdit: false },
       outbox: { id: 'outbox-a', status: 'PENDING' },
     });
-    expect(project).toMatchObject({ name: 'Project A', version: 4, executiveReviewStatus: 'PENDING' });
+    expect(project).toMatchObject({
+      name: 'Project A',
+      version: 4,
+      executiveReviewStatus: 'PENDING',
+      executiveReviewedAt: null,
+      executiveReviewedById: null,
+      executiveReviewedByName: null,
+      executiveReviewComment: null,
+    });
     expect(request).toMatchObject({
       requestKind: 'CHANGE', status: 'PENDING', baseProjectVersion: 3,
       targetProjectVersion: 4, requestVersion: 1, submittedOutboxId: 'outbox-a',
@@ -301,7 +734,7 @@ describe('project information private drafts', () => {
       ...h.base,
       idempotencyKey: 'management-pending-save',
       expectedDraftRevision: 0,
-      payload: validPayload({ name: 'Must not reopen review' }),
+      payload: validV2Payload({ name: 'Must not reopen review' }),
     });
 
     await expect(h.service.submit({
@@ -349,7 +782,7 @@ describe('project information private drafts', () => {
       ...h.base,
       idempotencyKey: 'management-reject-save',
       expectedDraftRevision: 0,
-      payload: validPayload({ name: 'Management resubmission' }),
+      payload: validV2Payload({ name: 'Management resubmission' }),
     });
     await h.service.submit({
       ...h.base,
@@ -410,7 +843,7 @@ describe('project information private drafts', () => {
       ...h.base,
       idempotencyKey: 'checkout-save',
       expectedDraftRevision: 3,
-      payload: validPayload({
+      payload: validV2Payload({
         status: 'COMPLETED',
         checkout: {
           finalPaymentReceived: true,
@@ -456,7 +889,7 @@ describe('project information private drafts', () => {
       ...h.base,
       idempotencyKey: 'checkout-invalid-save',
       expectedDraftRevision: 0,
-      payload: validPayload({
+      payload: validV2Payload({
         status: 'COMPLETED',
         checkout: {
           finalPaymentReceived: true,
@@ -473,6 +906,174 @@ describe('project information private drafts', () => {
     await expect(h.service.submit({
       ...h.base,
       idempotencyKey: 'checkout-invalid-submit',
+      expectedDraftRevision: 1,
+      expectedVersion: 3,
+    })).rejects.toMatchObject({ statusCode: 422, code: 'project_registration_invalid' });
+    expect(h.db.documents.has('orgs/tenant-a/project_requests/change-project-a')).toBe(false);
+  });
+
+  it('rejects a forged completion-evidence path instead of silently deleting the canonical PDF', async () => {
+    const h = harness();
+    const projectPath = 'orgs/tenant-a/projects/project-a';
+    const canonicalPerformanceCertificate = {
+      path: 'orgs/tenant-a/project-registration-documents/project-a/performance-certificate.pdf',
+      name: 'performance-certificate.pdf',
+      contentType: 'application/pdf',
+    };
+    h.db.documents.set(projectPath, {
+      ...h.db.documents.get(projectPath),
+      ...validV2Payload({
+        proposalDocument: {
+          path: 'orgs/tenant-a/project-registration-documents/project-a/proposal.pdf',
+          name: 'proposal.pdf',
+          contentType: 'application/pdf',
+        },
+        rfpRequestEvidenceDocument: null,
+        performanceCertificateDocument: canonicalPerformanceCertificate,
+      }),
+    });
+    await openedDraft(h);
+    await h.service.update({
+      ...h.base,
+      idempotencyKey: 'forged-checkout-save',
+      expectedDraftRevision: 0,
+      payload: validV2Payload({
+        proposalDocument: {
+          path: 'orgs/tenant-a/project-registration-documents/project-a/proposal.pdf',
+          name: 'proposal.pdf',
+          contentType: 'application/pdf',
+        },
+        rfpRequestEvidenceDocument: null,
+        status: 'COMPLETED',
+        checkout: {
+          finalPaymentReceived: true,
+          bankBalanceZero: true,
+          performanceCertificateReceived: true,
+          taxInvoiceEvidenceConfirmed: false,
+          finalSettlementReportConfirmed: false,
+          usbEvidenceSubmitted: false,
+          evidenceDeletedAfterUsb: false,
+        },
+        performanceCertificateDocument: {
+          path: 'orgs/other-tenant/project-registration-documents/other/forged-performance.pdf',
+          name: 'forged-performance.pdf',
+          contentType: 'application/pdf',
+        },
+      }),
+    });
+
+    await expect(h.service.submit({
+      ...h.base,
+      idempotencyKey: 'forged-checkout-submit',
+      expectedDraftRevision: 1,
+      expectedVersion: 3,
+    })).rejects.toMatchObject({ statusCode: 422, code: 'project_registration_invalid' });
+    expect(h.db.documents.get(projectPath).performanceCertificateDocument)
+      .toEqual(canonicalPerformanceCertificate);
+    expect(h.db.documents.has('orgs/tenant-a/project_requests/change-project-a')).toBe(false);
+  });
+
+  it('rejects a legacy-v1 project information submission instead of bypassing the seven-document contract', async () => {
+    const h = harness();
+    await openedDraft(h);
+    await h.service.update({
+      ...h.base,
+      idempotencyKey: 'legacy-v1-save',
+      expectedDraftRevision: 0,
+      payload: validPayload({ registrationRequirementsVersion: 1 }),
+    });
+
+    await expect(h.service.submit({
+      ...h.base,
+      idempotencyKey: 'legacy-v1-submit',
+      expectedDraftRevision: 1,
+      expectedVersion: 3,
+    })).rejects.toMatchObject({ statusCode: 422, code: 'project_registration_invalid' });
+    expect(h.db.documents.has('orgs/tenant-a/project_requests/change-project-a')).toBe(false);
+  });
+
+  it('rejects explicit removal of a completion PDF while its confirmation remains checked', async () => {
+    const h = harness();
+    const projectPath = 'orgs/tenant-a/projects/project-a';
+    const canonicalPerformanceCertificate = {
+      path: 'orgs/tenant-a/project-registration-documents/project-a/performance-certificate.pdf',
+      name: 'performance-certificate.pdf',
+      contentType: 'application/pdf',
+    };
+    h.db.documents.set(projectPath, {
+      ...h.db.documents.get(projectPath),
+      ...validV2Payload({
+        proposalDocument: {
+          path: 'orgs/tenant-a/project-registration-documents/project-a/proposal.pdf',
+        },
+        rfpRequestEvidenceDocument: null,
+        performanceCertificateDocument: canonicalPerformanceCertificate,
+      }),
+    });
+    await openedDraft(h);
+    await h.service.update({
+      ...h.base,
+      idempotencyKey: 'removed-checkout-save',
+      expectedDraftRevision: 0,
+      payload: validV2Payload({
+        proposalDocument: {
+          path: 'orgs/tenant-a/project-registration-documents/project-a/proposal.pdf',
+        },
+        rfpRequestEvidenceDocument: null,
+        status: 'COMPLETED',
+        checkout: {
+          finalPaymentReceived: true,
+          bankBalanceZero: true,
+          performanceCertificateReceived: true,
+          taxInvoiceEvidenceConfirmed: false,
+          finalSettlementReportConfirmed: false,
+          usbEvidenceSubmitted: false,
+          evidenceDeletedAfterUsb: false,
+        },
+        performanceCertificateDocument: null,
+      }),
+    });
+
+    await expect(h.service.submit({
+      ...h.base,
+      idempotencyKey: 'removed-checkout-submit',
+      expectedDraftRevision: 1,
+      expectedVersion: 3,
+    })).rejects.toMatchObject({ statusCode: 422, code: 'project_registration_invalid' });
+    expect(h.db.documents.get(projectPath).performanceCertificateDocument)
+      .toEqual(canonicalPerformanceCertificate);
+  });
+
+  it('requires checkout fields when editing an already-completed project even if status is omitted', async () => {
+    const h = harness();
+    const projectPath = 'orgs/tenant-a/projects/project-a';
+    h.db.documents.set(projectPath, {
+      ...h.db.documents.get(projectPath),
+      status: 'COMPLETED',
+      checkout: {
+        finalPaymentReceived: true,
+        bankBalanceZero: true,
+        performanceCertificateReceived: false,
+        taxInvoiceEvidenceConfirmed: false,
+        finalSettlementReportConfirmed: false,
+        usbEvidenceSubmitted: false,
+        evidenceDeletedAfterUsb: false,
+      },
+    });
+    await openedDraft(h);
+    const payload = validV2Payload({ name: 'Completed project rename' });
+    delete payload.status;
+    delete payload.checkout;
+    await h.service.update({
+      ...h.base,
+      idempotencyKey: 'completed-omitted-checkout-save',
+      expectedDraftRevision: 0,
+      payload,
+    });
+
+    await expect(h.service.submit({
+      ...h.base,
+      idempotencyKey: 'completed-omitted-checkout-submit',
       expectedDraftRevision: 1,
       expectedVersion: 3,
     })).rejects.toMatchObject({ statusCode: 422, code: 'project_registration_invalid' });
@@ -541,6 +1142,367 @@ describe('project information private drafts', () => {
     }));
     expect(replaced.body.draft.attachmentRefs).toHaveLength(1);
     expect(replaced.body.draft.attachmentRefs[0].name).toBe('replacement.pdf');
+    expect(h.db.documents.get('outbox/cleanup-outbox-1')).toMatchObject({
+      eventType: 'draft.attachments.cleanup',
+      entityType: 'project_info_draft',
+      payload: {
+        draftId: expect.stringMatching(/^v1_/),
+        paths: [uploaded.body.attachment.path],
+      },
+    });
+  });
+
+  it('clears canonical contract analysis when a private replacement is uploaded and submitted with null analysis', async () => {
+    const storage = {
+      uploadDraftAttachment: vi.fn(async (input) => ({
+        path: `orgs/${input.tenantId}/project-registration-drafts/${input.draftId}/${input.attachmentId}-${input.fileName}`,
+        name: input.fileName,
+        size: input.buffer.byteLength,
+        contentType: input.mimeType,
+        uploadedAt: '2026-07-12T00:01:00.000Z',
+      })),
+      deleteDraftAttachment: vi.fn(async () => undefined),
+    };
+    const h = harness({ storageService: storage });
+    const projectPath = 'orgs/tenant-a/projects/project-a';
+    h.db.documents.set(projectPath, {
+      ...h.db.documents.get(projectPath),
+      contractAnalysis: { summary: 'canonical contract A analysis' },
+    });
+    await openedDraft(h, 'open-contract-analysis');
+    const replacement = await h.service.addAttachment({
+      ...h.base,
+      idempotencyKey: 'upload-contract-b',
+      expectedDraftRevision: 0,
+      documentKind: 'contract',
+      fileName: 'contract-b.pdf',
+      mimeType: 'application/pdf',
+      fileSize: VALID_PDF.byteLength,
+      buffer: VALID_PDF,
+    });
+
+    expect(replacement.body.draft.payload.contractAnalysis).toBeNull();
+    await h.service.update({
+      ...h.base,
+      idempotencyKey: 'save-contract-b-failed-analysis',
+      expectedDraftRevision: 1,
+      payload: validV2Payload({
+        contractDocument: { path: replacement.body.attachment.path },
+        contractAnalysis: null,
+      }),
+    });
+    await h.service.submit({
+      ...h.base,
+      idempotencyKey: 'submit-contract-b-failed-analysis',
+      expectedDraftRevision: 2,
+      expectedVersion: 3,
+    });
+
+    const request = h.db.documents.get('orgs/tenant-a/project_requests/change-project-a');
+    expect(request.proposedSnapshot.contractDocument).toMatchObject({
+      documentKind: 'contract',
+      path: replacement.body.attachment.path,
+    });
+    expect(request.proposedSnapshot.contractAnalysis).toBeNull();
+    expect(request.payload.contractAnalysis).toBeNull();
+  });
+
+  it('removes a private attachment only with the owning lease fence and advances the draft revision', async () => {
+    const storage = {
+      uploadDraftAttachment: vi.fn(async (input) => ({
+        path: `orgs/${input.tenantId}/project-registration-drafts/${input.draftId}/${input.attachmentId}-${input.fileName}`,
+        name: input.fileName,
+        size: input.buffer.byteLength,
+        contentType: input.mimeType,
+        uploadedAt: '2026-07-12T00:01:00.000Z',
+      })),
+      deleteDraftAttachment: vi.fn(async () => undefined),
+    };
+    const h = harness({ storageService: storage });
+    await openedDraft(h);
+    const uploaded = await h.service.addAttachment({
+      ...h.base,
+      idempotencyKey: 'remove-upload',
+      expectedDraftRevision: 0,
+      documentKind: 'contract',
+      fileName: 'contract.pdf',
+      mimeType: 'application/pdf',
+      fileSize: VALID_PDF.byteLength,
+      buffer: VALID_PDF,
+    });
+    await h.service.update({
+      ...h.base,
+      idempotencyKey: 'remove-save-path',
+      expectedDraftRevision: 1,
+      payload: validPayload({ contractDocument: { path: uploaded.body.attachment.path } }),
+    });
+
+    await expect(h.service.removeAttachment({
+      ...h.base,
+      fence: h.base.fence + 1,
+      idempotencyKey: 'remove-wrong-fence',
+      expectedDraftRevision: 2,
+      documentKind: 'contract',
+    })).rejects.toMatchObject({ statusCode: 423, code: 'edit_lease_held' });
+    expect(storage.deleteDraftAttachment).not.toHaveBeenCalled();
+    expect(h.db.documents.has('outbox/cleanup-outbox-1')).toBe(false);
+
+    const removed = await h.service.removeAttachment({
+      ...h.base,
+      idempotencyKey: 'remove-contract',
+      expectedDraftRevision: 2,
+      documentKind: 'contract',
+    });
+
+    expect(removed.body.draft).toMatchObject({
+      draftRevision: 3,
+      attachmentRefs: [],
+      payload: { contractDocument: null },
+    });
+    expect(storage.deleteDraftAttachment).toHaveBeenCalledOnce();
+    expect(storage.deleteDraftAttachment).toHaveBeenCalledWith({
+      tenantId: 'tenant-a',
+      draftId: expect.stringMatching(/^v1_/),
+      path: uploaded.body.attachment.path,
+    });
+    expect(h.db.documents.get('outbox/cleanup-outbox-1')).toMatchObject({
+      eventType: 'draft.attachments.cleanup',
+      payload: {
+        draftId: expect.stringMatching(/^v1_/),
+        paths: [uploaded.body.attachment.path],
+      },
+    });
+  });
+
+  it('replaces proposal with RFP evidence in the private edit draft and submitted request', async () => {
+    const storage = {
+      uploadDraftAttachment: vi.fn(async (input) => ({
+        path: `orgs/${input.tenantId}/project-registration-drafts/${input.draftId}/${input.attachmentId}-${input.fileName}`,
+        name: input.fileName,
+        size: input.buffer.byteLength,
+        contentType: input.mimeType,
+        uploadedAt: '2026-07-12T00:01:00.000Z',
+      })),
+      deleteDraftAttachment: vi.fn(async () => undefined),
+    };
+    const h = harness({ storageService: storage });
+    await openedDraft(h);
+    const common = {
+      ...h.base,
+      mimeType: 'application/pdf',
+      fileSize: VALID_PDF.byteLength,
+      buffer: VALID_PDF,
+    };
+    const proposal = await h.service.addAttachment({
+      ...common,
+      idempotencyKey: 'alternative-proposal-upload',
+      expectedDraftRevision: 0,
+      documentKind: 'proposal',
+      fileName: 'proposal.pdf',
+    });
+    const rfp = await h.service.addAttachment({
+      ...common,
+      idempotencyKey: 'alternative-rfp-upload',
+      expectedDraftRevision: 1,
+      documentKind: 'rfp_request_evidence',
+      fileName: 'rfp.pdf',
+    });
+
+    expect(rfp.body.draft.attachmentRefs.map((item) => item.documentKind))
+      .toEqual(['rfp_request_evidence']);
+    expect(storage.deleteDraftAttachment).toHaveBeenCalledWith({
+      tenantId: 'tenant-a',
+      draftId: expect.stringMatching(/^v1_/),
+      path: proposal.body.attachment.path,
+    });
+
+    await h.service.submit({
+      ...h.base,
+      idempotencyKey: 'alternative-submit',
+      expectedDraftRevision: 2,
+      expectedVersion: 3,
+    });
+
+    expect(h.db.documents.get('outbox/outbox-a').payload.attachmentRefs.map((item) => item.documentKind))
+      .toEqual(['rfp_request_evidence']);
+    expect(h.db.documents.get('orgs/tenant-a/project_requests/change-project-a').proposedSnapshot)
+      .toMatchObject({
+        proposalDocument: null,
+        rfpRequestEvidenceDocument: { documentKind: 'rfp_request_evidence', name: 'rfp.pdf' },
+      });
+  });
+
+  it.each([
+    {
+      label: 'canonical proposal with private RFP evidence',
+      canonicalField: 'proposalDocument',
+      canonicalKind: 'proposal',
+      replacementField: 'rfpRequestEvidenceDocument',
+      replacementKind: 'rfp_request_evidence',
+    },
+    {
+      label: 'canonical RFP evidence with private proposal',
+      canonicalField: 'rfpRequestEvidenceDocument',
+      canonicalKind: 'rfp_request_evidence',
+      replacementField: 'proposalDocument',
+      replacementKind: 'proposal',
+    },
+  ])('submits $label without resurrecting the replaced canonical alternative', async ({
+    canonicalField,
+    canonicalKind,
+    replacementField,
+    replacementKind,
+  }) => {
+    const storage = {
+      uploadDraftAttachment: vi.fn(async (input) => ({
+        path: `orgs/${input.tenantId}/project-registration-drafts/${input.draftId}/${input.attachmentId}-${input.fileName}`,
+        name: input.fileName,
+        size: input.buffer.byteLength,
+        contentType: input.mimeType,
+        uploadedAt: '2026-07-12T00:01:00.000Z',
+      })),
+      deleteDraftAttachment: vi.fn(async () => undefined),
+    };
+    const h = harness({ storageService: storage });
+    h.db.documents.set('orgs/tenant-a/projects/project-a', {
+      ...h.db.documents.get('orgs/tenant-a/projects/project-a'),
+      ...validV2Payload({
+        proposalDocument: null,
+        rfpRequestEvidenceDocument: null,
+        [canonicalField]: {
+          path: `orgs/tenant-a/project-registration-documents/project-a/${canonicalKind}.pdf`,
+          name: `${canonicalKind}.pdf`,
+          contentType: 'application/pdf',
+        },
+      }),
+    });
+    await openedDraft(h);
+    await h.service.addAttachment({
+      ...h.base,
+      idempotencyKey: `canonical-alternative-${replacementKind}`,
+      expectedDraftRevision: 0,
+      documentKind: replacementKind,
+      fileName: `${replacementKind}.pdf`,
+      mimeType: 'application/pdf',
+      fileSize: VALID_PDF.byteLength,
+      buffer: VALID_PDF,
+    });
+
+    await h.service.submit({
+      ...h.base,
+      idempotencyKey: `canonical-alternative-submit-${replacementKind}`,
+      expectedDraftRevision: 1,
+      expectedVersion: 3,
+    });
+
+    const proposed = h.db.documents.get('orgs/tenant-a/project_requests/change-project-a').proposedSnapshot;
+    expect(proposed[canonicalField]).toBeNull();
+    expect(proposed[replacementField]).toMatchObject({ documentKind: replacementKind });
+  });
+
+  it('rejects client-forged document paths when no validated private attachment exists', async () => {
+    const h = harness();
+    h.db.documents.set('orgs/tenant-a/projects/project-a', {
+      ...h.db.documents.get('orgs/tenant-a/projects/project-a'),
+      ...validV2Payload({
+        proposalDocument: {
+          path: 'orgs/tenant-a/project-registration-documents/project-a/proposal.pdf',
+        },
+        rfpRequestEvidenceDocument: null,
+      }),
+    });
+    await openedDraft(h);
+    await h.service.update({
+      ...h.base,
+      idempotencyKey: 'forged-document-save',
+      expectedDraftRevision: 0,
+      payload: validV2Payload({
+        contractDocument: { path: 'orgs/other-tenant/project-registration-documents/other/contract.pdf' },
+        customerBusinessRegistrationDocument: { path: 'missing-customer.pdf' },
+        quoteDocument: { path: 'missing-quote.pdf' },
+        proposalDocument: null,
+        rfpRequestEvidenceDocument: { path: 'missing-rfp.pdf' },
+      }),
+    });
+
+    await expect(h.service.submit({
+      ...h.base,
+      idempotencyKey: 'forged-document-submit',
+      expectedDraftRevision: 1,
+      expectedVersion: 3,
+    })).rejects.toMatchObject({ statusCode: 422, code: 'project_registration_invalid' });
+    expect(h.db.documents.has('orgs/tenant-a/project_requests/change-project-a')).toBe(false);
+  });
+
+  it.each([
+    { requestStatus: 'PENDING', projectReviewStatus: 'APPROVED', resubmit: false },
+    { requestStatus: 'REJECTED', projectReviewStatus: 'REVISION_REJECTED', resubmit: true },
+  ])('preserves server-stored replacement documents when reopening a $requestStatus change', async ({
+    requestStatus,
+    projectReviewStatus,
+    resubmit,
+  }) => {
+    const h = harness();
+    const projectPath = 'orgs/tenant-a/projects/project-a';
+    const requestPath = 'orgs/tenant-a/project_requests/change-project-a';
+    const proposedRfp = {
+      path: 'orgs/tenant-a/project-registration-documents/project-a/replacement-rfp.pdf',
+      name: 'replacement-rfp.pdf',
+      contentType: 'application/pdf',
+      visibility: 'PRIVATE',
+    };
+    const canonical = validV2Payload({
+      proposalDocument: {
+        path: 'orgs/tenant-a/project-registration-documents/project-a/proposal.pdf',
+      },
+      rfpRequestEvidenceDocument: null,
+    });
+    const previousPayload = validV2Payload({
+      proposalDocument: null,
+      rfpRequestEvidenceDocument: proposedRfp,
+    });
+    h.db.documents.set(projectPath, {
+      ...h.db.documents.get(projectPath),
+      ...canonical,
+      executiveReviewStatus: projectReviewStatus,
+      managementPlanningReviewStatus: 'AGREED',
+      projectCode: 'AXR-2026-001',
+    });
+    h.db.documents.set(requestPath, {
+      id: 'change-project-a',
+      requestKind: 'CHANGE',
+      status: requestStatus,
+      requestVersion: 1,
+      targetProjectId: 'project-a',
+      targetProjectVersion: 4,
+      payload: previousPayload,
+      proposedSnapshot: previousPayload,
+    });
+
+    const opened = await openedDraft(h);
+    expect(opened.body.draft.payload).toMatchObject({
+      proposalDocument: null,
+      rfpRequestEvidenceDocument: proposedRfp,
+    });
+
+    await h.service.submit({
+      ...h.base,
+      idempotencyKey: `stored-replacement-submit-${requestStatus.toLowerCase()}`,
+      expectedDraftRevision: 0,
+      expectedVersion: 3,
+      resubmit,
+      ...(resubmit ? { reviewComment: '문서 보완 완료' } : {}),
+    });
+
+    expect(h.db.documents.get(requestPath).proposedSnapshot).toMatchObject({
+      proposalDocument: null,
+      rfpRequestEvidenceDocument: proposedRfp,
+    });
+    expect(h.db.documents.get(projectPath)).toMatchObject({
+      executiveReviewStatus: 'PENDING',
+      managementPlanningReviewStatus: 'AGREED',
+      projectCode: 'AXR-2026-001',
+    });
   });
 
   it('maps a new original-document kind into the canonical change request field', async () => {
@@ -651,5 +1613,84 @@ describe('project information private drafts', () => {
       buffer: fakePdf,
     })).rejects.toMatchObject({ statusCode: 422, code: 'draft_attachment_invalid' });
     expect(storage.uploadDraftAttachment).not.toHaveBeenCalled();
+  });
+
+  it('serves an owner edit-draft attachment as private no-store bytes', async () => {
+    const service = {
+      readAttachment: vi.fn(async () => ({
+        buffer: Buffer.from('private-edit-pdf'), contentType: 'application/pdf', size: 16,
+        name: 'contract\"\r\nX-Test: injected.pdf',
+      })),
+    };
+    const app = express();
+    app.use((req, _res, next) => {
+      req.context = {
+        tenantId: 'tenant-a', actorId: 'actor-a', actorRole: 'pm', actorName: 'Actor A', requestId: 'request-a',
+      };
+      next();
+    });
+    mountProjectInfoDraftRoutes(app, { enabled: true, projectInfoDraftService: service });
+    app.use((error, _req, res, _next) => {
+      res.status(error.statusCode || 500).json({ error: error.code || 'internal_error' });
+    });
+
+    const response = await request(app)
+      .get('/api/v1/project-info-drafts/project-a/attachments/contract')
+      .expect(200);
+
+    expect(response.headers['content-type']).toContain('application/pdf');
+    expect(response.headers['cache-control']).toBe('private, no-store');
+    expect(response.headers['x-content-type-options']).toBe('nosniff');
+    expect(response.headers['content-disposition']).toContain('%22%0D%0AX-Test%3A%20injected.pdf');
+    expect(response.headers['x-test']).toBeUndefined();
+    expect(response.body).toEqual(Buffer.from('private-edit-pdf'));
+    expect(service.readAttachment).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-a', actorId: 'actor-a', projectId: 'project-a', documentKind: 'contract',
+    }));
+  });
+
+  it('passes the typed attachment kind, revision, and lease fence to DELETE', async () => {
+    const service = {
+      removeAttachment: vi.fn(async () => ({
+        status: 200,
+        replayed: false,
+        body: { draft: { projectId: 'project-a', draftRevision: 3 } },
+      })),
+    };
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.context = {
+        tenantId: 'tenant-a', actorId: 'actor-a', actorRole: 'pm', actorName: 'Actor A',
+        requestId: 'request-a', idempotencyKey: req.header('idempotency-key') || undefined,
+      };
+      next();
+    });
+    mountProjectInfoDraftRoutes(app, { enabled: true, projectInfoDraftService: service });
+    app.use((error, _req, res, _next) => {
+      res.status(error.statusCode || 500).json({ error: error.code || 'internal_error' });
+    });
+
+    await request(app)
+      .delete('/api/v1/project-info-drafts/project-a/attachments/tax_invoice')
+      .set({
+        'idempotency-key': 'info-remove-route',
+        'x-edit-session-id': 'session-a',
+        'x-edit-lease-id': 'lease-a',
+        'x-edit-fence': '4',
+      })
+      .send({ expectedDraftRevision: 2 })
+      .expect(200);
+
+    expect(service.removeAttachment).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-a',
+      actorId: 'actor-a',
+      projectId: 'project-a',
+      sessionId: 'session-a',
+      leaseId: 'lease-a',
+      fence: 4,
+      expectedDraftRevision: 2,
+      documentKind: 'tax_invoice',
+    }));
   });
 });

--- a/server/bff/routes/project-registration-drafts.mjs
+++ b/server/bff/routes/project-registration-drafts.mjs
@@ -17,13 +17,14 @@ import {
 } from '../edit-lease.mjs';
 import {
   parseWithSchema,
+  projectDraftAttachmentDeleteSchema,
   projectRegistrationDraftAttachmentSchema,
   projectRegistrationDraftCreateSchema,
   projectRegistrationDraftPatchSchema,
   projectRegistrationDraftSubmitSchema,
 } from '../schemas.mjs';
 import { buildRequestFingerprint, sha256 } from '../utils.mjs';
-import { createOutboxEvent } from '../outbox.mjs';
+import { DRAFT_ATTACHMENT_CLEANUP_EVENT_TYPE, createOutboxEvent } from '../outbox.mjs';
 import { buildProjectRegistrationCanonicalDocuments } from './projects.mjs';
 import {
   PROJECT_REGISTRATION_DOCUMENT_KINDS,
@@ -31,6 +32,16 @@ import {
 } from '../project-document-validation.mjs';
 
 const RESOURCE_TYPE = 'project-registration';
+const DOCUMENT_FIELD_BY_KIND = {
+  contract: 'contractDocument',
+  customer_business_registration: 'customerBusinessRegistrationDocument',
+  quote: 'quoteDocument',
+  proposal: 'proposalDocument',
+  proposal_word_original: 'proposalWordOriginalDocument',
+  proposal_ppt_original: 'proposalPptOriginalDocument',
+  presentation_ppt_original: 'presentationPptOriginalDocument',
+  rfp_request_evidence: 'rfpRequestEvidenceDocument',
+};
 const MAX_DRAFT_DOCUMENT_BYTES = 900 * 1024;
 const MAX_ATTACHMENT_REFS = 100;
 const MAX_DRAFT_PAYLOAD_DEPTH = 20;
@@ -87,6 +98,23 @@ function ownerId(draft = {}) {
 
 function attachmentRefs(draft = {}) {
   return Array.isArray(draft.attachmentRefs) ? draft.attachmentRefs : [];
+}
+
+function replacementDocumentKinds(documentKind) {
+  return documentKind === 'proposal' || documentKind === 'rfp_request_evidence'
+    ? ['proposal', 'rfp_request_evidence']
+    : [documentKind];
+}
+
+function payloadWithoutAttachment(payload, documentKind, removedAttachments) {
+  const next = { ...(payload || {}) };
+  const field = DOCUMENT_FIELD_BY_KIND[documentKind];
+  const removedPaths = new Set(removedAttachments.map((attachment) => readOptionalText(attachment?.path)).filter(Boolean));
+  if (field && removedPaths.has(readOptionalText(next[field]?.path))) {
+    next[field] = null;
+  }
+  if (documentKind === 'contract') next.contractAnalysis = null;
+  return next;
 }
 
 function relocationAttachmentRefs(draft, current) {
@@ -343,6 +371,20 @@ function draftAudit(current, actorRole, action, revision, timestamp, metadata = 
   };
 }
 
+function attachmentCleanupEvent(createEvent, current, paths, timestamp) {
+  const uniquePaths = [...new Set(paths.map(readOptionalText).filter(Boolean))];
+  if (uniquePaths.length === 0) return null;
+  return createEvent({
+    tenantId: current.tenantId,
+    requestId: current.requestId,
+    eventType: DRAFT_ATTACHMENT_CLEANUP_EVENT_TYPE,
+    entityType: 'project_registration_draft',
+    entityId: current.draftId,
+    payload: { draftId: current.draftId, paths: uniquePaths },
+    createdAt: timestamp,
+  });
+}
+
 export function createProjectRegistrationDraftService({
   db,
   now = () => new Date().toISOString(),
@@ -352,6 +394,7 @@ export function createProjectRegistrationDraftService({
   createProjectId = defaultProjectId,
   createProjectRequestId = defaultProjectRequestId,
   createRegistrationOutboxEvent = createOutboxEvent,
+  createAttachmentCleanupOutboxEvent = createOutboxEvent,
   auditChainService,
   idempotencyService,
   draftStorageService,
@@ -587,6 +630,31 @@ export function createProjectRegistrationDraftService({
         const { draft } = await ownedDraft(tx, current);
         return { draft: draftContract(draft) };
       });
+    },
+
+    async readAttachment(input) {
+      if (!draftStorageService?.downloadDraftAttachment) {
+        throw new Error('Draft attachment storage service is required');
+      }
+      const current = context(input, { sessionRequired: false, idempotencyRequired: false });
+      const documentKind = requiredText(input?.documentKind, 'documentKind');
+      if (!PROJECT_REGISTRATION_DOCUMENT_KINDS.includes(documentKind)) {
+        throw createHttpError(400, 'documentKind is invalid', 'draft_attachment_invalid');
+      }
+      const attachment = await db.runTransaction(async (tx) => {
+        const { draft } = await ownedDraft(tx, current);
+        const match = attachmentRefs(draft).findLast((item) => item?.documentKind === documentKind);
+        if (!match || !readOptionalText(match.path)) {
+          throw createHttpError(404, 'Project registration draft attachment not found', 'not_found');
+        }
+        return match;
+      });
+      const downloaded = await draftStorageService.downloadDraftAttachment({
+        tenantId: current.tenantId,
+        draftId: current.draftId,
+        path: attachment.path,
+      });
+      return { ...downloaded, name: readOptionalText(attachment.name) || 'attachment.pdf' };
     },
 
     async update(input) {
@@ -862,6 +930,7 @@ export function createProjectRegistrationDraftService({
       if (!PROJECT_REGISTRATION_DOCUMENT_KINDS.includes(documentKind)) {
         throw createHttpError(400, 'documentKind is invalid', 'draft_attachment_invalid');
       }
+      const replacedDocumentKinds = replacementDocumentKinds(documentKind);
       assertProjectAttachment(buffer, mimeType, fileName, documentKind);
       const attachmentId = documentId(createAttachmentId(), 'attachmentId');
       const method = 'POST';
@@ -906,7 +975,7 @@ export function createProjectRegistrationDraftService({
         assertRevision(draft, expectedDraftRevision);
         if (
           attachmentRefs(draft).length >= MAX_ATTACHMENT_REFS
-          && !attachmentRefs(draft).some((attachment) => attachment?.documentKind === documentKind)
+          && !attachmentRefs(draft).some((attachment) => replacedDocumentKinds.includes(attachment?.documentKind))
         ) {
           throw createHttpError(422, 'Draft attachment limit exceeded', 'draft_attachment_limit_exceeded');
         }
@@ -982,11 +1051,14 @@ export function createProjectRegistrationDraftService({
           });
           const revision = assertRevision(draft, expectedDraftRevision) + 1;
           replacedAttachments = attachmentRefs(draft)
-            .filter((currentAttachment) => currentAttachment?.documentKind === documentKind);
+            .filter((currentAttachment) => replacedDocumentKinds.includes(currentAttachment?.documentKind));
           const next = {
             ...draft,
+            payload: payloadWithoutAttachment(draft.payload, documentKind, replacedAttachments),
             attachmentRefs: [
-              ...attachmentRefs(draft).filter((currentAttachment) => currentAttachment?.documentKind !== documentKind),
+              ...attachmentRefs(draft).filter(
+                (currentAttachment) => !replacedDocumentKinds.includes(currentAttachment?.documentKind),
+              ),
               attachment,
             ],
             draftRevision: revision,
@@ -1002,6 +1074,17 @@ export function createProjectRegistrationDraftService({
           ]);
           tx.set(ref, next);
           completeIdempotency(tx, current, lock, { method, path, status: 200, body }, nowDate);
+          const cleanupEvent = attachmentCleanupEvent(
+            createAttachmentCleanupOutboxEvent,
+            current,
+            replacedAttachments
+              .filter((replaced) => readOptionalText(replaced?.path) && replaced.path !== attachment.path)
+              .map((replaced) => replaced.path),
+            timestamp,
+          );
+          if (cleanupEvent) {
+            tx.create(db.doc(`outbox/${documentId(cleanupEvent.id, 'outboxEvent.id')}`), cleanupEvent);
+          }
           return { status: 200, body, replayed: false };
         });
         if (outcome.replayed) await cleanup();
@@ -1028,6 +1111,112 @@ export function createProjectRegistrationDraftService({
         await cleanup();
         throw error;
       }
+    },
+
+    async removeAttachment(input) {
+      if (!draftStorageService?.deleteDraftAttachment) {
+        throw new Error('Draft attachment storage service is required');
+      }
+      const current = context(input);
+      const leaseId = documentId(input?.leaseId, 'leaseId');
+      const fence = positiveFence(input?.fence);
+      const expectedDraftRevision = Number(input?.expectedDraftRevision);
+      if (!Number.isInteger(expectedDraftRevision) || expectedDraftRevision < 0) {
+        throw createHttpError(400, 'expectedDraftRevision must be a non-negative integer', 'draft_request_invalid');
+      }
+      const documentKind = requiredText(input?.documentKind, 'documentKind');
+      if (!PROJECT_REGISTRATION_DOCUMENT_KINDS.includes(documentKind)) {
+        throw createHttpError(400, 'documentKind is invalid', 'draft_attachment_invalid');
+      }
+      const method = 'DELETE';
+      const path = `/api/v1/project-registration-drafts/${current.draftId}/attachments/${documentKind}`;
+      const requestFingerprint = buildRequestFingerprint({
+        method,
+        path,
+        body: {
+          actorId: current.actorId,
+          sessionId: current.sessionId,
+          leaseId,
+          fence,
+          expectedDraftRevision,
+          documentKind,
+        },
+      });
+
+      const result = await db.runTransaction(async (tx) => {
+        const nowDate = clockDate(now);
+        const timestamp = nowDate.toISOString();
+        const { actorRole, ref, draft } = await ownedDraft(tx, current);
+        const lock = await checkIdempotency(tx, current, requestFingerprint, nowDate);
+        if (lock.mode === 'replay') {
+          return { outcome: { status: lock.status, body: lock.body, replayed: true }, removedAttachments: [] };
+        }
+        const lockError = idempotencyError(lock);
+        if (lockError) throw lockError;
+        assertActive(draft);
+        await assertOwnedInTransaction({
+          tx,
+          leaseRef: leaseRef(current),
+          tenantId: current.tenantId,
+          resourceType: RESOURCE_TYPE,
+          resourceId: current.draftId,
+          actorId: current.actorId,
+          sessionId: current.sessionId,
+          leaseId,
+          fence,
+          serverNow: nowDate,
+        });
+        const revision = assertRevision(draft, expectedDraftRevision) + 1;
+        const removedAttachments = attachmentRefs(draft)
+          .filter((attachment) => attachment?.documentKind === documentKind && readOptionalText(attachment?.path));
+        if (removedAttachments.length === 0) {
+          throw createHttpError(404, 'Project registration draft attachment not found', 'not_found');
+        }
+        const next = {
+          ...draft,
+          payload: payloadWithoutAttachment(draft.payload, documentKind, removedAttachments),
+          attachmentRefs: attachmentRefs(draft).filter((attachment) => attachment?.documentKind !== documentKind),
+          draftRevision: revision,
+          updatedAt: timestamp,
+        };
+        assertDraftSize(next);
+        const body = { draft: draftContract(next) };
+        await auditChainService.appendManyInTransaction(tx, [
+          draftAudit(current, actorRole, 'PROJECT_REGISTRATION_DRAFT_ATTACHMENT_REMOVE', revision, timestamp, {
+            fence,
+            documentKind,
+            attachmentIds: removedAttachments.map((attachment) => readOptionalText(attachment?.attachmentId)).filter(Boolean),
+          }),
+        ]);
+        tx.set(ref, next);
+        completeIdempotency(tx, current, lock, { method, path, status: 200, body }, nowDate);
+        const cleanupEvent = attachmentCleanupEvent(
+          createAttachmentCleanupOutboxEvent,
+          current,
+          removedAttachments.map((attachment) => attachment.path),
+          timestamp,
+        );
+        if (cleanupEvent) {
+          tx.create(db.doc(`outbox/${documentId(cleanupEvent.id, 'outboxEvent.id')}`), cleanupEvent);
+        }
+        return { outcome: { status: 200, body, replayed: false }, removedAttachments };
+      });
+
+      await Promise.all(result.removedAttachments.map(async (attachment) => {
+        try {
+          await draftStorageService.deleteDraftAttachment({
+            tenantId: current.tenantId,
+            draftId: current.draftId,
+            path: attachment.path,
+          });
+        } catch {
+          console.warn('[bff] removed draft attachment cleanup failed', {
+            requestId: current.requestId,
+            errorCode: 'draft_attachment_remove_cleanup_failed',
+          });
+        }
+      }));
+      return result.outcome;
     },
   };
 }
@@ -1073,6 +1262,21 @@ function sendOutcome(res, outcome) {
   res.status(outcome.status).json(outcome.body);
 }
 
+function sendPrivateDraftAttachment(res, attachment) {
+  const buffer = Buffer.isBuffer(attachment?.buffer)
+    ? attachment.buffer
+    : Buffer.from(attachment?.buffer || []);
+  const contentType = readOptionalText(attachment?.contentType);
+  res.setHeader('content-type', /^[A-Za-z0-9!#$&^_.+-]+\/[A-Za-z0-9!#$&^_.+-]+$/.test(contentType)
+    ? contentType
+    : 'application/octet-stream');
+  res.setHeader('content-length', String(buffer.byteLength));
+  res.setHeader('cache-control', 'private, no-store');
+  res.setHeader('x-content-type-options', 'nosniff');
+  res.setHeader('content-disposition', `inline; filename*=UTF-8''${encodeURIComponent(readOptionalText(attachment?.name) || 'attachment.pdf')}`);
+  res.status(200).send(buffer);
+}
+
 function decodeBase64(value, expectedSize) {
   if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
     throw createHttpError(400, 'contentBase64 is invalid', 'draft_attachment_invalid');
@@ -1112,6 +1316,16 @@ export function mountProjectRegistrationDraftRoutes(app, {
     }));
   }));
 
+  app.get('/api/v1/project-registration-drafts/:draftId/attachments/:documentKind', asyncHandler(async (req, res) => {
+    assertActorRoleAllowed(req, PROJECT_REQUEST_ROUTE_ROLES, 'read a project registration draft attachment');
+    const current = await routeContext(req, piiProtector);
+    sendPrivateDraftAttachment(res, await projectRegistrationDraftService.readAttachment({
+      ...current,
+      draftId: routeDraftId(req),
+      documentKind: requiredText(req.params?.documentKind, 'documentKind'),
+    }));
+  }));
+
   app.patch('/api/v1/project-registration-drafts/:draftId', asyncHandler(async (req, res) => {
     assertActorRoleAllowed(req, PROJECT_REQUEST_ROUTE_ROLES, 'save a project registration draft');
     const parsed = parseWithSchema(projectRegistrationDraftPatchSchema, req.body);
@@ -1134,6 +1348,19 @@ export function mountProjectRegistrationDraftRoutes(app, {
       draftId: routeDraftId(req),
       ...parsed,
       buffer: decodeBase64(parsed.contentBase64, parsed.fileSize),
+    }));
+  }));
+
+  app.delete('/api/v1/project-registration-drafts/:draftId/attachments/:documentKind', asyncHandler(async (req, res) => {
+    assertActorRoleAllowed(req, PROJECT_REQUEST_ROUTE_ROLES, 'remove a project registration draft file');
+    const parsed = parseWithSchema(projectDraftAttachmentDeleteSchema, req.body);
+    const current = await routeContext(req, piiProtector);
+    sendOutcome(res, await projectRegistrationDraftService.removeAttachment({
+      ...current,
+      ...routeOwnership(req),
+      draftId: routeDraftId(req),
+      documentKind: requiredText(req.params?.documentKind, 'documentKind'),
+      ...parsed,
     }));
   }));
 

--- a/server/bff/routes/project-registration-drafts.test.mjs
+++ b/server/bff/routes/project-registration-drafts.test.mjs
@@ -10,6 +10,7 @@ import {
 } from './project-registration-drafts.mjs';
 
 const VALID_PDF = Buffer.from('%PDF-1.4\n');
+const VALID_V2_PROJECT_NAME = 'Private';
 
 function clone(value) {
   return value === undefined ? undefined : structuredClone(value);
@@ -85,6 +86,7 @@ function createDb(seed = {}) {
 function createHarness({
   seed = {},
   storageService,
+  cleanupOutboxEventFactory,
   nowMs = Date.parse('2026-07-10T00:00:00.000Z'),
   auditChainService: auditOverride,
 } = {}) {
@@ -113,6 +115,7 @@ function createHarness({
   let draftSequence = 0;
   let leaseSequence = 0;
   let attachmentSequence = 0;
+  let cleanupOutboxSequence = 0;
   const auditChainService = auditOverride || {
     appendManyInTransaction: vi.fn(async () => []),
   };
@@ -135,6 +138,14 @@ function createHarness({
       nextAttemptAt: input.createdAt,
       updatedAt: input.createdAt,
     }),
+    createAttachmentCleanupOutboxEvent: cleanupOutboxEventFactory || ((input) => ({
+      id: `cleanup-outbox-${++cleanupOutboxSequence}`,
+      ...input,
+      status: 'PENDING',
+      attempts: 0,
+      nextAttemptAt: input.createdAt,
+      updatedAt: input.createdAt,
+    })),
     auditChainService,
     idempotencyService,
     draftStorageService: storageService,
@@ -212,6 +223,32 @@ function validRegistrationPayload(overrides = {}) {
 function validRegistrationV2Payload(overrides = {}) {
   const payload = validRegistrationPayload({
     registrationRequirementsVersion: 2,
+    name: VALID_V2_PROJECT_NAME,
+    teamMembers: [
+      'Head A · 사업 최종 책임자 · 100% · 실제 참여',
+      'Actor A · 실무책임자 · 100% · 실제 참여',
+      'Operator A · 운영매니저 · 100% · 실제 참여',
+    ].join(', '),
+    teamMembersDetailed: [
+      {
+        memberName: 'Head A',
+        role: '사업 최종 책임자',
+        participationRate: 100,
+        isDocumentOnly: false,
+      },
+      {
+        memberName: 'Actor A',
+        role: '실무책임자',
+        participationRate: 100,
+        isDocumentOnly: false,
+      },
+      {
+        memberName: 'Operator A',
+        role: '운영매니저',
+        participationRate: 100,
+        isDocumentOnly: false,
+      },
+    ],
     contractStart: '2026-01-01',
     contractEnd: '2027-12-31',
     contractAmount: 300_000,
@@ -481,6 +518,49 @@ describe('project registration draft service', () => {
     );
   });
 
+  it('downloads a stored draft attachment only for its owner and exact document kind', async () => {
+    const downloadDraftAttachment = vi.fn(async () => ({
+      buffer: Buffer.from('private-draft-pdf'),
+      contentType: 'application/pdf',
+      size: 17,
+    }));
+    const { db, service, base } = createHarness({
+      storageService: { downloadDraftAttachment },
+    });
+    const created = await service.create({ ...base, idempotencyKey: 'idem-preview-create' });
+    const draftId = created.body.draft.draftId;
+    const path = `orgs/tenant-a/project-registration-drafts/${draftId}/attachment-a-contract.pdf`;
+    db.documents.set(`orgs/tenant-a/projectRequestDrafts/${draftId}`, {
+      ...db.documents.get(`orgs/tenant-a/projectRequestDrafts/${draftId}`),
+      attachmentRefs: [{
+        attachmentId: 'attachment-a', documentKind: 'contract', path,
+        name: 'contract.pdf', size: 17, contentType: 'application/pdf',
+      }],
+    });
+
+    await expect(service.readAttachment({ ...base, draftId, documentKind: 'contract' }))
+      .resolves.toMatchObject({
+        buffer: Buffer.from('private-draft-pdf'), name: 'contract.pdf', contentType: 'application/pdf',
+      });
+    await expectHttpError(
+      service.readAttachment({ ...base, actorId: 'actor-b', draftId, documentKind: 'contract' }),
+      404,
+      'not_found',
+    );
+    await expectHttpError(
+      service.readAttachment({ ...base, draftId, documentKind: 'quote' }),
+      404,
+      'not_found',
+    );
+    await expectHttpError(
+      service.readAttachment({ ...base, draftId, documentKind: 'browser-controlled' }),
+      400,
+      'draft_attachment_invalid',
+    );
+    expect(downloadDraftAttachment).toHaveBeenCalledOnce();
+    expect(downloadDraftAttachment).toHaveBeenCalledWith({ tenantId: 'tenant-a', draftId, path });
+  });
+
   it('revision-saves only the draft, replays exactly, and rejects stale or wrong-session writes', async () => {
     const { db, service, base } = createHarness();
     const created = await service.create({ ...base, idempotencyKey: 'idem-patch-create' });
@@ -583,7 +663,7 @@ describe('project registration draft service', () => {
     expect(replay).toEqual({ ...first, replayed: true });
     expect(db.documents.get('orgs/tenant-a/projects/project-1')).toMatchObject({
       id: 'project-1',
-      name: 'Private project',
+      name: VALID_V2_PROJECT_NAME,
       registrationSource: 'pm_portal',
       executiveReviewStatus: 'PENDING',
       version: 1,
@@ -596,7 +676,7 @@ describe('project registration draft service', () => {
       sourceDraftId: created.body.draft.draftId,
       status: 'PENDING',
       approvedProjectId: 'project-1',
-      payload: { name: 'Private project' },
+      payload: { name: VALID_V2_PROJECT_NAME },
     });
     expect(db.documents.get('orgs/tenant-a/project_requests/project-request-1').payload)
       .not.toHaveProperty('arbitraryBrowserField');
@@ -622,13 +702,13 @@ describe('project registration draft service', () => {
       createdAt: '2025-01-01T00:00:00.000Z',
       projectId: 'project-1',
       projectIds: ['existing-project', 'project-1'],
-      projectNames: { 'existing-project': 'Existing', 'project-1': 'Private project' },
+      projectNames: { 'existing-project': 'Existing', 'project-1': VALID_V2_PROJECT_NAME },
       lastLoginAt: '2026-07-10T00:00:00.000Z',
       portalProfile: {
         role: 'preserved-profile-role',
         projectId: 'project-1',
         projectIds: ['existing-project', 'project-1'],
-        projectNames: { 'existing-project': 'Existing', 'project-1': 'Private project' },
+        projectNames: { 'existing-project': 'Existing', 'project-1': VALID_V2_PROJECT_NAME },
       },
     });
     expect([...db.documents.keys()].filter((path) => path === 'outbox/outbox-1')).toHaveLength(1);
@@ -754,6 +834,78 @@ describe('project registration draft service', () => {
       leaseId: created.body.lease.leaseId,
       fence: created.body.lease.fence,
       expectedDraftRevision: 0,
+    });
+
+    expect(db.documents.get('outbox/outbox-1').payload.attachmentRefs.map((item) => item.documentKind))
+      .toEqual(['rfp_request_evidence', 'contract', 'customer_business_registration', 'quote']);
+  });
+
+  it('replaces proposal with RFP evidence in the private draft and final submission', async () => {
+    const storageService = {
+      uploadDraftAttachment: vi.fn(async ({ tenantId, draftId, attachmentId, fileName, buffer, mimeType }) => ({
+        path: `orgs/${tenantId}/project-registration-drafts/${draftId}/${attachmentId}-${fileName}`,
+        name: fileName,
+        size: buffer.byteLength,
+        contentType: mimeType,
+        uploadedAt: '2026-07-10T00:00:00.000Z',
+      })),
+      deleteDraftAttachment: vi.fn(async () => undefined),
+    };
+    const { db, service, base } = createHarness({ storageService });
+    const created = await service.create({
+      ...base,
+      idempotencyKey: 'idem-v2-alternative-create',
+      payload: validRegistrationV2Payload(),
+    });
+    const common = {
+      ...base,
+      draftId: created.body.draft.draftId,
+      leaseId: created.body.lease.leaseId,
+      fence: created.body.lease.fence,
+      mimeType: 'application/pdf',
+      fileSize: VALID_PDF.byteLength,
+      buffer: VALID_PDF,
+    };
+    const proposal = await service.addAttachment({
+      ...common,
+      idempotencyKey: 'idem-v2-alternative-proposal',
+      expectedDraftRevision: 0,
+      documentKind: 'proposal',
+      fileName: 'proposal.pdf',
+    });
+    await service.addAttachment({
+      ...common,
+      idempotencyKey: 'idem-v2-alternative-rfp',
+      expectedDraftRevision: 1,
+      documentKind: 'rfp_request_evidence',
+      fileName: 'rfp.pdf',
+    });
+    for (const [offset, documentKind] of ['contract', 'customer_business_registration', 'quote'].entries()) {
+      await service.addAttachment({
+        ...common,
+        idempotencyKey: `idem-v2-alternative-${documentKind}`,
+        expectedDraftRevision: offset + 2,
+        documentKind,
+        fileName: `${documentKind}.pdf`,
+      });
+    }
+
+    const storedDraft = db.documents.get(`orgs/tenant-a/projectRequestDrafts/${created.body.draft.draftId}`);
+    expect(storedDraft.attachmentRefs.map((item) => item.documentKind))
+      .toEqual(['rfp_request_evidence', 'contract', 'customer_business_registration', 'quote']);
+    expect(storageService.deleteDraftAttachment).toHaveBeenCalledWith({
+      tenantId: 'tenant-a',
+      draftId: created.body.draft.draftId,
+      path: proposal.body.attachment.path,
+    });
+
+    await service.submit({
+      ...base,
+      idempotencyKey: 'idem-v2-alternative-submit',
+      draftId: created.body.draft.draftId,
+      leaseId: created.body.lease.leaseId,
+      fence: created.body.lease.fence,
+      expectedDraftRevision: 5,
     });
 
     expect(db.documents.get('outbox/outbox-1').payload.attachmentRefs.map((item) => item.documentKind))
@@ -1129,7 +1281,7 @@ describe('project registration draft service', () => {
       })),
       deleteDraftAttachment: vi.fn(async () => undefined),
     };
-    const { service, base } = createHarness({ storageService });
+    const { db, service, base } = createHarness({ storageService });
     const created = await service.create({ ...base, idempotencyKey: 'idem-replace-create' });
     const common = {
       ...base,
@@ -1152,6 +1304,166 @@ describe('project registration draft service', () => {
       tenantId: 'tenant-a',
       draftId: created.body.draft.draftId,
       path: first.body.attachment.path,
+    });
+    expect(db.documents.get('outbox/cleanup-outbox-1')).toMatchObject({
+      eventType: 'draft.attachments.cleanup',
+      entityType: 'project_registration_draft',
+      entityId: created.body.draft.draftId,
+      payload: {
+        draftId: created.body.draft.draftId,
+        paths: [first.body.attachment.path],
+      },
+      status: 'PENDING',
+    });
+  });
+
+  it('clears stale contract analysis when a private contract is replaced before submission', async () => {
+    let uploadCount = 0;
+    const storageService = {
+      uploadDraftAttachment: vi.fn(async ({ tenantId, draftId, attachmentId, fileName, buffer, mimeType }) => ({
+        path: `orgs/${tenantId}/project-registration-drafts/${draftId}/${attachmentId}-${++uploadCount}-${fileName}`,
+        name: fileName,
+        size: buffer.byteLength,
+        contentType: mimeType,
+        uploadedAt: '2026-07-10T00:00:00.000Z',
+      })),
+      deleteDraftAttachment: vi.fn(async () => undefined),
+    };
+    const { db, service, base } = createHarness({ storageService });
+    const created = await service.create({
+      ...base,
+      idempotencyKey: 'idem-contract-analysis-create',
+      payload: validRegistrationV2Payload(),
+    });
+    const attachmentInput = {
+      ...base,
+      draftId: created.body.draft.draftId,
+      leaseId: created.body.lease.leaseId,
+      fence: created.body.lease.fence,
+      documentKind: 'contract',
+      mimeType: 'application/pdf',
+      fileSize: VALID_PDF.byteLength,
+      buffer: VALID_PDF,
+    };
+    const first = await service.addAttachment({
+      ...attachmentInput,
+      idempotencyKey: 'idem-contract-analysis-first',
+      expectedDraftRevision: 0,
+      fileName: 'contract-a.pdf',
+    });
+    await service.update({
+      ...base,
+      draftId: created.body.draft.draftId,
+      leaseId: created.body.lease.leaseId,
+      fence: created.body.lease.fence,
+      idempotencyKey: 'idem-contract-analysis-save-a',
+      expectedDraftRevision: 1,
+      payload: validRegistrationV2Payload({
+        contractDocument: { path: first.body.attachment.path },
+        contractAnalysis: { summary: 'contract A analysis' },
+      }),
+    });
+    const replacement = await service.addAttachment({
+      ...attachmentInput,
+      idempotencyKey: 'idem-contract-analysis-replacement',
+      expectedDraftRevision: 2,
+      fileName: 'contract-b.pdf',
+    });
+
+    expect(replacement.body.draft.payload.contractAnalysis).toBeNull();
+    addRequiredRegistrationAttachments(
+      db,
+      created.body.draft.draftId,
+      [replacement.body.attachment],
+    );
+    await service.submit({
+      ...base,
+      idempotencyKey: 'idem-contract-analysis-submit',
+      draftId: created.body.draft.draftId,
+      leaseId: created.body.lease.leaseId,
+      fence: created.body.lease.fence,
+      expectedDraftRevision: 3,
+    });
+
+    expect(db.documents.get('orgs/tenant-a/projects/project-1').contractAnalysis).toBeNull();
+    expect(db.documents.get('orgs/tenant-a/project_requests/project-request-1').payload.contractAnalysis).toBeNull();
+  });
+
+  it('removes a private attachment only with the owning lease fence and advances the draft revision', async () => {
+    const storageService = {
+      uploadDraftAttachment: vi.fn(async ({ tenantId, draftId, attachmentId, fileName, buffer, mimeType }) => ({
+        path: `orgs/${tenantId}/project-registration-drafts/${draftId}/${attachmentId}-${fileName}`,
+        name: fileName,
+        size: buffer.byteLength,
+        contentType: mimeType,
+        uploadedAt: '2026-07-10T00:00:00.000Z',
+      })),
+      deleteDraftAttachment: vi.fn(async () => undefined),
+    };
+    const { db, service, base } = createHarness({ storageService });
+    const created = await service.create({ ...base, idempotencyKey: 'idem-remove-create' });
+    const uploaded = await service.addAttachment({
+      ...base,
+      draftId: created.body.draft.draftId,
+      leaseId: created.body.lease.leaseId,
+      fence: created.body.lease.fence,
+      idempotencyKey: 'idem-remove-upload',
+      expectedDraftRevision: 0,
+      documentKind: 'contract',
+      fileName: 'contract.pdf',
+      mimeType: 'application/pdf',
+      fileSize: VALID_PDF.byteLength,
+      buffer: VALID_PDF,
+    });
+    await service.update({
+      ...base,
+      draftId: created.body.draft.draftId,
+      leaseId: created.body.lease.leaseId,
+      fence: created.body.lease.fence,
+      idempotencyKey: 'idem-remove-save-path',
+      expectedDraftRevision: 1,
+      payload: { contractDocument: { path: uploaded.body.attachment.path } },
+    });
+
+    await expectHttpError(service.removeAttachment({
+      ...base,
+      draftId: created.body.draft.draftId,
+      leaseId: created.body.lease.leaseId,
+      fence: created.body.lease.fence + 1,
+      idempotencyKey: 'idem-remove-wrong-fence',
+      expectedDraftRevision: 2,
+      documentKind: 'contract',
+    }), 423, 'edit_lease_held');
+    expect(storageService.deleteDraftAttachment).not.toHaveBeenCalled();
+    expect(db.documents.has('outbox/cleanup-outbox-1')).toBe(false);
+
+    const removed = await service.removeAttachment({
+      ...base,
+      draftId: created.body.draft.draftId,
+      leaseId: created.body.lease.leaseId,
+      fence: created.body.lease.fence,
+      idempotencyKey: 'idem-remove-contract',
+      expectedDraftRevision: 2,
+      documentKind: 'contract',
+    });
+
+    expect(removed.body.draft).toMatchObject({
+      draftRevision: 3,
+      attachmentRefs: [],
+      payload: { contractDocument: null },
+    });
+    expect(storageService.deleteDraftAttachment).toHaveBeenCalledOnce();
+    expect(storageService.deleteDraftAttachment).toHaveBeenCalledWith({
+      tenantId: 'tenant-a',
+      draftId: created.body.draft.draftId,
+      path: uploaded.body.attachment.path,
+    });
+    expect(db.documents.get('outbox/cleanup-outbox-1')).toMatchObject({
+      eventType: 'draft.attachments.cleanup',
+      payload: {
+        draftId: created.body.draft.draftId,
+        paths: [uploaded.body.attachment.path],
+      },
     });
   });
 
@@ -1304,6 +1616,13 @@ describe('project registration draft routes', () => {
       get: vi.fn(async () => ({ draft: { draftId: 'draft-a' } })),
       update: vi.fn(async () => ({ status: 200, replayed: false, body: { draft: { draftId: 'draft-a', draftRevision: 1 } } })),
       addAttachment: vi.fn(async () => ({ status: 200, replayed: false, body: { draft: { draftId: 'draft-a', draftRevision: 2 } } })),
+      removeAttachment: vi.fn(async () => ({ status: 200, replayed: false, body: { draft: { draftId: 'draft-a', draftRevision: 3 } } })),
+      readAttachment: vi.fn(async () => ({
+        buffer: Buffer.from('private-draft-pdf'),
+        contentType: 'application/pdf',
+        size: 17,
+        name: 'contract\"\r\nX-Test: injected.pdf',
+      })),
       submit: vi.fn(async () => ({
         status: 201,
         replayed: false,
@@ -1436,6 +1755,49 @@ describe('project registration draft routes', () => {
       .set({ ...headers, 'idempotency-key': 'idem-route-attachment-kind-missing' })
       .send({ ...body, documentKind: undefined })
       .expect(400);
+  });
+
+  it('passes the typed attachment kind, revision, and lease fence to DELETE', async () => {
+    const { app, service } = createRouteApp();
+    await request(app)
+      .delete('/api/v1/project-registration-drafts/draft-a/attachments/quote')
+      .set({
+        'idempotency-key': 'idem-route-attachment-remove',
+        'x-edit-session-id': 'session-a',
+        'x-edit-lease-id': 'lease-a',
+        'x-edit-fence': '4',
+      })
+      .send({ expectedDraftRevision: 2 })
+      .expect(200);
+
+    expect(service.removeAttachment).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-a',
+      actorId: 'actor-a',
+      draftId: 'draft-a',
+      sessionId: 'session-a',
+      leaseId: 'lease-a',
+      fence: 4,
+      expectedDraftRevision: 2,
+      documentKind: 'quote',
+    }));
+  });
+
+  it('serves an owner draft attachment as private no-store bytes without edit lease headers', async () => {
+    const { app, service } = createRouteApp();
+
+    const response = await request(app)
+      .get('/api/v1/project-registration-drafts/draft-a/attachments/contract')
+      .expect(200);
+
+    expect(response.headers['content-type']).toContain('application/pdf');
+    expect(response.headers['cache-control']).toBe('private, no-store');
+    expect(response.headers['x-content-type-options']).toBe('nosniff');
+    expect(response.headers['content-disposition']).toContain('%22%0D%0AX-Test%3A%20injected.pdf');
+    expect(response.headers['x-test']).toBeUndefined();
+    expect(response.body).toEqual(Buffer.from('private-draft-pdf'));
+    expect(service.readAttachment).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-a', actorId: 'actor-a', draftId: 'draft-a', documentKind: 'contract',
+    }));
   });
 
   it('returns 422 for a root array before the real create service writes anything', async () => {

--- a/server/bff/routes/projects.mjs
+++ b/server/bff/routes/projects.mjs
@@ -1169,39 +1169,44 @@ function assertRegistrationV2Requirements(payload, attachmentRefs) {
   }
   const startYear = Number(contractStart.slice(0, 4));
   const endYear = Number(contractEnd.slice(0, 4));
-  if (endYear - startYear > 20 || !Array.isArray(payload.financialYears)) {
+  if (endYear - startYear > 20) {
     invalidRegistration('Project registration financialYears are invalid');
   }
-  const rows = new Map();
-  for (const row of payload.financialYears) {
-    if (!row || typeof row !== 'object' || Array.isArray(row)) {
-      invalidRegistration('Project registration financial year row is invalid');
+  if (endYear > startYear) {
+    if (!Array.isArray(payload.financialYears)) {
+      invalidRegistration('Project registration financialYears are invalid');
     }
-    const year = row.year;
-    if (!Number.isSafeInteger(year) || year < startYear || year > endYear || rows.has(year)) {
+    const rows = new Map();
+    for (const row of payload.financialYears) {
+      if (!row || typeof row !== 'object' || Array.isArray(row)) {
+        invalidRegistration('Project registration financial year row is invalid');
+      }
+      const year = row.year;
+      if (!Number.isSafeInteger(year) || year < startYear || year > endYear || rows.has(year)) {
+        invalidRegistration('Project registration financial year coverage is invalid');
+      }
+      for (const field of REGISTRATION_AMOUNT_FIELDS) {
+        assertRegistrationAmount(row[field], `financialYears.${year}.${field}`, { required: true });
+      }
+      if (typeof row.profitRate !== 'number' || !Number.isFinite(row.profitRate) || row.profitRate < 0 || row.profitRate > 1) {
+        invalidRegistration(`Project registration financialYears.${year}.profitRate must be between 0 and 1`);
+      }
+      if (row.confirmed !== true) {
+        invalidRegistration(`Project registration financialYears.${year} requires human confirmation`);
+      }
+      rows.set(year, row);
+    }
+    for (let year = startYear; year <= endYear; year += 1) {
+      if (!rows.has(year)) invalidRegistration(`Project registration financial year is missing: ${year}`);
+    }
+    if (rows.size !== endYear - startYear + 1) {
       invalidRegistration('Project registration financial year coverage is invalid');
     }
     for (const field of REGISTRATION_AMOUNT_FIELDS) {
-      assertRegistrationAmount(row[field], `financialYears.${year}.${field}`, { required: true });
-    }
-    if (typeof row.profitRate !== 'number' || !Number.isFinite(row.profitRate) || row.profitRate < 0 || row.profitRate > 1) {
-      invalidRegistration(`Project registration financialYears.${year}.profitRate must be between 0 and 1`);
-    }
-    if (row.confirmed !== true) {
-      invalidRegistration(`Project registration financialYears.${year} requires human confirmation`);
-    }
-    rows.set(year, row);
-  }
-  for (let year = startYear; year <= endYear; year += 1) {
-    if (!rows.has(year)) invalidRegistration(`Project registration financial year is missing: ${year}`);
-  }
-  if (rows.size !== endYear - startYear + 1) {
-    invalidRegistration('Project registration financial year coverage is invalid');
-  }
-  for (const field of REGISTRATION_AMOUNT_FIELDS) {
-    const annualTotal = [...rows.values()].reduce((sum, row) => sum + row[field], 0);
-    if (!Number.isSafeInteger(annualTotal) || annualTotal !== payload[field]) {
-      invalidRegistration(`Project registration financialYears ${field} total does not match`);
+      const annualTotal = [...rows.values()].reduce((sum, row) => sum + row[field], 0);
+      if (!Number.isSafeInteger(annualTotal) || annualTotal !== payload[field]) {
+        invalidRegistration(`Project registration financialYears ${field} total does not match`);
+      }
     }
   }
 
@@ -1410,6 +1415,7 @@ export function buildProjectRegistrationCanonicalDocuments({
     phase: normalizeProjectPhase(readOptionalText(payload.phase)),
     description: readOptionalText(payload.description),
     clientOrg: readOptionalText(payload.clientOrg),
+    businessManagementGoogleFolderLink: readOptionalText(payload.businessManagementGoogleFolderLink) || undefined,
     department: normalizeProjectOrganizationLabel(payload.department),
     groupwareName: readOptionalText(payload.groupwareName) || undefined,
     currency: normalizeProjectCurrency(readOptionalText(payload.currency)),
@@ -1588,6 +1594,7 @@ function buildProjectRequestPayloadFromProject(project, existingPayload = {}) {
     phase: normalizeProjectPhase(pickText('phase')),
     description: pickText('description'),
     clientOrg: pickText('clientOrg'),
+    businessManagementGoogleFolderLink: pickText('businessManagementGoogleFolderLink'),
     department: pickText('department'),
     groupwareName: pickText('groupwareName'),
     currency: normalizeProjectCurrency(pickText('currency')),
@@ -1703,6 +1710,7 @@ export function buildProjectPatchFromChangeRequestPayload(payload = {}, currentP
     phase: normalizeProjectPhase(readOptionalText(payload.phase) || currentProject.phase),
     description: readOptionalText(payload.description),
     clientOrg: readOptionalText(payload.clientOrg),
+    businessManagementGoogleFolderLink: readOptionalText(payload.businessManagementGoogleFolderLink) || undefined,
     department: resolveProjectDepartmentFromPayload(payload, currentProject),
     cic: resolveProjectCicFromPayload(payload, currentProject),
     groupwareName: readOptionalText(payload.groupwareName) || readOptionalText(currentProject.groupwareName) || undefined,
@@ -1775,6 +1783,7 @@ const PROJECT_INFO_CHANGE_LABELS = {
   name: '프로젝트명',
   officialContractName: '공식 계약명',
   clientOrg: '계약 대상',
+  businessManagementGoogleFolderLink: '사업관리 구글폴더링크',
   department: '담당조직(CIC)',
   type: '프로젝트 유형',
   contractStart: '계약 시작일',
@@ -1821,7 +1830,7 @@ const PROJECT_INFO_CHANGE_LABELS = {
 };
 
 const PROJECT_INFO_PAYLOAD_FIELDS = [
-  'name', 'officialContractName', 'type', 'status', 'phase', 'description', 'clientOrg',
+  'name', 'officialContractName', 'type', 'status', 'phase', 'description', 'clientOrg', 'businessManagementGoogleFolderLink',
   'department', 'groupwareName', 'currency', 'contractAmount', 'salesVatAmount',
   'totalRevenueAmount', 'supportAmount', 'financialInputFlags', 'registrationRequirementsVersion',
   'financialYears', 'registrationConfirmations', 'registrationOptionalDocumentNotes', 'checkout', 'contractStart', 'contractEnd',

--- a/server/bff/routes/projects.mjs
+++ b/server/bff/routes/projects.mjs
@@ -265,9 +265,16 @@ function buildProjectExecutiveReviewSlackPayload({ project, projectRequest, revi
 }
 
 function assertProjectRequestMatchesProject(request, projectId) {
-  const requestProjectId = readOptionalText(request?.approvedProjectId);
   const normalizedProjectId = readOptionalText(projectId);
-  if (requestProjectId && normalizedProjectId && requestProjectId !== normalizedProjectId) {
+  const requestProjectIds = [request?.approvedProjectId, request?.targetProjectId]
+    .map(readOptionalText)
+    .filter(Boolean);
+  if (
+    !normalizedProjectId
+    || requestProjectIds.length === 0
+    || requestProjectIds.some((requestProjectId) => requestProjectId !== normalizedProjectId)
+  ) {
+    const requestProjectId = requestProjectIds.join(', ') || '(missing)';
     throw createHttpError(
       409,
       `Project request does not belong to project: ${requestProjectId} != ${normalizedProjectId}`,
@@ -466,6 +473,205 @@ async function readProjectAttachmentMember({ db, tenantId, actorId }) {
   return member;
 }
 
+function hasProjectRequestAccess({ actorId, member, projectId, project }) {
+  const profile = member?.portalProfile && typeof member.portalProfile === 'object'
+    ? member.portalProfile
+    : {};
+  const assignedProjectIds = new Set([
+    member?.projectId,
+    ...(Array.isArray(member?.projectIds) ? member.projectIds : []),
+    profile.projectId,
+    ...(Array.isArray(profile.projectIds) ? profile.projectIds : []),
+  ].map(readOptionalText).filter(Boolean));
+  return ['admin', 'finance'].includes(normalizeRole(member?.role))
+    || assignedProjectIds.has(readOptionalText(projectId))
+    || [
+      project?.createdBy,
+      project?.registeredById,
+      project?.managerId,
+      project?.executiveApproverId,
+    ].map(readOptionalText).includes(readOptionalText(actorId));
+}
+
+function sortProjectRequests(requests) {
+  return requests.sort((left, right) => (
+    String(right.requestedAt || '').localeCompare(String(left.requestedAt || ''))
+    || String(left.id).localeCompare(String(right.id))
+  ));
+}
+
+const PROJECT_REQUEST_QUERY_LIMIT = 500;
+
+function getBoundedProjectRequestSnapshot(query) {
+  return query.limit(PROJECT_REQUEST_QUERY_LIMIT).get();
+}
+
+function parseProjectRequestQueryProjectIds(value) {
+  const projectIds = Array.isArray(value)
+    ? Array.from(new Set(value.map(readOptionalText).filter(Boolean)))
+    : [];
+  if (projectIds.length > 200 || projectIds.some((projectId) => projectId.includes('/'))) {
+    throw createHttpError(400, 'Project request query is invalid', 'project_request_query_invalid');
+  }
+  return projectIds;
+}
+
+async function preferCanonicalProjectRequests({ db, tenantId, canonicalRequests, legacyRequests }) {
+  const unprobedLegacyIds = Array.from(legacyRequests.keys()).filter((id) => !canonicalRequests.has(id));
+  const canonicalProbes = await Promise.all(unprobedLegacyIds.map(async (id) => {
+    const snap = await db.doc(`orgs/${tenantId}/project_requests/${id}`).get();
+    return snap.exists ? [id, { ...(snap.data() || {}), id }] : null;
+  }));
+  canonicalProbes.forEach((entry) => {
+    if (entry) canonicalRequests.set(entry[0], entry[1]);
+  });
+  return sortProjectRequests(Array.from(new Set([
+    ...canonicalRequests.keys(),
+    ...legacyRequests.keys(),
+  ])).map((id) => canonicalRequests.get(id) || legacyRequests.get(id)));
+}
+
+async function queryProjectRequestsByProjectIds({ db, tenantId, projectIds }) {
+  const normalizedProjectIds = Array.from(new Set((Array.isArray(projectIds) ? projectIds : [])
+    .map(readOptionalText)
+    .filter((projectId) => projectId && !projectId.includes('/'))));
+  if (!normalizedProjectIds.length) return [];
+  const projectIdChunks = [];
+  for (let index = 0; index < normalizedProjectIds.length; index += 30) {
+    projectIdChunks.push(normalizedProjectIds.slice(index, index + 30));
+  }
+  const queryCollection = async (collectionName) => {
+    const collectionRef = db.collection(`orgs/${tenantId}/${collectionName}`);
+    const snapshots = await Promise.all(projectIdChunks.flatMap((projectIdChunk) => [
+      getBoundedProjectRequestSnapshot(collectionRef.where('approvedProjectId', 'in', projectIdChunk)),
+      getBoundedProjectRequestSnapshot(collectionRef.where('targetProjectId', 'in', projectIdChunk)),
+    ]));
+    const rows = new Map();
+    snapshots.forEach((snapshot) => {
+      snapshot.docs.forEach((doc) => rows.set(doc.id, { ...(doc.data() || {}), id: doc.id }));
+    });
+    return rows;
+  };
+  const [canonicalRequests, legacyRequests] = await Promise.all([
+    queryCollection('project_requests'),
+    queryCollection('projectRequests'),
+  ]);
+  const requests = await preferCanonicalProjectRequests({ db, tenantId, canonicalRequests, legacyRequests });
+  const requestedProjectIds = new Set(normalizedProjectIds);
+  return requests.filter((request) => [request.approvedProjectId, request.targetProjectId]
+    .map(readOptionalText)
+    .some((projectId) => requestedProjectIds.has(projectId)));
+}
+
+async function readPendingProjectChangeRequests({ db, tenantId, actorId, projectIds }) {
+  const member = await readProjectAttachmentMember({ db, tenantId, actorId });
+  if (!['admin', 'finance'].includes(normalizeRole(member?.role))) {
+    const projectSnapshots = await Promise.all(projectIds.map((projectId) => (
+      db.doc(`orgs/${tenantId}/projects/${projectId}`).get()
+    )));
+    if (projectSnapshots.some((snapshot, index) => (
+      !snapshot.exists
+      || !hasProjectRequestAccess({
+        actorId,
+        member,
+        projectId: projectIds[index],
+        project: snapshot.data() || {},
+      })
+    ))) {
+      throw createHttpError(403, 'Project request access denied', 'forbidden');
+    }
+  }
+  const requests = await queryProjectRequestsByProjectIds({ db, tenantId, projectIds });
+  return requests
+    .filter((request) => readOptionalText(request.requestKind) === 'CHANGE'
+      && readOptionalText(request.status) === 'PENDING')
+    .map((request) => ({
+      id: request.id,
+      requestKind: 'CHANGE',
+      targetProjectId: readOptionalText(request.targetProjectId) || null,
+      approvedProjectId: readOptionalText(request.approvedProjectId) || null,
+      status: 'PENDING',
+      requestedAt: readOptionalText(request.requestedAt) || null,
+      baseProjectVersion: Number.isInteger(request.baseProjectVersion) ? request.baseProjectVersion : null,
+      targetProjectVersion: Number.isInteger(request.targetProjectVersion) ? request.targetProjectVersion : null,
+    }));
+}
+
+async function readAssignedProjectRequests({ db, tenantId, actorId }) {
+  await readProjectAttachmentMember({ db, tenantId, actorId });
+  const normalizedActorId = readOptionalText(actorId);
+  const assignedProjects = await db.collection(`orgs/${tenantId}/projects`)
+    .where('executiveApproverId', '==', normalizedActorId)
+    .get();
+  const assignedProjectIds = new Set(assignedProjects.docs.map((doc) => doc.id));
+  const projectIdChunks = [];
+  const projectIds = Array.from(assignedProjectIds);
+  for (let index = 0; index < projectIds.length; index += 30) {
+    projectIdChunks.push(projectIds.slice(index, index + 30));
+  }
+
+  const queryCollection = async (collectionName) => {
+    const collectionRef = db.collection(`orgs/${tenantId}/${collectionName}`);
+    const queries = [
+      collectionRef.where('payload.executiveApproverId', '==', normalizedActorId),
+      collectionRef.where('proposedSnapshot.executiveApproverId', '==', normalizedActorId),
+      ...projectIdChunks.flatMap((projectIdChunk) => [
+        collectionRef.where('approvedProjectId', 'in', projectIdChunk),
+        collectionRef.where('targetProjectId', 'in', projectIdChunk),
+      ]),
+    ];
+    const snapshots = await Promise.all(queries.map(getBoundedProjectRequestSnapshot));
+    const rows = new Map();
+    snapshots.forEach((snapshot) => {
+      snapshot.docs.forEach((doc) => rows.set(doc.id, { ...(doc.data() || {}), id: doc.id }));
+    });
+    return rows;
+  };
+
+  const [canonicalRequests, legacyRequests] = await Promise.all([
+    queryCollection('project_requests'),
+    queryCollection('projectRequests'),
+  ]);
+  const projectRequests = await preferCanonicalProjectRequests({
+    db,
+    tenantId,
+    canonicalRequests,
+    legacyRequests,
+  });
+  const assigned = projectRequests.map((projectRequest) => {
+    const payload = resolveProjectRequestPayloadForReview(projectRequest);
+    const requestApproverId = readOptionalText(payload?.executiveApproverId);
+    if (requestApproverId) return requestApproverId === normalizedActorId ? projectRequest : null;
+    const projectId = readOptionalText(projectRequest.targetProjectId || projectRequest.approvedProjectId);
+    return assignedProjectIds.has(projectId) ? projectRequest : null;
+  });
+
+  const items = sortProjectRequests(assigned
+    .filter(Boolean)
+    .filter((projectRequest) => projectRequestAttachmentsArePublished(projectRequest, tenantId)));
+  const projects = new Map(assignedProjects.docs.map((doc) => [
+    doc.id,
+    { id: doc.id, ...(doc.data() || {}) },
+  ]));
+  const missingProjectIds = Array.from(new Set(items
+    .map((item) => readOptionalText(item.targetProjectId || item.approvedProjectId))
+    .filter((projectId) => projectId && !projects.has(projectId))));
+  const missingProjectSnapshots = await Promise.all(missingProjectIds.map((projectId) => (
+    db.doc(`orgs/${tenantId}/projects/${projectId}`).get()
+  )));
+  missingProjectSnapshots.forEach((snapshot, index) => {
+    if (snapshot.exists) {
+      const projectId = missingProjectIds[index];
+      projects.set(projectId, { id: projectId, ...(snapshot.data() || {}) });
+    }
+  });
+
+  return {
+    items,
+    projects: Array.from(projects.values()).sort((left, right) => String(left.id).localeCompare(String(right.id))),
+  };
+}
+
 function sendPrivateProjectAttachment(res, downloaded, attachment, objectName) {
   const buffer = Buffer.isBuffer(downloaded?.buffer)
     ? downloaded.buffer
@@ -493,6 +699,14 @@ const PRIVATE_DOCUMENT_KINDS = PROJECT_INFO_DOCUMENT_KINDS;
 const REGISTRATION_AMOUNT_FIELDS = ['contractAmount', 'salesVatAmount', 'totalRevenueAmount', 'supportAmount'];
 const REGISTRATION_PAYMENT_FIELDS = ['contract', 'interim', 'final'];
 const REGISTRATION_FINANCIAL_FLAG_FIELDS = ['contractAmount', 'salesVatAmount', 'totalRevenueAmount', 'supportAmount'];
+const REGISTRATION_SETTLEMENT_TYPES = new Set(['TYPE1', 'TYPE2', 'TYPE3', 'TYPE4', 'TYPE5', 'NONE']);
+const REGISTRATION_SETTLEMENT_BASES = new Set([
+  'SUPPLY_AMOUNT', '공급가액', 'SUPPLY_PRICE', '공급대가', 'OTHER', '기타', 'NONE',
+]);
+const REGISTRATION_V2_SETTLEMENT_BASES = new Set([
+  'SUPPLY_AMOUNT', '공급가액', 'SUPPLY_PRICE', '공급대가', 'NONE',
+]);
+const REGISTRATION_ACCOUNT_TYPES = new Set(['DEDICATED', 'OPERATING', 'NONE', 'OTHER']);
 const SETTLEMENT_SYSTEM_CODES = new Set([
   'E_NARA_DOUM', 'IRIS', 'RCMS', 'EZBARO', 'E_HIJO', 'EDUFINE',
   'HAPPYEUM', 'AGRIX', 'BOTAEM_E', 'SMTECH', 'KOCCA_PMS', 'NIPA',
@@ -580,7 +794,6 @@ function assertRegistrationFinancials(payload, type) {
 }
 
 function assertRegistrationTeamMembers(value) {
-  if (value === undefined || value === null) return;
   if (!Array.isArray(value)) invalidRegistration('Project registration teamMembersDetailed is invalid');
   value.forEach((member, index) => {
     if (!member || typeof member !== 'object' || Array.isArray(member)) {
@@ -616,6 +829,31 @@ function assertRegistrationTeamMembers(value) {
       invalidRegistration(`Project registration teamMembersDetailed.${index} labor allocation period is invalid`);
     }
   });
+  if (!value.some((member) => (
+    readOptionalText(member?.role) === '운영매니저' && member?.isDocumentOnly === false
+  ))) {
+    const hasDocumentOnlyOperatingManager = value.some((member) => (
+      readOptionalText(member?.role) === '운영매니저' && member?.isDocumentOnly === true
+    ));
+    invalidRegistration(hasDocumentOnlyOperatingManager
+      ? 'Project registration requires at least one actual operating manager'
+      : 'Project registration requires at least one operating manager');
+  }
+  if (!value.some((member) => (
+    readOptionalText(member?.role) === '사업 최종 책임자' && member?.isDocumentOnly === false
+  ))) {
+    invalidRegistration('Project registration requires an actual project final responsible member');
+  }
+  const invalidSettlementSupport = value.some((member) => {
+    if (readOptionalText(member?.role) !== '정산지원') return false;
+    const memberName = readOptionalText(member?.memberName);
+    const memberNickname = readOptionalText(member?.memberNickname);
+    const allowed = ['송성미', '최지윤'].includes(memberName) || ['도담', '써니'].includes(memberNickname);
+    return member?.isDocumentOnly !== false || !allowed;
+  });
+  if (invalidSettlementSupport) {
+    invalidRegistration('Project registration settlement support must be 도담 or 써니');
+  }
 }
 
 function assertRegistrationV2PaymentPlan(payload) {
@@ -772,14 +1010,15 @@ function normalizeRegistrationFinancialYears(value) {
   return value.flatMap((row) => {
     const year = Number(row?.year);
     if (!Number.isSafeInteger(year) || year < 2000 || year > 2099) return [];
-    const profitRate = Number(row?.profitRate);
+    const contractAmount = registrationAmount(row?.contractAmount);
+    const totalRevenueAmount = registrationAmount(row?.totalRevenueAmount);
     return [{
       year,
-      contractAmount: registrationAmount(row?.contractAmount),
+      contractAmount,
       salesVatAmount: registrationAmount(row?.salesVatAmount),
-      totalRevenueAmount: registrationAmount(row?.totalRevenueAmount),
+      totalRevenueAmount,
       supportAmount: registrationAmount(row?.supportAmount),
-      profitRate: Number.isFinite(profitRate) ? Math.min(1, Math.max(0, profitRate)) : 0,
+      profitRate: contractAmount > 0 ? Math.min(1, totalRevenueAmount / contractAmount) : 0,
       confirmed: row?.confirmed === true,
     }];
   });
@@ -825,8 +1064,11 @@ function normalizeProjectCheckout(value) {
 }
 
 function assertProjectCheckoutPayload(payload, attachmentRefs, currentProject) {
-  const status = normalizeProjectStatus(readOptionalText(payload?.status));
+  const status = normalizeProjectStatus(readOptionalText(currentProject?.status || payload?.status));
   if (!['COMPLETED', 'COMPLETED_PENDING_PAYMENT'].includes(status)) return;
+  if (!payload || typeof payload !== 'object' || !Object.hasOwn(payload, 'checkout')) {
+    invalidRegistration('Completed project checkout is required');
+  }
   const checkout = payload?.checkout;
   if (!checkout || typeof checkout !== 'object' || Array.isArray(checkout)) {
     invalidRegistration('Completed project checkout is required');
@@ -868,11 +1110,29 @@ function assertRegistrationV2Requirements(payload, attachmentRefs) {
       invalidRegistration(`Project registration ${field} is required`);
     }
   }
-  if (normalizeSettlementType(readOptionalText(payload.settlementType)) === 'NONE') {
-    invalidRegistration('Project registration settlementType is required');
+  const settlementType = readOptionalText(payload.settlementType);
+  const basis = readOptionalText(payload.basis);
+  const accountType = readOptionalText(payload.accountType);
+  const settlementSystem = readOptionalText(payload.settlementSystem);
+  const laborSettlementBasis = readOptionalText(payload.laborSettlementBasis);
+  if (!REGISTRATION_SETTLEMENT_TYPES.has(settlementType)) {
+    invalidRegistration('Project registration settlementType is invalid');
   }
-  if (normalizeBasis(readOptionalText(payload.basis)) === 'NONE') {
-    invalidRegistration('Project registration basis is required');
+  if (!REGISTRATION_SETTLEMENT_BASES.has(basis)) {
+    invalidRegistration('Project registration basis is invalid');
+  }
+  if (!REGISTRATION_V2_SETTLEMENT_BASES.has(basis)) {
+    invalidRegistration('Project registration basis is invalid for requirements version 2');
+  }
+  const settlementDetailsEnabled = normalizeBasis(basis) !== 'NONE';
+  if (settlementDetailsEnabled && accountType && !REGISTRATION_ACCOUNT_TYPES.has(accountType)) {
+    invalidRegistration('Project registration accountType is invalid');
+  }
+  if (settlementDetailsEnabled && settlementSystem && !SETTLEMENT_SYSTEM_CODES.has(settlementSystem)) {
+    invalidRegistration('Project registration settlementSystem is invalid');
+  }
+  if (settlementDetailsEnabled && laborSettlementBasis && !LABOR_SETTLEMENT_BASES.has(laborSettlementBasis)) {
+    invalidRegistration('Project registration laborSettlementBasis is invalid');
   }
   assertRegistrationV2PaymentPlan(payload);
 
@@ -882,6 +1142,14 @@ function assertRegistrationV2Requirements(payload, attachmentRefs) {
   const missingDocumentKind = REGISTRATION_REQUIRED_DOCUMENT_KINDS.find((kind) => !attachedKinds.has(kind));
   if (missingDocumentKind) {
     invalidRegistration(`Project registration required attachment is missing: ${missingDocumentKind}`);
+  }
+  const hasProposal = attachedKinds.has('proposal');
+  const hasRfpRequestEvidence = attachedKinds.has('rfp_request_evidence');
+  if (!hasProposal && !hasRfpRequestEvidence) {
+    invalidRegistration('Project registration requires proposal or RFP evidence');
+  }
+  if (hasProposal && hasRfpRequestEvidence) {
+    invalidRegistration('Project registration requires exactly one of proposal or RFP evidence');
   }
   const optionalNotes = normalizeRegistrationOptionalDocumentNotes(payload.registrationOptionalDocumentNotes);
   for (const [documentKind, noteField] of [
@@ -941,14 +1209,17 @@ function assertRegistrationV2Requirements(payload, attachmentRefs) {
   if (!confirmations || typeof confirmations !== 'object' || Array.isArray(confirmations)) {
     invalidRegistration('Project registration confirmations are required');
   }
-  if (confirmations.laborIncludesFourInsurance !== true) {
-    invalidRegistration('Project registration 4-insurance confirmation is required');
-  }
-  if (confirmations.laborIncludesRetirementPay !== true) {
-    invalidRegistration('Project registration retirement pay confirmation is required');
-  }
-  if (confirmations.customerSettlementBasisConfirmed !== true) {
-    invalidRegistration('Project registration customer settlement basis confirmation is required');
+  const requiresSettlementConfirmations = settlementDetailsEnabled;
+  if (requiresSettlementConfirmations) {
+    if (confirmations.laborIncludesFourInsurance !== true) {
+      invalidRegistration('Project registration 4-insurance confirmation is required');
+    }
+    if (confirmations.laborIncludesRetirementPay !== true) {
+      invalidRegistration('Project registration retirement pay confirmation is required');
+    }
+    if (confirmations.customerSettlementBasisConfirmed !== true) {
+      invalidRegistration('Project registration customer settlement basis confirmation is required');
+    }
   }
   if (typeof confirmations.modusignContractUsed !== 'boolean') {
     invalidRegistration('Project registration Modusign confirmation is required');
@@ -958,23 +1229,101 @@ function assertRegistrationV2Requirements(payload, attachmentRefs) {
   }
 }
 
-function trustedRegistrationRequirementAttachments(currentProject, attachmentRefs) {
-  const canonicalFields = {
-    contract: 'contractDocument',
-    customer_business_registration: 'customerBusinessRegistrationDocument',
-    quote: 'quoteDocument',
-    proposal: 'proposalDocument',
-    proposal_word_original: 'proposalWordOriginalDocument',
-    proposal_ppt_original: 'proposalPptOriginalDocument',
-    presentation_ppt_original: 'presentationPptOriginalDocument',
-    rfp_request_evidence: 'rfpRequestEvidenceDocument',
+const REGISTRATION_REQUIREMENT_DOCUMENT_FIELDS = {
+  contract: 'contractDocument',
+  customer_business_registration: 'customerBusinessRegistrationDocument',
+  quote: 'quoteDocument',
+  proposal: 'proposalDocument',
+  proposal_word_original: 'proposalWordOriginalDocument',
+  proposal_ppt_original: 'proposalPptOriginalDocument',
+  presentation_ppt_original: 'presentationPptOriginalDocument',
+  rfp_request_evidence: 'rfpRequestEvidenceDocument',
+};
+
+const PROJECT_INFO_DOCUMENT_FIELDS = [
+  ...new Set([
+    ...Object.values(REGISTRATION_REQUIREMENT_DOCUMENT_FIELDS),
+    'performanceCertificateDocument',
+    'taxInvoiceDocument',
+    'finalSettlementReportDocument',
+  ]),
+];
+
+function trustedStoredChangeRequestDocuments(previousRequest) {
+  if (
+    readOptionalText(previousRequest?.requestKind) !== 'CHANGE'
+    || !['PENDING', 'REJECTED'].includes(readOptionalText(previousRequest?.status))
+  ) return {};
+  const source = previousRequest?.proposedSnapshot && typeof previousRequest.proposedSnapshot === 'object'
+    ? previousRequest.proposedSnapshot
+    : previousRequest?.payload;
+  if (!source || typeof source !== 'object' || Array.isArray(source)) return {};
+  return Object.fromEntries(PROJECT_INFO_DOCUMENT_FIELDS.flatMap((field) => (
+    readOptionalText(source[field]?.path) ? [[field, source[field]]] : []
+  )));
+}
+
+function trustedRegistrationRequirementAttachments(
+  currentProject,
+  payload,
+  attachmentRefs,
+  trustedStoredDocuments = {},
+) {
+  const privateAttachments = new Map((Array.isArray(attachmentRefs) ? attachmentRefs : [])
+    .flatMap((attachment) => {
+      const documentKind = readOptionalText(attachment?.documentKind);
+      const path = readOptionalText(attachment?.path);
+      return documentKind && path ? [[documentKind, { documentKind, path }]] : [];
+    }));
+  const privateAlternativeAttached = privateAttachments.has('proposal')
+    || privateAttachments.has('rfp_request_evidence');
+  const payloadDocument = (field) => {
+    if (!payload || typeof payload !== 'object' || !Object.hasOwn(payload, field)) return undefined;
+    const path = readOptionalText(payload[field]?.path);
+    if (!path) return null;
+    const canonicalPath = readOptionalText(currentProject?.[field]?.path);
+    if (canonicalPath && path === canonicalPath) return { path: canonicalPath };
+    const storedPath = readOptionalText(trustedStoredDocuments?.[field]?.path);
+    return storedPath && path === storedPath ? { path: storedPath } : null;
   };
-  return [
-    ...(Array.isArray(attachmentRefs) ? attachmentRefs : []),
-    ...Object.entries(canonicalFields).flatMap(([documentKind, field]) => (
-      readOptionalText(currentProject?.[field]?.path) ? [{ documentKind, path: currentProject[field].path }] : []
-    )),
-  ];
+  const canonicalFields = {
+    ...REGISTRATION_REQUIREMENT_DOCUMENT_FIELDS,
+  };
+  return Object.entries(canonicalFields).flatMap(([documentKind, field]) => {
+    const privateAttachment = privateAttachments.get(documentKind);
+    if (privateAttachment) return [privateAttachment];
+    if (privateAlternativeAttached && ['proposal', 'rfp_request_evidence'].includes(documentKind)) return [];
+    const proposedDocument = payloadDocument(field);
+    if (proposedDocument !== undefined) {
+      return proposedDocument ? [{ documentKind, path: proposedDocument.path }] : [];
+    }
+    const canonicalPath = readOptionalText(currentProject?.[field]?.path);
+    return canonicalPath ? [{ documentKind, path: canonicalPath }] : [];
+  });
+}
+
+function assertTrustedProjectInfoDocumentReferences(
+  currentProject,
+  payload,
+  attachmentRefs,
+  trustedStoredDocuments = {},
+) {
+  const privateDocuments = registrationPrivateDocuments(attachmentRefs);
+  const privateAlternativeAttached = Boolean(
+    privateDocuments.proposalDocument || privateDocuments.rfpRequestEvidenceDocument,
+  );
+  for (const field of PROJECT_INFO_DOCUMENT_FIELDS) {
+    if (!payload || typeof payload !== 'object' || !Object.hasOwn(payload, field)) continue;
+    const candidate = payload[field];
+    if (candidate === null || candidate === undefined) continue;
+    if (privateDocuments[field]) continue;
+    if (privateAlternativeAttached && ['proposalDocument', 'rfpRequestEvidenceDocument'].includes(field)) continue;
+    const candidatePath = readOptionalText(candidate?.path);
+    const canonicalPath = readOptionalText(currentProject?.[field]?.path);
+    const storedPath = readOptionalText(trustedStoredDocuments?.[field]?.path);
+    if (candidatePath && (candidatePath === canonicalPath || candidatePath === storedPath)) continue;
+    invalidRegistration(`Project information document path is not trusted: ${field}`);
+  }
 }
 
 function assertRegistrationPayload(payload) {
@@ -1009,6 +1358,19 @@ function assertRegistrationPayload(payload) {
   }
 }
 
+function assertDistinctExecutiveApprover(payload, actorId, ownerId) {
+  const executiveApproverId = readOptionalText(payload?.executiveApproverId);
+  const requesterIds = new Set([
+    readOptionalText(actorId),
+    readOptionalText(ownerId),
+    readOptionalText(payload?.registeredById),
+    readOptionalText(payload?.managerId),
+  ].filter(Boolean));
+  if (executiveApproverId && requesterIds.has(executiveApproverId)) {
+    invalidRegistration('Project designated executive approver must differ from the requester');
+  }
+}
+
 export function buildProjectRegistrationCanonicalDocuments({
   tenantId,
   projectId,
@@ -1026,11 +1388,18 @@ export function buildProjectRegistrationCanonicalDocuments({
   if (registrationRequirementsVersion(payload.registrationRequirementsVersion) !== 2) {
     invalidRegistration('New project registration requires requirements version 2');
   }
+  if (readOptionalText(payload.settlementType) === 'NONE') {
+    invalidRegistration('Project registration settlementType NONE is not available in requirements version 2');
+  }
   assertRegistrationV2Requirements(payload, requirementsAttachmentRefs);
   const ownerId = readOptionalText(payload.registeredById) || readOptionalText(payload.managerId) || actorId;
+  assertDistinctExecutiveApprover(payload, actorId, ownerId);
   const ownerName = readOptionalText(payload.registeredByName) || readOptionalText(payload.managerName) || actorName;
   const ownerEmail = readOptionalText(payload.registeredByEmail) || (ownerId === actorId ? readOptionalText(actorEmail) : '');
   const fundInputMode = normalizeProjectFundInputMode(readOptionalText(payload.fundInputMode));
+  const settlementType = normalizeSettlementType(readOptionalText(payload.settlementType));
+  const basis = normalizeBasis(readOptionalText(payload.basis));
+  const settlementDetailsEnabled = basis !== 'NONE';
   const documents = registrationPrivateDocuments(attachmentRefs);
   const teamMembersDetailed = normalizeProjectTeamMembersDetailed(payload.teamMembersDetailed);
   const requestPayload = stripUndefinedDeep({
@@ -1059,11 +1428,13 @@ export function buildProjectRegistrationCanonicalDocuments({
     contractStart: readOptionalText(payload.contractStart),
     contractEnd: readOptionalText(payload.contractEnd),
     contractType: normalizeProjectContractType(payload.contractType),
-    settlementType: normalizeSettlementType(readOptionalText(payload.settlementType)),
-    basis: normalizeBasis(readOptionalText(payload.basis)),
-    accountType: normalizeAccountType(readOptionalText(payload.accountType)),
-    settlementSystem: normalizeSettlementSystemCode(payload.settlementSystem),
-    laborSettlementBasis: normalizeLaborSettlementBasis(payload.laborSettlementBasis),
+    settlementType,
+    basis,
+    accountType: !settlementDetailsEnabled ? 'NONE' : normalizeAccountType(readOptionalText(payload.accountType)),
+    settlementSystem: !settlementDetailsEnabled ? 'NONE' : normalizeSettlementSystemCode(payload.settlementSystem),
+    laborSettlementBasis: !settlementDetailsEnabled
+      ? 'NONE'
+      : normalizeLaborSettlementBasis(payload.laborSettlementBasis),
     laborTransferPlan: normalizeLaborTransferPlan(payload.laborTransferPlan),
     fundInputMode,
     settlementSheetPolicy: registrationSettlementSheetPolicy(payload.settlementSheetPolicy, fundInputMode),
@@ -1169,7 +1540,7 @@ function normalizeBasis(value) {
 }
 
 function normalizeAccountType(value) {
-  return value === 'DEDICATED' || value === 'OPERATING' ? value : 'NONE';
+  return value === 'DEDICATED' || value === 'OPERATING' || value === 'OTHER' ? value : 'NONE';
 }
 
 function normalizeProjectFundInputMode(value) {
@@ -1202,6 +1573,11 @@ function buildProjectRequestPayloadFromProject(project, existingPayload = {}) {
     : readOptionalText(existingPayload[key]);
   const pickValue = (key) => hasProjectField(key) ? project?.[key] : existingPayload[key];
   const pickNumber = (key) => Number.isFinite(project?.[key]) ? project[key] : existingPayload[key];
+  const settlementType = normalizeSettlementType(pickText('settlementType'));
+  const basis = normalizeBasis(pickText('basis'));
+  const settlementDetailsEnabled = Number(pickValue('registrationRequirementsVersion')) === 2
+    ? basis !== 'NONE'
+    : settlementType !== 'NONE';
 
   return {
     ...(existingPayload && typeof existingPayload === 'object' ? existingPayload : {}),
@@ -1228,11 +1604,13 @@ function buildProjectRequestPayloadFromProject(project, existingPayload = {}) {
     contractStart: pickText('contractStart'),
     contractEnd: pickText('contractEnd'),
     contractType: normalizeProjectContractType(pickText('contractType')),
-    settlementType: normalizeSettlementType(pickText('settlementType')),
-    basis: normalizeBasis(pickText('basis')),
-    accountType: normalizeAccountType(pickText('accountType')),
-    settlementSystem: normalizeSettlementSystemCode(pickText('settlementSystem')),
-    laborSettlementBasis: normalizeLaborSettlementBasis(pickText('laborSettlementBasis')),
+    settlementType,
+    basis: Number(pickValue('registrationRequirementsVersion')) === 2 || settlementDetailsEnabled ? basis : 'NONE',
+    accountType: !settlementDetailsEnabled ? 'NONE' : normalizeAccountType(pickText('accountType')),
+    settlementSystem: !settlementDetailsEnabled ? 'NONE' : normalizeSettlementSystemCode(pickText('settlementSystem')),
+    laborSettlementBasis: !settlementDetailsEnabled
+      ? 'NONE'
+      : normalizeLaborSettlementBasis(pickText('laborSettlementBasis')),
     laborTransferPlan: normalizeLaborTransferPlan(pickValue('laborTransferPlan')),
     fundInputMode: normalizeProjectFundInputMode(pickText('fundInputMode')),
     settlementSheetPolicy: pickValue('settlementSheetPolicy') || undefined,
@@ -1313,6 +1691,10 @@ export function buildProjectPatchFromChangeRequestPayload(payload = {}, currentP
     || readOptionalText(currentProject.registeredByName)
     || readOptionalText(currentProject.managerName);
   const teamMembersDetailed = normalizeProjectTeamMembersDetailed(payload.teamMembersDetailed);
+  const settlementType = normalizeSettlementType(readOptionalText(payload.settlementType));
+  const registrationVersion = registrationRequirementsVersion(payload.registrationRequirementsVersion);
+  const basis = normalizeBasis(readOptionalText(payload.basis));
+  const settlementDetailsEnabled = registrationVersion === 2 ? basis !== 'NONE' : settlementType !== 'NONE';
   return normalizeProjectRevenueFields(stripUndefinedDeep({
     name: readOptionalText(payload.name) || readOptionalText(currentProject.name),
     officialContractName: readOptionalText(payload.officialContractName),
@@ -1330,7 +1712,7 @@ export function buildProjectPatchFromChangeRequestPayload(payload = {}, currentP
     totalRevenueAmount: Number.isFinite(Number(payload.totalRevenueAmount)) ? Math.max(0, Math.round(Number(payload.totalRevenueAmount))) : 0,
     supportAmount: Number.isFinite(Number(payload.supportAmount)) ? Math.max(0, Math.round(Number(payload.supportAmount))) : 0,
     financialInputFlags: payload.financialInputFlags,
-    registrationRequirementsVersion: registrationRequirementsVersion(payload.registrationRequirementsVersion),
+    registrationRequirementsVersion: registrationVersion,
     financialYears: normalizeRegistrationFinancialYears(payload.financialYears),
     registrationConfirmations: normalizeRegistrationConfirmations(payload.registrationConfirmations),
     registrationOptionalDocumentNotes: normalizeRegistrationOptionalDocumentNotes(
@@ -1340,11 +1722,13 @@ export function buildProjectPatchFromChangeRequestPayload(payload = {}, currentP
     contractStart: readOptionalText(payload.contractStart),
     contractEnd: readOptionalText(payload.contractEnd),
     contractType: normalizeProjectContractType(payload.contractType),
-    settlementType: normalizeSettlementType(readOptionalText(payload.settlementType)),
-    basis: normalizeBasis(readOptionalText(payload.basis)),
-    accountType: normalizeAccountType(readOptionalText(payload.accountType)),
-    settlementSystem: normalizeSettlementSystemCode(payload.settlementSystem),
-    laborSettlementBasis: normalizeLaborSettlementBasis(payload.laborSettlementBasis),
+    settlementType,
+    basis: registrationVersion === 2 || settlementDetailsEnabled ? basis : 'NONE',
+    accountType: !settlementDetailsEnabled ? 'NONE' : normalizeAccountType(readOptionalText(payload.accountType)),
+    settlementSystem: !settlementDetailsEnabled ? 'NONE' : normalizeSettlementSystemCode(payload.settlementSystem),
+    laborSettlementBasis: !settlementDetailsEnabled
+      ? 'NONE'
+      : normalizeLaborSettlementBasis(payload.laborSettlementBasis),
     laborTransferPlan: normalizeLaborTransferPlan(payload.laborTransferPlan),
     fundInputMode: normalizeProjectFundInputMode(readOptionalText(payload.fundInputMode)),
     settlementSheetPolicy: payload.settlementSheetPolicy,
@@ -1397,8 +1781,9 @@ const PROJECT_INFO_CHANGE_LABELS = {
   contractEnd: '계약 종료일',
   currency: '통화',
   contractAmount: '계약금액',
+  salesVatAmount: '총매출부가세',
   totalRevenueAmount: '총수익',
-  supportAmount: '지원금',
+  supportAmount: '총지원금',
   settlementType: '정산 유형',
   basis: '정산 기준',
   accountType: '통장 유형',
@@ -1409,7 +1794,7 @@ const PROJECT_INFO_CHANGE_LABELS = {
   registeredByName: '사업 담당자',
   executiveApproverName: '지정 결재자',
   teamName: '사내기업팀',
-  teamMembersDetailed: '서류상 참여인력',
+  teamMembersDetailed: '참여인력 (서류상·실제)',
   paymentPlan: '입금 분할',
   paymentExpectedMonths: '입금 예상월',
   advanceInterimBelow70Reason: '선금·중도금 70% 미만 사유',
@@ -1425,8 +1810,8 @@ const PROJECT_INFO_CHANGE_LABELS = {
   proposalPptOriginalDocument: '제안서 PPT 원본',
   presentationPptOriginalDocument: '발표자료 PPT 원본',
   rfpRequestEvidenceDocument: 'RFP 또는 요청 메일 증빙',
-  registrationOptionalDocumentNotes: '선택 첨부 미첨부 사유',
-  customerBusinessRegistrationDocument: '발주처 사업자등록증 PDF',
+  registrationOptionalDocumentNotes: '원본 파일 미첨부 사유',
+  customerBusinessRegistrationDocument: '고객사 사업자등록증 PDF',
   financialYears: '연도별 재무',
   registrationConfirmations: '등록 확인사항',
   checkout: '종료사업 체크아웃',
@@ -1471,62 +1856,68 @@ function projectInfoChanges(beforeSnapshot, proposedSnapshot) {
   });
 }
 
-function projectInfoPayloadWithDocuments(payload, project, attachmentRefs) {
+function projectInfoPayloadWithDocuments(payload, project, attachmentRefs, trustedStoredDocuments = {}) {
   const privateDocuments = registrationPrivateDocuments(attachmentRefs);
+  const privateAlternativeAttached = Boolean(
+    privateDocuments.proposalDocument || privateDocuments.rfpRequestEvidenceDocument,
+  );
+  const effectiveDocument = (field) => {
+    if (privateDocuments[field]) return privateDocuments[field];
+    if (privateAlternativeAttached && ['proposalDocument', 'rfpRequestEvidenceDocument'].includes(field)) return null;
+    if (Object.hasOwn(payload, field)) {
+      const payloadPath = readOptionalText(payload[field]?.path);
+      const canonicalPath = readOptionalText(project[field]?.path);
+      if (payloadPath && canonicalPath && payloadPath === canonicalPath) return project[field];
+      const storedPath = readOptionalText(trustedStoredDocuments[field]?.path);
+      return payloadPath && storedPath && payloadPath === storedPath ? trustedStoredDocuments[field] : null;
+    }
+    return project[field] || null;
+  };
   const normalizedPatch = buildProjectPatchFromChangeRequestPayload(payload, project);
   const proposedWithLegacyFallback = buildProjectRequestPayloadFromProject({ ...project, ...normalizedPatch }, payload);
   const proposed = Object.fromEntries(PROJECT_INFO_PAYLOAD_FIELDS.flatMap((field) => (
     Object.hasOwn(proposedWithLegacyFallback, field) ? [[field, proposedWithLegacyFallback[field]]] : []
   )));
+  const contractDocument = effectiveDocument('contractDocument');
+  const contractWasReplaced = Boolean(
+    readOptionalText(contractDocument?.path)
+    && readOptionalText(contractDocument?.path) !== readOptionalText(project.contractDocument?.path),
+  );
+  const contractAnalysis = Object.hasOwn(payload, 'contractAnalysis')
+    ? payload.contractAnalysis
+    : (contractWasReplaced ? null : project.contractAnalysis);
   return stripUndefinedDeep({
     ...proposed,
-    contractDocument: privateDocuments.contractDocument || payload.contractDocument || project.contractDocument || null,
-    customerBusinessRegistrationDocument: privateDocuments.customerBusinessRegistrationDocument
-      || payload.customerBusinessRegistrationDocument
-      || project.customerBusinessRegistrationDocument
-      || null,
-    quoteDocument: privateDocuments.quoteDocument || payload.quoteDocument || project.quoteDocument || null,
-    proposalDocument: privateDocuments.proposalDocument || payload.proposalDocument || project.proposalDocument || null,
-    proposalWordOriginalDocument: privateDocuments.proposalWordOriginalDocument
-      || payload.proposalWordOriginalDocument
-      || project.proposalWordOriginalDocument
-      || null,
-    proposalPptOriginalDocument: privateDocuments.proposalPptOriginalDocument
-      || payload.proposalPptOriginalDocument
-      || project.proposalPptOriginalDocument
-      || null,
-    presentationPptOriginalDocument: privateDocuments.presentationPptOriginalDocument
-      || payload.presentationPptOriginalDocument
-      || project.presentationPptOriginalDocument
-      || null,
-    rfpRequestEvidenceDocument: privateDocuments.rfpRequestEvidenceDocument
-      || payload.rfpRequestEvidenceDocument
-      || project.rfpRequestEvidenceDocument
-      || null,
-    performanceCertificateDocument: privateDocuments.performanceCertificateDocument
-      || payload.performanceCertificateDocument
-      || project.performanceCertificateDocument
-      || null,
-    taxInvoiceDocument: privateDocuments.taxInvoiceDocument
-      || payload.taxInvoiceDocument
-      || project.taxInvoiceDocument
-      || null,
-    finalSettlementReportDocument: privateDocuments.finalSettlementReportDocument
-      || payload.finalSettlementReportDocument
-      || project.finalSettlementReportDocument
-      || null,
-    contractAnalysis: payload.contractAnalysis || project.contractAnalysis || null,
+    contractDocument,
+    customerBusinessRegistrationDocument: effectiveDocument('customerBusinessRegistrationDocument'),
+    quoteDocument: effectiveDocument('quoteDocument'),
+    proposalDocument: effectiveDocument('proposalDocument'),
+    proposalWordOriginalDocument: effectiveDocument('proposalWordOriginalDocument'),
+    proposalPptOriginalDocument: effectiveDocument('proposalPptOriginalDocument'),
+    presentationPptOriginalDocument: effectiveDocument('presentationPptOriginalDocument'),
+    rfpRequestEvidenceDocument: effectiveDocument('rfpRequestEvidenceDocument'),
+    performanceCertificateDocument: effectiveDocument('performanceCertificateDocument'),
+    taxInvoiceDocument: effectiveDocument('taxInvoiceDocument'),
+    finalSettlementReportDocument: effectiveDocument('finalSettlementReportDocument'),
+    contractAnalysis: contractAnalysis && typeof contractAnalysis === 'object'
+      ? contractAnalysis
+      : null,
   });
 }
 
 export function buildProjectInfoDraftSeed(project, previousRequest) {
-  const isPendingChange = readOptionalText(previousRequest?.requestKind) === 'CHANGE'
-    && readOptionalText(previousRequest?.status) === 'PENDING';
-  const pendingPayload = isPendingChange
+  const isResumableChange = readOptionalText(previousRequest?.requestKind) === 'CHANGE'
+    && ['PENDING', 'REJECTED'].includes(readOptionalText(previousRequest?.status));
+  const pendingPayload = isResumableChange
     ? (previousRequest.proposedSnapshot || previousRequest.payload)
     : null;
   if (pendingPayload && typeof pendingPayload === 'object' && !Array.isArray(pendingPayload)) {
-    return projectInfoPayloadWithDocuments(pendingPayload, project, []);
+    return projectInfoPayloadWithDocuments(
+      pendingPayload,
+      project,
+      [],
+      trustedStoredChangeRequestDocuments(previousRequest),
+    );
   }
   return projectInfoPayloadWithDocuments(buildProjectRequestPayloadFromProject(project), project, []);
 }
@@ -1545,50 +1936,102 @@ export function buildProjectInfoChangeSubmission({
   resubmit = false,
   reviewComment,
 }) {
+  const trustedStoredDocuments = trustedStoredChangeRequestDocuments(previousRequest);
   assertRegistrationPayload(payload);
+  if (registrationRequirementsVersion(payload.registrationRequirementsVersion) !== 2) {
+    invalidRegistration('Project information changes require registration requirements version 2');
+  }
+  const ownerId = readOptionalText(payload.registeredById)
+    || readOptionalText(payload.managerId)
+    || readOptionalText(project.registeredById)
+    || readOptionalText(project.managerId)
+    || actorId;
+  assertDistinctExecutiveApprover(payload, actorId, ownerId);
+  assertTrustedProjectInfoDocumentReferences(
+    project,
+    payload,
+    attachmentRefs,
+    trustedStoredDocuments,
+  );
   assertRegistrationV2Requirements(
     payload,
-    trustedRegistrationRequirementAttachments(project, attachmentRefs),
+    trustedRegistrationRequirementAttachments(project, payload, attachmentRefs, trustedStoredDocuments),
   );
-  assertProjectCheckoutPayload(payload, attachmentRefs, project);
   const beforeSnapshot = projectInfoPayloadWithDocuments(
     buildProjectRequestPayloadFromProject(project, previousRequest?.payload),
     project,
     [],
   );
-  const proposedSnapshot = projectInfoPayloadWithDocuments(payload, project, attachmentRefs);
+  const proposedSnapshot = projectInfoPayloadWithDocuments(
+    payload,
+    project,
+    attachmentRefs,
+    trustedStoredDocuments,
+  );
+  assertProjectCheckoutPayload(payload, attachmentRefs, proposedSnapshot);
   const changedFields = projectInfoChanges(beforeSnapshot, proposedSnapshot);
   const currentVersion = Number.isInteger(project.version) && project.version > 0 ? project.version : 1;
   const requestVersion = Number.isInteger(previousRequest?.requestVersion) && previousRequest.requestVersion > 0
     ? previousRequest.requestVersion + 1
     : 1;
   const managementPlanningResubmission = isManagementPlanningRevisionRejected(project);
-  if (resubmit && !managementPlanningResubmission && !isExecutiveRevisionRejected(project)) {
+  const executiveResubmission = isExecutiveRevisionRejected(project);
+  if (resubmit && !managementPlanningResubmission && !executiveResubmission) {
     throw createHttpError(409, 'Project is not awaiting resubmission', 'invalid_resubmit_state');
   }
-  const projectPatch = resubmit
+  const shouldResubmit = resubmit || managementPlanningResubmission || executiveResubmission;
+  const previousExecutiveReviewStatus = readOptionalText(project.executiveReviewStatus) || 'PENDING';
+  const executiveReviewReopens = !shouldResubmit
+    && ['APPROVED', 'PLANNING_AGREED'].includes(previousExecutiveReviewStatus);
+  const currentExecutiveHistory = Array.isArray(project.executiveReviewHistory)
+    ? project.executiveReviewHistory
+    : [];
+  const previousReviewedAt = readOptionalText(project.executiveReviewedAt);
+  const previousReviewedById = readOptionalText(project.executiveReviewedById);
+  const previousReviewedByName = readOptionalText(project.executiveReviewedByName);
+  const previousReviewComment = readOptionalText(project.executiveReviewComment);
+  const previousDecisionAlreadyRecorded = currentExecutiveHistory.some((entry) => (
+    readOptionalText(entry?.status) === previousExecutiveReviewStatus
+      && readOptionalText(entry?.reviewedAt) === previousReviewedAt
+      && readOptionalText(entry?.reviewedById) === previousReviewedById
+  ));
+  const previousDecisionHistory = executiveReviewReopens
+    && !previousDecisionAlreadyRecorded
+    && (previousReviewedAt || previousReviewedById || previousReviewedByName || previousReviewComment)
+    ? [{
+        status: previousExecutiveReviewStatus,
+        previousStatus: null,
+        reviewedAt: previousReviewedAt || null,
+        reviewedById: previousReviewedById || null,
+        reviewedByName: previousReviewedByName || null,
+        reviewComment: previousReviewComment || null,
+      }]
+    : [];
+  const executivePendingPatch = {
+    executiveReviewStatus: 'PENDING',
+    executiveReviewedAt: null,
+    executiveReviewedById: null,
+    executiveReviewedByName: null,
+    executiveReviewComment: null,
+    executiveReviewHistory: [
+      ...currentExecutiveHistory,
+      ...previousDecisionHistory,
+      {
+        status: 'PENDING',
+        previousStatus: previousExecutiveReviewStatus,
+        reviewedAt: timestamp,
+        reviewedById: actorId,
+        reviewedByName: actorName,
+        reviewComment: readOptionalText(reviewComment) || null,
+        ...(changedFields.length ? { changes: changedFields } : {}),
+      },
+    ],
+  };
+  const projectPatch = shouldResubmit
     ? (managementPlanningResubmission
       ? buildManagementPlanningResubmissionPatch()
-      : {
-        executiveReviewStatus: 'PENDING',
-        executiveReviewedAt: timestamp,
-        executiveReviewedById: actorId,
-        executiveReviewedByName: actorName,
-        executiveReviewComment: readOptionalText(reviewComment) || null,
-        executiveReviewHistory: [
-          ...(Array.isArray(project.executiveReviewHistory) ? project.executiveReviewHistory : []),
-          {
-            status: 'PENDING',
-            previousStatus: readOptionalText(project.executiveReviewStatus) || 'PENDING',
-            reviewedAt: timestamp,
-            reviewedById: actorId,
-            reviewedByName: actorName,
-            reviewComment: readOptionalText(reviewComment) || null,
-            ...(changedFields.length ? { changes: changedFields } : {}),
-          },
-        ],
-      })
-    : {};
+      : executivePendingPatch)
+    : (executiveReviewReopens ? executivePendingPatch : {});
   const projectRequestId = `change-${readOptionalText(project.id)}`;
   const projectRequest = stripUndefinedDeep({
     id: projectRequestId,
@@ -1630,6 +2073,59 @@ function resolveProjectRequestPayloadForReview(request) {
     return request.proposedSnapshot;
   }
   return request?.payload || {};
+}
+
+function projectRequestAttachmentsArePublished(request, tenantId) {
+  const payload = resolveProjectRequestPayloadForReview(request);
+  const privatePrefix = `orgs/${tenantId}/project-registration-drafts/`;
+  const hasUnpublishedAttachment = PROJECT_INFO_DOCUMENT_FIELDS.some((field) => (
+    readOptionalText(payload?.[field]?.path).startsWith(privatePrefix)
+  ));
+  const registrationIsAwaitingPublication = readOptionalText(request?.requestKind) === 'REGISTRATION'
+    && registrationRequirementsVersion(payload?.registrationRequirementsVersion) === 2
+    && !readOptionalText(request?.registrationAttachmentsPublishedAt)
+    && !hasCanonicalRegistrationV2Documents(request, payload, tenantId);
+  return !hasUnpublishedAttachment && !registrationIsAwaitingPublication;
+}
+
+function assertProjectRequestAttachmentsPublished(request, tenantId) {
+  if (!projectRequestAttachmentsArePublished(request, tenantId)) {
+    throw createHttpError(
+      409,
+      'Submitted attachments are still being prepared for review',
+      'project_attachments_processing',
+    );
+  }
+}
+
+function hasCanonicalRegistrationV2Documents(request, payload, tenantId) {
+  const projectId = readOptionalText(request?.approvedProjectId || request?.targetProjectId);
+  if (!projectId || projectId.includes('/')) return false;
+  const canonicalPrefix = `orgs/${tenantId}/project-registration-documents/${projectId}/`;
+  const isCanonicalDocument = (field) => {
+    const path = readOptionalText(payload?.[field]?.path);
+    const objectName = path.startsWith(canonicalPrefix) ? path.slice(canonicalPrefix.length) : '';
+    return Boolean(objectName && !objectName.includes('/'));
+  };
+  const allExistingDocumentsAreCanonical = PROJECT_INFO_DOCUMENT_FIELDS.every((field) => (
+    !readOptionalText(payload?.[field]?.path) || isCanonicalDocument(field)
+  ));
+  if (!allExistingDocumentsAreCanonical) return false;
+  if (!REGISTRATION_REQUIRED_DOCUMENT_KINDS.every((kind) => (
+    isCanonicalDocument(REGISTRATION_REQUIREMENT_DOCUMENT_FIELDS[kind])
+  ))) return false;
+  const hasProposal = isCanonicalDocument(REGISTRATION_REQUIREMENT_DOCUMENT_FIELDS.proposal);
+  const hasRfpEvidence = isCanonicalDocument(REGISTRATION_REQUIREMENT_DOCUMENT_FIELDS.rfp_request_evidence);
+  if (hasProposal === hasRfpEvidence) return false;
+  const optionalNotes = normalizeRegistrationOptionalDocumentNotes(payload.registrationOptionalDocumentNotes);
+  return [
+    ['proposal_word_original', 'proposalWordOriginal'],
+    ['proposal_ppt_original', 'proposalPptOriginal'],
+    ['presentation_ppt_original', 'presentationPptOriginal'],
+  ].every(([documentKind, noteField]) => (
+    isCanonicalDocument(REGISTRATION_REQUIREMENT_DOCUMENT_FIELDS[documentKind])
+      || Boolean(optionalNotes[noteField])
+  ));
 }
 
 function normalizeParticipationRate(value) {
@@ -1751,6 +2247,10 @@ export async function tryEnsureProjectRootFolder({
 }
 
 function resolveParticipationSettlementSystem(project) {
+  if (
+    Number(project?.registrationRequirementsVersion) === 2
+    && normalizeBasis(project?.basis) === 'NONE'
+  ) return 'NONE';
   const selectedSystem = normalizeSettlementSystemCode(project?.settlementSystem);
   if (selectedSystem !== 'NONE') return selectedSystem;
   if (project?.settlementType === 'TYPE5' || project?.accountType === 'DEDICATED') {
@@ -2120,6 +2620,50 @@ export function mountProjectRoutes(app, {
     res.status(200).json(buildListResponse(items, limit));
   }));
 
+  app.get('/api/v1/project-requests/assigned-to-me', asyncHandler(async (req, res) => {
+    const { tenantId, actorId } = req.context;
+    const { items, projects } = await readAssignedProjectRequests({ db, tenantId, actorId });
+    res.setHeader('cache-control', 'private, no-store');
+    res.status(200).json({ items, projects });
+  }));
+
+  app.post('/api/v1/project-requests/pending-changes', asyncHandler(async (req, res) => {
+    const { tenantId, actorId } = req.context;
+    const projectIds = parseProjectRequestQueryProjectIds(req.body?.projectIds);
+    const items = await readPendingProjectChangeRequests({ db, tenantId, actorId, projectIds });
+    res.setHeader('cache-control', 'private, no-store');
+    res.status(200).json({ items });
+  }));
+
+  app.post('/api/v1/project-requests/review-inbox', asyncHandler(async (req, res) => {
+    const { tenantId, actorId } = req.context;
+    assertActorRoleAllowed(req, ['admin', 'finance'], 'read the project review inbox');
+    await readProjectAttachmentMember({ db, tenantId, actorId });
+    const projectIds = parseProjectRequestQueryProjectIds(req.body?.projectIds);
+    const items = (await queryProjectRequestsByProjectIds({ db, tenantId, projectIds }))
+      .filter((projectRequest) => projectRequestAttachmentsArePublished(projectRequest, tenantId));
+    res.setHeader('cache-control', 'private, no-store');
+    res.status(200).json({ items });
+  }));
+
+  app.get('/api/v1/projects/:projectId/latest-request', asyncHandler(async (req, res) => {
+    const { tenantId, actorId } = req.context;
+    const projectId = readOptionalText(req.params.projectId);
+    if (!projectId || projectId.includes('/')) {
+      throw createHttpError(400, 'Project request lookup is invalid', 'project_request_query_invalid');
+    }
+    const member = await readProjectAttachmentMember({ db, tenantId, actorId });
+    const projectSnap = await db.doc(`orgs/${tenantId}/projects/${projectId}`).get();
+    if (!projectSnap.exists) throw createHttpError(404, `Project not found: ${projectId}`, 'not_found');
+    const project = projectSnap.data() || {};
+    if (!hasProjectRequestAccess({ actorId, member, projectId, project })) {
+      throw createHttpError(403, 'Project request access denied', 'forbidden');
+    }
+    const items = await queryProjectRequestsByProjectIds({ db, tenantId, projectIds: [projectId] });
+    res.setHeader('cache-control', 'private, no-store');
+    res.status(200).json({ item: items[0] || null });
+  }));
+
   app.get('/api/v1/projects/:projectId/attachments/:documentKind', asyncHandler(async (req, res) => {
     const { tenantId, actorId } = req.context;
     const projectId = readOptionalText(req.params.projectId);
@@ -2200,13 +2744,23 @@ export function mountProjectRoutes(app, {
       throw createHttpError(400, 'Project request attachment is invalid', 'project_request_attachment_invalid');
     }
     const member = await readProjectAttachmentMember({ db, tenantId, actorId });
-    if (!['admin', 'finance'].includes(normalizeRole(member.role))) {
-      throw createHttpError(403, 'Project attachment access denied', 'forbidden');
-    }
     const projectRequest = await readProjectRequestById(db, tenantId, requestId);
     if (!projectRequest) throw createHttpError(404, `Project request not found: ${requestId}`, 'not_found');
     const projectId = readOptionalText(projectRequest.targetProjectId || projectRequest.approvedProjectId);
     const payload = resolveProjectRequestPayloadForReview(projectRequest);
+    const storedRole = normalizeRole(member.role);
+    const requestApproverId = readOptionalText(payload?.executiveApproverId);
+    if (!['admin', 'finance'].includes(storedRole)) {
+      let isDesignatedApprover = requestApproverId === actorId;
+      if (!requestApproverId && projectId) {
+        const projectSnap = await db.doc(`orgs/${tenantId}/projects/${projectId}`).get();
+        isDesignatedApprover = projectSnap.exists
+          && readOptionalText(projectSnap.data()?.executiveApproverId) === actorId;
+      }
+      if (!isDesignatedApprover) {
+        throw createHttpError(403, 'Project attachment access denied', 'forbidden');
+      }
+    }
     const attachment = payload?.[field];
     const path = readOptionalText(attachment?.path);
     const expectedPrefix = `orgs/${tenantId}/project-registration-documents/${projectId}/`;
@@ -2698,7 +3252,7 @@ export function mountProjectRoutes(app, {
       );
     }
     const projectPath = `orgs/${tenantId}/projects/${projectId}`;
-    let reviewerName = readOptionalText(actorName) || readOptionalText(actorEmail) || actorId;
+    const reviewerName = readOptionalText(actorName) || readOptionalText(actorEmail) || actorId;
     const now = new Date().toISOString();
     await ensureDocumentExists(db, projectPath, `Project not found: ${projectId}`);
     const { request, requestId: resolvedRequestId, refs } = await resolveProjectRequestDocuments({
@@ -2738,7 +3292,9 @@ export function mountProjectRoutes(app, {
         if (designatedApproverId && requesterIds.has(actorId)) {
           throw createHttpError(403, 'Requester cannot approve their own project registration', 'self_approval_forbidden');
         }
-        reviewerName = readOptionalText(currentProject.executiveApproverName) || reviewerName;
+        if (parsed.reviewStatus === 'APPROVED') {
+          assertProjectRequestAttachmentsPublished(reviewRequest, tenantId);
+        }
         const legacyProjectCode = isLegacyPlanningAgreement ? requireProjectCode(currentProject.projectCode) : null;
         const submittedCode = normalizeProjectCode(parsed.projectCode);
         if (isLegacyPlanningAgreement && submittedCode && requireProjectCode(submittedCode) !== legacyProjectCode) {
@@ -2852,6 +3408,7 @@ export function mountProjectRoutes(app, {
   app.post('/api/v1/projects/:projectId/management-planning-review', createMutatingRoute(idempotencyService, async (req) => {
     const { tenantId, actorId, actorEmail, actorName } = req.context;
     assertActorRoleAllowed(req, ['admin', 'finance'], 'review project management planning status');
+    await readProjectAttachmentMember({ db, tenantId, actorId });
     const projectId = readOptionalText(req.params.projectId);
     if (!projectId) {
       throw createHttpError(400, 'project id is required', 'missing_project_id');
@@ -2876,6 +3433,9 @@ export function mountProjectRoutes(app, {
       requestId: parsed.requestId,
       projectId,
     });
+    const appliesResubmittedChange = parsed.reviewStatus === 'AGREED'
+      && isProjectChangeRequest(request)
+      && readOptionalText(request?.status) === 'PENDING';
 
     await mergeProjectAndRequestDocs({
       db,
@@ -2902,6 +3462,18 @@ export function mountProjectRoutes(app, {
           ? currentProject.managementPlanningReviewHistory
           : [];
         const isAgreed = parsed.reviewStatus === 'AGREED';
+        const appliesCurrentChange = isAgreed
+          && isProjectChangeRequest(reviewRequest)
+          && readOptionalText(reviewRequest?.status) === 'PENDING';
+        if (appliesCurrentChange) {
+          assertProjectRequestAttachmentsPublished(reviewRequest, tenantId);
+        }
+        const approvedChangePatch = appliesCurrentChange
+          ? buildProjectPatchFromChangeRequestPayload(
+            resolveProjectRequestPayloadForReview(reviewRequest),
+            currentProject,
+          )
+          : {};
         if (isAgreed && projectCode && projectCodeClaimRef) {
           const existingProjectCode = normalizeProjectCode(currentProject.projectCode);
           if (existingProjectCode && existingProjectCode !== projectCode) {
@@ -2910,6 +3482,17 @@ export function mountProjectRoutes(app, {
           const codeSnap = await tx.get(projectCodeClaimRef);
           const claim = codeSnap.exists ? (codeSnap.data() || {}) : {};
           if (codeSnap.exists && readOptionalText(claim.projectId) !== projectId) {
+            throw createHttpError(409, 'Project code is already assigned to another project', 'project_code_conflict');
+          }
+          const projectsWithCodes = await tx.get(db.collection(`orgs/${tenantId}/projects`));
+          const legacyConflict = projectsWithCodes.docs.find((projectDoc) => {
+            if (projectDoc.id === projectId) return false;
+            const candidate = projectDoc.data() || {};
+            return [candidate.projectCodeKey, candidate.projectCode]
+              .map(normalizeProjectCode)
+              .includes(projectCode);
+          });
+          if (legacyConflict) {
             throw createHttpError(409, 'Project code is already assigned to another project', 'project_code_conflict');
           }
           tx.set(projectCodeClaimRef, {
@@ -2923,6 +3506,7 @@ export function mountProjectRoutes(app, {
         }
 
         return {
+          ...approvedChangePatch,
           managementPlanningReviewStatus: parsed.reviewStatus,
           managementPlanningReviewedAt: now,
           managementPlanningReviewedById: actorId,
@@ -2943,7 +3527,7 @@ export function mountProjectRoutes(app, {
           ],
         };
       },
-      buildRequestPatch: () => {
+      buildRequestPatch: (_currentProject, currentRequest, nextVersion) => {
         if (!resolvedRequestId) return null;
         const isAgreed = parsed.reviewStatus === 'AGREED';
         const reviewComment = readOptionalText(parsed.reviewComment);
@@ -2971,10 +3555,16 @@ export function mountProjectRoutes(app, {
           rejectedReason: null,
           approvedProjectId: projectId,
           targetProjectId: projectId,
+          ...(isProjectChangeRequest(currentRequest || request)
+            && readOptionalText((currentRequest || request)?.status) === 'PENDING' ? {
+              approvedSnapshot: resolveProjectRequestPayloadForReview(currentRequest || request),
+              approvedProjectVersion: nextVersion,
+            } : {}),
           updatedAt: now,
         };
       },
       requestRefs: resolvedRequestId ? refs : [],
+      enforceChangeRequestVersion: appliesResubmittedChange,
       tenantId,
       actorId,
       now,

--- a/server/bff/routes/projects.test.ts
+++ b/server/bff/routes/projects.test.ts
@@ -3,6 +3,7 @@ import request from 'supertest';
 import { describe, expect, it, vi } from 'vitest';
 import {
   buildProjectRegistrationCanonicalDocuments,
+  buildProjectInfoChangeSubmission,
   buildProjectPatchFromChangeRequestPayload,
   formatProjectTypeSlackLabel,
   mergeProjectAndRequestDocs,
@@ -46,13 +47,22 @@ function registrationV2Payload(overrides: Record<string, unknown> = {}) {
     paymentPlan: { contract: 150_000, interim: 60_000, final: 90_000 },
     paymentExpectedMonths: { contract: '2026-01', interim: '2026-06', final: '2027-12' },
     advanceInterimBelow70Reason: '',
-    teamMembersDetailed: [{
-      memberName: '변민욱',
-      memberNickname: '보람',
-      role: '실무책임자',
-      participationRate: 50,
-      isDocumentOnly: true,
-    }],
+    teamMembersDetailed: [
+      {
+        memberName: '변민욱',
+        memberNickname: '보람',
+        role: '운영매니저',
+        participationRate: 50,
+        isDocumentOnly: false,
+      },
+      {
+        memberName: '김세은',
+        memberNickname: '람쥐',
+        role: '사업 최종 책임자',
+        participationRate: 0,
+        isDocumentOnly: false,
+      },
+    ],
     financialInputFlags: {
       contractAmount: true,
       salesVatAmount: true,
@@ -80,14 +90,24 @@ function registrationV2Payload(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function registrationV2Canonical(payload = registrationV2Payload(), requiredKinds = registrationV2AttachmentKinds) {
+function registrationV2Canonical(
+  payload = registrationV2Payload(),
+  requiredKinds = registrationV2AttachmentKinds,
+  attachmentKinds: string[] = [],
+) {
   return buildProjectRegistrationCanonicalDocuments({
     tenantId: 'mysc',
     projectId: 'project-v2',
     projectRequestId: 'request-v2',
     sourceDraftId: 'draft-v2',
     payload,
-    attachmentRefs: [],
+    attachmentRefs: attachmentKinds.map((documentKind) => ({
+      documentKind,
+      path: `orgs/mysc/project-registration-drafts/draft-v2/${documentKind}.pdf`,
+      name: `${documentKind}.pdf`,
+      size: 3,
+      contentType: 'application/pdf',
+    })),
     requirementsAttachmentRefs: requiredKinds.map((documentKind) => ({
       documentKind,
       path: `orgs/mysc/project-registration-drafts/draft-v2/${documentKind}.pdf`,
@@ -103,6 +123,42 @@ function registrationV2Canonical(payload = registrationV2Payload(), requiredKind
 }
 
 describe('project route helpers', () => {
+  it('does not restore canonical contract analysis when a private replacement omits analysis', () => {
+    const canonical = registrationV2Canonical(
+      registrationV2Payload({ contractAnalysis: { summary: 'canonical contract A analysis' } }),
+      registrationV2AttachmentKinds,
+      registrationV2AttachmentKinds,
+    );
+    const privateContract = {
+      documentKind: 'contract',
+      path: 'orgs/mysc/project-registration-drafts/change-v2/contract-b.pdf',
+      name: 'contract-b.pdf',
+      size: 3,
+      contentType: 'application/pdf',
+    };
+    const payload = {
+      ...canonical.projectRequest.payload,
+      contractDocument: { path: privateContract.path },
+    };
+    delete payload.contractAnalysis;
+
+    const submission = buildProjectInfoChangeSubmission({
+      tenantId: 'mysc',
+      project: canonical.project,
+      previousRequest: null,
+      payload,
+      attachmentRefs: [privateContract],
+      actorId: 'pm-a',
+      actorName: 'PM A',
+      actorEmail: 'pm-a@example.com',
+      timestamp: '2026-07-14T00:00:00.000Z',
+      targetProjectVersion: 2,
+    });
+
+    expect(submission.projectRequest.proposedSnapshot.contractAnalysis).toBeNull();
+    expect(submission.projectRequest.payload.contractAnalysis).toBeNull();
+  });
+
   it('builds a registration v2 canonical record after the PPT four-document contract and confirmations pass', () => {
     const canonical = registrationV2Canonical();
 
@@ -122,7 +178,10 @@ describe('project route helpers', () => {
       settlementSystem: 'BOTAEM_E',
       laborSettlementBasis: 'INCLUDE_ACTUAL_SALARY',
       paymentExpectedMonths: { contract: '2026-01', interim: '2026-06', final: '2027-12' },
-      teamMembersDetailed: [{ role: '실무책임자', isDocumentOnly: true }],
+      teamMembersDetailed: [
+        { role: '운영매니저', isDocumentOnly: false },
+        { role: '사업 최종 책임자', isDocumentOnly: false },
+      ],
       executiveApproverId: 'head-a',
       executiveApproverName: '조직장 A',
       executiveApproverEmail: 'head-a@mysc.co.kr',
@@ -154,7 +213,203 @@ describe('project route helpers', () => {
     });
   });
 
-  it('accepts proposal/RFP evidence as optional context when original-file notes are present', () => {
+  it('derives annual profit rates and removes settlement-only values when the v2 settlement basis is none', () => {
+    const canonical = registrationV2Canonical(registrationV2Payload({
+      settlementType: 'TYPE1',
+      basis: 'NONE',
+      accountType: 'DEDICATED',
+      settlementSystem: 'BOTAEM_E',
+      laborSettlementBasis: 'INCLUDE_ACTUAL_SALARY',
+      financialYears: [
+        { year: 2026, contractAmount: 100_000, salesVatAmount: 10_000, totalRevenueAmount: 40_000, supportAmount: 0, profitRate: 0, confirmed: true },
+        { year: 2027, contractAmount: 200_000, salesVatAmount: 20_000, totalRevenueAmount: 80_000, supportAmount: 10_000, profitRate: 0.9, confirmed: true },
+      ],
+    }));
+
+    expect(canonical.projectRequest.payload.financialYears).toEqual([
+      expect.objectContaining({ year: 2026, profitRate: 0.4 }),
+      expect.objectContaining({ year: 2027, profitRate: 0.4 }),
+    ]);
+    expect(canonical.projectRequest.payload).toMatchObject({
+      settlementType: 'TYPE1',
+      basis: 'NONE',
+      accountType: 'NONE',
+      settlementSystem: 'NONE',
+      laborSettlementBasis: 'NONE',
+    });
+  });
+
+  it('rejects a registration whose requester is also the designated organization-head approver', () => {
+    expect(() => registrationV2Canonical(registrationV2Payload({
+      executiveApproverId: 'pm-a',
+      executiveApproverName: 'PM A',
+      executiveApproverEmail: 'pm-a@example.com',
+    }))).toThrow(/designated executive approver must differ from the requester/i);
+  });
+
+  it('preserves a new registration project name longer than 10 characters', () => {
+    expect(registrationV2Canonical(registrationV2Payload({
+      name: '26프로젝트이름글자수제한없는테스트',
+    })).projectRequest.payload.name).toBe('26프로젝트이름글자수제한없는테스트');
+  });
+
+  it('requires an actual project final responsible member', () => {
+    expect(() => registrationV2Canonical(registrationV2Payload({
+      teamMembersDetailed: [{
+        memberName: '변민욱', memberNickname: '보람', role: '운영매니저', participationRate: 50, isDocumentOnly: false,
+      }],
+    }))).toThrowError('Project registration requires an actual project final responsible member');
+  });
+
+  it('allows only 도담 or 써니 as settlement support', () => {
+    expect(() => registrationV2Canonical(registrationV2Payload({
+      teamMembersDetailed: [
+        {
+          memberName: '변민욱', memberNickname: '보람', role: '운영매니저', participationRate: 50, isDocumentOnly: false,
+        },
+        {
+          memberName: '김세은', memberNickname: '람쥐', role: '사업 최종 책임자', participationRate: 0, isDocumentOnly: false,
+        },
+        {
+          memberName: '다른 구성원', memberNickname: '', role: '정산지원', participationRate: 0, isDocumentOnly: false,
+        },
+      ],
+    }))).toThrowError('Project registration settlement support must be 도담 or 써니');
+  });
+
+  it('rejects a change request whose submitter is also the designated organization-head approver', () => {
+    const payload = registrationV2Payload({
+      executiveApproverId: 'pm-a',
+      executiveApproverName: 'PM A',
+      executiveApproverEmail: 'pm-a@example.com',
+    });
+    const attachmentRefs = registrationV2AttachmentKinds.map((documentKind) => ({
+      documentKind,
+      path: `orgs/mysc/project-registration-drafts/change-v2/${documentKind}.pdf`,
+      name: `${documentKind}.pdf`,
+      size: 3,
+      contentType: 'application/pdf',
+    }));
+
+    expect(() => buildProjectInfoChangeSubmission({
+      tenantId: 'mysc',
+      project: { id: 'project-v2', version: 4, registeredById: 'pm-a', managerId: 'pm-a' },
+      previousRequest: null,
+      payload,
+      attachmentRefs,
+      actorId: 'pm-a',
+      actorName: 'PM A',
+      actorEmail: 'pm-a@example.com',
+      timestamp: '2026-07-14T00:00:00.000Z',
+      targetProjectVersion: 5,
+    })).toThrow(/designated executive approver must differ from the requester/i);
+  });
+
+  it('forces an organization-head rejection back to the organization-head queue even when a client omits resubmit', () => {
+    const canonical = registrationV2Canonical(
+      registrationV2Payload(),
+      registrationV2AttachmentKinds,
+      registrationV2AttachmentKinds,
+    );
+    const submission = buildProjectInfoChangeSubmission({
+      tenantId: 'mysc',
+      project: {
+        ...canonical.project,
+        executiveReviewStatus: 'REVISION_REJECTED',
+        executiveReviewedAt: '2026-07-13T00:00:00.000Z',
+        executiveReviewedById: 'head-a',
+        executiveReviewedByName: '조직장 A',
+        executiveReviewComment: '계약 기간을 보완해 주세요.',
+      },
+      previousRequest: null,
+      payload: { ...canonical.projectRequest.payload, description: '조직장 반려 보완본' },
+      attachmentRefs: [],
+      actorId: 'pm-a',
+      actorName: 'PM A',
+      actorEmail: 'pm-a@example.com',
+      timestamp: '2026-07-14T00:00:00.000Z',
+      targetProjectVersion: 2,
+      resubmit: false,
+      reviewComment: '계약 기간을 보완했습니다.',
+    });
+
+    expect(submission.projectPatch).toMatchObject({
+      executiveReviewStatus: 'PENDING',
+      executiveReviewedAt: null,
+      executiveReviewedById: null,
+      executiveReviewedByName: null,
+    });
+  });
+
+  it('preserves the organization-head approval and returns a planning rejection only to planning review when a client omits resubmit', () => {
+    const canonical = registrationV2Canonical(
+      registrationV2Payload(),
+      registrationV2AttachmentKinds,
+      registrationV2AttachmentKinds,
+    );
+    const submission = buildProjectInfoChangeSubmission({
+      tenantId: 'mysc',
+      project: {
+        ...canonical.project,
+        executiveReviewStatus: 'APPROVED',
+        executiveReviewedAt: '2026-07-12T00:00:00.000Z',
+        executiveReviewedById: 'head-a',
+        executiveReviewedByName: '조직장 A',
+        managementPlanningReviewStatus: 'REVISION_REJECTED',
+        managementPlanningReviewedAt: '2026-07-13T00:00:00.000Z',
+        managementPlanningReviewedById: 'planning-a',
+        managementPlanningReviewedByName: '경영기획실 A',
+        managementPlanningReviewComment: '프로젝트 코드를 확인해 주세요.',
+      },
+      previousRequest: null,
+      payload: { ...canonical.projectRequest.payload, description: '경영기획실 반려 보완본' },
+      attachmentRefs: [],
+      actorId: 'pm-a',
+      actorName: 'PM A',
+      actorEmail: 'pm-a@example.com',
+      timestamp: '2026-07-14T00:00:00.000Z',
+      targetProjectVersion: 2,
+      resubmit: false,
+      reviewComment: '프로젝트 코드 확인 내용을 보완했습니다.',
+    });
+
+    expect(submission.projectPatch).toEqual({
+      managementPlanningReviewStatus: 'PENDING',
+      managementPlanningReviewedAt: null,
+      managementPlanningReviewedById: null,
+      managementPlanningReviewedByName: null,
+      managementPlanningReviewComment: null,
+    });
+    expect(submission.projectPatch).not.toHaveProperty('executiveReviewStatus');
+  });
+
+  it('allows a v2 settlement-none basis without labor or customer settlement confirmations', () => {
+    const canonical = registrationV2Canonical(registrationV2Payload({
+      settlementType: 'TYPE1',
+      basis: 'NONE',
+      settlementSystem: 'NONE',
+      laborSettlementBasis: 'NONE',
+      registrationConfirmations: {
+        laborIncludesFourInsurance: null,
+        laborIncludesRetirementPay: null,
+        customerSettlementBasisConfirmed: false,
+        modusignContractUsed: false,
+        originalContractSubmitted: true,
+      },
+    }));
+
+    expect(canonical.projectRequest.payload).toMatchObject({
+      settlementType: 'TYPE1',
+      basis: 'NONE',
+      registrationConfirmations: {
+        laborIncludesFourInsurance: null,
+        laborIncludesRetirementPay: null,
+        customerSettlementBasisConfirmed: false,
+      },
+    });
+  });
+
+  it('requires proposal or RFP evidence while accepting either alternative', () => {
     const fixedDocumentKinds = ['contract', 'customer_business_registration', 'quote'];
 
     expect(() => registrationV2Canonical(registrationV2Payload(), [...fixedDocumentKinds, 'proposal'])).not.toThrow();
@@ -163,15 +418,54 @@ describe('project route helpers', () => {
       ...fixedDocumentKinds,
       'proposal',
       'rfp_request_evidence',
-    ])).not.toThrow();
-    expect(() => registrationV2Canonical(registrationV2Payload(), fixedDocumentKinds)).not.toThrow();
+    ])).toThrowError('Project registration requires exactly one of proposal or RFP evidence');
+    expect(() => registrationV2Canonical(registrationV2Payload(), fixedDocumentKinds))
+      .toThrowError('Project registration requires proposal or RFP evidence');
     expect(() => registrationV2Canonical(registrationV2Payload({
       registrationOptionalDocumentNotes: {
         proposalWordOriginal: '',
         proposalPptOriginal: '',
         presentationPptOriginal: '',
       },
-    }), fixedDocumentKinds)).toThrowError('Project registration optional attachment note is missing: proposal_word_original');
+    }), [...fixedDocumentKinds, 'proposal']))
+      .toThrowError('Project registration optional attachment note is missing: proposal_word_original');
+  });
+
+  it('accepts the PPT settlement-none basis for registration v2', () => {
+    expect(() => registrationV2Canonical(registrationV2Payload({
+      settlementType: 'TYPE1',
+      basis: 'NONE',
+    }))).not.toThrow();
+  });
+
+  it('rejects the removed settlement-none business type for a new registration', () => {
+    expect(() => registrationV2Canonical(registrationV2Payload({
+      settlementType: 'NONE',
+    }))).toThrowError('Project registration settlementType NONE is not available in requirements version 2');
+  });
+
+  it('rejects the removed 기타 settlement basis for registration v2', () => {
+    expect(() => registrationV2Canonical(registrationV2Payload({
+      basis: '기타',
+    }))).toThrowError('Project registration basis is invalid for requirements version 2');
+  });
+
+  it('preserves the PPT 기타 bank-account type for registration v2', () => {
+    const canonical = registrationV2Canonical(registrationV2Payload({
+      accountType: 'OTHER',
+    }));
+
+    expect(canonical.projectRequest.payload.accountType).toBe('OTHER');
+  });
+
+  it.each([
+    ['settlement type', { settlementType: 'TYPE9' }, 'Project registration settlementType is invalid'],
+    ['settlement basis', { basis: 'garbage' }, 'Project registration basis is invalid'],
+    ['account type', { accountType: 'garbage' }, 'Project registration accountType is invalid'],
+    ['settlement system', { settlementSystem: 'garbage' }, 'Project registration settlementSystem is invalid'],
+    ['labor settlement basis', { laborSettlementBasis: 'garbage' }, 'Project registration laborSettlementBasis is invalid'],
+  ])('rejects an unknown %s instead of normalizing it to NONE', (_label, overrides, message) => {
+    expect(() => registrationV2Canonical(registrationV2Payload(overrides))).toThrowError(message);
   });
 
   it.each([undefined, 1])('rejects new canonical registration requirements version %s', (version) => {
@@ -217,6 +511,16 @@ describe('project route helpers', () => {
       'team document-only choice',
       { teamMembersDetailed: [{ memberName: '변민욱', role: '실무책임자', participationRate: 50 }] },
       'Project registration teamMembersDetailed.0.isDocumentOnly is required',
+    ],
+    [
+      'operating manager',
+      { teamMembersDetailed: [{ memberName: '변민욱', role: '실무책임자', participationRate: 50, isDocumentOnly: false }] },
+      'Project registration requires at least one operating manager',
+    ],
+    [
+      'actual operating manager',
+      { teamMembersDetailed: [{ memberName: '변민욱', role: '운영매니저', participationRate: 0, isDocumentOnly: true }] },
+      'Project registration requires at least one actual operating manager',
     ],
   ])('rejects registration v2 with incomplete %s', (_label, overrides, message) => {
     expect(() => registrationV2Canonical(registrationV2Payload(overrides))).toThrowError(message);
@@ -623,6 +927,60 @@ describe('project route helpers', () => {
     });
   });
 
+  it('allows the designated organization-head approver to read a pending request contract regardless of member role', async () => {
+    const path = 'orgs/mysc/project-registration-documents/project-a/pending-contract.pdf';
+    const downloadProjectRegistrationAttachment = vi.fn(async () => ({
+      buffer: Buffer.from('approver-request-pdf'), contentType: 'application/pdf', size: 20,
+    }));
+    const db = {
+      doc: vi.fn((documentPath: string) => ({
+        get: vi.fn(async () => {
+          if (documentPath.includes('/members/')) {
+            return {
+              exists: true,
+              data: () => ({ uid: 'head-a', role: 'pm', status: 'ACTIVE' }),
+            };
+          }
+          if (documentPath.includes('/project_requests/')) {
+            return {
+              exists: true,
+              data: () => ({
+                id: 'request-a',
+                status: 'PENDING',
+                targetProjectId: 'project-a',
+                payload: {
+                  executiveApproverId: 'head-a',
+                  contractDocument: { path, name: 'pending-contract.pdf', contentType: 'application/pdf' },
+                },
+              }),
+            };
+          }
+          return { exists: false, data: () => null };
+        }),
+      })),
+    };
+    const app = express();
+    app.use((req: any, _res, next) => {
+      req.context = { tenantId: 'mysc', actorId: 'head-a', actorRole: 'pm' };
+      next();
+    });
+    mountProjectRoutes(app, {
+      db,
+      now: () => '2026-07-10T00:00:00.000Z',
+      idempotencyService: {},
+      projectRequestContractStorageService: { downloadProjectRegistrationAttachment },
+    } as any);
+
+    const response = await request(app)
+      .get('/api/v1/project-requests/request-a/attachments/contract');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(Buffer.from('approver-request-pdf'));
+    expect(downloadProjectRegistrationAttachment).toHaveBeenCalledWith({
+      tenantId: 'mysc', projectId: 'project-a', path,
+    });
+  });
+
   it('canonicalizes organization labels in registration documents before they are written', () => {
     const canonical = registrationV2Canonical(registrationV2Payload({ department: 'AXR Team' }));
 
@@ -630,8 +988,22 @@ describe('project route helpers', () => {
     expect(canonical.project).toMatchObject({ department: 'AXR팀', cic: 'AXR팀' });
   });
 
-  it('denies a PM before reading pending project request attachment metadata', async () => {
-    const requestGet = vi.fn();
+  it('denies an unrelated PM after checking the request approver without downloading the attachment', async () => {
+    const requestGet = vi.fn(async () => ({
+      exists: true,
+      data: () => ({
+        id: 'request-a',
+        status: 'PENDING',
+        targetProjectId: 'project-a',
+        payload: {
+          executiveApproverId: 'head-a',
+          contractDocument: {
+            path: 'orgs/mysc/project-registration-documents/project-a/contract.pdf',
+            name: 'contract.pdf',
+          },
+        },
+      }),
+    }));
     const db = {
       doc: vi.fn((documentPath: string) => ({
         get: documentPath.includes('/members/')
@@ -663,7 +1035,7 @@ describe('project route helpers', () => {
 
     expect(response.status).toBe(403);
     expect(response.body.error).toBe('forbidden');
-    expect(requestGet).not.toHaveBeenCalled();
+    expect(requestGet).toHaveBeenCalledOnce();
     expect(downloadProjectRegistrationAttachment).not.toHaveBeenCalled();
   });
 
@@ -769,6 +1141,72 @@ describe('project route helpers', () => {
     });
   });
 
+  it('rejects an explicit change request whose target project belongs to another project', async () => {
+    const db = {
+      doc: vi.fn((path: string) => ({
+        path,
+        get: vi.fn(async () => ({
+          exists: path.includes('/project_requests/'),
+          data: () => ({ targetProjectId: 'p-other', requestKind: 'CHANGE', payload: { name: 'Wrong target' } }),
+        })),
+      })),
+    };
+
+    await expect(resolveProjectRequestDocuments({
+      db,
+      tenantId: 'mysc',
+      requestId: 'change-pr001',
+      projectId: 'p001',
+    })).rejects.toMatchObject({
+      statusCode: 409,
+      code: 'request_project_mismatch',
+    });
+  });
+
+  it('rejects an explicit request without any project binding', async () => {
+    const db = {
+      doc: vi.fn((path: string) => ({
+        path,
+        get: vi.fn(async () => ({
+          exists: path.includes('/project_requests/'),
+          data: () => ({ requestKind: 'CHANGE', payload: { name: 'Unbound request' } }),
+        })),
+      })),
+    };
+
+    await expect(resolveProjectRequestDocuments({
+      db,
+      tenantId: 'mysc',
+      requestId: 'unbound-pr001',
+      projectId: 'p001',
+    })).rejects.toMatchObject({
+      statusCode: 409,
+      code: 'request_project_mismatch',
+    });
+  });
+
+  it('rejects an explicit request when its project bindings disagree', async () => {
+    const db = {
+      doc: vi.fn((path: string) => ({
+        path,
+        get: vi.fn(async () => ({
+          exists: path.includes('/project_requests/'),
+          data: () => ({ approvedProjectId: 'p001', targetProjectId: 'p-other', payload: { name: 'Split binding' } }),
+        })),
+      })),
+    };
+
+    await expect(resolveProjectRequestDocuments({
+      db,
+      tenantId: 'mysc',
+      requestId: 'split-pr001',
+      projectId: 'p001',
+    })).rejects.toMatchObject({
+      statusCode: 409,
+      code: 'request_project_mismatch',
+    });
+  });
+
   it('falls back to approvedProjectId lookup without requestedAt ordering for old request docs', async () => {
     const requestRef = { path: 'orgs/mysc/project_requests/pr001' };
     const orderedGet = vi.fn(async () => ({ empty: true, docs: [] }));
@@ -857,7 +1295,7 @@ describe('project route helpers', () => {
       id: 'p001',
       version: 1,
       executiveApproverId: 'head-a',
-      executiveApproverName: '조직장 A',
+      executiveApproverName: '제출자가 입력한 이름',
       executiveReviewStatus: 'PENDING',
     };
     const projectRequest = { targetProjectId: 'p001', approvedProjectId: 'p001', payload: { name: '등록 요청' } };
@@ -891,6 +1329,7 @@ describe('project route helpers', () => {
         actorId: 'head-a',
         actorRole: 'admin',
         actorEmail: 'head-a@example.com',
+        actorName: '인증된 조직장 A',
         requestId: 'request-a',
         idempotencyKey: 'executive-review-a',
       };
@@ -914,11 +1353,243 @@ describe('project route helpers', () => {
     expect(response.status).toBe(200);
     expect(tx.set).toHaveBeenNthCalledWith(1, expect.objectContaining(projectRef), expect.objectContaining({
       executiveReviewedById: 'head-a',
-      executiveReviewedByName: '조직장 A',
+      executiveReviewedByName: '인증된 조직장 A',
     }), { merge: true });
     expect(tx.set).toHaveBeenNthCalledWith(2, expect.objectContaining(requestRef), expect.objectContaining({
       reviewedBy: 'head-a',
-      reviewedByName: '조직장 A',
+      reviewedByName: '인증된 조직장 A',
+    }), { merge: true });
+  });
+
+  it.each([
+    {
+      label: 'change request with private draft paths',
+      requestId: 'change-p001',
+      projectRequest: {
+        requestKind: 'CHANGE',
+        targetProjectId: 'p001',
+        approvedProjectId: 'p001',
+        requestedBy: 'pm-a',
+        status: 'PENDING',
+        baseProjectVersion: 2,
+        targetProjectVersion: 3,
+        payload: {
+          executiveApproverId: 'head-a',
+          contractDocument: {
+            path: 'orgs/mysc/project-registration-drafts/private-change/contract.pdf',
+            name: 'contract.pdf',
+          },
+        },
+        proposedSnapshot: {
+          executiveApproverId: 'head-a',
+          contractDocument: {
+            path: 'orgs/mysc/project-registration-drafts/private-change/contract.pdf',
+            name: 'contract.pdf',
+          },
+        },
+        submittedOutboxId: 'outbox-change-p001',
+      },
+    },
+    {
+      label: 'new registration before canonical attachments are published',
+      requestId: 'registration-p001',
+      projectRequest: {
+        requestKind: 'REGISTRATION',
+        targetProjectId: 'p001',
+        approvedProjectId: 'p001',
+        requestedBy: 'pm-a',
+        status: 'PENDING',
+        payload: {
+          registrationRequirementsVersion: 2,
+          executiveApproverId: 'head-a',
+          contractDocument: null,
+          customerBusinessRegistrationDocument: null,
+          quoteDocument: null,
+          proposalDocument: null,
+        },
+        submittedOutboxId: 'outbox-registration-p001',
+      },
+    },
+    {
+      label: 'markerless v2 registration missing the three original-document slots',
+      requestId: 'registration-p001',
+      projectRequest: {
+        requestKind: 'REGISTRATION',
+        targetProjectId: 'p001',
+        approvedProjectId: 'p001',
+        requestedBy: 'pm-a',
+        status: 'PENDING',
+        payload: {
+          registrationRequirementsVersion: 2,
+          executiveApproverId: 'head-a',
+          contractDocument: {
+            path: 'orgs/mysc/project-registration-documents/p001/contract.pdf',
+            name: 'contract.pdf',
+          },
+          customerBusinessRegistrationDocument: {
+            path: 'orgs/mysc/project-registration-documents/p001/customer.pdf',
+            name: 'customer.pdf',
+          },
+          quoteDocument: {
+            path: 'orgs/mysc/project-registration-documents/p001/quote.pdf',
+            name: 'quote.pdf',
+          },
+          proposalDocument: {
+            path: 'orgs/mysc/project-registration-documents/p001/proposal.pdf',
+            name: 'proposal.pdf',
+          },
+          rfpRequestEvidenceDocument: null,
+        },
+        submittedOutboxId: 'outbox-registration-p001',
+      },
+    },
+  ])('blocks organization-head approval until attachments are published: $label', async ({ requestId, projectRequest }) => {
+    const projectRef = { path: 'orgs/mysc/projects/p001' };
+    const requestRef = { path: `orgs/mysc/project_requests/${requestId}` };
+    const project = {
+      id: 'p001',
+      version: 3,
+      executiveApproverId: 'head-a',
+      executiveApproverName: '조직장 A',
+      executiveReviewStatus: 'PENDING',
+    };
+    const tx = {
+      get: vi.fn(async (ref: { path: string }) => ref.path.includes('/projects/')
+        ? { exists: true, data: () => project }
+        : { exists: true, data: () => projectRequest }),
+      set: vi.fn(),
+    };
+    const db = {
+      doc: vi.fn((path: string) => ({
+        path,
+        get: vi.fn(async () => {
+          if (path === projectRef.path) return { exists: true, data: () => project };
+          if (path === requestRef.path) return { exists: true, data: () => projectRequest };
+          return { exists: false, data: () => null };
+        }),
+      })),
+      runTransaction: vi.fn(async (handler) => handler(tx)),
+    };
+    const idempotencyService = {
+      begin: vi.fn(async () => ({ mode: 'acquired', requestFingerprint: 'fingerprint-a' })),
+      complete: vi.fn(),
+      fail: vi.fn(),
+    };
+    const app = express();
+    app.use(express.json());
+    app.use((req: any, _res, next) => {
+      req.context = {
+        tenantId: 'mysc',
+        actorId: 'head-a',
+        actorRole: 'pm',
+        actorEmail: 'head-a@example.com',
+        requestId: 'request-a',
+        idempotencyKey: 'executive-review-pending-attachments',
+      };
+      next();
+    });
+    mountProjectRoutes(app, {
+      db,
+      now: () => '2026-07-14T00:00:00.000Z',
+      idempotencyService,
+    } as any);
+    app.use((error: any, _req, res, _next) => {
+      res.status(error.statusCode || 500).json({ error: error.code || 'internal_error' });
+    });
+
+    const response = await request(app).post('/api/v1/projects/p001/executive-review').send({
+      requestId,
+      reviewStatus: 'APPROVED',
+    });
+
+    expect(response.status).toBe(409);
+    expect(response.body.error).toBe('project_attachments_processing');
+    expect(tx.set).not.toHaveBeenCalled();
+  });
+
+  it('allows a legacy v2 registration without a publication marker when all seven document slots are canonical or explained', async () => {
+    const projectRef = { path: 'orgs/mysc/projects/p001' };
+    const requestRef = { path: 'orgs/mysc/project_requests/registration-p001' };
+    const canonicalPrefix = 'orgs/mysc/project-registration-documents/p001/';
+    const project = {
+      id: 'p001',
+      version: 3,
+      executiveApproverId: 'head-a',
+      executiveApproverName: '조직장 A',
+      executiveReviewStatus: 'PENDING',
+    };
+    const projectRequest = {
+      requestKind: 'REGISTRATION',
+      approvedProjectId: 'p001',
+      requestedBy: 'pm-a',
+      status: 'PENDING',
+      payload: {
+        registrationRequirementsVersion: 2,
+        executiveApproverId: 'head-a',
+        contractDocument: { path: `${canonicalPrefix}contract.pdf`, name: 'contract.pdf' },
+        customerBusinessRegistrationDocument: { path: `${canonicalPrefix}customer.pdf`, name: 'customer.pdf' },
+        quoteDocument: { path: `${canonicalPrefix}quote.pdf`, name: 'quote.pdf' },
+        proposalDocument: { path: `${canonicalPrefix}proposal.pdf`, name: 'proposal.pdf' },
+        rfpRequestEvidenceDocument: null,
+        registrationOptionalDocumentNotes: {
+          proposalWordOriginal: '고객사 미제공',
+          proposalPptOriginal: '해당 없음',
+          presentationPptOriginal: '해당 없음',
+        },
+      },
+    };
+    const tx = {
+      get: vi.fn(async (ref: { path: string }) => ref.path.includes('/projects/')
+        ? { exists: true, data: () => project }
+        : { exists: true, data: () => projectRequest }),
+      set: vi.fn(),
+    };
+    const db = {
+      doc: vi.fn((path: string) => ({
+        path,
+        get: vi.fn(async () => {
+          if (path === projectRef.path) return { exists: true, data: () => project };
+          if (path === requestRef.path) return { exists: true, data: () => projectRequest };
+          return { exists: false, data: () => null };
+        }),
+      })),
+      runTransaction: vi.fn(async (handler) => handler(tx)),
+    };
+    const idempotencyService = {
+      begin: vi.fn(async () => ({ mode: 'acquired', requestFingerprint: 'fingerprint-a' })),
+      complete: vi.fn(),
+      fail: vi.fn(),
+    };
+    const app = express();
+    app.use(express.json());
+    app.use((req: any, _res, next) => {
+      req.context = {
+        tenantId: 'mysc',
+        actorId: 'head-a',
+        actorRole: 'pm',
+        actorEmail: 'head-a@example.com',
+        requestId: 'request-a',
+        idempotencyKey: 'executive-review-legacy-canonical',
+      };
+      next();
+    });
+    mountProjectRoutes(app, {
+      db,
+      now: () => '2026-07-14T00:00:00.000Z',
+      idempotencyService,
+    } as any);
+    app.use((error: any, _req, res, _next) => {
+      res.status(error.statusCode || 500).json({ error: error.code || 'internal_error' });
+    });
+
+    const response = await request(app).post('/api/v1/projects/p001/executive-review').send({
+      requestId: 'registration-p001',
+      reviewStatus: 'APPROVED',
+    });
+
+    expect(response.status).toBe(200);
+    expect(tx.set).toHaveBeenCalledWith(expect.objectContaining(projectRef), expect.objectContaining({
+      executiveReviewStatus: 'APPROVED',
     }), { merge: true });
   });
 
@@ -1062,7 +1733,7 @@ describe('project route helpers', () => {
     expect(tx.set).not.toHaveBeenCalled();
   });
 
-  it('allows the designated approver through existing write permissions without a separate member role', async () => {
+  it('allows a designated viewer approver without introducing a separate member role', async () => {
     const projectRef = { path: 'orgs/mysc/projects/p001' };
     const requestRef = { path: 'orgs/mysc/project_requests/pr001' };
     const project = {
@@ -1113,10 +1784,11 @@ describe('project route helpers', () => {
       req.context = {
         tenantId: 'mysc',
         actorId: 'head-a',
-        actorRole: 'pm',
+        actorRole: 'viewer',
         actorEmail: 'head-a@example.com',
+        actorName: '조직장 A',
         requestId: 'request-a',
-        idempotencyKey: 'executive-review-designated-write-core',
+        idempotencyKey: 'executive-review-designated-viewer',
       };
       next();
     });
@@ -1384,5 +2056,407 @@ describe('project route helpers', () => {
       existingFolderId: '',
     });
     expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns only project requests assigned to the authenticated active reviewer', async () => {
+    const collectionRows = {
+      projects: [
+        { id: 'project-a', executiveApproverId: 'head-a' },
+        { id: 'project-change', executiveApproverId: 'head-a' },
+        { id: 'project-legacy', executiveApproverId: 'head-a' },
+        { id: 'project-processing', executiveApproverId: 'head-a' },
+        { id: 'project-payload-only', executiveApproverId: 'head-b', name: '요청 기준 배정 프로젝트' },
+        { id: 'project-other', executiveApproverId: 'head-b' },
+      ],
+      project_requests: [
+        {
+          id: 'request-assigned',
+          approvedProjectId: 'project-a',
+          requestedAt: '2026-07-20T02:00:00.000Z',
+          payload: { executiveApproverId: 'head-a', contractAmount: 100_000 },
+        },
+        {
+          id: 'request-processing',
+          requestKind: 'REGISTRATION',
+          approvedProjectId: 'project-processing',
+          requestedAt: '2026-07-20T04:30:00.000Z',
+          status: 'PENDING',
+          payload: { executiveApproverId: 'head-a', registrationRequirementsVersion: 2 },
+        },
+        {
+          id: 'request-change-assigned',
+          requestKind: 'CHANGE',
+          targetProjectId: 'project-change',
+          requestedAt: '2026-07-20T04:00:00.000Z',
+          payload: { executiveApproverId: 'head-b', contractAmount: 500_000 },
+          proposedSnapshot: { executiveApproverId: 'head-a', contractAmount: 200_000 },
+        },
+        {
+          id: 'request-other',
+          approvedProjectId: 'project-other',
+          requestedAt: '2026-07-20T03:00:00.000Z',
+          payload: { executiveApproverId: 'head-b', contractAmount: 999_000 },
+        },
+        {
+          id: 'request-payload-only',
+          targetProjectId: 'project-payload-only',
+          requestedAt: '2026-07-20T03:30:00.000Z',
+          payload: { executiveApproverId: 'head-a', contractAmount: 300_000 },
+        },
+        {
+          id: 'request-shadowed',
+          approvedProjectId: 'project-other',
+          requestedAt: '2026-07-20T05:00:00.000Z',
+          payload: { executiveApproverId: 'head-b', contractAmount: 777_000 },
+        },
+      ],
+      projectRequests: [
+        {
+          id: 'request-legacy-assigned',
+          approvedProjectId: 'project-legacy',
+          requestedAt: '2026-07-20T01:00:00.000Z',
+          payload: { name: '기존 요청' },
+        },
+        {
+          id: 'request-shadowed',
+          approvedProjectId: 'project-a',
+          requestedAt: '2026-07-20T06:00:00.000Z',
+          payload: { executiveApproverId: 'head-a', contractAmount: 666_000 },
+        },
+      ],
+    };
+    const readField = (row: Record<string, any>, field: string) => field
+      .split('.')
+      .reduce((value: any, key) => value?.[key], row);
+    const queryCalls: Array<{ path: string; clauses: Array<[string, string, unknown]> }> = [];
+    const requestQueryLimits: number[] = [];
+    const makeQuery = (path: string, clauses: Array<[string, string, unknown]> = []): any => ({
+      where: (field: string, operator: string, value: unknown) => makeQuery(path, [...clauses, [field, operator, value]]),
+      limit: (value: number) => {
+        requestQueryLimits.push(value);
+        return makeQuery(path, clauses);
+      },
+      get: vi.fn(async () => {
+        queryCalls.push({ path, clauses });
+        if (!clauses.length) throw new Error(`unbounded collection read: ${path}`);
+        const collectionName = path.split('/').at(-1) as keyof typeof collectionRows;
+        const rows = collectionRows[collectionName] || [];
+        const matches = rows.filter((row) => clauses.every(([field, operator, value]) => {
+          const actual = readField(row, field);
+          if (operator === '==') return actual === value;
+          if (operator === 'in') return Array.isArray(value) && value.includes(actual);
+          return false;
+        }));
+        return { docs: matches.map((row) => ({ id: row.id, data: () => row })) };
+      }),
+    });
+    const db = {
+      collection: vi.fn((path: string) => makeQuery(path)),
+      doc: vi.fn((path: string) => ({
+        get: vi.fn(async () => {
+          if (path === 'orgs/mysc/members/head-a') {
+            return { exists: true, data: () => ({ uid: 'head-a', role: 'pm', status: 'ACTIVE' }) };
+          }
+          const [collectionName, id] = path.split('/').slice(-2) as [keyof typeof collectionRows, string];
+          const row = collectionRows[collectionName]?.find((item) => item.id === id);
+          if (row) {
+            return { exists: true, id, data: () => row };
+          }
+          return { exists: false, data: () => null };
+        }),
+      })),
+    };
+    const app = express();
+    app.use((req: any, _res, next) => {
+      req.context = { tenantId: 'mysc', actorId: 'head-a', actorRole: 'pm' };
+      next();
+    });
+    mountProjectRoutes(app, {
+      db,
+      now: () => '2026-07-20T00:00:00.000Z',
+      idempotencyService: {},
+    } as any);
+    app.use((error: any, _req, res, _next) => {
+      res.status(error.statusCode || 500).json({ error: error.code || 'internal_error' });
+    });
+
+    const response = await request(app).get('/api/v1/project-requests/assigned-to-me');
+
+    expect(response.status).toBe(200);
+    expect(response.headers['cache-control']).toBe('private, no-store');
+    expect(response.body.items.map((item: { id: string }) => item.id)).toEqual([
+      'request-change-assigned',
+      'request-payload-only',
+      'request-assigned',
+      'request-legacy-assigned',
+    ]);
+    expect(JSON.stringify(response.body)).not.toContain('request-other');
+    expect(JSON.stringify(response.body)).not.toContain('999000');
+    expect(JSON.stringify(response.body)).not.toContain('666000');
+    expect(response.body.projects.map((project: { id: string }) => project.id)).toEqual([
+      'project-a',
+      'project-change',
+      'project-legacy',
+      'project-payload-only',
+      'project-processing',
+    ]);
+    expect(queryCalls).not.toContainEqual(expect.objectContaining({ clauses: [] }));
+    expect(requestQueryLimits.length).toBeGreaterThan(0);
+    expect(new Set(requestQueryLimits)).toEqual(new Set([500]));
+  });
+
+  it('serves latest, pending-summary, and review-inbox views without client Firestore access', async () => {
+    const collectionRows = {
+      project_requests: [
+        {
+          id: 'change-pending',
+          requestKind: 'CHANGE',
+          targetProjectId: 'project-a',
+          approvedProjectId: 'project-a',
+          status: 'PENDING',
+          requestedAt: '2026-07-20T01:00:00.000Z',
+          targetProjectVersion: 4,
+          payload: { contractAmount: 999_000 },
+        },
+        {
+          id: 'registration-latest',
+          requestKind: 'REGISTRATION',
+          targetProjectId: 'project-a',
+          approvedProjectId: 'project-a',
+          status: 'APPROVED',
+          requestedAt: '2026-07-20T02:00:00.000Z',
+          payload: { name: '프로젝트 A' },
+        },
+        {
+          id: 'registration-processing',
+          requestKind: 'REGISTRATION',
+          targetProjectId: 'project-a',
+          approvedProjectId: 'project-a',
+          status: 'PENDING',
+          requestedAt: '2026-07-20T00:30:00.000Z',
+          payload: { name: '게시 중 프로젝트', registrationRequirementsVersion: 2 },
+        },
+        {
+          id: 'shadowed-cross-project',
+          requestKind: 'CHANGE',
+          targetProjectId: 'project-b',
+          approvedProjectId: 'project-b',
+          status: 'PENDING',
+          requestedAt: '2026-07-20T04:00:00.000Z',
+          payload: { contractAmount: 555_000 },
+        },
+      ],
+      projectRequests: [
+        {
+          id: 'legacy-other',
+          requestKind: 'CHANGE',
+          approvedProjectId: 'project-b',
+          status: 'PENDING',
+          requestedAt: '2026-07-20T03:00:00.000Z',
+          payload: { contractAmount: 777_000 },
+        },
+        {
+          id: 'shadowed-cross-project',
+          requestKind: 'CHANGE',
+          targetProjectId: 'project-a',
+          approvedProjectId: 'project-a',
+          status: 'PENDING',
+          requestedAt: '2026-07-20T04:00:00.000Z',
+          payload: { contractAmount: 444_000 },
+        },
+      ],
+    };
+    const queryCalls: Array<{ path: string; field: string; operator: string; value: unknown }> = [];
+    const requestQueryLimits: number[] = [];
+    const readField = (row: Record<string, any>, field: string) => field
+      .split('.')
+      .reduce((value: any, key) => value?.[key], row);
+    const db = {
+      collection: vi.fn((path: string) => ({
+        where: (field: string, operator: string, value: unknown) => ({
+          limit: (queryLimit: number) => ({ get: vi.fn(async () => {
+            requestQueryLimits.push(queryLimit);
+            queryCalls.push({ path, field, operator, value });
+            const rows = path.endsWith('/project_requests')
+              ? collectionRows.project_requests
+              : collectionRows.projectRequests;
+            const matches = rows.filter((row) => {
+              const actual = readField(row, field);
+              if (operator === '==') return actual === value;
+              if (operator === 'in') return Array.isArray(value) && value.includes(actual);
+              return false;
+            });
+            return { docs: matches.map((row) => ({ id: row.id, data: () => row })) };
+          }) }),
+        }),
+      })),
+      doc: vi.fn((path: string) => ({
+        get: vi.fn(async () => {
+          if (path === 'orgs/mysc/members/finance-a') {
+            return { exists: true, data: () => ({ uid: 'finance-a', role: 'finance', status: 'ACTIVE' }) };
+          }
+          if (path === 'orgs/mysc/projects/project-a') {
+            return { exists: true, data: () => ({ id: 'project-a', managerId: 'pm-a' }) };
+          }
+          const id = path.split('/').at(-1);
+          const canonical = collectionRows.project_requests.find((row) => row.id === id);
+          return canonical
+            ? { exists: true, id, data: () => canonical }
+            : { exists: false, data: () => null };
+        }),
+      })),
+    };
+    const app = express();
+    app.use(express.json());
+    app.use((req: any, _res, next) => {
+      req.context = { tenantId: 'mysc', actorId: 'finance-a', actorRole: 'finance' };
+      next();
+    });
+    mountProjectRoutes(app, {
+      db,
+      now: () => '2026-07-20T00:00:00.000Z',
+      idempotencyService: {},
+    } as any);
+    app.use((error: any, _req, res, _next) => {
+      res.status(error.statusCode || 500).json({ error: error.code || 'internal_error' });
+    });
+
+    const pending = await request(app)
+      .post('/api/v1/project-requests/pending-changes')
+      .send({ projectIds: ['project-a'] });
+    const oversizedPending = await request(app)
+      .post('/api/v1/project-requests/pending-changes')
+      .send({ projectIds: Array.from({ length: 201 }, (_, index) => `project-${index}`) });
+    const inbox = await request(app).post('/api/v1/project-requests/review-inbox').send({ projectIds: ['project-a'] });
+    const latest = await request(app).get('/api/v1/projects/project-a/latest-request');
+
+    expect(pending.status).toBe(200);
+    expect(oversizedPending.status).toBe(400);
+    expect(oversizedPending.body.error).toBe('project_request_query_invalid');
+    expect(pending.body.items).toEqual([expect.objectContaining({ id: 'change-pending' })]);
+    expect(JSON.stringify(pending.body)).not.toContain('999000');
+    expect(JSON.stringify(pending.body)).not.toContain('777000');
+    expect(JSON.stringify(pending.body)).not.toContain('shadowed-cross-project');
+    expect(inbox.status).toBe(200);
+    expect(inbox.body.items.map((item: { id: string }) => item.id)).toEqual(['registration-latest', 'change-pending']);
+    expect(JSON.stringify(inbox.body)).not.toContain('shadowed-cross-project');
+    expect(latest.status).toBe(200);
+    expect(latest.body.item).toEqual(expect.objectContaining({ id: 'registration-latest' }));
+    expect(queryCalls.every((call) => call.field && call.operator)).toBe(true);
+    expect(new Set(requestQueryLimits)).toEqual(new Set([500]));
+  });
+
+  it('denies pending change summaries for project IDs outside an ACTIVE PM assignment', async () => {
+    const db = {
+      collection: vi.fn((path: string) => ({
+        where: (_field: string, _operator: string, _value: unknown) => ({
+          limit: (_queryLimit: number) => ({
+            get: vi.fn(async () => ({
+              docs: path.endsWith('/project_requests')
+                ? [{
+                    id: 'change-project-a',
+                    data: () => ({
+                      requestKind: 'CHANGE',
+                      targetProjectId: 'project-a',
+                      status: 'PENDING',
+                      requestedAt: '2026-07-20T01:00:00.000Z',
+                    }),
+                  }]
+                : [],
+            })),
+          }),
+        }),
+      })),
+      doc: vi.fn((path: string) => ({
+        get: vi.fn(async () => {
+          if (path === 'orgs/mysc/members/pm-a') {
+            return {
+              exists: true,
+              data: () => ({ uid: 'pm-a', role: 'pm', status: 'ACTIVE', projectIds: ['project-b'] }),
+            };
+          }
+          if (path === 'orgs/mysc/projects/project-a') {
+            return { exists: true, data: () => ({ managerId: 'pm-b', executiveApproverId: 'head-a' }) };
+          }
+          return { exists: false, data: () => null };
+        }),
+      })),
+    };
+    const app = express();
+    app.use(express.json());
+    app.use((req: any, _res, next) => {
+      req.context = { tenantId: 'mysc', actorId: 'pm-a', actorRole: 'pm' };
+      next();
+    });
+    mountProjectRoutes(app, {
+      db,
+      now: () => '2026-07-20T00:00:00.000Z',
+      idempotencyService: {},
+    } as any);
+    app.use((error: any, _req, res, _next) => {
+      res.status(error.statusCode || 500).json({ error: error.code || 'internal_error' });
+    });
+
+    const response = await request(app)
+      .post('/api/v1/project-requests/pending-changes')
+      .send({ projectIds: ['project-a'] });
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe('forbidden');
+    expect(db.collection).not.toHaveBeenCalled();
+  });
+
+  it('chunks legacy request fallback queries within the Firestore in-query limit', async () => {
+    const inQuerySizes: number[] = [];
+    const db = {
+      collection: vi.fn((path: string) => ({
+        where: (field: string, operator: string, value: unknown) => ({
+          get: vi.fn(async () => {
+            if (operator === 'in') inQuerySizes.push(Array.isArray(value) ? value.length : 0);
+            if (path.endsWith('/projects') && field === 'executiveApproverId') {
+              return {
+                docs: Array.from({ length: 31 }, (_, index) => ({
+                  id: `project-${String(index + 1).padStart(2, '0')}`,
+                  data: () => ({ executiveApproverId: 'head-a' }),
+                })),
+              };
+            }
+            return { docs: [] };
+          }),
+          limit: (_queryLimit: number) => ({
+            get: vi.fn(async () => {
+              if (operator === 'in') inQuerySizes.push(Array.isArray(value) ? value.length : 0);
+              return { docs: [] };
+            }),
+          }),
+        }),
+      })),
+      doc: vi.fn((path: string) => ({
+        get: vi.fn(async () => path === 'orgs/mysc/members/head-a'
+          ? { exists: true, data: () => ({ uid: 'head-a', role: 'pm', status: 'ACTIVE' }) }
+          : { exists: false, data: () => null }),
+      })),
+    };
+    const app = express();
+    app.use((req: any, _res, next) => {
+      req.context = { tenantId: 'mysc', actorId: 'head-a', actorRole: 'pm' };
+      next();
+    });
+    mountProjectRoutes(app, {
+      db,
+      now: () => '2026-07-20T00:00:00.000Z',
+      idempotencyService: {},
+    } as any);
+    app.use((error: any, _req, res, _next) => {
+      res.status(error.statusCode || 500).json({ error: error.code || 'internal_error' });
+    });
+
+    const response = await request(app).get('/api/v1/project-requests/assigned-to-me');
+
+    expect(response.status).toBe(200);
+    expect(response.body.items).toEqual([]);
+    expect(inQuerySizes).toContain(30);
+    expect(inQuerySizes).toContain(1);
+    expect(Math.max(...inQuerySizes)).toBe(30);
   });
 });

--- a/server/bff/routes/projects.test.ts
+++ b/server/bff/routes/projects.test.ts
@@ -213,6 +213,26 @@ describe('project route helpers', () => {
     });
   });
 
+  it('preserves the business-management Google folder link in both review and project records', () => {
+    const link = 'https://drive.google.com/drive/folders/project-management-folder';
+    const canonical = registrationV2Canonical(registrationV2Payload({
+      businessManagementGoogleFolderLink: link,
+    }));
+
+    expect(canonical.projectRequest.payload.businessManagementGoogleFolderLink).toBe(link);
+    expect(canonical.project.businessManagementGoogleFolderLink).toBe(link);
+  });
+
+  it('allows a single-year registration without annual financial rows', () => {
+    const canonical = registrationV2Canonical(registrationV2Payload({
+      contractEnd: '2026-12-31',
+      paymentExpectedMonths: { contract: '2026-01', interim: '2026-06', final: '2026-12' },
+      financialYears: [],
+    }));
+
+    expect(canonical.projectRequest.payload.financialYears).toEqual([]);
+  });
+
   it('derives annual profit rates and removes settlement-only values when the v2 settlement basis is none', () => {
     const canonical = registrationV2Canonical(registrationV2Payload({
       settlementType: 'TYPE1',

--- a/server/bff/schemas.mjs
+++ b/server/bff/schemas.mjs
@@ -30,6 +30,10 @@ export const projectRegistrationDraftAttachmentSchema = z.object({
   contentBase64: NON_EMPTY_STRING.max(PROJECT_REGISTRATION_ATTACHMENT_BASE64_MAX_LENGTH),
 }).strict();
 
+export const projectDraftAttachmentDeleteSchema = z.object({
+  expectedDraftRevision: z.number().int().nonnegative(),
+}).strict();
+
 export const projectRegistrationDraftSubmitSchema = z.object({
   expectedDraftRevision: z.number().int().nonnegative(),
 }).strict();

--- a/src/app/components/portal/PortalLayout.shell.test.ts
+++ b/src/app/components/portal/PortalLayout.shell.test.ts
@@ -18,6 +18,7 @@ describe('PortalLayout shell actions', () => {
     expect(portalLayoutSource).not.toContain("label: '사업비 입력(주간)'");
     expect(portalLayoutSource).toContain("label: '인건비/공지'");
     expect(portalLayoutSource).toContain("label: '프로젝트 수정'");
+    expect(portalLayoutSource).toContain("label: '프로젝트 등록/승인'");
     expect(portalLayoutSource.indexOf("label: '명함 DB'")).toBeGreaterThan(
       portalLayoutSource.indexOf("label: '프로젝트 등록 요청'"),
     );
@@ -74,6 +75,8 @@ describe('PortalLayout shell actions', () => {
 
   it('keeps portal navigation explicit without onboarding or project-select redirect effects', () => {
     expect(portalLayoutSource).toContain('isPortalStandaloneEntryPath');
+    expect(portalLayoutSource).toContain('isProjectRegistrationPath');
+    expect(portalLayoutSource).toContain('&& !isProjectRegistrationPath');
     expect(portalLayoutSource).toContain('blockedPortalAccess');
     expect(portalLayoutSource).toContain("navigate('/portal/project-select')");
     expect(portalLayoutSource).not.toContain("navigate('/portal/weekly-expenses')");
@@ -81,6 +84,13 @@ describe('PortalLayout shell actions', () => {
     expect(portalLayoutSource).not.toContain("navigate('/', { replace: true })");
     expect(portalLayoutSource).not.toContain('shouldForcePortalOnboarding');
     expect(portalLayoutSource).not.toContain('resolvePortalProjectSelectPath(currentPath)');
+  });
+
+  it('keeps project registration inside the global portal shell even before a project is assigned', () => {
+    expect(portalLayoutSource).toContain("location.pathname === '/portal/register-project'");
+    expect(portalLayoutSource).toContain("location.pathname.startsWith('/portal/register-project/')");
+    expect(portalLayoutSource).toContain('!portalUser && !isProjectRegistrationPath');
+    expect(portalLayoutSource).toContain("if (isProjectRegistrationPath) return '프로젝트 등록';");
   });
 
   it('exposes stable portal navigation test ids for release-gate flows', () => {

--- a/src/app/components/portal/PortalLayout.tsx
+++ b/src/app/components/portal/PortalLayout.tsx
@@ -4,6 +4,7 @@ import {
   LogOut,
   FolderKanban, Menu,
   Plus, Pencil,
+  ClipboardCheck,
   CircleDollarSign,
   BarChart3,
   Loader2,
@@ -108,6 +109,7 @@ const NAV_SECTIONS: PortalNavSection[] = [
   {
     title: '프로젝트 배정 및 등록',
     items: [
+      { to: '/portal/project-approvals', icon: ClipboardCheck, label: '프로젝트 등록/승인' },
       { to: '/portal/edit-project', icon: Pencil, label: '프로젝트 수정' },
       { to: '/portal/register-project', icon: Plus, label: '프로젝트 등록 요청', accent: true },
       { to: '/portal/business-cards', icon: UserRoundCheck, label: '명함 DB' },
@@ -188,6 +190,8 @@ function PortalContent() {
   const navigationHandlerRef = useRef<((attempt: PortalNavigationAttempt) => boolean) | null>(null);
   const currentPath = `${location.pathname}${location.search}${location.hash}`;
   const isCashflowWorkspace = location.pathname.startsWith('/portal/cashflow');
+  const isProjectRegistrationPath = location.pathname === '/portal/register-project'
+    || location.pathname.startsWith('/portal/register-project/');
   const blockedPortalAccess = Boolean(
     !authLoading
     && !portalLoading
@@ -295,9 +299,10 @@ function PortalContent() {
   ), [currentFundInputMode, labEnabled]);
   const topNavItems = useMemo(() => navSections.flatMap((section) => section.items), [navSections]);
   const currentSectionLabel = useMemo(() => {
+    if (isProjectRegistrationPath) return '프로젝트 등록';
     const current = topNavItems.find((item) => isActive(item.to, item.exact));
     return current?.label || '프로젝트 선택';
-  }, [topNavItems, location.pathname]);
+  }, [isProjectRegistrationPath, topNavItems, location.pathname]);
   const shellCommandItems = useMemo(() => buildPortalShellCommandItems({
     role: authUser?.role,
     currentPath,
@@ -397,11 +402,13 @@ function PortalContent() {
     return <Outlet />;
   }
 
-  if (isPortalStandaloneEntryPath(location.pathname) && !isAdminSpaceRole(authUser?.role)) {
+  if (isPortalStandaloneEntryPath(location.pathname)
+    && !isProjectRegistrationPath
+    && !isAdminSpaceRole(authUser?.role)) {
     return <Outlet />;
   }
 
-  if (!portalUser && !isAdminSpaceRole(authUser?.role)) {
+  if (!portalUser && !isProjectRegistrationPath && !isAdminSpaceRole(authUser?.role)) {
     return (
       <div className="min-h-screen bg-slate-50 px-6 py-8 dark:bg-slate-950">
         <div className="mx-auto w-full max-w-6xl">

--- a/src/app/components/portal/PortalProjectEdit.persist-shell.test.ts
+++ b/src/app/components/portal/PortalProjectEdit.persist-shell.test.ts
@@ -13,15 +13,25 @@ describe('PortalProjectEdit persistence shell', () => {
     expect(source).not.toContain('setDoc(');
   });
 
-  it('uses the executive review resubmit endpoint only for explicit resubmission', () => {
-    expect(source).toContain("resubmit: actionId === 'resubmit'");
-    expect(source).toContain("actionId === 'resubmit' && resubmitComment.trim()");
+  it('forces every rejected edit through the stage-aware resubmission path', () => {
+    expect(source).toContain("const shouldResubmit = canResubmit || actionId === 'resubmit'");
+    expect(source).toContain('resubmit: shouldResubmit');
+    expect(source).toContain('shouldResubmit && resubmitComment.trim()');
+    expect(source).not.toContain("resubmit: actionId === 'resubmit'");
     expect(source).not.toContain('resubmitProjectExecutiveReviewViaBff');
   });
 
-  it('reads canonical and legacy project request collections so reviewer feedback is retained', () => {
-    expect(source).toContain("['project_requests', 'projectRequests']");
-    expect(source).toContain('const sourceRows = new Map<string, ProjectRequest>()');
+  it('shows a single resubmit action after either approval stage rejects the project', () => {
+    expect(source).toContain("canResubmit\n            ? [{ id: 'resubmit', label: '수정 후 다시 제출'");
+    expect(source).toContain(": [{ id: 'save', label: '최종 저장', icon: Save }]");
+    expect(source).not.toContain("{ id: 'save', label: '최종 저장', icon: Save },\n          ...(canResubmit");
+  });
+
+  it('reads the latest canonical-preferred request through the permission-checked BFF', () => {
+    expect(source).toContain('fetchLatestProjectRequestViaBff');
+    expect(source).toContain('latest project request fetch failed');
+    expect(source).not.toContain("['project_requests', 'projectRequests']");
+    expect(source).not.toContain("collection(db, 'tenants'");
   });
 
   it('keeps the project edit draft key stable across request listener updates', () => {
@@ -44,5 +54,13 @@ describe('PortalProjectEdit persistence shell', () => {
     expect(source).toContain("managementPlanningReview.status === 'REVISION_REJECTED'");
     expect(source).toContain('data-testid="portal-management-planning-review"');
     expect(source).toContain('buildPortalProjectReviewFeedback(project, requestDoc)');
+    expect(source).toContain('기존 조직장 승인 이력은 유지되며, 보완한 요청은 경영기획실 재검토 화면에 표시됩니다.');
+    expect(source).toContain("canManagementPlanningResubmit\n                ?");
+    expect(source).toContain('조직장 승인 전까지 프로젝트 원장은 바뀌지 않으며');
+  });
+
+  it('matches the BFF 2,000-character resubmission memo limit in the editor', () => {
+    expect(source).toContain('maxLength={2000}');
+    expect(source).toContain('{resubmitComment.length.toLocaleString()}/2,000자');
   });
 });

--- a/src/app/components/portal/PortalProjectEdit.private-draft.shell.test.ts
+++ b/src/app/components/portal/PortalProjectEdit.private-draft.shell.test.ts
@@ -42,4 +42,56 @@ describe('PortalProjectEdit private draft boundary', () => {
     expect(source).not.toContain('resubmitProjectExecutiveReviewViaBff');
     expect(source).not.toContain('uploadProjectRequestContractFile');
   });
+
+  it('loads private edit-draft attachment blobs through the owner-authorized BFF for review previews', () => {
+    expect(source).toContain('downloadProjectInfoDraftAttachmentViaBff');
+    expect(source).toContain('usePrivateDraftDocumentPreviews');
+    expect(source).toContain('enabled: record !== null');
+    expect(source).toContain('signal,');
+    expect(source).toContain('documentPreviewUrls={documentPreviewUrls}');
+    expect(source).toContain('documentPreviewStates={documentPreviewStates}');
+    expect(source).toContain('onLoadDocumentPreview={loadDocumentPreview}');
+    expect(source).not.toContain('Promise.all(attachments');
+  });
+
+  it('analyzes a replacement contract without creating a second public upload', () => {
+    expect(source).toContain('extractTextFromPdf(file)');
+    expect(source).toContain('analyzeProjectRequestContractViaBff({');
+    expect(source).toContain("kind === 'contract'");
+    expect(source).toMatch(/return\s*\{\s*document:\s*attachmentDocument\(uploaded\.attachment\),\s*contractAnalysis\s*\}/);
+    expect(source).not.toContain('processProjectRequestContractViaBff');
+    expect(source).not.toContain('contractAnalysis: null }');
+  });
+
+  it('upgrades canonical and private legacy edit drafts to the registration-v2 contract', () => {
+    expect(source).toContain('registrationRequirementsVersion: 2');
+    expect(source).toContain('...buildProjectEditorDraftFromProject(');
+    expect(source).toContain('previewAttachmentsFromPrivateDraft');
+    expect(source).toContain('attachments: previewAttachments');
+    expect(source).toContain('[...attachments.values()]');
+  });
+
+  it('restores only the latest private proposal alternative after a refresh', () => {
+    expect(source).toContain('latestPrivateAlternativeDocumentKind');
+    expect(source).toContain("latestAlternativeKind === 'rfp_request_evidence' ? { proposalDocument: null }");
+    expect(source).toContain("latestAlternativeKind === 'proposal' ? { rfpRequestEvidenceDocument: null }");
+    expect(source).toContain("attachments.delete('proposal')");
+    expect(source).toContain("attachments.delete('rfp_request_evidence')");
+  });
+
+  it('removes private replacement attachments through the fenced draft API before clearing editor state', () => {
+    expect(source).toContain('const removeDocument = useCallback');
+    expect(source).toContain('draftClient.removeAttachment(ownership');
+    expect(source).toContain('onRemoveProjectDocument={removeDocument}');
+    expect(source).toContain('canRemoveProjectDocuments');
+  });
+
+  it('closes the editable session and private previews after a successful submission', () => {
+    expect(source).toContain('const [submitted, setSubmitted] = useState(false)');
+    expect(source).toContain('lease.canEdit && record !== null && !submitted');
+    expect(source).toContain('enabled: record !== null && !submitted');
+    expect(source).toContain('setSubmitted(true)');
+    expect(source).toContain('setRecord(null)');
+    expect(source).toContain("navigate('/portal/project-select')");
+  });
 });

--- a/src/app/components/portal/PortalProjectEdit.tsx
+++ b/src/app/components/portal/PortalProjectEdit.tsx
@@ -11,22 +11,29 @@ import {
   Save,
   SendHorizontal,
 } from 'lucide-react';
-import { collection, limit, onSnapshot, orderBy, query, where } from 'firebase/firestore';
 import { toast } from 'sonner';
 import { useAuth } from '../../data/auth-store';
 import { useProjectDepartmentSettings } from '../../data/project-department-settings';
 import { usePortalStore } from '../../data/portal-store';
 import type { FileAttachment, Project, ProjectRequest } from '../../data/types';
-import { getAuthInstance, getOrgCollectionPath } from '../../lib/firebase';
+import { getAuthInstance } from '../../lib/firebase';
 import { useFirebase } from '../../lib/firebase-context';
+import { extractTextFromPdf } from '../../lib/pdf-extract';
 import { createEditLeaseClient } from '../../lib/edit-lease-client';
+import { downloadProjectInfoDraftAttachmentViaBff } from '../../lib/project-request-attachment-client';
 import {
   createProjectInfoDraftClient,
   type ProjectInfoAttachment,
+  type ProjectInfoDocumentKind,
   type ProjectInfoDraft,
   type ProjectInfoFileLike,
 } from '../../lib/project-info-draft-client';
-import type { ActorLike } from '../../lib/platform-bff-client';
+import {
+  analyzeProjectRequestContractViaBff,
+  fetchLatestProjectRequestViaBff,
+  isPlatformApiEnabled,
+  type ActorLike,
+} from '../../lib/platform-bff-client';
 import { openEditSession, type EditSession } from '../../platform/edit-session';
 import {
   buildProjectEditorDraftFromProject,
@@ -61,8 +68,26 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '../ui/alert-dialog';
+import { usePrivateDraftDocumentPreviews } from './usePrivateDraftDocumentPreviews';
 
 type DraftClient = ReturnType<typeof createProjectInfoDraftClient>;
+
+const PROJECT_INFO_PREVIEW_FIELDS: Array<{
+  documentKind: ProjectRequestDocumentKind;
+  field: keyof ProjectEditorDraft;
+}> = [
+  { documentKind: 'contract', field: 'contractDocument' },
+  { documentKind: 'customer_business_registration', field: 'customerBusinessRegistrationDocument' },
+  { documentKind: 'quote', field: 'quoteDocument' },
+  { documentKind: 'proposal', field: 'proposalDocument' },
+  { documentKind: 'proposal_word_original', field: 'proposalWordOriginalDocument' },
+  { documentKind: 'proposal_ppt_original', field: 'proposalPptOriginalDocument' },
+  { documentKind: 'presentation_ppt_original', field: 'presentationPptOriginalDocument' },
+  { documentKind: 'rfp_request_evidence', field: 'rfpRequestEvidenceDocument' },
+  { documentKind: 'performance_certificate', field: 'performanceCertificateDocument' },
+  { documentKind: 'tax_invoice', field: 'taxInvoiceDocument' },
+  { documentKind: 'final_settlement_report', field: 'finalSettlementReportDocument' },
+];
 
 function resolveExecutiveBanner(project: Project) {
   const status = project.executiveReviewStatus || 'PENDING';
@@ -124,14 +149,27 @@ function attachmentDocument(attachment: ProjectInfoAttachment): FileAttachment {
   };
 }
 
+function latestPrivateAlternativeDocumentKind(attachmentRefs: ProjectInfoAttachment[]) {
+  let latest: 'proposal' | 'rfp_request_evidence' | null = null;
+  for (const attachment of attachmentRefs) {
+    if (attachment.documentKind === 'proposal' || attachment.documentKind === 'rfp_request_evidence') {
+      latest = attachment.documentKind;
+    }
+  }
+  return latest;
+}
+
 function editorDraftFromPrivate(record: ProjectInfoDraft): ProjectEditorDraft {
   const documents: Partial<Record<ProjectRequestDocumentKind, FileAttachment>> = {};
   for (const attachment of record.attachmentRefs) documents[attachment.documentKind] = attachmentDocument(attachment);
+  const latestAlternativeKind = latestPrivateAlternativeDocumentKind(record.attachmentRefs);
   return createProjectEditorDraft({
     ...(record.payload as Partial<ProjectEditorDraft>),
     ...(documents.contract ? { contractDocument: documents.contract } : {}),
     ...(documents.quote ? { quoteDocument: documents.quote } : {}),
-    ...(documents.proposal ? { proposalDocument: documents.proposal } : {}),
+    ...(latestAlternativeKind === 'proposal'
+      ? { proposalDocument: documents.proposal }
+      : latestAlternativeKind === 'rfp_request_evidence' ? { proposalDocument: null } : {}),
     ...(documents.proposal_word_original
       ? { proposalWordOriginalDocument: documents.proposal_word_original }
       : {}),
@@ -141,9 +179,9 @@ function editorDraftFromPrivate(record: ProjectInfoDraft): ProjectEditorDraft {
     ...(documents.presentation_ppt_original
       ? { presentationPptOriginalDocument: documents.presentation_ppt_original }
       : {}),
-    ...(documents.rfp_request_evidence
+    ...(latestAlternativeKind === 'rfp_request_evidence'
       ? { rfpRequestEvidenceDocument: documents.rfp_request_evidence }
-      : {}),
+      : latestAlternativeKind === 'proposal' ? { rfpRequestEvidenceDocument: null } : {}),
     ...(documents.customer_business_registration
       ? { customerBusinessRegistrationDocument: documents.customer_business_registration }
       : {}),
@@ -154,7 +192,29 @@ function editorDraftFromPrivate(record: ProjectInfoDraft): ProjectEditorDraft {
     ...(documents.final_settlement_report
       ? { finalSettlementReportDocument: documents.final_settlement_report }
       : {}),
+    registrationRequirementsVersion: 2,
   });
+}
+
+function previewAttachmentsFromPrivateDraft(record: ProjectInfoDraft | null) {
+  if (!record) return [];
+  const attachments = new Map<ProjectRequestDocumentKind, { documentKind: ProjectRequestDocumentKind; path: string }>();
+  const payload = record.payload as Partial<ProjectEditorDraft>;
+  for (const { documentKind, field } of PROJECT_INFO_PREVIEW_FIELDS) {
+    const document = payload[field] as FileAttachment | null | undefined;
+    const path = String(document?.path || '').trim();
+    if (path) attachments.set(documentKind, { documentKind, path });
+  }
+  for (const attachment of record.attachmentRefs) {
+    if (attachment.path) attachments.set(attachment.documentKind, {
+      documentKind: attachment.documentKind,
+      path: attachment.path,
+    });
+  }
+  const latestAlternativeKind = latestPrivateAlternativeDocumentKind(record.attachmentRefs);
+  if (latestAlternativeKind === 'rfp_request_evidence') attachments.delete('proposal');
+  if (latestAlternativeKind === 'proposal') attachments.delete('rfp_request_evidence');
+  return [...attachments.values()];
 }
 
 function ProjectInfoEditor({
@@ -179,6 +239,7 @@ function ProjectInfoEditor({
   const navigate = useNavigate();
   const { orgId } = useFirebase();
   const [record, setRecord] = useState<ProjectInfoDraft | null>(null);
+  const [submitted, setSubmitted] = useState(false);
   const [busyActionId, setBusyActionId] = useState<string | null>(null);
   const [saveSuccessDialogOpen, setSaveSuccessDialogOpen] = useState(false);
   const [resubmitComment, setResubmitComment] = useState('');
@@ -212,7 +273,27 @@ function ProjectInfoEditor({
     [canonicalDraft, record],
   );
   const autosaveKey = `portal-edit-${orgId}-${project.id}-${actor.uid}`;
-  const editorCanEdit = lease.canEdit && record !== null;
+  const editorCanEdit = lease.canEdit && record !== null && !submitted;
+  const previewAttachments = useMemo(() => previewAttachmentsFromPrivateDraft(record), [record]);
+  const loadDraftDocumentPreview = useCallback(({ documentKind, signal }: {
+    documentKind: ProjectRequestDocumentKind;
+    signal: AbortSignal;
+  }) => downloadProjectInfoDraftAttachmentViaBff({
+    tenantId: orgId,
+    actor,
+    projectId: project.id,
+    documentKind,
+    signal,
+  }), [actor, orgId, project.id]);
+  const {
+    documentPreviewUrls,
+    documentPreviewStates,
+    loadDocumentPreview,
+  } = usePrivateDraftDocumentPreviews({
+    attachments: previewAttachments,
+    enabled: record !== null && !submitted,
+    loadAttachment: loadDraftDocumentPreview,
+  });
   const releaseLeaseAfterDraftOpenFailure = useCallback(async (error: unknown, fallback: string) => {
     recordLoadedRef.current = false;
     setRecord(null);
@@ -294,7 +375,36 @@ function ProjectInfoEditor({
       });
       revisionRef.current = uploaded.draft.draftRevision;
       setRecord(uploaded.draft);
-      return { document: attachmentDocument(uploaded.attachment), contractAnalysis: null };
+      let contractAnalysis = null;
+      if (kind === 'contract') {
+        try {
+          const documentText = await extractTextFromPdf(file);
+          contractAnalysis = await analyzeProjectRequestContractViaBff({
+            tenantId: orgId,
+            actor,
+            fileName: file.name,
+            documentText,
+          });
+        } catch (error) {
+          console.error('[PortalProjectEdit] contract analysis failed:', error);
+          toast.warning('계약서는 저장했지만 자동 분석에 실패했습니다. 입력값을 직접 확인해 주세요.');
+        }
+      }
+      return { document: attachmentDocument(uploaded.attachment), contractAnalysis };
+    })
+  )), [actor, draftClient, enqueueMutation, orgId, record, withOwnership]);
+
+  const removeDocument = useCallback((kind: ProjectRequestDocumentKind) => enqueueMutation(() => (
+    withOwnership(async (ownership) => {
+      if (!record) throw new Error('수정 임시저장이 준비되지 않았습니다.');
+      const hasPrivateAttachment = record.attachmentRefs.some((attachment) => attachment.documentKind === kind);
+      if (!hasPrivateAttachment) return;
+      const removed = await draftClient.removeAttachment(ownership, {
+        expectedDraftRevision: revisionRef.current,
+        documentKind: kind as ProjectInfoDocumentKind,
+      });
+      revisionRef.current = removed.draft.draftRevision;
+      setRecord(removed.draft);
     })
   )), [draftClient, enqueueMutation, record, withOwnership]);
 
@@ -306,15 +416,20 @@ function ProjectInfoEditor({
     }
     setBusyActionId(actionId);
     try {
+      const shouldResubmit = canResubmit || actionId === 'resubmit';
       await enqueueMutation(() => withOwnership((ownership) => draftClient.submit(ownership, {
         expectedDraftRevision: revisionRef.current,
         expectedVersion: Number.isInteger(project.version) && Number(project.version) > 0 ? Number(project.version) : 1,
-        resubmit: actionId === 'resubmit',
-        ...(actionId === 'resubmit' && resubmitComment.trim() ? { reviewComment: resubmitComment.trim() } : {}),
+        resubmit: shouldResubmit,
+        ...(shouldResubmit && resubmitComment.trim() ? { reviewComment: resubmitComment.trim() } : {}),
       })));
       await lease.checkStatus();
-      if (actionId === 'resubmit') setResubmitComment('');
+      if (shouldResubmit) setResubmitComment('');
+      setSubmitted(true);
+      recordLoadedRef.current = false;
+      setRecord(null);
       setSaveSuccessDialogOpen(true);
+      void lease.release();
     } catch (error) {
       toast.error(error instanceof Error ? error.message : '저장에 실패했습니다. 다시 시도해주세요.');
       throw error;
@@ -357,10 +472,12 @@ function ProjectInfoEditor({
       <Textarea
         value={resubmitComment}
         onChange={(event) => setResubmitComment(event.target.value)}
+        maxLength={2000}
         placeholder="보완한 내용을 짧게 남길 수 있습니다."
         className="mt-2 min-h-[88px] border-white/70 bg-white/85 text-sm text-slate-900"
         disabled={!editorCanEdit}
       />
+      <p className="mt-1 text-right text-[10px] text-slate-500">{resubmitComment.length.toLocaleString()}/2,000자</p>
     </div>
   );
 
@@ -420,17 +537,23 @@ function ProjectInfoEditor({
         initialDraft={initialDraft}
         draftKey={autosaveKey}
         members={members}
+        requesterId={actor.uid}
         departmentOptions={departmentOptions}
         topSlot={topSlot}
         readOnly={!editorCanEdit}
-        canRemoveContractDocument={false}
-        canRemoveProjectDocuments={false}
-        autosave={record ? { key: autosaveKey, disabled: !editorCanEdit, onSave: persistDraft } : undefined}
-        actions={[
-          { id: 'save', label: '최종 저장', icon: Save },
-          ...(canResubmit ? [{ id: 'resubmit', label: '수정 후 다시 제출', icon: SendHorizontal, variant: 'secondary' as const }] : []),
-        ]}
+        canRemoveContractDocument={Boolean(record?.attachmentRefs.some((attachment) => attachment.documentKind === 'contract'))}
+        canRemoveProjectDocuments
+        onRemoveProjectDocument={removeDocument}
+        autosave={record && !submitted ? { key: autosaveKey, disabled: !editorCanEdit, onSave: persistDraft } : undefined}
+        actions={submitted ? [] : (
+          canResubmit
+            ? [{ id: 'resubmit', label: '수정 후 다시 제출', icon: SendHorizontal, variant: 'secondary' as const }]
+            : [{ id: 'save', label: '최종 저장', icon: Save }]
+        )}
         busyActionId={busyActionId}
+        documentPreviewUrls={documentPreviewUrls}
+        documentPreviewStates={documentPreviewStates}
+        onLoadDocumentPreview={loadDocumentPreview}
         onContractFileUpload={async (file) => {
           const uploaded = await uploadDocument('contract', file);
           return { contractDocument: uploaded.document, contractAnalysis: uploaded.contractAnalysis };
@@ -454,7 +577,12 @@ function ProjectInfoEditor({
         onReacquire={() => { void startEditing(); }}
         onTakeover={() => { void lease.takeover(); }}
       />
-      <AlertDialog open={saveSuccessDialogOpen} onOpenChange={setSaveSuccessDialogOpen}>
+      <AlertDialog open={saveSuccessDialogOpen}
+        onOpenChange={(open) => {
+          setSaveSuccessDialogOpen(open);
+          if (!open && submitted) navigate('/portal/project-select');
+        }}
+      >
         <AlertDialogContent className="max-w-md border border-slate-200 bg-white">
           <AlertDialogHeader className="items-center text-center">
             <div className="flex h-12 w-12 items-center justify-center rounded-full bg-emerald-50 text-emerald-700">
@@ -462,11 +590,13 @@ function ProjectInfoEditor({
             </div>
             <AlertDialogTitle className="text-xl text-slate-950">프로젝트 수정 요청이 등록되었습니다</AlertDialogTitle>
             <AlertDialogDescription className="text-sm leading-6 text-slate-600">
-              관리자 승인 전까지 프로젝트 원장은 바뀌지 않으며, 승인 대기열에서 최신 수정 요청으로 검토됩니다.
+              {canManagementPlanningResubmit
+                ? '기존 조직장 승인 이력은 유지되며, 보완한 요청은 경영기획실 재검토 화면에 표시됩니다.'
+                : '조직장 승인 전까지 프로젝트 원장은 바뀌지 않으며, 조직장 검토 화면에서 최신 수정 요청으로 확인됩니다.'}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter className="sm:justify-center">
-            <AlertDialogAction onClick={() => setSaveSuccessDialogOpen(false)}>확인</AlertDialogAction>
+            <AlertDialogAction onClick={() => navigate('/portal/project-select')}>프로젝트 목록으로</AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
@@ -480,7 +610,7 @@ export function PortalProjectEdit() {
   const { projectId: routeProjectIdParam } = useParams<{ projectId: string }>();
   const routeProjectId = routeProjectIdParam?.trim() || '';
   const { user } = useAuth();
-  const { db, isOnline, orgId } = useFirebase();
+  const { orgId } = useFirebase();
   const { activeProjectId, isLoading: portalLoading, members, myProject: sessionProject, projects } = usePortalStore();
   const { options: departmentOptions } = useProjectDepartmentSettings();
   const routeProject = routeProjectId ? projects.find((project) => project.id === routeProjectId) || null : null;
@@ -502,35 +632,27 @@ export function PortalProjectEdit() {
   }, [currentPath, navigate, project?.id, routeProjectId]);
 
   useEffect(() => {
-    if (!db || !isOnline || !project?.id) {
+    if (!project?.id || !user?.uid || !isPlatformApiEnabled()) {
       setRequestDoc(null);
       return undefined;
     }
-    const sourceRows = new Map<string, ProjectRequest>();
-    const publish = () => {
-      const latest = Array.from(sourceRows.values())
-        .sort((left, right) => String(right.requestedAt || '').localeCompare(String(left.requestedAt || '')))[0] || null;
-      setRequestDoc(latest);
-    };
-    const unsubscribers = (['project_requests', 'projectRequests'] as const).map((collectionName) => {
-      const requestQuery = query(
-        collection(db, getOrgCollectionPath(orgId, collectionName)),
-        where('approvedProjectId', '==', project.id),
-        orderBy('requestedAt', 'desc'),
-        limit(1),
-      );
-      return onSnapshot(requestQuery, (snapshot) => {
-        const request = snapshot.docs[0]?.data() as ProjectRequest | undefined;
-        if (request) sourceRows.set(collectionName, request);
-        else sourceRows.delete(collectionName);
-        publish();
-      }, () => {
-        sourceRows.delete(collectionName);
-        publish();
-      });
-    });
-    return () => unsubscribers.forEach((unsubscribe) => unsubscribe());
-  }, [db, isOnline, orgId, project?.id]);
+    let disposed = false;
+    void (async () => {
+      try {
+        const idToken = user.idToken || await getAuthInstance()?.currentUser?.getIdToken() || undefined;
+        const request = await fetchLatestProjectRequestViaBff({
+          tenantId: orgId,
+          actor: { uid: user.uid, email: user.email, role: user.role, idToken },
+          projectId: project.id,
+        });
+        if (!disposed) setRequestDoc(request);
+      } catch (cause) {
+        console.error('[PortalProjectEdit] latest project request fetch failed:', cause);
+        if (!disposed) setRequestDoc(null);
+      }
+    })();
+    return () => { disposed = true; };
+  }, [orgId, project?.id, user?.email, user?.idToken, user?.role, user?.uid]);
 
   useEffect(() => {
     if (!user?.uid || !project?.id) {
@@ -582,7 +704,10 @@ export function PortalProjectEdit() {
   const canonicalDraft = useMemo(() => {
     if (!project) return createProjectEditorDraft();
     const pendingChange = requestDoc?.status === 'PENDING' && resolveProjectRequestKind(requestDoc) === 'CHANGE';
-    return buildProjectEditorDraftFromProject(project, pendingChange ? resolveProjectRequestPayload(requestDoc) : undefined);
+    return createProjectEditorDraft({
+      ...buildProjectEditorDraftFromProject(project, pendingChange ? resolveProjectRequestPayload(requestDoc) : undefined),
+      registrationRequirementsVersion: 2,
+    });
   }, [project, requestDoc]);
 
   if (!project && portalLoading) {

--- a/src/app/components/portal/PortalProjectRegister.shell.test.ts
+++ b/src/app/components/portal/PortalProjectRegister.shell.test.ts
@@ -36,6 +36,25 @@ describe('PortalProjectRegister private draft session', () => {
     expect(source).toContain('attachmentDocument(uploaded.attachment)');
   });
 
+  it('analyzes the validated private contract and returns its extracted fields to the editor', () => {
+    expect(source).toContain('extractTextFromPdf(file)');
+    expect(source).toContain('analyzeProjectRequestContractViaBff({');
+    expect(source).toContain("kind === 'contract'");
+    expect(source).toMatch(/return\s*\{\s*document:\s*attachmentDocument\(uploaded\.attachment\),\s*contractAnalysis\s*\}/);
+    expect(source).not.toContain('contractAnalysis: null }');
+  });
+
+  it('loads private attachment blobs through the owner-authorized BFF for review previews', () => {
+    expect(source).toContain('downloadProjectRegistrationDraftAttachmentViaBff');
+    expect(source).toContain('usePrivateDraftDocumentPreviews');
+    expect(source).toContain('enabled: !submitted');
+    expect(source).toContain('signal,');
+    expect(source).toContain('documentPreviewUrls={documentPreviewUrls}');
+    expect(source).toContain('documentPreviewStates={documentPreviewStates}');
+    expect(source).toContain('onLoadDocumentPreview={loadDocumentPreview}');
+    expect(source).not.toContain('Promise.all(attachments');
+  });
+
   it('does not remount the editor for token-only auth refreshes', () => {
     const effect = source.slice(source.indexOf('useEffect(() => {', source.indexOf('export function PortalProjectRegister')));
     expect(effect).toContain('identityKey');
@@ -49,5 +68,15 @@ describe('PortalProjectRegister private draft session', () => {
     expect(source).toContain('const autosave = useMemo(() => ({');
     expect(source).toContain('initialDraft={editorDraft}');
     expect(source).toContain('autosave={autosave}');
+  });
+
+  it('opens legacy private drafts under the current registration-v2 contract', () => {
+    expect(source).toContain('registrationRequirementsVersion: 2');
+    expect(source.indexOf('registrationRequirementsVersion: 2')).toBeGreaterThan(source.indexOf('...(record.payload as Partial<ProjectEditorDraft>)'));
+  });
+
+  it('names the organization-head review destination explicitly', () => {
+    expect(source).toContain('지정 결재자의 조직장 검토 화면');
+    expect(source).not.toContain('관리자 검토 화면');
   });
 });

--- a/src/app/components/portal/PortalProjectRegister.tsx
+++ b/src/app/components/portal/PortalProjectRegister.tsx
@@ -8,7 +8,9 @@ import { usePortalStore } from '../../data/portal-store';
 import type { FileAttachment } from '../../data/types';
 import { getAuthInstance } from '../../lib/firebase';
 import { useFirebase } from '../../lib/firebase-context';
+import { extractTextFromPdf } from '../../lib/pdf-extract';
 import { createEditLeaseClient } from '../../lib/edit-lease-client';
+import { downloadProjectRegistrationDraftAttachmentViaBff } from '../../lib/project-request-attachment-client';
 import {
   createProjectRegistrationDraftClient,
   type ProjectRegistrationAttachment,
@@ -16,7 +18,7 @@ import {
   type ProjectRegistrationFileLike,
   type ProjectRegistrationDocumentKind,
 } from '../../lib/project-registration-draft-client';
-import type { ActorLike } from '../../lib/platform-bff-client';
+import { analyzeProjectRequestContractViaBff, type ActorLike } from '../../lib/platform-bff-client';
 import { openEditSession, type EditSession } from '../../platform/edit-session';
 import {
   buildProjectRequestPayloadFromDraft,
@@ -29,6 +31,7 @@ import { useEditLease } from '../editing/useEditLease';
 import { ProjectEditorWizard } from '../projects/ProjectEditorWizard';
 import { Button } from '../ui/button';
 import { Card, CardContent } from '../ui/card';
+import { usePrivateDraftDocumentPreviews } from './usePrivateDraftDocumentPreviews';
 
 type DraftClient = ReturnType<typeof createProjectRegistrationDraftClient>;
 
@@ -58,6 +61,7 @@ function draftForEditor(record: ProjectRegistrationDraft): ProjectEditorDraft {
     presentationPptOriginalDocument: documents.presentation_ppt_original || null,
     rfpRequestEvidenceDocument: documents.rfp_request_evidence || null,
     customerBusinessRegistrationDocument: documents.customer_business_registration || null,
+    registrationRequirementsVersion: 2,
   });
 }
 
@@ -89,6 +93,25 @@ function RegistrationEditor({
     resourceId: record.draftId,
   }), [actor, orgId, record.draftId, session.sessionId]);
   const lease = useEditLease({ client: leaseClient });
+  const loadDraftDocumentPreview = useCallback(({ documentKind, signal }: {
+    documentKind: ProjectRequestDocumentKind;
+    signal: AbortSignal;
+  }) => downloadProjectRegistrationDraftAttachmentViaBff({
+    tenantId: orgId,
+    actor,
+    draftId: record.draftId,
+    documentKind,
+    signal,
+  }), [actor, orgId, record.draftId]);
+  const {
+    documentPreviewUrls,
+    documentPreviewStates,
+    loadDocumentPreview,
+  } = usePrivateDraftDocumentPreviews({
+    attachments: record.attachmentRefs,
+    enabled: !submitted,
+    loadAttachment: loadDraftDocumentPreview,
+  });
 
   useEffect(() => {
     void lease.checkStatus();
@@ -144,9 +167,48 @@ function RegistrationEditor({
       });
       revisionRef.current = uploaded.draft.draftRevision;
       setRecord(uploaded.draft);
-      return { document: attachmentDocument(uploaded.attachment), contractAnalysis: null };
+      let contractAnalysis = null;
+      if (kind === 'contract') {
+        try {
+          const documentText = await extractTextFromPdf(file);
+          contractAnalysis = await analyzeProjectRequestContractViaBff({
+            tenantId: orgId,
+            actor,
+            fileName: file.name,
+            documentText,
+          });
+        } catch (error) {
+          console.error('[PortalProjectRegister] contract analysis failed:', error);
+          toast.warning('계약서는 저장했지만 자동 분석에 실패했습니다. 입력값을 직접 확인해 주세요.');
+        }
+      }
+      return { document: attachmentDocument(uploaded.attachment), contractAnalysis };
+    })
+  )), [actor, draftClient, enqueueMutation, orgId, record.draftId, withOwnership]);
+
+  const removeDocument = useCallback((kind: ProjectRequestDocumentKind) => enqueueMutation(() => (
+    withOwnership(async (ownership) => {
+      if (![
+        'contract',
+        'customer_business_registration',
+        'quote',
+        'proposal',
+        'proposal_word_original',
+        'proposal_ppt_original',
+        'presentation_ppt_original',
+        'rfp_request_evidence',
+      ].includes(kind)) {
+        throw new Error('신규 등록에서 지원하지 않는 첨부 종류입니다.');
+      }
+      const removed = await draftClient.removeAttachment(record.draftId, ownership, {
+        expectedDraftRevision: revisionRef.current,
+        documentKind: kind as ProjectRegistrationDocumentKind,
+      });
+      revisionRef.current = removed.draft.draftRevision;
+      setRecord(removed.draft);
     })
   )), [draftClient, enqueueMutation, record.draftId, withOwnership]);
+
   const editorDraft = useMemo(() => draftForEditor(record), [record]);
   const autosave = useMemo(() => ({
     key: `portal-register-${record.draftId}`,
@@ -178,7 +240,7 @@ function RegistrationEditor({
             </div>
             <div>
               <h1 className="text-xl font-semibold text-slate-950">프로젝트 등록 요청이 최종 저장되었습니다</h1>
-              <p className="mt-2 text-sm text-slate-600">이제 관리자 검토 화면에 표시됩니다.</p>
+              <p className="mt-2 text-sm text-slate-600">이제 지정 결재자의 조직장 검토 화면에 표시됩니다.</p>
             </div>
             <Button onClick={() => navigate('/portal/project-select')}>프로젝트 선택으로 돌아가기</Button>
           </CardContent>
@@ -215,19 +277,25 @@ function RegistrationEditor({
       <ProjectEditorWizard
         mode="portal-register"
         title="프로젝트 등록"
-        description="임시저장 내용은 본인에게만 보이며, 최종 저장 후 관리자에게 표시됩니다."
+        description="임시저장 내용은 본인에게만 보이며, 최종 저장 후 지정 결재자의 조직장 검토 화면에 표시됩니다."
         embeddedInShell
         initialDraft={editorDraft}
         draftKey={`portal-register-${record.draftId}`}
         members={members}
+        requesterId={actor.uid}
         departmentOptions={departmentOptions}
         topSlot={topSlot}
         readOnly={!lease.canEdit}
         autosave={autosave}
         actions={[{ id: 'submit', label: '최종 저장', icon: Send }]}
         busyActionId={busyActionId}
+        documentPreviewUrls={documentPreviewUrls}
+        documentPreviewStates={documentPreviewStates}
+        onLoadDocumentPreview={loadDocumentPreview}
         onProjectDocumentFileUpload={({ kind, file }) => uploadDocument(kind, file)}
-        canRemoveProjectDocuments={false}
+        canRemoveContractDocument
+        canRemoveProjectDocuments
+        onRemoveProjectDocument={removeDocument}
         onLeave={async () => {
           if (!await lease.release()) throw new Error('edit lease release failed');
         }}

--- a/src/app/components/portal/usePrivateDraftDocumentPreviews.shell.test.ts
+++ b/src/app/components/portal/usePrivateDraftDocumentPreviews.shell.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(new URL('./usePrivateDraftDocumentPreviews.ts', import.meta.url), 'utf8');
+
+describe('private draft document preview lifecycle', () => {
+  it('loads only the contract eagerly and keeps all other documents user-triggered', () => {
+    expect(source).toContain("if (nextAttachments.has('contract')) void loadDocumentPreview('contract')");
+    expect(source).not.toContain('Promise.all');
+  });
+
+  it('caches each exact attachment and updates preview URLs incrementally', () => {
+    expect(source).toContain('`${attachment.documentKind}\\u0000${attachment.path}`');
+    expect(source).toContain('cacheRef.current.get(key)');
+    expect(source).toContain('setDocumentPreviewUrls((current) => ({ ...current, [documentKind]: url }))');
+  });
+
+  it('aborts downloads and revokes object URLs when attachments are replaced or previews are disabled', () => {
+    expect(source).toContain('new AbortController()');
+    expect(source).toContain('controller.abort()');
+    expect(source).toContain('URL.revokeObjectURL(url)');
+    expect(source).toContain('if (!enabled)');
+    expect(source).toContain('releaseAll(true)');
+    expect(source).toContain('releaseAll(false)');
+  });
+});

--- a/src/app/components/portal/usePrivateDraftDocumentPreviews.ts
+++ b/src/app/components/portal/usePrivateDraftDocumentPreviews.ts
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ProjectRequestDocumentKind } from '../../platform/project-contract-upload';
+
+export type PrivateDraftDocumentPreviewState = {
+  status: 'idle' | 'loading' | 'ready' | 'error';
+  error?: string;
+};
+
+type PrivateDraftAttachmentRef = {
+  documentKind: ProjectRequestDocumentKind;
+  path: string;
+};
+
+type LoadPrivateDraftAttachment = (input: {
+  documentKind: ProjectRequestDocumentKind;
+  signal: AbortSignal;
+}) => Promise<{ blob: Blob }>;
+
+function attachmentCacheKey(attachment: PrivateDraftAttachmentRef) {
+  return `${attachment.documentKind}\u0000${attachment.path}`;
+}
+
+export function usePrivateDraftDocumentPreviews({
+  attachments,
+  enabled = true,
+  loadAttachment,
+}: {
+  attachments: PrivateDraftAttachmentRef[];
+  enabled?: boolean;
+  loadAttachment: LoadPrivateDraftAttachment;
+}) {
+  const [documentPreviewUrls, setDocumentPreviewUrls] = useState<Partial<Record<ProjectRequestDocumentKind, string>>>({});
+  const [documentPreviewStates, setDocumentPreviewStates] = useState<Partial<Record<ProjectRequestDocumentKind, PrivateDraftDocumentPreviewState>>>({});
+  const attachmentKey = useMemo(() => JSON.stringify(attachments.map(({ documentKind, path }) => ({ documentKind, path }))), [attachments]);
+  const currentAttachmentsRef = useRef(new Map<ProjectRequestDocumentKind, PrivateDraftAttachmentRef>());
+  const cacheRef = useRef(new Map<string, string>());
+  const controllersRef = useRef(new Map<string, AbortController>());
+  const stateKeysRef = useRef(new Map<ProjectRequestDocumentKind, string>());
+  const statesRef = useRef(new Map<ProjectRequestDocumentKind, PrivateDraftDocumentPreviewState>());
+  const loadAttachmentRef = useRef(loadAttachment);
+  const enabledRef = useRef(enabled);
+  const mountedRef = useRef(true);
+
+  loadAttachmentRef.current = loadAttachment;
+  enabledRef.current = enabled;
+
+  const releaseAll = useCallback((publish: boolean) => {
+    controllersRef.current.forEach((controller) => controller.abort());
+    controllersRef.current.clear();
+    cacheRef.current.forEach((url) => URL.revokeObjectURL(url));
+    cacheRef.current.clear();
+    stateKeysRef.current.clear();
+    statesRef.current.clear();
+    if (publish) {
+      setDocumentPreviewUrls({});
+      setDocumentPreviewStates({});
+    }
+  }, []);
+
+  const loadDocumentPreview = useCallback(async (documentKind: ProjectRequestDocumentKind) => {
+    const attachment = currentAttachmentsRef.current.get(documentKind);
+    if (!attachment || !enabledRef.current || !mountedRef.current) return;
+
+    const key = attachmentCacheKey(attachment);
+    const cachedUrl = cacheRef.current.get(key);
+    if (cachedUrl) {
+      statesRef.current.set(documentKind, { status: 'ready' });
+      setDocumentPreviewUrls((current) => ({ ...current, [documentKind]: cachedUrl }));
+      setDocumentPreviewStates((current) => ({ ...current, [documentKind]: { status: 'ready' } }));
+      return;
+    }
+    if (controllersRef.current.has(key)) return;
+
+    const controller = new AbortController();
+    controllersRef.current.set(key, controller);
+    stateKeysRef.current.set(documentKind, key);
+    statesRef.current.set(documentKind, { status: 'loading' });
+    setDocumentPreviewStates((current) => ({ ...current, [documentKind]: { status: 'loading' } }));
+
+    try {
+      const { blob } = await loadAttachmentRef.current({ documentKind, signal: controller.signal });
+      if (controller.signal.aborted || !enabledRef.current || !mountedRef.current) return;
+      const currentAttachment = currentAttachmentsRef.current.get(documentKind);
+      if (!currentAttachment || attachmentCacheKey(currentAttachment) !== key) return;
+
+      const url = URL.createObjectURL(blob);
+      cacheRef.current.set(key, url);
+      statesRef.current.set(documentKind, { status: 'ready' });
+      setDocumentPreviewUrls((current) => ({ ...current, [documentKind]: url }));
+      setDocumentPreviewStates((current) => ({ ...current, [documentKind]: { status: 'ready' } }));
+    } catch (error) {
+      if (controller.signal.aborted || !mountedRef.current) return;
+      const previewState = {
+        status: 'error' as const,
+        error: error instanceof Error ? error.message : '첨부 파일을 불러오지 못했습니다.',
+      };
+      statesRef.current.set(documentKind, previewState);
+      setDocumentPreviewStates((current) => ({
+        ...current,
+        [documentKind]: previewState,
+      }));
+    } finally {
+      if (controllersRef.current.get(key) === controller) controllersRef.current.delete(key);
+    }
+  }, []);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      releaseAll(false);
+    };
+  }, [releaseAll]);
+
+  useEffect(() => {
+    const nextAttachments = new Map<ProjectRequestDocumentKind, PrivateDraftAttachmentRef>();
+    for (const attachment of JSON.parse(attachmentKey) as PrivateDraftAttachmentRef[]) {
+      nextAttachments.set(attachment.documentKind, attachment);
+    }
+    currentAttachmentsRef.current = nextAttachments;
+
+    if (!enabled) {
+      releaseAll(true);
+      return;
+    }
+
+    const activeKeys = new Set(Array.from(nextAttachments.values(), attachmentCacheKey));
+    for (const [key, controller] of controllersRef.current) {
+      if (!activeKeys.has(key)) {
+        controller.abort();
+        controllersRef.current.delete(key);
+      }
+    }
+    for (const [key, url] of cacheRef.current) {
+      if (!activeKeys.has(key)) {
+        URL.revokeObjectURL(url);
+        cacheRef.current.delete(key);
+      }
+    }
+
+    const nextUrls: Partial<Record<ProjectRequestDocumentKind, string>> = {};
+    const nextStates: Partial<Record<ProjectRequestDocumentKind, PrivateDraftDocumentPreviewState>> = {};
+    const nextStateMap = new Map<ProjectRequestDocumentKind, PrivateDraftDocumentPreviewState>();
+    for (const [documentKind, attachment] of nextAttachments) {
+      const key = attachmentCacheKey(attachment);
+      const cachedUrl = cacheRef.current.get(key);
+      if (cachedUrl) {
+        nextUrls[documentKind] = cachedUrl;
+        nextStates[documentKind] = { status: 'ready' };
+      } else if (controllersRef.current.has(key)) {
+        nextStates[documentKind] = { status: 'loading' };
+      } else if (stateKeysRef.current.get(documentKind) === key) {
+        nextStates[documentKind] = statesRef.current.get(documentKind) || { status: 'idle' };
+      } else {
+        stateKeysRef.current.set(documentKind, key);
+        nextStates[documentKind] = { status: 'idle' };
+      }
+      nextStateMap.set(documentKind, nextStates[documentKind]!);
+    }
+    statesRef.current = nextStateMap;
+    setDocumentPreviewUrls(nextUrls);
+    setDocumentPreviewStates(nextStates);
+    if (nextAttachments.has('contract')) void loadDocumentPreview('contract');
+  }, [attachmentKey, enabled, loadDocumentPreview, releaseAll]);
+
+  const visibleDocumentPreviewUrls = useMemo(() => {
+    if (!enabled) return {};
+    const visible: Partial<Record<ProjectRequestDocumentKind, string>> = {};
+    for (const attachment of JSON.parse(attachmentKey) as PrivateDraftAttachmentRef[]) {
+      const key = attachmentCacheKey(attachment);
+      const cachedUrl = cacheRef.current.get(key);
+      if (cachedUrl && cachedUrl === documentPreviewUrls[attachment.documentKind]) {
+        visible[attachment.documentKind] = cachedUrl;
+      }
+    }
+    return visible;
+  }, [attachmentKey, documentPreviewUrls, enabled]);
+  const visibleDocumentPreviewStates = useMemo(() => {
+    if (!enabled) return {};
+    const visible: Partial<Record<ProjectRequestDocumentKind, PrivateDraftDocumentPreviewState>> = {};
+    for (const attachment of JSON.parse(attachmentKey) as PrivateDraftAttachmentRef[]) {
+      const state = documentPreviewStates[attachment.documentKind];
+      if (stateKeysRef.current.get(attachment.documentKind) === attachmentCacheKey(attachment) && state) {
+        visible[attachment.documentKind] = state;
+      }
+    }
+    return visible;
+  }, [attachmentKey, documentPreviewStates, enabled]);
+
+  return {
+    documentPreviewUrls: visibleDocumentPreviewUrls,
+    documentPreviewStates: visibleDocumentPreviewStates,
+    loadDocumentPreview,
+  };
+}

--- a/src/app/components/projects/ContractDocumentPreview.tsx
+++ b/src/app/components/projects/ContractDocumentPreview.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, FileText } from 'lucide-react';
+import { ExternalLink, FileText, Loader2 } from 'lucide-react';
 import type { FileAttachment } from '../../data/types';
 import { Button } from '../ui/button';
 
@@ -11,6 +11,11 @@ interface ContractDocumentPreviewProps {
   descriptionClassName?: string;
   className?: string;
   privateDraftAttachment?: boolean;
+  previewState?: {
+    status: 'idle' | 'loading' | 'ready' | 'error';
+    error?: string;
+  };
+  onLoadPreview?: () => void | Promise<void>;
 }
 
 function isPdfDocument(document: ContractDocumentPreviewAttachment) {
@@ -26,9 +31,12 @@ export function ContractDocumentPreview({
   descriptionClassName = 'text-slate-600',
   className = '',
   privateDraftAttachment = false,
+  previewState,
+  onLoadPreview,
 }: ContractDocumentPreviewProps) {
   const downloadURL = String(document?.downloadURL || '').trim();
   const canPreviewPdf = !!document && !!downloadURL && isPdfDocument(document);
+  const canLoadPrivatePreview = !!document && !downloadURL && privateDraftAttachment && !!onLoadPreview;
 
   return (
     <div className={`overflow-hidden rounded-3xl border border-slate-200 bg-white ${className}`} data-testid="contract-document-preview">
@@ -64,25 +72,47 @@ export function ContractDocumentPreview({
         />
       ) : (
         <div className="flex min-h-[220px] items-center justify-center bg-slate-50 px-5 py-8 text-center">
-          <div>
+          <div aria-live="polite">
             <p className="text-[13px] font-semibold text-slate-800">
               {downloadURL
                 ? '이 파일 형식은 화면 미리보기를 지원하지 않습니다.'
-                : document && privateDraftAttachment
-                  ? '첨부 파일이 안전하게 임시저장되었습니다.'
-                  : document
-                    ? '첨부 파일 원문을 불러올 수 없습니다.'
-                  : '첨부된 계약서 파일이 없습니다.'}
+                : canLoadPrivatePreview && previewState?.status === 'loading'
+                  ? '첨부 파일 원문을 안전하게 불러오는 중입니다.'
+                  : canLoadPrivatePreview && previewState?.status === 'error'
+                    ? '첨부 파일 원문을 불러오지 못했습니다.'
+                    : canLoadPrivatePreview
+                      ? '원문을 불러와 검토할 수 있습니다.'
+                      : document && privateDraftAttachment
+                        ? '첨부 파일이 안전하게 임시저장되었습니다.'
+                        : document
+                          ? '첨부 파일 원문을 불러올 수 없습니다.'
+                          : '첨부된 계약서 파일이 없습니다.'}
             </p>
             <p className="mt-2 text-[12px] text-slate-500">
               {downloadURL
                 ? '새 탭에서 원문 파일을 확인해 주세요.'
-                : document && privateDraftAttachment
-                  ? '최종 저장 후 권한이 있는 사용자만 원문을 열 수 있습니다.'
-                  : document
-                    ? '파일 권한 또는 원문 링크 상태를 확인해 주세요.'
-                  : '계약서가 첨부되면 이 영역에 PDF 원문이 표시됩니다.'}
+                : canLoadPrivatePreview && previewState?.status === 'error'
+                  ? (previewState.error || '잠시 후 다시 시도해 주세요.')
+                  : canLoadPrivatePreview
+                    ? '검토할 때만 다운로드하며, 불러온 원문은 이 화면을 벗어나면 정리됩니다.'
+                    : document && privateDraftAttachment
+                      ? '최종 저장 후 권한이 있는 사용자만 원문을 열 수 있습니다.'
+                      : document
+                        ? '파일 권한 또는 원문 링크 상태를 확인해 주세요.'
+                        : '계약서가 첨부되면 이 영역에 PDF 원문이 표시됩니다.'}
             </p>
+            {canLoadPrivatePreview ? (
+              <Button
+                type="button"
+                variant="outline"
+                className="mt-4 h-9 gap-1.5 px-4 text-[12px]"
+                disabled={previewState?.status === 'loading'}
+                onClick={() => void onLoadPreview?.()}
+              >
+                {previewState?.status === 'loading' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+                {previewState?.status === 'error' ? '원문 다시 불러오기' : previewState?.status === 'loading' ? '불러오는 중' : '원문 불러오기'}
+              </Button>
+            ) : null}
           </div>
         </div>
       )}

--- a/src/app/components/projects/ProjectDetailPage.shell.test.ts
+++ b/src/app/components/projects/ProjectDetailPage.shell.test.ts
@@ -7,6 +7,7 @@ const source = readFileSync(resolve(import.meta.dirname, 'ProjectDetailPage.tsx'
 describe('ProjectDetailPage shell contract', () => {
   it('shows a pending PM change request without replacing the approved project master values', () => {
     expect(source).toContain('usePendingProjectChangeRequests');
+    expect(source).toContain('usePendingProjectChangeRequests(pendingProjectIds)');
     expect(source).toContain('pendingProjectChangeRequest');
     expect(source).toContain('수정 중');
     expect(source).toContain('describeProjectRequestVersion');

--- a/src/app/components/projects/ProjectDetailPage.tsx
+++ b/src/app/components/projects/ProjectDetailPage.tsx
@@ -90,7 +90,8 @@ export function ProjectDetailPage() {
 
   const project = getProjectById(projectId || '');
   const projectLedgers = getProjectLedgers(projectId || '');
-  const pendingProjectChangeMap = usePendingProjectChangeRequests();
+  const pendingProjectIds = useMemo(() => project?.id ? [project.id] : [], [project?.id]);
+  const pendingProjectChangeMap = usePendingProjectChangeRequests(pendingProjectIds);
   const pendingProjectChangeRequest = project ? pendingProjectChangeMap.get(project.id) || null : null;
 
   const revenueFinancials = project ? normalizeProjectRevenueFields(project, 'totalRevenueAmount') : null;

--- a/src/app/components/projects/ProjectEditorWizard.shell.test.ts
+++ b/src/app/components/projects/ProjectEditorWizard.shell.test.ts
@@ -8,6 +8,12 @@ const portalRegisterSource = readFileSync(resolve(import.meta.dirname, '../porta
 const contractDocumentPolicySource = readFileSync(resolve(import.meta.dirname, '../../platform/project-contract-document-policy.ts'), 'utf8');
 
 describe('ProjectEditorWizard dropdown contract', () => {
+  it('lets the portal shell own the page title without rendering a duplicate editor header', () => {
+    expect(source.match(/>\{title\}<\/h1>/g)).toHaveLength(1);
+    expect(source).toContain('{embeddedInShell ? (');
+    expect(source).toContain('<div className="flex justify-end">');
+  });
+
   it('renders editor dropdowns from canonical option maps instead of surface-local labels', () => {
     expect(source).toContain('getProjectTypeSelectableOptions');
     expect(source).toContain('PROJECT_TYPE_LABELS[type]');
@@ -45,13 +51,21 @@ describe('ProjectEditorWizard dropdown contract', () => {
   it('lets project registration and edit choose a designated executive approver from the member directory', () => {
     expect(source).toContain('지정 결재자 *');
     expect(source).toContain('const selectedExecutiveApprover = useMemo');
-    expect(source).toContain('if (!draft.executiveApproverId || !selectedExecutiveApprover)');
+    expect(source).toContain('const executiveApproverOptions = useMemo');
+    expect(source).toContain('requesterId?: string');
+    expect(source).toContain('member.uid !== draft.registeredById && member.uid !== requesterId');
+    expect(portalRegisterSource).toContain('requesterId={actor.uid}');
+    expect(source).toContain('requesterId, ownerOptions');
+    expect(source).toContain('const isSelfExecutiveApprover = Boolean(');
+    expect(source).toContain('사업 담당자와 지정 결재자는 달라야 합니다.');
   });
 
   it('uses a searchable team member picker for registration and edit flows', () => {
     expect(source).toContain('function TeamMemberSearchCombobox');
     expect(source).toContain('<CommandInput placeholder="이름/닉네임으로 검색" />');
-    expect(source).toContain('PROJECT_TEAM_MEMBER_OPTIONS.length}명 중 검색');
+    expect(source).toContain('buildProjectTeamMemberOptions(members)');
+    expect(source).toContain('options.length}명 중 검색');
+    expect(source).toContain('options={availableTeamMemberOptions}');
     expect(source).toContain('<TeamMemberSearchCombobox');
     expect(source).toContain("aria-label={selectedLabel ? `팀원 선택: ${selectedLabel}` : '팀원 검색'}");
     expect(source).toContain('selectedNames={selectedNames}');
@@ -68,7 +82,7 @@ describe('ProjectEditorWizard dropdown contract', () => {
   });
 
   it('uses project operations terminology and exposes currency selection', () => {
-    expect(source).toContain('서류상 참여인력');
+    expect(source).toContain('참여인력 (서류상·실제)');
     expect(source).toContain("{ id: 'team', label: '팀/인력', icon: Users }");
     expect(source).not.toContain('<Label className="text-xs">팀원 구성</Label>');
     expect(source).toContain('<Label className="text-xs">통화</Label>');
@@ -133,6 +147,41 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain('formatProjectAmountInput(draft.paymentPlan.final, true)');
   });
 
+  it('shows annual profit rates as derived values and keys v2 settlement details to the basis', () => {
+    expect(source).toContain('연도별 계약금액과 총수익으로 자동 계산');
+    expect(source).toContain('value={`${(row.profitRate * 100).toFixed(2)}%`}');
+    expect(source).not.toContain("updateFinancialYear(\n                      index,\n                      'profitRate'");
+    expect(source).toContain("const settlementDetailsEnabled = usesRegistrationV2 ? draft.basis !== 'NONE' : draft.settlementType !== 'NONE'");
+    expect(source).toContain("requiresSettlementConfirmations ? (");
+    expect(source).toContain('정산 기준이 정산없음이면 통장·정산 시스템 입력이 필요하지 않습니다.');
+  });
+
+  it('renders the PPT v2 business-type and settlement-basis options without removed values', () => {
+    expect(source).toContain("usesRegistrationV2 ? '사업유형' : '정산 유형'");
+    expect(source).toContain("usesRegistrationV2 && draft.settlementType === 'NONE' ? undefined : draft.settlementType");
+    expect(source).toContain(".filter(([key]) => !usesRegistrationV2 || key !== 'NONE')");
+    expect(source).toContain(".filter(([key]) => usesRegistrationV2 ? key !== '기타' : key !== 'NONE')");
+    expect(source).toContain("if (draft.settlementType === 'NONE') issues.push({ step: 'financial', label: '사업유형' })");
+    expect(source).toContain("value={REGISTRATION_V2_BASIS_LABELS[draft.basis as Exclude<Basis, '기타'>]}");
+  });
+
+  it('balances the desktop review grid without changing the DOM reading order', () => {
+    expect(source).not.toContain('className="contents lg:block lg:space-y-4"');
+    expect(source).toContain('<Card className="shadow-none lg:col-start-1 lg:row-start-1 lg:self-start">');
+    expect(source).toContain('<Card className="shadow-none lg:col-start-2 lg:row-span-3 lg:row-start-1 lg:self-start">');
+    expect(source).toContain('<Card className="shadow-none lg:col-start-1 lg:row-start-2 lg:self-start">');
+    expect(source).toContain('<Card className="shadow-none lg:col-start-1 lg:row-start-3 lg:self-start">');
+
+    const basicIndex = source.indexOf('>기본 정보</CardTitle>');
+    const financialIndex = source.indexOf('>계약/재무</CardTitle>');
+    const teamIndex = source.indexOf('>팀/인력</CardTitle>');
+    const paymentIndex = source.indexOf('>입금/정산</CardTitle>');
+    expect(basicIndex).toBeGreaterThan(-1);
+    expect(basicIndex).toBeLessThan(financialIndex);
+    expect(financialIndex).toBeLessThan(teamIndex);
+    expect(teamIndex).toBeLessThan(paymentIndex);
+  });
+
   it('keeps portal edit drafts stable when async listener data refreshes', () => {
     expect(source).toContain('const lastResetKeyRef = useRef<string | null>(null)');
     expect(source).toContain("const resetKey = `${draftKey}::${autosave?.key || ''}`");
@@ -142,12 +191,23 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).not.toContain('lastInitialDraftFingerprintRef');
   });
 
+  it('upgrades restored portal autosaves to the registration-v2 contract', () => {
+    expect(source).toContain('function normalizeRestoredProjectEditorDraft');
+    expect(source).toContain("mode === 'portal-register' || mode === 'portal-edit'");
+    expect(source).toContain('registrationRequirementsVersion: 2');
+    expect(source).toContain('normalizeRestoredProjectEditorDraft(restoreCandidate.draft, mode)');
+  });
+
   it('uses the project name as the single PPT registration name', () => {
     expect(source).toContain('프로젝트명 *');
     expect(source).not.toContain('그룹웨어 등록명');
     expect(source).toContain('계약서에 기재된 계약명 그대로 입력');
     expect(source).toContain('띄어쓰기를 포함해 계약서 표기와 동일하게 입력해 주세요.');
     expect(source).toContain('예: 26농식품AC');
+    expect(source).not.toContain('maxLength=');
+    expect(source).not.toContain('프로젝트명 10자 이하');
+    expect(source).not.toContain('/10자');
+    expect(source).not.toContain("event.target.value.slice(0, mode === 'portal-register' ? 10 : 80)");
     expect(source).toContain('계약연도+프로젝트명 형식으로 입력해 주세요.');
     expect(source).toContain('재경팀이 부여하는 프로젝트 코드는 직접 입력하지 않습니다.');
     expect(source).toContain('다년도 사업은 같은 프로젝트명을 사용해 주세요.');
@@ -162,10 +222,31 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).not.toContain('const updateProjectName = (value: string)');
   });
 
+  it('uses the PPT financial total labels in both entry and review surfaces', () => {
+    expect(source).toContain('총매출부가세');
+    expect(source).toContain('총지원금');
+    expect(source).toContain('총수익률');
+    expect(source).not.toContain('label="매출 부가세"');
+    expect(source).not.toContain('label="지원금"');
+    expect(source).not.toContain('label="수익률"');
+  });
+
+  it('keeps the PPT five-step navigation horizontal on desktop and stacked on mobile', () => {
+    expect(source).toContain('lg:grid-cols-5');
+    expect(source).toContain('grid gap-1.5 lg:grid-cols-5');
+    expect(source).not.toContain('lg:grid-cols-[220px_minmax(0,1fr)]');
+  });
+
   it('warns users to verify the uploaded contract before saving', () => {
     expect(source).toContain('등록하려는 계약서가 맞는지 꼭 확인해주세요!');
     expect(source).toContain('descriptionClassName="text-rose-600"');
     expect(source).not.toContain('업로드된 PDF를 마지막 확인 단계에서 바로 봅니다.');
+    expect(source).toContain('documentPreviewUrls?: Partial<Record<ProjectRequestDocumentKind, string>>');
+    expect(source).toContain('documentPreviewStates?: Partial<Record<ProjectRequestDocumentKind');
+    expect(source).toContain('onLoadDocumentPreview?: (kind: ProjectRequestDocumentKind)');
+    expect(source).toContain('documentPreviewUrls?.[kind] || document.downloadURL');
+    expect(source).toContain('원문 불러오기');
+    expect(source).toContain('원문 다시 불러오기');
   });
 
   it('supports contract PDF upload before saving registration or edit drafts', () => {
@@ -196,14 +277,41 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain("'customer_business_registration'");
     expect(source).toContain("'proposal'");
     expect(source).toContain("'rfp_request_evidence'");
-    expect(source).toContain('제안서 PDF *');
-    expect(source).toContain('RFP 또는 요청 메일 증빙 (제안서가 없는 경우) *');
+    expect(source).toContain("'proposal_word_original'");
+    expect(source).toContain("'proposal_ppt_original'");
+    expect(source).toContain("'presentation_ppt_original'");
+    expect(source).toContain('등록 제출서류 7종');
+    expect(source).toContain('stacked');
+    expect(source).toContain("className=\"grid gap-1.5 text-left\"");
+    expect(source).toContain('4번은 제안서 PDF 또는 RFP/요청 메일 증빙 중 하나만 제출하면 됩니다.');
+    expect(source).toContain('제안서 PDF 또는 RFP/요청 메일 증빙 *');
     expect(source).toContain("if (!draft.proposalDocument && !draft.rfpRequestEvidenceDocument)");
-    expect(source).toContain('등록 필수 첨부');
-    expect(source).not.toContain('등록 첨부 7종');
-    expect(source).not.toContain("if (draft.settlementType === 'NONE') issues.push");
-    expect(source).not.toContain("if (draft.basis === 'NONE') issues.push");
-    expect(source).toContain('발주처 사업자등록증 PDF');
+    expect(source).toContain('if (draft.proposalDocument && draft.rfpRequestEvidenceDocument)');
+    expect(source).toContain('제안서와 RFP/요청 메일 중 하나만 남겨주세요.');
+    expect(source).toContain('등록 제출서류');
+    expect(source).toContain("if (draft.settlementType === 'NONE') issues.push({ step: 'financial', label: '사업유형' })");
+    expect(source).toContain('고객사 사업자등록증 PDF');
+    expect(source).toContain('원본 파일 또는 미첨부 사유');
+    expect(source).toContain('계약 종료일은 시작일 이후여야 합니다.');
+    expect(source).toContain('인건비 투입 종료월은 시작월 이후여야 합니다.');
+    expect(source).toContain('실제 투입 운영 매니저 1인 이상');
+    expect(source).toContain("const requiresSettlementConfirmations = usesRegistrationV2 ? draft.basis !== 'NONE' : draft.settlementType !== 'NONE'");
+    expect(source).toContain('정산 기준이 정산없음인 사업은 인건비·고객사 정산 확인을 입력하지 않습니다.');
+    expect(source).toContain('md:grid-cols-2 xl:grid-cols-4');
+    expect(source).not.toContain('xl:grid-cols-[132px_minmax(0,1.4fr)_minmax(0,1fr)_110px_120px_140px_140px]');
+    expect(source).toContain('alternativeDocumentAttached');
+    expect(source).toContain("rfpRequestEvidenceDocument: kind === 'proposal' ? null : prev.rfpRequestEvidenceDocument");
+    expect(source).toContain("proposalDocument: kind === 'rfp_request_evidence' ? null : prev.proposalDocument");
+    expect(source).toContain('업로드하면 기존 대체서류를 교체합니다.');
+    expect(source).not.toContain('disabled: alternativeDocumentAttached');
+    expect(source).toContain('제안서: ${draft.proposalDocument.name}');
+    expect(source).toContain('RFP/요청 메일: ${draft.rfpRequestEvidenceDocument.name}');
+    expect(source).toContain('특이사항 (메모란)');
+    expect(source).not.toContain('lg:sticky lg:bottom-4');
+    expect(source).not.toContain('발주처');
+    expect(source).toMatch(/number: 5,\s+label: '제안서 Word 원본'/);
+    expect(source).toMatch(/number: 6,\s+label: '제안서 PPT 원본'/);
+    expect(source).toMatch(/number: 7,\s+label: '발표자료 PPT 원본'/);
     expect(source).toContain('연도별 계약·재무 *');
     expect(source).toContain('계약기간 전체 연도별 재무 확인');
     expect(source).toContain('4대보험 포함 확인');
@@ -237,6 +345,7 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain('const registrationDocumentKinds = onProjectDocumentFileUpload');
     expect(source).toContain("REGISTRATION_DOCUMENT_KINDS.filter((kind) => kind === 'contract')");
     expect(source).toContain('const checkoutDocumentKinds = onProjectDocumentFileUpload ? CHECKOUT_DOCUMENT_KINDS : []');
+    expect(source).toContain('if (onProjectDocumentFileUpload) {');
     expect(source).toContain('registrationDocumentKinds.map((kind) => renderProjectDocumentUpload(kind))');
     expect(source).toContain('checkoutDocumentKinds.map((kind) => renderProjectDocumentUpload(kind))');
   });
@@ -245,9 +354,9 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain('readOnly?: boolean');
     expect(source).toContain('<fieldset disabled={readOnly} className="contents">');
     expect(source).toContain('disabled={readOnly || autosaveState');
-    expect(source).toContain("disabled={readOnly || autosaveState === 'saving' || !!busyActionId");
+    expect(source).toContain("disabled={readOnly || autosaveState === 'saving' || uploadInProgress || hasPendingRetryFile || !!busyActionId");
     expect(source).toContain('shouldResetProjectEditorDraft({');
-    expect(source).toContain('autosave?.onSave, draftKey, readOnly');
+    expect(source).toContain('autosave?.onSave, draftKey, hasPendingRetryFile, readOnly, uploadInProgress');
   });
 
   it('keeps failed attachment files retryable and clears the input only after success', () => {
@@ -272,11 +381,23 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source.indexOf('persistAutosaveSnapshot(draft, stepIndex)')).toBeLessThan(source.indexOf('await onSubmit(createProjectEditorDraft(draft), actionId)'));
   });
 
-  it('does not offer a local-only attachment removal in private registration drafts', () => {
+  it('never saves or submits a stale snapshot while an attachment mutation is in flight', () => {
+    expect(source).toContain('if (uploadInProgress || hasPendingRetryFile) return false;');
+    expect(source).toContain("toast.error('첨부파일 처리를 완료한 뒤 임시저장해 주세요.')");
+    expect(source).toContain("toast.error('첨부파일 처리를 완료한 뒤 최종 저장해 주세요.')");
+    expect(source).toContain("disabled={readOnly || autosaveState === 'saving' || uploadInProgress || hasPendingRetryFile}");
+    expect(source).toContain("disabled={readOnly || autosaveState === 'saving' || uploadInProgress || hasPendingRetryFile || !!busyActionId || action.disabled || !canSubmit}");
+  });
+
+  it('removes private registration attachments through the owner-authorized draft API before clearing local state', () => {
     expect(source).toContain('canRemoveProjectDocuments?: boolean');
+    expect(source).toContain('onRemoveProjectDocument?: (kind: ProjectRequestDocumentKind) => void | Promise<void>;');
     expect(source).toContain('const canRemove = canRemoveProjectDocuments &&');
-    expect(portalRegisterSource).toContain('canRemoveProjectDocuments={false}');
-    expect(source).toContain("privateDraftAttachment={mode === 'portal-register'");
+    expect(source).toContain('await onRemoveProjectDocument?.(kind)');
+    expect(portalRegisterSource).toContain('canRemoveProjectDocuments');
+    expect(portalRegisterSource).toContain('onRemoveProjectDocument={removeDocument}');
+    expect(portalRegisterSource).toContain('draftClient.removeAttachment(record.draftId, ownership');
+    expect(source).toContain('privateDraftAttachment={Boolean(documentPreviewStates?.contract)');
   });
 });
 

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -974,6 +974,11 @@ export function ProjectEditorWizard({
   const hasTotalRevenueAmountInput = financialInputFlags.totalRevenueAmount;
   const hasSupportAmountInput = financialInputFlags.supportAmount;
   const usesRegistrationV2 = draft.registrationRequirementsVersion === 2;
+  const hasMultiYearContract = Boolean(
+    /^\d{4}-\d{2}-\d{2}$/.test(draft.contractStart)
+    && /^\d{4}-\d{2}-\d{2}$/.test(draft.contractEnd)
+    && draft.contractStart.slice(0, 4) !== draft.contractEnd.slice(0, 4),
+  );
   const settlementDetailsEnabled = usesRegistrationV2 ? draft.basis !== 'NONE' : draft.settlementType !== 'NONE';
   const requiresSettlementConfirmations = usesRegistrationV2 ? draft.basis !== 'NONE' : draft.settlementType !== 'NONE';
   const showProjectCheckout = draft.status === 'COMPLETED' || draft.status === 'COMPLETED_PENDING_PAYMENT';
@@ -1316,7 +1321,9 @@ export function ProjectEditorWizard({
         && annualTotal('salesVatAmount') === draft.salesVatAmount
         && annualTotal('totalRevenueAmount') === draft.totalRevenueAmount
         && annualTotal('supportAmount') === draft.supportAmount;
-      if (!financialYearsComplete || !annualTotalsMatch) issues.push({ step: 'financial', label: '계약기간 전체 연도별 재무 확인' });
+      if (hasMultiYearContract && (!financialYearsComplete || !annualTotalsMatch)) {
+        issues.push({ step: 'financial', label: '계약기간 전체 연도별 재무 확인' });
+      }
       if (draft.settlementType === 'NONE') issues.push({ step: 'financial', label: '사업유형' });
       if (requiresSettlementConfirmations) {
         if (draft.registrationConfirmations.laborIncludesFourInsurance !== true) issues.push({ step: 'payment', label: '4대보험 포함 확인' });
@@ -1374,7 +1381,7 @@ export function ProjectEditorWizard({
       issues.push({ step: 'team', label: '인건비 투입 종료월은 시작월 이후여야 합니다.' });
     }
     return issues;
-  }, [departmentOptionSet, draft, hasContractAmountInput, onProjectDocumentFileUpload, requiresAdvanceInterimReason, requiresSettlementConfirmations, selectedExecutiveApprover, showProjectCheckout, usesRegistrationV2]);
+  }, [departmentOptionSet, draft, hasContractAmountInput, hasMultiYearContract, onProjectDocumentFileUpload, requiresAdvanceInterimReason, requiresSettlementConfirmations, selectedExecutiveApprover, showProjectCheckout, usesRegistrationV2]);
 
   const canSubmit = submitIssues.length === 0;
 
@@ -1446,6 +1453,20 @@ export function ProjectEditorWizard({
             사업자등록증상 법인명을 띄어쓰기까지 동일하게 입력해 주세요.
           </p>
         </div>
+      </div>
+
+      <div>
+        <Label className="text-xs">사업관리 구글폴더링크</Label>
+        <Input
+          type="url"
+          value={draft.businessManagementGoogleFolderLink}
+          onChange={(event) => update('businessManagementGoogleFolderLink', event.target.value)}
+          placeholder="https://drive.google.com/drive/folders/..."
+          className="mt-1 h-9 text-sm"
+        />
+        <p className="mt-1 text-[11px] leading-5 text-muted-foreground">
+          사업관리용 Google Drive 폴더 링크를 입력해 주세요.
+        </p>
       </div>
 
       <div>
@@ -1770,9 +1791,9 @@ export function ProjectEditorWizard({
             inputMode="numeric"
             value={formatProjectAmountInput(draft.contractAmount, hasContractAmountInput)}
             onChange={(event) => updateAmount('contractAmount', event.target.value)}
-            readOnly={usesRegistrationV2}
+            readOnly={usesRegistrationV2 && hasMultiYearContract}
             placeholder="0"
-            className={cn('mt-1 h-9 text-sm', usesRegistrationV2 && 'bg-muted/40')}
+            className={cn('mt-1 h-9 text-sm', usesRegistrationV2 && hasMultiYearContract && 'bg-muted/40')}
           />
           <p className="mt-1 text-[10px] text-muted-foreground">
             {hasContractAmountInput ? `${PROJECT_CURRENCY_LABELS[draft.currency]} ${fmtKRW(draft.contractAmount)}` : '미입력'}
@@ -1787,9 +1808,9 @@ export function ProjectEditorWizard({
             inputMode="numeric"
             value={formatProjectAmountInput(draft.salesVatAmount, hasSalesVatAmountInput)}
             onChange={(event) => updateAmount('salesVatAmount', event.target.value)}
-            readOnly={usesRegistrationV2}
+            readOnly={usesRegistrationV2 && hasMultiYearContract}
             placeholder="0"
-            className={cn('mt-1 h-9 text-sm', usesRegistrationV2 && 'bg-muted/40')}
+            className={cn('mt-1 h-9 text-sm', usesRegistrationV2 && hasMultiYearContract && 'bg-muted/40')}
           />
         </div>
         <div>
@@ -1798,9 +1819,9 @@ export function ProjectEditorWizard({
             inputMode="numeric"
             value={formatProjectAmountInput(draft.totalRevenueAmount, hasTotalRevenueAmountInput)}
             onChange={(event) => updateAmount('totalRevenueAmount', event.target.value)}
-            readOnly={usesRegistrationV2}
+            readOnly={usesRegistrationV2 && hasMultiYearContract}
             placeholder="0"
-            className={cn('mt-1 h-9 text-sm', usesRegistrationV2 && 'bg-muted/40')}
+            className={cn('mt-1 h-9 text-sm', usesRegistrationV2 && hasMultiYearContract && 'bg-muted/40')}
           />
         </div>
         <div>
@@ -1809,9 +1830,9 @@ export function ProjectEditorWizard({
             inputMode="numeric"
             value={formatProjectAmountInput(draft.supportAmount, hasSupportAmountInput)}
             onChange={(event) => updateAmount('supportAmount', event.target.value)}
-            readOnly={usesRegistrationV2}
+            readOnly={usesRegistrationV2 && hasMultiYearContract}
             placeholder="0"
-            className={cn('mt-1 h-9 text-sm', usesRegistrationV2 && 'bg-muted/40')}
+            className={cn('mt-1 h-9 text-sm', usesRegistrationV2 && hasMultiYearContract && 'bg-muted/40')}
           />
         </div>
         <div>
@@ -1823,12 +1844,12 @@ export function ProjectEditorWizard({
         </div>
       </div>
 
-      {usesRegistrationV2 ? (
+      {usesRegistrationV2 && hasMultiYearContract ? (
         <div className="space-y-3 rounded-xl border border-slate-200 bg-slate-50/70 p-4">
           <div>
             <Label className="text-xs font-semibold">연도별 계약·재무 *</Label>
             <p className="mt-1 text-[11px] text-muted-foreground">
-              계약기간의 모든 연도를 각각 입력하고 확인해야 하며, 위 합계는 연도별 입력값으로 자동 계산됩니다.
+              다년도 사업은 계약기간의 모든 연도를 각각 입력하고 확인해야 하며, 위 합계는 연도별 입력값으로 자동 계산됩니다.
             </p>
           </div>
           {draft.financialYears.length === 0 ? (
@@ -1842,7 +1863,7 @@ export function ProjectEditorWizard({
                 {([
                   ['contractAmount', '계약금액'],
                   ['salesVatAmount', '매출 부가세'],
-                  ['totalRevenueAmount', '총수익'],
+                  ['totalRevenueAmount', '수익'],
                   ['supportAmount', '지원금'],
                 ] as const).map(([field, label]) => (
                   <div key={field}>
@@ -2530,6 +2551,7 @@ export function ProjectEditorWizard({
             <ReviewRow label="프로젝트 유형" value={PROJECT_TYPE_LABELS[draft.type]} />
             <ReviewRow label="계약서 유형" value={normalizeProjectContractType(draft.contractType)} />
             <ReviewRow label="계약 대상" value={draft.clientOrg} />
+            <ReviewRow label="사업관리 구글폴더링크" value={draft.businessManagementGoogleFolderLink} />
             <ReviewRow label="프로젝트 목적" value={draft.projectPurpose} />
             <ReviewRow label="프로젝트 주요 내용" value={draft.description} />
             {canEditProjectStatus(mode) ? (
@@ -2551,7 +2573,7 @@ export function ProjectEditorWizard({
             <ReviewRow label="총지원금" value={formatStoredProjectAmount(draft.supportAmount, financialInputFlags.supportAmount)} />
             <ReviewRow label="총수익률" value={profitRateLabel ? `${profitRateLabel}%` : '-'} />
             <ReviewRow label={usesRegistrationV2 ? '사업유형' : '정산 유형'} value={SETTLEMENT_TYPE_LABELS[draft.settlementType]} />
-            {usesRegistrationV2 ? (
+            {usesRegistrationV2 && hasMultiYearContract ? (
               <ReviewRow label="정산 기준" value={REGISTRATION_V2_BASIS_LABELS[draft.basis as Exclude<Basis, '기타'>]} />
             ) : settlementDetailsEnabled ? (
               <ReviewRow label="정산 기준" value={draft.basis === 'NONE' ? '-' : BASIS_LABELS[draft.basis]} />

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -33,6 +33,7 @@ import {
   PROJECT_CURRENCY_LABELS,
   PROJECT_FUND_INPUT_MODE_LABELS,
   PROJECT_PHASE_LABELS,
+  REGISTRATION_V2_BASIS_LABELS,
   PROJECT_STATUS_LABELS,
   PROJECT_TYPE_LABELS,
   SETTLEMENT_TYPE_LABELS,
@@ -54,7 +55,10 @@ import {
   type SettlementSystemCode,
 } from '../../data/types';
 import { PROJECT_DEPARTMENT_OPTIONS, dedupeProjectDepartmentLabels } from '../../data/project-department-options';
-import { PROJECT_TEAM_MEMBER_OPTION_MAP, PROJECT_TEAM_MEMBER_OPTIONS } from '../../data/project-team-member-options';
+import {
+  buildProjectTeamMemberOptions,
+  type ProjectTeamMemberOption,
+} from '../../data/project-team-member-options';
 import {
   formatProjectAmountInput,
   formatStoredProjectAmount,
@@ -73,7 +77,12 @@ import {
   type ProjectRequestDocumentKind,
 } from '../../platform/project-contract-upload';
 import { formatProfitRatePercentInput } from '../../platform/project-financials';
-import { createProjectEditorDraft, type ProjectEditorDraft, type ProjectEditorMode } from '../../platform/project-editor';
+import {
+  createProjectEditorDraft,
+  hasInvalidProjectContractPeriod,
+  type ProjectEditorDraft,
+  type ProjectEditorMode,
+} from '../../platform/project-editor';
 import { normalizeProjectDepartment } from '../../platform/project-cic';
 import {
   AlertDialog,
@@ -87,7 +96,12 @@ import {
 } from '../ui/alert-dialog';
 import {
   formatProjectTeamMembersSummary,
+  hasInvalidProjectTeamMemberLaborPeriod,
+  hasInvalidProjectSettlementSupportMember,
   hasIncompleteProjectTeamMembers,
+  hasProjectFinalResponsibleMember,
+  hasProjectOperatingManager,
+  isProjectSettlementSupportMember,
   normalizeProjectTeamMemberDraftRows,
   parseProjectTeamMemberIdentityInput,
   PROJECT_TEAM_MEMBER_ROLES,
@@ -139,6 +153,7 @@ interface ProjectEditorWizardProps {
   description?: string;
   embeddedInShell?: boolean;
   members?: OrgMember[];
+  requesterId?: string;
   departmentOptions?: string[];
   topSlot?: ReactNode;
   actions: ProjectEditorAction[];
@@ -152,6 +167,13 @@ interface ProjectEditorWizardProps {
     document: FileAttachment;
     contractAnalysis: ProjectRequestContractAnalysis | null;
   }>;
+  documentPreviewUrls?: Partial<Record<ProjectRequestDocumentKind, string>>;
+  documentPreviewStates?: Partial<Record<ProjectRequestDocumentKind, {
+    status: 'idle' | 'loading' | 'ready' | 'error';
+    error?: string;
+  }>>;
+  onLoadDocumentPreview?: (kind: ProjectRequestDocumentKind) => void | Promise<void>;
+  onRemoveProjectDocument?: (kind: ProjectRequestDocumentKind) => void | Promise<void>;
   contractAnalysisMergeMode?: 'fill-empty' | 'none';
   canRemoveContractDocument?: boolean;
   canRemoveProjectDocuments?: boolean;
@@ -174,6 +196,9 @@ const REGISTRATION_DOCUMENT_KINDS: ProjectRequestDocumentKind[] = [
   'customer_business_registration',
   'quote',
   'proposal',
+  'proposal_word_original',
+  'proposal_ppt_original',
+  'presentation_ppt_original',
   'rfp_request_evidence',
 ];
 const CHECKOUT_DOCUMENT_KINDS: ProjectRequestDocumentKind[] = [
@@ -183,13 +208,13 @@ const CHECKOUT_DOCUMENT_KINDS: ProjectRequestDocumentKind[] = [
 ];
 const PROJECT_DOCUMENT_LABELS: Record<ProjectRequestDocumentKind, string> = {
   contract: '계약서 PDF',
-  customer_business_registration: '발주처 사업자등록증 PDF',
+  customer_business_registration: '고객사 사업자등록증 PDF',
   quote: '견적서 PDF',
-  proposal: '제안서 PDF *',
-  proposal_word_original: '제안서 Word 원본 (선택)',
-  proposal_ppt_original: '제안서 PPT 원본 (선택)',
-  presentation_ppt_original: '발표자료 PPT 원본 (선택)',
-  rfp_request_evidence: 'RFP 또는 요청 메일 증빙 (제안서가 없는 경우) *',
+  proposal: '제안서 PDF',
+  proposal_word_original: '제안서 Word 원본',
+  proposal_ppt_original: '제안서 PPT 원본',
+  presentation_ppt_original: '발표자료 PPT 원본',
+  rfp_request_evidence: 'RFP/요청 메일 증빙',
   performance_certificate: '수행확인서 PDF',
   tax_invoice: '세금계산서 PDF',
   final_settlement_report: '최종 정산보고서 PDF',
@@ -225,6 +250,73 @@ const OPTIONAL_REGISTRATION_DOCUMENT_NOTE_FIELD = {
   proposal_ppt_original: 'proposalPptOriginal',
   presentation_ppt_original: 'presentationPptOriginal',
 } as const;
+const OPTIONAL_REGISTRATION_DOCUMENT_REQUIREMENTS = [
+  {
+    kind: 'proposal_word_original',
+    noteField: 'proposalWordOriginal',
+    issueLabel: '제안서 Word 원본 파일 또는 미첨부 사유',
+  },
+  {
+    kind: 'proposal_ppt_original',
+    noteField: 'proposalPptOriginal',
+    issueLabel: '제안서 PPT 원본 파일 또는 미첨부 사유',
+  },
+  {
+    kind: 'presentation_ppt_original',
+    noteField: 'presentationPptOriginal',
+    issueLabel: '발표자료 PPT 원본 파일 또는 미첨부 사유',
+  },
+] as const;
+type RegistrationDocumentSlot = {
+  number: number;
+  label: string;
+  description: string;
+  kinds: ProjectRequestDocumentKind[];
+};
+const REGISTRATION_DOCUMENT_SLOTS: RegistrationDocumentSlot[] = [
+  {
+    number: 1,
+    label: '계약서 PDF *',
+    description: '등록하려는 계약서 원문을 제출해 주세요.',
+    kinds: ['contract'],
+  },
+  {
+    number: 2,
+    label: '고객사 사업자등록증 PDF *',
+    description: '계약 대상 고객사의 사업자등록증을 제출해 주세요.',
+    kinds: ['customer_business_registration'],
+  },
+  {
+    number: 3,
+    label: '견적서 PDF *',
+    description: '계약 금액과 범위를 확인할 수 있는 견적서를 제출해 주세요.',
+    kinds: ['quote'],
+  },
+  {
+    number: 4,
+    label: '제안서 PDF 또는 RFP/요청 메일 증빙 *',
+    description: '4번은 제안서 PDF 또는 RFP/요청 메일 증빙 중 하나만 제출하면 됩니다.',
+    kinds: ['proposal', 'rfp_request_evidence'],
+  },
+  {
+    number: 5,
+    label: '제안서 Word 원본',
+    description: '원본 파일 또는 미첨부 사유를 입력해 주세요.',
+    kinds: ['proposal_word_original'],
+  },
+  {
+    number: 6,
+    label: '제안서 PPT 원본',
+    description: '원본 파일 또는 미첨부 사유를 입력해 주세요.',
+    kinds: ['proposal_ppt_original'],
+  },
+  {
+    number: 7,
+    label: '발표자료 PPT 원본',
+    description: '원본 파일 또는 미첨부 사유를 입력해 주세요.',
+    kinds: ['presentation_ppt_original'],
+  },
+];
 type AutosaveState = 'idle' | 'saving' | 'saved' | 'error';
 type StoredProjectEditorDraft = {
   schemaVersion: number;
@@ -291,6 +383,15 @@ function writeStoredProjectEditorDraft(key: string, value: StoredProjectEditorDr
 function removeStoredProjectEditorDraft(key: string) {
   if (typeof localStorage === 'undefined') return;
   localStorage.removeItem(getProjectEditorAutosaveStorageKey(key));
+}
+
+function normalizeRestoredProjectEditorDraft(draft: ProjectEditorDraft, mode: ProjectEditorMode) {
+  return createProjectEditorWizardDraft({
+    ...draft,
+    ...(mode === 'portal-register' || mode === 'portal-edit'
+      ? { registrationRequirementsVersion: 2 as const }
+      : {}),
+  });
 }
 
 function formatAutosaveTime(value: string) {
@@ -401,6 +502,8 @@ function createProjectEditorWizardDraft(overrides: Partial<ProjectEditorDraft> =
 
 interface TeamMemberSearchComboboxProps {
   member: ProjectTeamMemberAssignment;
+  options: ProjectTeamMemberOption[];
+  optionMap: Record<string, ProjectTeamMemberOption>;
   selectedNames: Set<string>;
   currentTeamMemberOptionExists: boolean;
   onSelect: (patch: Partial<ProjectTeamMemberAssignment>) => void;
@@ -408,6 +511,8 @@ interface TeamMemberSearchComboboxProps {
 
 function TeamMemberSearchCombobox({
   member,
+  options,
+  optionMap,
   selectedNames,
   currentTeamMemberOptionExists,
   onSelect,
@@ -423,7 +528,7 @@ function TeamMemberSearchCombobox({
       setOpen(false);
       return;
     }
-    const option = PROJECT_TEAM_MEMBER_OPTION_MAP[value];
+    const option = optionMap[value];
     onSelect({
       inputMode: 'search',
       identityInput: undefined,
@@ -462,7 +567,7 @@ function TeamMemberSearchCombobox({
               </CommandItem>
             </CommandGroup>
             <CommandSeparator />
-            <CommandGroup heading={`${PROJECT_TEAM_MEMBER_OPTIONS.length}명 중 검색`}>
+            <CommandGroup heading={`${options.length}명 중 검색`}>
               {!currentTeamMemberOptionExists && member.memberName ? (
                 <CommandItem
                   value={`${member.memberName} ${member.memberNickname}`}
@@ -480,7 +585,7 @@ function TeamMemberSearchCombobox({
                   </span>
                 </CommandItem>
               ) : null}
-              {PROJECT_TEAM_MEMBER_OPTIONS.map((option) => {
+              {options.map((option) => {
                 const disabled = selectedNames.has(option.value);
                 const selected = option.value === member.memberName;
                 return (
@@ -514,6 +619,7 @@ export function ProjectEditorWizard({
   description,
   embeddedInShell = false,
   members = [],
+  requesterId,
   departmentOptions,
   topSlot,
   actions,
@@ -521,6 +627,10 @@ export function ProjectEditorWizard({
   readOnly = false,
   onContractFileUpload,
   onProjectDocumentFileUpload,
+  documentPreviewUrls,
+  documentPreviewStates,
+  onLoadDocumentPreview,
+  onRemoveProjectDocument,
   contractAnalysisMergeMode = 'fill-empty',
   canRemoveContractDocument,
   canRemoveProjectDocuments = true,
@@ -680,6 +790,7 @@ export function ProjectEditorWizard({
     nextDraft: ProjectEditorDraft,
     nextStepIndex: number,
   ) => {
+    if (uploadInProgress || hasPendingRetryFile) return false;
     if (readOnly || !autosave?.key || autosave.disabled) return false;
     const now = new Date().toISOString();
     const storedDraft: StoredProjectEditorDraft = {
@@ -703,7 +814,7 @@ export function ProjectEditorWizard({
       setAutosaveState('error');
       return false;
     }
-  }, [autosave?.disabled, autosave?.key, autosave?.onSave, draftKey, readOnly]);
+  }, [autosave?.disabled, autosave?.key, autosave?.onSave, draftKey, hasPendingRetryFile, readOnly, uploadInProgress]);
 
   const saveDraftAndRelease = useCallback(async () => {
     if (uploadInProgress || hasPendingRetryFile) {
@@ -794,7 +905,7 @@ export function ProjectEditorWizard({
   }, [blocker]);
 
   useEffect(() => {
-    if (readOnly || !autosave?.key || autosave.disabled || restoreCandidate) return undefined;
+    if (readOnly || !autosave?.key || autosave.disabled || restoreCandidate || uploadInProgress || hasPendingRetryFile) return undefined;
     const isInitialDraft = stepIndex === 0 && JSON.stringify(createProjectEditorDraft(draft)) === initialDraftFingerprint;
     if (isInitialDraft) return undefined;
 
@@ -802,11 +913,11 @@ export function ProjectEditorWizard({
       void persistAutosaveSnapshot(draft, stepIndex);
     }, 1000);
     return () => window.clearTimeout(timer);
-  }, [autosave?.disabled, autosave?.key, draft, initialDraftFingerprint, persistAutosaveSnapshot, readOnly, restoreCandidate, stepIndex]);
+  }, [autosave?.disabled, autosave?.key, draft, hasPendingRetryFile, initialDraftFingerprint, persistAutosaveSnapshot, readOnly, restoreCandidate, stepIndex, uploadInProgress]);
 
   const restoreLocalDraft = () => {
     if (!restoreCandidate) return;
-    setDraft(createProjectEditorWizardDraft(restoreCandidate.draft));
+    setDraft(normalizeRestoredProjectEditorDraft(restoreCandidate.draft, mode));
     setStepIndex(Math.max(0, Math.min(STEPS.length - 1, restoreCandidate.stepIndex || 0)));
     setLastAutosavedAt(restoreCandidate.updatedAt);
     setAutosaveState('saved');
@@ -820,6 +931,10 @@ export function ProjectEditorWizard({
   };
 
   const handleManualAutosave = async () => {
+    if (uploadInProgress || hasPendingRetryFile) {
+      toast.error('첨부파일 처리를 완료한 뒤 임시저장해 주세요.');
+      return;
+    }
     const saved = await persistAutosaveSnapshot(draft, stepIndex);
     if (saved) toast.success('임시저장되었습니다.');
     else toast.error('임시저장에 실패했습니다. 잠시 후 다시 시도해 주세요.');
@@ -827,6 +942,10 @@ export function ProjectEditorWizard({
 
   const handleActionSubmit = async (actionId: string) => {
     if (submitInFlightRef.current) return;
+    if (uploadInProgress || hasPendingRetryFile) {
+      toast.error('첨부파일 처리를 완료한 뒤 최종 저장해 주세요.');
+      return;
+    }
     submitInFlightRef.current = true;
     try {
       if (autosave?.key && !await persistAutosaveSnapshot(draft, stepIndex)) {
@@ -855,6 +974,8 @@ export function ProjectEditorWizard({
   const hasTotalRevenueAmountInput = financialInputFlags.totalRevenueAmount;
   const hasSupportAmountInput = financialInputFlags.supportAmount;
   const usesRegistrationV2 = draft.registrationRequirementsVersion === 2;
+  const settlementDetailsEnabled = usesRegistrationV2 ? draft.basis !== 'NONE' : draft.settlementType !== 'NONE';
+  const requiresSettlementConfirmations = usesRegistrationV2 ? draft.basis !== 'NONE' : draft.settlementType !== 'NONE';
   const showProjectCheckout = draft.status === 'COMPLETED' || draft.status === 'COMPLETED_PENDING_PAYMENT';
   const paymentPlanTotal = draft.paymentPlan.contract + draft.paymentPlan.interim + draft.paymentPlan.final;
   const advanceInterimRatio = draft.contractAmount > 0
@@ -867,23 +988,41 @@ export function ProjectEditorWizard({
   const teamMembersSummary = formatProjectTeamMembersSummary(draft.teamMembersDetailed, '', '\n');
   const projectTypeOptions = getProjectTypeSelectableOptions(draft.type);
   const contractTypeOptions = getProjectContractTypeSelectableOptions(draft.contractType);
+  const teamMemberOptions = useMemo(() => buildProjectTeamMemberOptions(members), [members]);
+  const teamMemberOptionMap = useMemo(() => Object.fromEntries(
+    teamMemberOptions.map((option) => [option.value, option]),
+  ) as Record<string, ProjectTeamMemberOption>, [teamMemberOptions]);
   const ownerOptions = useMemo(
     () => [...members]
       .filter((member) => String(member.uid || '').trim())
       .sort((left, right) => String(left.name || left.email || left.uid).localeCompare(String(right.name || right.email || right.uid), 'ko')),
     [members],
   );
+  const executiveApproverOptions = useMemo(
+    () => ownerOptions.filter((member) => (
+      member.uid !== draft.registeredById && member.uid !== requesterId
+    )),
+    [draft.registeredById, requesterId, ownerOptions],
+  );
   const selectedOwner = useMemo(
     () => ownerOptions.find((member) => member.uid === draft.registeredById) || null,
     [draft.registeredById, ownerOptions],
   );
-  const selectedExecutiveApprover = useMemo(
+  const linkedExecutiveApprover = useMemo(
     () => ownerOptions.find((member) => member.uid === draft.executiveApproverId) || null,
     [draft.executiveApproverId, ownerOptions],
   );
+  const selectedExecutiveApprover = useMemo(
+    () => executiveApproverOptions.find((member) => member.uid === draft.executiveApproverId) || null,
+    [draft.executiveApproverId, executiveApproverOptions],
+  );
+  const isSelfExecutiveApprover = Boolean(
+    draft.executiveApproverId
+      && (draft.executiveApproverId === draft.registeredById || draft.executiveApproverId === requesterId),
+  );
   const hasUnlinkedStoredOwner = Boolean(draft.registeredById && !selectedOwner);
   const hasUnlinkedStoredExecutiveApprover = Boolean(
-    draft.executiveApproverId && !selectedExecutiveApprover,
+    draft.executiveApproverId && !linkedExecutiveApprover,
   );
 
   useEffect(() => {
@@ -935,7 +1074,7 @@ export function ProjectEditorWizard({
 
   const updateFinancialYear = (
     index: number,
-    key: 'contractAmount' | 'salesVatAmount' | 'totalRevenueAmount' | 'supportAmount' | 'profitRate' | 'confirmed',
+    key: 'contractAmount' | 'salesVatAmount' | 'totalRevenueAmount' | 'supportAmount' | 'confirmed',
     value: number | boolean,
   ) => {
     setDraft((prev) => {
@@ -1054,6 +1193,8 @@ export function ProjectEditorWizard({
         return createProjectEditorWizardDraft({
           ...prev,
           [PROJECT_DOCUMENT_FIELD[kind]]: processed.document,
+          rfpRequestEvidenceDocument: kind === 'proposal' ? null : prev.rfpRequestEvidenceDocument,
+          proposalDocument: kind === 'rfp_request_evidence' ? null : prev.proposalDocument,
           ...(noteField ? {
             registrationOptionalDocumentNotes: {
               ...prev.registrationOptionalDocumentNotes,
@@ -1095,29 +1236,33 @@ export function ProjectEditorWizard({
     await processProjectDocument(kind, file, input);
   };
 
-  const removeContractDocument = () => {
-    setDraft((prev) => createProjectEditorWizardDraft({
-      ...prev,
-      contractDocument: initialContractDocument && !contractDocumentEditPolicy.canRemoveExistingContractDocument
-        ? initialContractDocument
-        : null,
-      contractAnalysis: initialContractDocument && !contractDocumentEditPolicy.canRemoveExistingContractDocument
-        ? initialContractAnalysis
-        : null,
-    }));
-    setDocumentUploadState((prev) => ({ ...prev, contract: 'idle' }));
-    setDocumentUploadError((prev) => ({ ...prev, contract: '' }));
-    delete retryDocumentFileRef.current.contract;
-  };
-
-  const removeSupplementalDocument = (kind: Exclude<ProjectRequestDocumentKind, 'contract'>) => {
-    setDraft((prev) => createProjectEditorWizardDraft({
-      ...prev,
-      [PROJECT_DOCUMENT_FIELD[kind]]: null,
-    }));
-    setDocumentUploadState((prev) => ({ ...prev, [kind]: 'idle' }));
+  const removeProjectDocument = async (kind: ProjectRequestDocumentKind) => {
+    setDocumentUploadState((prev) => ({ ...prev, [kind]: 'extracting' }));
     setDocumentUploadError((prev) => ({ ...prev, [kind]: '' }));
-    delete retryDocumentFileRef.current[kind];
+    try {
+      await onRemoveProjectDocument?.(kind);
+      setDraft((prev) => createProjectEditorWizardDraft({
+        ...prev,
+        ...(kind === 'contract'
+          ? {
+              contractDocument: initialContractDocument && !contractDocumentEditPolicy.canRemoveExistingContractDocument
+                ? initialContractDocument
+                : null,
+              contractAnalysis: initialContractDocument && !contractDocumentEditPolicy.canRemoveExistingContractDocument
+                ? initialContractAnalysis
+                : null,
+            }
+          : { [PROJECT_DOCUMENT_FIELD[kind]]: null }),
+      }));
+      setDocumentUploadState((prev) => ({ ...prev, [kind]: 'idle' }));
+      delete retryDocumentFileRef.current[kind];
+      toast.success(`${PROJECT_DOCUMENT_BUTTON_LABELS[kind]} 첨부를 제거했습니다.`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : `${PROJECT_DOCUMENT_BUTTON_LABELS[kind]} 첨부 제거에 실패했습니다.`;
+      setDocumentUploadState((prev) => ({ ...prev, [kind]: 'error' }));
+      setDocumentUploadError((prev) => ({ ...prev, [kind]: message }));
+      toast.error('첨부 제거 실패', { description: message });
+    }
   };
 
   const submitIssues = useMemo(() => {
@@ -1134,10 +1279,27 @@ export function ProjectEditorWizard({
       if (!draft.projectPurpose.trim()) issues.push({ step: 'basic', label: '프로젝트 목적' });
       if (!draft.description.trim()) issues.push({ step: 'basic', label: '프로젝트 주요 내용' });
       if (!draft.contractDocument) issues.push({ step: 'financial', label: '계약서 PDF' });
-      if (!draft.customerBusinessRegistrationDocument) issues.push({ step: 'financial', label: '발주처 사업자등록증 PDF' });
-      if (!draft.quoteDocument) issues.push({ step: 'financial', label: '견적서 PDF' });
-      if (!draft.proposalDocument && !draft.rfpRequestEvidenceDocument) {
-        issues.push({ step: 'financial', label: '제안서 또는 RFP/요청 메일 증빙' });
+      if (onProjectDocumentFileUpload) {
+        if (!draft.customerBusinessRegistrationDocument) issues.push({ step: 'financial', label: '고객사 사업자등록증 PDF' });
+        if (!draft.quoteDocument) issues.push({ step: 'financial', label: '견적서 PDF' });
+        if (!draft.proposalDocument && !draft.rfpRequestEvidenceDocument) {
+          issues.push({ step: 'financial', label: '제안서 또는 RFP/요청 메일 증빙' });
+        }
+        if (draft.proposalDocument && draft.rfpRequestEvidenceDocument) {
+          issues.push({ step: 'financial', label: '제안서와 RFP/요청 메일 중 하나만 남겨주세요.' });
+        }
+        OPTIONAL_REGISTRATION_DOCUMENT_REQUIREMENTS.forEach(({ kind, noteField, issueLabel }) => {
+          if (!draft[PROJECT_DOCUMENT_FIELD[kind]] && !draft.registrationOptionalDocumentNotes[noteField].trim()) {
+            issues.push({ step: 'financial', label: issueLabel });
+          }
+        });
+      }
+      if (
+        draft.contractStart.trim()
+        && draft.contractEnd.trim()
+        && hasInvalidProjectContractPeriod(draft.contractStart, draft.contractEnd)
+      ) {
+        issues.push({ step: 'financial', label: '계약 종료일은 시작일 이후여야 합니다.' });
       }
       const startYear = Number(draft.contractStart.slice(0, 4));
       const endYear = Number(draft.contractEnd.slice(0, 4));
@@ -1155,9 +1317,12 @@ export function ProjectEditorWizard({
         && annualTotal('totalRevenueAmount') === draft.totalRevenueAmount
         && annualTotal('supportAmount') === draft.supportAmount;
       if (!financialYearsComplete || !annualTotalsMatch) issues.push({ step: 'financial', label: '계약기간 전체 연도별 재무 확인' });
-      if (draft.registrationConfirmations.laborIncludesFourInsurance !== true) issues.push({ step: 'payment', label: '4대보험 포함 확인' });
-      if (draft.registrationConfirmations.laborIncludesRetirementPay !== true) issues.push({ step: 'payment', label: '퇴직급여 포함 확인' });
-      if (!draft.registrationConfirmations.customerSettlementBasisConfirmed) issues.push({ step: 'payment', label: '발주처 정산 기준 확인' });
+      if (draft.settlementType === 'NONE') issues.push({ step: 'financial', label: '사업유형' });
+      if (requiresSettlementConfirmations) {
+        if (draft.registrationConfirmations.laborIncludesFourInsurance !== true) issues.push({ step: 'payment', label: '4대보험 포함 확인' });
+        if (draft.registrationConfirmations.laborIncludesRetirementPay !== true) issues.push({ step: 'payment', label: '퇴직급여 포함 확인' });
+        if (!draft.registrationConfirmations.customerSettlementBasisConfirmed) issues.push({ step: 'payment', label: '고객사 정산 기준 확인' });
+      }
       if (draft.registrationConfirmations.modusignContractUsed === null) issues.push({ step: 'payment', label: '모두싸인 사용 여부' });
       if (
         draft.registrationConfirmations.modusignContractUsed === false
@@ -1188,14 +1353,28 @@ export function ProjectEditorWizard({
       }
     }
     if (!draft.managerName.trim()) issues.push({ step: 'team', label: 'PM' });
-    if (!draft.executiveApproverId || !selectedExecutiveApprover) {
+    if (isSelfExecutiveApprover) {
+      issues.push({ step: 'team', label: '사업 담당자와 지정 결재자는 달라야 합니다.' });
+    } else if (!draft.executiveApproverId || !selectedExecutiveApprover) {
       issues.push({ step: 'team', label: '지정 결재자' });
     }
     if (usesRegistrationV2 && hasIncompleteProjectTeamMembers(draft.teamMembersDetailed)) {
       issues.push({ step: 'team', label: '참여인력 이름·역할·서류상 여부' });
     }
+    if (usesRegistrationV2 && !hasProjectOperatingManager(draft.teamMembersDetailed)) {
+      issues.push({ step: 'team', label: '실제 투입 운영 매니저 1인 이상' });
+    }
+    if (usesRegistrationV2 && !hasProjectFinalResponsibleMember(draft.teamMembersDetailed)) {
+      issues.push({ step: 'team', label: '실제 투입 사업 최종 책임자' });
+    }
+    if (usesRegistrationV2 && hasInvalidProjectSettlementSupportMember(draft.teamMembersDetailed)) {
+      issues.push({ step: 'team', label: '정산지원은 도담 또는 써니를 실제 투입인력으로 선택' });
+    }
+    if (usesRegistrationV2 && hasInvalidProjectTeamMemberLaborPeriod(draft.teamMembersDetailed)) {
+      issues.push({ step: 'team', label: '인건비 투입 종료월은 시작월 이후여야 합니다.' });
+    }
     return issues;
-  }, [departmentOptionSet, draft, hasContractAmountInput, requiresAdvanceInterimReason, selectedExecutiveApprover, showProjectCheckout, usesRegistrationV2]);
+  }, [departmentOptionSet, draft, hasContractAmountInput, onProjectDocumentFileUpload, requiresAdvanceInterimReason, requiresSettlementConfirmations, selectedExecutiveApprover, showProjectCheckout, usesRegistrationV2]);
 
   const canSubmit = submitIssues.length === 0;
 
@@ -1245,18 +1424,13 @@ export function ProjectEditorWizard({
         <Label className="text-xs">프로젝트명 *</Label>
         <Input
           value={draft.name}
-          onChange={(event) => update('name', event.target.value.slice(0, mode === 'portal-register' ? 10 : 80))}
+          onChange={(event) => update('name', event.target.value)}
           placeholder="예: 26농식품AC"
           className="mt-1 h-9 text-sm"
         />
-        <div className="mt-1 flex flex-wrap items-start justify-between gap-x-3 gap-y-1">
-          <p className="max-w-3xl text-[11px] leading-5 text-muted-foreground">
-            계약연도+프로젝트명 형식으로 입력해 주세요. 재경팀이 부여하는 프로젝트 코드는 직접 입력하지 않습니다. 다년도 사업은 같은 프로젝트명을 사용해 주세요.
-          </p>
-          {mode === 'portal-register' ? (
-            <p className="shrink-0 text-[10px] text-muted-foreground">{draft.name.length}/10자</p>
-          ) : null}
-        </div>
+        <p className="mt-1 max-w-3xl text-[11px] leading-5 text-muted-foreground">
+          계약연도+프로젝트명 형식으로 입력해 주세요. 재경팀이 부여하는 프로젝트 코드는 직접 입력하지 않습니다. 다년도 사업은 같은 프로젝트명을 사용해 주세요.
+        </p>
       </div>
 
       <div>
@@ -1313,8 +1487,19 @@ export function ProjectEditorWizard({
     </div>
   );
 
-  const renderProjectDocumentUpload = (kind: ProjectRequestDocumentKind) => {
+  const renderProjectDocumentUpload = (
+    kind: ProjectRequestDocumentKind,
+    options: {
+      slotNumber?: number;
+      label?: string;
+      description?: string;
+      embedded?: boolean;
+      disabled?: boolean;
+    } = {},
+  ) => {
     const document = draft[PROJECT_DOCUMENT_FIELD[kind]] as FileAttachment | null;
+    const documentDownloadURL = document ? (documentPreviewUrls?.[kind] || document.downloadURL) : '';
+    const previewState = documentPreviewStates?.[kind];
     const uploadState = documentUploadState[kind];
     const uploadError = documentUploadError[kind];
     const inputRef = getDocumentInputRef(kind);
@@ -1322,31 +1507,43 @@ export function ProjectEditorWizard({
       ? contractDocumentEditPolicy.canRemoveCurrentContractDocument
       : Boolean(document));
     const removeLabel = kind === 'contract' ? contractDocumentEditPolicy.removeButtonLabel : '첨부 제거';
-    const remove = kind === 'contract' ? removeContractDocument : () => removeSupplementalDocument(kind);
+    const remove = () => { void removeProjectDocument(kind); };
     const optionalNoteField = OPTIONAL_REGISTRATION_DOCUMENT_NOTE_FIELD[
       kind as keyof typeof OPTIONAL_REGISTRATION_DOCUMENT_NOTE_FIELD
     ];
+    const description = options.description || (kind === 'contract'
+      ? (contractAnalysisMergeMode === 'none'
+          ? 'PDF를 올리면 계약서 원문과 검토용 첨부를 저장합니다. 입력값은 자동으로 바꾸지 않습니다.'
+          : 'PDF를 올리면 계약명, 계약기간, 계약금액, 계약 대상 후보를 읽어와 빈 항목만 채웁니다.')
+      : kind === 'proposal_word_original'
+        ? '원본 DOCX를 올립니다. 파일이 없으면 아래에 미첨부 사유 또는 해당 없음을 적어주세요.'
+        : kind === 'proposal_ppt_original' || kind === 'presentation_ppt_original'
+          ? '원본 PPTX를 올립니다. 파일이 없으면 아래에 미첨부 사유 또는 해당 없음을 적어주세요.'
+          : kind === 'rfp_request_evidence'
+            ? 'RFP 또는 요청 메일 원본을 PDF, DOCX, EML, MSG 중 하나로 올려주세요.'
+            : 'PDF를 올리면 검토용 첨부로 저장합니다.');
 
     return (
-      <div key={kind} className="rounded-xl border border-slate-200 bg-slate-50/70 p-4">
+      <div
+        key={kind}
+        className={cn(
+          options.embedded
+            ? 'rounded-lg border border-slate-200 bg-white p-3'
+            : 'rounded-xl border border-slate-200 bg-slate-50/70 p-4',
+        )}
+      >
         <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-          <div className="min-w-0">
+          <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
-              <FileText className="h-4 w-4 text-slate-600" />
-              <Label className="text-xs font-semibold">{PROJECT_DOCUMENT_LABELS[kind]}</Label>
+              {options.slotNumber ? (
+                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-[#001e46] text-[11px] font-semibold text-white">
+                  {options.slotNumber}
+                </span>
+              ) : <FileText className="h-4 w-4 text-slate-600" />}
+              <Label className="text-xs font-semibold">{options.label || PROJECT_DOCUMENT_LABELS[kind]}</Label>
             </div>
             <p className="mt-1 text-[11px] leading-5 text-muted-foreground">
-              {kind === 'contract'
-                ? (contractAnalysisMergeMode === 'none'
-                    ? 'PDF를 올리면 계약서 원문과 검토용 첨부를 저장합니다. 입력값은 자동으로 바꾸지 않습니다.'
-                    : 'PDF를 올리면 계약명, 계약기간, 계약금액, 계약 대상 후보를 읽어와 빈 항목만 채웁니다.')
-                : kind === 'proposal_word_original'
-                  ? '원본 DOCX를 올립니다. 파일이 없으면 아래에 미첨부 사유 또는 해당 없음을 적어주세요.'
-                  : kind === 'proposal_ppt_original' || kind === 'presentation_ppt_original'
-                    ? '원본 PPTX를 올립니다. 파일이 없으면 아래에 미첨부 사유 또는 해당 없음을 적어주세요.'
-                    : kind === 'rfp_request_evidence'
-                      ? 'RFP 또는 요청 메일 원본을 PDF, DOCX, EML, MSG 중 하나로 올려주세요.'
-                      : 'PDF를 올리면 검토용 첨부로 저장합니다.'}
+              {description}
             </p>
             {document ? (
               <div className="mt-3 flex flex-wrap items-center gap-2 text-[12px]">
@@ -1354,13 +1551,32 @@ export function ProjectEditorWizard({
                 <span className="text-muted-foreground">
                   {(document.size / 1024 / 1024).toFixed(2)} MB
                 </span>
-                {document.downloadURL ? (
+                {documentDownloadURL ? (
                   <Button asChild type="button" variant="outline" size="sm" className="h-7 px-2 text-[11px]">
-                    <a href={document.downloadURL} target="_blank" rel="noreferrer">원문 보기</a>
+                    <a href={documentDownloadURL} target="_blank" rel="noreferrer">원문 보기</a>
+                  </Button>
+                ) : document && previewState && onLoadDocumentPreview ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-7 px-2 text-[11px]"
+                    disabled={previewState.status === 'loading'}
+                    onClick={() => void onLoadDocumentPreview(kind)}
+                  >
+                    {previewState.status === 'loading' ? <Loader2 className="mr-1 h-3.5 w-3.5 animate-spin" /> : null}
+                    {previewState.status === 'error' ? '원문 다시 불러오기' : previewState.status === 'loading' ? '불러오는 중' : '원문 불러오기'}
                   </Button>
                 ) : null}
                 {canRemove ? (
-                  <Button type="button" variant="ghost" size="sm" className="h-7 px-2 text-[11px] text-rose-600" onClick={remove}>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 px-2 text-[11px] text-rose-600"
+                    disabled={uploadState === 'extracting'}
+                    onClick={remove}
+                  >
                     <X className="mr-1 h-3.5 w-3.5" />
                     {removeLabel}
                   </Button>
@@ -1376,7 +1592,7 @@ export function ProjectEditorWizard({
                     ...draft.registrationOptionalDocumentNotes,
                     [optionalNoteField]: event.target.value,
                   })}
-                  placeholder="예: 해당 없음 / 발주처에서 원본을 제공하지 않음"
+                  placeholder="예: 해당 없음 / 고객사에서 원본을 제공하지 않음"
                   className="mt-1 h-9 bg-white text-sm"
                 />
               </div>
@@ -1395,6 +1611,11 @@ export function ProjectEditorWizard({
             {uploadError ? (
               <p className="mt-2 text-[11px] text-rose-600">{uploadError}</p>
             ) : null}
+            {previewState?.status === 'error' ? (
+              <p className="mt-2 text-[11px] text-rose-600" role="alert">
+                {previewState.error || '첨부 파일을 불러오지 못했습니다.'}
+              </p>
+            ) : null}
           </div>
           <div className="shrink-0">
             <input
@@ -1408,7 +1629,7 @@ export function ProjectEditorWizard({
               type="button"
               variant="outline"
               className="w-full gap-2 lg:w-auto"
-              disabled={uploadState === 'extracting'}
+              disabled={uploadState === 'extracting' || options.disabled}
               onClick={() => {
                 const retryFile = retryDocumentFileRef.current[kind];
                 if (retryFile) void processProjectDocument(kind, retryFile, inputRef.current || undefined);
@@ -1428,11 +1649,61 @@ export function ProjectEditorWizard({
     );
   };
 
+  const renderRegistrationDocumentSlot = (slot: RegistrationDocumentSlot) => {
+    if (slot.kinds.length === 1) {
+      return renderProjectDocumentUpload(slot.kinds[0], {
+        slotNumber: slot.number,
+        label: slot.label,
+        description: slot.description,
+      });
+    }
+
+    return (
+      <div key={slot.number} className="rounded-xl border border-slate-200 bg-slate-50/70 p-4">
+        <div className="flex items-start gap-2">
+          <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md bg-[#001e46] text-[11px] font-semibold text-white">
+            {slot.number}
+          </span>
+          <div>
+            <Label className="text-xs font-semibold">{slot.label}</Label>
+            <p className="mt-1 text-[11px] leading-5 text-muted-foreground">{slot.description}</p>
+          </div>
+        </div>
+        <div className="mt-3 grid gap-3 lg:grid-cols-2">
+          {slot.kinds.map((kind) => {
+            const alternativeDocumentAttached = kind === 'proposal'
+              ? Boolean(draft.rfpRequestEvidenceDocument)
+              : kind === 'rfp_request_evidence'
+                ? Boolean(draft.proposalDocument)
+                : false;
+            return renderProjectDocumentUpload(kind, {
+              embedded: true,
+              label: PROJECT_DOCUMENT_LABELS[kind],
+              description: alternativeDocumentAttached
+                ? '업로드하면 기존 대체서류를 교체합니다.'
+                : undefined,
+            });
+          })}
+        </div>
+      </div>
+    );
+  };
+
   const renderFinancialStep = () => (
     <div className="space-y-4">
       {onContractFileUpload || onProjectDocumentFileUpload ? (
         <div className="space-y-3">
-          {registrationDocumentKinds.map((kind) => renderProjectDocumentUpload(kind))}
+          {usesRegistrationV2 && onProjectDocumentFileUpload ? (
+            <>
+              <div className="rounded-xl border border-slate-200 bg-white px-4 py-3">
+                <p className="text-sm font-semibold text-[#001e46]">등록 제출서류 7종</p>
+                <p className="mt-1 text-[11px] leading-5 text-muted-foreground">
+                  1~3번은 필수이며, 4번은 두 문서 중 하나를 제출합니다. 5~7번은 원본 파일 또는 미첨부 사유를 남겨주세요.
+                </p>
+              </div>
+              {REGISTRATION_DOCUMENT_SLOTS.map(renderRegistrationDocumentSlot)}
+            </>
+          ) : registrationDocumentKinds.map((kind) => renderProjectDocumentUpload(kind))}
         </div>
       ) : null}
 
@@ -1511,7 +1782,7 @@ export function ProjectEditorWizard({
 
       <div className="grid gap-4 lg:grid-cols-4">
         <div>
-          <Label className="text-xs">매출 부가세</Label>
+          <Label className="text-xs">총매출부가세</Label>
           <Input
             inputMode="numeric"
             value={formatProjectAmountInput(draft.salesVatAmount, hasSalesVatAmountInput)}
@@ -1533,7 +1804,7 @@ export function ProjectEditorWizard({
           />
         </div>
         <div>
-          <Label className="text-xs">지원금</Label>
+          <Label className="text-xs">총지원금</Label>
           <Input
             inputMode="numeric"
             value={formatProjectAmountInput(draft.supportAmount, hasSupportAmountInput)}
@@ -1544,7 +1815,7 @@ export function ProjectEditorWizard({
           />
         </div>
         <div>
-          <Label className="text-xs">수익률</Label>
+          <Label className="text-xs">총수익률</Label>
           <Input value={profitRateLabel ? `${profitRateLabel}%` : '-'} readOnly className="mt-1 h-9 bg-muted/40 text-sm" />
           <p className="mt-1 text-[10px] text-muted-foreground">
             총수익 / 계약금액 기준 자동 계산
@@ -1587,18 +1858,13 @@ export function ProjectEditorWizard({
                 <div>
                   <Label className="text-[11px]">수익률(%)</Label>
                   <Input
-                    type="number"
-                    min={0}
-                    max={100}
-                    step="0.01"
-                    value={Number((row.profitRate * 100).toFixed(2))}
-                    onChange={(event) => updateFinancialYear(
-                      index,
-                      'profitRate',
-                      Math.min(1, Math.max(0, Number(event.target.value) / 100 || 0)),
-                    )}
-                    className="mt-1 h-9 text-sm"
+                    value={`${(row.profitRate * 100).toFixed(2)}%`}
+                    readOnly
+                    className="mt-1 h-9 bg-muted/40 text-sm"
                   />
+                  <p className="mt-1 text-[10px] text-muted-foreground">
+                    연도별 계약금액과 총수익으로 자동 계산
+                  </p>
                 </div>
               </div>
               <label className="mt-3 flex items-center gap-2 text-[12px] text-slate-700">
@@ -1646,86 +1912,111 @@ export function ProjectEditorWizard({
 
       <div className="grid gap-4 lg:grid-cols-4">
         <div>
-          <Label className="text-xs">정산 유형</Label>
+          <Label className="text-xs">{usesRegistrationV2 ? '사업유형' : '정산 유형'}</Label>
           <Select
-            value={draft.settlementType}
+            value={usesRegistrationV2 && draft.settlementType === 'NONE' ? undefined : draft.settlementType}
             onValueChange={(value) => update('settlementType', value as SettlementType)}
           >
-            <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue placeholder="정산 유형 선택" /></SelectTrigger>
+            <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue placeholder={usesRegistrationV2 ? '사업유형 선택' : '정산 유형 선택'} /></SelectTrigger>
             <SelectContent>
-              {(Object.entries(SETTLEMENT_TYPE_LABELS) as [SettlementType, string][]).map(([key, value]) => (
-                <SelectItem key={key} value={key}>{value}</SelectItem>
-                ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div>
-          <Label className="text-xs">정산 기준</Label>
-          <Select
-            value={draft.basis}
-            onValueChange={(value) => update('basis', value as Basis)}
-          >
-            <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue placeholder="정산 기준 선택" /></SelectTrigger>
-            <SelectContent>
-              {(Object.entries(BASIS_LABELS) as [Basis, string][]).map(([key, value]) => (
-                <SelectItem key={key} value={key}>{value}</SelectItem>
-                ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div>
-          <Label className="text-xs">통장 유형</Label>
-          <Select value={draft.accountType} onValueChange={(value) => update('accountType', value as AccountType)}>
-            <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue /></SelectTrigger>
-            <SelectContent>
-              {(Object.entries(ACCOUNT_TYPE_LABELS) as [AccountType, string][]).map(([key, value]) => (
+              {(Object.entries(SETTLEMENT_TYPE_LABELS) as [SettlementType, string][]).filter(([key]) => !usesRegistrationV2 || key !== 'NONE').map(([key, value]) => (
                 <SelectItem key={key} value={key}>{value}</SelectItem>
               ))}
             </SelectContent>
           </Select>
         </div>
-        <div>
-          <Label className="text-xs">자금 입력 방식</Label>
-          <Select value={draft.fundInputMode} onValueChange={(value) => updateFundInputMode(value as ProjectFundInputMode)}>
-            <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue /></SelectTrigger>
-            <SelectContent>
-              {(Object.entries(PROJECT_FUND_INPUT_MODE_LABELS) as [ProjectFundInputMode, string][]).map(([key, value]) => (
-                <SelectItem key={key} value={key}>{value}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <p className="mt-1 text-[10px] text-muted-foreground">
-            {draft.fundInputMode === 'DIRECT_ENTRY'
-              ? '정산 시트 또는 엑셀 템플릿으로 직접 입력합니다.'
-              : '통장내역 업로드 후 정산 시트로 이어서 입력합니다.'}
-          </p>
-        </div>
+        {usesRegistrationV2 ? (
+          <div>
+            <Label className="text-xs">정산 기준</Label>
+            <Select value={draft.basis} onValueChange={(value) => update('basis', value as Basis)}>
+              <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {(Object.entries(BASIS_LABELS) as [Basis, string][]).filter(([key]) => usesRegistrationV2 ? key !== '기타' : key !== 'NONE').map(([key]) => (
+                  <SelectItem key={key} value={key}>{REGISTRATION_V2_BASIS_LABELS[key as Exclude<Basis, '기타'>]}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        ) : draft.settlementType === 'NONE' ? (
+          <div className="lg:col-span-3 rounded-lg border border-dashed border-slate-300 bg-slate-50 px-3 py-3 text-[12px] text-muted-foreground">
+            정산 없음은 정산 기준·통장·정산 시스템 입력이 필요하지 않습니다.
+          </div>
+        ) : (
+          <div>
+            <Label className="text-xs">정산 기준</Label>
+            <Select value={draft.basis === 'NONE' ? undefined : draft.basis} onValueChange={(value) => update('basis', value as Basis)}>
+              <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue placeholder="정산 기준 선택" /></SelectTrigger>
+              <SelectContent>
+                {(Object.entries(BASIS_LABELS) as [Basis, string][]).filter(([key]) => usesRegistrationV2 ? key !== '기타' : key !== 'NONE').map(([key, value]) => (
+                  <SelectItem key={key} value={key}>{value}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+        {settlementDetailsEnabled ? (
+          <>
+            <div>
+              <Label className="text-xs">통장 유형</Label>
+              <Select value={draft.accountType} onValueChange={(value) => update('accountType', value as AccountType)}>
+                <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {(Object.entries(ACCOUNT_TYPE_LABELS) as [AccountType, string][]).map(([key, value]) => (
+                    <SelectItem key={key} value={key}>{value}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label className="text-xs">자금 입력 방식</Label>
+              <Select value={draft.fundInputMode} onValueChange={(value) => updateFundInputMode(value as ProjectFundInputMode)}>
+                <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {(Object.entries(PROJECT_FUND_INPUT_MODE_LABELS) as [ProjectFundInputMode, string][]).map(([key, value]) => (
+                    <SelectItem key={key} value={key}>{value}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="mt-1 text-[10px] text-muted-foreground">
+                {draft.fundInputMode === 'DIRECT_ENTRY'
+                  ? '정산 시트 또는 엑셀 템플릿으로 직접 입력합니다.'
+                  : '통장내역 업로드 후 정산 시트로 이어서 입력합니다.'}
+              </p>
+            </div>
+          </>
+        ) : usesRegistrationV2 ? (
+          <div className="lg:col-span-2 rounded-lg border border-dashed border-slate-300 bg-slate-50 px-3 py-3 text-[12px] text-muted-foreground">
+            정산 기준이 정산없음이면 통장·정산 시스템 입력이 필요하지 않습니다.
+          </div>
+        ) : null}
       </div>
 
-      <div className="grid gap-4 lg:grid-cols-2">
-        <div>
-          <Label className="text-xs">정산 시스템</Label>
-          <Select value={draft.settlementSystem} onValueChange={(value) => update('settlementSystem', value as SettlementSystemCode)}>
-            <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue /></SelectTrigger>
-            <SelectContent>
-              {(Object.entries(SETTLEMENT_SYSTEM_LABELS) as [SettlementSystemCode, string][]).map(([key, value]) => (
-                <SelectItem key={key} value={key}>{value}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+      {settlementDetailsEnabled ? (
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div>
+            <Label className="text-xs">정산 시스템</Label>
+            <Select value={draft.settlementSystem} onValueChange={(value) => update('settlementSystem', value as SettlementSystemCode)}>
+              <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {(Object.entries(SETTLEMENT_SYSTEM_LABELS) as [SettlementSystemCode, string][]).map(([key, value]) => (
+                  <SelectItem key={key} value={key}>{value}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label className="text-xs">인건비 정산 기준</Label>
+            <Select value={draft.laborSettlementBasis} onValueChange={(value) => update('laborSettlementBasis', value as LaborSettlementBasis)}>
+              <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {(Object.entries(LABOR_SETTLEMENT_BASIS_LABELS) as [LaborSettlementBasis, string][]).map(([key, value]) => (
+                  <SelectItem key={key} value={key}>{value}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
         </div>
-        <div>
-          <Label className="text-xs">인건비 정산 기준</Label>
-          <Select value={draft.laborSettlementBasis} onValueChange={(value) => update('laborSettlementBasis', value as LaborSettlementBasis)}>
-            <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue /></SelectTrigger>
-            <SelectContent>
-              {(Object.entries(LABOR_SETTLEMENT_BASIS_LABELS) as [LaborSettlementBasis, string][]).map(([key, value]) => (
-                <SelectItem key={key} value={key}>{value}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      </div>
+      ) : null}
 
     </div>
   );
@@ -1771,7 +2062,7 @@ export function ProjectEditorWizard({
         <div>
           <Label className="text-xs">지정 결재자 *</Label>
           <Select value={selectedExecutiveApprover?.uid} onValueChange={(value) => {
-            const member = ownerOptions.find((item) => item.uid === value);
+            const member = executiveApproverOptions.find((item) => item.uid === value);
             if (!member) return;
             setDraft((prev) => createProjectEditorDraft({
               ...prev,
@@ -1779,15 +2070,15 @@ export function ProjectEditorWizard({
               executiveApproverName: member.name || member.email || member.uid,
               executiveApproverEmail: member.email || '',
             }));
-          }} disabled={ownerOptions.length === 0}>
+          }} disabled={executiveApproverOptions.length === 0}>
             <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue placeholder="구성원 원장에서 선택" /></SelectTrigger>
             <SelectContent>
-              {ownerOptions.map((member) => (
+              {executiveApproverOptions.map((member) => (
                 <SelectItem key={member.uid} value={member.uid}>
                   {member.email ? `${member.name || member.uid} (${member.email})` : (member.name || member.uid)}
                 </SelectItem>
               ))}
-              {ownerOptions.length === 0 ? (
+              {executiveApproverOptions.length === 0 ? (
                 <SelectItem value="__no_org_members__" disabled>구성원 원장을 불러오는 중입니다</SelectItem>
               ) : null}
             </SelectContent>
@@ -1795,7 +2086,11 @@ export function ProjectEditorWizard({
           <p className="mt-1 text-[11px] text-muted-foreground">
             선택한 구성원이 조직장 승인 결재선의 대기 결재자로 표시됩니다.
           </p>
-          {hasUnlinkedStoredExecutiveApprover ? (
+          {isSelfExecutiveApprover ? (
+            <p className="mt-1 text-[11px] text-red-700">
+              사업 담당자와 지정 결재자는 달라야 합니다.
+            </p>
+          ) : hasUnlinkedStoredExecutiveApprover ? (
             <p className="mt-1 text-[11px] text-red-700">
               현재 저장된 결재자 값이 구성원 원장에 없습니다. 원장에서 다시 선택해야 저장 후 연결됩니다.
             </p>
@@ -1804,7 +2099,7 @@ export function ProjectEditorWizard({
       </div>
       <div className="flex items-center justify-between gap-3">
         <div>
-          <Label className="text-xs">서류상 참여인력</Label>
+          <Label className="text-xs">참여인력 (서류상·실제)</Label>
           <p className="mt-1 text-[10px] text-muted-foreground">계약·협약서에 남길 참여인력, 역할, 참여율을 같은 구조로 저장합니다.</p>
         </div>
         <Button type="button" onClick={addTeamMember} className="gap-2">
@@ -1826,8 +2121,17 @@ export function ProjectEditorWizard({
                 .map((item, itemIndex) => (itemIndex === index ? '' : item.memberName))
                 .filter(Boolean),
             );
+            const availableTeamMemberOptions = member.role === '정산지원'
+              ? teamMemberOptions.filter((option) => isProjectSettlementSupportMember({
+                memberName: option.name,
+                memberNickname: option.nickname,
+              }))
+              : teamMemberOptions;
+            const availableTeamMemberOptionMap = member.role === '정산지원'
+              ? Object.fromEntries(availableTeamMemberOptions.map((option) => [option.value, option])) as Record<string, ProjectTeamMemberOption>
+              : teamMemberOptionMap;
             const currentTeamMemberOptionExists = !member.memberName
-              || PROJECT_TEAM_MEMBER_OPTIONS.some((option) => option.value === member.memberName);
+              || availableTeamMemberOptions.some((option) => option.value === member.memberName);
             return (
               <div key={`team-member-${index}`} className="rounded-xl border border-border/60 bg-background/70 p-4">
                 <div className="flex items-center justify-between gap-3">
@@ -1836,7 +2140,7 @@ export function ProjectEditorWizard({
                     <Trash2 className="h-3.5 w-3.5" />
                   </Button>
                 </div>
-                <div className="mt-3 grid gap-3 lg:grid-cols-2 xl:grid-cols-[132px_minmax(0,1.4fr)_minmax(0,1fr)_110px_120px_140px_140px]">
+                <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
                   <div>
                     <Label className="text-xs">입력 방식</Label>
                     <Select
@@ -1862,6 +2166,8 @@ export function ProjectEditorWizard({
                     {teamMemberInputMode === 'search' ? (
                       <TeamMemberSearchCombobox
                         member={member}
+                        options={availableTeamMemberOptions}
+                        optionMap={availableTeamMemberOptionMap}
                         selectedNames={selectedNames}
                         currentTeamMemberOptionExists={currentTeamMemberOptionExists}
                         onSelect={(patch) => updateTeamMember(index, patch)}
@@ -1887,6 +2193,9 @@ export function ProjectEditorWizard({
                         {PROJECT_TEAM_MEMBER_ROLES.map((role) => <SelectItem key={role} value={role}>{role}</SelectItem>)}
                       </SelectContent>
                     </Select>
+                    {member.role === '정산지원' && !isProjectSettlementSupportMember(member) ? (
+                      <p className="mt-1 text-[10px] text-red-700">정산지원은 도담 또는 써니를 선택해 주세요.</p>
+                    ) : null}
                   </div>
                   <div>
                     <Label className="text-xs">참여율(%)</Label>
@@ -1900,13 +2209,19 @@ export function ProjectEditorWizard({
                       className="mt-1 h-9 text-sm"
                     />
                   </div>
-                  <label className="flex items-center gap-2 self-end pb-2 text-[12px] text-slate-700">
-                    <Checkbox
-                      checked={member.isDocumentOnly === true}
-                      onCheckedChange={(checked) => updateTeamMember(index, { isDocumentOnly: checked === true })}
-                    />
-                    서류상 인력
-                  </label>
+                  <div>
+                    <Label className="text-xs">참여 구분</Label>
+                    <Select
+                      value={member.isDocumentOnly === true ? 'document' : 'actual'}
+                      onValueChange={(value) => updateTeamMember(index, { isDocumentOnly: value === 'document' })}
+                    >
+                      <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue /></SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="actual">실제 투입인력</SelectItem>
+                        <SelectItem value="document">서류상 참여인력</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
                   <div>
                     <Label className="text-xs">인건비 시작월</Label>
                     <Input
@@ -1971,73 +2286,90 @@ export function ProjectEditorWizard({
           <Textarea
             value={draft.advanceInterimBelow70Reason}
             onChange={(event) => update('advanceInterimBelow70Reason', event.target.value)}
-            placeholder="발주처 지급 조건 등 70% 미만인 이유를 입력"
+            placeholder="고객사 지급 조건 등 70% 미만인 이유를 입력"
             className="mt-1 min-h-[72px] text-sm"
           />
         </div>
       ) : null}
-      <div>
-        <Label className="text-xs">입금 계획 설명</Label>
-        <Textarea
-          value={draft.paymentPlanDesc}
-          onChange={(event) => update('paymentPlanDesc', event.target.value)}
-          placeholder="예: 검수 완료 후 세금계산서 발행, 발행일로부터 14일 이내 입금"
-          className="mt-1 min-h-[92px] text-sm"
-        />
-      </div>
-      <div>
-        <Label className="text-xs">입금/정산 안내</Label>
-        <Textarea
-          value={draft.settlementGuide}
-          onChange={(event) => update('settlementGuide', event.target.value)}
-          placeholder="예: 이나라도움 수령, 공급가액 기준, 선지급 후 정산"
-          className="mt-1 min-h-[92px] text-sm"
-        />
-      </div>
-      <div>
-        <Label className="text-xs">최종 입금 메모</Label>
-        <Textarea value={draft.finalPaymentNote} onChange={(event) => update('finalPaymentNote', event.target.value)} className="mt-1 min-h-[72px] text-sm" />
-      </div>
-      <div>
-        <Label className="text-xs">기타 참고사항</Label>
-        <Textarea value={draft.note} onChange={(event) => update('note', event.target.value)} className="mt-1 min-h-[88px] text-sm" />
-      </div>
+      {usesRegistrationV2 ? (
+        <div>
+          <Label className="text-xs">특이사항 (메모란)</Label>
+          <Textarea value={draft.note} onChange={(event) => update('note', event.target.value)} className="mt-1 min-h-[88px] text-sm" />
+        </div>
+      ) : (
+        <>
+          <div>
+            <Label className="text-xs">입금 계획 설명</Label>
+            <Textarea
+              value={draft.paymentPlanDesc}
+              onChange={(event) => update('paymentPlanDesc', event.target.value)}
+              placeholder="예: 검수 완료 후 세금계산서 발행, 발행일로부터 14일 이내 입금"
+              className="mt-1 min-h-[92px] text-sm"
+            />
+          </div>
+          <div>
+            <Label className="text-xs">입금/정산 안내</Label>
+            <Textarea
+              value={draft.settlementGuide}
+              onChange={(event) => update('settlementGuide', event.target.value)}
+              placeholder="예: 이나라도움 수령, 공급가액 기준, 선지급 후 정산"
+              className="mt-1 min-h-[92px] text-sm"
+            />
+          </div>
+          <div>
+            <Label className="text-xs">최종 입금 메모</Label>
+            <Textarea value={draft.finalPaymentNote} onChange={(event) => update('finalPaymentNote', event.target.value)} className="mt-1 min-h-[72px] text-sm" />
+          </div>
+          <div>
+            <Label className="text-xs">기타 참고사항</Label>
+            <Textarea value={draft.note} onChange={(event) => update('note', event.target.value)} className="mt-1 min-h-[88px] text-sm" />
+          </div>
+        </>
+      )}
       {usesRegistrationV2 ? (
         <div className="space-y-3 rounded-xl border border-slate-200 bg-slate-50/70 p-4">
           <div>
             <Label className="text-xs font-semibold">등록 전 확인사항 *</Label>
             <p className="mt-1 text-[11px] text-muted-foreground">계약 및 정산 기준을 사람이 직접 대조한 뒤 체크해 주세요.</p>
           </div>
-          <label className="flex items-center gap-2 text-[12px] text-slate-700">
-            <Checkbox
-              checked={draft.registrationConfirmations.laborIncludesFourInsurance === true}
-              onCheckedChange={(checked) => update('registrationConfirmations', {
-                ...draft.registrationConfirmations,
-                laborIncludesFourInsurance: checked === true,
-              })}
-            />
-            인건비에 4대보험 사업주 부담분이 포함되어 있습니다.
-          </label>
-          <label className="flex items-center gap-2 text-[12px] text-slate-700">
-            <Checkbox
-              checked={draft.registrationConfirmations.laborIncludesRetirementPay === true}
-              onCheckedChange={(checked) => update('registrationConfirmations', {
-                ...draft.registrationConfirmations,
-                laborIncludesRetirementPay: checked === true,
-              })}
-            />
-            인건비에 퇴직급여 충당액이 포함되어 있습니다.
-          </label>
-          <label className="flex items-center gap-2 text-[12px] text-slate-700">
-            <Checkbox
-              checked={draft.registrationConfirmations.customerSettlementBasisConfirmed}
-              onCheckedChange={(checked) => update('registrationConfirmations', {
-                ...draft.registrationConfirmations,
-                customerSettlementBasisConfirmed: checked === true,
-              })}
-            />
-            발주처와 정산 기준을 확인했습니다.
-          </label>
+          {requiresSettlementConfirmations ? (
+            <>
+              <label className="flex items-center gap-2 text-[12px] text-slate-700">
+                <Checkbox
+                  checked={draft.registrationConfirmations.laborIncludesFourInsurance === true}
+                  onCheckedChange={(checked) => update('registrationConfirmations', {
+                    ...draft.registrationConfirmations,
+                    laborIncludesFourInsurance: checked === true,
+                  })}
+                />
+                인건비에 4대보험 사업주 부담분이 포함되어 있습니다.
+              </label>
+              <label className="flex items-center gap-2 text-[12px] text-slate-700">
+                <Checkbox
+                  checked={draft.registrationConfirmations.laborIncludesRetirementPay === true}
+                  onCheckedChange={(checked) => update('registrationConfirmations', {
+                    ...draft.registrationConfirmations,
+                    laborIncludesRetirementPay: checked === true,
+                  })}
+                />
+                인건비에 퇴직급여 충당액이 포함되어 있습니다.
+              </label>
+              <label className="flex items-center gap-2 text-[12px] text-slate-700">
+                <Checkbox
+                  checked={draft.registrationConfirmations.customerSettlementBasisConfirmed}
+                  onCheckedChange={(checked) => update('registrationConfirmations', {
+                    ...draft.registrationConfirmations,
+                    customerSettlementBasisConfirmed: checked === true,
+                  })}
+                />
+                고객사와 정산 기준을 확인했습니다.
+              </label>
+            </>
+          ) : (
+            <p className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-[12px] text-slate-600">
+              정산 기준이 정산없음인 사업은 인건비·고객사 정산 확인을 입력하지 않습니다.
+            </p>
+          )}
           <div className="grid gap-3 lg:grid-cols-2">
             <div>
               <Label className="text-xs">모두싸인으로 계약했나요? *</Label>
@@ -2128,10 +2460,56 @@ export function ProjectEditorWizard({
     </div>
   );
 
-  const ReviewRow = ({ label, value }: { label: string; value: ReactNode }) => (
-    <div className="flex items-start justify-between gap-3 border-b border-border/50 py-2 last:border-0">
+  const registrationDocumentReviewItems = [
+    { number: 1, label: '계약서 PDF', value: draft.contractDocument?.name || '미첨부' },
+    { number: 2, label: '고객사 사업자등록증 PDF', value: draft.customerBusinessRegistrationDocument?.name || '미첨부' },
+    { number: 3, label: '견적서 PDF', value: draft.quoteDocument?.name || '미첨부' },
+    {
+      number: 4,
+      label: '제안서 PDF 또는 RFP/요청 메일 증빙',
+      value: [
+        draft.proposalDocument ? `제안서: ${draft.proposalDocument.name}` : '',
+        draft.rfpRequestEvidenceDocument ? `RFP/요청 메일: ${draft.rfpRequestEvidenceDocument.name}` : '',
+      ].filter(Boolean).join(' · ') || '미첨부',
+    },
+    {
+      number: 5,
+      label: '제안서 Word 원본',
+      value: draft.proposalWordOriginalDocument?.name
+        || (draft.registrationOptionalDocumentNotes.proposalWordOriginal
+          ? `미첨부 사유: ${draft.registrationOptionalDocumentNotes.proposalWordOriginal}`
+          : '미첨부'),
+    },
+    {
+      number: 6,
+      label: '제안서 PPT 원본',
+      value: draft.proposalPptOriginalDocument?.name
+        || (draft.registrationOptionalDocumentNotes.proposalPptOriginal
+          ? `미첨부 사유: ${draft.registrationOptionalDocumentNotes.proposalPptOriginal}`
+          : '미첨부'),
+    },
+    {
+      number: 7,
+      label: '발표자료 PPT 원본',
+      value: draft.presentationPptOriginalDocument?.name
+        || (draft.registrationOptionalDocumentNotes.presentationPptOriginal
+          ? `미첨부 사유: ${draft.registrationOptionalDocumentNotes.presentationPptOriginal}`
+          : '미첨부'),
+    },
+  ];
+
+  const ReviewRow = ({ label, value, stacked = false }: { label: string; value: ReactNode; stacked?: boolean }) => (
+    <div className={cn(
+      'border-b border-border/50 last:border-0',
+      stacked ? 'py-3' : 'flex items-start justify-between gap-3 py-2',
+    )}>
       <span className="shrink-0 text-[11px] text-muted-foreground">{label}</span>
-      <span className="whitespace-pre-line text-right text-[12px] font-medium text-slate-900">{value || '-'}</span>
+      <div className={cn(
+        'whitespace-pre-line text-[12px] font-medium text-slate-900',
+        stacked ? 'mt-2 w-full text-left' : 'text-right',
+      )}>
+        {value || '-'}
+      </div>
     </div>
   );
 
@@ -2142,8 +2520,8 @@ export function ProjectEditorWizard({
           제출 전 {submitIssues.map((issue) => issue.label).join(', ')} 입력이 필요합니다.
         </div>
       ) : null}
-      <div className="grid gap-4 lg:grid-cols-2">
-        <Card className="shadow-none">
+      <div className="grid gap-4 lg:grid-cols-2 lg:items-start">
+        <Card className="shadow-none lg:col-start-1 lg:row-start-1 lg:self-start">
           <CardHeader className="pb-2"><CardTitle className="text-sm">기본 정보</CardTitle></CardHeader>
           <CardContent>
             <ReviewRow label="담당조직(CIC)" value={draft.department} />
@@ -2162,22 +2540,30 @@ export function ProjectEditorWizard({
             ) : null}
           </CardContent>
         </Card>
-        <Card className="shadow-none">
+        <Card className="shadow-none lg:col-start-2 lg:row-span-3 lg:row-start-1 lg:self-start">
           <CardHeader className="pb-2"><CardTitle className="text-sm">계약/재무</CardTitle></CardHeader>
           <CardContent>
             <ReviewRow label="기간" value={`${draft.contractStart || '-'} ~ ${draft.contractEnd || '-'}`} />
             <ReviewRow label="통화" value={PROJECT_CURRENCY_LABELS[draft.currency]} />
             <ReviewRow label="계약금액" value={formatStoredProjectAmount(draft.contractAmount, financialInputFlags.contractAmount)} />
-            <ReviewRow label="매출 부가세" value={formatStoredProjectAmount(draft.salesVatAmount, financialInputFlags.salesVatAmount)} />
+            <ReviewRow label="총매출부가세" value={formatStoredProjectAmount(draft.salesVatAmount, financialInputFlags.salesVatAmount)} />
             <ReviewRow label="총수익" value={formatStoredProjectAmount(draft.totalRevenueAmount, financialInputFlags.totalRevenueAmount)} />
-            <ReviewRow label="지원금" value={formatStoredProjectAmount(draft.supportAmount, financialInputFlags.supportAmount)} />
-            <ReviewRow label="수익률" value={profitRateLabel ? `${profitRateLabel}%` : '-'} />
-            <ReviewRow label="정산 유형" value={SETTLEMENT_TYPE_LABELS[draft.settlementType]} />
-            <ReviewRow label="정산 기준" value={BASIS_LABELS[draft.basis]} />
-            <ReviewRow label="통장 유형" value={ACCOUNT_TYPE_LABELS[draft.accountType]} />
-            <ReviewRow label="정산 시스템" value={SETTLEMENT_SYSTEM_LABELS[draft.settlementSystem]} />
-            <ReviewRow label="인건비 정산 기준" value={LABOR_SETTLEMENT_BASIS_LABELS[draft.laborSettlementBasis]} />
-            <ReviewRow label="자금 입력 방식" value={PROJECT_FUND_INPUT_MODE_LABELS[draft.fundInputMode]} />
+            <ReviewRow label="총지원금" value={formatStoredProjectAmount(draft.supportAmount, financialInputFlags.supportAmount)} />
+            <ReviewRow label="총수익률" value={profitRateLabel ? `${profitRateLabel}%` : '-'} />
+            <ReviewRow label={usesRegistrationV2 ? '사업유형' : '정산 유형'} value={SETTLEMENT_TYPE_LABELS[draft.settlementType]} />
+            {usesRegistrationV2 ? (
+              <ReviewRow label="정산 기준" value={REGISTRATION_V2_BASIS_LABELS[draft.basis as Exclude<Basis, '기타'>]} />
+            ) : settlementDetailsEnabled ? (
+              <ReviewRow label="정산 기준" value={draft.basis === 'NONE' ? '-' : BASIS_LABELS[draft.basis]} />
+            ) : null}
+            {settlementDetailsEnabled ? (
+              <>
+                <ReviewRow label="통장 유형" value={ACCOUNT_TYPE_LABELS[draft.accountType]} />
+                <ReviewRow label="정산 시스템" value={SETTLEMENT_SYSTEM_LABELS[draft.settlementSystem]} />
+                <ReviewRow label="인건비 정산 기준" value={LABOR_SETTLEMENT_BASIS_LABELS[draft.laborSettlementBasis]} />
+                <ReviewRow label="자금 입력 방식" value={PROJECT_FUND_INPUT_MODE_LABELS[draft.fundInputMode]} />
+              </>
+            ) : null}
             {usesRegistrationV2 ? (
               <>
                 <ReviewRow
@@ -2187,28 +2573,41 @@ export function ProjectEditorWizard({
                   )).join('\n')}
                 />
                 <ReviewRow
-                  label="등록 필수 첨부"
-                  value={[
-                    `1. 계약서: ${draft.contractDocument?.name || '미첨부'}`,
-                    `2. 사업자등록증: ${draft.customerBusinessRegistrationDocument?.name || '미첨부'}`,
-                    `3. 견적서: ${draft.quoteDocument?.name || '미첨부'}`,
-                    `4. 제안서 또는 RFP/요청 메일: ${draft.proposalDocument?.name || draft.rfpRequestEvidenceDocument?.name || '미첨부'}`,
-                  ].join('\n')}
+                  label="등록 제출서류 7종"
+                  stacked
+                  value={(
+                    <div className="grid gap-1.5 text-left">
+                      {registrationDocumentReviewItems.map((item) => (
+                        <div
+                          key={item.number}
+                          className="grid grid-cols-[20px_minmax(0,1fr)] items-start gap-2 rounded-md bg-slate-50 px-2.5 py-2"
+                        >
+                          <span className="flex h-5 w-5 items-center justify-center rounded bg-[#001e46] text-[10px] font-semibold text-white">
+                            {item.number}
+                          </span>
+                          <div className="min-w-0">
+                            <p className="text-[11px] font-semibold text-slate-700">{item.label}</p>
+                            <p className="mt-0.5 break-words text-[12px] text-slate-950">{item.value}</p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
                 />
               </>
             ) : null}
           </CardContent>
         </Card>
-        <Card className="shadow-none">
+        <Card className="shadow-none lg:col-start-1 lg:row-start-2 lg:self-start">
           <CardHeader className="pb-2"><CardTitle className="text-sm">팀/인력</CardTitle></CardHeader>
           <CardContent>
             <ReviewRow label="PM" value={draft.managerName} />
             <ReviewRow label="담당자 계정" value={draft.managerId || '-'} />
             <ReviewRow label="지정 결재자" value={draft.executiveApproverName} />
-            <ReviewRow label="서류상 참여인력" value={teamMembersSummary} />
+            <ReviewRow label="참여인력 (서류상·실제)" value={teamMembersSummary} />
           </CardContent>
         </Card>
-        <Card className="shadow-none">
+        <Card className="shadow-none lg:col-start-1 lg:row-start-3 lg:self-start">
           <CardHeader className="pb-2"><CardTitle className="text-sm">입금/정산</CardTitle></CardHeader>
           <CardContent>
             <ReviewRow label="선금/계약금" value={formatPaymentPlanAmount(draft.paymentPlan.contract, draft.contractAmount)} />
@@ -2219,17 +2618,29 @@ export function ProjectEditorWizard({
             <ReviewRow label="잔금 예상월" value={draft.paymentExpectedMonths.final} />
             <ReviewRow label="선금+중도금 비율" value={advanceInterimRatio === null ? '-' : `${(advanceInterimRatio * 100).toFixed(1)}%`} />
             {requiresAdvanceInterimReason ? <ReviewRow label="70% 미만 사유" value={draft.advanceInterimBelow70Reason} /> : null}
-            <ReviewRow label="입금 계획" value={draft.paymentPlanDesc} />
-            <ReviewRow label="입금/정산 안내" value={draft.settlementGuide} />
-            <ReviewRow label="최종 입금 메모" value={draft.finalPaymentNote} />
-            <ReviewRow label="기타 참고사항" value={draft.note} />
+            {usesRegistrationV2 ? (
+              <ReviewRow label="특이사항" value={draft.note} />
+            ) : (
+              <>
+                <ReviewRow label="입금 계획" value={draft.paymentPlanDesc} />
+                <ReviewRow label="입금/정산 안내" value={draft.settlementGuide} />
+                <ReviewRow label="최종 입금 메모" value={draft.finalPaymentNote} />
+                <ReviewRow label="기타 참고사항" value={draft.note} />
+              </>
+            )}
             {usesRegistrationV2 ? (
               <ReviewRow
                 label="등록 확인사항"
                 value={[
-                  `4대보험 ${draft.registrationConfirmations.laborIncludesFourInsurance ? '확인' : '미확인'}`,
-                  `퇴직급여 ${draft.registrationConfirmations.laborIncludesRetirementPay ? '확인' : '미확인'}`,
-                  `발주처 정산기준 ${draft.registrationConfirmations.customerSettlementBasisConfirmed ? '확인' : '미확인'}`,
+                  requiresSettlementConfirmations
+                    ? `4대보험 ${draft.registrationConfirmations.laborIncludesFourInsurance ? '확인' : '미확인'}`
+                    : '인건비·고객사 정산 확인 해당 없음',
+                  requiresSettlementConfirmations
+                    ? `퇴직급여 ${draft.registrationConfirmations.laborIncludesRetirementPay ? '확인' : '미확인'}`
+                    : '',
+                  requiresSettlementConfirmations
+                    ? `고객사 정산기준 ${draft.registrationConfirmations.customerSettlementBasisConfirmed ? '확인' : '미확인'}`
+                    : '',
                   `모두싸인 ${draft.registrationConfirmations.modusignContractUsed === null ? '미선택' : draft.registrationConfirmations.modusignContractUsed ? '사용' : '미사용'}`,
                   draft.registrationConfirmations.modusignContractUsed === false
                     ? `원본 제출 ${draft.registrationConfirmations.originalContractSubmitted ? '확인' : '미확인'}`
@@ -2248,8 +2659,13 @@ export function ProjectEditorWizard({
         {draft.contractDocument ? (
           <div className="lg:col-span-2">
             <ContractDocumentPreview
-              document={draft.contractDocument}
-              privateDraftAttachment={mode === 'portal-register' && !draft.contractDocument.downloadURL}
+              document={{
+                ...draft.contractDocument,
+                downloadURL: documentPreviewUrls?.contract || draft.contractDocument.downloadURL,
+              }}
+              privateDraftAttachment={Boolean(documentPreviewStates?.contract) && !(documentPreviewUrls?.contract || draft.contractDocument.downloadURL)}
+              previewState={documentPreviewStates?.contract}
+              onLoadPreview={onLoadDocumentPreview ? () => onLoadDocumentPreview('contract') : undefined}
               title="계약서 원문"
               description="등록하려는 계약서가 맞는지 꼭 확인해주세요!"
               descriptionClassName="text-rose-600"
@@ -2259,8 +2675,13 @@ export function ProjectEditorWizard({
         {draft.quoteDocument ? (
           <div className="lg:col-span-2">
             <ContractDocumentPreview
-              document={draft.quoteDocument}
-              privateDraftAttachment={mode === 'portal-register' && !draft.quoteDocument.downloadURL}
+              document={{
+                ...draft.quoteDocument,
+                downloadURL: documentPreviewUrls?.quote || draft.quoteDocument.downloadURL,
+              }}
+              privateDraftAttachment={Boolean(documentPreviewStates?.quote) && !(documentPreviewUrls?.quote || draft.quoteDocument.downloadURL)}
+              previewState={documentPreviewStates?.quote}
+              onLoadPreview={onLoadDocumentPreview ? () => onLoadDocumentPreview('quote') : undefined}
               title="견적서 원문"
               description="첨부한 견적서가 맞는지 확인해주세요."
             />
@@ -2269,28 +2690,58 @@ export function ProjectEditorWizard({
         {draft.proposalDocument ? (
           <div className="lg:col-span-2">
             <ContractDocumentPreview
-              document={draft.proposalDocument}
-              privateDraftAttachment={mode === 'portal-register' && !draft.proposalDocument.downloadURL}
+              document={{
+                ...draft.proposalDocument,
+                downloadURL: documentPreviewUrls?.proposal || draft.proposalDocument.downloadURL,
+              }}
+              privateDraftAttachment={Boolean(documentPreviewStates?.proposal) && !(documentPreviewUrls?.proposal || draft.proposalDocument.downloadURL)}
+              previewState={documentPreviewStates?.proposal}
+              onLoadPreview={onLoadDocumentPreview ? () => onLoadDocumentPreview('proposal') : undefined}
               title="제안서 원문"
               description="첨부한 제안서가 맞는지 확인해주세요."
+            />
+          </div>
+        ) : null}
+        {draft.rfpRequestEvidenceDocument ? (
+          <div className="lg:col-span-2">
+            <ContractDocumentPreview
+              document={{
+                ...draft.rfpRequestEvidenceDocument,
+                downloadURL: documentPreviewUrls?.rfp_request_evidence || draft.rfpRequestEvidenceDocument.downloadURL,
+              }}
+              privateDraftAttachment={Boolean(documentPreviewStates?.rfp_request_evidence) && !(documentPreviewUrls?.rfp_request_evidence || draft.rfpRequestEvidenceDocument.downloadURL)}
+              previewState={documentPreviewStates?.rfp_request_evidence}
+              onLoadPreview={onLoadDocumentPreview ? () => onLoadDocumentPreview('rfp_request_evidence') : undefined}
+              title="RFP/요청 메일 증빙 원문"
+              description="첨부한 RFP 또는 요청 메일 증빙이 맞는지 확인해주세요."
             />
           </div>
         ) : null}
         {draft.customerBusinessRegistrationDocument ? (
           <div className="lg:col-span-2">
             <ContractDocumentPreview
-              document={draft.customerBusinessRegistrationDocument}
-              privateDraftAttachment={!draft.customerBusinessRegistrationDocument.downloadURL}
-              title="발주처 사업자등록증 원문"
-              description="첨부한 발주처 사업자등록증이 맞는지 확인해주세요."
+              document={{
+                ...draft.customerBusinessRegistrationDocument,
+                downloadURL: documentPreviewUrls?.customer_business_registration || draft.customerBusinessRegistrationDocument.downloadURL,
+              }}
+              privateDraftAttachment={Boolean(documentPreviewStates?.customer_business_registration) && !(documentPreviewUrls?.customer_business_registration || draft.customerBusinessRegistrationDocument.downloadURL)}
+              previewState={documentPreviewStates?.customer_business_registration}
+              onLoadPreview={onLoadDocumentPreview ? () => onLoadDocumentPreview('customer_business_registration') : undefined}
+              title="고객사 사업자등록증 원문"
+              description="첨부한 고객사 사업자등록증이 맞는지 확인해주세요."
             />
           </div>
         ) : null}
         {showProjectCheckout && draft.performanceCertificateDocument ? (
           <div className="lg:col-span-2">
             <ContractDocumentPreview
-              document={draft.performanceCertificateDocument}
-              privateDraftAttachment={!draft.performanceCertificateDocument.downloadURL}
+              document={{
+                ...draft.performanceCertificateDocument,
+                downloadURL: documentPreviewUrls?.performance_certificate || draft.performanceCertificateDocument.downloadURL,
+              }}
+              privateDraftAttachment={Boolean(documentPreviewStates?.performance_certificate) && !(documentPreviewUrls?.performance_certificate || draft.performanceCertificateDocument.downloadURL)}
+              previewState={documentPreviewStates?.performance_certificate}
+              onLoadPreview={onLoadDocumentPreview ? () => onLoadDocumentPreview('performance_certificate') : undefined}
               title="수행확인서 원문"
               description="종료사업 수행확인서 증빙입니다."
             />
@@ -2299,8 +2750,13 @@ export function ProjectEditorWizard({
         {showProjectCheckout && draft.taxInvoiceDocument ? (
           <div className="lg:col-span-2">
             <ContractDocumentPreview
-              document={draft.taxInvoiceDocument}
-              privateDraftAttachment={!draft.taxInvoiceDocument.downloadURL}
+              document={{
+                ...draft.taxInvoiceDocument,
+                downloadURL: documentPreviewUrls?.tax_invoice || draft.taxInvoiceDocument.downloadURL,
+              }}
+              privateDraftAttachment={Boolean(documentPreviewStates?.tax_invoice) && !(documentPreviewUrls?.tax_invoice || draft.taxInvoiceDocument.downloadURL)}
+              previewState={documentPreviewStates?.tax_invoice}
+              onLoadPreview={onLoadDocumentPreview ? () => onLoadDocumentPreview('tax_invoice') : undefined}
               title="세금계산서 원문"
               description="종료사업 세금계산서 증빙입니다."
             />
@@ -2309,8 +2765,13 @@ export function ProjectEditorWizard({
         {showProjectCheckout && draft.finalSettlementReportDocument ? (
           <div className="lg:col-span-2">
             <ContractDocumentPreview
-              document={draft.finalSettlementReportDocument}
-              privateDraftAttachment={!draft.finalSettlementReportDocument.downloadURL}
+              document={{
+                ...draft.finalSettlementReportDocument,
+                downloadURL: documentPreviewUrls?.final_settlement_report || draft.finalSettlementReportDocument.downloadURL,
+              }}
+              privateDraftAttachment={Boolean(documentPreviewStates?.final_settlement_report) && !(documentPreviewUrls?.final_settlement_report || draft.finalSettlementReportDocument.downloadURL)}
+              previewState={documentPreviewStates?.final_settlement_report}
+              onLoadPreview={onLoadDocumentPreview ? () => onLoadDocumentPreview('final_settlement_report') : undefined}
               title="최종 정산보고서 원문"
               description="종료사업 최종 정산보고서 증빙입니다."
             />
@@ -2409,15 +2870,15 @@ export function ProjectEditorWizard({
         </div>
       ) : null}
 
-      <div className="grid gap-4 lg:grid-cols-[220px_minmax(0,1fr)] lg:items-start">
-      <Card className="border-slate-200/80 shadow-sm lg:sticky lg:top-4">
+      <div className="space-y-4">
+      <Card className="border-slate-200/80 shadow-sm">
         <CardContent className="p-3">
           <div className="mb-4 flex items-center justify-between text-xs text-muted-foreground">
             <span>{stepIndex + 1} / {STEPS.length}</span>
             <span>{step.label}</span>
           </div>
           <Progress value={((stepIndex + 1) / STEPS.length) * 100} />
-          <div className="mt-4 grid gap-1.5">
+          <div className="mt-4 grid gap-1.5 lg:grid-cols-5">
             {STEPS.map((item, index) => {
               const Icon = item.icon;
               const active = index === stepIndex;
@@ -2426,7 +2887,7 @@ export function ProjectEditorWizard({
                   key={item.id}
                   type="button"
                   onClick={() => setStepIndex(index)}
-                  className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-left text-xs transition-colors ${
+                  className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-left text-xs transition-colors lg:justify-center lg:py-3 ${
                     active ? 'border-[#001e46] bg-slate-50 text-[#001e46]' : 'border-border bg-white text-muted-foreground hover:bg-muted/40'
                   }`}
                 >
@@ -2454,7 +2915,7 @@ export function ProjectEditorWizard({
       </Card>
       </div>
 
-      <div className="z-20 rounded-2xl border border-slate-200 bg-white/95 px-4 py-3 shadow-lg backdrop-blur lg:sticky lg:bottom-4">
+      <div className="z-20 rounded-2xl border border-slate-200 bg-white/95 px-4 py-3 shadow-lg backdrop-blur">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex items-center gap-2 text-[12px] text-muted-foreground">
             <CalendarRange className="h-4 w-4" />
@@ -2482,7 +2943,7 @@ export function ProjectEditorWizard({
                 type="button"
                 variant="outline"
                 onClick={() => void handleManualAutosave()}
-                disabled={readOnly || autosaveState === 'saving'}
+                disabled={readOnly || autosaveState === 'saving' || uploadInProgress || hasPendingRetryFile}
                 className="gap-2"
               >
                 {autosaveState === 'saving' ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
@@ -2512,7 +2973,7 @@ export function ProjectEditorWizard({
                     key={action.id}
                     type="button"
                     variant={action.variant || 'default'}
-                    disabled={readOnly || autosaveState === 'saving' || !!busyActionId || action.disabled || !canSubmit}
+                    disabled={readOnly || autosaveState === 'saving' || uploadInProgress || hasPendingRetryFile || !!busyActionId || action.disabled || !canSubmit}
                     onClick={() => void handleActionSubmit(action.id)}
                     className="gap-2"
                   >

--- a/src/app/components/projects/ProjectListPage.shell.test.ts
+++ b/src/app/components/projects/ProjectListPage.shell.test.ts
@@ -115,11 +115,14 @@ describe('ProjectListPage shell contract', () => {
     expect(source).not.toContain('onClick={() => navigate(`/projects/${p.id}`)}');
   });
 
-  it('surfaces pending PM change requests from both request collections', () => {
+  it('surfaces pending PM change requests through the permission-checked BFF summary', () => {
     expect(source).toContain('usePendingProjectChangeRequests');
+    expect(source).toContain('usePendingProjectChangeRequests(projectIds)');
     expect(source).toContain('수정 검토 중');
-    expect(pendingHookSource).toContain("const PROJECT_REQUEST_COLLECTIONS: ProjectRequestCollectionName[] = ['project_requests', 'projectRequests']");
+    expect(pendingHookSource).toContain('fetchPendingProjectChangeRequestsViaBff');
+    expect(pendingHookSource).toContain('projectIds,');
     expect(pendingHookSource).toContain("request.requestKind !== 'CHANGE'");
     expect(pendingHookSource).toContain("request.targetProjectId || request.approvedProjectId");
+    expect(pendingHookSource).not.toContain("collection(db, 'tenants'");
   });
 });

--- a/src/app/components/projects/ProjectListPage.tsx
+++ b/src/app/components/projects/ProjectListPage.tsx
@@ -63,7 +63,8 @@ export function ProjectListPage() {
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const [activeTab, setActiveTab] = useState<string>('contract-pending');
   const [expandedProjectId, setExpandedProjectId] = useState<string | null>(null);
-  const pendingProjectChangeMap = usePendingProjectChangeRequests();
+  const projectIds = useMemo(() => allProjects.map((project) => project.id).filter(Boolean), [allProjects]);
+  const pendingProjectChangeMap = usePendingProjectChangeRequests(projectIds);
 
   const {
     active: activeProjects,

--- a/src/app/components/projects/ProjectMigrationAuditPage.shell.test.ts
+++ b/src/app/components/projects/ProjectMigrationAuditPage.shell.test.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import type { MigrationAuditConsoleRecord } from '../../platform/project-migration-console';
+import { buildMigrationReviewDocumentSlots } from './migration-audit/MigrationAuditDocumentDialog';
 
 const pageSource = readFileSync(resolve(import.meta.dirname, 'ProjectMigrationAuditPage.tsx'), 'utf8');
 const controlBarSource = readFileSync(resolve(import.meta.dirname, 'migration-audit/MigrationAuditControlBar.tsx'), 'utf8');
@@ -34,6 +36,29 @@ describe('ProjectMigrationAuditPage review flow', () => {
     expect(pageSource).not.toContain('isSameMigrationAuditCic');
     expect(documentSource).toContain('canFinalize: boolean');
     expect(documentSource).toContain('지정된 조직장만 승인 또는 반려할 수 있습니다.');
+    expect(documentSource.indexOf('requestPayload?.executiveApproverName')).toBeLessThan(
+      documentSource.indexOf('record.project.executiveApproverName'),
+    );
+  });
+
+  it('exposes an assignee-only portal inbox without broadening the admin review route', () => {
+    expect(pageSource).toContain('assigneeOnly?: boolean');
+    expect(pageSource).toContain('export function ProjectAssigneeApprovalPage()');
+    expect(pageSource).toContain('const { projects, portalUser } = usePortalStore()');
+    expect(pageSource).toContain('<ProjectMigrationAuditPageContent assigneeOnly projects={projects} currentUser={portalUser} />');
+    expect(pageSource).toContain("const effectiveInboxScope = assigneeOnly ? 'MINE' : inboxScope");
+    expect(pageSource).toContain('assigneeOnly={assigneeOnly}');
+    expect(controlBarSource).toContain('assigneeOnly?: boolean');
+    expect(controlBarSource).toContain('!isManagementPlanning && !assigneeOnly');
+    expect(pageSource).toContain('fetchAssignedProjectRequestsViaBff');
+    expect(pageSource).toContain('fetchProjectReviewInboxViaBff');
+    expect(pageSource).toContain('const assignedInbox = await fetchAssignedProjectRequestsViaBff');
+    expect(pageSource).toContain('setRequests(assignedInbox.requests)');
+    expect(pageSource).toContain('setAssignedProjects(assignedInbox.projects)');
+    expect(pageSource).toContain('assignedProjects.forEach((project) => projectsById.set(project.id, project))');
+    expect(pageSource).toContain('buildMigrationAuditConsoleRecords(recordProjects, requests)');
+    expect(pageSource).toContain('requestLoadError');
+    expect(pageSource).not.toContain("collection(db, 'tenants'");
   });
 
   it('uses a separate management-planning command only after organization approval', () => {
@@ -47,13 +72,110 @@ describe('ProjectMigrationAuditPage review flow', () => {
     expect(recordListSource).toContain('프로젝트 코드');
   });
 
-  it('keeps the contract in the document popup and fetches private originals through the BFF', () => {
-    expect(pageSource).toContain('resolveMigrationReviewContractDocument');
+  it('prefills and locks an already-issued project code during planning re-review', () => {
+    expect(pageSource).toContain("setProjectCode(String(openRecord?.project.projectCode || '').trim())");
+    expect(pageSource).toContain('const existingProjectCode = String(openRecord?.project.projectCode || \'\').trim()');
+    expect(pageSource).toContain('readOnly={Boolean(existingProjectCode)}');
+    expect(pageSource).toContain('이미 부여된 프로젝트 코드는 변경할 수 없습니다.');
+  });
+
+  it('matches the BFF 2,000-character approval and rejection memo limit', () => {
+    expect(pageSource).toContain('maxLength={2000}');
+    expect(pageSource).toContain('{reviewComment.length.toLocaleString()}/2,000자');
+  });
+
+  it('shows all seven logical submission slots and fetches each stored original through the BFF', () => {
+    expect(documentSource).toContain('data-testid="migration-review-document-slots"');
+    expect(documentSource).toContain("number: 1");
+    expect(documentSource).toContain("number: 7");
+    expect(documentSource).toContain("kinds: ['proposal', 'rfp_request_evidence']");
+    expect(documentSource).toContain('customerBusinessRegistrationDocument');
+    expect(documentSource).toContain('proposalWordOriginalDocument');
+    expect(documentSource).toContain('proposalPptOriginalDocument');
+    expect(documentSource).toContain('presentationPptOriginalDocument');
+    expect(documentSource).toContain('registrationOptionalDocumentNotes');
+    expect(pageSource).toContain('usePrivateDraftDocumentPreviews');
+    expect(pageSource).toContain('REVIEW_DOCUMENT_FIELDS');
     expect(pageSource).toContain('downloadProjectRequestAttachmentViaBff');
-    expect(pageSource).toContain('URL.createObjectURL');
-    expect(pageSource).toContain('URL.revokeObjectURL');
+    expect(pageSource).toContain('downloadProjectAttachmentViaBff');
+    expect(pageSource).toContain('onLoadDocumentPreview={loadDocumentPreview}');
     expect(documentSource).toContain('ContractDocumentPreview');
+    expect(documentSource).toContain('onLoadDocumentPreview');
+    expect(documentSource).toContain('미첨부 사유');
     expect(previewSource).toContain('data-testid="contract-document-preview"');
     expect(previewSource).toContain('<iframe');
+    expect(previewSource).toContain('새 탭');
+    expect(documentSource).toContain('제출 원문을 안전하게 불러오는 중입니다.');
+    expect(documentSource).toContain('PDF 미리보기가 비어 있으면 새 탭에서 원문을 확인하고');
+  });
+
+  it('treats the submitted snapshot as authoritative and preserves optional-file reasons', () => {
+    const record = {
+      project: {
+        contractDocument: { name: 'old-contract.pdf', path: 'projects/old-contract.pdf' },
+        proposalWordOriginalDocument: { name: 'old-proposal.docx', path: 'projects/old-proposal.docx' },
+        registrationOptionalDocumentNotes: {
+          proposalWordOriginal: '기존 프로젝트 사유',
+          proposalPptOriginal: '',
+          presentationPptOriginal: '',
+        },
+      },
+      request: {
+        requestKind: 'REGISTRATION',
+        payload: {
+          contractDocument: { name: 'submitted-contract.pdf', path: 'requests/submitted-contract.pdf' },
+          customerBusinessRegistrationDocument: { name: 'customer.pdf', path: 'requests/customer.pdf' },
+          quoteDocument: { name: 'quote.pdf', path: 'requests/quote.pdf' },
+          proposalDocument: null,
+          rfpRequestEvidenceDocument: { name: 'request.eml', path: 'requests/request.eml' },
+          proposalWordOriginalDocument: null,
+          proposalPptOriginalDocument: null,
+          presentationPptOriginalDocument: null,
+          registrationOptionalDocumentNotes: {
+            proposalWordOriginal: '고객사가 Word 원본을 제공하지 않음',
+            proposalPptOriginal: '제안서가 PDF로만 작성됨',
+            presentationPptOriginal: '별도 발표자료 없음',
+          },
+        },
+      },
+    } as unknown as MigrationAuditConsoleRecord;
+
+    const slots = buildMigrationReviewDocumentSlots(record);
+
+    expect(slots).toHaveLength(7);
+    expect(slots[0]?.entries[0]?.document.name).toBe('submitted-contract.pdf');
+    expect(slots[3]?.entries.map((entry) => entry.kind)).toEqual(['rfp_request_evidence']);
+    expect(slots[4]?.entries).toEqual([]);
+    expect(slots[4]?.note).toBe('고객사가 Word 원본을 제공하지 않음');
+    expect(slots[5]?.note).toBe('제안서가 PDF로만 작성됨');
+    expect(slots[6]?.note).toBe('별도 발표자료 없음');
+  });
+
+  it('surfaces contradictory slot-four data and does not revive cleared or inaccessible metadata', () => {
+    const record = {
+      project: {
+        registrationOptionalDocumentNotes: {
+          proposalWordOriginal: '과거 미첨부 사유',
+          proposalPptOriginal: '',
+          presentationPptOriginal: '',
+        },
+      },
+      request: {
+        requestKind: 'REGISTRATION',
+        payload: {
+          customerBusinessRegistrationDocument: { name: '경로가 없는 파일.pdf' },
+          proposalDocument: { name: 'proposal.pdf', path: 'requests/proposal.pdf' },
+          rfpRequestEvidenceDocument: { name: 'request.eml', path: 'requests/request.eml' },
+          registrationOptionalDocumentNotes: null,
+        },
+      },
+    } as unknown as MigrationAuditConsoleRecord;
+
+    const slots = buildMigrationReviewDocumentSlots(record);
+
+    expect(slots[1]?.entries).toEqual([]);
+    expect(slots[3]?.entries.map((entry) => entry.kind)).toEqual(['proposal', 'rfp_request_evidence']);
+    expect(slots[3]?.conflict).toBe(true);
+    expect(slots[4]?.note).toBe('');
   });
 });

--- a/src/app/components/projects/ProjectMigrationAuditPage.tsx
+++ b/src/app/components/projects/ProjectMigrationAuditPage.tsx
@@ -1,18 +1,20 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { ClipboardCheck, Loader2 } from 'lucide-react';
-import { collection, onSnapshot, orderBy, query } from 'firebase/firestore';
 import { toast } from 'sonner';
 import { useAuth } from '../../data/auth-store';
+import { usePortalStore } from '../../data/portal-store';
 import { useAppStore } from '../../data/store';
 import type { Project, ProjectExecutiveReviewStatus, ProjectRequest } from '../../data/types';
-import { getOrgRootPath } from '../../lib/firebase';
 import { useFirebase } from '../../lib/firebase-context';
 import {
+  fetchAssignedProjectRequestsViaBff,
+  fetchProjectReviewInboxViaBff,
   isPlatformApiEnabled,
   reviewProjectExecutiveStatusViaBff,
   reviewProjectManagementPlanningStatusViaBff,
 } from '../../lib/platform-bff-client';
 import { downloadProjectAttachmentViaBff, downloadProjectRequestAttachmentViaBff } from '../../lib/project-request-attachment-client';
+import type { ProjectRequestDocumentKind } from '../../platform/project-contract-upload';
 import {
   type MigrationAuditConsoleRecord,
   type MigrationAuditConsoleStatus,
@@ -24,8 +26,8 @@ import {
 } from '../../platform/project-migration-console';
 import { getManagementPlanningReview } from '../../platform/project-management-planning-review';
 import { resolveProjectRequestKind, resolveProjectRequestPayload } from '../../platform/project-change-request';
-import { resolveMigrationReviewContractDocument } from '../../platform/project-migration-review-dossier';
 import { PageHeader } from '../layout/PageHeader';
+import { usePrivateDraftDocumentPreviews } from '../portal/usePrivateDraftDocumentPreviews';
 import { Card, CardContent } from '../ui/card';
 import { MigrationAuditControlBar } from './migration-audit/MigrationAuditControlBar';
 import { MigrationAuditRecordList } from './migration-audit/MigrationAuditRecordList';
@@ -45,10 +47,23 @@ import { Input } from '../ui/input';
 
 type ReviewActionMode = 'approve' | 'reject' | 'discard';
 export type ProjectRegistrationReviewStage = 'executive' | 'managementPlanning';
-type ProjectRequestCollectionName = 'project_requests' | 'projectRequests';
-type ProjectRequestWithSource = ProjectRequest & { __collectionName?: ProjectRequestCollectionName };
+const REVIEW_DOCUMENT_FIELDS = {
+  contract: 'contractDocument',
+  customer_business_registration: 'customerBusinessRegistrationDocument',
+  quote: 'quoteDocument',
+  proposal: 'proposalDocument',
+  rfp_request_evidence: 'rfpRequestEvidenceDocument',
+  proposal_word_original: 'proposalWordOriginalDocument',
+  proposal_ppt_original: 'proposalPptOriginalDocument',
+  presentation_ppt_original: 'presentationPptOriginalDocument',
+} as const satisfies Partial<Record<ProjectRequestDocumentKind, keyof Project>>;
+type ReviewDocumentField = typeof REVIEW_DOCUMENT_FIELDS[keyof typeof REVIEW_DOCUMENT_FIELDS];
 
-const PROJECT_REQUEST_COLLECTIONS: ProjectRequestCollectionName[] = ['project_requests', 'projectRequests'];
+type ReviewDocumentSource = {
+  source: 'project' | 'request';
+  projectId: string;
+  requestId: string;
+};
 
 function getReviewDialogTitle(mode: ReviewActionMode, reviewStage: ProjectRegistrationReviewStage): string {
   if (reviewStage === 'managementPlanning') return mode === 'approve' ? '프로젝트 코드 부여에 합의할까요?' : '프로젝트 코드를 반려할까요?';
@@ -104,18 +119,28 @@ type ProjectMigrationAuditPageProps = {
   embedded?: boolean;
   reviewScope?: 'all' | 'pending';
   reviewStage?: ProjectRegistrationReviewStage;
+  assigneeOnly?: boolean;
 };
 
-export function ProjectMigrationAuditPage({
+type ProjectMigrationAuditPageContentProps = ProjectMigrationAuditPageProps & {
+  projects: Project[];
+  currentUser?: { name?: string; email?: string } | null;
+};
+
+function ProjectMigrationAuditPageContent({
   embedded = false,
   reviewScope = 'all',
   reviewStage = 'executive',
-}: ProjectMigrationAuditPageProps = {}) {
+  assigneeOnly = false,
+  projects,
+  currentUser,
+}: ProjectMigrationAuditPageContentProps) {
   const { user: authUser } = useAuth();
-  const { projects, currentUser } = useAppStore();
-  const { db, isOnline, orgId } = useFirebase();
+  const { orgId } = useFirebase();
   const [requests, setRequests] = useState<ProjectRequest[]>([]);
+  const [assignedProjects, setAssignedProjects] = useState<Project[]>([]);
   const [loadingRequests, setLoadingRequests] = useState(true);
+  const [requestLoadError, setRequestLoadError] = useState('');
   const [cicFilter, setCicFilter] = useState('ALL');
   const [statusFilter, setStatusFilter] = useState<'ALL' | MigrationAuditConsoleStatus>('PENDING');
   const [searchQuery, setSearchQuery] = useState('');
@@ -125,50 +150,67 @@ export function ProjectMigrationAuditPage({
   const [reviewComment, setReviewComment] = useState('');
   const [projectCode, setProjectCode] = useState('');
   const [acting, setActing] = useState(false);
-  const [secureContractDocument, setSecureContractDocument] = useState({ key: '', url: '', error: '' });
+  const [requestReloadVersion, setRequestReloadVersion] = useState(0);
   const isManagementPlanning = reviewStage === 'managementPlanning';
+  const reviewProjectIds = useMemo(() => projects.map((project) => project.id).filter(Boolean), [projects]);
 
   useEffect(() => {
-    if (!db || !isOnline) {
+    if (!isPlatformApiEnabled() || !authUser?.uid) {
       setRequests([]);
+      setAssignedProjects([]);
       setLoadingRequests(false);
+      setRequestLoadError('프로젝트 결재 서버 연결을 확인하지 못했습니다. 다시 로그인한 뒤 확인해 주세요.');
       return undefined;
     }
-
-    setLoadingRequests(true);
-    const sourceRows = new Map<ProjectRequestCollectionName, ProjectRequestWithSource[]>();
-    const initializedSources = new Set<ProjectRequestCollectionName>();
     let disposed = false;
-    const publish = () => {
-      if (disposed) return;
-      setRequests(Array.from(sourceRows.values()).flat());
-      if (initializedSources.size === PROJECT_REQUEST_COLLECTIONS.length) setLoadingRequests(false);
-    };
-    const unsubscribers = PROJECT_REQUEST_COLLECTIONS.map((collectionName) => onSnapshot(
-      query(collection(db, `${getOrgRootPath(orgId)}/${collectionName}`), orderBy('requestedAt', 'desc')),
-      (snapshot) => {
-        sourceRows.set(collectionName, snapshot.docs.map((docSnap) => ({
-          ...(docSnap.data() as ProjectRequest),
-          id: String((docSnap.data() as ProjectRequest).id || docSnap.id),
-          __collectionName: collectionName,
-        })));
-        initializedSources.add(collectionName);
-        publish();
-      },
-      (error) => {
-        console.error(`[ProjectMigrationAuditPage] ${collectionName} listen error:`, error);
-        sourceRows.set(collectionName, []);
-        initializedSources.add(collectionName);
-        publish();
-      },
-    ));
-    return () => {
-      disposed = true;
-      unsubscribers.forEach((unsubscribe) => unsubscribe());
-    };
-  }, [db, isOnline, orgId]);
+    setLoadingRequests(true);
+    setRequestLoadError('');
+    void (async () => {
+      try {
+        const actor = {
+          uid: authUser.uid,
+          email: authUser.email,
+          role: authUser.role,
+          idToken: authUser.idToken,
+        };
+        if (assigneeOnly) {
+          const assignedInbox = await fetchAssignedProjectRequestsViaBff({ tenantId: orgId, actor });
+          if (!disposed) {
+            setRequests(assignedInbox.requests);
+            setAssignedProjects(assignedInbox.projects);
+          }
+        } else {
+          const nextRequests = await fetchProjectReviewInboxViaBff({
+            tenantId: orgId,
+            actor,
+            projectIds: reviewProjectIds,
+          });
+          if (!disposed) {
+            setRequests(nextRequests);
+            setAssignedProjects([]);
+          }
+        }
+      } catch (error) {
+        console.error('[ProjectMigrationAuditPage] project request fetch error:', error);
+        if (!disposed) {
+          setRequests([]);
+          setAssignedProjects([]);
+          setRequestLoadError('PM 등록 프로젝트와 접수 이력을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.');
+        }
+      } finally {
+        if (!disposed) setLoadingRequests(false);
+      }
+    })();
+    return () => { disposed = true; };
+  }, [assigneeOnly, authUser?.email, authUser?.idToken, authUser?.role, authUser?.uid, orgId, requestReloadVersion, reviewProjectIds]);
 
-  const records = useMemo(() => buildMigrationAuditConsoleRecords(projects, requests), [projects, requests]);
+  const recordProjects = useMemo(() => {
+    if (assignedProjects.length === 0) return projects;
+    const projectsById = new Map(projects.map((project) => [project.id, project]));
+    assignedProjects.forEach((project) => projectsById.set(project.id, project));
+    return Array.from(projectsById.values());
+  }, [assignedProjects, projects]);
+  const records = useMemo(() => buildMigrationAuditConsoleRecords(recordProjects, requests), [recordProjects, requests]);
   const stageRecords = useMemo(() => {
     if (isManagementPlanning) return buildManagementPlanningRecords(records);
     return buildExecutiveRecords(records);
@@ -177,58 +219,85 @@ export function ProjectMigrationAuditPage({
     ? stageRecords.filter((record) => record.status === 'PENDING')
     : stageRecords, [reviewScope, stageRecords]);
   const reviewerDepartment = String(authUser?.department || '').trim();
+  const effectiveInboxScope = assigneeOnly ? 'MINE' : inboxScope;
   const inboxRecords = useMemo(() => {
-    if (isManagementPlanning || inboxScope === 'ALL') return scopedRecords;
+    if (isManagementPlanning || effectiveInboxScope === 'ALL') return scopedRecords;
     return scopedRecords.filter((record) => {
       const approverId = resolveProjectRequestPayload(record.request)?.executiveApproverId || record.project.executiveApproverId;
       return Boolean(authUser?.uid && approverId === authUser.uid);
     });
-  }, [authUser?.uid, inboxScope, isManagementPlanning, scopedRecords]);
+  }, [authUser?.uid, effectiveInboxScope, isManagementPlanning, scopedRecords]);
   const summaryRecords = useMemo(() => filterMigrationAuditConsoleRecords(inboxRecords, { cic: cicFilter, status: 'ALL', searchQuery }), [cicFilter, inboxRecords, searchQuery]);
   const filteredRecords = useMemo(() => filterMigrationAuditConsoleRecords(summaryRecords, { cic: cicFilter, status: statusFilter, searchQuery }), [cicFilter, searchQuery, statusFilter, summaryRecords]);
   const summary = useMemo(() => summarizeMigrationAuditConsole(summaryRecords), [summaryRecords]);
   const cicOptions = useMemo(() => collectMigrationAuditCicOptions(inboxRecords), [inboxRecords]);
   const openRecord = useMemo(() => summaryRecords.find((record) => record.id === openRecordId) || null, [openRecordId, summaryRecords]);
-  const contractDocument = openRecord ? resolveMigrationReviewContractDocument(openRecord.project, openRecord.request) : null;
-  const contractDocumentPath = String(contractDocument?.path || '').trim();
-  const contractDownloadUrl = String(contractDocument?.downloadURL || '').trim();
-  const requestContractPath = String(resolveProjectRequestPayload(openRecord?.request)?.contractDocument?.path || '').trim();
-  const requestId = String(openRecord?.request?.id || '').trim();
-  const projectId = String(openRecord?.project.id || '').trim();
-  const contractAttachmentSource = requestId && contractDocumentPath === requestContractPath ? 'request' : projectId && contractDocumentPath ? 'project' : '';
-  const contractAttachmentId = contractAttachmentSource === 'request' ? requestId : projectId;
-  const secureContractDocumentKey = contractAttachmentSource && contractAttachmentId && contractDocumentPath ? `${contractAttachmentSource}:${contractAttachmentId}:${contractDocumentPath}` : '';
-  const secureContractDocumentUrl = secureContractDocument.key === secureContractDocumentKey ? secureContractDocument.url : '';
-  const privateAttachmentError = secureContractDocument.key === secureContractDocumentKey ? secureContractDocument.error : '';
+  const existingProjectCode = String(openRecord?.project.projectCode || '').trim();
+  const reviewDocumentAccess = useMemo(() => {
+    const sources = new Map<ProjectRequestDocumentKind, ReviewDocumentSource>();
+    const attachments: Array<{ documentKind: ProjectRequestDocumentKind; path: string }> = [];
+    if (!openRecord) return { attachments, sources };
+
+    const payload = resolveProjectRequestPayload(openRecord.request);
+    const requestId = String(openRecord.request?.id || '').trim();
+    const projectId = String(openRecord.project.id || '').trim();
+    (Object.entries(REVIEW_DOCUMENT_FIELDS) as Array<[ProjectRequestDocumentKind, ReviewDocumentField]>).forEach(([documentKind, field]) => {
+      const requestDocument = payload?.[field];
+      const projectDocument = openRecord.project[field];
+      const document = requestDocument !== undefined ? requestDocument : projectDocument;
+      const path = String(document?.path || '').trim();
+      const downloadURL = String(document?.downloadURL || '').trim();
+      if (!path || downloadURL) return;
+
+      const requestPath = String(requestDocument?.path || '').trim();
+      const source = requestId && requestPath === path ? 'request' : 'project';
+      if ((source === 'request' && !requestId) || (source === 'project' && !projectId)) return;
+      attachments.push({ documentKind, path });
+      sources.set(documentKind, { source, projectId, requestId });
+    });
+    return { attachments, sources };
+  }, [openRecord]);
+  const loadReviewDocumentPreview = useCallback(async ({
+    documentKind,
+    signal,
+  }: {
+    documentKind: ProjectRequestDocumentKind;
+    signal: AbortSignal;
+  }) => {
+    const source = reviewDocumentAccess.sources.get(documentKind);
+    if (!source || !authUser?.uid) throw new Error('첨부 파일을 불러올 권한 정보를 확인하지 못했습니다.');
+    const actor = { uid: authUser.uid, email: authUser.email, role: authUser.role, idToken: authUser.idToken };
+    if (source.source === 'request') {
+      return downloadProjectRequestAttachmentViaBff({
+        tenantId: orgId,
+        actor,
+        requestId: source.requestId,
+        documentKind,
+        signal,
+      });
+    }
+    return downloadProjectAttachmentViaBff({
+      tenantId: orgId,
+      actor,
+      projectId: source.projectId,
+      documentKind,
+      signal,
+    });
+  }, [authUser?.email, authUser?.idToken, authUser?.role, authUser?.uid, orgId, reviewDocumentAccess]);
+  const {
+    documentPreviewUrls,
+    documentPreviewStates,
+    loadDocumentPreview,
+  } = usePrivateDraftDocumentPreviews({
+    attachments: reviewDocumentAccess.attachments,
+    enabled: Boolean(openRecord && isPlatformApiEnabled() && authUser?.uid),
+    loadAttachment: loadReviewDocumentPreview,
+  });
   const designatedApproverId = resolveProjectRequestPayload(openRecord?.request)?.executiveApproverId || openRecord?.project.executiveApproverId;
   const canExecutiveFinalize = Boolean(authUser?.uid && designatedApproverId === authUser.uid);
   const role = String(authUser?.role || '').trim().toLowerCase();
   const canManagementPlanningFinalize = role === 'admin' || role === 'finance';
   const canFinalize = isManagementPlanning ? canManagementPlanningFinalize : canExecutiveFinalize;
-
-  useEffect(() => {
-    setSecureContractDocument({ key: secureContractDocumentKey, url: '', error: '' });
-    if (!isPlatformApiEnabled() || !authUser?.uid || !contractAttachmentSource || !contractAttachmentId || !contractDocumentPath || contractDownloadUrl) return undefined;
-    let disposed = false;
-    let objectUrl = '';
-    const actor = { uid: authUser.uid, email: authUser.email, role: authUser.role, idToken: authUser.idToken };
-    const download = contractAttachmentSource === 'request'
-      ? downloadProjectRequestAttachmentViaBff({ tenantId: orgId, actor, requestId, documentKind: 'contract' })
-      : downloadProjectAttachmentViaBff({ tenantId: orgId, actor, projectId, documentKind: 'contract' });
-    void download.then(({ blob }) => {
-      if (disposed) return;
-      objectUrl = URL.createObjectURL(blob);
-      setSecureContractDocument({ key: secureContractDocumentKey, url: objectUrl, error: '' });
-    }).catch((error) => {
-      if (disposed) return;
-      console.error('[ProjectMigrationAuditPage] private attachment download failed:', error);
-      setSecureContractDocument({ key: secureContractDocumentKey, url: '', error: '보안 원문을 불러오지 못했습니다. 권한 또는 파일 처리 상태를 확인해 주세요.' });
-    });
-    return () => {
-      disposed = true;
-      if (objectUrl) URL.revokeObjectURL(objectUrl);
-    };
-  }, [authUser?.email, authUser?.idToken, authUser?.role, authUser?.uid, contractAttachmentId, contractAttachmentSource, contractDocumentPath, contractDownloadUrl, orgId, projectId, requestId, secureContractDocumentKey]);
 
   async function handleConfirmAction() {
     if (!openRecord || !actionMode) return;
@@ -269,6 +338,7 @@ export function ProjectMigrationAuditPage({
           },
         });
         toast.success(actionMode === 'approve' ? '프로젝트 코드를 부여하고 합의했습니다.' : '반려 사유를 PM에게 전달했습니다.', { description: openRecord.title });
+        setRequestReloadVersion((version) => version + 1);
         setActionMode(null);
         setReviewComment('');
         setProjectCode('');
@@ -294,6 +364,7 @@ export function ProjectMigrationAuditPage({
         review: { requestId: openRecord.request?.id, reviewStatus: nextExecutiveStatus, reviewComment: trimmedComment || undefined, reviewerName },
       });
       toast.success(actionMode === 'approve' ? '프로젝트를 승인했습니다.' : actionMode === 'reject' ? '수정 요청 후 반려로 처리했습니다.' : '중복·폐기로 처리했습니다.', { description: openRecord.title });
+      setRequestReloadVersion((version) => version + 1);
       setActionMode(null);
       setReviewComment('');
     } catch (error) {
@@ -310,22 +381,33 @@ export function ProjectMigrationAuditPage({
 
   return (
     <div className="space-y-6">
-      {!embedded ? <PageHeader icon={ClipboardCheck} iconGradient={isManagementPlanning ? 'linear-gradient(135deg, #0f2f57 0%, #174a7c 100%)' : 'linear-gradient(135deg, #0f766e 0%, #0ea5e9 100%)'} title={pageTitle} description={pageDescription} badge={isManagementPlanning ? '경영기획실 합의' : '대표 검토'} /> : null}
-      {!db || !isOnline ? <Card><CardContent className="p-4 text-[12px] text-muted-foreground">Firebase 연결이 없어서 PM 등록 프로젝트와 접수 이력을 읽지 못했습니다. Firestore 연결 후 다시 확인해 주세요.</CardContent></Card> : null}
-      <MigrationAuditControlBar cicOptions={cicOptions} cicFilter={cicFilter} onCicFilterChange={setCicFilter} inboxScope={inboxScope} onInboxScopeChange={setInboxScope} reviewerDepartment={reviewerDepartment} statusFilter={statusFilter} onStatusFilterChange={setStatusFilter} searchQuery={searchQuery} onSearchQueryChange={setSearchQuery} summary={summary} reviewStage={reviewStage} />
+      {!embedded ? <PageHeader icon={ClipboardCheck} iconGradient={isManagementPlanning ? 'linear-gradient(135deg, #0f2f57 0%, #174a7c 100%)' : 'linear-gradient(135deg, #0f766e 0%, #0ea5e9 100%)'} title={pageTitle} description={pageDescription} badge={isManagementPlanning ? '경영기획실 합의' : '조직장 결재'} /> : null}
+      {requestLoadError ? <Card><CardContent className="p-4 text-[12px] text-muted-foreground">{requestLoadError}</CardContent></Card> : null}
+      <MigrationAuditControlBar cicOptions={cicOptions} cicFilter={cicFilter} onCicFilterChange={setCicFilter} inboxScope={effectiveInboxScope} onInboxScopeChange={setInboxScope} reviewerDepartment={reviewerDepartment} statusFilter={statusFilter} onStatusFilterChange={setStatusFilter} searchQuery={searchQuery} onSearchQueryChange={setSearchQuery} summary={summary} reviewStage={reviewStage} assigneeOnly={assigneeOnly} />
       {loadingRequests ? <Card><CardContent className="flex items-center justify-center gap-2 py-16 text-[12px] text-muted-foreground"><Loader2 className="h-4 w-4 animate-spin" />PM 등록 프로젝트와 접수 이력을 불러오는 중입니다…</CardContent></Card> : <MigrationAuditRecordList records={filteredRecords} onOpen={(record) => setOpenRecordId(record.id)} reviewStage={reviewStage} />}
-      <MigrationAuditDocumentDialog open={!!openRecord} record={openRecord} acting={acting} canFinalize={canFinalize} contractDocumentDownloadURL={secureContractDocumentUrl || contractDownloadUrl} contractDocumentError={privateAttachmentError} reviewStage={reviewStage} onOpenChange={(open) => { if (!open) setOpenRecordId(null); }} onApprove={() => { setActionMode('approve'); setReviewComment(''); setProjectCode(''); }} onReject={() => { setActionMode('reject'); setReviewComment(isManagementPlanning ? '' : (openRecord?.project.executiveReviewComment || '')); setProjectCode(''); }} />
+      <MigrationAuditDocumentDialog open={!!openRecord} record={openRecord} acting={acting} canFinalize={canFinalize} documentPreviewUrls={documentPreviewUrls} documentPreviewStates={documentPreviewStates} reviewStage={reviewStage} onLoadDocumentPreview={loadDocumentPreview} onOpenChange={(open) => { if (!open) setOpenRecordId(null); }} onApprove={() => { setActionMode('approve'); setReviewComment(''); setProjectCode(String(openRecord?.project.projectCode || '').trim()); }} onReject={() => { setActionMode('reject'); setReviewComment(isManagementPlanning ? '' : (openRecord?.project.executiveReviewComment || '')); setProjectCode(''); }} />
       <AlertDialog open={!!actionMode} onOpenChange={(open) => { if (!open) { setActionMode(null); setReviewComment(''); setProjectCode(''); } }}>
         <AlertDialogContent>
           <AlertDialogHeader><AlertDialogTitle>{getReviewDialogTitle(actionMode || 'approve', reviewStage)}</AlertDialogTitle><AlertDialogDescription>{getProjectRequestReviewDescription(actionMode || 'approve', openRecord?.request, reviewStage)}</AlertDialogDescription></AlertDialogHeader>
           <div className="space-y-2">
-            {isManagementPlanning && actionMode === 'approve' ? <div className="space-y-2"><label htmlFor="management-planning-project-code" className="text-[12px] font-medium text-slate-700">프로젝트 코드</label><Input id="management-planning-project-code" value={projectCode} onChange={(event) => setProjectCode(event.target.value)} placeholder="예: MYSC-2026-001" className="rounded-none border-slate-400" autoComplete="off" /><p className="text-[11px] leading-5 text-slate-500">합의 저장과 함께 프로젝트 원장에 저장되며, 이후 운영 화면의 기준 코드로 사용됩니다.</p></div> : null}
+            {isManagementPlanning && actionMode === 'approve' ? <div className="space-y-2"><label htmlFor="management-planning-project-code" className="text-[12px] font-medium text-slate-700">프로젝트 코드</label><Input id="management-planning-project-code" value={projectCode} onChange={(event) => setProjectCode(event.target.value)} readOnly={Boolean(existingProjectCode)} placeholder="예: MYSC-2026-001" className="rounded-none border-slate-400" autoComplete="off" /><p className="text-[11px] leading-5 text-slate-500">{existingProjectCode ? '이미 부여된 프로젝트 코드는 변경할 수 없습니다.' : '합의 저장과 함께 프로젝트 원장에 저장되며, 이후 운영 화면의 기준 코드로 사용됩니다.'}</p></div> : null}
             <p className="text-[12px] font-medium text-slate-700">{actionMode === 'approve' ? (isManagementPlanning ? '합의 메모' : '승인 메모') : actionMode === 'reject' ? '반려 사유' : '폐기 사유'}</p>
-            <Textarea value={reviewComment} onChange={(event) => setReviewComment(event.target.value)} placeholder={actionMode === 'approve' ? (isManagementPlanning ? '합의 판단 근거를 남길 수 있습니다.' : '승인 판단 근거를 남길 수 있습니다.') : 'PM이 보완 내용을 이해할 수 있도록 반려 사유를 남겨 주세요.'} className="min-h-[120px]" />
+            <Textarea value={reviewComment} onChange={(event) => setReviewComment(event.target.value)} maxLength={2000} placeholder={actionMode === 'approve' ? (isManagementPlanning ? '합의 판단 근거를 남길 수 있습니다.' : '승인 판단 근거를 남길 수 있습니다.') : 'PM이 보완 내용을 이해할 수 있도록 반려 사유를 남겨 주세요.'} className="min-h-[120px]" />
+            <p className="text-right text-[10px] text-slate-500">{reviewComment.length.toLocaleString()}/2,000자</p>
           </div>
           <AlertDialogFooter><AlertDialogCancel disabled={acting}>취소</AlertDialogCancel><AlertDialogAction onClick={(event) => { event.preventDefault(); void handleConfirmAction(); }} disabled={acting || (isManagementPlanning && actionMode === 'approve' && !projectCode.trim()) || (actionMode !== 'approve' && !reviewComment.trim())}>{acting ? '저장 중...' : actionMode === 'approve' ? (isManagementPlanning ? '합의 및 코드 저장' : '승인 저장') : actionMode === 'reject' ? '반려 저장' : '폐기 저장'}</AlertDialogAction></AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
     </div>
   );
+}
+
+export function ProjectMigrationAuditPage(props: ProjectMigrationAuditPageProps = {}) {
+  const { projects, currentUser } = useAppStore();
+  return <ProjectMigrationAuditPageContent {...props} projects={projects} currentUser={currentUser} />;
+}
+
+export function ProjectAssigneeApprovalPage() {
+  const { projects, portalUser } = usePortalStore();
+  return <ProjectMigrationAuditPageContent assigneeOnly projects={projects} currentUser={portalUser} />;
 }

--- a/src/app/components/projects/ProjectWizard.tsx
+++ b/src/app/components/projects/ProjectWizard.tsx
@@ -215,6 +215,7 @@ export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: Projec
       initialDraft={initialDraft}
       draftKey={`admin-${editProject?.id || 'new'}-${editProject?.updatedAt || initialPhase}`}
       members={members}
+      requesterId={currentUser?.uid}
       departmentOptions={departmentOptions}
       actions={editProject ? [
         { id: 'save', label: '수정 저장', icon: Save },

--- a/src/app/components/projects/migration-audit/MigrationAuditControlBar.tsx
+++ b/src/app/components/projects/migration-audit/MigrationAuditControlBar.tsx
@@ -27,6 +27,7 @@ interface MigrationAuditControlBarProps {
   onSearchQueryChange: (value: string) => void;
   summary: MigrationAuditConsoleSummary;
   reviewStage?: MigrationAuditReviewStage;
+  assigneeOnly?: boolean;
 }
 
 export function MigrationAuditControlBar({
@@ -42,6 +43,7 @@ export function MigrationAuditControlBar({
   onSearchQueryChange,
   summary,
   reviewStage = 'executive',
+  assigneeOnly = false,
 }: MigrationAuditControlBarProps) {
   const isManagementPlanning = reviewStage === 'managementPlanning';
   const reviewLabel = isManagementPlanning ? '경영기획실 합의' : '조직장 결재';
@@ -86,8 +88,8 @@ export function MigrationAuditControlBar({
           </div>
         </div>
 
-        <div className={`grid gap-4 ${isManagementPlanning ? 'xl:grid-cols-[minmax(180px,230px)_minmax(180px,230px)_minmax(260px,1fr)]' : 'xl:grid-cols-[minmax(180px,230px)_minmax(180px,230px)_minmax(180px,230px)_minmax(260px,1fr)]'}`}>
-          {!isManagementPlanning ? (
+        <div className={`grid gap-4 ${isManagementPlanning || assigneeOnly ? 'xl:grid-cols-[minmax(180px,230px)_minmax(180px,230px)_minmax(260px,1fr)]' : 'xl:grid-cols-[minmax(180px,230px)_minmax(180px,230px)_minmax(180px,230px)_minmax(260px,1fr)]'}`}>
+          {!isManagementPlanning && !assigneeOnly ? (
             <div className="space-y-1.5">
               <p className="text-[12px] font-semibold text-slate-600">검토함</p>
               <Select value={inboxScope} onValueChange={(value) => onInboxScopeChange(value as 'MINE' | 'ALL')}>

--- a/src/app/components/projects/migration-audit/MigrationAuditDocumentDialog.tsx
+++ b/src/app/components/projects/migration-audit/MigrationAuditDocumentDialog.tsx
@@ -1,10 +1,10 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { FileAttachment, ProjectRegistrationOptionalDocumentNotes } from '../../../data/types';
 import type { MigrationAuditConsoleRecord } from '../../../platform/project-migration-console';
 import { getMigrationAuditStatusLabel } from '../../../platform/project-migration-console';
 import { resolveProjectRequestPayload } from '../../../platform/project-change-request';
-import {
-  buildMigrationReviewDossier,
-  resolveMigrationReviewContractDocument,
-} from '../../../platform/project-migration-review-dossier';
+import type { ProjectRequestDocumentKind } from '../../../platform/project-contract-upload';
+import { buildMigrationReviewDossier } from '../../../platform/project-migration-review-dossier';
 import {
   getManagementPlanningReview,
   getManagementPlanningReviewLabel,
@@ -24,12 +24,107 @@ interface MigrationAuditDocumentDialogProps {
   record: MigrationAuditConsoleRecord | null;
   acting: boolean;
   canFinalize: boolean;
-  contractDocumentDownloadURL?: string;
-  contractDocumentError?: string;
+  documentPreviewUrls?: Partial<Record<ProjectRequestDocumentKind, string>>;
+  documentPreviewStates?: Partial<Record<ProjectRequestDocumentKind, {
+    status: 'idle' | 'loading' | 'ready' | 'error';
+    error?: string;
+  }>>;
   reviewStage?: 'executive' | 'managementPlanning';
+  onLoadDocumentPreview?: (kind: ProjectRequestDocumentKind) => void | Promise<void>;
   onOpenChange: (open: boolean) => void;
   onApprove: () => void;
   onReject: () => void;
+}
+
+type ReviewDocumentField =
+  | 'contractDocument'
+  | 'customerBusinessRegistrationDocument'
+  | 'quoteDocument'
+  | 'proposalDocument'
+  | 'rfpRequestEvidenceDocument'
+  | 'proposalWordOriginalDocument'
+  | 'proposalPptOriginalDocument'
+  | 'presentationPptOriginalDocument';
+
+type ReviewDocumentDefinition = {
+  kind: ProjectRequestDocumentKind;
+  field: ReviewDocumentField;
+  label: string;
+};
+
+type ReviewDocumentSlotDefinition = {
+  number: number;
+  label: string;
+  kinds: ProjectRequestDocumentKind[];
+  noteField?: keyof ProjectRegistrationOptionalDocumentNotes;
+};
+
+type ReviewDocumentEntry = ReviewDocumentDefinition & {
+  document: FileAttachment;
+};
+
+type ReviewDocumentSlot = ReviewDocumentSlotDefinition & {
+  entries: ReviewDocumentEntry[];
+  note: string;
+  conflict: boolean;
+};
+
+const REVIEW_DOCUMENT_DEFINITIONS: ReviewDocumentDefinition[] = [
+  { kind: 'contract', field: 'contractDocument', label: '계약서 PDF' },
+  { kind: 'customer_business_registration', field: 'customerBusinessRegistrationDocument', label: '고객사 사업자등록증 PDF' },
+  { kind: 'quote', field: 'quoteDocument', label: '견적서 PDF' },
+  { kind: 'proposal', field: 'proposalDocument', label: '제안서 PDF' },
+  { kind: 'rfp_request_evidence', field: 'rfpRequestEvidenceDocument', label: 'RFP/요청 메일 증빙' },
+  { kind: 'proposal_word_original', field: 'proposalWordOriginalDocument', label: '제안서 Word 원본' },
+  { kind: 'proposal_ppt_original', field: 'proposalPptOriginalDocument', label: '제안서 PPT 원본' },
+  { kind: 'presentation_ppt_original', field: 'presentationPptOriginalDocument', label: '발표자료 PPT 원본' },
+];
+
+const REVIEW_DOCUMENT_SLOTS: ReviewDocumentSlotDefinition[] = [
+  { number: 1, label: '계약서 PDF', kinds: ['contract'] },
+  { number: 2, label: '고객사 사업자등록증 PDF', kinds: ['customer_business_registration'] },
+  { number: 3, label: '견적서 PDF', kinds: ['quote'] },
+  { number: 4, label: '제안서 PDF 또는 RFP/요청 메일 증빙', kinds: ['proposal', 'rfp_request_evidence'] },
+  { number: 5, label: '제안서 Word 원본', kinds: ['proposal_word_original'], noteField: 'proposalWordOriginal' },
+  { number: 6, label: '제안서 PPT 원본', kinds: ['proposal_ppt_original'], noteField: 'proposalPptOriginal' },
+  { number: 7, label: '발표자료 PPT 원본', kinds: ['presentation_ppt_original'], noteField: 'presentationPptOriginal' },
+];
+
+function isFileAttachment(value: unknown): value is FileAttachment {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const attachment = value as Partial<FileAttachment>;
+  return Boolean(String(attachment.path || attachment.downloadURL || '').trim());
+}
+
+export function buildMigrationReviewDocumentSlots(record: MigrationAuditConsoleRecord): ReviewDocumentSlot[] {
+  const payload = resolveProjectRequestPayload(record.request);
+  const requestNotes = payload?.registrationOptionalDocumentNotes;
+  const notes: Partial<ProjectRegistrationOptionalDocumentNotes> = requestNotes !== undefined
+    ? (requestNotes || {})
+    : (record.project.registrationOptionalDocumentNotes || {});
+  const documentByKind = new Map<ProjectRequestDocumentKind, ReviewDocumentEntry>();
+
+  REVIEW_DOCUMENT_DEFINITIONS.forEach((definition) => {
+    const requestDocument = payload?.[definition.field];
+    const document = requestDocument !== undefined
+      ? requestDocument
+      : record.project[definition.field];
+    if (!isFileAttachment(document)) return;
+    documentByKind.set(definition.kind, { ...definition, document });
+  });
+
+  return REVIEW_DOCUMENT_SLOTS.map((slot) => {
+    const entries = slot.kinds.flatMap((kind) => {
+      const entry = documentByKind.get(kind);
+      return entry ? [entry] : [];
+    });
+    return {
+      ...slot,
+      entries,
+      note: slot.noteField ? String(notes[slot.noteField] || '').trim() : '',
+      conflict: slot.number === 4 && entries.length > 1,
+    };
+  });
 }
 
 function formatDateTime(value?: string) {
@@ -74,18 +169,37 @@ export function MigrationAuditDocumentDialog({
   record,
   acting,
   canFinalize,
-  contractDocumentDownloadURL = '',
-  contractDocumentError = '',
+  documentPreviewUrls = {},
+  documentPreviewStates = {},
   reviewStage = 'executive',
+  onLoadDocumentPreview,
   onOpenChange,
   onApprove,
   onReject,
 }: MigrationAuditDocumentDialogProps) {
+  const documentSlots = useMemo(
+    () => record ? buildMigrationReviewDocumentSlots(record) : [],
+    [record],
+  );
+  const documentEntries = useMemo(
+    () => documentSlots.flatMap((slot) => slot.entries),
+    [documentSlots],
+  );
+  const [selectedDocumentKind, setSelectedDocumentKind] = useState<ProjectRequestDocumentKind>('contract');
+
+  useEffect(() => {
+    if (!open) return;
+    const preferredKind = documentEntries.some((entry) => entry.kind === 'contract')
+      ? 'contract'
+      : documentEntries[0]?.kind;
+    if (preferredKind) setSelectedDocumentKind(preferredKind);
+  }, [documentEntries, open, record?.id]);
+
   if (!record) return null;
 
   const dossier = buildMigrationReviewDossier(record.project, record.request);
   const requestPayload = resolveProjectRequestPayload(record.request);
-  const designatedApproverName = record.project.executiveApproverName || requestPayload?.executiveApproverName || '';
+  const designatedApproverName = requestPayload?.executiveApproverName || record.project.executiveApproverName || '';
   const isManagementPlanning = reviewStage === 'managementPlanning';
   const organizationReviewStatus = record.project.executiveReviewStatus;
   const organizationDecisionState = organizationReviewStatus === 'APPROVED'
@@ -109,10 +223,11 @@ export function MigrationAuditDocumentDialog({
     : undefined;
   const managementReviewedByName = latestManagementDecision?.reviewedByName || managementReview.reviewedByName;
   const managementReviewedAt = latestManagementDecision?.reviewedAt || managementReview.reviewedAt;
-  const contractDocument = resolveMigrationReviewContractDocument(record.project, record.request);
-  const contractDocumentUrl = contractDocumentDownloadURL || contractDocument?.downloadURL || '';
-  const attachmentNames = [contractDocument?.name, requestPayload?.quoteDocument?.name, requestPayload?.proposalDocument?.name]
-    .filter((name): name is string => Boolean(name?.trim()));
+  const selectedDocument = documentEntries.find((entry) => entry.kind === selectedDocumentKind) || null;
+  const selectedPreviewUrl = selectedDocument
+    ? documentPreviewUrls[selectedDocument.kind] || selectedDocument.document.downloadURL || ''
+    : '';
+  const selectedPreviewState = selectedDocument ? documentPreviewStates[selectedDocument.kind] : undefined;
   const reviewMessages = dossier.audit.history.filter((entry) => entry.reviewComment !== '-' && entry.reviewComment !== 'PM 신규 등록');
   const managementMessages = managementReview.history.filter((entry) => Boolean(entry.reviewComment?.trim()));
   const requestReviewComment = String(record.request?.reviewComment || '').trim();
@@ -191,9 +306,105 @@ export function MigrationAuditDocumentDialog({
           <section className="mt-6"><h3 className="border-b-2 border-slate-700 pb-2 text-[14px] font-bold">등록 내용</h3><dl className="border border-t-0 border-slate-400">
             <DocumentCell label="프로젝트 목적" value={dossier.notes.projectPurpose} /><DocumentCell label="상세 설명" value={dossier.notes.description} /><DocumentCell label="참여 조건" value={dossier.notes.participantCondition} /><DocumentCell label="비고" value={dossier.notes.note} />
           </dl></section>
-          <section className="mt-6"><h3 className="border-b-2 border-slate-700 pb-2 text-[14px] font-bold">첨부자료</h3>
-            <div className="border border-t-0 border-slate-400 px-4 py-3 text-[12px] leading-6 text-slate-800">{attachmentNames.length > 0 ? attachmentNames.join(' · ') : '등록된 첨부자료가 없습니다.'}{contractDocumentError ? <p className="mt-1 text-[11px] text-rose-700">{contractDocumentError}</p> : null}</div>
-            <ContractDocumentPreview document={contractDocument ? { ...contractDocument, downloadURL: contractDocumentUrl } : null} title="계약서 PDF 원문" description="등록 요청에 첨부된 계약서 원문을 문서 안에서 확인합니다." className="rounded-none border-t-0 border-slate-400" />
+          <section className="mt-6">
+            <h3 className="border-b-2 border-slate-700 pb-2 text-[14px] font-bold">등록 제출서류 7종</h3>
+            <div className="border border-t-0 border-slate-400" data-testid="migration-review-document-slots">
+              <div className="hidden grid-cols-[48px_220px_minmax(0,1fr)_108px] border-b border-slate-400 bg-slate-100 text-[11px] font-semibold text-slate-700 md:grid">
+                <div className="border-r border-slate-400 px-2 py-2 text-center">번호</div>
+                <div className="border-r border-slate-400 px-3 py-2">구분</div>
+                <div className="border-r border-slate-400 px-3 py-2">제출 파일 / 미첨부 사유</div>
+                <div className="px-3 py-2 text-center">원문</div>
+              </div>
+              {documentSlots.map((slot) => (
+                <div
+                  key={slot.number}
+                  className="grid border-b border-slate-300 last:border-b-0 md:grid-cols-[48px_220px_minmax(0,1fr)_108px]"
+                  data-testid={`migration-review-document-slot-${slot.number}`}
+                >
+                  <div className="flex items-center justify-center border-b border-slate-300 bg-slate-50 px-2 py-3 text-[11px] font-semibold text-slate-800 md:border-r md:border-b-0 md:border-slate-400">
+                    {slot.number}
+                  </div>
+                  <div className="flex items-center border-b border-slate-300 px-3 py-3 text-[11px] font-semibold leading-5 text-slate-800 md:border-r md:border-b-0 md:border-slate-400">
+                    {slot.label}
+                  </div>
+                  <div className="min-w-0 border-b border-slate-300 px-3 py-3 text-[12px] leading-5 text-slate-800 md:border-r md:border-b-0 md:border-slate-400">
+                    {slot.entries.length > 0 ? (
+                      <div className="space-y-2">
+                        {slot.entries.map((entry) => {
+                          const state = documentPreviewStates[entry.kind];
+                          return (
+                            <div key={entry.kind} data-document-kind={entry.kind}>
+                              <p className="break-all font-medium">{entry.document.name || entry.label}</p>
+                              {slot.entries.length > 1 ? <p className="text-[10px] text-slate-500">{entry.label}</p> : null}
+                              {state?.status === 'error' ? (
+                                <p className="mt-1 text-[10px] text-rose-700">{state.error || '원문을 불러오지 못했습니다.'}</p>
+                              ) : null}
+                            </div>
+                          );
+                        })}
+                        {slot.conflict ? (
+                          <p className="border-t border-amber-300 pt-2 text-[10px] font-semibold text-amber-800">
+                            제출 규칙 불일치 · 제안서와 RFP/요청 증빙이 함께 등록되었습니다. 두 원문을 모두 확인해 주세요.
+                          </p>
+                        ) : null}
+                      </div>
+                    ) : slot.note ? (
+                      <p><span className="font-semibold text-slate-600">미첨부 사유</span> · {slot.note}</p>
+                    ) : (
+                      <p className="text-rose-700">미제출</p>
+                    )}
+                  </div>
+                  <div className="flex items-center justify-center px-3 py-3">
+                    {slot.entries.length > 0 ? (
+                      <div className="flex flex-wrap justify-center gap-1.5">
+                        {slot.entries.map((entry) => {
+                          const previewUrl = documentPreviewUrls[entry.kind] || entry.document.downloadURL || '';
+                          const state = documentPreviewStates[entry.kind];
+                          return (
+                            <Button
+                              key={entry.kind}
+                              type="button"
+                              variant={selectedDocumentKind === entry.kind ? 'default' : 'outline'}
+                              size="sm"
+                              className="h-8 rounded-none px-2.5 text-[11px]"
+                              disabled={state?.status === 'loading'}
+                              onClick={() => {
+                                setSelectedDocumentKind(entry.kind);
+                                if (!previewUrl) void onLoadDocumentPreview?.(entry.kind);
+                              }}
+                            >
+                              {state?.status === 'loading' ? '불러오는 중' : state?.status === 'error' ? '다시 열기' : '원문 보기'}
+                            </Button>
+                          );
+                        })}
+                      </div>
+                    ) : (
+                      <span className="text-[10px] text-slate-400">해당 없음</span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+            {selectedDocument ? (
+              <ContractDocumentPreview
+                document={{ ...selectedDocument.document, downloadURL: selectedPreviewUrl }}
+                title={`${selectedDocument.label} 원문`}
+                description={selectedPreviewState?.status === 'loading'
+                  ? '제출 원문을 안전하게 불러오는 중입니다.'
+                  : selectedPreviewState?.status === 'error'
+                    ? (selectedPreviewState.error || '원문을 불러오지 못했습니다. 다시 열기를 시도해 주세요.')
+                    : 'PDF 미리보기가 비어 있으면 새 탭에서 원문을 확인하고, Word·PPT·메일 원본도 새 탭에서 내려받아 대조합니다.'}
+                descriptionClassName={selectedPreviewState?.status === 'error' ? 'text-rose-700' : 'text-slate-600'}
+                className="rounded-none border-t-0 border-slate-400"
+                privateDraftAttachment={!selectedPreviewUrl}
+                previewState={selectedPreviewState}
+                onLoadPreview={onLoadDocumentPreview ? () => onLoadDocumentPreview(selectedDocument.kind) : undefined}
+              />
+            ) : (
+              <div className="border border-t-0 border-slate-400 bg-slate-50 px-4 py-8 text-center text-[12px] text-slate-500">
+                검토할 수 있는 제출 원문이 없습니다.
+              </div>
+            )}
           </section>
 
           {isActionPending && canFinalize ? <footer className="mt-7 flex justify-end gap-2 border-t border-slate-300 pt-4"><Button type="button" variant="outline" className="rounded-none border-slate-500" onClick={onReject} disabled={acting}>반려</Button><Button type="button" className="rounded-none bg-[#174a7c] hover:bg-[#103a63]" onClick={onApprove} disabled={acting}>{isManagementPlanning ? '합의' : '승인'}</Button></footer> : null}

--- a/src/app/components/projects/usePendingProjectChangeRequests.ts
+++ b/src/app/components/projects/usePendingProjectChangeRequests.ts
@@ -1,12 +1,11 @@
 import { useEffect, useState } from 'react';
-import { collection, onSnapshot, query, where } from 'firebase/firestore';
+import { useAuth } from '../../data/auth-store';
 import type { ProjectRequest } from '../../data/types';
-import { getOrgRootPath } from '../../lib/firebase';
 import { useFirebase } from '../../lib/firebase-context';
-
-type ProjectRequestCollectionName = 'project_requests' | 'projectRequests';
-
-const PROJECT_REQUEST_COLLECTIONS: ProjectRequestCollectionName[] = ['project_requests', 'projectRequests'];
+import {
+  fetchPendingProjectChangeRequestsViaBff,
+  isPlatformApiEnabled,
+} from '../../lib/platform-bff-client';
 
 function buildPendingChangeMap(requests: ProjectRequest[]): Map<string, ProjectRequest> {
   const next = new Map<string, ProjectRequest>();
@@ -22,43 +21,42 @@ function buildPendingChangeMap(requests: ProjectRequest[]): Map<string, ProjectR
   return next;
 }
 
-export function usePendingProjectChangeRequests(): Map<string, ProjectRequest> {
-  const { db, isOnline, orgId } = useFirebase();
+export function usePendingProjectChangeRequests(projectIds: string[]): Map<string, ProjectRequest> {
+  const { orgId } = useFirebase();
+  const { user } = useAuth();
   const [pendingProjectChangeMap, setPendingProjectChangeMap] = useState<Map<string, ProjectRequest>>(new Map());
 
   useEffect(() => {
-    if (!db || !isOnline) {
+    if (!user?.uid || !isPlatformApiEnabled()) {
       setPendingProjectChangeMap(new Map());
       return undefined;
     }
-
-    const collectionRows = new Map<ProjectRequestCollectionName, ProjectRequest[]>();
-    const publish = () => {
-      setPendingProjectChangeMap(buildPendingChangeMap(Array.from(collectionRows.values()).flat()));
+    let disposed = false;
+    const load = async () => {
+      try {
+        const requests = await fetchPendingProjectChangeRequestsViaBff({
+          tenantId: orgId,
+          projectIds,
+          actor: {
+            uid: user.uid,
+            email: user.email,
+            role: user.role,
+            idToken: user.idToken,
+          },
+        });
+        if (!disposed) setPendingProjectChangeMap(buildPendingChangeMap(requests));
+      } catch (error) {
+        console.error('[usePendingProjectChangeRequests] BFF fetch failed:', error);
+        if (!disposed) setPendingProjectChangeMap(new Map());
+      }
     };
-
-    const unsubscribes = PROJECT_REQUEST_COLLECTIONS.map((collectionName) => {
-      const q = query(
-        collection(db, `${getOrgRootPath(orgId)}/${collectionName}`),
-        where('status', '==', 'PENDING'),
-      );
-      return onSnapshot(q, (snapshot) => {
-        collectionRows.set(collectionName, snapshot.docs.map((docSnap) => ({
-          ...(docSnap.data() as ProjectRequest),
-          id: docSnap.id,
-        })));
-        publish();
-      }, (error) => {
-        console.error(`[usePendingProjectChangeRequests] ${collectionName} listen failed:`, error);
-        collectionRows.set(collectionName, []);
-        publish();
-      });
-    });
-
+    void load();
+    window.addEventListener('focus', load);
     return () => {
-      unsubscribes.forEach((unsubscribe) => unsubscribe());
+      disposed = true;
+      window.removeEventListener('focus', load);
     };
-  }, [db, isOnline, orgId]);
+  }, [orgId, projectIds, user?.email, user?.idToken, user?.role, user?.uid]);
 
   return pendingProjectChangeMap;
 }

--- a/src/app/data/member-documents.test.ts
+++ b/src/app/data/member-documents.test.ts
@@ -134,6 +134,7 @@ describe('member document helpers', () => {
       name: '홍길동',
       email: 'hong@mysc.co.kr',
       role: 'pm',
+      status: 'ACTIVE',
       avatarUrl: undefined,
     }]);
   });

--- a/src/app/data/portal-project-status.shell.test.ts
+++ b/src/app/data/portal-project-status.shell.test.ts
@@ -35,7 +35,7 @@ describe('portal project status editing contract', () => {
 
   it('uses PM-facing settlement labels instead of X-style wording', () => {
     expect(typesSource).toContain("NONE: '정산 없음'");
-    expect(typesSource).toContain("NONE: '정산 기준 없음'");
+    expect(typesSource).not.toContain("NONE: '정산 기준 없음'");
     expect(typesSource).not.toContain("NONE: '해당없음(정산대상 아님)'");
     expect(typesSource).not.toContain('정산 X');
   });

--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -2578,6 +2578,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
       advanceInterimBelow70Reason: requestPayload.advanceInterimBelow70Reason,
       paymentPlanDesc: requestPayload.paymentPlanDesc,
       clientOrg: requestPayload.clientOrg,
+      businessManagementGoogleFolderLink: requestPayload.businessManagementGoogleFolderLink || '',
       groupwareName: requestPayload.groupwareName || '',
       participantCondition: requestPayload.participantCondition,
       teamMembersDetailed: requestPayload.teamMembersDetailed || [],

--- a/src/app/data/project-team-member-options.test.ts
+++ b/src/app/data/project-team-member-options.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { EMPLOYEES } from './participation-data';
-import { findProjectTeamMemberOption, PROJECT_TEAM_MEMBER_OPTIONS } from './project-team-member-options';
+import {
+  buildProjectTeamMemberOptions,
+  findProjectTeamMemberOption,
+  PROJECT_TEAM_MEMBER_OPTIONS,
+} from './project-team-member-options';
 
 describe('project-team-member-options', () => {
   it('stays in parity with the canonical employee list', () => {
@@ -25,5 +29,24 @@ describe('project-team-member-options', () => {
     expect(findProjectTeamMemberOption('박지연')?.nickname).toBe('느티');
     expect(findProjectTeamMemberOption('느티')?.name).toBe('박지연');
     expect(findProjectTeamMemberOption('김소영 (소이)')?.name).toBe('김소영');
+  });
+
+  it('builds the picker from the live member directory and excludes inactive records', () => {
+    const options = buildProjectTeamMemberOptions([
+      { uid: 'u-boram', name: '변민욱', email: 'boram@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
+      { uid: 'u-new', name: '신규구성원(새별)', email: 'new@mysc.co.kr', role: 'viewer', status: 'ACTIVE' },
+      { uid: 'u-left', name: '퇴사자', email: 'left@mysc.co.kr', role: 'viewer', status: 'INACTIVE' },
+    ]);
+
+    expect(options).toEqual([
+      expect.objectContaining({ name: '변민욱', nickname: '보람', label: '변민욱 (보람)' }),
+      expect.objectContaining({ name: '신규구성원', nickname: '새별', label: '신규구성원 (새별)' }),
+    ]);
+    expect(options.map((option) => option.name)).not.toContain('퇴사자');
+    expect(options.map((option) => option.name)).not.toContain('박지연');
+  });
+
+  it('keeps the canonical fallback for offline harnesses without a member directory', () => {
+    expect(buildProjectTeamMemberOptions([])).toBe(PROJECT_TEAM_MEMBER_OPTIONS);
   });
 });

--- a/src/app/data/project-team-member-options.ts
+++ b/src/app/data/project-team-member-options.ts
@@ -1,4 +1,5 @@
 import { EMPLOYEES } from './participation-data';
+import type { OrgMember } from './types';
 
 export interface ProjectTeamMemberOption {
   value: string;
@@ -36,4 +37,37 @@ export function findProjectTeamMemberOption(value: string): ProjectTeamMemberOpt
   const normalized = String(value || '').trim().toLowerCase();
   if (!normalized) return undefined;
   return PROJECT_TEAM_MEMBER_SEARCH_MAP.get(normalized);
+}
+
+function splitMemberDisplayName(value: string): { name: string; nickname: string } {
+  const normalized = String(value || '').trim();
+  const match = normalized.match(/^(.+?)\s*\(([^()]+)\)\s*$/);
+  if (!match) return { name: normalized, nickname: '' };
+  return { name: match[1].trim(), nickname: match[2].trim() };
+}
+
+export function buildProjectTeamMemberOptions(members: OrgMember[]): ProjectTeamMemberOption[] {
+  if (!members.length) return PROJECT_TEAM_MEMBER_OPTIONS;
+
+  const options = new Map<string, ProjectTeamMemberOption>();
+  members.forEach((member) => {
+    const status = String(member.status || '').trim().toUpperCase();
+    if (status === 'INACTIVE' || status === 'DELETED') return;
+    const parsed = splitMemberDisplayName(member.name || '');
+    if (!String(member.uid || '').trim() || !parsed.name) return;
+    const canonical = findProjectTeamMemberOption(parsed.name);
+    const nickname = parsed.nickname || canonical?.nickname || '';
+    const key = parsed.name.toLowerCase();
+    if (options.has(key)) return;
+    options.set(key, {
+      value: parsed.name,
+      name: parsed.name,
+      nickname,
+      label: nickname ? `${parsed.name} (${nickname})` : parsed.name,
+    });
+  });
+
+  const liveOptions = [...options.values()]
+    .sort((left, right) => left.label.localeCompare(right.label, 'ko'));
+  return liveOptions.length ? liveOptions : PROJECT_TEAM_MEMBER_OPTIONS;
 }

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -666,6 +666,7 @@ export interface Project {
   paymentPlanDesc: string;       // 입금계획 텍스트 (e.g. "선금80%, 잔금20%")
   // MYSC-specific fields
   clientOrg: string;             // 발주기관(계약기관)
+  businessManagementGoogleFolderLink?: string;
   groupwareName: string;         // 그룹웨어 프로젝트등록명
   participantCondition: string;  // 참여기업 조건
   note?: string;                  // PM/관리자 참고 메모
@@ -849,6 +850,7 @@ export interface ProjectRequestPayload {
   phase?: ProjectPhase;
   description: string;
   clientOrg: string;
+  businessManagementGoogleFolderLink?: string;
   department: string;
   groupwareName?: string;
   currency?: ProjectCurrency;

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -29,7 +29,7 @@ export type SettlementType = 'TYPE1' | 'TYPE2' | 'TYPE3' | 'TYPE4' | 'TYPE5' | '
 export type Basis = '공급가액' | '공급대가' | '기타' | 'NONE';
 export type ProjectCurrency = 'KRW' | 'USD';
 
-export type AccountType = 'DEDICATED' | 'OPERATING' | 'NONE'; // 전용계좌 사업(이나라도움) / 전용계좌(이나라도움x) / 일반 사업
+export type AccountType = 'DEDICATED' | 'OPERATING' | 'NONE' | 'OTHER'; // 전용계좌 사업(이나라도움) / 전용계좌(이나라도움x) / 일반 사업 / 기타
 export type ProjectFundInputMode = 'BANK_UPLOAD' | 'DIRECT_ENTRY';
 export type SettlementSheetPolicyPreset = 'STANDARD' | 'DIRECT_ENTRY' | 'BALANCE_TRACKING';
 export type SettlementSheetDerivedField = 'balance' | 'expenseAmount' | 'bankAmount' | 'vatIn';
@@ -159,7 +159,13 @@ export const BASIS_LABELS: Record<Basis, string> = {
   '공급가액': '공급가액 기준',
   '공급대가': '공급대가 기준',
   기타: '기타',
-  NONE: '정산 기준 없음',
+  NONE: '정산 없음',
+};
+
+export const REGISTRATION_V2_BASIS_LABELS: Record<Exclude<Basis, '기타'>, string> = {
+  '공급가액': '공급가액 정산',
+  '공급대가': '공급대가 정산',
+  NONE: '정산 없음',
 };
 
 export function normalizeSettlementType(raw: unknown): SettlementType {
@@ -179,10 +185,11 @@ export const ACCOUNT_TYPE_LABELS: Record<AccountType, string> = {
   DEDICATED: '전용계좌 사업(이나라도움)',
   OPERATING: '전용계좌(이나라도움x)',
   NONE: '일반 사업',
+  OTHER: '기타',
 };
 
 export function normalizeAccountType(raw: unknown): AccountType {
-  if (raw === 'DEDICATED' || raw === 'OPERATING') return raw;
+  if (raw === 'DEDICATED' || raw === 'OPERATING' || raw === 'OTHER') return raw;
   return 'NONE';
 }
 
@@ -450,7 +457,7 @@ export const SETTLEMENT_SYSTEM_LABELS: Record<SettlementSystemCode, string> = {
   NIPA: 'NIPA (정보통신산업진흥원)',
   ACCOUNTANT: '회계사정산',
   PRIVATE: '민간사업',
-  NONE: '미정',
+  NONE: '정산없음',
 };
 
 export const SETTLEMENT_SYSTEM_SHORT: Record<SettlementSystemCode, string> = {
@@ -468,14 +475,14 @@ export const SETTLEMENT_SYSTEM_SHORT: Record<SettlementSystemCode, string> = {
   NIPA: 'NIPA',
   ACCOUNTANT: '회계사정산',
   PRIVATE: '민간',
-  NONE: '미정',
+  NONE: '정산없음',
 };
 
 export const LABOR_SETTLEMENT_BASIS_LABELS: Record<LaborSettlementBasis, string> = {
-  INCLUDE_ACTUAL_SALARY: '포함 실급여',
-  EXCLUDE_ACTUAL_SALARY: '제외 실급여',
+  INCLUDE_ACTUAL_SALARY: '4대보험, 퇴직금포함 실급여',
+  EXCLUDE_ACTUAL_SALARY: '4대보험, 퇴직금 제외 실급여',
   FIXED_AMOUNT: '정액정산',
-  NONE: '미정',
+  NONE: '정산없음',
 };
 
 export function normalizeSettlementSystemCode(raw: unknown): SettlementSystemCode {
@@ -540,6 +547,7 @@ export interface OrgMember {
   name: string;
   email: string;
   role: UserRole;
+  status?: string;
   avatarUrl?: string;
 }
 

--- a/src/app/lib/firestore-service.ts
+++ b/src/app/lib/firestore-service.ts
@@ -227,6 +227,7 @@ export function buildMemberDirectoryList(docs: MemberDirectoryDocInput[]): OrgMe
       name: String(merged.name || ''),
       email: String(merged.email || ''),
       role: (merged.role || 'pm') as OrgMember['role'],
+      status: typeof merged.status === 'string' ? merged.status.trim().toUpperCase() : undefined,
       avatarUrl: typeof merged.avatarUrl === 'string' ? merged.avatarUrl : undefined,
     };
   }).filter((member) => member.uid);

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -7,6 +7,10 @@ import {
   changeTransactionStateViaBff,
   deepSyncAuthGovernanceUserViaBff,
   fetchAuthGovernanceUsersViaBff,
+  fetchAssignedProjectRequestsViaBff,
+  fetchLatestProjectRequestViaBff,
+  fetchPendingProjectChangeRequestsViaBff,
+  fetchProjectReviewInboxViaBff,
   fetchProjectsViaBff,
   linkProjectEvidenceDriveRootViaBff,
   notifyProjectRequestRegistrationViaBff,
@@ -484,6 +488,112 @@ describe('platform-bff-client', () => {
       timeoutMs: 10000,
     }));
     expect(client.get).toHaveBeenNthCalledWith(2, '/api/v1/projects?limit=200&cursor=page-2', expect.any(Object));
+  });
+
+  it('reads only the authenticated reviewer\'s project requests through the scoped BFF inbox', async () => {
+    const client = asMockClient({
+      post: vi.fn(),
+      get: vi.fn(async () => ({
+        data: {
+          items: [{
+            id: 'request-head-a',
+            approvedProjectId: 'project-a',
+            payload: { executiveApproverId: 'head-a' },
+          }],
+          projects: [{ id: 'project-a', name: 'Project A' }],
+        },
+      })),
+      request: vi.fn(),
+    });
+
+    const result = await fetchAssignedProjectRequestsViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'head-a', role: 'pm', idToken: 'token-abc' },
+      client,
+    });
+
+    expect(result).toEqual({
+      requests: [expect.objectContaining({ id: 'request-head-a', approvedProjectId: 'project-a' })],
+      projects: [expect.objectContaining({ id: 'project-a', name: 'Project A' })],
+    });
+    expect(client.get).toHaveBeenCalledWith('/api/v1/project-requests/assigned-to-me', expect.objectContaining({
+      tenantId: 'mysc',
+      timeoutMs: 10000,
+    }));
+  });
+
+  it('reads latest, pending-summary, and privileged review request views through the BFF', async () => {
+    const client = asMockClient({
+      post: vi.fn(async (path: string) => ({
+        data: { items: [{ id: path.includes('pending-changes') ? 'pending-a' : 'review-a', requestKind: 'CHANGE' }] },
+      })),
+      get: vi.fn()
+        .mockResolvedValueOnce({ data: { item: { id: 'latest-a', approvedProjectId: 'project-a' } } }),
+      request: vi.fn(),
+    });
+    const actor = { uid: 'pm-a', role: 'pm', idToken: 'token-abc' };
+
+    await expect(fetchLatestProjectRequestViaBff({
+      tenantId: 'mysc', actor, projectId: 'project-a', client,
+    })).resolves.toEqual(expect.objectContaining({ id: 'latest-a' }));
+    await expect(fetchPendingProjectChangeRequestsViaBff({
+      tenantId: 'mysc', actor, projectIds: ['project-a'], client,
+    })).resolves.toEqual([expect.objectContaining({ id: 'pending-a' })]);
+    await expect(fetchProjectReviewInboxViaBff({
+      tenantId: 'mysc', actor, projectIds: ['project-a'], client,
+    })).resolves.toEqual([expect.objectContaining({ id: 'review-a' })]);
+
+    expect(client.get).toHaveBeenNthCalledWith(1, '/api/v1/projects/project-a/latest-request', expect.objectContaining({ timeoutMs: 10000 }));
+    expect(client.post).toHaveBeenNthCalledWith(1, '/api/v1/project-requests/pending-changes', expect.objectContaining({
+      body: { projectIds: ['project-a'] },
+      timeoutMs: 10000,
+    }));
+    expect(client.post).toHaveBeenNthCalledWith(2, '/api/v1/project-requests/review-inbox', expect.objectContaining({
+      body: { projectIds: ['project-a'] },
+      timeoutMs: 10000,
+    }));
+  });
+
+  it('chunks 201 project ids and returns deduplicated requests in stable requested order', async () => {
+    const projectIds = Array.from({ length: 201 }, (_, index) => `project-${index + 1}`);
+    const client = asMockClient({
+      post: vi.fn(async (_path: string, options: { body?: unknown }) => {
+        const batch = (options.body as { projectIds: string[] }).projectIds;
+        return {
+          data: {
+            items: batch.length === 200
+              ? [
+                { id: 'request-b', requestedAt: '2026-07-20T00:00:00.000Z' },
+                { id: 'request-duplicate', requestedAt: '2026-07-19T00:00:00.000Z' },
+              ]
+              : [
+                { id: 'request-a', requestedAt: '2026-07-20T00:00:00.000Z' },
+                { id: 'request-duplicate', requestedAt: '2026-07-19T00:00:00.000Z' },
+              ],
+          },
+        };
+      }),
+      get: vi.fn(),
+      request: vi.fn(),
+    });
+    const actor = { uid: 'reviewer-a', role: 'admin' };
+
+    await expect(fetchProjectReviewInboxViaBff({
+      tenantId: 'mysc', actor, projectIds: [...projectIds, 'project-1', ' '], client,
+    })).resolves.toEqual([
+      expect.objectContaining({ id: 'request-a' }),
+      expect.objectContaining({ id: 'request-b' }),
+      expect.objectContaining({ id: 'request-duplicate' }),
+    ]);
+    await expect(fetchPendingProjectChangeRequestsViaBff({
+      tenantId: 'mysc', actor, projectIds, client,
+    })).resolves.toHaveLength(3);
+
+    expect(client.post).toHaveBeenCalledTimes(4);
+    expect((client.post.mock.calls[0]?.[1]?.body as { projectIds: string[] }).projectIds).toHaveLength(200);
+    expect((client.post.mock.calls[1]?.[1]?.body as { projectIds: string[] }).projectIds).toHaveLength(1);
+    expect((client.post.mock.calls[2]?.[1]?.body as { projectIds: string[] }).projectIds).toHaveLength(200);
+    expect((client.post.mock.calls[3]?.[1]?.body as { projectIds: string[] }).projectIds).toHaveLength(1);
   });
 
   it('calls project trash and restore endpoints', async () => {

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -2,6 +2,7 @@ import { featureFlags, parseFeatureFlag } from '../config/feature-flags';
 import type {
   AccountType,
   Project,
+  ProjectRequest,
   ProjectExecutiveReviewStatus,
   ProjectManagementPlanningReviewStatus,
   ProjectSheetSourceSnapshot,
@@ -1412,6 +1413,110 @@ export async function fetchProjectsViaBff(params: {
     seenCursors.add(nextCursor);
     cursor = nextCursor;
   }
+}
+
+export async function fetchAssignedProjectRequestsViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  client?: PlatformApiClientLike;
+}): Promise<{ requests: ProjectRequest[]; projects: Project[] }> {
+  const apiClient = resolveClient(params.client);
+  const response = await apiClient.get<{ items: ProjectRequest[]; projects: Project[] }>(
+    '/api/v1/project-requests/assigned-to-me',
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      timeoutMs: 10000,
+    },
+  );
+  return {
+    requests: Array.isArray(response.data?.items) ? response.data.items : [],
+    projects: Array.isArray(response.data?.projects) ? response.data.projects : [],
+  };
+}
+
+const PROJECT_REQUEST_PROJECT_ID_BATCH_SIZE = 200;
+
+async function fetchProjectRequestsByProjectIds(params: {
+  apiClient: PlatformApiClientLike;
+  path: string;
+  tenantId: string;
+  actor: ActorLike;
+  projectIds: string[];
+}): Promise<ProjectRequest[]> {
+  const projectIds = Array.from(new Set(params.projectIds.map((id) => id.trim()).filter(Boolean)));
+  const batches: string[][] = [];
+  for (let index = 0; index < projectIds.length; index += PROJECT_REQUEST_PROJECT_ID_BATCH_SIZE) {
+    batches.push(projectIds.slice(index, index + PROJECT_REQUEST_PROJECT_ID_BATCH_SIZE));
+  }
+  const responses = await Promise.all(batches.map((batch) => params.apiClient.post<{ items: ProjectRequest[] }>(
+    params.path,
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      body: { projectIds: batch },
+      timeoutMs: 10000,
+    },
+  )));
+  const requestsById = new Map<string, ProjectRequest>();
+  responses.forEach((response) => {
+    if (!Array.isArray(response.data?.items)) return;
+    response.data.items.forEach((request) => requestsById.set(request.id, request));
+  });
+  return Array.from(requestsById.values()).sort((left, right) => (
+    String(right.requestedAt || '').localeCompare(String(left.requestedAt || ''))
+    || String(left.id).localeCompare(String(right.id))
+  ));
+}
+
+export async function fetchPendingProjectChangeRequestsViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectIds: string[];
+  client?: PlatformApiClientLike;
+}): Promise<ProjectRequest[]> {
+  const apiClient = resolveClient(params.client);
+  return fetchProjectRequestsByProjectIds({
+    apiClient,
+    path: '/api/v1/project-requests/pending-changes',
+    tenantId: params.tenantId,
+    actor: params.actor,
+    projectIds: params.projectIds,
+  });
+}
+
+export async function fetchProjectReviewInboxViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectIds: string[];
+  client?: PlatformApiClientLike;
+}): Promise<ProjectRequest[]> {
+  const apiClient = resolveClient(params.client);
+  return fetchProjectRequestsByProjectIds({
+    apiClient,
+    path: '/api/v1/project-requests/review-inbox',
+    tenantId: params.tenantId,
+    actor: params.actor,
+    projectIds: params.projectIds,
+  });
+}
+
+export async function fetchLatestProjectRequestViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectId: string;
+  client?: PlatformApiClientLike;
+}): Promise<ProjectRequest | null> {
+  const apiClient = resolveClient(params.client);
+  const response = await apiClient.get<{ item: ProjectRequest | null }>(
+    `/api/v1/projects/${encodeURIComponent(params.projectId)}/latest-request`,
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      timeoutMs: 10000,
+    },
+  );
+  return response.data?.item || null;
 }
 
 function resolveClient(client?: PlatformApiClientLike): PlatformApiClientLike {

--- a/src/app/lib/project-info-draft-client.test.ts
+++ b/src/app/lib/project-info-draft-client.test.ts
@@ -34,7 +34,7 @@ function harness() {
         lease: { state: 'RELEASED', canEdit: false }, outbox: { id: 'outbox-a', status: 'PENDING' },
       } }),
     patch: vi.fn(async () => ({ data: { draft: { ...DRAFT, draftRevision: 3 } } })),
-    request: vi.fn(),
+    request: vi.fn(async () => ({ data: { draft: { ...DRAFT, draftRevision: 4 } } })),
   } as unknown as ProjectInfoDraftApiClient;
   const client = createProjectInfoDraftClient({
     tenantId: 'mysc',
@@ -47,7 +47,7 @@ function harness() {
 }
 
 describe('project information draft client', () => {
-  it('gets, opens, saves, uploads and submits only through the project-scoped BFF contract', async () => {
+  it('gets, opens, saves, uploads, removes and submits only through the project-scoped BFF contract', async () => {
     const { api, client } = harness();
     const ownership = { leaseId: 'lease-a', fence: 3 };
     await client.get();
@@ -61,8 +61,12 @@ describe('project information draft client', () => {
         arrayBuffer: async () => new Uint8Array([0x70, 0x64, 0x66]).buffer,
       },
     });
-    const submitted = await client.submit(ownership, {
+    const removed = await client.removeAttachment(ownership, {
       expectedDraftRevision: 3,
+      documentKind: 'contract',
+    });
+    const submitted = await client.submit(ownership, {
+      expectedDraftRevision: 4,
       expectedVersion: 3,
       resubmit: true,
       reviewComment: '보완 완료',
@@ -85,9 +89,13 @@ describe('project information draft client', () => {
     expect(api.post).toHaveBeenNthCalledWith(3, `${path}/submit`, expect.objectContaining({
       headers,
       body: {
-        expectedDraftRevision: 3, expectedVersion: 3, resubmit: true, reviewComment: '보완 완료',
+        expectedDraftRevision: 4, expectedVersion: 3, resubmit: true, reviewComment: '보완 완료',
       },
     }));
+    expect(api.request).toHaveBeenCalledWith(`${path}/attachments/contract`, expect.objectContaining({
+      method: 'DELETE', headers, body: { expectedDraftRevision: 3 },
+    }));
+    expect(removed.draft.draftRevision).toBe(4);
     expect(submitted).toMatchObject({ status: 'SUBMITTED', projectVersion: 4 });
   });
 

--- a/src/app/lib/project-info-draft-client.ts
+++ b/src/app/lib/project-info-draft-client.ts
@@ -235,6 +235,22 @@ export function createProjectInfoDraftClient(options: {
       return { draft: parseDraft(body.draft, projectId), attachment: parseAttachment(body.attachment) };
     },
 
+    async removeAttachment(
+      ownership: { leaseId: string; fence: number },
+      input: { expectedDraftRevision: number; documentKind: ProjectInfoDocumentKind },
+    ) {
+      const response = await client.request<unknown>(
+        `${path}/attachments/${encodeURIComponent(input.documentKind)}`,
+        {
+          method: 'DELETE',
+          ...request,
+          headers: ownershipHeaders(sessionId, ownership),
+          body: { expectedDraftRevision: revision(input.expectedDraftRevision) },
+        },
+      );
+      return parseDraftBody(response.data, projectId);
+    },
+
     async submit(
       ownership: { leaseId: string; fence: number },
       input: {

--- a/src/app/lib/project-registration-draft-client.test.ts
+++ b/src/app/lib/project-registration-draft-client.test.ts
@@ -55,7 +55,7 @@ function harness() {
         outbox: { id: 'outbox-a', status: 'PENDING' },
       } }),
     patch: vi.fn(async () => ({ data: { draft: { ...DRAFT, draftRevision: 3 } } })),
-    request: vi.fn(),
+    request: vi.fn(async () => ({ data: { draft: { ...DRAFT, draftRevision: 5 } } })),
   } as unknown as ProjectRegistrationDraftApiClient;
   const client = createProjectRegistrationDraftClient({
     tenantId: 'mysc',
@@ -83,7 +83,7 @@ describe('project registration draft client', () => {
     }));
   });
 
-  it('saves, uploads, and submits with the exact revision and lease fence', async () => {
+  it('saves, uploads, removes, and submits with the exact revision and lease fence', async () => {
     const { api, client } = harness();
     const ownership = { leaseId: 'lease-a', fence: 3 };
     await client.create({ payload: {}, stepIndex: 0 });
@@ -93,12 +93,16 @@ describe('project registration draft client', () => {
       documentKind: 'contract',
       file: {
         name: 'contract.pdf',
-        type: 'application/pdf',
+        type: 'application/octet-stream',
         size: 3,
         arrayBuffer: async () => new Uint8Array([0x70, 0x64, 0x66]).buffer,
       },
     });
-    const submitted = await client.submit('draft-a', ownership, { expectedDraftRevision: 4 });
+    const removed = await client.removeAttachment('draft-a', ownership, {
+      expectedDraftRevision: 4,
+      documentKind: 'contract',
+    });
+    const submitted = await client.submit('draft-a', ownership, { expectedDraftRevision: 5 });
 
     const headers = {
       'x-edit-session-id': '11111111-1111-4111-8111-111111111111',
@@ -111,13 +115,26 @@ describe('project registration draft client', () => {
     }));
     expect(api.post).toHaveBeenNthCalledWith(2, '/api/v1/project-registration-drafts/draft-a/attachments', expect.objectContaining({
       headers,
-      body: expect.objectContaining({ contentBase64: 'cGRm', fileSize: 3 }),
+      body: expect.objectContaining({
+        contentBase64: 'cGRm',
+        fileSize: 3,
+        mimeType: 'application/pdf',
+      }),
     }));
     expect(api.post).toHaveBeenNthCalledWith(3, '/api/v1/project-registration-drafts/draft-a/submit', expect.objectContaining({
       headers,
-      body: { expectedDraftRevision: 4 },
+      body: { expectedDraftRevision: 5 },
     }));
+    expect(api.request).toHaveBeenCalledWith(
+      '/api/v1/project-registration-drafts/draft-a/attachments/contract',
+      expect.objectContaining({
+        method: 'DELETE',
+        headers,
+        body: { expectedDraftRevision: 4 },
+      }),
+    );
     expect(uploaded.attachment.path).toContain('/draft-a/');
+    expect(removed.draft.draftRevision).toBe(5);
     expect(submitted).toMatchObject({ status: 'SUBMITTED', projectId: 'project-a' });
   });
 

--- a/src/app/lib/project-registration-draft-client.ts
+++ b/src/app/lib/project-registration-draft-client.ts
@@ -244,6 +244,23 @@ export function createProjectRegistrationDraftClient(options: {
       return { draft: parseDraft(body.draft), attachment: parseAttachment(body.attachment) };
     },
 
+    async removeAttachment(
+      draftId: string,
+      ownership: { leaseId: string; fence: number },
+      input: { expectedDraftRevision: number; documentKind: ProjectRegistrationDocumentKind },
+    ) {
+      const response = await client.request<unknown>(
+        `${pathFor(draftId)}/attachments/${encodeURIComponent(input.documentKind)}`,
+        {
+          method: 'DELETE',
+          ...request,
+          headers: ownershipHeaders(sessionId, ownership),
+          body: { expectedDraftRevision: revision(input.expectedDraftRevision) },
+        },
+      );
+      return parseDraftBody(response.data);
+    },
+
     async submit(
       draftId: string,
       ownership: { leaseId: string; fence: number },

--- a/src/app/lib/project-request-attachment-client.test.ts
+++ b/src/app/lib/project-request-attachment-client.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
-import { downloadProjectAttachmentViaBff, downloadProjectRequestAttachmentViaBff } from './project-request-attachment-client';
+import {
+  downloadProjectAttachmentViaBff,
+  downloadProjectInfoDraftAttachmentViaBff,
+  downloadProjectRegistrationDraftAttachmentViaBff,
+  downloadProjectRequestAttachmentViaBff,
+} from './project-request-attachment-client';
 
 describe('project request attachment client', () => {
   it('downloads a pending attachment with authorization headers and no token in the URL', async () => {
@@ -45,6 +50,58 @@ describe('project request attachment client', () => {
     expect(fetchImpl).toHaveBeenCalledWith(
       expect.stringMatching(/\/api\/v1\/projects\/project-a\/attachments\/contract$/),
       expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it.each([
+    ['registration', downloadProjectRegistrationDraftAttachmentViaBff, { draftId: 'draft-a' }, '/api/v1/project-registration-drafts/draft-a/attachments/contract'],
+    ['information edit', downloadProjectInfoDraftAttachmentViaBff, { projectId: 'project-a' }, '/api/v1/project-info-drafts/project-a/attachments/contract'],
+  ])('downloads an owner-authorized %s draft attachment without exposing credentials', async (_label, download, id, suffix) => {
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => new Response(new Blob(['private-draft'], { type: 'application/pdf' }), {
+      status: 200,
+      headers: { 'content-disposition': "attachment; filename*=UTF-8''draft-contract.pdf" },
+    }));
+
+    const result = await download({
+      tenantId: 'mysc',
+      actor: { uid: 'pm-a', role: 'pm', idToken: 'draft-token' },
+      ...id,
+      documentKind: 'contract',
+      fetchImpl,
+    } as never);
+
+    const [url, options] = fetchImpl.mock.calls[0]!;
+    expect(String(url)).toMatch(new RegExp(`${suffix}$`));
+    expect(String(url)).not.toContain('draft-token');
+    expect(new Headers(options?.headers).get('authorization')).toBe('Bearer draft-token');
+    expect(result.fileName).toBe('draft-contract.pdf');
+  });
+
+  it('rejects an unsafe draft document kind before issuing a request', async () => {
+    const fetchImpl = vi.fn();
+    await expect(downloadProjectRegistrationDraftAttachmentViaBff({
+      tenantId: 'mysc', actor: { uid: 'pm-a', role: 'pm' }, draftId: 'draft-a',
+      documentKind: '../contract' as never, fetchImpl,
+    })).rejects.toThrow('document kind is invalid');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('forwards cancellation to private draft downloads', async () => {
+    const controller = new AbortController();
+    const fetchImpl = vi.fn(async () => new Response(new Blob(['private-draft']), { status: 200 }));
+
+    await downloadProjectRegistrationDraftAttachmentViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'pm-a', role: 'pm' },
+      draftId: 'draft-a',
+      documentKind: 'contract',
+      fetchImpl,
+      signal: controller.signal,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ signal: controller.signal }),
     );
   });
 });

--- a/src/app/lib/project-request-attachment-client.ts
+++ b/src/app/lib/project-request-attachment-client.ts
@@ -16,12 +16,94 @@ function contentDispositionFileName(value: string | null) {
   }
 }
 
+const DRAFT_DOCUMENT_KINDS = new Set<ProjectRequestDocumentKind>([
+  'contract',
+  'customer_business_registration',
+  'quote',
+  'proposal',
+  'proposal_word_original',
+  'proposal_ppt_original',
+  'presentation_ppt_original',
+  'rfp_request_evidence',
+  'performance_certificate',
+  'tax_invoice',
+  'final_settlement_report',
+]);
+
+function assertDraftDocumentKind(value: ProjectRequestDocumentKind) {
+  if (!DRAFT_DOCUMENT_KINDS.has(value)) throw new Error('document kind is invalid');
+}
+
+async function downloadDraftAttachment(params: {
+  tenantId: string;
+  actor: ActorLike;
+  path: string;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+}): Promise<{ blob: Blob; fileName: string }> {
+  const response = await (params.fetchImpl || globalThis.fetch)(
+    `${readPlatformApiRuntimeConfig().baseUrl}${params.path}`,
+    {
+      method: 'GET',
+      headers: buildStandardHeaders({
+        tenantId: params.tenantId,
+        actor: toRequestActor(params.actor),
+        method: 'GET',
+      }),
+      signal: params.signal,
+    },
+  );
+  if (!response.ok) {
+    const message = (await response.text()).trim();
+    throw new Error(message || '임시저장 첨부 파일을 불러오지 못했습니다.');
+  }
+  return {
+    blob: await response.blob(),
+    fileName: contentDispositionFileName(response.headers.get('content-disposition')) || 'attachment',
+  };
+}
+
+export async function downloadProjectRegistrationDraftAttachmentViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  draftId: string;
+  documentKind: ProjectRequestDocumentKind;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+}) {
+  const draftId = params.draftId.trim();
+  if (!draftId || draftId.includes('/')) throw new Error('project registration draft ID is invalid');
+  assertDraftDocumentKind(params.documentKind);
+  return downloadDraftAttachment({
+    ...params,
+    path: `/api/v1/project-registration-drafts/${encodeURIComponent(draftId)}/attachments/${params.documentKind}`,
+  });
+}
+
+export async function downloadProjectInfoDraftAttachmentViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectId: string;
+  documentKind: ProjectRequestDocumentKind;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+}) {
+  const projectId = params.projectId.trim();
+  if (!projectId || projectId.includes('/')) throw new Error('project ID is invalid');
+  assertDraftDocumentKind(params.documentKind);
+  return downloadDraftAttachment({
+    ...params,
+    path: `/api/v1/project-info-drafts/${encodeURIComponent(projectId)}/attachments/${params.documentKind}`,
+  });
+}
+
 export async function downloadProjectRequestAttachmentViaBff(params: {
   tenantId: string;
   actor: ActorLike;
   requestId: string;
   documentKind: ProjectRequestDocumentKind;
   fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
 }): Promise<{ blob: Blob; fileName: string }> {
   const requestId = params.requestId.trim();
   if (!requestId || requestId.includes('/')) throw new Error('project request ID is invalid');
@@ -34,6 +116,7 @@ export async function downloadProjectRequestAttachmentViaBff(params: {
         actor: toRequestActor(params.actor),
         method: 'GET',
       }),
+      signal: params.signal,
     },
   );
   if (!response.ok) {
@@ -52,6 +135,7 @@ export async function downloadProjectAttachmentViaBff(params: {
   projectId: string;
   documentKind: ProjectRequestDocumentKind;
   fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
 }): Promise<{ blob: Blob; fileName: string }> {
   const projectId = params.projectId.trim();
   if (!projectId || projectId.includes('/')) throw new Error('project ID is invalid');
@@ -64,6 +148,7 @@ export async function downloadProjectAttachmentViaBff(params: {
         actor: toRequestActor(params.actor),
         method: 'GET',
       }),
+      signal: params.signal,
     },
   );
   if (!response.ok) {

--- a/src/app/platform/admin-foundation.shell.test.ts
+++ b/src/app/platform/admin-foundation.shell.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { NAV_GROUPS } from './nav-config';
 
 const navConfigSource = readFileSync(
   resolve(import.meta.dirname, 'nav-config.ts'),
@@ -30,6 +31,12 @@ describe('admin monitoring foundation shell contract', () => {
     expect(navConfigSource).toContain("label: '조직DB'");
     expect(navConfigSource).not.toContain("label: '캐시플로 추출'");
     expect(navConfigSource).not.toContain("label: '사업이관'");
+  });
+
+  it('keeps each admin navigation destination unique', () => {
+    const destinations = NAV_GROUPS.flatMap((group) => group.items.map((item) => item.to));
+
+    expect(destinations).toEqual([...new Set(destinations)]);
   });
 
   it('registers a dedicated cashflow export route under the admin shell', () => {

--- a/src/app/platform/firestore-rules-policy.test.ts
+++ b/src/app/platform/firestore-rules-policy.test.ts
@@ -251,6 +251,28 @@ describe('firestore rules policy alignment', () => {
     );
   });
 
+  it('keeps both project request collections behind BFF-only Firestore rules', () => {
+    const catchallExclusionRule = firestoreRulesText.match(
+      /function isCatchallExcludedCollection\(collection\) \{[\s\S]*?\n    \}/,
+    )?.[0] || '';
+    for (const collection of ['project_requests', 'projectRequests']) {
+      expect(catchallExclusionRule).toContain(`collection in ['${collection}']`);
+      expect(firestoreRulesText).toMatch(
+        new RegExp(`match /orgs/\\{orgId\\}/${collection}/\\{requestId\\} \\{\\s*allow read, write: if false;\\s*\\}`),
+      );
+    }
+  });
+
+  it('keeps project code uniqueness claims behind BFF-only Firestore rules', () => {
+    const catchallExclusionRule = firestoreRulesText.match(
+      /function isCatchallExcludedCollection\(collection\) \{[\s\S]*?\n    \}/,
+    )?.[0] || '';
+    expect(catchallExclusionRule).toContain("collection in ['projectCodeClaims']");
+    expect(firestoreRulesText).toMatch(
+      /match \/orgs\/\{orgId\}\/projectCodeClaims\/\{claimId\} \{\s*allow read, write: if false;\s*\}/,
+    );
+  });
+
   it('keeps edit lease secrets behind BFF-only Firestore rules', () => {
     expect(firestoreRulesText).toContain("|| collection in ['editLeases']");
     expect(firestoreRulesText).toMatch(

--- a/src/app/platform/nav-config.ts
+++ b/src/app/platform/nav-config.ts
@@ -37,7 +37,6 @@ export const NAV_GROUPS: NavGroup[] = [
     label: '경영기획실',
     items: [
       { to: '/cashflow/analytics', icon: BarChart3, label: '통합 관리' },
-      { to: '/management-planning/project-codes', icon: Hash, label: '프로젝트 코드 부여' },
       { to: '/approvals', icon: ListChecks, label: '등록/승인', accent: true },
       { to: '/management-planning/project-codes', icon: Hash, label: '프로젝트 코드 부여', accent: true },
     ],

--- a/src/app/platform/navigation.test.ts
+++ b/src/app/platform/navigation.test.ts
@@ -291,6 +291,7 @@ describe('portal standalone entry paths', () => {
     expect(isPortalStandaloneEntryPath('/portal/project-settings')).toBe(false);
     expect(isPortalStandaloneEntryPath('/portal/weekly-expenses')).toBe(true);
     expect(isPortalStandaloneEntryPath('/portal/register-project')).toBe(true);
+    expect(isPortalStandaloneEntryPath('/portal/project-approvals')).toBe(true);
     expect(isPortalStandaloneEntryPath('/portal')).toBe(false);
     expect(isPortalStandaloneEntryPath('/portal/budget')).toBe(false);
   });

--- a/src/app/platform/navigation.ts
+++ b/src/app/platform/navigation.ts
@@ -162,6 +162,7 @@ function matchesPathPrefix(pathname: string, prefix: string): boolean {
 const PORTAL_STANDALONE_ENTRY_PATHS = [
   '/portal/onboarding',
   '/portal/project-select',
+  '/portal/project-approvals',
   '/portal/register-project',
   '/portal/weekly-expenses',
 ] as const;

--- a/src/app/platform/project-contract-upload.test.ts
+++ b/src/app/platform/project-contract-upload.test.ts
@@ -107,4 +107,14 @@ describe('project-contract-upload', () => {
     expect(resolveProjectDocumentMimeType('proposal_word_original', { name: 'proposal.docx', type: '' } as File))
       .toBe('application/vnd.openxmlformats-officedocument.wordprocessingml.document');
   });
+
+  it.each([
+    ['contract', 'contract.pdf', 'application/pdf'],
+    ['proposal_word_original', 'proposal.docx', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
+    ['proposal_ppt_original', 'proposal.pptx', 'application/vnd.openxmlformats-officedocument.presentationml.presentation'],
+    ['rfp_request_evidence', 'request.eml', 'message/rfc822'],
+    ['rfp_request_evidence', 'request.msg', 'application/vnd.ms-outlook'],
+  ] as const)('canonicalizes generic browser MIME for %s', (kind, name, expected) => {
+    expect(resolveProjectDocumentMimeType(kind, { name, type: 'application/octet-stream' } as File)).toBe(expected);
+  });
 });

--- a/src/app/platform/project-contract-upload.ts
+++ b/src/app/platform/project-contract-upload.ts
@@ -49,13 +49,13 @@ export function resolveProjectDocumentMimeType(
   kind: ProjectRequestDocumentKind,
   file: Pick<File, 'name' | 'type'>,
 ): string {
-  if (file.type.trim()) return file.type.trim().toLowerCase();
   const name = file.name.trim().toLowerCase();
   if (name.endsWith('.docx')) return DOCX_MIME;
   if (name.endsWith('.pptx')) return PPTX_MIME;
   if (name.endsWith('.eml')) return 'message/rfc822';
   if (name.endsWith('.msg')) return 'application/vnd.ms-outlook';
-  return 'application/pdf';
+  if (name.endsWith('.pdf') || PDF_ONLY_KINDS.has(kind)) return 'application/pdf';
+  return file.type.trim().toLowerCase() || 'application/octet-stream';
 }
 
 function readText(value: unknown): string {

--- a/src/app/platform/project-editor.test.ts
+++ b/src/app/platform/project-editor.test.ts
@@ -135,7 +135,7 @@ describe('project editor draft mapping', () => {
     const draft = createProjectEditorDraft({
       registrationRequirementsVersion: 2,
       contractStart: '2026-01-01',
-      contractEnd: '2026-12-31',
+      contractEnd: '2027-12-31',
       contractAmount: 120_000,
       totalRevenueAmount: 90_000,
       financialYears: [{
@@ -161,6 +161,35 @@ describe('project editor draft mapping', () => {
       accountType: 'NONE',
       settlementSystem: 'NONE',
       laborSettlementBasis: 'NONE',
+    });
+  });
+
+  it('keeps single-year totals as the source of truth without annual rows', () => {
+    const draft = createProjectEditorDraft({
+      registrationRequirementsVersion: 2,
+      contractStart: '2026-01-01',
+      contractEnd: '2026-12-31',
+      contractAmount: 120_000,
+      salesVatAmount: 12_000,
+      totalRevenueAmount: 90_000,
+      supportAmount: 5_000,
+      financialYears: [{
+        year: 2026,
+        contractAmount: 120_000,
+        salesVatAmount: 12_000,
+        totalRevenueAmount: 90_000,
+        supportAmount: 5_000,
+        profitRate: 0.75,
+        confirmed: true,
+      }],
+    });
+
+    expect(draft.financialYears).toEqual([]);
+    expect(draft).toMatchObject({
+      contractAmount: 120_000,
+      salesVatAmount: 12_000,
+      totalRevenueAmount: 90_000,
+      supportAmount: 5_000,
     });
   });
 
@@ -302,6 +331,7 @@ describe('project editor draft mapping', () => {
       paymentExpectedMonths: { contract: '2026-04', interim: '2026-06', final: '2026-10' },
       advanceInterimBelow70Reason: '발주처 지급 조건',
       finalPaymentNote: '잔금은 검수 후 2주 이내',
+      businessManagementGoogleFolderLink: 'https://drive.google.com/drive/folders/project-folder',
       quoteDocument: {
         path: 'orgs/mysc/project-request-documents/u001/quote.pdf',
         name: 'quote.pdf',
@@ -331,6 +361,7 @@ describe('project editor draft mapping', () => {
     ]);
     expect(payload.teamMembers).toBe('김다은 (데이나) / 총괄책임자 / 60% / 실제 참여 / 인건비 2026-04~2026-09, 변민욱 (보람) / 실무책임자 / 40% / 서류상 인력');
     expect(payload.groupwareName).toBe('기후테크');
+    expect(payload.businessManagementGoogleFolderLink).toBe('https://drive.google.com/drive/folders/project-folder');
     expect(payload.settlementSystem).toBe('KOCCA_PMS');
     expect(payload.laborSettlementBasis).toBe('FIXED_AMOUNT');
     expect(payload.paymentPlan).toEqual({ contract: 50_000, interim: 30_000, final: 20_000 });

--- a/src/app/platform/project-editor.test.ts
+++ b/src/app/platform/project-editor.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import type { Project } from '../data/types';
 import {
+  ACCOUNT_TYPE_LABELS,
   getProjectTypeSelectableOptions,
+  LABOR_SETTLEMENT_BASIS_LABELS,
+  normalizeAccountType,
   normalizeProjectContractType,
   PROJECT_CONTRACT_TYPE_OPTIONS,
   PROJECT_TYPE_LABELS,
+  SETTLEMENT_SYSTEM_LABELS,
 } from '../data/types';
 import {
   buildProjectEditorDraftFromProject,
@@ -12,7 +16,22 @@ import {
   buildProjectEditorReviewChanges,
   buildProjectRequestPayloadFromDraft,
   createProjectEditorDraft,
+  hasInvalidProjectContractPeriod,
 } from './project-editor';
+
+describe('project registration period validation', () => {
+  it('accepts a real ordered ISO contract period', () => {
+    expect(hasInvalidProjectContractPeriod('2026-01-01', '2026-12-31')).toBe(false);
+  });
+
+  it.each([
+    ['2026-12-31', '2026-01-01'],
+    ['2026-02-30', '2026-12-31'],
+    ['2026-01-01', '2026-13-01'],
+  ])('rejects invalid contract period %s ~ %s', (start, end) => {
+    expect(hasInvalidProjectContractPeriod(start, end)).toBe(true);
+  });
+});
 
 const baseProject: Project = {
   id: 'p-1',
@@ -109,6 +128,85 @@ describe('project editor draft mapping', () => {
     expect(draft.laborTransferPlan).toEqual({
       mode: 'MONTHLY_WEEK_3',
       milestoneAmounts: { contract: 0, interim: 0, final: 0 },
+    });
+  });
+
+  it('derives annual profit rates and clears settlement-only fields when the v2 basis is none', () => {
+    const draft = createProjectEditorDraft({
+      registrationRequirementsVersion: 2,
+      contractStart: '2026-01-01',
+      contractEnd: '2026-12-31',
+      contractAmount: 120_000,
+      totalRevenueAmount: 90_000,
+      financialYears: [{
+        year: 2026,
+        contractAmount: 120_000,
+        salesVatAmount: 0,
+        totalRevenueAmount: 90_000,
+        supportAmount: 0,
+        profitRate: 0,
+        confirmed: true,
+      }],
+      settlementType: 'TYPE1',
+      basis: 'NONE',
+      accountType: 'DEDICATED',
+      settlementSystem: 'BOTAEM_E',
+      laborSettlementBasis: 'INCLUDE_ACTUAL_SALARY',
+    });
+
+    expect(draft.financialYears[0].profitRate).toBe(0.75);
+    expect(draft).toMatchObject({
+      settlementType: 'TYPE1',
+      basis: 'NONE',
+      accountType: 'NONE',
+      settlementSystem: 'NONE',
+      laborSettlementBasis: 'NONE',
+    });
+  });
+
+  it('preserves the legacy v1 settlement-type NONE clearing behavior', () => {
+    expect(createProjectEditorDraft({
+      registrationRequirementsVersion: 1,
+      settlementType: 'NONE',
+      basis: '공급대가',
+      accountType: 'DEDICATED',
+      settlementSystem: 'BOTAEM_E',
+      laborSettlementBasis: 'INCLUDE_ACTUAL_SALARY',
+    })).toMatchObject({
+      settlementType: 'NONE',
+      basis: 'NONE',
+      accountType: 'NONE',
+      settlementSystem: 'NONE',
+      laborSettlementBasis: 'NONE',
+    });
+  });
+
+  it('preserves legacy v1 details when the type enables settlement even if the old basis is NONE', () => {
+    expect(createProjectEditorDraft({
+      registrationRequirementsVersion: 1,
+      settlementType: 'TYPE1',
+      basis: 'NONE',
+      accountType: 'DEDICATED',
+      settlementSystem: 'BOTAEM_E',
+      laborSettlementBasis: 'INCLUDE_ACTUAL_SALARY',
+    })).toMatchObject({
+      settlementType: 'TYPE1',
+      basis: 'NONE',
+      accountType: 'DEDICATED',
+      settlementSystem: 'BOTAEM_E',
+      laborSettlementBasis: 'INCLUDE_ACTUAL_SALARY',
+    });
+  });
+
+  it('exposes the exact PPT labels for settlement-none and other account options', () => {
+    expect(ACCOUNT_TYPE_LABELS.OTHER).toBe('기타');
+    expect(normalizeAccountType('OTHER')).toBe('OTHER');
+    expect(SETTLEMENT_SYSTEM_LABELS.NONE).toBe('정산없음');
+    expect(LABOR_SETTLEMENT_BASIS_LABELS).toMatchObject({
+      INCLUDE_ACTUAL_SALARY: '4대보험, 퇴직금포함 실급여',
+      EXCLUDE_ACTUAL_SALARY: '4대보험, 퇴직금 제외 실급여',
+      FIXED_AMOUNT: '정액정산',
+      NONE: '정산없음',
     });
   });
 
@@ -527,7 +625,7 @@ describe('project editor draft mapping', () => {
     expect(draft.status).toBe('CONTRACT_PENDING');
     expect(draft.phase).toBe('CONFIRMED');
     expect(draft.settlementType).toBe('NONE');
-    expect(draft.basis).toBe('공급가액');
+    expect(draft.basis).toBe('NONE');
     expect(draft.accountType).toBe('NONE');
     expect(draft.fundInputMode).toBe('BANK_UPLOAD');
   });

--- a/src/app/platform/project-editor.ts
+++ b/src/app/platform/project-editor.ts
@@ -81,6 +81,7 @@ export interface ProjectEditorDraft {
   type: ProjectType;
   description: string;
   clientOrg: string;
+  businessManagementGoogleFolderLink: string;
   department: string;
   projectPurpose: string;
   status: ProjectStatus;
@@ -160,6 +161,7 @@ const DEFAULT_DRAFT: ProjectEditorDraft = {
   type: 'D1',
   description: '',
   clientOrg: '',
+  businessManagementGoogleFolderLink: '',
   department: '',
   projectPurpose: '',
   status: 'CONTRACT_PENDING',
@@ -295,6 +297,7 @@ function projectFinancialYears(
   const startYear = dateYear(contractStart);
   const endYear = dateYear(contractEnd);
   if (!startYear || !endYear || startYear > endYear || endYear - startYear > 20) return [];
+  if (startYear === endYear) return [];
   return Array.from({ length: endYear - startYear + 1 }, (_, offset) => {
     const year = startYear + offset;
     return normalized.get(year) || {
@@ -435,6 +438,7 @@ const REVIEW_CHANGE_FIELDS: Array<{
   { key: 'name', label: '프로젝트명', before: (project) => normalizeChangeValue(project.name), after: (draft) => normalizeChangeValue(draft.name) },
   { key: 'officialContractName', label: '공식 계약명', before: (project) => normalizeChangeValue(project.officialContractName), after: (draft) => normalizeChangeValue(draft.officialContractName) },
   { key: 'clientOrg', label: '계약 대상', before: (project) => normalizeChangeValue(project.clientOrg), after: (draft) => normalizeChangeValue(draft.clientOrg) },
+  { key: 'businessManagementGoogleFolderLink', label: '사업관리 구글폴더링크', before: (project) => normalizeChangeValue(project.businessManagementGoogleFolderLink), after: (draft) => normalizeChangeValue(draft.businessManagementGoogleFolderLink) },
   { key: 'department', label: '담당조직(CIC)', before: (project) => normalizeChangeValue(project.department), after: (draft) => normalizeChangeValue(draft.department) },
   { key: 'type', label: '프로젝트 유형', before: (project) => PROJECT_TYPE_LABELS[normalizeProjectType(project.type)] || '-', after: (draft) => PROJECT_TYPE_LABELS[normalizeProjectType(draft.type)] || '-' },
   { key: 'contractPeriod', label: '계약 기간', before: (project) => formatDateRangeForChange(project.contractStart, project.contractEnd), after: (draft) => formatDateRangeForChange(draft.contractStart, draft.contractEnd) },
@@ -591,6 +595,9 @@ export function buildProjectEditorDraftFromProject(
     type: normalizeProjectType(normalizedProject.type || payload?.type),
     description: text(normalizedProject.description || payload?.description),
     clientOrg: text(normalizedProject.clientOrg || payload?.clientOrg),
+    businessManagementGoogleFolderLink: text(
+      normalizedProject.businessManagementGoogleFolderLink || payload?.businessManagementGoogleFolderLink,
+    ),
     department: normalizeProjectDepartment(
       normalizedProject.department || normalizedProject.cic || payload?.department,
     ),
@@ -692,6 +699,7 @@ export function buildProjectRequestPayloadFromDraft(draftInput: ProjectEditorDra
     phase: normalizeProjectPhase(draft.phase),
     description: text(draft.description),
     clientOrg: text(draft.clientOrg),
+    businessManagementGoogleFolderLink: text(draft.businessManagementGoogleFolderLink),
     department: normalizeProjectDepartment(draft.department),
     groupwareName: text(draft.name),
     currency: normalizeProjectCurrency(draft.currency),
@@ -829,6 +837,7 @@ export function buildProjectEditorProjectPatch(
     advanceInterimBelow70Reason: text(draft.advanceInterimBelow70Reason),
     paymentPlanDesc: text(draft.paymentPlanDesc),
     clientOrg: text(draft.clientOrg),
+    businessManagementGoogleFolderLink: text(draft.businessManagementGoogleFolderLink),
     groupwareName: text(draft.name),
     participantCondition: text(draft.participantCondition),
     note: text(draft.note),

--- a/src/app/platform/project-editor.ts
+++ b/src/app/platform/project-editor.ts
@@ -60,6 +60,21 @@ import { normalizeProjectDepartment, resolveProjectCic } from './project-cic';
 
 export type ProjectEditorMode = 'portal-register' | 'portal-edit' | 'admin';
 
+function isRealIsoDate(value: string) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [year, month, day] = value.split('-').map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCFullYear() === year
+    && date.getUTCMonth() === month - 1
+    && date.getUTCDate() === day;
+}
+
+export function hasInvalidProjectContractPeriod(startValue: unknown, endValue: unknown) {
+  const start = String(startValue || '').trim();
+  const end = String(endValue || '').trim();
+  return !isRealIsoDate(start) || !isRealIsoDate(end) || start > end;
+}
+
 export interface ProjectEditorDraft {
   name: string;
   officialContractName: string;
@@ -245,6 +260,11 @@ function dateYear(value: unknown): number | null {
   return match ? Number(match[1]) : null;
 }
 
+function projectFinancialYearProfitRate(contractAmount: number, totalRevenueAmount: number): number {
+  if (contractAmount <= 0) return 0;
+  return Math.min(1, totalRevenueAmount / contractAmount);
+}
+
 function projectFinancialYears(
   value: unknown,
   contractStart: unknown,
@@ -259,13 +279,15 @@ function projectFinancialYears(
     const source = row as Partial<ProjectFinancialYear>;
     const year = Number(source.year);
     if (!Number.isSafeInteger(year) || year < 2000 || year > 2099 || normalized.has(year)) continue;
+    const contractAmount = nonNegativeAmount(source.contractAmount);
+    const totalRevenueAmount = nonNegativeAmount(source.totalRevenueAmount);
     normalized.set(year, {
       year,
-      contractAmount: nonNegativeAmount(source.contractAmount),
+      contractAmount,
       salesVatAmount: nonNegativeAmount(source.salesVatAmount),
-      totalRevenueAmount: nonNegativeAmount(source.totalRevenueAmount),
+      totalRevenueAmount,
       supportAmount: nonNegativeAmount(source.supportAmount),
-      profitRate: Math.min(1, Math.max(0, Number(source.profitRate) || 0)),
+      profitRate: projectFinancialYearProfitRate(contractAmount, totalRevenueAmount),
       confirmed: source.confirmed === true,
     });
   }
@@ -281,7 +303,12 @@ function projectFinancialYears(
       salesVatAmount: offset === 0 ? nonNegativeAmount(totals.salesVatAmount) : 0,
       totalRevenueAmount: offset === 0 ? nonNegativeAmount(totals.totalRevenueAmount) : 0,
       supportAmount: offset === 0 ? nonNegativeAmount(totals.supportAmount) : 0,
-      profitRate: offset === 0 ? Math.min(1, Math.max(0, Number(totals.profitRate) || 0)) : 0,
+      profitRate: offset === 0
+        ? projectFinancialYearProfitRate(
+          nonNegativeAmount(totals.contractAmount),
+          nonNegativeAmount(totals.totalRevenueAmount),
+        )
+        : 0,
       confirmed: false,
     };
   });
@@ -424,7 +451,7 @@ const REVIEW_CHANGE_FIELDS: Array<{
   { key: 'registeredByName', label: '사업 담당자', before: (project) => normalizeChangeValue(project.registeredByName || project.managerName), after: (draft) => normalizeChangeValue(draft.registeredByName || draft.managerName) },
   { key: 'executiveApproverName', label: '지정 결재자', before: (project) => normalizeChangeValue(project.executiveApproverName), after: (draft) => normalizeChangeValue(draft.executiveApproverName) },
   { key: 'teamName', label: '사내기업팀', before: (project) => normalizeChangeValue(project.teamName), after: (draft) => normalizeChangeValue(draft.teamName) },
-  { key: 'teamMembersDetailed', label: '서류상 참여인력', before: (project) => formatTeamMembersForChange(project.teamMembersDetailed), after: (draft) => formatTeamMembersForChange(draft.teamMembersDetailed) },
+  { key: 'teamMembersDetailed', label: '참여인력 (서류상·실제)', before: (project) => formatTeamMembersForChange(project.teamMembersDetailed), after: (draft) => formatTeamMembersForChange(draft.teamMembersDetailed) },
   { key: 'paymentPlan', label: '입금 분할', before: (project) => formatPaymentPlanForChange(project.paymentPlan), after: (draft) => formatPaymentPlanForChange(draft.paymentPlan) },
   { key: 'paymentExpectedMonths', label: '입금 예상월', before: (project) => formatPaymentExpectedMonthsForChange(project.paymentExpectedMonths), after: (draft) => formatPaymentExpectedMonthsForChange(draft.paymentExpectedMonths) },
   { key: 'advanceInterimBelow70Reason', label: '선금·중도금 70% 미만 사유', before: (project) => normalizeChangeValue(project.advanceInterimBelow70Reason), after: (draft) => normalizeChangeValue(draft.advanceInterimBelow70Reason) },
@@ -440,7 +467,7 @@ const REVIEW_CHANGE_FIELDS: Array<{
   { key: 'proposalPptOriginalDocument', label: '제안서 PPT 원본', before: (project) => normalizeChangeValue(project.proposalPptOriginalDocument?.name), after: (draft) => normalizeChangeValue(draft.proposalPptOriginalDocument?.name) },
   { key: 'presentationPptOriginalDocument', label: '발표자료 PPT 원본', before: (project) => normalizeChangeValue(project.presentationPptOriginalDocument?.name), after: (draft) => normalizeChangeValue(draft.presentationPptOriginalDocument?.name) },
   { key: 'rfpRequestEvidenceDocument', label: 'RFP 또는 요청 메일 증빙', before: (project) => normalizeChangeValue(project.rfpRequestEvidenceDocument?.name), after: (draft) => normalizeChangeValue(draft.rfpRequestEvidenceDocument?.name) },
-  { key: 'customerBusinessRegistrationDocument', label: '발주처 사업자등록증 PDF', before: (project) => normalizeChangeValue(project.customerBusinessRegistrationDocument?.name), after: (draft) => normalizeChangeValue(draft.customerBusinessRegistrationDocument?.name) },
+  { key: 'customerBusinessRegistrationDocument', label: '고객사 사업자등록증 PDF', before: (project) => normalizeChangeValue(project.customerBusinessRegistrationDocument?.name), after: (draft) => normalizeChangeValue(draft.customerBusinessRegistrationDocument?.name) },
   { key: 'performanceCertificateDocument', label: '수행확인서 PDF', before: (project) => normalizeChangeValue(project.performanceCertificateDocument?.name), after: (draft) => normalizeChangeValue(draft.performanceCertificateDocument?.name) },
   { key: 'taxInvoiceDocument', label: '세금계산서 PDF', before: (project) => normalizeChangeValue(project.taxInvoiceDocument?.name), after: (draft) => normalizeChangeValue(draft.taxInvoiceDocument?.name) },
   { key: 'finalSettlementReportDocument', label: '최종 정산보고서 PDF', before: (project) => normalizeChangeValue(project.finalSettlementReportDocument?.name), after: (draft) => normalizeChangeValue(draft.finalSettlementReportDocument?.name) },
@@ -448,6 +475,9 @@ const REVIEW_CHANGE_FIELDS: Array<{
 
 export function createProjectEditorDraft(overrides: Partial<ProjectEditorDraft> = {}): ProjectEditorDraft {
   const version = registrationRequirementsVersion(overrides.registrationRequirementsVersion);
+  const settlementType = normalizeSettlementType(overrides.settlementType ?? DEFAULT_DRAFT.settlementType);
+  const basis = normalizeBasis(overrides.basis ?? DEFAULT_DRAFT.basis);
+  const settlementDetailsEnabled = version === 2 ? basis !== 'NONE' : settlementType !== 'NONE';
   const totals = {
     contractAmount: nonNegativeAmount(overrides.contractAmount ?? DEFAULT_DRAFT.contractAmount),
     salesVatAmount: nonNegativeAmount(overrides.salesVatAmount ?? DEFAULT_DRAFT.salesVatAmount),
@@ -470,13 +500,17 @@ export function createProjectEditorDraft(overrides: Partial<ProjectEditorDraft> 
     type: normalizeProjectType(overrides.type ?? DEFAULT_DRAFT.type),
     status: normalizeProjectStatus(overrides.status ?? DEFAULT_DRAFT.status),
     phase: normalizeProjectPhase(overrides.phase ?? DEFAULT_DRAFT.phase),
-    settlementType: normalizeSettlementType(overrides.settlementType ?? DEFAULT_DRAFT.settlementType),
-    basis: normalizeBasis(overrides.basis ?? DEFAULT_DRAFT.basis),
-    accountType: normalizeAccountType(overrides.accountType ?? DEFAULT_DRAFT.accountType),
-    settlementSystem: normalizeSettlementSystemCode(overrides.settlementSystem ?? DEFAULT_DRAFT.settlementSystem),
-    laborSettlementBasis: normalizeLaborSettlementBasis(
-      overrides.laborSettlementBasis ?? DEFAULT_DRAFT.laborSettlementBasis,
-    ),
+    settlementType,
+    basis: version === 2 || settlementDetailsEnabled ? basis : 'NONE',
+    accountType: !settlementDetailsEnabled
+      ? 'NONE'
+      : normalizeAccountType(overrides.accountType ?? DEFAULT_DRAFT.accountType),
+    settlementSystem: !settlementDetailsEnabled
+      ? 'NONE'
+      : normalizeSettlementSystemCode(overrides.settlementSystem ?? DEFAULT_DRAFT.settlementSystem),
+    laborSettlementBasis: !settlementDetailsEnabled
+      ? 'NONE'
+      : normalizeLaborSettlementBasis(overrides.laborSettlementBasis ?? DEFAULT_DRAFT.laborSettlementBasis),
     fundInputMode: normalizeProjectFundInputMode(overrides.fundInputMode ?? DEFAULT_DRAFT.fundInputMode),
     settlementSheetPolicy: normalizeSettlementSheetPolicy(
       overrides.settlementSheetPolicy ?? DEFAULT_DRAFT.settlementSheetPolicy,

--- a/src/app/platform/project-request-review.ts
+++ b/src/app/platform/project-request-review.ts
@@ -254,6 +254,7 @@ function buildChecklistGroups(payload: ProjectRequestPayload, analysisHighlights
     buildTextItem('clientOrg', '계약 대상', payload.clientOrg, {
       status: analysisStatusByKey.get('clientOrg') || undefined,
     }),
+    buildTextItem('businessManagementGoogleFolderLink', '사업관리 구글폴더링크', payload.businessManagementGoogleFolderLink || ''),
     buildTextItem('department', '담당조직(CIC)', payload.department),
     buildTextItem('managerName', 'PM', payload.managerName),
   ];

--- a/src/app/platform/project-team-members.test.ts
+++ b/src/app/platform/project-team-members.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
   formatProjectTeamMembersSummary,
+  hasInvalidProjectTeamMemberLaborPeriod,
   hasIncompleteProjectTeamMembers,
+  hasInvalidProjectSettlementSupportMember,
+  hasProjectFinalResponsibleMember,
+  hasProjectOperatingManager,
   normalizeProjectTeamMemberDraftRows,
   normalizeProjectTeamMembers,
   parseProjectTeamMemberIdentityInput,
@@ -94,6 +98,69 @@ describe('project-team-members', () => {
       { memberName: '김다은', memberNickname: '데이나', role: '', participationRate: 50 },
     ]);
     expect(hasIncompleteProjectTeamMembers(members)).toBe(true);
+  });
+
+  it('rejects a reversed labor allocation period before submit', () => {
+    expect(hasInvalidProjectTeamMemberLaborPeriod([{
+      memberName: '김다은',
+      memberNickname: '',
+      role: '운영매니저',
+      participationRate: 50,
+      isDocumentOnly: false,
+      laborAllocationStartMonth: '2026-09',
+      laborAllocationEndMonth: '2026-03',
+    }])).toBe(true);
+    expect(hasInvalidProjectTeamMemberLaborPeriod([{
+      memberName: '김다은',
+      memberNickname: '',
+      role: '운영매니저',
+      participationRate: 50,
+      isDocumentOnly: false,
+      laborAllocationStartMonth: '2026-03',
+      laborAllocationEndMonth: '2026-09',
+    }])).toBe(false);
+    expect(hasInvalidProjectTeamMemberLaborPeriod([{
+      memberName: '김다은',
+      memberNickname: '',
+      role: '운영매니저',
+      participationRate: 50,
+      isDocumentOnly: false,
+      laborAllocationStartMonth: '2026-13',
+      laborAllocationEndMonth: '2027-01',
+    }])).toBe(true);
+  });
+
+  it('requires at least one operating manager for registration v2', () => {
+    expect(hasProjectOperatingManager([])).toBe(false);
+    expect(hasProjectOperatingManager([
+      { memberName: '김다은', memberNickname: '', role: '실무책임자', participationRate: 50, isDocumentOnly: false },
+    ])).toBe(false);
+    expect(hasProjectOperatingManager([
+      { memberName: '김다은', memberNickname: '', role: '운영매니저', participationRate: 50, isDocumentOnly: false },
+    ])).toBe(true);
+    expect(hasProjectOperatingManager([
+      { memberName: '김다은', memberNickname: '', role: '운영매니저', participationRate: 0, isDocumentOnly: true },
+    ])).toBe(false);
+  });
+
+  it('requires an actual project final responsible member for registration v2', () => {
+    expect(hasProjectFinalResponsibleMember([])).toBe(false);
+    expect(hasProjectFinalResponsibleMember([
+      { memberName: '김다은', memberNickname: '', role: '사업 최종 책임자', participationRate: 0, isDocumentOnly: true },
+    ])).toBe(false);
+    expect(hasProjectFinalResponsibleMember([
+      { memberName: '김다은', memberNickname: '', role: '사업 최종 책임자', participationRate: 0, isDocumentOnly: false },
+    ])).toBe(true);
+  });
+
+  it('allows only 도담 or 써니 as settlement support', () => {
+    expect(hasInvalidProjectSettlementSupportMember([
+      { memberName: '송성미', memberNickname: '도담', role: '정산지원', participationRate: 0, isDocumentOnly: false },
+      { memberName: '최지윤', memberNickname: '써니', role: '정산지원', participationRate: 0, isDocumentOnly: false },
+    ])).toBe(false);
+    expect(hasInvalidProjectSettlementSupportMember([
+      { memberName: '다른 구성원', memberNickname: '', role: '정산지원', participationRate: 0, isDocumentOnly: false },
+    ])).toBe(true);
   });
 
   it('parses manual identity input in 이름(별명) format', () => {

--- a/src/app/platform/project-team-members.ts
+++ b/src/app/platform/project-team-members.ts
@@ -16,7 +16,7 @@ function toRate(value: unknown) {
 
 function toMonth(value: unknown) {
   const normalized = String(value || '').trim();
-  return /^\d{4}-\d{2}$/.test(normalized) ? normalized : '';
+  return /^\d{4}-(0[1-9]|1[0-2])$/.test(normalized) ? normalized : '';
 }
 
 export function parseProjectTeamMemberIdentityInput(value: string) {
@@ -95,6 +95,50 @@ export function hasIncompleteProjectTeamMembers(
   members: ProjectTeamMemberAssignment[] | null | undefined,
 ) {
   return normalizeProjectTeamMembers(members).some((member) => !isProjectTeamMemberComplete(member));
+}
+
+export function hasProjectOperatingManager(
+  members: ProjectTeamMemberAssignment[] | null | undefined,
+) {
+  return normalizeProjectTeamMembers(members).some((member) => (
+    member.role === '운영매니저' && member.isDocumentOnly === false
+  ));
+}
+
+export function hasProjectFinalResponsibleMember(
+  members: ProjectTeamMemberAssignment[] | null | undefined,
+) {
+  return normalizeProjectTeamMembers(members).some((member) => (
+    member.role === '사업 최종 책임자' && member.isDocumentOnly === false
+  ));
+}
+
+export function isProjectSettlementSupportMember(
+  member: Pick<ProjectTeamMemberAssignment, 'memberName' | 'memberNickname'>,
+) {
+  const name = String(member.memberName || '').trim();
+  const nickname = String(member.memberNickname || '').trim();
+  return name === '송성미' || name === '최지윤' || nickname === '도담' || nickname === '써니';
+}
+
+export function hasInvalidProjectSettlementSupportMember(
+  members: ProjectTeamMemberAssignment[] | null | undefined,
+) {
+  return normalizeProjectTeamMembers(members).some((member) => (
+    member.role === '정산지원'
+    && (member.isDocumentOnly !== false || !isProjectSettlementSupportMember(member))
+  ));
+}
+
+export function hasInvalidProjectTeamMemberLaborPeriod(
+  members: ProjectTeamMemberAssignment[] | null | undefined,
+) {
+  return (Array.isArray(members) ? members : []).some((member) => {
+    const start = String(member?.laborAllocationStartMonth || '').trim();
+    const end = String(member?.laborAllocationEndMonth || '').trim();
+    if ((start && !toMonth(start)) || (end && !toMonth(end))) return true;
+    return Boolean(start && end && start > end);
+  });
 }
 
 export function formatProjectTeamMemberLine(member: ProjectTeamMemberAssignment) {

--- a/src/app/routes.portal-canonical.shell.test.ts
+++ b/src/app/routes.portal-canonical.shell.test.ts
@@ -18,6 +18,7 @@ describe('portal canonical edit resource routes', () => {
 
   it('keeps ID-less legacy entry routes available for SPA migration', () => {
     expect(source).toContain("{ path: 'register-project', element: <S C={PortalProjectRegister} /> }");
+    expect(source).toContain("{ path: 'project-approvals', element: <S C={ProjectAssigneeApprovalPage} /> }");
     expect(source).toContain("{ path: 'edit-project', element: <S C={PortalProjectEdit} /> }");
     expect(source).toContain("{ path: 'cashflow', element: <S C={PortalCashflowPage} /> }");
     expect(source).toContain("{ path: 'cashflow/sheets-lab', element: <S C={CashflowSheetLabPage} /> }");

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -47,6 +47,7 @@ const BoardFeedPage = lazyRoute(() => import('./components/board/BoardFeedPage')
 const BoardPostPage = lazyRoute(() => import('./components/board/BoardPostPage'), 'BoardPostPage');
 const ProjectListPage = lazyRoute(() => import('./components/projects/ProjectListPage'), 'ProjectListPage');
 const ProjectMigrationAuditPage = lazyRoute(() => import('./components/projects/ProjectMigrationAuditPage'), 'ProjectMigrationAuditPage');
+const ProjectAssigneeApprovalPage = lazyRoute(() => import('./components/projects/ProjectMigrationAuditPage'), 'ProjectAssigneeApprovalPage');
 const ProjectCodeIssuancePage = lazyRoute(() => import('./components/projects/ProjectCodeIssuancePage'), 'ProjectCodeIssuancePage');
 const ProjectDetailPage = lazyRoute(() => import('./components/projects/ProjectDetailPage'), 'ProjectDetailPage');
 const ProjectWizardPage = lazyRoute(() => import('./components/projects/ProjectWizardPage'), 'ProjectWizardPage');
@@ -202,6 +203,7 @@ export const router = createBrowserRouter([
       { path: 'bank-statements', element: <S C={PortalBankStatementPage} /> },
       { path: 'personnel', element: <S C={PortalPersonnel} /> },
       { path: 'change-requests', element: <S C={PortalChangeRequests} /> },
+      { path: 'project-approvals', element: <S C={ProjectAssigneeApprovalPage} /> },
       { path: 'register-project', element: <S C={PortalProjectRegister} /> },
       { path: 'register-project/:draftId', element: <S C={PortalProjectRegister} /> },
       { path: 'edit-project', element: <S C={PortalProjectEdit} /> },


### PR DESCRIPTION
## 변경 요약
- 실무자 포털의 프로젝트 등록·수정 계약을 기획 PPT 기준으로 정렬
- 제출 서류 7종, 프로젝트명 글자 수 제한 제거, 계약서 미리보기·메모 흐름 반영
- 조직장 승인 → 경영기획실 합의 → 프로젝트 코드 부여 흐름 및 결재 문서 UI 반영
- 프론트/BFF/Firestore Rules 계약과 회귀 테스트 보강
- 현재 단계에서는 멤버 권한을 추가 분리하지 않음

## 검증
- `npm test`: 308 files passed, 10 skipped / 2,282 tests passed, 222 skipped
- `npm run policy:verify`: pass
- `npm run build`: pass
- `git diff --check origin/main...HEAD`: pass
- OpenCode/Codex read-only review 완료 (P0 없음)

## 스테이지 배포 게이트
이 변경에는 `firestore.rules`가 포함됩니다. 현재 `stage-deploy.yml`은 Vercel만 배포하고, 스테이지 전용 Firestore Rules 배포 자격증명은 등록되어 있지 않습니다.

프론트/BFF만 먼저 올라가 Rules와 계약이 어긋나는 상황을 막기 위해 아래 조건 전에는 병합하지 않습니다.
1. 스테이지 전용 최소 권한 Firebase 배포 계정 준비
2. 프로덕션 프로젝트 ID 차단 가드 포함
3. Firestore Rules 배포 후 스테이지 smoke test 통과

운영 배포는 이 PR 범위에 포함하지 않습니다.
