### PR TITLE
refactor(cashflow): 공식 시트 값을 고정 좌표로 연동

### DIFF
--- a/server/bff/cashflow-sheet-snapshot.mjs
+++ b/server/bff/cashflow-sheet-snapshot.mjs
@@ -269,15 +269,6 @@ function readWholeWon(
   return classified.amount;
 }
 
-function findControlColumnIndex(template, matrix, headerText, legacyColumnIndex) {
-  const projectionSection = template?.sections?.find((section) => section.mode === 'projection');
-  if (!Number.isInteger(projectionSection?.headerRowIndex)) return legacyColumnIndex;
-  const header = matrix?.[projectionSection.headerRowIndex] || [];
-  const normalizedTarget = normalizedText(headerText).replace(/\s+/g, '').toLowerCase();
-  const found = header.findIndex((value) => normalizedText(value).replace(/\s+/g, '').toLowerCase() === normalizedTarget);
-  return found >= 0 ? found : null;
-}
-
 function controlRow({ matrix, row, weekColumns, issues, controlColumnIndex }) {
   const field = `${row.kind}:${row.lineId || row.derivedKind}`;
   const amounts = weekColumns.map((week) => readWholeWon(
@@ -341,8 +332,8 @@ export function extractCashflowSheetFacts({ template = {}, matrix = [], cells = 
   const projectionSection = template?.sections?.find((section) => section.mode === 'projection');
   const weekColumns = (projectionSection?.weekColumns || [])
     .sort((left, right) => left.yearMonth.localeCompare(right.yearMonth) || left.weekNo - right.weekNo);
-  const depositControlColumnIndex = findControlColumnIndex(template, matrix, '입금Total', 66);
-  const unpaidControlColumnIndex = findControlColumnIndex(template, matrix, '미지급Total', 67);
+  const depositControlColumnIndex = 70; // BS
+  const unpaidControlColumnIndex = 71; // BT
   const depositScheduleRows = weekColumns.map((week) => {
     const taxInvoiceIssuedDate = normalizeDateCell(matrix?.[6]?.[week.columnIndex]);
     const expectedDepositDate = normalizeDateCell(matrix?.[7]?.[week.columnIndex]);

--- a/server/bff/cashflow-sheet-snapshot.test.mjs
+++ b/server/bff/cashflow-sheet-snapshot.test.mjs
@@ -92,8 +92,8 @@ describe('cashflow sheet pinned snapshot', () => {
     expect(first.summary).toEqual({ cellCount: 2, valueCount: 1, emptyCount: 1, invalidCount: 0 });
   });
 
-  it('pins business metadata, the five-week deposit schedule, and BO/BP controls', () => {
-    const matrix = Array.from({ length: 55 }, () => Array.from({ length: 68 }, () => ''));
+  it('pins business metadata, the five-week deposit schedule, and BS/BT controls', () => {
+    const matrix = Array.from({ length: 55 }, () => Array.from({ length: 72 }, () => ''));
     matrix[0][1] = '최종 업데이트 : 2026.07.01 최종작성자: 보람';
     matrix[1][1] = 'Type1. 세금계산서발행+공급가액기준';
     matrix[2][1] = '전용계좌사업';
@@ -106,10 +106,10 @@ describe('cashflow sheet pinned snapshot', () => {
       matrix[13][columnIndex] = String((weekIndex + 1) * 10);
       matrix[36][columnIndex] = String((weekIndex + 1) * 5);
     }
-    matrix[8][66] = '15,000';
-    matrix[8][67] = '85,000';
-    matrix[13][66] = '150';
-    matrix[36][66] = '75';
+    matrix[8][70] = '15,000';
+    matrix[8][71] = '85,000';
+    matrix[13][70] = '150';
+    matrix[36][70] = '75';
 
     const weekColumns = Array.from({ length: 5 }, (_, weekIndex) => ({
       yearMonth: '2026-06', weekNo: weekIndex + 1, columnIndex: 3 + weekIndex,
@@ -155,14 +155,14 @@ describe('cashflow sheet pinned snapshot', () => {
       }],
       annualCashflowTotals: [],
       controlTotals: {
-        deposit: { sourceCell: 'BO9', value: 15000, computed: 15000, matches: true },
-        unpaid: { sourceCell: 'BP9', value: 85000 },
+        deposit: { sourceCell: 'BS9', value: 15000, computed: 15000, matches: true },
+        unpaid: { sourceCell: 'BT9', value: 85000 },
         projection: [{
-          kind: 'line', lineId: 'SALES_IN', sourceCell: 'BO14', value: 150, computed: 150, matches: true,
+          kind: 'line', lineId: 'SALES_IN', sourceCell: 'BS14', value: 150, computed: 150, matches: true,
           annualValues: [{ year: 2026, value: 150 }],
         }],
         actual: [{
-          kind: 'line', lineId: 'SALES_IN', sourceCell: 'BO37', value: 75, computed: 75, matches: true,
+          kind: 'line', lineId: 'SALES_IN', sourceCell: 'BS37', value: 75, computed: 75, matches: true,
           annualValues: [{ year: 2026, value: 75 }],
         }],
       },
@@ -170,17 +170,17 @@ describe('cashflow sheet pinned snapshot', () => {
     });
   });
 
-  it('treats future blank week cells as zero for BO sums without inventing deposit values', () => {
-    const matrix = Array.from({ length: 55 }, () => Array.from({ length: 68 }, () => ''));
+  it('treats future blank week cells as zero for BS sums without inventing deposit values', () => {
+    const matrix = Array.from({ length: 55 }, () => Array.from({ length: 72 }, () => ''));
     const weekColumns = Array.from({ length: 60 }, (_, index) => ({
       yearMonth: `2026-${String(Math.floor(index / 5) + 1).padStart(2, '0')}`,
       weekNo: (index % 5) + 1,
       columnIndex: 3 + index,
     }));
     matrix[8][3] = '1000';
-    matrix[8][66] = '1000';
+    matrix[8][70] = '1000';
     matrix[13][3] = '100';
-    matrix[13][66] = '100';
+    matrix[13][70] = '100';
     const facts = extractCashflowSheetFacts({
       matrix,
       template: {
@@ -196,20 +196,18 @@ describe('cashflow sheet pinned snapshot', () => {
     expect(facts.controlTotals.projection[0]).toMatchObject({ computed: 100, value: 100, matches: true });
   });
 
-  it('finds the moving Total columns and keeps week values beyond the 2026 layout', () => {
+  it('uses the official fixed BS/BT control columns', () => {
     const matrix = Array.from({ length: 55 }, () => Array.from({ length: 72 }, () => ''));
-    matrix[0][68] = '입금\nTotal';
-    matrix[0][69] = '미지급 Total';
     const weekColumns = [
       { yearMonth: '2027-01', weekNo: 4, columnIndex: 63 },
-      { yearMonth: '2027-01', weekNo: 5, columnIndex: 64 },
+      { yearMonth: '2027-01', weekNo: 5, columnIndex: 62 },
     ];
     matrix[8][63] = '1000';
-    matrix[8][64] = '2000';
-    matrix[8][68] = '3000';
+    matrix[8][62] = '2000';
+    matrix[8][70] = '3000';
     matrix[13][63] = '100';
-    matrix[13][64] = '200';
-    matrix[13][68] = '300';
+    matrix[13][62] = '200';
+    matrix[13][70] = '300';
 
     const facts = extractCashflowSheetFacts({
       matrix,
@@ -222,28 +220,28 @@ describe('cashflow sheet pinned snapshot', () => {
     });
 
     expect(facts.depositScheduleRows).toHaveLength(2);
-    expect(facts.controlTotals.deposit).toMatchObject({ sourceCell: 'BQ9', value: 3000, computed: 3000, matches: true });
-    expect(facts.controlTotals.projection[0]).toMatchObject({ sourceCell: 'BQ14', value: 300, computed: 300, matches: true });
+    expect(facts.controlTotals.deposit).toMatchObject({ sourceCell: 'BS9', value: 3000, computed: 3000, matches: true });
+    expect(facts.controlTotals.projection[0]).toMatchObject({ sourceCell: 'BS14', value: 300, computed: 300, matches: true });
   });
 
   it('groups sheet finance checks by calendar year using the registered cashflow lines', () => {
-    const matrix = Array.from({ length: 55 }, () => Array.from({ length: 68 }, () => ''));
+    const matrix = Array.from({ length: 55 }, () => Array.from({ length: 72 }, () => ''));
     const weekColumns = [
       { yearMonth: '2025-12', weekNo: 5, columnIndex: 3 },
       { yearMonth: '2026-01', weekNo: 1, columnIndex: 4 },
     ];
     matrix[8][3] = '100';
     matrix[8][4] = '200';
-    matrix[8][66] = '300';
+    matrix[8][70] = '300';
     matrix[13][3] = '10';
     matrix[13][4] = '20';
-    matrix[13][66] = '30';
+    matrix[13][70] = '30';
     matrix[14][3] = '30';
     matrix[14][4] = '40';
-    matrix[14][66] = '70';
+    matrix[14][70] = '70';
     matrix[15][3] = '50';
     matrix[15][4] = '60';
-    matrix[15][66] = '110';
+    matrix[15][70] = '110';
 
     const facts = extractCashflowSheetFacts({
       matrix,

--- a/server/bff/cashflow-sheet-template.mjs
+++ b/server/bff/cashflow-sheet-template.mjs
@@ -2,11 +2,35 @@ import cashflowPolicyData from '../../src/app/policies/cashflow-policy.json' wit
 
 const WEEK_LABEL_RE = /^(\d{2})-(\d{1,2})-(\d{1,2})$/;
 const ANNUAL_YEAR_LABEL_RE = /^(\d{4})년$/;
-const SUPPORTED_MODES = ['projection', 'actual'];
-const MIN_WEEK_LABELS_PER_SECTION = 2;
+const MODES = ['projection', 'actual'];
 const LINE_ENTRIES = Array.isArray(cashflowPolicyData.lineEntries) ? cashflowPolicyData.lineEntries : [];
-const EXPECTED_LINE_IDS = LINE_ENTRIES.map((entry) => entry.lineId);
-const EXPECTED_DERIVED_KINDS = ['deposit_total', 'withdrawal_total', 'balance'];
+const WEEK_COLUMN_INDEXES = Array.from({ length: 60 }, (_, index) => index + 4); // E:BL
+const ANNUAL_COLUMN_INDEXES = [2, 3, 64, 65, 66, 67, 68, 69]; // C:D, BM:BR
+const SOURCE_YEAR_TOTAL_COLUMN_INDEX = 70; // BS
+const SECTION_LAYOUTS = [
+  {
+    mode: 'projection',
+    headerRowIndex: 11,
+    weekRowIndex: 12,
+    lineRowIndexes: [14, 15, 16, 17, 18, 19, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30],
+    derivedRows: [
+      { rowIndex: 21, kind: 'deposit_total', label: '입금 합계' },
+      { rowIndex: 31, kind: 'withdrawal_total', label: '출금 합계' },
+      { rowIndex: 32, kind: 'balance', label: '잔액 (※ 중요)' },
+    ],
+  },
+  {
+    mode: 'actual',
+    headerRowIndex: 34,
+    weekRowIndex: 35,
+    lineRowIndexes: [37, 38, 39, 40, 41, 42, 43, 45, 46, 47, 48, 49, 50, 51, 52, 53],
+    derivedRows: [
+      { rowIndex: 44, kind: 'deposit_total', label: '입금 합계' },
+      { rowIndex: 54, kind: 'withdrawal_total', label: '출금 합계' },
+      { rowIndex: 55, kind: 'balance', label: '잔액' },
+    ],
+  },
+];
 
 function normalizeText(value) {
   return String(value ?? '').replace(/\s+/g, ' ').trim();
@@ -21,7 +45,7 @@ export function buildCashflowLineLookup(lineEntries) {
   const ambiguousKeys = new Set();
 
   for (const entry of lineEntries) {
-    for (const mode of SUPPORTED_MODES) {
+    for (const mode of MODES) {
       const modeLabel = mode === 'projection' ? entry.projectionLabel : entry.actualLabel;
       for (const label of [entry.lineId, entry.label, ...(entry.aliases || []), modeLabel]) {
         for (const normalized of new Set([normalizeText(label), normalizeLabelKey(label)].filter(Boolean))) {
@@ -39,12 +63,9 @@ export function buildCashflowLineLookup(lineEntries) {
   }
 
   return (label, mode, direction) => {
-    const prefix = `${mode}|${direction}|`;
-    const keys = new Set([normalizeText(label), normalizeLabelKey(label)]
-      .filter(Boolean)
-      .map((normalized) => `${prefix}${normalized}`));
-    if ([...keys].some((key) => ambiguousKeys.has(key))) return null;
-    for (const key of keys) {
+    for (const normalized of [normalizeText(label), normalizeLabelKey(label)].filter(Boolean)) {
+      const key = `${mode}|${direction}|${normalized}`;
+      if (ambiguousKeys.has(key)) return null;
       const entry = entriesByKey.get(key);
       if (entry) return entry;
     }
@@ -55,12 +76,12 @@ export function buildCashflowLineLookup(lineEntries) {
 const resolveLineEntry = buildCashflowLineLookup(LINE_ENTRIES);
 
 function columnName(columnIndex) {
-  let n = columnIndex + 1;
+  let number = columnIndex + 1;
   let name = '';
-  while (n > 0) {
-    const mod = (n - 1) % 26;
-    name = String.fromCharCode(65 + mod) + name;
-    n = Math.floor((n - 1) / 26);
+  while (number > 0) {
+    const remainder = (number - 1) % 26;
+    name = String.fromCharCode(65 + remainder) + name;
+    number = Math.floor((number - 1) / 26);
   }
   return name;
 }
@@ -76,347 +97,186 @@ export function cashflowMappingKey({ mode, lineId, yearMonth, weekNo }) {
 export function parseCashflowWeekLabel(value) {
   const match = WEEK_LABEL_RE.exec(normalizeText(value));
   if (!match) return null;
-  const year = Number.parseInt(match[1], 10);
+  const year = 2000 + Number.parseInt(match[1], 10);
   const month = Number.parseInt(match[2], 10);
   const weekNo = Number.parseInt(match[3], 10);
-  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(weekNo)) return null;
   if (month < 1 || month > 12 || weekNo < 1 || weekNo > 5) return null;
   return {
     raw: normalizeText(value),
-    year: 2000 + year,
+    year,
     month,
-    yearMonth: `${2000 + year}-${String(month).padStart(2, '0')}`,
+    yearMonth: `${year}-${String(month).padStart(2, '0')}`,
     weekNo,
   };
 }
 
-function detectWeekColumns(row) {
-  return (row || [])
-    .map((cell, columnIndex) => {
-      const parsed = parseCashflowWeekLabel(cell);
-      if (!parsed) return null;
-      return {
-        ...parsed,
-        columnIndex,
-        a1: toA1(0, columnIndex).replace(/\d+$/, ''),
-      };
-    })
+function annualColumn(matrix, rowIndex, columnIndex) {
+  const match = ANNUAL_YEAR_LABEL_RE.exec(normalizeText(matrix?.[rowIndex]?.[columnIndex]));
+  if (!match) return null;
+  return {
+    year: Number.parseInt(match[1], 10),
+    columnIndex,
+    a1: toA1(rowIndex, columnIndex),
+  };
+}
+
+function fixedSection(matrix, layout, reasons) {
+  const weekColumns = WEEK_COLUMN_INDEXES.map((columnIndex) => {
+    const parsed = parseCashflowWeekLabel(matrix?.[layout.weekRowIndex]?.[columnIndex]);
+    if (!parsed) {
+      reasons.push({
+        code: 'cashflow_week_header_invalid',
+        mode: layout.mode,
+        sourceCell: toA1(layout.weekRowIndex, columnIndex),
+        message: `${layout.mode} 주차 헤더가 공식 양식과 다릅니다.`,
+      });
+      return null;
+    }
+    return {
+      ...parsed,
+      rowIndex: layout.weekRowIndex,
+      columnIndex,
+      a1: toA1(layout.weekRowIndex, columnIndex),
+    };
+  }).filter(Boolean);
+
+  const annualColumns = ANNUAL_COLUMN_INDEXES
+    .map((columnIndex) => annualColumn(matrix, layout.headerRowIndex, columnIndex))
     .filter(Boolean);
-}
-
-function detectAnnualYearColumns(row) {
-  return (row || [])
-    .map((cell, columnIndex) => {
-      const match = ANNUAL_YEAR_LABEL_RE.exec(normalizeText(cell));
-      if (!match) return null;
-      return {
-        year: Number.parseInt(match[1], 10),
-        columnIndex,
-        a1: toA1(0, columnIndex).replace(/\d+$/, ''),
-      };
-    })
-    .filter((column) => Number.isSafeInteger(column?.year));
-}
-
-function readRowLabel(row) {
-  const searchLimit = Math.min(4, row?.length || 0);
-  for (let index = 0; index < searchLimit; index += 1) {
-    const label = normalizeText(row[index]);
-    if (label) return { label, columnIndex: index };
+  const sourceYear = weekColumns[0]?.year;
+  const sourceTotalHeader = normalizeText(matrix?.[layout.headerRowIndex]?.[SOURCE_YEAR_TOTAL_COLUMN_INDEX]);
+  if (Number.isSafeInteger(sourceYear) && ['Total', `${sourceYear}년 합계`].includes(sourceTotalHeader)) {
+    annualColumns.push({
+      year: sourceYear,
+      columnIndex: SOURCE_YEAR_TOTAL_COLUMN_INDEX,
+      a1: toA1(layout.headerRowIndex, SOURCE_YEAR_TOTAL_COLUMN_INDEX),
+    });
   }
-  return { label: '', columnIndex: -1 };
-}
-
-function resolveDerivedKind(label) {
-  const normalized = normalizeLabelKey(label);
-  if (!normalized) return null;
-  if (normalized === '입금합계') return 'deposit_total';
-  if (normalized === '출금합계') return 'withdrawal_total';
-  if (normalized === '잔액' || normalized === '잔액(※중요)') return 'balance';
-  return null;
-}
-
-function normalizeMatrix(matrix) {
-  return Array.isArray(matrix)
-    ? matrix.map((row) => (Array.isArray(row) ? row.map((cell) => String(cell ?? '')) : []))
-    : [];
-}
-
-function detectSectionCandidates(rows) {
-  return rows
-    .map((row, rowIndex) => {
-      const weekColumns = detectWeekColumns(row).map((week) => ({
-        ...week,
-        rowIndex,
-        a1: toA1(rowIndex, week.columnIndex),
-      }));
-      if (weekColumns.length < MIN_WEEK_LABELS_PER_SECTION) return null;
-      return { rowIndex, weekColumns };
-    })
-    .filter(Boolean)
-    .sort((a, b) => a.rowIndex - b.rowIndex);
-}
-
-function resolveModeFromRow(row) {
-  const searchLimit = Math.min(6, row?.length || 0);
-  let hasProjection = false;
-  let hasActual = false;
-  for (let index = 0; index < searchLimit; index += 1) {
-    const normalized = normalizeLabelKey(row[index]).toLowerCase();
-    if (!normalized) continue;
-    hasProjection ||= normalized.includes('projection');
-    hasActual ||= normalized.includes('actual');
-  }
-  if (hasProjection === hasActual) return null;
-  return hasProjection ? 'projection' : 'actual';
-}
-
-function detectCashflowSectionCandidates(rows) {
-  const sections = [];
-  const seenModes = new Set();
-
-  for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
-    const mode = resolveModeFromRow(rows[rowIndex]);
-    if (!SUPPORTED_MODES.includes(mode) || seenModes.has(mode)) continue;
-
-    for (let weekRowIndex = rowIndex + 1; weekRowIndex < Math.min(rows.length, rowIndex + 6); weekRowIndex += 1) {
-      const weekColumns = detectWeekColumns(rows[weekRowIndex]).map((week) => ({
-        ...week,
-        rowIndex: weekRowIndex,
-        a1: toA1(weekRowIndex, week.columnIndex),
-      }));
-      if (weekColumns.length < MIN_WEEK_LABELS_PER_SECTION) continue;
-      sections.push({
-        mode,
-        headerRowIndex: rowIndex,
-        rowIndex: weekRowIndex,
-        weekColumns,
-      });
-      seenModes.add(mode);
-      break;
-    }
-  }
-
-  return sections.sort((a, b) => a.rowIndex - b.rowIndex);
-}
-
-function analyzeSection({ rows, candidate, nextCandidate, mode }) {
-  const lineRows = [];
-  const derivedRows = [];
-  const ignoredRows = [];
-  const duplicateLineIds = new Set();
-  const seenLineIds = new Set();
-  const endRowIndex = nextCandidate?.headerRowIndex ?? rows.length;
-  const annualColumns = detectAnnualYearColumns(rows[candidate.headerRowIndex]).map((column) => ({
-    ...column,
-    a1: toA1(candidate.headerRowIndex, column.columnIndex),
-  }));
-  let direction = 'IN';
-
-  for (let rowIndex = candidate.rowIndex + 1; rowIndex < endRowIndex; rowIndex += 1) {
-    const row = rows[rowIndex] || [];
-    const { label, columnIndex } = readRowLabel(row);
-    if (!label) continue;
-
-    const derivedKind = resolveDerivedKind(label);
-    if (derivedKind) {
-      derivedRows.push({
-        rowIndex,
-        label,
-        labelColumnIndex: columnIndex,
-        a1: toA1(rowIndex, columnIndex),
-        kind: derivedKind,
-      });
-      if (derivedKind === 'deposit_total') direction = 'OUT';
-      continue;
-    }
-
-    const lineEntry = resolveLineEntry(label, mode, direction);
-    if (lineEntry) {
-      if (seenLineIds.has(lineEntry.lineId)) duplicateLineIds.add(lineEntry.lineId);
-      seenLineIds.add(lineEntry.lineId);
-      lineRows.push({
-        rowIndex,
-        label,
-        labelColumnIndex: columnIndex,
-        a1: toA1(rowIndex, columnIndex),
-        lineId: lineEntry.lineId,
-        canonicalLabel: lineEntry.label,
-        direction: lineEntry.direction,
-      });
-      continue;
-    }
-
-    ignoredRows.push({
-      rowIndex,
-      label,
-      labelColumnIndex: columnIndex,
-      a1: toA1(rowIndex, columnIndex),
-      reason: 'unmapped_row_label',
+  if (annualColumns.length !== ANNUAL_COLUMN_INDEXES.length + 1) {
+    reasons.push({
+      code: 'cashflow_annual_header_invalid',
+      mode: layout.mode,
+      message: `${layout.mode} 연간 합계 헤더가 공식 양식과 다릅니다.`,
     });
   }
 
-  const mappings = [];
-  const annualMappings = [];
-  for (const lineRow of lineRows) {
-    for (const week of candidate.weekColumns) {
-      mappings.push({
-        mode,
-        lineId: lineRow.lineId,
-        label: lineRow.label,
-        canonicalLabel: lineRow.canonicalLabel,
-        direction: lineRow.direction,
-        yearMonth: week.yearMonth,
-        weekNo: week.weekNo,
-        rowIndex: lineRow.rowIndex,
-        columnIndex: week.columnIndex,
-        a1: toA1(lineRow.rowIndex, week.columnIndex),
-        source: 'sheet_layout',
+  const lineRows = layout.lineRowIndexes.map((rowIndex, index) => {
+    const expected = LINE_ENTRIES[index];
+    const label = normalizeText(matrix?.[rowIndex]?.[0]);
+    const resolved = expected ? resolveLineEntry(label, layout.mode, expected.direction) : null;
+    if (!expected || resolved?.lineId !== expected.lineId) {
+      reasons.push({
+        code: 'cashflow_line_invalid',
+        mode: layout.mode,
+        sourceCell: toA1(rowIndex, 0),
+        lineIds: expected ? [expected.lineId] : [],
+        message: `${layout.mode} 항목 행이 공식 양식과 다릅니다.`,
       });
     }
-    for (const column of annualColumns) {
-      annualMappings.push({
-        mode,
-        lineId: lineRow.lineId,
-        label: lineRow.label,
-        canonicalLabel: lineRow.canonicalLabel,
-        direction: lineRow.direction,
-        year: column.year,
-        rowIndex: lineRow.rowIndex,
-        columnIndex: column.columnIndex,
-        a1: toA1(lineRow.rowIndex, column.columnIndex),
-        source: 'sheet_annual_total',
-      });
-    }
-  }
+    return {
+      rowIndex,
+      label,
+      canonicalLabel: expected?.label,
+      labelColumnIndex: 0,
+      a1: toA1(rowIndex, 0),
+      lineId: expected?.lineId,
+      direction: expected?.direction,
+    };
+  }).filter((row) => row.lineId && row.direction);
 
-  const missingLineIds = EXPECTED_LINE_IDS.filter((lineId) => !seenLineIds.has(lineId));
+  const derivedRows = layout.derivedRows.map((row) => {
+    const label = normalizeText(matrix?.[row.rowIndex]?.[0]);
+    if (normalizeLabelKey(label) !== normalizeLabelKey(row.label)) {
+      reasons.push({
+        code: 'cashflow_derived_row_invalid',
+        mode: layout.mode,
+        sourceCell: toA1(row.rowIndex, 0),
+        message: `${layout.mode} 합계/잔액 행이 공식 양식과 다릅니다.`,
+      });
+    }
+    return {
+      ...row,
+      label,
+      labelColumnIndex: 0,
+      a1: toA1(row.rowIndex, 0),
+    };
+  });
+
+  const mappings = lineRows.flatMap((lineRow) => weekColumns.map((week) => ({
+    mode: layout.mode,
+    lineId: lineRow.lineId,
+    label: lineRow.label,
+    canonicalLabel: lineRow.canonicalLabel,
+    direction: lineRow.direction,
+    yearMonth: week.yearMonth,
+    weekNo: week.weekNo,
+    rowIndex: lineRow.rowIndex,
+    columnIndex: week.columnIndex,
+    a1: toA1(lineRow.rowIndex, week.columnIndex),
+    source: 'sheet_layout',
+  })));
+  const annualMappings = lineRows.flatMap((lineRow) => annualColumns.map((column) => ({
+    mode: layout.mode,
+    lineId: lineRow.lineId,
+    label: lineRow.label,
+    canonicalLabel: lineRow.canonicalLabel,
+    direction: lineRow.direction,
+    year: column.year,
+    rowIndex: lineRow.rowIndex,
+    columnIndex: column.columnIndex,
+    a1: toA1(lineRow.rowIndex, column.columnIndex),
+    source: 'sheet_annual_total',
+  })));
 
   return {
-    mode,
-    headerRowIndex: Math.max(0, candidate.rowIndex - 1),
-    weekRowIndex: candidate.rowIndex,
-    weekColumns: candidate.weekColumns,
+    mode: layout.mode,
+    headerRowIndex: layout.headerRowIndex,
+    weekRowIndex: layout.weekRowIndex,
+    weekColumns,
     annualColumns,
     lineRows,
     derivedRows,
-    ignoredRows,
+    ignoredRows: [],
     mappings,
     annualMappings,
-    missingLineIds,
-    duplicateLineIds: Array.from(duplicateLineIds),
+    missingLineIds: [],
+    duplicateLineIds: [],
   };
 }
 
 export function analyzeCashflowSheetTemplate(matrix) {
-  const rows = normalizeMatrix(matrix);
-  const cashflowCandidates = detectCashflowSectionCandidates(rows);
-  const candidates = cashflowCandidates.length >= 2 ? cashflowCandidates : detectSectionCandidates(rows).slice(0, 2)
-    .map((candidate, index) => ({ ...candidate, mode: SUPPORTED_MODES[index], headerRowIndex: Math.max(0, candidate.rowIndex - 1) }));
+  const rows = Array.isArray(matrix)
+    ? matrix.map((row) => (Array.isArray(row) ? row.map((cell) => String(cell ?? '')) : []))
+    : [];
   const reasons = [];
-
-  if (candidates.length < 2) {
+  const sections = SECTION_LAYOUTS.map((layout) => fixedSection(rows, layout, reasons));
+  const projectionWeeks = sections[0].weekColumns.map((week) => week.raw);
+  const actualWeeks = sections[1].weekColumns.map((week) => week.raw);
+  if (projectionWeeks.length !== 60 || JSON.stringify(projectionWeeks) !== JSON.stringify(actualWeeks)) {
     reasons.push({
-      code: 'cashflow_sections_missing',
-      message: 'Projection/Actual 섹션의 주차 라벨 행을 찾지 못했습니다.',
+      code: 'cashflow_week_headers_mismatch',
+      message: 'Projection과 Actual 주차 헤더가 일치하지 않습니다.',
     });
   }
 
-  const selectedCandidates = SUPPORTED_MODES
-    .map((mode) => candidates.find((candidate) => candidate.mode === mode))
-    .filter(Boolean);
-  const sections = selectedCandidates.map((candidate, index) => analyzeSection({
-    rows,
-    candidate,
-    nextCandidate: selectedCandidates[index + 1],
-    mode: candidate.mode || SUPPORTED_MODES[index],
-  }));
-
-  for (const section of sections) {
-    if (section.missingLineIds.length > 0) {
-      reasons.push({
-        code: 'cashflow_line_missing',
-        mode: section.mode,
-        lineIds: section.missingLineIds,
-        message: `${section.mode} 섹션에서 cashflow 라벨을 찾지 못했습니다.`,
-      });
-    }
-    if (section.duplicateLineIds.length > 0) {
-      reasons.push({
-        code: 'cashflow_line_duplicate',
-        mode: section.mode,
-        lineIds: section.duplicateLineIds,
-        message: `${section.mode} 섹션에 중복 cashflow 라벨이 있습니다.`,
-      });
-    }
-
-    const lineIds = section.lineRows.map((row) => row.lineId);
-    if (lineIds.length !== EXPECTED_LINE_IDS.length
-      || lineIds.some((lineId, index) => lineId !== EXPECTED_LINE_IDS[index])) {
-      reasons.push({
-        code: 'cashflow_line_order_invalid',
-        mode: section.mode,
-        expectedLineIds: EXPECTED_LINE_IDS,
-        actualLineIds: lineIds,
-        message: `${section.mode} 섹션 cashflow 라벨 순서가 정책과 다릅니다.`,
-      });
-    }
-
-    const derivedKinds = section.derivedRows.map((row) => row.kind);
-    const missingDerivedKinds = EXPECTED_DERIVED_KINDS.filter((kind) => !derivedKinds.includes(kind));
-    const duplicateDerivedKinds = EXPECTED_DERIVED_KINDS.filter(
-      (kind) => derivedKinds.filter((candidate) => candidate === kind).length > 1,
-    );
-    if (missingDerivedKinds.length > 0) {
-      reasons.push({
-        code: 'cashflow_derived_row_missing',
-        mode: section.mode,
-        kinds: missingDerivedKinds,
-        message: `${section.mode} 섹션 합계/잔액 행이 부족합니다.`,
-      });
-    }
-    if (duplicateDerivedKinds.length > 0) {
-      reasons.push({
-        code: 'cashflow_derived_row_duplicate',
-        mode: section.mode,
-        kinds: duplicateDerivedKinds,
-        message: `${section.mode} 섹션 합계/잔액 행이 중복되었습니다.`,
-      });
-    }
-    if (missingDerivedKinds.length === 0
-      && duplicateDerivedKinds.length === 0
-      && derivedKinds.some((kind, index) => kind !== EXPECTED_DERIVED_KINDS[index])) {
-      reasons.push({
-        code: 'cashflow_derived_row_order_invalid',
-        mode: section.mode,
-        expectedKinds: EXPECTED_DERIVED_KINDS,
-        actualKinds: derivedKinds,
-        message: `${section.mode} 섹션 합계/잔액 행 순서가 다릅니다.`,
-      });
-    }
-  }
-
-  if (cashflowCandidates.length > 2) {
+  const projectionYears = sections[0].annualColumns.map((column) => column.year);
+  const actualYears = sections[1].annualColumns.map((column) => column.year);
+  if (JSON.stringify(projectionYears) !== JSON.stringify(actualYears)) {
     reasons.push({
-      code: 'cashflow_extra_week_sections',
-      count: cashflowCandidates.length,
-      message: '지원 템플릿보다 많은 주차 라벨 섹션이 감지되었습니다.',
+      code: 'cashflow_annual_headers_mismatch',
+      message: 'Projection과 Actual 연간 합계 헤더가 일치하지 않습니다.',
     });
   }
 
   const mappingCandidates = sections.flatMap((section) => section.mappings);
-  const ignoredRows = sections.flatMap((section) => section.ignoredRows.map((row) => ({ ...row, mode: section.mode })));
-  const derivedRows = sections.flatMap((section) => section.derivedRows.map((row) => ({ ...row, mode: section.mode })));
-  const supported = sections.length === 2 && reasons.length === 0;
-
   return {
-    supported,
+    supported: reasons.length === 0,
     policyVersion: cashflowPolicyData.version || 'cashflow-policy-v1',
     sectionOrder: ['projection', 'actual'],
     sections,
     mappingCandidates,
-    derivedRows,
-    ignoredRows,
+    derivedRows: sections.flatMap((section) => section.derivedRows.map((row) => ({ ...row, mode: section.mode }))),
+    ignoredRows: [],
     reasons,
     stats: {
       rowCount: rows.length,

--- a/server/bff/cashflow-sheet-template.test.mjs
+++ b/server/bff/cashflow-sheet-template.test.mjs
@@ -6,137 +6,71 @@ import {
   toA1,
 } from './cashflow-sheet-template.mjs';
 
-const PROJECTION_IN_LINES = [
-  ['MYSC_PREPAY_IN', 'MYSC 선입금 - 직접사업비 등'],
-  ['MYSC_PREPAY_LABOR_IN', 'MYSC 선입금 - MYSC 인건비'],
-  ['MYSC_PREPAY_INPUT_VAT_IN', 'MYSC 선입금 - 메입부가세'],
-  ['SALES_IN', '매출액(입금)'],
-  ['SALES_VAT_IN', '매출부가세(입금)'],
-  ['TEAM_SUPPORT_IN', '팀지원금(입금)'],
-  ['BANK_INTEREST_IN', '은행이자(입금)'],
+const PROJECTION_LABELS = [
+  'MYSC 선입금 - 직접사업비 등',
+  'MYSC 선입금 - MYSC 인건비',
+  'MYSC 선입금 - 메입부가세',
+  '매출액(입금)',
+  '매출부가세(입금)',
+  '팀지원금(입금)',
+  '은행이자(입금)',
+  'MYSC 선입금 - 직접사업비 등',
+  'MYSC 선입금 - MYSC 인건비',
+  '직접사업비(공급가액)',
+  '매입부가세',
+  'MYSC인건비',
+  'MYSC수익',
+  '매출부가세(출금)',
+  '팀지원금(출금)',
+  '은행이자(출금)',
 ];
-
-const PROJECTION_OUT_LINES = [
-  ['MYSC_PREPAY_DIRECT_OUT', 'MYSC 선입금 - 직접사업비 등'],
-  ['MYSC_PREPAY_LABOR_OUT', 'MYSC 선입금 - MYSC 인건비'],
-  ['DIRECT_COST_OUT', '직접사업비(공급가액)'],
-  ['INPUT_VAT_OUT', '매입부가세'],
-  ['MYSC_LABOR_OUT', 'MYSC인건비'],
-  ['MYSC_PROFIT_OUT', 'MYSC수익'],
-  ['SALES_VAT_OUT', '매출부가세(출금)'],
-  ['TEAM_SUPPORT_OUT', '팀지원금(출금)'],
-  ['BANK_INTEREST_OUT', '은행이자(출금)'],
+const ACTUAL_LABELS = [
+  'MYSC 선입금 - 직접사업비 등(입금)',
+  'MYSC 선입금 - MYSC 인건비(입금)',
+  'MYSC 선입금 - 매입부가세(입금)',
+  ...PROJECTION_LABELS.slice(3, 7),
+  'MYSC 선입금 - 직접사업비 등(출금)',
+  'MYSC 선입금 - MYSC 인건비(출금)',
+  ...PROJECTION_LABELS.slice(9),
 ];
+const LINE_ROWS = {
+  projection: [14, 15, 16, 17, 18, 19, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30],
+  actual: [37, 38, 39, 40, 41, 42, 43, 45, 46, 47, 48, 49, 50, 51, 52, 53],
+};
 
-const ACTUAL_IN_LINES = [
-  ['MYSC_PREPAY_IN', 'MYSC 선입금 - 직접사업비 등(입금)'],
-  ['MYSC_PREPAY_LABOR_IN', 'MYSC 선입금 - MYSC 인건비(입금)'],
-  ['MYSC_PREPAY_INPUT_VAT_IN', 'MYSC 선입금 - 매입부가세(입금)'],
-  ...PROJECTION_IN_LINES.slice(3),
-];
-
-const ACTUAL_OUT_LINES = [
-  ['MYSC_PREPAY_DIRECT_OUT', 'MYSC 선입금 - 직접사업비 등(출금)'],
-  ['MYSC_PREPAY_LABOR_OUT', 'MYSC 선입금 - MYSC 인건비(출금)'],
-  ...PROJECTION_OUT_LINES.slice(2),
-];
-
-const EXPECTED_LINE_IDS = [...PROJECTION_IN_LINES, ...PROJECTION_OUT_LINES].map(([lineId]) => lineId);
-
-function makeWeekLabels(count, startMonth = 1) {
-  const labels = [];
-  let month = startMonth;
-  let weekNo = 1;
-  for (let i = 0; i < count; i += 1) {
-    labels.push(`26-${month}-${weekNo}`);
-    weekNo += 1;
-    if (weekNo > 5) {
-      month += 1;
-      weekNo = 1;
-    }
-  }
-  return labels;
-}
-
-function buildSection({ weekLabels, actual = false, firstWeekColumn = 3, lineOverrides = {} }) {
-  const width = firstWeekColumn + weekLabels.length + 5;
-  const empty = () => Array.from({ length: width }, () => '');
-  const rows = [];
-  const header = empty();
-  header[0] = actual ? 'ACTUAL' : 'Projection';
-  ['2027년 01월', '2027년 02월', '2027년 03월', 'Total', '미입금액'].forEach((label, index) => {
-    header[firstWeekColumn + weekLabels.length + index] = label;
+function makeOfficialMatrix() {
+  const matrix = Array.from({ length: 60 }, () => Array.from({ length: 72 }, () => ''));
+  matrix[11][0] = 'Projection';
+  matrix[34][0] = 'ACTUAL';
+  const annualYears = ['2024년', '2025년', '2027년', '2028년', '2029년', '2030년', '2031년', '2032년'];
+  [2, 3, 64, 65, 66, 67, 68, 69].forEach((columnIndex, index) => {
+    matrix[11][columnIndex] = annualYears[index];
+    matrix[34][columnIndex] = annualYears[index];
   });
-  rows.push(header);
-  const weekRow = empty();
-  weekLabels.forEach((label, index) => {
-    weekRow[firstWeekColumn + index] = label;
-  });
-  rows.push(weekRow);
-  const inLines = actual ? ACTUAL_IN_LINES : PROJECTION_IN_LINES;
-  const outLines = actual ? ACTUAL_OUT_LINES : PROJECTION_OUT_LINES;
-  for (const [lineId, label] of inLines) {
-    const row = empty();
-    row[0] = lineOverrides[lineId] || label;
-    rows.push(row);
+  matrix[11][70] = 'Total';
+  matrix[34][70] = 'Total';
+  for (let index = 0; index < 60; index += 1) {
+    const label = `26-${Math.floor(index / 5) + 1}-${(index % 5) + 1}`;
+    matrix[12][index + 4] = label;
+    matrix[35][index + 4] = label;
   }
-  const inTotal = empty();
-  inTotal[0] = '입금 합계';
-  rows.push(inTotal);
-  for (const [lineId, label] of outLines) {
-    const row = empty();
-    row[0] = lineOverrides[lineId] || label;
-    rows.push(row);
-  }
-  const outTotal = empty();
-  outTotal[0] = '출금 합계';
-  rows.push(outTotal);
-  const balance = empty();
-  balance[0] = actual ? '잔액' : '잔액 (※ 중요)';
-  rows.push(balance);
-  return rows;
-}
-
-function buildTemplateMatrix({ weekCount = 60, firstWeekColumn = 3, projectionOverrides = {}, actualOverrides = {} } = {}) {
-  return [
-    ['사업비 cashflow'],
-    ['안내 문구는 매핑 대상이 아닙니다.'],
-    [],
-    ...buildSection({
-      weekLabels: makeWeekLabels(weekCount),
-      firstWeekColumn,
-      lineOverrides: projectionOverrides,
-    }),
-    [],
-    ...buildSection({
-      weekLabels: makeWeekLabels(weekCount),
-      firstWeekColumn,
-      actual: true,
-      lineOverrides: actualOverrides,
-    }),
-    [],
-    ['주의사항', '이 아래 설명은 매핑에서 제외합니다.'],
-  ];
-}
-
-function buildNonCashflowWeeklyBlock({ weekCount = 60, firstWeekColumn = 3 } = {}) {
-  const width = firstWeekColumn + weekCount + 2;
-  const empty = () => Array.from({ length: width }, () => '');
-  const header = empty();
-  header[0] = '사업비 입금예상 (MYSC계좌기준)';
-  const weekRow = empty();
-  makeWeekLabels(weekCount).forEach((label, index) => {
-    weekRow[firstWeekColumn + index] = label;
+  LINE_ROWS.projection.forEach((rowIndex, index) => {
+    matrix[rowIndex][0] = PROJECTION_LABELS[index];
   });
-  const dateRow = empty();
-  dateRow[0] = '입금일';
-  const amountRow = empty();
-  amountRow[0] = '입금액';
-  return [header, weekRow, dateRow, amountRow, []];
+  LINE_ROWS.actual.forEach((rowIndex, index) => {
+    matrix[rowIndex][0] = ACTUAL_LABELS[index];
+  });
+  [
+    [21, '입금 합계'], [31, '출금 합계'], [32, '잔액 (※ 중요)'],
+    [44, '입금 합계'], [54, '출금 합계'], [55, '잔액'],
+  ].forEach(([rowIndex, label]) => {
+    matrix[rowIndex][0] = label;
+  });
+  return matrix;
 }
 
-describe('cashflow sheet template mapping', () => {
-  it('parses YY-M-W week labels into authoritative join keys', () => {
+describe('cashflow official fixed template', () => {
+  it('keeps the week and A1 helpers used by config and snapshots', () => {
     expect(parseCashflowWeekLabel('26-1-1')).toEqual({
       raw: '26-1-1',
       year: 2026,
@@ -145,258 +79,74 @@ describe('cashflow sheet template mapping', () => {
       weekNo: 1,
     });
     expect(parseCashflowWeekLabel('2026-1-1')).toBeNull();
-    expect(parseCashflowWeekLabel('26-13-1')).toBeNull();
-    expect(parseCashflowWeekLabel('26-1-7')).toBeNull();
+    expect(toA1(14, 4)).toBe('E15');
+    expect(toA1(53, 63)).toBe('BL54');
   });
 
-  it('builds A1 coordinates without hardcoding a final column', () => {
-    expect(toA1(11, 3)).toBe('D12');
-    expect(toA1(30, 62)).toBe('BK31');
-    expect(toA1(2, 64)).toBe('BM3');
-  });
-
-  it('maps the upper section as projection and the lower section as actual', () => {
-    const result = analyzeCashflowSheetTemplate(buildTemplateMatrix({ weekCount: 60 }));
+  it('maps only the official fixed coordinates', () => {
+    const result = analyzeCashflowSheetTemplate(makeOfficialMatrix());
 
     expect(result.supported).toBe(true);
-    expect(result.sections.map((section) => section.mode)).toEqual(['projection', 'actual']);
-    expect(result.sections[0].weekColumns).toHaveLength(60);
-    expect(result.sections[1].weekColumns).toHaveLength(60);
-    expect(result.sections[0].lineRows).toHaveLength(16);
-    expect(result.sections[1].lineRows).toHaveLength(16);
-    expect(result.sections[0].mappings).toHaveLength(960);
-    expect(result.sections[1].mappings).toHaveLength(960);
+    expect(result.reasons).toEqual([]);
     expect(result.mappingCandidates).toHaveLength(1_920);
-    expect(result.sections.map((section) => section.lineRows.map((row) => row.lineId))).toEqual([
-      EXPECTED_LINE_IDS,
-      EXPECTED_LINE_IDS,
-    ]);
-    expect(result.mappingCandidates[0]).toMatchObject({
+    expect(result.sections.map((section) => section.weekColumns.length)).toEqual([60, 60]);
+    expect(result.sections.map((section) => section.annualMappings.length)).toEqual([144, 144]);
+    expect(result.sections[0].mappings[0]).toMatchObject({
       mode: 'projection',
       lineId: 'MYSC_PREPAY_IN',
       yearMonth: '2026-01',
       weekNo: 1,
-      source: 'sheet_layout',
+      a1: 'E15',
     });
-    expect(result.mappingCandidates.some((mapping) => mapping.mode === 'actual')).toBe(true);
-    expect(result.sections[0].lineRows
-      .filter((row) => row.label === 'MYSC 선입금 - 직접사업비 등')
-      .map((row) => row.lineId)).toEqual(['MYSC_PREPAY_IN', 'MYSC_PREPAY_DIRECT_OUT']);
-    expect(result.sections[0].lineRows
-      .filter((row) => row.label === 'MYSC 선입금 - MYSC 인건비')
-      .map((row) => row.lineId)).toEqual(['MYSC_PREPAY_LABOR_IN', 'MYSC_PREPAY_LABOR_OUT']);
-    expect(result.sections[0].weekColumns.at(-1).a1).toMatch(/^BK\d+$/);
-    expect(result.mappingCandidates.every((mapping) => mapping.columnIndex <= 62)).toBe(true);
-    expect(result.stats.maxColumnCount).toBe(68);
-  });
-
-  it('ignores a non-cashflow weekly block above the Projection header', () => {
-    const result = analyzeCashflowSheetTemplate([
-      ['최종 업데이트'],
-      ...buildNonCashflowWeeklyBlock({ weekCount: 60 }),
-      ...buildTemplateMatrix({ weekCount: 60 }),
-    ]);
-
-    expect(result.supported).toBe(true);
-    expect(result.reasons).toEqual([]);
-    expect(result.sections.map((section) => section.mode)).toEqual(['projection', 'actual']);
-    expect(result.sections[0]).toMatchObject({
-      mode: 'projection',
-      lineRows: expect.arrayContaining([
-        expect.objectContaining({
-          label: 'MYSC 선입금 - 직접사업비 등',
-          canonicalLabel: 'MYSC 선입금(잔금 등 입금 필요 시)',
-          lineId: 'MYSC_PREPAY_IN',
-        }),
-      ]),
+    expect(result.sections[1].mappings.at(-1)).toMatchObject({
+      mode: 'actual',
+      lineId: 'BANK_INTEREST_OUT',
+      yearMonth: '2026-12',
+      weekNo: 5,
+      a1: 'BL54',
     });
-    expect(result.sections[0].lineRows).toHaveLength(16);
-    expect(result.sections[1].lineRows).toHaveLength(16);
-  });
-
-  it('does not mistake the Projection - Actual difference heading for the Projection section', () => {
-    const matrix = buildTemplateMatrix({ weekCount: 4 });
-    const projectionHeaderIndex = matrix.findIndex((row) => row[0] === 'Projection');
-    matrix.splice(projectionHeaderIndex, 0, ['Projection - Actual 차이']);
-    const projectionHeader = matrix.find((row) => row[0] === 'Projection');
-    projectionHeader[1] = '2024년';
-    projectionHeader[2] = '2025년';
-
-    const result = analyzeCashflowSheetTemplate(matrix);
-
-    expect(result.supported).toBe(true);
-    expect(result.sections[0].headerRowIndex).toBe(matrix.indexOf(projectionHeader));
-    expect(result.sections[0].annualColumns.map((column) => column.year)).toEqual([2024, 2025]);
-  });
-
-  it('scans weekly columns dynamically when the last column is not BK', () => {
-    const result = analyzeCashflowSheetTemplate(buildTemplateMatrix({ weekCount: 8, firstWeekColumn: 5 }));
-
-    expect(result.supported).toBe(true);
-    expect(result.sections[0].weekColumns).toHaveLength(8);
-    expect(result.sections[0].weekColumns[0].a1).toMatch(/^F\d+$/);
-    expect(result.sections[0].weekColumns.at(-1).a1).not.toMatch(/^BK\d+$/);
-    expect(result.sections[0].mappings).toHaveLength(128);
-    expect(result.sections[1].mappings).toHaveLength(128);
-  });
-
-  it('separates totals and balance rows from cashflow line mappings', () => {
-    const result = analyzeCashflowSheetTemplate(buildTemplateMatrix({ weekCount: 4 }));
-
-    expect(result.derivedRows.map((row) => `${row.mode}:${row.kind}`)).toEqual([
-      'projection:deposit_total',
-      'projection:withdrawal_total',
-      'projection:balance',
-      'actual:deposit_total',
-      'actual:withdrawal_total',
-      'actual:balance',
-    ]);
-    expect(result.mappingCandidates.some((mapping) => String(mapping.lineId).includes('합계'))).toBe(false);
-    expect(result.mappingCandidates).toHaveLength(128);
-  });
-
-  it('rejects missing cashflow labels with specific reasons', () => {
-    const result = analyzeCashflowSheetTemplate(buildTemplateMatrix({
-      weekCount: 4,
-      projectionOverrides: { SALES_IN: '알 수 없는 입금 라벨' },
-    }));
-
-    expect(result.supported).toBe(false);
-    expect(result.reasons).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        code: 'cashflow_line_missing',
-        mode: 'projection',
-        lineIds: expect.arrayContaining(['SALES_IN']),
-      }),
-    ]));
-  });
-
-  it('does not resolve a label from the wrong direction', () => {
-    const result = analyzeCashflowSheetTemplate(buildTemplateMatrix({
-      weekCount: 4,
-      projectionOverrides: { MYSC_PREPAY_LABOR_IN: 'MYSC 선입금 - MYSC 인건비(출금)' },
-    }));
-
-    expect(result.supported).toBe(false);
-    expect(result.reasons).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        code: 'cashflow_line_missing',
-        mode: 'projection',
-        lineIds: expect.arrayContaining(['MYSC_PREPAY_LABOR_IN']),
-      }),
-    ]));
-  });
-
-  it('rejects duplicate cashflow labels inside a section', () => {
-    const result = analyzeCashflowSheetTemplate(buildTemplateMatrix({
-      weekCount: 4,
-      actualOverrides: { BANK_INTEREST_IN: '매출액(입금)' },
-    }));
-
-    expect(result.supported).toBe(false);
-    expect(result.reasons).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        code: 'cashflow_line_duplicate',
-        mode: 'actual',
-        lineIds: expect.arrayContaining(['SALES_IN']),
-      }),
-    ]));
-  });
-
-  it('rejects stored cashflow lines that are not in policy order', () => {
-    const matrix = buildTemplateMatrix({ weekCount: 4 });
-    const projectionHeaderIndex = matrix.findIndex((row) => row[0] === 'Projection');
-    [matrix[projectionHeaderIndex + 2], matrix[projectionHeaderIndex + 3]] = [
-      matrix[projectionHeaderIndex + 3],
-      matrix[projectionHeaderIndex + 2],
-    ];
-
-    const result = analyzeCashflowSheetTemplate(matrix);
-
-    expect(result.supported).toBe(false);
-    expect(result.reasons).toEqual(expect.arrayContaining([
-      expect.objectContaining({ code: 'cashflow_line_order_invalid', mode: 'projection' }),
-    ]));
-  });
-
-  it('rejects a missing derived row', () => {
-    const matrix = buildTemplateMatrix({ weekCount: 4 });
-    matrix.find((row) => row[0] === '출금 합계')[0] = '알 수 없는 합계';
-
-    const result = analyzeCashflowSheetTemplate(matrix);
-
-    expect(result.supported).toBe(false);
-    expect(result.reasons).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        code: 'cashflow_derived_row_missing',
-        mode: 'projection',
-        kinds: ['withdrawal_total'],
-      }),
-    ]));
-  });
-
-  it('rejects a duplicate derived row', () => {
-    const matrix = buildTemplateMatrix({ weekCount: 4 });
-    const withdrawalTotalIndex = matrix.findIndex((row) => row[0] === '출금 합계');
-    matrix.splice(withdrawalTotalIndex + 1, 0, [...matrix[withdrawalTotalIndex]]);
-
-    const result = analyzeCashflowSheetTemplate(matrix);
-
-    expect(result.supported).toBe(false);
-    expect(result.reasons).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        code: 'cashflow_derived_row_duplicate',
-        mode: 'projection',
-        kinds: ['withdrawal_total'],
-      }),
-    ]));
-  });
-
-  it('rejects reordered derived rows', () => {
-    const matrix = buildTemplateMatrix({ weekCount: 4 });
-    const withdrawalTotalIndex = matrix.findIndex((row) => row[0] === '출금 합계');
-    [matrix[withdrawalTotalIndex], matrix[withdrawalTotalIndex + 1]] = [
-      matrix[withdrawalTotalIndex + 1],
-      matrix[withdrawalTotalIndex],
-    ];
-
-    const result = analyzeCashflowSheetTemplate(matrix);
-
-    expect(result.supported).toBe(false);
-    expect(result.reasons).toEqual(expect.arrayContaining([
-      expect.objectContaining({ code: 'cashflow_derived_row_order_invalid', mode: 'projection' }),
-    ]));
-  });
-
-  it('ignores explanatory text containing the word balance after the table', () => {
-    const matrix = buildTemplateMatrix({ weekCount: 4 });
-    matrix.push(['Projection Total 금액(잔액=0원)을 맞추세요.']);
-
-    const result = analyzeCashflowSheetTemplate(matrix);
-
-    expect(result.supported).toBe(true);
-    expect(result.sections[1].derivedRows.map((row) => row.kind)).toEqual([
-      'deposit_total',
-      'withdrawal_total',
-      'balance',
+    expect(result.sections[0].annualColumns.map(({ year, a1 }) => [year, a1])).toEqual([
+      [2024, 'C12'], [2025, 'D12'], [2027, 'BM12'], [2028, 'BN12'],
+      [2029, 'BO12'], [2030, 'BP12'], [2031, 'BQ12'], [2032, 'BR12'],
+      [2026, 'BS12'],
     ]);
   });
 
-  it('fails closed when different line IDs share a normalized label in one mode and direction', () => {
+  it('fails closed instead of guessing when an official coordinate changes', () => {
+    const matrix = makeOfficialMatrix();
+    matrix[14][0] = '';
+
+    const result = analyzeCashflowSheetTemplate(matrix);
+
+    expect(result.supported).toBe(false);
+    expect(result.reasons).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        code: 'cashflow_line_invalid',
+        mode: 'projection',
+        sourceCell: 'A15',
+        lineIds: ['MYSC_PREPAY_IN'],
+      }),
+    ]));
+  });
+
+  it('fails when Projection and Actual no longer describe the same 60 weeks', () => {
+    const matrix = makeOfficialMatrix();
+    matrix[35][63] = '26-12-4';
+
+    const result = analyzeCashflowSheetTemplate(matrix);
+
+    expect(result.supported).toBe(false);
+    expect(result.reasons).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'cashflow_week_headers_mismatch' }),
+    ]));
+  });
+
+  it('keeps ambiguous labels unresolved at the trust boundary', () => {
     const resolve = buildCashflowLineLookup([
       { lineId: 'LINE_A', label: '공 유 라벨', direction: 'IN', aliases: [] },
       { lineId: 'LINE_B', label: '공유라벨', direction: 'IN', aliases: [] },
     ]);
 
-    expect(resolve('공 유 라벨', 'projection', 'IN')).toBeNull();
     expect(resolve('공유라벨', 'projection', 'IN')).toBeNull();
-  });
-
-  it('allows duplicate normalized labels owned by the same line ID', () => {
-    const resolve = buildCashflowLineLookup([
-      { lineId: 'LINE_A', label: '공 유 라벨', direction: 'IN', aliases: ['공유라벨'] },
-    ]);
-
-    expect(resolve('공유라벨', 'actual', 'IN')).toMatchObject({ lineId: 'LINE_A' });
   });
 });

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -29,7 +29,7 @@ import {
   parseWithSchema,
 } from '../schemas.mjs';
 
-const CASHFLOW_SHEET_LAB_READ_RANGE = 'A1:ZZ220';
+const CASHFLOW_SHEET_LAB_READ_RANGE = 'A1:BT60';
 const DEFAULT_SHEET_PREVIEW_CACHE_TTL_MS = 15_000;
 const CASHFLOW_USAGE_SHEET_NAME_PARTS = ['cashflow', '사용내역', '연동'];
 const CASHFLOW_WEEK_BASIS = 'sheet_range';

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -42,6 +42,22 @@ const ACTUAL_OUT_LABELS = [
 ];
 
 const JANUARY_FINANCE_WEEKS = ['26-1-1', '26-1-2', '26-1-3', '26-1-4', '26-1-5'];
+const FULL_YEAR_FINANCE_WEEKS = Array.from({ length: 12 }, (_, monthIndex) => (
+  Array.from({ length: 5 }, (_unused, weekIndex) => `26-${monthIndex + 1}-${weekIndex + 1}`)
+)).flat();
+function officialAnnualColumns(sourceYear) {
+  return new Map([
+    [sourceYear - 2, 2],
+    [sourceYear - 1, 3],
+    [sourceYear + 1, 64],
+    [sourceYear + 2, 65],
+    [sourceYear + 3, 66],
+    [sourceYear + 4, 67],
+    [sourceYear + 5, 68],
+    [sourceYear + 6, 69],
+    [sourceYear, 70],
+  ]);
+}
 const CASHFLOW_LINE_IDS = [
   'MYSC_PREPAY_IN', 'MYSC_PREPAY_LABOR_IN', 'MYSC_PREPAY_INPUT_VAT_IN',
   'SALES_IN', 'SALES_VAT_IN', 'TEAM_SUPPORT_IN', 'BANK_INTEREST_IN',
@@ -128,44 +144,67 @@ function javaAnnualApplyResponse(request) {
   };
 }
 
-function buildSection(actual = false, weekLabels = ['26-1-1', '26-1-2', '26-1-3'], annualYears = [], annualValue = '') {
-  const firstWeekColumn = annualYears.length > 0 ? 2 + annualYears.length : 3;
-  const header = [actual ? 'ACTUAL' : 'Projection'];
-  annualYears.forEach((year, index) => {
-    header[2 + index] = `${year}년`;
-  });
-  const weekRow = [...Array(firstWeekColumn).fill(''), ...weekLabels];
-  const valueCells = weekLabels.map(() => '999');
-  const annualValueCells = annualYears.map((year) => (year === 2027 ? '' : annualValue));
-  const inLabels = actual ? ACTUAL_IN_LABELS : PROJECTION_IN_LABELS;
-  const outLabels = actual ? ACTUAL_OUT_LABELS : PROJECTION_OUT_LABELS;
-  return [
-    header,
-    weekRow,
-    ...inLabels.map((label) => [label, '', ...(annualYears.length > 0 ? annualValueCells : ['']), ...valueCells]),
-    ['입금 합계', '', ...(annualYears.length > 0 ? annualValueCells : ['']), ...valueCells],
-    ...outLabels.map((label) => [label, '', ...(annualYears.length > 0 ? annualValueCells : ['']), ...valueCells]),
-    ['출금 합계', '', ...(annualYears.length > 0 ? annualValueCells : ['']), ...valueCells],
-    [actual ? '잔액' : '잔액 (※ 중요)', '', ...(annualYears.length > 0 ? annualValueCells : ['']), ...valueCells],
-  ];
+function buildOfficialMatrix({
+  weekLabels = FULL_YEAR_FINANCE_WEEKS,
+  annualYears = [],
+  projectionAnnualValue = '',
+  actualAnnualValue = '',
+} = {}) {
+  const matrix = Array.from({ length: 60 }, () => Array(72).fill(''));
+  const sourceYear = 2000 + Number.parseInt(String(weekLabels[0] || '26').split('-')[0], 10);
+  const annualColumns = officialAnnualColumns(sourceYear);
+  const writeSection = (actual, annualValue) => {
+    const headerRowIndex = actual ? 34 : 11;
+    const weekRowIndex = actual ? 35 : 12;
+    const lineRowIndexes = actual
+      ? [37, 38, 39, 40, 41, 42, 43, 45, 46, 47, 48, 49, 50, 51, 52, 53]
+      : [14, 15, 16, 17, 18, 19, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30];
+    const derivedRows = actual
+      ? [[44, '입금 합계'], [54, '출금 합계'], [55, '잔액']]
+      : [[21, '입금 합계'], [31, '출금 합계'], [32, '잔액 (※ 중요)']];
+    matrix[headerRowIndex][0] = actual ? 'ACTUAL' : 'Projection';
+    for (const [year, columnIndex] of annualColumns) {
+      matrix[headerRowIndex][columnIndex] = columnIndex === 70 ? 'Total' : `${year}년`;
+    }
+    weekLabels.forEach((label, index) => {
+      matrix[weekRowIndex][4 + index] = label;
+    });
+    const inLabels = actual ? ACTUAL_IN_LABELS : PROJECTION_IN_LABELS;
+    const outLabels = actual ? ACTUAL_OUT_LABELS : PROJECTION_OUT_LABELS;
+    const labels = [...inLabels, ...outLabels];
+    lineRowIndexes.forEach((rowIndex, index) => {
+      matrix[rowIndex][0] = labels[index];
+      weekLabels.forEach((_label, weekIndex) => {
+        matrix[rowIndex][4 + weekIndex] = '999';
+      });
+      for (const year of annualYears) {
+        const columnIndex = annualColumns.get(year);
+        if (columnIndex !== undefined) matrix[rowIndex][columnIndex] = year === 2027 ? '' : annualValue;
+      }
+    });
+    derivedRows.forEach(([rowIndex, label]) => {
+      matrix[rowIndex][0] = label;
+      weekLabels.forEach((_week, weekIndex) => {
+        matrix[rowIndex][4 + weekIndex] = '999';
+      });
+    });
+  };
+  matrix[0][0] = 'title';
+  writeSection(false, projectionAnnualValue);
+  writeSection(true, actualAnnualValue);
+  return matrix;
 }
 
 function buildMatrix() {
-  return [
-    ['title'],
-    ...buildSection(false),
-    [],
-    ...buildSection(true),
-  ];
+  return buildOfficialMatrix();
 }
 
-function buildMatrixWithWeekLabels(weekLabels) {
-  return [
-    ['title'],
-    ...buildSection(false, weekLabels),
-    [],
-    ...buildSection(true, weekLabels),
-  ];
+function buildMatrixWithWeekLabels(requestedLabels) {
+  const sourceYear = Number.parseInt(String(requestedLabels?.[0] || '26').split('-')[0], 10);
+  const fullYearLabels = Array.from({ length: 12 }, (_, monthIndex) => (
+    Array.from({ length: 5 }, (_unused, weekIndex) => `${sourceYear}-${monthIndex + 1}-${weekIndex + 1}`)
+  )).flat();
+  return buildOfficialMatrix({ weekLabels: fullYearLabels });
 }
 
 async function loadSanitized260701FullYearFixture() {
@@ -176,36 +215,42 @@ async function loadSanitized260701FullYearFixture() {
   )));
   const sheet = workbook.getWorksheet('cashflow(사용내역 연동)');
   if (!sheet) throw new Error('Sanitized cashflow fixture sheet is missing');
-  return Array.from({ length: sheet.rowCount }, (_row, rowIndex) => (
+  const matrix = Array.from({ length: Math.max(sheet.rowCount, 60) }, (_row, rowIndex) => (
     Array.from({ length: sheet.columnCount }, (_column, columnIndex) => {
       const value = sheet.getCell(rowIndex + 1, columnIndex + 1).value;
       if (value && typeof value === 'object' && 'result' in value) return value.result ?? '';
       return value ?? '';
     })
   ));
+  matrix.forEach((row) => {
+    while (row.length < 72) row.push('');
+  });
+  for (const headerRowIndex of [11, 34]) {
+    for (const [year, columnIndex] of officialAnnualColumns(2026)) {
+      matrix[headerRowIndex][columnIndex] = columnIndex === 70 ? 'Total' : `${year}년`;
+    }
+  }
+  matrix[32][0] = '잔액 (※ 중요)';
+  matrix[55][0] = '잔액';
+  return matrix;
 }
 
 function buildMultiYearMatrix() {
-  const matrix = [
-    ['title'],
-    ...buildSection(false, JANUARY_FINANCE_WEEKS, [2024, 2025, 2027, 2028], '100'),
-    [],
-    ...buildSection(true, JANUARY_FINANCE_WEEKS, [2024, 2025, 2027, 2028], '50'),
-  ];
-  matrix[3][3] = '0';
+  const matrix = buildOfficialMatrix({
+    annualYears: [2024, 2025, 2027, 2028],
+    projectionAnnualValue: '100',
+    actualAnnualValue: '50',
+  });
+  matrix[14][3] = '0';
   return matrix;
 }
 
 function buildConflictingAnnualWeeklyMatrix() {
-  const weekLabels = Array.from({ length: 12 }, (_, monthIndex) => (
-    Array.from({ length: 5 }, (_unused, weekIndex) => `26-${monthIndex + 1}-${weekIndex + 1}`)
-  )).flat();
-  return [
-    ['title'],
-    ...buildSection(false, weekLabels, [2026], '100'),
-    [],
-    ...buildSection(true, weekLabels, [2026], '50'),
-  ];
+  return buildOfficialMatrix({
+    annualYears: [2026],
+    projectionAnnualValue: '100',
+    actualAnnualValue: '50',
+  });
 }
 
 function createDb({ project = { id: 'project-a' }, weeks = [], initialDocuments = {}, onGet, onQuery } = {}) {
@@ -437,7 +482,7 @@ describe('cashflow sheet lab route', () => {
     expect(snapshots).toHaveLength(1);
     expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_snapshot_months/')).toHaveLength(1);
     const yearSnapshots = db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_snapshot_years/');
-    expect(yearSnapshots).toHaveLength(5);
+    expect(yearSnapshots).toHaveLength(9);
     const reordered = yearSnapshots.find(({ data }) => data.year === 2025);
     reordered.data.projection.lineAmounts = Object.fromEntries(
       Object.entries(reordered.data.projection.lineAmounts).reverse(),
@@ -450,13 +495,15 @@ describe('cashflow sheet lab route', () => {
 
     expect(yearView.body).toMatchObject({
       selectedYear: 2026,
-      availableYears: [2024, 2025, 2026, 2027, 2028],
+      availableYears: [2024, 2025, 2026, 2027, 2028, 2029, 2030, 2031, 2032],
       navigationYears: [2025, 2026, 2027],
       readModelStatus: 'CURRENT',
       fallbackYears: [],
       mismatchYears: [],
     });
-    expect(yearView.body.years.map((row) => row.year)).toEqual([2024, 2025, 2026, 2027, 2028]);
+    expect(yearView.body.years.map((row) => row.year)).toEqual([
+      2024, 2025, 2026, 2027, 2028, 2029, 2030, 2031, 2032,
+    ]);
     expect(yearView.body.years.every((row) => row.storage === 'SNAPSHOT')).toBe(true);
   });
 
@@ -522,7 +569,7 @@ describe('cashflow sheet lab route', () => {
       .send({ idempotencyKey: 'annual-refresh-001' })
       .expect(200);
     expect(mirror.body.cells).toHaveLength(160);
-    expect(mirror.body.annualCells).toHaveLength(128);
+    expect(mirror.body.annualCells).toHaveLength(288);
 
     const stage = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
@@ -969,7 +1016,7 @@ describe('cashflow sheet lab route', () => {
     });
     const previewSpreadsheet = vi.fn(async () => {
       const matrix = buildMatrix();
-      matrix[3][3] = previewSpreadsheet.mock.calls.length === 1 ? '111' : '222';
+      matrix[14][4] = previewSpreadsheet.mock.calls.length === 1 ? '111' : '222';
       return {
         spreadsheetId: 'spreadsheet-a',
         selectedSheetName: 'cashflow(사용내역 연동)',
@@ -1025,7 +1072,7 @@ describe('cashflow sheet lab route', () => {
     const previewSpreadsheet = vi.fn(async () => {
       const callNumber = previewSpreadsheet.mock.calls.length;
       const matrix = buildMatrixWithWeekLabels(JANUARY_FINANCE_WEEKS);
-      matrix[3][3] = callNumber === 1 ? '111' : '222';
+      matrix[14][4] = callNumber === 1 ? '111' : '222';
       if (callNumber === 1) {
         markFirstPreviewStarted();
         await firstPreviewGate;
@@ -1066,7 +1113,7 @@ describe('cashflow sheet lab route', () => {
     expect(olderResponse.status).toBe(200);
     expect(olderResponse.body.sourceRevision).toBe(newerResponse.body.sourceRevision);
     expect(pinned.body.sourceRevision).toBe(newerResponse.body.sourceRevision);
-    expect(pinned.body.cells.find((cell) => cell.sourceCell === 'D4')?.amount).toBe(222);
+    expect(pinned.body.cells.find((cell) => cell.sourceCell === 'E15')?.amount).toBe(222);
   });
 
   it('does not install the first in-flight refresh after the saved config changes', async () => {
@@ -1821,7 +1868,7 @@ describe('cashflow sheet lab route', () => {
 
   it('blocks only a month containing an invalid pinned cell', async () => {
     const matrix = buildMatrix();
-    matrix[3][3] = '확인 필요';
+    matrix[14][4] = '확인 필요';
     const db = createDb({
       project: {
         id: 'project-a',
@@ -1864,7 +1911,7 @@ describe('cashflow sheet lab route', () => {
 
   it('preserves an EMPTY pinned cell as an authoritative removal candidate', async () => {
     const matrix = buildMatrixWithWeekLabels(JANUARY_FINANCE_WEEKS);
-    matrix[3][3] = '-';
+    matrix[14][4] = '-';
     const db = createDb({
       project: {
         id: 'project-a',
@@ -1916,7 +1963,7 @@ describe('cashflow sheet lab route', () => {
 
   it('compares Actual against the cashflow-sheet-lab source contribution instead of the aggregate', async () => {
     const matrix = buildMatrixWithWeekLabels(JANUARY_FINANCE_WEEKS);
-    matrix[28][3] = '600';
+    matrix[40][4] = '600';
     const db = createDb({
       project: {
         id: 'project-a',
@@ -1973,7 +2020,7 @@ describe('cashflow sheet lab route', () => {
 
   it('shows legacy aggregate Actual removals for human review before the one-time sheet overwrite', async () => {
     const matrix = buildMatrixWithWeekLabels(JANUARY_FINANCE_WEEKS);
-    matrix[28][3] = '-';
+    matrix[40][4] = '-';
     const db = createDb({
       project: {
         id: 'project-a',
@@ -2209,7 +2256,7 @@ describe('cashflow sheet lab route', () => {
         previewCalls += 1;
         if (previewCalls > 1) throw new Error('apply must use staged candidates');
         const matrix = buildMatrixWithWeekLabels(JANUARY_FINANCE_WEEKS);
-        matrix[4][3] = '';
+        matrix[15][4] = '';
         return {
           spreadsheetId: 'spreadsheet-a',
           spreadsheetTitle: 'Cashflow workbook',

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -327,6 +327,8 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('합계');
     expect(source).not.toContain("'서버 값'");
     expect(source).not.toContain("'값 없음'");
+    expect(source).toContain('>미입력</');
+    expect(source).toContain("cell.difference === null ? '미입력'");
   });
 
   it('keeps the last good month result during a same-month retry and lists every management finding', () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1587,7 +1587,7 @@ export function CashflowProjectSheet({
     return (
       <td key={`${input.lineId}-${input.targetYearMonth}-${input.weekNo}-p`} className={`min-w-[84px] border-l-[6px] border-l-white px-1 py-1 align-middle ${bgClass}`}>
         {isCollapsedEmpty ? (
-          <div className="py-0.5 text-center text-[12px] text-slate-300">-</div>
+          <div className="py-0.5 text-center text-[12px] text-slate-400">미입력</div>
         ) : (
           <div className={`h-5 px-1 text-right text-[12px] leading-5 tabular-nums ${shouldHighlightMismatch ? 'font-semibold text-red-700' : 'text-slate-900'}`}>
             {fmt(projection)}
@@ -1613,7 +1613,7 @@ export function CashflowProjectSheet({
     return (
       <td key={`${input.lineId}-${input.targetYearMonth}-${input.weekNo}-a`} className={`min-w-[84px] border-l-[6px] border-l-white px-1 py-1 align-middle ${bgClass}`}>
         {isCollapsedEmpty ? (
-          <div className="py-0.5 text-center text-[12px] text-slate-300">-</div>
+          <div className="py-0.5 text-center text-[12px] text-slate-400">미입력</div>
         ) : (
           <div className="h-5 px-1 text-right text-[12px] leading-5 tabular-nums text-slate-700">
             {fmt(actual)}
@@ -1764,7 +1764,7 @@ export function CashflowProjectSheet({
       const value = total?.lineAmounts?.[lineId] || 0;
       return (
         <td key={`${mode}-${lineId}-${year}-annual`} data-cashflow-board-column="true" className={`min-w-[84px] border-l-[6px] border-l-white px-1 py-1 text-right align-middle text-[12px] tabular-nums text-slate-700 ${isAltRow ? 'bg-slate-50' : 'bg-white'}`}>
-          {state === 'VALUE' || state === 'ZERO' ? fmt(value) : <span className="text-slate-300">-</span>}
+          {state === 'VALUE' || state === 'ZERO' ? fmt(value) : <span className="text-slate-400">미입력</span>}
         </td>
       );
     };
@@ -1897,7 +1897,7 @@ export function CashflowProjectSheet({
               {renderCashflowLineLabel(getCashflowModeLineLabel(lineId, mode))}
             </td>
             <td className={`px-4 py-2 text-right text-[12px] tabular-nums text-slate-700 ${rowIndex % 2 === 0 ? 'bg-white' : 'bg-slate-50'}`}>
-              {state === 'VALUE' || state === 'ZERO' ? fmt(total.lineAmounts[lineId] || 0) : <span className="text-slate-300">-</span>}
+              {state === 'VALUE' || state === 'ZERO' ? fmt(total.lineAmounts[lineId] || 0) : <span className="text-slate-400">미입력</span>}
             </td>
           </tr>
         );
@@ -2068,7 +2068,7 @@ export function CashflowProjectSheet({
                           className={`min-w-[96px] border-l-[6px] border-l-white px-2 py-2 text-right font-semibold tabular-nums ${differenceClass}`}
                           title={cell.difference === null ? `${cell.weekRange}\nBFF 비교 대상 기간 아님` : `${cell.weekRange}\nProjection ${fmt(cell.projection)} / Actual ${fmt(cell.actual)} / 차이 ${fmtSigned(cell.difference)}\n${diffColorExplanation(row.section, cell.difference)}`}
                         >
-                          {cell.difference === null ? '-' : fmtSigned(cell.difference)}
+                          {cell.difference === null ? '미입력' : fmtSigned(cell.difference)}
                         </td>
                       );
                     })}


### PR DESCRIPTION
## 변경 사항
- 공식 cashflow 시트 범위를 A1:BT60으로 고정하고 E:BL 주차 원장 및 C:D/BM:BS 연간 값을 좌표 기반으로 매핑
- 수식 재계산 없이 Google Sheets 표시값만 수집
- EMPTY/ZERO/VALUE 계약을 유지하고 화면의 EMPTY를 '미입력'으로 표시
- BS 기준연도 합계와 주차 합계를 대조할 수 있도록 유지

## 검증
- BFF/프론트 집중 회귀 테스트 132/132 통과
- 제공된 260701 엑셀 표시값 기준 1,920개 주차 매핑 및 24~32년 연간 열 인식
- npm run build 통과 (2,910 modules)
- Docker 미사용

## 범위 제한
- 기존 JVM/Firestore 셀 상태 계약은 충분하여 변경하지 않음
- Stage/Live 배포 없음