### PR TITLE
fix: recover settled sheet apply warning

### DIFF
--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
@@ -52,6 +52,7 @@ describe('CashflowSheetLabPage shell', () => {
     expect(pageSource).toContain('applyCashflowSheetLabViaBff');
     expect(pageSource).toContain('settledWeekChangeConfirmationId: pending.confirmationId');
     expect(pageSource).toContain('주간 정산 값과 다릅니다');
+    expect(pageSource).toContain('stageRunId: stagedRunId');
     expect(pageSource).toContain('getCashflowSheetLabShareAccountViaBff');
     expect(pageSource).toContain('resolveBffActor');
     expect(pageSource).toContain('requireBffActor');

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
@@ -883,8 +883,8 @@ export function CashflowSheetLabPage({
       }, 'warn');
       const settledWeekConfirmation = settledWeekConfirmationFromError(error);
       if (activeStep === 'apply' && settledWeekConfirmation) {
-        if (stageRunId) {
-          setSettledWeekWarning({ ...settledWeekConfirmation, stageRunId });
+        if (stagedRunId) {
+          setSettledWeekWarning({ ...settledWeekConfirmation, stageRunId: stagedRunId });
         } else {
           setErrorMessage(formatError(error));
         }


### PR DESCRIPTION
Fix the sheet-apply 409 handler to pass the staged run ID into the settled-week warning dialog. The user can now confirm or cancel instead of the page throwing ReferenceError. Verified with the focused UI shell test and production build.