### PR TITLE
fix: mirror full cashflow sheet annual layout

### DIFF
--- a/server/bff/cashflow-sheet-snapshot.mjs
+++ b/server/bff/cashflow-sheet-snapshot.mjs
@@ -111,6 +111,22 @@ function snapshotAnnualCell(mapping, matrix) {
   };
 }
 
+function snapshotTotalCell(mapping, matrix) {
+  const classified = classifyCashflowSheetCell(matrix?.[mapping.rowIndex]?.[mapping.columnIndex]);
+  const totalClassified = classified.state === 'VALUE' && classified.amount === 0
+    ? { state: 'ZERO', amount: 0 }
+    : classified;
+  return {
+    mode: mapping.mode,
+    kind: mapping.kind,
+    lineId: mapping.lineId,
+    direction: mapping.direction,
+    derivedKind: mapping.derivedKind,
+    sourceCell: mapping.a1,
+    ...totalClassified,
+  };
+}
+
 function compareCells(left, right) {
   return String(left.mode).localeCompare(String(right.mode))
     || String(left.yearMonth).localeCompare(String(right.yearMonth))
@@ -227,6 +243,34 @@ export function buildAnnualCashflowTotals({ cells, annualCells }) {
     });
 }
 
+function buildCashflowSheetTotal(totalCells, mode) {
+  const lineAmounts = {};
+  const lineStates = {};
+  for (const cell of totalCells.filter((candidate) => candidate.mode === mode && candidate.kind === 'line' && candidate.lineId)) {
+    lineStates[cell.lineId] = cell.state;
+    if (cell.state === 'VALUE' || cell.state === 'ZERO') lineAmounts[cell.lineId] = Number(cell.amount || 0);
+  }
+  const derivedAmount = (kind, fallback) => {
+    const cell = totalCells.find((candidate) => candidate.mode === mode && candidate.kind === 'derived' && candidate.derivedKind === kind);
+    return cell?.state === 'VALUE' || cell?.state === 'ZERO' ? Number(cell.amount || 0) : fallback;
+  };
+  const computedIn = Object.entries(lineAmounts)
+    .filter(([lineId]) => /^.+_IN$/.test(lineId))
+    .reduce((sum, [, amount]) => sum + Number(amount || 0), 0);
+  const computedOut = Object.entries(lineAmounts)
+    .filter(([lineId]) => /^.+_OUT$/.test(lineId))
+    .reduce((sum, [, amount]) => sum + Number(amount || 0), 0);
+  const totalIn = derivedAmount('deposit_total', computedIn);
+  const totalOut = derivedAmount('withdrawal_total', computedOut);
+  return {
+    lineAmounts,
+    lineStates,
+    totalIn,
+    totalOut,
+    net: derivedAmount('balance', totalIn - totalOut),
+  };
+}
+
 function matrixValue(matrix, rowIndex, columnIndex) {
   return normalizedText(matrix?.[rowIndex]?.[columnIndex]);
 }
@@ -327,7 +371,7 @@ function annualSheetFinancialTotals({ depositScheduleRows, projectionControls })
     }));
 }
 
