### PR TITLE
fix(cashflow): reduce duplicate reads and preserve JVM conflicts

### DIFF
--- a/server/bff/java-weekly-client.mjs
+++ b/server/bff/java-weekly-client.mjs
@@ -124,9 +124,17 @@ export function createJavaWeeklyClient({
   const requestTimeoutMs = Number.isSafeInteger(configuredTimeoutMs) && configuredTimeoutMs > 0
     ? Math.min(configuredTimeoutMs, 12_000)
     : 12_000;
-  const totalRequestTimeoutMs = Math.min(requestTimeoutMs * 2, 24_000);
-
-  async function requestJson({ context, method = 'GET', path, body, editSession, dataProjectId, deadlineAtMs }) {
+  async function requestJson({
+    context,
+    method = 'GET',
+    path,
+    body,
+    editSession,
+    dataProjectId,
+    deadlineAtMs,
+    attemptTimeoutMs = requestTimeoutMs,
+    retry = true,
+  }) {
     if (!baseUrl) {
       throw createHttpError(503, 'JVM weekly API base URL is not configured.', 'jvm_weekly_api_unconfigured');
     }
@@ -134,7 +142,8 @@ export function createJavaWeeklyClient({
     const callerDeadlineAtMs = Number.isFinite(Number(deadlineAtMs))
       ? Number(deadlineAtMs)
       : Number.POSITIVE_INFINITY;
-    const requestDeadlineAtMs = Math.min(requestStartedAt + totalRequestTimeoutMs, callerDeadlineAtMs);
+    const boundedAttemptTimeoutMs = Math.min(Math.max(1, attemptTimeoutMs), 24_000);
+    const requestDeadlineAtMs = callerDeadlineAtMs;
     const callerDeadlineReached = () => Number.isFinite(callerDeadlineAtMs) && Date.now() >= callerDeadlineAtMs;
     const callerDeadlineError = () => createHttpError(
       504,
@@ -150,7 +159,7 @@ export function createJavaWeeklyClient({
         throw error;
       }
       const controller = new AbortController();
-      const attemptTimeoutMs = Math.min(requestTimeoutMs, remainingMs);
+      const timeoutMs = Math.min(boundedAttemptTimeoutMs, remainingMs);
       let timeout;
       const timeoutPromise = new Promise((_resolve, reject) => {
         timeout = setTimeout(() => {
@@ -158,7 +167,7 @@ export function createJavaWeeklyClient({
           const error = new Error('JVM weekly API attempt timeout exceeded');
           error.name = 'AbortError';
           reject(error);
-        }, attemptTimeoutMs);
+        }, timeoutMs);
       });
       timeout.unref?.();
       const attemptPromise = (async () => {
@@ -197,6 +206,13 @@ export function createJavaWeeklyClient({
     } catch (error) {
       if (Number.isInteger(error?.statusCode)) throw error;
       if (callerDeadlineReached()) throw callerDeadlineError();
+      if (!retry) {
+        throw createHttpError(
+          503,
+          '현금흐름 저장 서버에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+          'jvm_weekly_api_unreachable',
+        );
+      }
       try {
         return await send();
       } catch (retryError) {
@@ -298,6 +314,8 @@ export function createJavaWeeklyClient({
       method: 'POST',
       path: `/api/v1/cashflow/${normalizedProjectId}/sheet-lab/batch/apply`,
       dataProjectId: bffDataProjectId,
+      attemptTimeoutMs: 24_000,
+      retry: false,
       body: {
         idempotencyKey,
         sourceRevision,

--- a/server/bff/java-weekly-client.test.mjs
+++ b/server/bff/java-weekly-client.test.mjs
@@ -149,6 +149,38 @@ describe('Java weekly cashflow client', () => {
     });
   });
 
+  it('waits once for a slow batch conflict instead of retrying and masking it as unreachable', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchImpl = vi.fn(() => new Promise((resolve) => {
+        setTimeout(() => resolve({
+          ok: false,
+          status: 409,
+          text: async () => JSON.stringify({ code: 'cashflow_revision_conflict', message: '원장 revision이 변경되었습니다.' }),
+        }), 10);
+      }));
+      const client = createJavaWeeklyClient({ env: stageEnv(), fetchImpl, jvmWeeklyApiTimeoutMs: 5 });
+      const request = client.applyCashflowSheetBatch({
+        context,
+        projectId: 'project-a',
+        idempotencyKey: 'apply-batch-slow-conflict',
+        sourceRevision: monthlyContract.sourceRevision,
+        targetRevision: monthlyContract.targetRevision,
+        months: [{ yearMonth: '2026-07', cells: monthlyContract.cells }],
+      });
+      const assertion = expect(request).rejects.toMatchObject({
+        statusCode: 409,
+        code: 'cashflow_revision_conflict',
+      });
+
+      await vi.advanceTimersByTimeAsync(11);
+      await assertion;
+      expect(fetchImpl).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('fails before network when BFF and JVM data projects differ', async () => {
     const fetchImpl = vi.fn();
     const client = createJavaWeeklyClient({

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
@@ -993,15 +993,6 @@ export function CashflowSheetLabPage({
                   <span className="font-bold">시트 연동 오류</span> · {mirror.lastRefreshError.message}
                 </div>
               ) : null}
-              {(mirror?.reconciliationWarnings?.length || 0) > 0 ? (
-                <div className="border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] text-amber-900">
-                  {mirror?.reconciliationWarnings?.map((warning) => (
-                    <div key={`${warning.year}-${warning.mode}`}>
-                      {warning.year}년 {warning.mode === 'projection' ? 'Projection' : 'Actual'} 주차 합계와 연간 합계가 다릅니다. 저장은 가능하며 해당 연도 주차 원장을 기준으로 사용합니다.
-                    </div>
-                  ))}
-                </div>
-              ) : null}
             </div>
           </li>
 
@@ -1029,9 +1020,6 @@ export function CashflowSheetLabPage({
                 </div>
               ) : (
                 <div className="space-y-2">
-                  <div className="border border-amber-200 bg-amber-50 px-3 py-2 text-[12px] leading-relaxed text-amber-900">
-                    버튼을 누르면 별도 검토 없이 시트 값으로 덮어씁니다. 월 결산된 기간은 변경되지 않습니다.
-                  </div>
                   <Button
                     ref={stageButtonRef}
                     type="button"

--- a/src/app/features/cashflow-sheet-compare/README.md
+++ b/src/app/features/cashflow-sheet-compare/README.md
@@ -322,3 +322,21 @@ transaction that already owns these values.
 - This closes only the weekly settlement lock phase. UI work and Stage
   deployment require their own tracked contract and the relevant retrospective
   phase audits; Live deployment remains prohibited without explicit approval.
+
+## 2026-07-23 duplicate-read and JVM error propagation fix
+
+**Hypothesis:** the Stage `503 jvm_weekly_api_unreachable` was not a network
+failure. Cloud Run returned a business `409` after 18–19 seconds, while the BFF
+aborted at 12 seconds and repeated the same 300 KB mutation. Concurrent page
+mounts also created separate API clients, so identical GET requests were not
+coalesced.
+
+**Execution:** default browser clients are reused, identical concurrent GETs
+share one promise, and the JVM monthly batch apply now makes one request with a
+24-second budget. The original JVM status and error body are preserved. Annual
+reconciliation remains available to server contracts but is no longer rendered
+as a blocking-looking warning in the sheet UI.
+
+**Evaluation:** 83 focused client, JVM bridge, and sheet-page tests passed. The
+production Vite build transformed 2,910 modules successfully. Docker was not
+used.

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -1607,8 +1607,10 @@ export async function fetchLatestProjectRequestViaBff(params: {
   return response.data?.item || null;
 }
 
+let defaultPlatformApiClient: PlatformApiClientLike | undefined;
+
 function resolveClient(client?: PlatformApiClientLike): PlatformApiClientLike {
-  return client || createPlatformApiClient();
+  return client || (defaultPlatformApiClient ||= createPlatformApiClient());
 }
 
 function encodeHeaderValue(value: string): string {

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -493,8 +493,10 @@ export interface CashflowSheetLabShareAccountResult {
 
 export const extractSpreadsheetIdFromSheetInput = extractSpreadsheetId;
 
+let sameOriginBffClient: PlatformApiClient | undefined;
+
 function createSameOriginBffClient(): PlatformApiClient {
-  return new PlatformApiClient({
+  return sameOriginBffClient ||= new PlatformApiClient({
     baseUrl: '',
     maxRetries: 1,
     retryDelayMs: 200,

--- a/src/app/platform/api-client.test.ts
+++ b/src/app/platform/api-client.test.ts
@@ -58,6 +58,30 @@ describe('PlatformApiClient', () => {
     expect(response.data).toBe('ok');
   });
 
+  it('coalesces identical concurrent GET requests and fetches again after completion', async () => {
+    let resolveFirst: ((response: Response) => void) | undefined;
+    const fetchImpl = vi.fn()
+      .mockImplementationOnce(() => new Promise<Response>((resolve) => { resolveFirst = resolve; }))
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }));
+    const client = new PlatformApiClient({ fetchImpl });
+    const options = { tenantId: 'mysc', actor: { id: 'u001' } };
+
+    const first = client.get<{ ok: boolean }>('/api/v1/cashflow/p001/activity', options);
+    const duplicate = client.get<{ ok: boolean }>('/api/v1/cashflow/p001/activity', options);
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    resolveFirst?.(new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+    await expect(Promise.all([first, duplicate])).resolves.toHaveLength(2);
+
+    await client.get('/api/v1/cashflow/p001/activity', options);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
   it('throws PlatformApiError on non-2xx responses', async () => {
     const fetchImpl = vi.fn(async () => {
       return new Response(JSON.stringify({ error: 'nope' }), {

--- a/src/app/platform/api-client.ts
+++ b/src/app/platform/api-client.ts
@@ -189,6 +189,7 @@ export class PlatformApiClient {
   private readonly retryDelayMs: number;
   private readonly retryOnStatuses: Set<number>;
   private readonly timeoutMs: number;
+  private readonly inFlightGets = new Map<string, Promise<ApiResponse<unknown>>>();
 
   constructor(options: PlatformApiClientOptions = {}) {
     this.baseUrl = (options.baseUrl || '').replace(/\/$/, '');
@@ -530,7 +531,27 @@ export class PlatformApiClient {
   }
 
   get<T>(path: string, options: Omit<PlatformRequestOptions, 'method'>): Promise<ApiResponse<T>> {
-    return this.request<T>(path, { ...options, method: 'GET' });
+    if (options.signal || options.requestId) {
+      return this.request<T>(path, { ...options, method: 'GET' });
+    }
+    const key = JSON.stringify([
+      path,
+      options.tenantId,
+      options.actor.id,
+      options.actor.role,
+      options.actor.idToken,
+      options.timeoutMs,
+      options.retries,
+      Array.from(new Headers(options.headers).entries()).sort(),
+    ]);
+    const existing = this.inFlightGets.get(key);
+    if (existing) return existing as Promise<ApiResponse<T>>;
+    const request = this.request<T>(path, { ...options, method: 'GET' });
+    this.inFlightGets.set(key, request);
+    void request.finally(() => {
+      if (this.inFlightGets.get(key) === request) this.inFlightGets.delete(key);
+    }).catch(() => undefined);
+    return request;
   }
 
   post<T>(path: string, options: Omit<PlatformRequestOptions, 'method'>): Promise<ApiResponse<T>> {


### PR DESCRIPTION
## 변경\n- 동일한 동시 GET 요청을 하나로 합쳐 대시보드 중복 조회 제거\n- JVM 월 배치 적용을 24초 단일 요청으로 변경해 실제 409 충돌 사유 보존\n- 연간 합계 불일치 및 덮어쓰기 안내 블록 숨김\n\n## 검증\n- focused tests: 83 passed\n- production Vite build: passed (2,910 modules)\n- Docker: not used\n\n## 배포 범위\n- Stage only\n- Live deployment prohibited