-export function extractCashflowSheetFacts({ template = {}, matrix = [], cells = [], annualCells = [] } = {}) {
+export function extractCashflowSheetFacts({ template = {}, matrix = [], cells = [], annualCells = [], totalCells = [] } = {}) {
   const issues = [];
   const projectionSection = template?.sections?.find((section) => section.mode === 'projection');
   const weekColumns = (projectionSection?.weekColumns || [])
@@ -407,6 +451,10 @@ export function extractCashflowSheetFacts({ template = {}, matrix = [], cells = 
     depositScheduleRows,
     annualFinancialTotals: annualSheetFinancialTotals({ depositScheduleRows, projectionControls }),
     annualCashflowTotals: buildAnnualCashflowTotals({ cells, annualCells }),
+    cashflowGrandTotals: {
+      projection: buildCashflowSheetTotal(totalCells, 'projection'),
+      actual: buildCashflowSheetTotal(totalCells, 'actual'),
+    },
     controlTotals: {
       deposit: {
         sourceCell: depositControlColumnIndex === null ? '' : toA1(8, depositControlColumnIndex),
@@ -442,8 +490,14 @@ export function createCashflowPinnedSnapshot({
     .flatMap((section) => section.annualMappings || [])
     .map((mapping) => snapshotAnnualCell(mapping, matrix))
     .sort(compareAnnualCells);
-  const sheetFacts = extractCashflowSheetFacts({ template, matrix, cells, annualCells });
-  const sourceRevision = revisionOf({ spreadsheetId, selectedSheetName, cells, annualCells, sheetFacts });
+  const totalCells = (template?.sections || [])
+    .flatMap((section) => section.totalMappings || [])
+    .map((mapping) => snapshotTotalCell(mapping, matrix))
+    .sort((left, right) => String(left.mode).localeCompare(String(right.mode))
+      || String(left.kind).localeCompare(String(right.kind))
+      || String(left.lineId || left.derivedKind || '').localeCompare(String(right.lineId || right.derivedKind || '')));
+  const sheetFacts = extractCashflowSheetFacts({ template, matrix, cells, annualCells, totalCells });
+  const sourceRevision = revisionOf({ spreadsheetId, selectedSheetName, cells, annualCells, totalCells, sheetFacts });
   const summary = cells.reduce((counts, cell) => {
     counts.cellCount += 1;
     if (cell.state === 'VALUE') counts.valueCount += 1;
@@ -475,6 +529,7 @@ export function createCashflowPinnedSnapshot({
     summary,
     cells,
     annualCells,
+    totalCells,
     sheetFacts,
   };
 }

--- a/server/bff/cashflow-sheet-snapshot.test.mjs
+++ b/server/bff/cashflow-sheet-snapshot.test.mjs
@@ -154,6 +154,10 @@ describe('cashflow sheet pinned snapshot', () => {
         supportAmount: 0,
       }],
       annualCashflowTotals: [],
+      cashflowGrandTotals: {
+        projection: { lineAmounts: {}, lineStates: {}, totalIn: 0, totalOut: 0, net: 0 },
+        actual: { lineAmounts: {}, lineStates: {}, totalIn: 0, totalOut: 0, net: 0 },
+      },
       controlTotals: {
         deposit: { sourceCell: 'BS9', value: 15000, computed: 15000, matches: true },
         unpaid: { sourceCell: 'BT9', value: 85000 },

--- a/server/bff/cashflow-sheet-template.mjs
+++ b/server/bff/cashflow-sheet-template.mjs
@@ -145,14 +145,22 @@ function fixedSection(matrix, layout, reasons) {
     .filter(Boolean);
   const sourceYear = weekColumns[0]?.year;
   const sourceTotalHeader = normalizeText(matrix?.[layout.headerRowIndex]?.[SOURCE_YEAR_TOTAL_COLUMN_INDEX]);
-  if (Number.isSafeInteger(sourceYear) && ['Total', `${sourceYear}년 합계`].includes(sourceTotalHeader)) {
-    annualColumns.push({
-      year: sourceYear,
+  const totalColumn = Number.isSafeInteger(sourceYear) && ['Total', `${sourceYear}년 합계`].includes(sourceTotalHeader)
+    ? {
       columnIndex: SOURCE_YEAR_TOTAL_COLUMN_INDEX,
       a1: toA1(layout.headerRowIndex, SOURCE_YEAR_TOTAL_COLUMN_INDEX),
+    }
+    : null;
+  // The source-year Total is retained as an annual reconciliation input as well as
+  // a display-only grand total. It must never replace the weekly source of truth.
+  if (totalColumn) {
+    annualColumns.push({
+      year: sourceYear,
+      columnIndex: totalColumn.columnIndex,
+      a1: totalColumn.a1,
     });
   }
-  if (annualColumns.length !== ANNUAL_COLUMN_INDEXES.length + 1) {
+  if (annualColumns.length !== ANNUAL_COLUMN_INDEXES.length + 1 || !totalColumn) {
     reasons.push({
       code: 'cashflow_annual_header_invalid',
       mode: layout.mode,
@@ -227,6 +235,27 @@ function fixedSection(matrix, layout, reasons) {
     a1: toA1(lineRow.rowIndex, column.columnIndex),
     source: 'sheet_annual_total',
   })));
+  const totalMappings = [
+    ...lineRows.map((lineRow) => ({
+      mode: layout.mode,
+      lineId: lineRow.lineId,
+      direction: lineRow.direction,
+      rowIndex: lineRow.rowIndex,
+      columnIndex: totalColumn?.columnIndex,
+      a1: totalColumn ? toA1(lineRow.rowIndex, totalColumn.columnIndex) : '',
+      source: 'sheet_grand_total',
+      kind: 'line',
+    })),
+    ...derivedRows.map((row) => ({
+      mode: layout.mode,
+      rowIndex: row.rowIndex,
+      columnIndex: totalColumn?.columnIndex,
+      a1: totalColumn ? toA1(row.rowIndex, totalColumn.columnIndex) : '',
+      source: 'sheet_grand_total',
+      kind: 'derived',
+      derivedKind: row.kind,
+    })),
+  ];
 
   return {
     mode: layout.mode,
@@ -234,11 +263,13 @@ function fixedSection(matrix, layout, reasons) {
     weekRowIndex: layout.weekRowIndex,
     weekColumns,
     annualColumns,
+    totalColumn,
     lineRows,
     derivedRows,
     ignoredRows: [],
     mappings,
     annualMappings,
+    totalMappings,
     missingLineIds: [],
     duplicateLineIds: [],
   };

--- a/server/bff/cashflow-sheet-template.test.mjs
+++ b/server/bff/cashflow-sheet-template.test.mjs
@@ -91,6 +91,7 @@ describe('cashflow official fixed template', () => {
     expect(result.mappingCandidates).toHaveLength(1_920);
     expect(result.sections.map((section) => section.weekColumns.length)).toEqual([60, 60]);
     expect(result.sections.map((section) => section.annualMappings.length)).toEqual([144, 144]);
+    expect(result.sections.map((section) => section.totalMappings.length)).toEqual([19, 19]);
     expect(result.sections[0].mappings[0]).toMatchObject({
       mode: 'projection',
       lineId: 'MYSC_PREPAY_IN',
@@ -107,9 +108,9 @@ describe('cashflow official fixed template', () => {
     });
     expect(result.sections[0].annualColumns.map(({ year, a1 }) => [year, a1])).toEqual([
       [2024, 'C12'], [2025, 'D12'], [2027, 'BM12'], [2028, 'BN12'],
-      [2029, 'BO12'], [2030, 'BP12'], [2031, 'BQ12'], [2032, 'BR12'],
-      [2026, 'BS12'],
+      [2029, 'BO12'], [2030, 'BP12'], [2031, 'BQ12'], [2032, 'BR12'], [2026, 'BS12'],
     ]);
+    expect(result.sections[0].totalColumn).toMatchObject({ a1: 'BS12' });
   });
 
   it('fails closed instead of guessing when an official coordinate changes', () => {

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -659,6 +659,18 @@ function mergeCashflowSourceMirror(previous, next, sourceYear) {
   ].sort((left, right) => Number(left.year) - Number(right.year)
     || readOptionalText(left.mode).localeCompare(readOptionalText(right.mode))
     || readOptionalText(left.lineId).localeCompare(readOptionalText(right.lineId)));
+  const previousTotalCells = readOptionalText(previous?.sourceRevision)
+    ? (previous.totalCells || [])
+      .map((cell) => ({ ...cell, sourceYear: Number(cell?.sourceYear) || previousSourceYear }))
+      .filter((cell) => cell.sourceYear !== sourceYear)
+    : [];
+  const totalCells = [
+    ...previousTotalCells,
+    ...(next.totalCells || []).map((cell) => ({ ...cell, sourceYear })),
+  ].sort((left, right) => Number(left.sourceYear) - Number(right.sourceYear)
+    || readOptionalText(left.mode).localeCompare(readOptionalText(right.mode))
+    || readOptionalText(left.kind).localeCompare(readOptionalText(right.kind))
+    || readOptionalText(left.lineId || left.derivedKind).localeCompare(readOptionalText(right.lineId || right.derivedKind)));
   const replaceYearRows = (previousRows, nextRows, yearOf) => [
     ...(previousRows || []).filter((row) => yearOf(row) !== sourceYear),
     ...(nextRows || []).filter((row) => yearOf(row) === sourceYear),
@@ -676,7 +688,7 @@ function mergeCashflowSourceMirror(previous, next, sourceYear) {
       activeWeekRange: next.activeWeekRange,
     },
   };
-  const sourceRevision = `sha256:${stableHash({ sources, cells, annualCells })}`;
+  const sourceRevision = `sha256:${stableHash({ sources, cells, annualCells, totalCells })}`;
   const summary = cells.reduce((counts, cell) => {
     counts.cellCount += 1;
     if (cell.state === 'VALUE') counts.valueCount += 1;
@@ -695,6 +707,15 @@ function mergeCashflowSourceMirror(previous, next, sourceYear) {
     (row) => Number(row?.year),
   );
   const annualCashflowTotals = buildAnnualCashflowTotals({ cells, annualCells });
+  const cashflowGrandTotalsBySourceYear = [
+    ...(previous?.sheetFacts?.cashflowGrandTotalsBySourceYear || [])
+      .filter((row) => Number(row?.sourceYear) !== sourceYear),
+    {
+      sourceYear,
+      ...(next?.sheetFacts?.cashflowGrandTotals || {}),
+    },
+  ].filter((row) => Number.isSafeInteger(Number(row?.sourceYear)))
+    .sort((left, right) => Number(left.sourceYear) - Number(right.sourceYear));
   const reconciliationWarnings = annualCashflowTotals.flatMap((row) => ['projection', 'actual'].flatMap((mode) => (
     ['MISMATCH', 'PARTIAL_WEEKLY'].includes(readOptionalText(row?.[mode]?.reconciliation?.status))
       ? [{ year: row.year, mode, ...row[mode].reconciliation }]
@@ -709,6 +730,7 @@ function mergeCashflowSourceMirror(previous, next, sourceYear) {
     sourceRevision,
     cells,
     annualCells,
+    totalCells,
     yearMonths: [...new Set(cells.map((cell) => readOptionalText(cell.yearMonth)).filter(Boolean))].sort(),
     years: [...new Set([
       ...cells.map((cell) => Number(readOptionalText(cell.yearMonth).slice(0, 4))),
@@ -720,6 +742,7 @@ function mergeCashflowSourceMirror(previous, next, sourceYear) {
       depositScheduleRows,
       annualFinancialTotals,
       annualCashflowTotals,
+      cashflowGrandTotalsBySourceYear,
     },
     reconciliationWarnings,
     appliedSourceRevision: previous?.appliedSourceRevision,

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -585,6 +585,7 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
     expect(mirror.body.cells).toHaveLength(160);
     expect(mirror.body.annualCells).toHaveLength(288);
+    expect(mirror.body.totalCells).toHaveLength(38);
 
     const stage = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -185,7 +185,8 @@ describe('CashflowProjectSheet monthly close shell', () => {
   });
 
   it('keeps the sheet refresh loading state open until the successful response is processed', () => {
-    expect(source).toContain('open={sheetRefreshLoading}');
+    expect(source).toContain('{sheetRefreshLoading ? (');
+    expect(source).toContain('aria-busy="true"');
     expect(source).toContain('시트 값을 불러오는 중입니다');
     expect(source).not.toContain('setSheetRefreshResult');
     expect(source).not.toContain('setSheetStageDialog');

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -298,10 +298,9 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain('시트 {fmt(check.sheet[field.key])} · 등록 {fmt(check.registered[field.key])}');
   });
 
-  it('keeps multi-year import data out of the cashflow view', () => {
+  it('removes multi-year navigation while keeping the selected-year board self-contained', () => {
     expect(source).not.toContain('getCashflowSheetLabYearViewViaBff');
     expect(source).not.toContain('cashflowYearView');
-    expect(source).not.toContain('data-cashflow-annual-summary="true"');
     expect(source).not.toContain('data-cashflow-block="multi-year-view"');
     expect(source).not.toContain('data-cashflow-year-view');
     expect(source).toContain('monthCloseResult?.dashboard?.canonical?.months');
@@ -318,10 +317,12 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('시트의 최신 값을 불러왔습니다.');
   });
 
-  it('renders only the selected year weekly ledger while retaining the server opening balance', () => {
-    expect(source).not.toContain('previousAnnualYears');
-    expect(source).not.toContain('followingAnnualYears');
-    expect(source).not.toContain('renderAnnualSummaryCell');
+  it('renders annual carry-forward and future totals around the selected year weekly ledger', () => {
+    expect(source).toContain('const previousAnnualYears = annualYears.filter((year) => year < selectedYear)');
+    expect(source).toContain('const followingAnnualYears = annualYears.filter((year) => year > selectedYear)');
+    expect(source).toContain('const renderAnnualSummaryCell');
+    expect(source).toContain('cashflowSheetMirror?.sheetFacts?.annualCashflowTotals');
+    expect(source).toContain('Total');
     expect(source).toContain('const visibleWeeks = annualWeeks');
     expect(source).toContain('openingBalances?.selectedYear === selectedYear');
     expect(source).toContain('annualOpeningBalance: openingBalance');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -2525,19 +2525,19 @@ export function CashflowProjectSheet({
 
       {renderUnifiedMonthlyBoard()}
 
-      <AlertDialog open={sheetRefreshLoading}>
-        <AlertDialogContent className="w-[calc(100vw-2rem)] max-w-[360px]">
-          <AlertDialogHeader>
-            <AlertDialogTitle className="flex items-center gap-2">
+      {sheetRefreshLoading ? (
+        <div className="fixed inset-0 z-[100] grid place-items-start bg-transparent px-4 pt-24" aria-live="polite" aria-busy="true">
+          <div role="status" className="w-full max-w-[420px] rounded-lg border border-slate-200 bg-white px-5 py-4 shadow-xl">
+            <div className="flex items-center gap-2 text-[14px] font-bold text-slate-950">
               <Loader2 className="h-4 w-4 animate-spin text-[#17324D]" />
               시트 값을 불러오는 중입니다
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              시트의 값을 고정해 MYSCube 원장에 반영할 준비를 하고 있습니다. 완료될 때까지 이 창을 닫지 말고 잠시 기다려 주세요.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-        </AlertDialogContent>
-      </AlertDialog>
+            </div>
+            <div className="mt-1 text-[12px] leading-5 text-slate-600">
+              시트의 최신 값을 고정하고 변경된 항목을 확인하고 있습니다. 완료될 때까지 잠시 기다려 주세요.
+            </div>
+          </div>
+        </div>
+      ) : null}
 
       <AlertDialog open={qaClockOpen} onOpenChange={(open) => { if (!qaClockBusy) setQaClockOpen(open); }}>
         <AlertDialogContent className="w-[calc(100vw-2rem)] max-w-[380px]">

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1637,7 +1637,6 @@ export function CashflowProjectSheet({
       );
     }
     const visibleWeeks = annualWeeks;
-    const appliedAnnualYears = new Set((cashflowSheetMirror?.appliedAnnualYears || []).map(Number));
     const mirroredAnnualTotals = new Map((cashflowSheetMirror?.sheetFacts?.annualCashflowTotals || [])
       .filter((row) => Number.isSafeInteger(row.year))
       .map((row) => [row.year, row]));
@@ -1647,7 +1646,7 @@ export function CashflowProjectSheet({
     ];
     const annualYears = [...new Set([
       ...openingBalanceYears,
-      ...[...mirroredAnnualTotals.keys()].filter((year) => appliedAnnualYears.has(year)),
+      ...mirroredAnnualTotals.keys(),
     ])]
       .filter((year) => year !== selectedYear)
       .sort((left, right) => left - right);
@@ -1720,11 +1719,27 @@ export function CashflowProjectSheet({
       projection: readServerSummary('projection'),
       actual: readServerSummary('actual'),
     };
-    const projectLineTotalFor = (mode: 'projection' | 'actual', lineId: CashflowSheetLineId) => annualYears.reduce(
-      (sum, year) => sum + Number(annualTotalFor(year, mode)?.lineAmounts?.[lineId] || 0),
-      Number(derived[mode].rowTotals[lineId] || 0),
-    );
+    const sheetGrandTotalFor = (mode: 'projection' | 'actual') => cashflowSheetMirror?.sheetFacts?.cashflowGrandTotalsBySourceYear
+      ?.find((total) => total.sourceYear === selectedYear)?.[mode] || null;
+    const projectLineTotalFor = (mode: 'projection' | 'actual', lineId: CashflowSheetLineId) => {
+      const sheetGrandTotal = sheetGrandTotalFor(mode);
+      if (Object.prototype.hasOwnProperty.call(sheetGrandTotal?.lineAmounts || {}, lineId)) {
+        return Number(sheetGrandTotal?.lineAmounts[lineId] || 0);
+      }
+      return annualYears.reduce(
+        (sum, year) => sum + Number(annualTotalFor(year, mode)?.lineAmounts?.[lineId] || 0),
+        Number(derived[mode].rowTotals[lineId] || 0),
+      );
+    };
     const projectTotalsFor = (mode: 'projection' | 'actual') => {
+      const sheetGrandTotal = sheetGrandTotalFor(mode);
+      if (sheetGrandTotal) {
+        return {
+          totalIn: Number(sheetGrandTotal.totalIn || 0),
+          totalOut: Number(sheetGrandTotal.totalOut || 0),
+          net: Number(sheetGrandTotal.net || 0),
+        };
+      }
       const totalIn = annualYears.reduce((sum, year) => sum + Number(annualTotalFor(year, mode)?.totalIn || 0), Number(derived[mode].monthTotals.totalIn || 0));
       const totalOut = annualYears.reduce((sum, year) => sum + Number(annualTotalFor(year, mode)?.totalOut || 0), Number(derived[mode].monthTotals.totalOut || 0));
       return { totalIn, totalOut, net: totalIn - totalOut };

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1637,7 +1637,40 @@ export function CashflowProjectSheet({
       );
     }
     const visibleWeeks = annualWeeks;
-    const boardColumnCount = visibleWeeks.length + 1;
+    const appliedAnnualYears = new Set((cashflowSheetMirror?.appliedAnnualYears || []).map(Number));
+    const mirroredAnnualTotals = new Map((cashflowSheetMirror?.sheetFacts?.annualCashflowTotals || [])
+      .filter((row) => Number.isSafeInteger(row.year))
+      .map((row) => [row.year, row]));
+    const openingBalanceYears = [
+      ...(monthCloseResult?.dashboard?.openingBalances?.projection?.sources || []).map((source) => source.year),
+      ...(monthCloseResult?.dashboard?.openingBalances?.actual?.sources || []).map((source) => source.year),
+    ];
+    const annualYears = [...new Set([
+      ...openingBalanceYears,
+      ...[...mirroredAnnualTotals.keys()].filter((year) => appliedAnnualYears.has(year)),
+    ])]
+      .filter((year) => year !== selectedYear)
+      .sort((left, right) => left - right);
+    const previousAnnualYears = annualYears.filter((year) => year < selectedYear);
+    const followingAnnualYears = annualYears.filter((year) => year > selectedYear);
+    const annualTotalFor = (year: number, mode: 'projection' | 'actual') => {
+      const jvmSource = monthCloseResult?.dashboard?.openingBalances?.selectedYear === selectedYear
+        ? monthCloseResult.dashboard.openingBalances[mode]?.sources?.find((source) => source.year === year)
+        : null;
+      if (jvmSource) {
+        const totalIn = CASHFLOW_IN_LINES.reduce((sum, lineId) => sum + Number(jvmSource.lineAmounts?.[lineId] || 0), 0);
+        const totalOut = CASHFLOW_OUT_LINES.reduce((sum, lineId) => sum + Number(jvmSource.lineAmounts?.[lineId] || 0), 0);
+        return {
+          lineAmounts: jvmSource.lineAmounts,
+          lineStates: jvmSource.lineStates,
+          totalIn,
+          totalOut,
+          net: totalIn - totalOut,
+        };
+      }
+      return mirroredAnnualTotals.get(year)?.[mode] || null;
+    };
+    const boardColumnCount = previousAnnualYears.length + visibleWeeks.length + followingAnnualYears.length + 2;
     const canonicalReadModel = monthCloseResult?.dashboard?.canonical;
     const readServerSummary = (mode: 'projection' | 'actual') => {
       const openingBalance = monthCloseResult?.dashboard?.openingBalances?.selectedYear === selectedYear
@@ -1687,6 +1720,15 @@ export function CashflowProjectSheet({
       projection: readServerSummary('projection'),
       actual: readServerSummary('actual'),
     };
+    const projectLineTotalFor = (mode: 'projection' | 'actual', lineId: CashflowSheetLineId) => annualYears.reduce(
+      (sum, year) => sum + Number(annualTotalFor(year, mode)?.lineAmounts?.[lineId] || 0),
+      Number(derived[mode].rowTotals[lineId] || 0),
+    );
+    const projectTotalsFor = (mode: 'projection' | 'actual') => {
+      const totalIn = annualYears.reduce((sum, year) => sum + Number(annualTotalFor(year, mode)?.totalIn || 0), Number(derived[mode].monthTotals.totalIn || 0));
+      const totalOut = annualYears.reduce((sum, year) => sum + Number(annualTotalFor(year, mode)?.totalOut || 0), Number(derived[mode].monthTotals.totalOut || 0));
+      return { totalIn, totalOut, net: totalIn - totalOut };
+    };
     const scrollBoard = (direction: -1 | 1) => {
       const container = cashflowBoardScrollRef.current;
       if (!container) return;
@@ -1703,6 +1745,30 @@ export function CashflowProjectSheet({
         behavior: 'smooth',
       });
     };
+    const renderAnnualLineCell = (mode: 'projection' | 'actual', lineId: CashflowSheetLineId, year: number, isAltRow: boolean) => {
+      const total = annualTotalFor(year, mode);
+      const state = total?.lineStates?.[lineId]
+        || (Object.prototype.hasOwnProperty.call(total?.lineAmounts || {}, lineId) ? 'VALUE' : 'EMPTY');
+      const value = Number(total?.lineAmounts?.[lineId] || 0);
+      return (
+        <td key={`${mode}-${lineId}-${year}-annual`} data-cashflow-board-column="true" className={`min-w-[84px] border-l-[6px] border-l-white px-1 py-1 text-right align-middle text-[12px] tabular-nums text-slate-700 ${isAltRow ? 'bg-slate-50' : 'bg-white'}`}>
+          {state === 'VALUE' || state === 'ZERO' ? fmt(value) : <span className="text-slate-400">미입력</span>}
+        </td>
+      );
+    };
+    const renderAnnualSummaryCell = (
+      mode: 'projection' | 'actual',
+      kind: 'totalIn' | 'totalOut' | 'net',
+      year: number,
+      emphasis: 'income' | 'expense' | 'balance',
+      rowTone?: 'income' | 'expense',
+    ) => renderSummaryCell({
+      keyName: `${mode}-${kind}-${year}-annual`,
+      value: Number(annualTotalFor(year, mode)?.[kind] || 0),
+      mode,
+      emphasis,
+      rowTone,
+    });
     const renderModeLineRows = (
       mode: 'projection' | 'actual',
       lineIds: CashflowSheetLineId[],
@@ -1714,15 +1780,17 @@ export function CashflowProjectSheet({
           <td className={`sticky left-0 z-20 w-[192px] min-w-[192px] border-r-[6px] border-r-white px-3 py-2 text-[12px] leading-4 ${tone === 'income' ? 'text-emerald-700' : 'text-red-700'} ${rowIndex % 2 === 0 ? 'bg-white' : 'bg-slate-50'} ${emphasized ? 'font-bold' : 'font-medium'}`}>
             {renderCashflowLineLabel(getCashflowModeLineLabel(lineId, mode))}
           </td>
+          {previousAnnualYears.map((year) => renderAnnualLineCell(mode, lineId, year, rowIndex % 2 === 1))}
           {visibleWeeks.map((week) => {
             const isThisWeek = todayYearMonth === week.yearMonth && todayIso >= week.weekStart && todayIso <= week.weekEnd;
             return mode === 'projection'
               ? renderProjectionCell({ targetYearMonth: week.yearMonth, weekNo: week.weekNo, lineId, isThisWeek, isAltRow: rowIndex % 2 === 1 })
               : renderActualCell({ targetYearMonth: week.yearMonth, weekNo: week.weekNo, lineId, isThisWeek, isAltRow: rowIndex % 2 === 1 });
           })}
+          {followingAnnualYears.map((year) => renderAnnualLineCell(mode, lineId, year, rowIndex % 2 === 1))}
           {renderSummaryCell({
             keyName: `${mode}-${lineId}-range`,
-            value: derived[mode].rowTotals[lineId] || 0,
+            value: projectLineTotalFor(mode, lineId),
             mode,
             isAltRow: rowIndex % 2 === 1,
             stickyRight: true,
@@ -1744,6 +1812,7 @@ export function CashflowProjectSheet({
           <td className="sticky left-0 z-20 w-[192px] min-w-[192px] border-r-[6px] border-r-white bg-[#EAF0F5] px-3 py-2 text-[12px] font-bold text-[#17324D]">
             {label}
           </td>
+          {previousAnnualYears.map((year) => renderAnnualSummaryCell(mode, kind, year, emphasis, rowTone))}
           {visibleWeeks.map((week, index) => renderSummaryCell({
             keyName: `${mode}-${kind}-${week.yearMonth}-${week.weekNo}`,
             value: derived[mode].weekTotals[index]?.[kind] || 0,
@@ -1752,9 +1821,10 @@ export function CashflowProjectSheet({
             emphasis,
             rowTone,
           }))}
+          {followingAnnualYears.map((year) => renderAnnualSummaryCell(mode, kind, year, emphasis, rowTone))}
           {renderSummaryCell({
             keyName: `${mode}-${kind}-range`,
-            value: derived[mode].monthTotals[kind],
+            value: projectTotalsFor(mode)[kind],
             mode,
             emphasis,
             stickyRight: true,
@@ -1770,6 +1840,12 @@ export function CashflowProjectSheet({
             <th className="sticky left-0 z-50 w-[192px] min-w-[192px] border-r-[6px] border-r-white bg-white px-3 py-2 text-left text-[12px] font-bold text-slate-800">
               항목
             </th>
+            {previousAnnualYears.map((year) => (
+              <th key={`${mode}-${year}-before`} data-cashflow-board-column="true" className="min-w-[84px] border-l-[6px] border-l-white bg-slate-100 px-1 py-2 text-center align-top font-semibold">
+                <div className="text-[12px] font-bold text-slate-800">{year}년</div>
+                <div className="text-[12px] font-normal text-slate-400">누적</div>
+              </th>
+            ))}
             {visibleWeeks.map((week) => {
               const isThisWeek = todayYearMonth === week.yearMonth && todayIso >= week.weekStart && todayIso <= week.weekEnd;
               return (
@@ -1780,8 +1856,14 @@ export function CashflowProjectSheet({
                 </th>
               );
             })}
+            {followingAnnualYears.map((year) => (
+              <th key={`${mode}-${year}-after`} data-cashflow-board-column="true" className="min-w-[84px] border-l-[6px] border-l-white bg-slate-100 px-1 py-2 text-center align-top font-semibold">
+                <div className="text-[12px] font-bold text-slate-800">{year}년</div>
+                <div className="text-[12px] font-normal text-slate-400">합계</div>
+              </th>
+            ))}
             <th className="sticky right-0 z-50 min-w-[84px] border-l-[6px] border-l-white bg-white px-1 py-2 text-left text-[12px] font-bold text-slate-800 shadow-[-12px_0_24px_rgba(15,23,42,0.08)]">
-              {selectedYear}년 합계
+              Total
             </th>
           </tr>
         </thead>

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -260,6 +260,18 @@ export interface CashflowSheetLabAnnualCell {
   rawValue?: string;
 }
 
+export interface CashflowSheetLabTotalCell {
+  mode: 'projection' | 'actual';
+  kind: 'line' | 'derived';
+  lineId?: string;
+  direction?: 'IN' | 'OUT';
+  derivedKind?: 'deposit_total' | 'withdrawal_total' | 'balance';
+  sourceCell: string;
+  state: 'VALUE' | 'ZERO' | 'EMPTY' | 'INVALID';
+  amount?: number;
+  rawValue?: string;
+}
+
 export interface CashflowSheetLabMirrorResult {
   schemaVersion?: number;
   projectId: string;
@@ -289,6 +301,7 @@ export interface CashflowSheetLabMirrorResult {
   summary?: { cellCount: number; valueCount: number; emptyCount: number; invalidCount: number };
   cells?: CashflowSheetLabMirrorCell[];
   annualCells?: CashflowSheetLabAnnualCell[];
+  totalCells?: CashflowSheetLabTotalCell[];
   sheetFacts?: {
     metadata?: {
       lastUpdateText?: { sourceCell: string; value: string };
@@ -319,6 +332,11 @@ export interface CashflowSheetLabMirrorResult {
       year: number;
       projection: CashflowSheetLabAnnualModeTotal;
       actual: CashflowSheetLabAnnualModeTotal;
+    }>;
+    cashflowGrandTotalsBySourceYear?: Array<{
+      sourceYear: number;
+      projection: CashflowSheetLabGrandTotal;
+      actual: CashflowSheetLabGrandTotal;
     }>;
   };
   financialYearChecks?: {
@@ -394,6 +412,14 @@ export interface CashflowSheetLabAnnualModeTotal {
     status: 'NOT_APPLICABLE' | 'PARTIAL_WEEKLY' | 'MATCH' | 'MISMATCH';
     mismatchedLineIds: string[];
   };
+}
+
+export interface CashflowSheetLabGrandTotal {
+  lineAmounts: Record<string, number>;
+  lineStates: Record<string, 'VALUE' | 'ZERO' | 'EMPTY'>;
+  totalIn: number;
+  totalOut: number;
+  net: number;
 }
 
 export interface CashflowSheetLabYearViewResult {


### PR DESCRIPTION
Summary: restore prior and future annual columns around the selected-year weekly ledger; preserve the sheet BS Total column as display-only source data; retain that Total as a reconciliation input without writing it into the ledger; keep sheet refresh progress visible without a blur backdrop. Verification: 120 tests passed and the TSX parse passed. Stage only; no Live deployment.