### PR TITLE
fix(cashflow): make month-close writes race safe

### DIFF
--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -1575,70 +1575,6 @@ function stableHash(value) {
   return createHash('sha256').update(JSON.stringify(value)).digest('hex');
 }
 
-function normalizeSettledWeekConfirmation(value, { requireId = true } = {}) {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const confirmationId = readOptionalText(value.confirmationId);
-  const targetRevision = readOptionalText(value.targetRevision);
-  const rawWeeks = Array.isArray(value.weeks) ? value.weeks : [];
-  if (
-    (requireId && !confirmationId)
-    || confirmationId.length > 100
-    || !/^sha256:[a-f0-9]{64}$/.test(targetRevision)
-    || rawWeeks.length < 1
-    || rawWeeks.length > 60
-  ) return null;
-  const weeks = rawWeeks.map((week) => ({
-    yearMonth: readOptionalText(week?.yearMonth),
-    weekNo: Number(week?.weekNo),
-    completionRevision: Number(week?.completionRevision),
-  }));
-  const keys = new Set();
-  for (const week of weeks) {
-    const key = `${week.yearMonth}:${week.weekNo}`;
-    if (
-      !/^20\d{2}-(0[1-9]|1[0-2])$/.test(week.yearMonth)
-      || !Number.isSafeInteger(week.weekNo)
-      || week.weekNo < 1
-      || week.weekNo > 5
-      || !Number.isSafeInteger(week.completionRevision)
-      || week.completionRevision < 0
-      || keys.has(key)
-    ) return null;
-    keys.add(key);
-  }
-  weeks.sort((left, right) => left.yearMonth.localeCompare(right.yearMonth) || left.weekNo - right.weekNo);
-  return { confirmationId, targetRevision, weeks };
-}
-
-function assertSettledWeekChangeResponse(result, confirmation) {
-  const rawChanges = result?.settledWeekChanges;
-  if (!Array.isArray(rawChanges)) {
-    throw createHttpError(502, 'JVM 정산 변경 응답을 확인할 수 없습니다.', 'cashflow_jvm_settled_week_change_verification_failed');
-  }
-  if (!confirmation) {
-    if (rawChanges.length === 0) return [];
-    throw createHttpError(502, '확인하지 않은 정산 변경이 반환되었습니다.', 'cashflow_jvm_settled_week_change_verification_failed');
-  }
-  const changes = rawChanges.map((change) => ({
-    yearMonth: readOptionalText(change?.yearMonth),
-    weekNo: Number(change?.weekNo),
-    completionRevision: Number(change?.completionRevision),
-    warningCount: Number(change?.warningCount),
-  })).sort((left, right) => left.yearMonth.localeCompare(right.yearMonth) || left.weekNo - right.weekNo);
-  const valid = changes.length === confirmation.weeks.length && changes.every((change, index) => {
-    const expected = confirmation.weeks[index];
-    return change.yearMonth === expected.yearMonth
-      && change.weekNo === expected.weekNo
-      && change.completionRevision === expected.completionRevision
-      && Number.isSafeInteger(change.warningCount)
-      && change.warningCount >= 1;
-  });
-  if (!valid) {
-    throw createHttpError(502, 'JVM 정산 변경 범위가 확인한 값과 다릅니다.', 'cashflow_jvm_settled_week_change_verification_failed');
-  }
-  return changes;
-}
-
 function assertApplyRequestMatches(stageRun, applyRequestHash) {
   if (readOptionalText(stageRun.applyRequestHash) !== readOptionalText(applyRequestHash)) {
     throw createHttpError(409, '다른 최종 반영 요청이 이미 이 검토본을 사용 중입니다.', 'cashflow_sheet_apply_in_progress');
@@ -1726,11 +1662,6 @@ async function restoreCashflowSheetApplyReady({
       applyRequestHash: null,
       applyFailedAt: new Date().toISOString(),
       applyFailure: routeErrorDetails(error),
-      ...(error?.code === 'cashflow_settled_week_change_confirmation_required'
-        ? { pendingSettledWeekChangeConfirmation: normalizeSettledWeekConfirmation(error?.details) }
-        : error?.code === 'cashflow_settled_week_change_confirmation_expired'
-          ? { pendingSettledWeekChangeConfirmation: null }
-        : {}),
     }), { merge: true });
   });
 }
@@ -1874,7 +1805,6 @@ async function applyStagedCashflowSheetLab({
     projectId,
     stagedRunId,
     applyRiskCandidates: Boolean(parsed.applyRiskCandidates),
-    settledWeekChangeConfirmationId: readOptionalText(parsed.settledWeekChangeConfirmationId) || null,
   });
   if (!stagedRunId) {
     throw createHttpError(400, '검토 후보 runId가 필요합니다.', 'cashflow_sheet_stage_run_required');
@@ -1882,28 +1812,11 @@ async function applyStagedCashflowSheetLab({
 
   let stageRun = await readCashflowSheetStageRun(db, tenantId, projectId, stagedRunId);
   const replaceAllActualSources = stageRun.replaceAllActualSources === true;
-  const requestedConfirmationId = readOptionalText(parsed.settledWeekChangeConfirmationId);
-  const pendingConfirmation = normalizeSettledWeekConfirmation(stageRun.pendingSettledWeekChangeConfirmation);
-  if (requestedConfirmationId && (
-    !pendingConfirmation
-    || pendingConfirmation.confirmationId !== requestedConfirmationId
-    || pendingConfirmation.targetRevision !== readOptionalText(stageRun.targetRevisionAtFetch)
-  )) {
-    throw createHttpError(
-      409,
-      '주간 정산 변경 확인 정보가 만료되었습니다. 시트 값을 다시 확인해 주세요.',
-      'cashflow_settled_week_change_confirmation_expired',
-    );
-  }
-  const settledWeekChangeConfirmation = requestedConfirmationId ? pendingConfirmation : null;
   const applyRequestHash = stableHash({
     stagedRunId,
     applyRiskCandidates: Boolean(parsed.applyRiskCandidates),
     ...(readOptionalText(parsed.closedMonthChangeReason) ? { closedMonthChangeReason: readOptionalText(parsed.closedMonthChangeReason) } : {}),
     ...(replaceAllActualSources ? { replaceAllActualSources: true } : {}),
-    ...(settledWeekChangeConfirmation
-      ? { settledWeekChangeConfirmationHash: stableHash(settledWeekChangeConfirmation) }
-      : {}),
   });
   if (readOptionalText(stageRun.status) === 'APPLIED') {
     assertApplyRequestMatches(stageRun, applyRequestHash);
@@ -2024,17 +1937,9 @@ async function applyStagedCashflowSheetLab({
 
   const javaResults = [];
   const javaAnnualResults = [];
-  const settledWeekChanges = [];
   let verifiedLineCount = 0;
   let targetRevision = readOptionalText(stageRun.targetRevisionAtFetch);
   let completedOperationCount = 0;
-  if (settledWeekChangeConfirmation && stagedMonths.length === 0) {
-    throw createHttpError(
-      409,
-      '주간 정산 변경 확인 대상 월이 없습니다.',
-      'cashflow_settled_week_change_confirmation_expired',
-    );
-  }
   try {
     const resolvedEditSession = typeof resolveEditSession === 'function'
       ? await resolveEditSession()
@@ -2062,11 +1967,9 @@ async function applyStagedCashflowSheetLab({
         yearMonth: month.yearMonth,
         cells: month.cells,
         replaceAllActualSources,
-        settledWeekChangeConfirmation,
         closedMonthChangeReason: readOptionalText(parsed.closedMonthChangeReason),
       });
       targetRevision = assertResultingTargetRevision(javaResult);
-      settledWeekChanges.push(...assertSettledWeekChangeResponse(javaResult, settledWeekChangeConfirmation));
       verifiedLineCount += verifyJavaMonthAppliedCells(javaResult, month, {
         projectId,
         sourceRevision: readOptionalText(stageRun.sourceRevision),
@@ -2096,7 +1999,6 @@ async function applyStagedCashflowSheetLab({
         targetRevision,
         months: stagedMonths.map((month) => ({ yearMonth: month.yearMonth, cells: month.cells })),
         replaceAllActualSources,
-        settledWeekChangeConfirmation,
         closedMonthChangeReason: readOptionalText(parsed.closedMonthChangeReason),
       });
       if (
@@ -2110,7 +2012,6 @@ async function applyStagedCashflowSheetLab({
         throw createHttpError(502, 'JVM 월 배치 저장 계약이 요청과 다릅니다.', 'cashflow_jvm_apply_verification_failed');
       }
       targetRevision = assertResultingTargetRevision(batchResult);
-      settledWeekChanges.push(...assertSettledWeekChangeResponse(batchResult, settledWeekChangeConfirmation));
       const returnedMonths = new Map((Array.isArray(batchResult?.months) ? batchResult.months : [])
         .map((month) => [readOptionalText(month?.yearMonth), month]));
       if (returnedMonths.size !== stagedMonths.length) {
@@ -2192,25 +2093,17 @@ async function applyStagedCashflowSheetLab({
       if (rejected) throw rejected.reason;
     }
   } catch (error) {
-    const handledError = error?.code === 'cashflow_settled_week_change_confirmation_required'
-      && !normalizeSettledWeekConfirmation(error?.details)
-      ? createHttpError(
-        502,
-        'JVM 주간 정산 변경 확인 계약이 올바르지 않습니다.',
-        'cashflow_jvm_settled_week_change_verification_failed',
-      )
-      : error;
-    const statusCode = Number(handledError?.statusCode || handledError?.status);
+    const statusCode = Number(error?.statusCode || error?.status);
     if (completedOperationCount === 0 && statusCode >= 400 && statusCode < 500) {
       await restoreCashflowSheetApplyReady({
         db,
         runRef: reservation.runRef,
         idempotencyKey: effectiveIdempotencyKey,
         applyRequestHash,
-        error: handledError,
+        error,
       });
     }
-    throw handledError;
+    throw error;
   }
 
   const appliedCells = [
@@ -2235,7 +2128,6 @@ async function applyStagedCashflowSheetLab({
     projectionLineCount,
     actualLineCount,
     skippedRiskLineCount: 0,
-    settledWeekChanges,
     lastAppliedAt: now,
     runId: `cashflow-sheet-apply:${projectId}:${now}`,
     stagedRunId,
@@ -2262,7 +2154,6 @@ async function applyStagedCashflowSheetLab({
         revision: Number(result.revision) || 0,
         auditId: readOptionalText(result.auditId) || undefined,
       })),
-      settledWeekChanges,
       verifiedLineCount,
     },
   };

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -1479,6 +1479,26 @@ function buildPinnedSheetChangeCandidates({ tenantId, projectId, runId, mirror, 
   };
 }
 
+function summarizeCandidateMonthDifferences(candidates, yearMonths = []) {
+  const requiredMonths = new Set((Array.isArray(yearMonths) ? yearMonths : [yearMonths])
+    .map(readOptionalText)
+    .filter(Boolean));
+  const summaries = new Map();
+  for (const candidate of candidates) {
+    const candidateMonth = readOptionalText(candidate?.yearMonth);
+    if (!candidateMonth || (requiredMonths.size > 0 && !requiredMonths.has(candidateMonth))) continue;
+    const summary = summaries.get(candidateMonth) || { yearMonth: candidateMonth, differenceCount: 0, weeks: new Set() };
+    summary.differenceCount += 1;
+    if (Number.isSafeInteger(Number(candidate?.weekNo))) summary.weeks.add(Number(candidate.weekNo));
+    summaries.set(candidateMonth, summary);
+  }
+  return [...summaries.values()].map((summary) => ({
+    yearMonth: summary.yearMonth,
+    differenceCount: summary.differenceCount,
+    weeks: [...summary.weeks].sort((left, right) => left - right),
+  })).sort((left, right) => left.yearMonth.localeCompare(right.yearMonth));
+}
+
 async function buildPinnedAnnualChangeCandidates({
   db,
   tenantId,
@@ -2094,6 +2114,15 @@ async function applyStagedCashflowSheetLab({
     }
   } catch (error) {
     const statusCode = Number(error?.statusCode || error?.status);
+    if (readOptionalText(error?.code) === 'cashflow_closed_month_reason_required') {
+      const requiredMonths = Array.isArray(error?.details?.closedMonths)
+        ? error.details.closedMonths
+        : [readOptionalText(error?.message).match(/\b20\d{2}-(?:0[1-9]|1[0-2])\b/)?.[0]].filter(Boolean);
+      error.details = {
+        ...(error?.details && typeof error.details === 'object' ? error.details : {}),
+        closedMonthDifferences: summarizeCandidateMonthDifferences(selectedCandidates, requiredMonths),
+      };
+    }
     if (completedOperationCount === 0 && statusCode >= 400 && statusCode < 500) {
       await restoreCashflowSheetApplyReady({
         db,

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -2720,6 +2720,10 @@ describe('cashflow sheet lab route', () => {
   });
 
   it('retries the same staged run with a reason after the JVM rejects a late closed-month change', async () => {
+    const twoFullMonths = [
+      ...JANUARY_FINANCE_WEEKS,
+      '26-2-1', '26-2-2', '26-2-3', '26-2-4', '26-2-5',
+    ];
     const db = createDb({
       project: {
         id: 'project-a',
@@ -2727,7 +2731,7 @@ describe('cashflow sheet lab route', () => {
           value: 'saved-spreadsheet-a',
           sheetName: 'cashflow(사용내역 연동)',
           startWeek: '26-1-1',
-          endWeek: '26-1-5',
+          endWeek: '26-2-5',
         },
       },
       initialDocuments: {
@@ -2736,7 +2740,14 @@ describe('cashflow sheet lab route', () => {
           tenantId: 'tenant-a',
           projectId: 'project-a',
           yearMonth: '2026-01',
-          status: 'CLOSED',
+          status: 'OPEN',
+        },
+        'orgs/tenant-a/monthly_closes/project-a-2026-02': {
+          contractVersion: 'cashflow-month-close-v1',
+          tenantId: 'tenant-a',
+          projectId: 'project-a',
+          yearMonth: '2026-02',
+          status: 'OPEN',
         },
       },
     });
@@ -2744,19 +2755,20 @@ describe('cashflow sheet lab route', () => {
       spreadsheetId: 'spreadsheet-a',
       selectedSheetName: 'cashflow(사용내역 연동)',
       availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
-      matrix: buildMatrixWithWeekLabels(JANUARY_FINANCE_WEEKS),
+      matrix: buildMatrixWithWeekLabels(twoFullMonths),
     }));
     const resultingTargetRevision = `sha256:${'4'.repeat(64)}`;
     let attempts = 0;
     const javaWeeklyClient = {
-      applyCashflowSheetLab: vi.fn(async (input) => {
+      applyCashflowSheetBatch: vi.fn(async (input) => {
         if (attempts++ === 0 && !input.closedMonthChangeReason) {
           throw Object.assign(new Error('reason required'), {
             statusCode: 409,
             code: 'cashflow_closed_month_reason_required',
+            details: { closedMonths: ['2026-01', '2026-02'] },
           });
         }
-        return javaApplyResponse(input, resultingTargetRevision);
+        return javaBatchApplyResponse(input, resultingTargetRevision);
       }),
     };
     const app = createApp({
@@ -2772,17 +2784,22 @@ describe('cashflow sheet lab route', () => {
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
       .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-rejected-retry' })
       .expect(200);
+    expect(stage.body.closedMonthDifferences).toEqual([]);
     const headers = {
       'x-edit-session-id': 'session-a',
       'x-edit-lease-id': 'lease-a',
       'x-edit-fence': '7',
     };
 
-    await request(app)
+    const rejected = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
       .set(headers)
       .send({ stageRunId: stage.body.runId, idempotencyKey: 'apply-rejected-first' })
       .expect(409);
+    expect(rejected.body.details.closedMonthDifferences).toEqual([
+      expect.objectContaining({ yearMonth: '2026-01', weeks: expect.any(Array) }),
+      expect.objectContaining({ yearMonth: '2026-02', weeks: expect.any(Array) }),
+    ]);
     expect(db.__getDocument(`orgs/tenant-a/cashflow_sheet_stage_runs/${stage.body.runId}`).status).toBe('READY');
     await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
@@ -2794,8 +2811,8 @@ describe('cashflow sheet lab route', () => {
       })
       .expect(200);
 
-    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(2);
-    const calls = javaWeeklyClient.applyCashflowSheetLab.mock.calls.map(([call]) => call);
+    expect(javaWeeklyClient.applyCashflowSheetBatch).toHaveBeenCalledTimes(2);
+    const calls = javaWeeklyClient.applyCashflowSheetBatch.mock.calls.map(([call]) => call);
     expect(calls[0].idempotencyKey).not.toBe(calls[1].idempotencyKey);
     expect(calls[1].closedMonthChangeReason).toBe('결산 후 실제 입금액 정정');
   });
@@ -2840,7 +2857,7 @@ describe('cashflow sheet lab route', () => {
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
       .send({ stageRunId: stage.body.runId, idempotencyKey: 'apply-settled-unconfirmed' })
       .expect(200);
-    expect(applied.body.settledWeekChanges).toEqual([]);
+    expect(applied.body.settledWeekChanges).toBeUndefined();
     expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(1);
     expect(javaWeeklyClient.applyCashflowSheetLab.mock.calls[0][0].settledWeekChangeConfirmation).toBeUndefined();
   });

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -2800,7 +2800,7 @@ describe('cashflow sheet lab route', () => {
     expect(calls[1].closedMonthChangeReason).toBe('결산 후 실제 입금액 정정');
   });
 
-  it('requires explicit confirmation before forwarding a settled-week sheet change', async () => {
+  it('applies a settled-week sheet change without a weekly confirmation', async () => {
     const db = createDb({
       project: {
         id: 'project-a',
@@ -2819,36 +2819,8 @@ describe('cashflow sheet lab route', () => {
       matrix: buildMatrixWithWeekLabels(JANUARY_FINANCE_WEEKS),
     }));
     const resultingTargetRevision = `sha256:${'5'.repeat(64)}`;
-    let expireConfirmation = false;
     const javaWeeklyClient = {
-      applyCashflowSheetLab: vi.fn(async (input) => {
-        if (!input.settledWeekChangeConfirmation) {
-          throw Object.assign(new Error('주간 정산 값과 시트 값이 다릅니다.'), {
-            statusCode: 409,
-            code: 'cashflow_settled_week_change_confirmation_required',
-            details: {
-              confirmationId: 'confirmation-a',
-              targetRevision: input.targetRevision,
-              weeks: [{ yearMonth: '2026-01', weekNo: 2, completionRevision: 1 }],
-            },
-          });
-        }
-        if (expireConfirmation) {
-          throw Object.assign(new Error('주간 정산 상태가 바뀌었습니다. 시트 값을 다시 확인해 주세요.'), {
-            statusCode: 409,
-            code: 'cashflow_settled_week_change_confirmation_expired',
-          });
-        }
-        return {
-          ...javaApplyResponse(input, resultingTargetRevision),
-          settledWeekChanges: [{
-            yearMonth: '2026-01',
-            weekNo: 2,
-            completionRevision: 1,
-            warningCount: 1,
-          }],
-        };
-      }),
+      applyCashflowSheetLab: vi.fn(async (input) => javaApplyResponse(input, resultingTargetRevision)),
     };
     const app = createApp({
       db,
@@ -2864,79 +2836,13 @@ describe('cashflow sheet lab route', () => {
       .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-settled-change' })
       .expect(200);
 
-    const unconfirmed = await request(app)
+    const applied = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
       .send({ stageRunId: stage.body.runId, idempotencyKey: 'apply-settled-unconfirmed' })
-      .expect(409);
-    expect(unconfirmed.body.details.confirmationId).toBe('confirmation-a');
-    expect(db.__getDocument(`orgs/tenant-a/cashflow_sheet_stage_runs/${stage.body.runId}`).status).toBe('READY');
-
-    await request(app)
-      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
-      .send({
-        stageRunId: stage.body.runId,
-        idempotencyKey: 'apply-settled-boolean-bypass',
-        allowLockedWeekChanges: true,
-      })
-      .expect(400);
-    await request(app)
-      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
-      .send({
-        stageRunId: stage.body.runId,
-        idempotencyKey: 'apply-settled-wrong-confirmation',
-        settledWeekChangeConfirmationId: 'confirmation-other',
-      })
-      .expect(409);
-
-    expireConfirmation = true;
-    await request(app)
-      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
-      .send({
-        stageRunId: stage.body.runId,
-        idempotencyKey: 'apply-settled-expired',
-        settledWeekChangeConfirmationId: unconfirmed.body.details.confirmationId,
-      })
-      .expect(409);
-    const afterExpiredConfirmation = db.__getDocument(`orgs/tenant-a/cashflow_sheet_stage_runs/${stage.body.runId}`);
-    expect(afterExpiredConfirmation.status).toBe('READY');
-    expect(afterExpiredConfirmation.pendingSettledWeekChangeConfirmation).toBeNull();
-
-    expireConfirmation = false;
-    const refreshedConfirmation = await request(app)
-      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
-      .send({ stageRunId: stage.body.runId, idempotencyKey: 'apply-settled-unconfirmed-refreshed' })
-      .expect(409);
-
-    const confirmed = await request(app)
-      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
-      .send({
-        stageRunId: stage.body.runId,
-        idempotencyKey: 'apply-settled-confirmed',
-        settledWeekChangeConfirmationId: refreshedConfirmation.body.details.confirmationId,
-      })
       .expect(200);
-
-    expect(confirmed.body.settledWeekChanges).toEqual([{
-      yearMonth: '2026-01',
-      weekNo: 2,
-      completionRevision: 1,
-      warningCount: 1,
-    }]);
-    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(4);
-    expect(javaWeeklyClient.applyCashflowSheetLab.mock.calls[3][0].settledWeekChangeConfirmation).toEqual({
-      confirmationId: 'confirmation-a',
-      targetRevision: stage.body.targetRevisionAtFetch,
-      weeks: [{ yearMonth: '2026-01', weekNo: 2, completionRevision: 1 }],
-    });
-    await request(app)
-      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
-      .send({
-        stageRunId: stage.body.runId,
-        idempotencyKey: 'apply-settled-confirmed-replay',
-        settledWeekChangeConfirmationId: refreshedConfirmation.body.details.confirmationId,
-      })
-      .expect(200);
-    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(4);
+    expect(applied.body.settledWeekChanges).toEqual([]);
+    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(1);
+    expect(javaWeeklyClient.applyCashflowSheetLab.mock.calls[0][0].settledWeekChangeConfirmation).toBeUndefined();
   });
 
   it('blocks a partial month instead of authoritatively replacing only weeks 4 and 5', async () => {

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -978,20 +978,25 @@ function projectFinancialYears(project = {}) {
     .filter(Number.isSafeInteger))].sort((left, right) => left - right);
 }
 
-async function composeProjectionTotal({ db, tenantId, projectId, project, cashflow, fallback, weeklyYearsHint = [] }) {
+function composeProjectionTotal({ project, cashflow, mirror, fallback, weeklyYearsHint = [] }) {
   const weekly = canonicalWeeklyProjection(cashflow, fallback);
   weekly.weeklyYears = [...new Set([...weekly.weeklyYears, ...weeklyYearsHint])].sort((left, right) => left - right);
   const annualYears = projectFinancialYears(project).filter((year) => !weekly.weeklyYears.includes(year));
-  const annual = await Promise.all(annualYears.map(async (year) => {
-    const id = Buffer.from(`${projectId}\n${year}`, 'utf8').toString('base64url');
-    const document = await readDocument(db, `orgs/${tenantId}/cashflow_sheet_year_totals/${id}`);
-    const values = objectValue(document?.projection) || {};
-    const states = objectValue(document?.projectionStates) || {};
-    const totalIn = CASHFLOW_IN_LINES.reduce((sum, lineId) => (
-      sum + (readOptionalText(states[lineId]) === 'VALUE' ? safeAmount(values[lineId]) : 0)
-    ), 0);
-    return { year, source: document ? 'ANNUAL' : 'MISSING', totalIn };
-  }));
+  const annualTotals = new Map((Array.isArray(mirror?.sheetFacts?.annualCashflowTotals)
+    ? mirror.sheetFacts.annualCashflowTotals
+    : []).map((row) => [Number(row?.year), row]));
+  const appliedAnnualYears = new Set((Array.isArray(mirror?.appliedAnnualYears)
+    ? mirror.appliedAnnualYears
+    : []).map(Number));
+  const sourceIsApplied = readOptionalText(mirror?.appliedSourceRevision) === readOptionalText(mirror?.sourceRevision);
+  const annual = annualYears.map((year) => {
+    const total = sourceIsApplied && appliedAnnualYears.has(year) ? annualTotals.get(year) : null;
+    return {
+      year,
+      source: total ? 'ANNUAL' : 'MISSING',
+      totalIn: safeAmount(total?.projection?.totalIn),
+    };
+  });
   return {
     totalIn: weekly.totalIn + annual.reduce((sum, row) => sum + row.totalIn, 0),
     years: [
@@ -1457,12 +1462,10 @@ async function composeCashflowMonthDashboard({ db, req, projectId, yearMonth, cl
       totalIn: safeAmount(canonicalWithComparison?.range?.projection?.totalIn ?? projection.totalIn),
       years: Array.isArray(closedSnapshot?.projectionYears) ? closedSnapshot.projectionYears : [],
     }
-    : await composeProjectionTotal({
-      db,
-      tenantId,
-      projectId,
+    : composeProjectionTotal({
       project,
       cashflow,
+      mirror,
       fallback: projection.totalIn,
       weeklyYearsHint: (Array.isArray(mirror?.appliedWeeklyYears) ? mirror.appliedWeeklyYears : mirror?.cells?.map((cell) => (
         Number(readOptionalText(cell?.yearMonth).slice(0, 4))

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -1279,13 +1279,14 @@ describe('JVM weekly API BFF proxy', () => {
     const project = documents.get('orgs/tenant-a/projects/project-a');
     project.contractStart = '2026-01-01';
     project.contractEnd = '2027-12-31';
-    const annualId = Buffer.from('project-a\n2027', 'utf8').toString('base64url');
-    documents.set(`orgs/tenant-a/cashflow_sheet_year_totals/${annualId}`, {
-      projectId: 'project-a',
+    const mirror = documents.get('orgs/tenant-a/cashflow_sheet_mirrors/project-a');
+    mirror.appliedAnnualYears = [2027];
+    mirror.appliedWeeklyYears = [2026];
+    mirror.sheetFacts.annualCashflowTotals = [{
       year: 2027,
-      projection: { SALES_IN: 650 },
-      projectionStates: { SALES_IN: 'VALUE' },
-    });
+      projection: { totalIn: 650 },
+      actual: { totalIn: 0 },
+    }];
     const cashflow = {
       projectId: 'project-a',
       readModel: {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -951,12 +951,13 @@ public class WeeklyExpenseController {
     }
 
     @org.springframework.web.bind.annotation.ExceptionHandler(WeeklyExpenseEditLeaseException.class)
-    public ResponseEntity<Map<String, String>> editLease(WeeklyExpenseEditLeaseException error) {
-        return ResponseEntity.status(error.statusCode()).body(Map.of(
-            "ok", "false",
-            "code", error.code(),
-            "message", error.getMessage()
-        ));
+    public ResponseEntity<Map<String, Object>> editLease(WeeklyExpenseEditLeaseException error) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("ok", false);
+        response.put("code", error.code());
+        response.put("message", error.getMessage());
+        if (!error.details().isEmpty()) response.put("details", error.details());
+        return ResponseEntity.status(error.statusCode()).body(response);
     }
 
     @org.springframework.web.bind.annotation.ExceptionHandler({

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseEditLeaseException.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseEditLeaseException.java
@@ -1,13 +1,26 @@
 package dev.merryai.innerplatform.weekly.api;
 
+import java.util.Map;
+
 public class WeeklyExpenseEditLeaseException extends RuntimeException {
     private final int statusCode;
     private final String code;
+    private final Map<String, Object> details;
 
     public WeeklyExpenseEditLeaseException(int statusCode, String code, String message) {
+        this(statusCode, code, message, Map.of());
+    }
+
+    public WeeklyExpenseEditLeaseException(
+        int statusCode,
+        String code,
+        String message,
+        Map<String, Object> details
+    ) {
         super(message);
         this.statusCode = statusCode;
         this.code = code;
+        this.details = details == null ? Map.of() : Map.copyOf(details);
     }
 
     public int statusCode() {
@@ -16,5 +29,9 @@ public class WeeklyExpenseEditLeaseException extends RuntimeException {
 
     public String code() {
         return code;
+    }
+
+    public Map<String, Object> details() {
+        return details;
     }
 }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -494,30 +494,11 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             .distinct()
             .sorted(Comparator.comparing(CashflowWeekScope::yearMonth).thenComparingInt(CashflowWeekScope::weekNo))
             .toList());
-        List<String> locked = new ArrayList<>();
         for (CashflowWeekScope scope : scopes) {
             requireYearMonth(scope.yearMonth());
             if (scope.weekNo() < 1 || scope.weekNo() > CashflowSheetLabApplyRequest.FINANCE_WEEK_COUNT) {
                 throw new IllegalArgumentException("Cashflow weekNo must be between 1 and 5.");
             }
-            if (isAuthorizedCashflowMonthAmendment(monthStateKey(tenantId, projectId, scope.yearMonth()))) {
-                continue;
-            }
-            String documentId = projectId + "-" + scope.yearMonth() + "-w" + scope.weekNo();
-            DocumentReference ref = db.document(cashflowWeeklyUpdateCompletionPath(tenantId, documentId));
-            Map<String, Object> document = cachedDocumentIfPresent(ref).orElseGet(() -> {
-                DocumentSnapshot snapshot = get(ref);
-                return snapshot.exists() ? data(snapshot) : Map.of();
-            });
-            if ("LOCKED".equals(text(document.get("status"), ""))) {
-                locked.add(scope.yearMonth() + " " + scope.weekNo() + "주차");
-            }
-        }
-        if (!locked.isEmpty()) {
-            throw new WeeklyExpenseConflictException(
-                "Cashflow week is locked: " + String.join(", ", locked)
-                    + ". Reopen it with a reason before changing values."
-            );
         }
     }
 
@@ -1718,48 +1699,16 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             ));
         }
 
-        List<String> replacementKeysToWrite = replacements.keySet().stream().toList();
+        List<String> replacementKeysToWrite = replacements.entrySet().stream()
+            .filter(entry -> !allProjectWeeks.containsKey(entry.getKey())
+                || cashflowWeekFinancialContentChanged(
+                    allProjectWeeks.get(entry.getKey()),
+                    entry.getValue()
+                ))
+            .map(Map.Entry::getKey)
+            .toList();
+        // Weekly settlement is operational status only. Closed-month authorization above is the sole write guard.
         List<CashflowSettledWeekChange> settledWeekChanges = List.of();
-        if (!allowLockedWeeks) {
-            replacementKeysToWrite = replacements.entrySet().stream()
-                .filter(entry -> !allProjectWeeks.containsKey(entry.getKey())
-                    || cashflowWeekFinancialContentChanged(
-                        allProjectWeeks.get(entry.getKey()),
-                        entry.getValue()
-                    ))
-                .map(Map.Entry::getKey)
-                .toList();
-            List<CashflowWeekScope> changedWeeks = replacementKeysToWrite.stream()
-                .map(key -> {
-                    WeekDocParts parts = parseCashflowWeekId(projectId, key);
-                    return new CashflowWeekScope(parts.yearMonth(), parts.weekNo());
-                })
-                .toList();
-            if (settledWeekChangeConfirmation != null) {
-                requireExactSettledWeekConfirmation(
-                    tenantId,
-                    projectId,
-                    changedWeeks,
-                    targetRevision,
-                    settledWeekChangeConfirmation
-                );
-                settledWeekChanges = recordCashflowSettledWeekChanges(
-                    tenantId,
-                    projectId,
-                    changedWeeks,
-                    sourceRevision,
-                    targetRevision,
-                    idempotencyKey
-                );
-            } else {
-                requireCashflowWeeksOpenForSheetApply(
-                    tenantId,
-                    projectId,
-                    changedWeeks,
-                    targetRevision
-                );
-            }
-        }
         for (String replacementKey : replacementKeysToWrite) {
             replaceDocument(cashflowWeekRef(tenantId, replacementKey), replacements.get(replacementKey));
         }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -384,8 +384,8 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
 
         CashflowBusinessDate businessDate = cashflowMonthCloseBusinessDate(actor.tenantId(), projectId);
         String requestedReason = text(reason, "").trim();
-        List<CashflowClosedMonthAmendment> amendments = new ArrayList<>();
-        Map<String, CashflowClosedMonthAmendment> authorized = currentCashflowMonthAmendments.get();
+        Map<String, Map<String, Object>> closedMonthDocuments = new LinkedHashMap<>();
+        List<String> postDeadlineMonths = new ArrayList<>();
         for (String yearMonth : months) {
             requireYearMonth(yearMonth);
             String key = monthStateKey(actor.tenantId(), projectId, yearMonth);
@@ -399,15 +399,28 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                 if (states != null) states.put(key, status);
             }
             if (!"CLOSED".equals(status)) continue;
+            closedMonthDocuments.put(yearMonth, close);
+            if (businessDate.date().isAfter(YearMonth.parse(yearMonth).plusMonths(1).atDay(10))) {
+                postDeadlineMonths.add(yearMonth);
+            }
+        }
+        if (requestedReason.isBlank() && !postDeadlineMonths.isEmpty()) {
+            throw new WeeklyExpenseEditLeaseException(
+                409,
+                "cashflow_closed_month_reason_required",
+                String.join(", ", postDeadlineMonths) + " 마감 후 변경 사유를 입력해 주세요.",
+                Map.of("closedMonths", postDeadlineMonths)
+            );
+        }
+
+        List<CashflowClosedMonthAmendment> amendments = new ArrayList<>();
+        Map<String, CashflowClosedMonthAmendment> authorized = currentCashflowMonthAmendments.get();
+        for (String yearMonth : months) {
+            String key = monthStateKey(actor.tenantId(), projectId, yearMonth);
+            Map<String, Object> close = closedMonthDocuments.get(yearMonth);
+            if (close == null) continue;
             LocalDate deadline = YearMonth.parse(yearMonth).plusMonths(1).atDay(10);
             boolean postDeadline = businessDate.date().isAfter(deadline);
-            if (postDeadline && requestedReason.isBlank()) {
-                throw new WeeklyExpenseEditLeaseException(
-                    409,
-                    "cashflow_closed_month_reason_required",
-                    yearMonth + " 마감 후 변경 사유를 입력해 주세요."
-                );
-            }
             long closeRevision = canonicalMonthCounter(close, "revision");
             long amendmentCount = addMonthCounters(optionalMonthCounter(close, "amendmentCount"), 1);
             long warningCount = addMonthCounters(optionalMonthCounter(close, "postDeadlineAmendmentWarningCount"), postDeadline ? 1 : 0);

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -35,8 +35,6 @@ import dev.merryai.innerplatform.weekly.api.UpsertProjectionRequest;
 import dev.merryai.innerplatform.weekly.api.UpsertProjectionResponse;
 import dev.merryai.innerplatform.weekly.api.WeeklyExpenseEditLeaseException;
 import dev.merryai.innerplatform.weekly.api.WeeklyExpenseConflictException;
-import dev.merryai.innerplatform.weekly.api.CashflowSettledWeekChangeConfirmation;
-import dev.merryai.innerplatform.weekly.api.CashflowSettledWeekChangeConfirmationRequiredException;
 import dev.merryai.innerplatform.weekly.api.WeeklyExpenseForbiddenException;
 import dev.merryai.innerplatform.weekly.domain.CashflowLineCatalog;
 import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseProjectionEntity;
@@ -70,7 +68,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -777,8 +774,8 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
-    void multiMonthApplyRequiresOneLateReasonAndRecordsTheClosedMonthOnce() {
-        Fixture fixture = fixture(activeMember(), activeLease(), true, LocalDate.parse("2026-08-11"));
+    void multiMonthApplyReportsEveryLateClosedMonthAndRecordsEachOnce() {
+        Fixture fixture = fixture(activeMember(), activeLease(), true, LocalDate.parse("2026-10-11"));
         fixture.documents.put("orgs/tenant-a/monthly_closes/project-a-2026-07", Map.of(
             "contractVersion", "cashflow-month-close-v1",
             "tenantId", "tenant-a",
@@ -792,6 +789,15 @@ class FirestoreCashflowLeaseGuardTest {
             "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w3",
             lockedWeeklyCompletion("2026-07", 3, 1)
         );
+        fixture.documents.put("orgs/tenant-a/monthly_closes/project-a-2026-08", Map.of(
+            "contractVersion", "cashflow-month-close-v1",
+            "tenantId", "tenant-a",
+            "projectId", "project-a",
+            "yearMonth", "2026-08",
+            "status", "CLOSED",
+            "revision", 1L,
+            "reopenCount", 0L
+        ));
         String targetRevision = FirestoreInheritedWeeklyExpensePersistence.computeCashflowTargetRevision(List.of());
         CashflowSheetLabApplyRequest july = monthlyRequest("batch-late-july", targetRevision, "2026-07", "");
         CashflowSheetLabApplyRequest august = monthlyRequest("batch-late-august", targetRevision, "2026-08", "");
@@ -809,6 +815,8 @@ class FirestoreCashflowLeaseGuardTest {
             .isInstanceOfSatisfying(WeeklyExpenseEditLeaseException.class, error -> {
                 assertThat(error.statusCode()).isEqualTo(409);
                 assertThat(error.code()).isEqualTo("cashflow_closed_month_reason_required");
+                assertThat(error.details().get("closedMonths"))
+                    .isEqualTo(List.of("2026-07", "2026-08"));
             });
         assertThat(fixture.documents.keySet()).noneMatch(path -> path.contains("/cashflow_weeks/"));
         assertThat(fixture.documents.keySet()).noneMatch(path -> path.contains("/cashflow_month_amendments/"));
@@ -834,9 +842,13 @@ class FirestoreCashflowLeaseGuardTest {
             .containsEntry("amendmentCount", 1L)
             .containsEntry("postDeadlineAmendmentWarningCount", 1L)
             .containsEntry("lastAmendmentReason", "결산 후 다중 월 입금액 정정");
+        assertThat(fixture.documents.get("orgs/tenant-a/monthly_closes/project-a-2026-08"))
+            .containsEntry("amendmentCount", 1L)
+            .containsEntry("postDeadlineAmendmentWarningCount", 1L)
+            .containsEntry("lastAmendmentReason", "결산 후 다중 월 입금액 정정");
         assertThat(fixture.documents.keySet().stream()
             .filter(path -> path.contains("/cashflow_month_amendments/")))
-            .hasSize(1);
+            .hasSize(2);
         assertThat(fixture.documents.keySet().stream()
             .filter(path -> path.contains("/weekly_api_audit_events/")))
             .hasSize(1);
@@ -1555,7 +1567,7 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
-    void lockedCashflowWeekRejectsProjectionUntilAReasonedReopen() {
+    void lockedCashflowWeekRemainsOperationalStatusWhileProjectionChanges() {
         Fixture fixture = fixture(activeMember(), Map.of());
         fixture.documents.put(
             "orgs/tenant-a/cashflow_weeks/project-a-2026-07-w3",
@@ -1578,58 +1590,21 @@ class FirestoreCashflowLeaseGuardTest {
             service.completeCashflowWeeklyUpdate(ACTOR, "project-a", lock)
         );
 
-        assertThatThrownBy(() -> fixture.persistence.runCommandTransaction(() -> service.upsertProjection(
+        assertThatCode(() -> fixture.persistence.runCommandTransaction(() -> service.upsertProjection(
             ACTOR,
             "project-a",
             FINAL_SESSION,
             new UpsertProjectionRequest("projection-while-locked", List.of(
                 new UpsertProjectionRequest.ProjectionLinePatch("2026-07", 3, "SALES_IN", BigDecimal.valueOf(200))
             ))
-        )))
-            .isInstanceOf(WeeklyExpenseConflictException.class)
-            .hasMessageContaining("locked");
-
-        assertThatThrownBy(() -> fixture.persistence.runCommandTransaction(() ->
-            service.reopenCashflowWeeklyUpdate(
-                ACTOR,
-                "project-a",
-                new ReopenCashflowWeeklyUpdateRequest("weekly-reopen-empty", "2026-07", 3, 1, "")
-            )
-        )).isInstanceOf(IllegalArgumentException.class);
-
-        CashflowWeeklyUpdateCompletionResponse reopened = fixture.persistence.runCommandTransaction(() ->
-            service.reopenCashflowWeeklyUpdate(
-                ACTOR,
-                "project-a",
-                new ReopenCashflowWeeklyUpdateRequest("weekly-reopen-1", "2026-07", 3, 1, "긴급 정정")
-            )
-        );
-        assertThat(reopened.status()).isEqualTo("OPEN");
-        assertThat(reopened.revision()).isEqualTo(2L);
-
-        assertThatCode(() -> fixture.persistence.runCommandTransaction(() -> service.upsertProjection(
-            ACTOR,
-            "project-a",
-            FINAL_SESSION,
-            new UpsertProjectionRequest("projection-after-reopen", List.of(
-                new UpsertProjectionRequest.ProjectionLinePatch("2026-07", 3, "SALES_IN", BigDecimal.valueOf(200))
-            ))
         ))).doesNotThrowAnyException();
 
-        CashflowWeeklyUpdateCompletionResponse relocked = fixture.persistence.runCommandTransaction(() ->
-            service.completeCashflowWeeklyUpdate(
-                ACTOR,
-                "project-a",
-                new CompleteCashflowWeeklyUpdateRequest(
-                    "weekly-lock-2", "2026-07", 3, "2026-07-16T11:00:00Z"
-                )
-            )
-        );
-        assertThat(relocked.status()).isEqualTo("LOCKED");
-        assertThat(relocked.revision()).isEqualTo(3L);
-        assertThat(fixture.documents).containsKey(
-            "orgs/tenant-a/cashflow_weekly_update_completion_versions/project-a-2026-07-w3-r3"
-        );
+        assertThat(fixture.documents.get("orgs/tenant-a/cashflow_weeks/project-a-2026-07-w3"))
+            .hasEntrySatisfying("projection", value -> assertThat((Map<String, Object>) value)
+                .containsEntry("SALES_IN", 200L));
+        assertThat(fixture.documents.get(
+            "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w3"
+        )).containsEntry("status", "LOCKED");
     }
 
     @Test
@@ -1659,129 +1634,31 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
-    void sheetApplyRejectsALockedChangedWeekWithoutPartialCanonicalWrites() {
+    void sheetApplyChangesASettledWeekWithoutWeeklyConfirmation() {
         Fixture fixture = fixture(activeMember(), activeLease());
         fixture.documents.put(
             "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w3",
             lockedWeeklyCompletion("2026-07", 3, 1)
         );
         String targetRevision = FirestoreInheritedWeeklyExpensePersistence.computeCashflowTargetRevision(List.of());
-
-        CashflowSheetLabApplyRequest unconfirmed = monthlyRequest("locked-sheet-apply", targetRevision, "");
-        Throwable initialError = catchThrowable(() -> fixture.persistence.runCommandTransaction(() -> commandService(
+        CashflowSheetLabApplyResponse response = fixture.persistence.runCommandTransaction(() -> commandService(
             fixture.persistence
         ).applyCashflowSheetLab(
             ACTOR,
             "project-a",
             SESSION,
-            unconfirmed
-        )));
-        assertThat(initialError)
-            .isInstanceOf(CashflowSettledWeekChangeConfirmationRequiredException.class)
-            .hasMessageContaining("다릅니다");
-        CashflowSettledWeekChangeConfirmationRequiredException initialConfirmation =
-            (CashflowSettledWeekChangeConfirmationRequiredException) initialError;
+            monthlyRequest("locked-sheet-apply", targetRevision, "")
+        ));
 
-        assertThat(fixture.documents.keySet()).noneMatch(path -> path.contains("/cashflow_weeks/"));
-
-        CashflowSheetLabApplyRequest forgedConfirmation = new CashflowSheetLabApplyRequest(
-            "locked-sheet-apply-forged",
-            unconfirmed.sourceRevision(),
-            unconfirmed.targetRevision(),
-            unconfirmed.yearMonth(),
-            unconfirmed.replaceAllActualSources(),
-            new CashflowSettledWeekChangeConfirmation(
-                "9999999999.forgedconfirmationtoken0000000000.invalid",
-                targetRevision,
-                initialConfirmation.weeks()
-            ),
-            null,
-            unconfirmed.cells()
-        );
-        assertThatThrownBy(() -> fixture.persistence.runCommandTransaction(() -> commandService(
-            fixture.persistence
-        ).applyCashflowSheetLab(ACTOR, "project-a", SESSION, forgedConfirmation)))
-            .isInstanceOf(dev.merryai.innerplatform.weekly.api.CashflowSettledWeekChangeConfirmationExpiredException.class);
-
-        String completionPath = "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w3";
-        Map<String, Object> unlockedCompletion = new LinkedHashMap<>(fixture.documents.get(completionPath));
-        unlockedCompletion.put("status", "OPEN");
-        fixture.documents.put(completionPath, unlockedCompletion);
-        CashflowSheetLabApplyRequest expiredConfirmation = new CashflowSheetLabApplyRequest(
-            "locked-sheet-apply-expired",
-            unconfirmed.sourceRevision(),
-            unconfirmed.targetRevision(),
-            unconfirmed.yearMonth(),
-            unconfirmed.replaceAllActualSources(),
-            new CashflowSettledWeekChangeConfirmation(
-                initialConfirmation.confirmationId(), targetRevision, initialConfirmation.weeks()
-            ),
-            null,
-            unconfirmed.cells()
-        );
-        assertThatThrownBy(() -> fixture.persistence.runCommandTransaction(() -> commandService(
-            fixture.persistence
-        ).applyCashflowSheetLab(ACTOR, "project-a", SESSION, expiredConfirmation)))
-            .isInstanceOf(dev.merryai.innerplatform.weekly.api.CashflowSettledWeekChangeConfirmationExpiredException.class);
-        fixture.documents.put(completionPath, lockedWeeklyCompletion("2026-07", 3, 1));
-        Map<String, Object> revisedCompletion = new LinkedHashMap<>(fixture.documents.get(completionPath));
-        revisedCompletion.put("revision", 2L);
-        fixture.documents.put(completionPath, revisedCompletion);
-        CashflowSheetLabApplyRequest staleConfirmation = new CashflowSheetLabApplyRequest(
-            "locked-sheet-apply-confirmed",
-            unconfirmed.sourceRevision(),
-            unconfirmed.targetRevision(),
-            unconfirmed.yearMonth(),
-            unconfirmed.replaceAllActualSources(),
-            new CashflowSettledWeekChangeConfirmation(
-                initialConfirmation.confirmationId(),
-                targetRevision,
-                initialConfirmation.weeks()
-            ),
-            null,
-            unconfirmed.cells()
-        );
-        Throwable staleError = catchThrowable(() -> fixture.persistence.runCommandTransaction(() -> commandService(
-            fixture.persistence
-        ).applyCashflowSheetLab(ACTOR, "project-a", SESSION, staleConfirmation)));
-        assertThat(staleError).isInstanceOf(CashflowSettledWeekChangeConfirmationRequiredException.class);
-        CashflowSettledWeekChangeConfirmationRequiredException freshConfirmation =
-            (CashflowSettledWeekChangeConfirmationRequiredException) staleError;
-        assertThat(fixture.documents.keySet()).noneMatch(path -> path.contains("/cashflow_weeks/"));
-
-        CashflowSheetLabApplyRequest confirmed = new CashflowSheetLabApplyRequest(
-            "locked-sheet-apply-confirmed-fresh",
-            unconfirmed.sourceRevision(),
-            unconfirmed.targetRevision(),
-            unconfirmed.yearMonth(),
-            unconfirmed.replaceAllActualSources(),
-            new CashflowSettledWeekChangeConfirmation(
-                freshConfirmation.confirmationId(),
-                targetRevision,
-                freshConfirmation.weeks()
-            ),
-            null,
-            unconfirmed.cells()
-        );
-        CashflowSheetLabApplyResponse response = fixture.persistence.runCommandTransaction(() -> commandService(
-            fixture.persistence
-        ).applyCashflowSheetLab(ACTOR, "project-a", SESSION, confirmed));
-
-        assertThat(response.settledWeekChanges()).singleElement().satisfies(change -> {
-            assertThat(change.yearMonth()).isEqualTo("2026-07");
-            assertThat(change.weekNo()).isEqualTo(3);
-            assertThat(change.completionRevision()).isEqualTo(2);
-            assertThat(change.warningCount()).isEqualTo(1);
-        });
+        assertThat(response.settledWeekChanges()).isEmpty();
+        assertThat(fixture.documents.keySet()).anyMatch(path -> path.contains("/cashflow_weeks/"));
         assertThat(fixture.documents.get(
-            completionPath
+            "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w3"
         ))
             .containsEntry("status", "LOCKED")
-            .containsEntry("postSettlementChangeWarningCount", 1L)
-            .containsEntry("lastPostSettlementChangeByUid", ACTOR.id())
-            .containsEntry("lastPostSettlementChangeTargetRevisionBefore", targetRevision);
+            .doesNotContainKeys("postSettlementChangeWarningCount", "lastPostSettlementChangeByUid");
         assertThat(fixture.documents.keySet())
-            .anyMatch(path -> path.contains("/cashflow_weekly_settlement_change_warnings/"));
+            .noneMatch(path -> path.contains("/cashflow_weekly_settlement_change_warnings/"));
     }
 
     @Test
@@ -1883,7 +1760,7 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
-    void weeklyExpenseActualReplacementRejectsALockedChangedWeek() {
+    void weeklyExpenseActualReplacementIgnoresWeeklySettlementStatus() {
         Fixture fixture = fixture(activeMember(), activeLease());
         fixture.documents.put(weekPath(), draftWeek());
         fixture.documents.put(
@@ -1891,7 +1768,7 @@ class FirestoreCashflowLeaseGuardTest {
             lockedWeeklyCompletion("2026-07", 1, 1)
         );
 
-        assertThatThrownBy(() -> fixture.persistence.runCommandTransaction(() -> {
+        assertThatCode(() -> fixture.persistence.runCommandTransaction(() -> {
             fixture.persistence.requireCashflowWritePermission(ACTOR, "project-a");
             fixture.persistence.replaceActualLines(
                 "tenant-a",
@@ -1902,13 +1779,14 @@ class FirestoreCashflowLeaseGuardTest {
                 ))
             );
             return null;
-        }))
-            .isInstanceOf(WeeklyExpenseConflictException.class)
-            .hasMessageContaining("locked");
+        })).doesNotThrowAnyException();
+        assertThat(fixture.documents.get(weekPath()))
+            .hasEntrySatisfying("actual", value -> assertThat((Map<String, Object>) value)
+                .containsEntry("SALES_IN", 50L));
     }
 
     @Test
-    void weeklySheetActualReplacementRejectsALockedChangedWeek() {
+    void weeklySheetActualReplacementIgnoresWeeklySettlementStatus() {
         Fixture fixture = fixture(activeMember(), activeLease());
         fixture.documents.put(weekPath(), draftWeek());
         fixture.documents.put(
@@ -1919,7 +1797,7 @@ class FirestoreCashflowLeaseGuardTest {
             "tenant-a", "project-a", "default", "Default"
         );
 
-        assertThatThrownBy(() -> fixture.persistence.runCommandTransaction(() -> {
+        assertThatCode(() -> fixture.persistence.runCommandTransaction(() -> {
             fixture.persistence.requireCashflowWritePermission(ACTOR, "project-a");
             fixture.persistence.replaceActuals(
                 sheet,
@@ -1928,13 +1806,14 @@ class FirestoreCashflowLeaseGuardTest {
                 ))
             );
             return null;
-        }))
-            .isInstanceOf(WeeklyExpenseConflictException.class)
-            .hasMessageContaining("locked");
+        })).doesNotThrowAnyException();
+        assertThat(fixture.documents.get(weekPath()))
+            .hasEntrySatisfying("actual", value -> assertThat((Map<String, Object>) value)
+                .containsEntry("SALES_IN", 50L));
     }
 
     @Test
-    void submitAndCloseCommandsCannotChangeStatusInsideALockedWeek() {
+    void submitAndCloseCommandsIgnoreWeeklySettlementStatus() {
         Fixture submitFixture = fixture(activeMember(), activeLease());
         submitFixture.documents.put(weekPath(), draftWeek());
         submitFixture.documents.put(
@@ -1942,16 +1821,14 @@ class FirestoreCashflowLeaseGuardTest {
             lockedWeeklyCompletion("2026-07", 1, 1)
         );
 
-        assertThatThrownBy(() -> submitFixture.persistence.runCommandTransaction(() -> commandService(
+        assertThatCode(() -> submitFixture.persistence.runCommandTransaction(() -> commandService(
             submitFixture.persistence
         ).submitWeek(
             ACTOR,
             "project-a",
             SESSION,
             new SubmitWeekRequest("locked-submit", "2026-07", 1)
-        )))
-            .isInstanceOf(WeeklyExpenseConflictException.class)
-            .hasMessageContaining("locked");
+        ))).doesNotThrowAnyException();
 
         Fixture closeFixture = fixture(
             member(Map.of("role", "finance", "projectIds", List.of())),
@@ -1963,20 +1840,18 @@ class FirestoreCashflowLeaseGuardTest {
             lockedWeeklyCompletion("2026-07", 1, 1)
         );
 
-        assertThatThrownBy(() -> closeFixture.persistence.runCommandTransaction(() -> commandService(
+        assertThatCode(() -> closeFixture.persistence.runCommandTransaction(() -> commandService(
             closeFixture.persistence
         ).closeWeek(
             ACTOR,
             "project-a",
             SESSION,
             closeRequest("locked-close", BigDecimal.valueOf(100))
-        )))
-            .isInstanceOf(WeeklyExpenseConflictException.class)
-            .hasMessageContaining("locked");
+        ))).doesNotThrowAnyException();
     }
 
     @Test
-    void submitWithASheetPreReadsTheWeekLockBeforeItsFirstWrite() {
+    void submitWithASheetDoesNotReadWeeklySettlementAsAWriteGuard() {
         Fixture fixture = fixture(activeMember(), activeLease());
         fixture.documents.put(weekPath(), draftWeek());
         SubmitWeekRequest request = new SubmitWeekRequest(
@@ -1993,15 +1868,10 @@ class FirestoreCashflowLeaseGuardTest {
             request
         ));
 
-        org.mockito.InOrder order = inOrder(fixture.transaction);
-        order.verify(fixture.transaction).get(argThat((DocumentReference ref) -> ref.getPath().equals(
+        verify(fixture.transaction, never()).get(argThat((DocumentReference ref) -> ref.getPath().equals(
             "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w1"
         )));
-        order.verify(fixture.transaction).set(
-            argThat((DocumentReference ref) -> ref.getPath().equals(sheetPath())),
-            any(),
-            any()
-        );
+        verify(fixture.transaction).set(argThat((DocumentReference ref) -> ref.getPath().equals(sheetPath())), any(), any());
     }
 
     @Test

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -201,29 +201,6 @@ function bffErrorCode(error: unknown): string {
   return source.body?.code || source.body?.error || '';
 }
 
-function settledWeekConfirmation(error: unknown): { confirmationId: string; labels: string[] } | null {
-  const source = error as {
-    body?: {
-      details?: {
-        confirmationId?: unknown;
-        weeks?: Array<{ yearMonth?: unknown; weekNo?: unknown }>;
-      };
-    };
-  };
-  if (bffErrorCode(error) !== 'cashflow_settled_week_change_confirmation_required') return null;
-  const confirmationId = typeof source.body?.details?.confirmationId === 'string'
-    ? source.body.details.confirmationId.trim()
-    : '';
-  const labels = (Array.isArray(source.body?.details?.weeks) ? source.body.details.weeks : [])
-    .map((week) => (
-      typeof week?.yearMonth === 'string' && Number.isInteger(Number(week?.weekNo))
-        ? `${week.yearMonth} ${Number(week.weekNo)}주차`
-        : ''
-    ))
-    .filter(Boolean);
-  return confirmationId && labels.length > 0 ? { confirmationId, labels } : null;
-}
-
 export function CashflowProjectSheet({
   projectId,
   projectName,
@@ -329,12 +306,6 @@ export function CashflowProjectSheet({
   const [sheetReviewDialogOpen, setSheetReviewDialogOpen] = useState(false);
   const [lateSheetApply, setLateSheetApply] = useState<CashflowSheetLabStageResult | null>(null);
   const [lateSheetChangeReason, setLateSheetChangeReason] = useState('');
-  const [settledSheetApply, setSettledSheetApply] = useState<{
-    stage: CashflowSheetLabStageResult;
-    confirmationId: string;
-    labels: string[];
-    closedMonthChangeReason: string;
-  } | null>(null);
   const [sheetStageApplyLoading, setSheetStageApplyLoading] = useState(false);
   const [cashflowEvents, setCashflowEvents] = useState<CashflowEvent[]>([]);
   const [cashflowEventsError, setCashflowEventsError] = useState<string | null>(null);
@@ -1220,7 +1191,6 @@ export function CashflowProjectSheet({
   const handleApplyStagedSheetValues = useCallback(async (
     stage: CashflowSheetLabStageResult,
     closedMonthChangeReason = '',
-    settledWeekChangeConfirmationId = '',
   ): Promise<void> => {
     if (!stage.runId || stage.stagedLineCount <= 0) return;
     const applyIdempotencyKey = `cashflow-sheet-apply-stage:${projectId}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
@@ -1232,7 +1202,6 @@ export function CashflowProjectSheet({
         stageRunId: stage.runId,
         applyRiskCandidates: true,
         closedMonthChangeReason,
-        settledWeekChangeConfirmationId: settledWeekChangeConfirmationId || undefined,
         idempotencyKey: applyIdempotencyKey,
       });
     };
@@ -1251,7 +1220,6 @@ export function CashflowProjectSheet({
       } : current);
       setLateSheetApply(null);
       setLateSheetChangeReason('');
-      setSettledSheetApply(null);
       toast.success(`시트 최신값 ${result.appliedLineCount.toLocaleString()}건을 원장에 반영했습니다.`);
     };
 
@@ -1289,15 +1257,6 @@ export function CashflowProjectSheet({
       if (bffErrorCode(finalError) === 'cashflow_closed_month_reason_required') {
         setLateSheetApply(stage);
         setLateSheetChangeReason('');
-        return;
-      }
-      const confirmation = settledWeekConfirmation(finalError);
-      if (confirmation) {
-        setSettledSheetApply({
-          stage,
-          ...confirmation,
-          closedMonthChangeReason,
-        });
         return;
       }
       toast.error(resolveApiErrorMessage(finalError, '시트 값을 원장에 반영하지 못했습니다.'));
@@ -2920,43 +2879,6 @@ export function CashflowProjectSheet({
         </AlertDialogContent>
       </AlertDialog>
 
-      <AlertDialog
-        open={!!settledSheetApply}
-        onOpenChange={(open) => {
-          if (!open && !sheetStageApplyLoading) setSettledSheetApply(null);
-        }}
-      >
-        <AlertDialogContent className="w-[calc(100vw-2rem)] max-w-[420px]">
-          <AlertDialogHeader>
-            <AlertDialogTitle>주간 정산 값과 다릅니다</AlertDialogTitle>
-            <AlertDialogDescription>
-              정산 완료 후 시트 값이 바뀐 주차입니다. 반영하면 잠금은 유지되고 변경 경고와 작업자가 서버 이력에 기록됩니다.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-[12px] leading-5 text-slate-700">
-            {settledSheetApply?.labels.slice(0, 4).map((label) => <div key={label}>{label}</div>)}
-            {(settledSheetApply?.labels.length || 0) > 4 && (
-              <div>외 {(settledSheetApply?.labels.length || 0) - 4}개 주차</div>
-            )}
-          </div>
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={sheetStageApplyLoading}>취소</AlertDialogCancel>
-            <Button
-              type="button"
-              className="bg-[#17324D] hover:bg-slate-800"
-              disabled={sheetStageApplyLoading || !settledSheetApply}
-              onClick={() => settledSheetApply && void handleApplyStagedSheetValues(
-                settledSheetApply.stage,
-                settledSheetApply.closedMonthChangeReason,
-                settledSheetApply.confirmationId,
-              )}
-            >
-              {sheetStageApplyLoading ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <Save className="mr-1.5 h-3.5 w-3.5" />}
-              경고 기록 후 반영
-            </Button>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
 
       <AlertDialog
         open={blocker.state === 'blocked'}

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1255,7 +1255,15 @@ export function CashflowProjectSheet({
       }
       logCashflowSettlement({ phase: 'error', operation: 'cashflow.sheet_apply', projectId, error: finalError });
       if (bffErrorCode(finalError) === 'cashflow_closed_month_reason_required') {
-        setLateSheetApply(stage);
+        const details = (finalError as {
+          body?: { details?: { closedMonthDifferences?: CashflowSheetLabStageResult['closedMonthDifferences'] } };
+        }).body?.details;
+        setLateSheetApply({
+          ...stage,
+          closedMonthDifferences: details?.closedMonthDifferences?.length
+            ? details.closedMonthDifferences
+            : stage.closedMonthDifferences,
+        });
         setLateSheetChangeReason('');
         return;
       }

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
@@ -50,8 +50,9 @@ describe('CashflowSheetLabPage shell', () => {
     expect(pageSource).toContain('saveCashflowSheetLabConfigViaBff');
     expect(pageSource).toContain('stageCashflowSheetLabViaBff');
     expect(pageSource).toContain('applyCashflowSheetLabViaBff');
-    expect(pageSource).toContain('settledWeekChangeConfirmationId: pending.confirmationId');
-    expect(pageSource).toContain('주간 정산 값과 다릅니다');
+    expect(pageSource).not.toContain('settledWeekChangeConfirmationId: pending.confirmationId');
+    expect(pageSource).not.toContain('주간 정산 값과 다릅니다');
+    expect(pageSource).toContain('cashflow_closed_month_reason_required');
     expect(pageSource).toContain('stageRunId: stagedRunId');
     expect(pageSource).toContain('getCashflowSheetLabShareAccountViaBff');
     expect(pageSource).toContain('resolveBffActor');

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
@@ -53,7 +53,8 @@ describe('CashflowSheetLabPage shell', () => {
     expect(pageSource).not.toContain('settledWeekChangeConfirmationId: pending.confirmationId');
     expect(pageSource).not.toContain('주간 정산 값과 다릅니다');
     expect(pageSource).toContain('cashflow_closed_month_reason_required');
-    expect(pageSource).toContain('stageRunId: stagedRunId');
+    expect(pageSource).toContain('stageRunId: staged.runId');
+    expect(pageSource).toContain('handleOverwriteSheetValues(closedMonthChangeReason.trim(), closedMonthStage)');
     expect(pageSource).toContain('getCashflowSheetLabShareAccountViaBff');
     expect(pageSource).toContain('resolveBffActor');
     expect(pageSource).toContain('requireBffActor');
@@ -82,7 +83,7 @@ describe('CashflowSheetLabPage shell', () => {
     expect(pageSource).toContain('buildSourceKey');
     expect(pageSource).toContain('reviewedSourceKey === sourceKey');
     expect(pageSource).toContain('buildSourceKey({ projectId, sourceYear, value: sheetLink, sheetName: nextSheetName, startWeek, endWeek })');
-    expect(pageSource).toContain('expectedMirrorRevision: mirror.sourceRevision');
+    expect(pageSource).toContain('expectedMirrorRevision,');
     expect(pageSource).toContain('const refreshIdempotencyKey =');
     expect(pageSource).toContain('const stageIdempotencyKey =');
     expect(pageSource).toContain('const applyIdempotencyKey =');
@@ -133,10 +134,10 @@ describe('CashflowSheetLabPage shell', () => {
     expect(pageSource).not.toContain('applyDialogOpen');
     expect(pageSource).toContain('별도 운영자 검토는 없으며');
     expect(pageSource).toContain("staged.status === 'BLOCKED'");
-    expect(pageSource).toContain('staged.closedMonthDifferences');
+    expect(pageSource).toContain('staged?.closedMonthDifferences');
     expect(pageSource).toContain('결산 후 값이 달라요');
     expect(pageSource).toContain('외 ${hiddenWeekCount}개 주차');
-    expect(pageSource).toContain('월 결산으로 이동');
+    expect(pageSource).toContain('캐시플로우로 이동');
     expect(pageSource).toContain('max-w-[360px]');
     expect(pageSource).toContain('max-h-28');
     expect(pageSource).not.toContain('stageCandidates');

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
@@ -58,28 +58,6 @@ function getErrorCode(error: unknown) {
   return apiError?.code || apiError?.body?.code || apiError?.body?.error || '';
 }
 
-function settledWeekConfirmationFromError(error: unknown) {
-  const apiError = error as {
-    body?: {
-      details?: {
-        confirmationId?: unknown;
-        weeks?: Array<{ yearMonth?: unknown; weekNo?: unknown }>;
-      };
-    };
-  };
-  if (getErrorCode(error) !== 'cashflow_settled_week_change_confirmation_required') return null;
-  const confirmationId = typeof apiError?.body?.details?.confirmationId === 'string'
-    ? apiError.body.details.confirmationId.trim()
-    : '';
-  const weeks = Array.isArray(apiError?.body?.details?.weeks) ? apiError.body.details.weeks : [];
-  const labels = weeks.map((week) => (
-    typeof week?.yearMonth === 'string' && Number.isInteger(Number(week?.weekNo))
-      ? `${week.yearMonth} ${Number(week.weekNo)}주차`
-      : ''
-  )).filter(Boolean);
-  return confirmationId && labels.length > 0 ? { confirmationId, labels } : null;
-}
-
 function logCashflowLab(event: string, details: Record<string, unknown>, level: 'info' | 'warn' = 'info') {
   recordDevtoolsLog({
     kind: 'cashflow_transaction',
@@ -307,11 +285,7 @@ export function CashflowSheetLabPage({
   const [errorMessage, setErrorMessage] = useState('');
   const [statusMessage, setStatusMessage] = useState('');
   const [closedMonthWarning, setClosedMonthWarning] = useState<NonNullable<CashflowSheetLabStageResult['closedMonthDifferences']>>([]);
-  const [settledWeekWarning, setSettledWeekWarning] = useState<{
-    labels: string[];
-    stageRunId: string;
-    confirmationId: string;
-  } | null>(null);
+  const [closedMonthChangeReason, setClosedMonthChangeReason] = useState('');
   const [loading, setLoading] = useState(false);
   const [accountLoading, setAccountLoading] = useState(false);
   const [tutorialOpen, setTutorialOpen] = useState(false);
@@ -733,18 +707,19 @@ export function CashflowSheetLabPage({
     }
   }
 
-  async function handleOverwriteSheetValues() {
+  async function handleOverwriteSheetValues(monthCloseChangeReason = '') {
     if (!projectId || loading || !spreadsheetId || mirror?.status !== 'FRESH' || !mirror.sourceRevision || reviewedSourceKey !== sourceKey) return;
     const startedAt = Date.now();
     const stageIdempotencyKey = `cashflow-sheet-lab-stage:${projectId}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
     const applyIdempotencyKey = `cashflow-sheet-lab-apply:${projectId}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
     let activeStep: 'stage' | 'apply' = 'stage';
     let stagedRunId = '';
+    let closedMonthDifferences: NonNullable<CashflowSheetLabStageResult['closedMonthDifferences']> = [];
     setLoading(true);
     setErrorMessage('');
     setStatusMessage('');
     setClosedMonthWarning([]);
-    setSettledWeekWarning(null);
+    setClosedMonthChangeReason('');
     setReflectResult(null);
     logCashflowLab('overwrite.sheet_values.start', {
       projectId,
@@ -776,6 +751,7 @@ export function CashflowSheetLabPage({
       }
       const stageDurationMs = Date.now() - stageStartedAt;
       stagedRunId = staged.runId || '';
+      closedMonthDifferences = staged.closedMonthDifferences || [];
       setReviewedSourceKey(sourceKey);
       logCashflowLab('stage.sheet_values.ok', {
         projectId,
@@ -788,19 +764,15 @@ export function CashflowSheetLabPage({
         durationMs: stageDurationMs,
         totalDurationMs: Date.now() - startedAt,
       });
-      if (staged.status === 'BLOCKED' || staged.riskLineCount > 0) {
+      if (staged.status === 'BLOCKED') {
         logCashflowLab('overwrite.sheet_values.blocked', {
           projectId,
           spreadsheetId,
           riskLineCount: staged.riskLineCount,
           durationMs: Date.now() - startedAt,
         }, 'warn');
-        if ((staged.closedMonthDifferences || []).length > 0) {
-          setClosedMonthWarning(staged.closedMonthDifferences || []);
-        } else {
-          const blockedMonths = staged.blockedMonths?.join(', ');
-          setErrorMessage(`반영할 수 없는 시트 범위가 있습니다.${blockedMonths ? ` 확인할 월: ${blockedMonths}` : ''}`);
-        }
+        const blockedMonths = staged.blockedMonths?.join(', ');
+        setErrorMessage(`반영할 수 없는 시트 범위가 있습니다.${blockedMonths ? ` 확인할 월: ${blockedMonths}` : ''}`);
         return;
       }
       if (staged.stagedLineCount === 0) {
@@ -829,6 +801,7 @@ export function CashflowSheetLabPage({
           actor: requestActor,
           projectId,
           stageRunId: staged.runId,
+          closedMonthChangeReason: monthCloseChangeReason,
           idempotencyKey: applyIdempotencyKey,
         })
       ));
@@ -881,61 +854,11 @@ export function CashflowSheetLabPage({
         totalDurationMs: Date.now() - startedAt,
         ...errorDiagnostics(error),
       }, 'warn');
-      const settledWeekConfirmation = settledWeekConfirmationFromError(error);
-      if (activeStep === 'apply' && settledWeekConfirmation) {
-        if (stagedRunId) {
-          setSettledWeekWarning({ ...settledWeekConfirmation, stageRunId: stagedRunId });
-        } else {
-          setErrorMessage(formatError(error));
-        }
+      if (activeStep === 'apply' && getErrorCode(error) === 'cashflow_closed_month_reason_required') {
+        setClosedMonthWarning(closedMonthDifferences);
       } else {
         setErrorMessage(formatError(error));
       }
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function confirmSettledWeekChanges() {
-    if (!settledWeekWarning || loading) return;
-    const pending = settledWeekWarning;
-    const startedAt = Date.now();
-    setLoading(true);
-    setErrorMessage('');
-    try {
-      const result = await runWithBffAuthRetry('apply.settled_week_changes', (requestActor) => (
-        applyCashflowSheetLabViaBff({
-          tenantId: orgId,
-          actor: requestActor,
-          projectId,
-          stageRunId: pending.stageRunId,
-          settledWeekChangeConfirmationId: pending.confirmationId,
-          idempotencyKey: `cashflow-sheet-lab-settled-change:${projectId}:${Date.now()}:${Math.random().toString(16).slice(2)}`,
-        })
-      ));
-      if (!result) return;
-      setSettledWeekWarning(null);
-      setReflectResult({
-        appliedLineCount: result.appliedLineCount,
-        projectionLineCount: result.projectionLineCount,
-        actualLineCount: result.actualLineCount,
-        skippedRiskLineCount: result.skippedRiskLineCount,
-        lastAppliedAt: result.lastAppliedAt,
-      });
-      const warningCount = result.settledWeekChanges?.length || pending.labels.length;
-      setStatusMessage(`시트 값을 반영하고 정산 후 변경 경고 ${warningCount}건을 기록했습니다.`);
-      logCashflowLab('apply.settled_week_changes.ok', {
-        projectId,
-        settledWeekChangeCount: warningCount,
-        durationMs: Date.now() - startedAt,
-      }, 'warn');
-    } catch (error) {
-      setErrorMessage(formatError(error));
-      logCashflowLab('apply.settled_week_changes.error', {
-        projectId,
-        durationMs: Date.now() - startedAt,
-        ...errorDiagnostics(error),
-      }, 'warn');
     } finally {
       setLoading(false);
     }
@@ -1161,7 +1084,7 @@ export function CashflowSheetLabPage({
           <DialogHeader className="space-y-1 text-left">
             <DialogTitle className="text-[17px]">결산 후 값이 달라요</DialogTitle>
             <DialogDescription className="text-[12px] leading-relaxed text-slate-600">
-              결산 원장과 시트값이 다른 주차입니다. 급한 수정은 월 결산을 재오픈한 뒤 다시 반영해 주세요.
+              월 결산 이후 변경입니다. 사유를 남기면 변경 이력과 경고 횟수에 함께 기록됩니다.
             </DialogDescription>
           </DialogHeader>
           <div className="max-h-28 space-y-1 overflow-y-auto rounded-lg bg-amber-50 px-3 py-2 text-[12px] font-semibold text-amber-950">
@@ -1170,48 +1093,24 @@ export function CashflowSheetLabPage({
             ))}
             {closedMonthWarning.length > 3 && <div>외 {closedMonthWarning.length - 3}개 월</div>}
           </div>
+          <textarea
+            value={closedMonthChangeReason}
+            onChange={(event) => setClosedMonthChangeReason(event.target.value.slice(0, 1000))}
+            placeholder="예: 결산 후 확인된 실제 입금액 정정"
+            className="min-h-20 w-full rounded-lg border border-slate-300 px-3 py-2 text-[13px]"
+            disabled={loading}
+          />
           <DialogFooter className="flex-row justify-end gap-2 sm:space-x-0">
             <Button type="button" variant="outline" className="h-9" onClick={() => setClosedMonthWarning([])}>
               닫기
             </Button>
-            <Button
-              type="button"
-              className="h-9"
-              onClick={() => {
-                setClosedMonthWarning([]);
-                navigate(`/portal/cashflow/${encodeURIComponent(projectId)}`);
-              }}
-            >
-              월 결산으로 이동
+            <Button type="button" className="h-9" disabled={loading || !closedMonthChangeReason.trim()} onClick={() => void handleOverwriteSheetValues(closedMonthChangeReason.trim())}>
+              사유와 함께 반영
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
-      <Dialog open={settledWeekWarning !== null} onOpenChange={(open) => !open && setSettledWeekWarning(null)}>
-        <DialogContent className="max-w-[380px] gap-4 rounded-xl p-5 sm:max-w-[380px]">
-          <DialogHeader className="space-y-1 text-left">
-            <DialogTitle className="text-[17px]">주간 정산 값과 다릅니다</DialogTitle>
-            <DialogDescription className="text-[12px] leading-relaxed text-slate-600">
-              시트값을 반영하면 정산 이후 변경으로 기록되고 경고가 누적됩니다. 그래도 반영하시겠습니까?
-            </DialogDescription>
-          </DialogHeader>
-          <div className="max-h-28 space-y-1 overflow-y-auto rounded-lg bg-amber-50 px-3 py-2 text-[12px] font-semibold text-amber-950">
-            {settledWeekWarning?.labels.slice(0, 4).map((label) => <div key={label}>{label}</div>)}
-            {(settledWeekWarning?.labels.length || 0) > 4 && (
-              <div>외 {(settledWeekWarning?.labels.length || 0) - 4}개 주차</div>
-            )}
-          </div>
-          <DialogFooter className="flex-row justify-end gap-2 sm:space-x-0">
-            <Button type="button" variant="outline" className="h-9" onClick={() => setSettledWeekWarning(null)}>
-              취소
-            </Button>
-            <Button type="button" className="h-9" disabled={loading} onClick={() => void confirmSettledWeekChanges()}>
-              {loading ? '반영 중…' : '경고 기록 후 반영'}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
 
       <Dialog open={tutorialOpen} onOpenChange={handleTutorialOpenChange}>
         <DialogContent

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
@@ -58,6 +58,13 @@ function getErrorCode(error: unknown) {
   return apiError?.code || apiError?.body?.code || apiError?.body?.error || '';
 }
 
+function getClosedMonthDifferences(error: unknown) {
+  const apiError = error as {
+    body?: { details?: { closedMonthDifferences?: CashflowSheetLabStageResult['closedMonthDifferences'] } };
+  };
+  return apiError.body?.details?.closedMonthDifferences || [];
+}
+
 function logCashflowLab(event: string, details: Record<string, unknown>, level: 'info' | 'warn' = 'info') {
   recordDevtoolsLog({
     kind: 'cashflow_transaction',
@@ -285,6 +292,7 @@ export function CashflowSheetLabPage({
   const [errorMessage, setErrorMessage] = useState('');
   const [statusMessage, setStatusMessage] = useState('');
   const [closedMonthWarning, setClosedMonthWarning] = useState<NonNullable<CashflowSheetLabStageResult['closedMonthDifferences']>>([]);
+  const [closedMonthStage, setClosedMonthStage] = useState<CashflowSheetLabStageResult | null>(null);
   const [closedMonthChangeReason, setClosedMonthChangeReason] = useState('');
   const [loading, setLoading] = useState(false);
   const [accountLoading, setAccountLoading] = useState(false);
@@ -707,39 +715,51 @@ export function CashflowSheetLabPage({
     }
   }
 
-  async function handleOverwriteSheetValues(monthCloseChangeReason = '') {
-    if (!projectId || loading || !spreadsheetId || mirror?.status !== 'FRESH' || !mirror.sourceRevision || reviewedSourceKey !== sourceKey) return;
+  async function handleOverwriteSheetValues(
+    monthCloseChangeReason = '',
+    stagedOverride: CashflowSheetLabStageResult | null = null,
+  ) {
+    if (
+      !projectId
+      || loading
+      || !spreadsheetId
+      || (!stagedOverride && (mirror?.status !== 'FRESH' || !mirror.sourceRevision || reviewedSourceKey !== sourceKey))
+    ) return;
     const startedAt = Date.now();
+    const expectedMirrorRevision = mirror?.sourceRevision || '';
     const stageIdempotencyKey = `cashflow-sheet-lab-stage:${projectId}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
     const applyIdempotencyKey = `cashflow-sheet-lab-apply:${projectId}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
-    let activeStep: 'stage' | 'apply' = 'stage';
-    let stagedRunId = '';
-    let closedMonthDifferences: NonNullable<CashflowSheetLabStageResult['closedMonthDifferences']> = [];
+    let activeStep: 'stage' | 'apply' = stagedOverride ? 'apply' : 'stage';
+    let staged = stagedOverride;
+    let stageDurationMs = 0;
     setLoading(true);
     setErrorMessage('');
     setStatusMessage('');
-    setClosedMonthWarning([]);
-    setClosedMonthChangeReason('');
+    if (!stagedOverride) {
+      setClosedMonthWarning([]);
+      setClosedMonthStage(null);
+      setClosedMonthChangeReason('');
+    }
     setReflectResult(null);
     logCashflowLab('overwrite.sheet_values.start', {
       projectId,
       spreadsheetId,
     });
-    logCashflowLab('stage.sheet_values.start', {
-      projectId,
-      spreadsheetId,
-    });
     try {
-      const stageStartedAt = Date.now();
-      const staged = await runWithBffAuthRetry('stage.sheet_values', (requestActor) => (
-        stageCashflowSheetLabViaBff({
-          tenantId: orgId,
-          actor: requestActor,
-          projectId,
-          expectedMirrorRevision: mirror.sourceRevision,
-          idempotencyKey: stageIdempotencyKey,
-        })
-      ));
+      if (!staged) {
+        logCashflowLab('stage.sheet_values.start', { projectId, spreadsheetId });
+        const stageStartedAt = Date.now();
+        staged = await runWithBffAuthRetry('stage.sheet_values', (requestActor) => (
+          stageCashflowSheetLabViaBff({
+            tenantId: orgId,
+            actor: requestActor,
+            projectId,
+            expectedMirrorRevision,
+            idempotencyKey: stageIdempotencyKey,
+          })
+        ));
+        stageDurationMs = Date.now() - stageStartedAt;
+      }
       if (!staged) {
         logCashflowLab('overwrite.sheet_values.cancelled', {
           projectId,
@@ -749,21 +769,20 @@ export function CashflowSheetLabPage({
         }, 'warn');
         return;
       }
-      const stageDurationMs = Date.now() - stageStartedAt;
-      stagedRunId = staged.runId || '';
-      closedMonthDifferences = staged.closedMonthDifferences || [];
-      setReviewedSourceKey(sourceKey);
-      logCashflowLab('stage.sheet_values.ok', {
-        projectId,
-        spreadsheetId: staged.spreadsheetId,
-        sheetName: staged.selectedSheetName,
-        stagedLineCount: staged.stagedLineCount,
-        projectionLineCount: staged.projectionLineCount,
-        actualLineCount: staged.actualLineCount,
-        riskLineCount: staged.riskLineCount,
-        durationMs: stageDurationMs,
-        totalDurationMs: Date.now() - startedAt,
-      });
+      if (!stagedOverride) {
+        setReviewedSourceKey(sourceKey);
+        logCashflowLab('stage.sheet_values.ok', {
+          projectId,
+          spreadsheetId: staged.spreadsheetId,
+          sheetName: staged.selectedSheetName,
+          stagedLineCount: staged.stagedLineCount,
+          projectionLineCount: staged.projectionLineCount,
+          actualLineCount: staged.actualLineCount,
+          riskLineCount: staged.riskLineCount,
+          durationMs: stageDurationMs,
+          totalDurationMs: Date.now() - startedAt,
+        });
+      }
       if (staged.status === 'BLOCKED') {
         logCashflowLab('overwrite.sheet_values.blocked', {
           projectId,
@@ -788,6 +807,7 @@ export function CashflowSheetLabPage({
       }
       activeStep = 'apply';
       const applyStartedAt = Date.now();
+      const stagedRunId = staged.runId;
       logCashflowLab('apply.sheet_values.start', {
         projectId,
         spreadsheetId,
@@ -800,7 +820,7 @@ export function CashflowSheetLabPage({
           tenantId: orgId,
           actor: requestActor,
           projectId,
-          stageRunId: staged.runId,
+          stageRunId: stagedRunId,
           closedMonthChangeReason: monthCloseChangeReason,
           idempotencyKey: applyIdempotencyKey,
         })
@@ -824,6 +844,9 @@ export function CashflowSheetLabPage({
         skippedRiskLineCount: result.skippedRiskLineCount,
         lastAppliedAt: result.lastAppliedAt,
       });
+      setClosedMonthStage(null);
+      setClosedMonthWarning([]);
+      setClosedMonthChangeReason('');
       setStatusMessage(`시트 값 ${result.appliedLineCount.toLocaleString()}건으로 MYSCube를 덮어썼습니다.`);
       logCashflowLab('apply.sheet_values.ok', {
         projectId,
@@ -855,7 +878,13 @@ export function CashflowSheetLabPage({
         ...errorDiagnostics(error),
       }, 'warn');
       if (activeStep === 'apply' && getErrorCode(error) === 'cashflow_closed_month_reason_required') {
-        setClosedMonthWarning(closedMonthDifferences);
+        const serverDifferences = getClosedMonthDifferences(error);
+        setClosedMonthStage(staged);
+        setClosedMonthWarning(
+          serverDifferences.length
+            ? serverDifferences
+            : staged?.closedMonthDifferences || [],
+        );
       } else {
         setErrorMessage(formatError(error));
       }
@@ -1079,7 +1108,15 @@ export function CashflowSheetLabPage({
         )}
       </section>
 
-      <Dialog open={closedMonthWarning.length > 0} onOpenChange={(open) => !open && setClosedMonthWarning([])}>
+      <Dialog
+        open={Boolean(closedMonthStage)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setClosedMonthStage(null);
+            setClosedMonthWarning([]);
+          }
+        }}
+      >
         <DialogContent className="max-w-[360px] gap-4 rounded-xl p-5 sm:max-w-[360px]">
           <DialogHeader className="space-y-1 text-left">
             <DialogTitle className="text-[17px]">결산 후 값이 달라요</DialogTitle>
@@ -1087,12 +1124,14 @@ export function CashflowSheetLabPage({
               월 결산 이후 변경입니다. 사유를 남기면 변경 이력과 경고 횟수에 함께 기록됩니다.
             </DialogDescription>
           </DialogHeader>
-          <div className="max-h-28 space-y-1 overflow-y-auto rounded-lg bg-amber-50 px-3 py-2 text-[12px] font-semibold text-amber-950">
-            {closedMonthWarning.slice(0, 3).map((summary) => (
-              <div key={summary.yearMonth}>{formatClosedMonthDifference(summary)}</div>
-            ))}
-            {closedMonthWarning.length > 3 && <div>외 {closedMonthWarning.length - 3}개 월</div>}
-          </div>
+          {closedMonthWarning.length > 0 && (
+            <div className="max-h-28 space-y-1 overflow-y-auto rounded-lg bg-amber-50 px-3 py-2 text-[12px] font-semibold text-amber-950">
+              {closedMonthWarning.slice(0, 3).map((summary) => (
+                <div key={summary.yearMonth}>{formatClosedMonthDifference(summary)}</div>
+              ))}
+              {closedMonthWarning.length > 3 && <div>외 {closedMonthWarning.length - 3}개 월</div>}
+            </div>
+          )}
           <textarea
             value={closedMonthChangeReason}
             onChange={(event) => setClosedMonthChangeReason(event.target.value.slice(0, 1000))}
@@ -1101,10 +1140,15 @@ export function CashflowSheetLabPage({
             disabled={loading}
           />
           <DialogFooter className="flex-row justify-end gap-2 sm:space-x-0">
-            <Button type="button" variant="outline" className="h-9" onClick={() => setClosedMonthWarning([])}>
+            <Button type="button" variant="outline" className="h-9" onClick={() => setClosedMonthStage(null)}>
               닫기
             </Button>
-            <Button type="button" className="h-9" disabled={loading || !closedMonthChangeReason.trim()} onClick={() => void handleOverwriteSheetValues(closedMonthChangeReason.trim())}>
+            <Button
+              type="button"
+              className="h-9"
+              disabled={loading || !closedMonthStage || !closedMonthChangeReason.trim()}
+              onClick={() => void handleOverwriteSheetValues(closedMonthChangeReason.trim(), closedMonthStage)}
+            >
               사유와 함께 반영
             </Button>
           </DialogFooter>

--- a/src/app/features/cashflow-sheet-compare/README.md
+++ b/src/app/features/cashflow-sheet-compare/README.md
@@ -314,46 +314,29 @@ transaction that already owns these values.
 - Independent read-only re-audit scored this phase 100/100: contract/main path
   20/20; atomicity/concurrency 15/15; snapshot/hash/version 15/15;
 
-### 2026-07-23: settled-week sheet amendment warning
+### 2026-07-23: month-close-only sheet amendment contract
 
 **Planning and hypothesis**
 
-A sheet import is an authoritative value copy, but it must not silently bypass
-a weekly settlement. The first apply therefore remains a non-writing
-precondition check. If a changed week is `LOCKED`, the JVM returns a structured
-confirmation challenge containing the exact week, weekly-completion revision,
-and canonical target revision. The UI asks whether the user wants to apply
-values that differ from the settled snapshot. A confirmed retry is allowed;
-monthly close and its post-deadline reason requirement remain the stronger
-rule.
+A sheet import is an authoritative value copy. Weekly settlement is an
+operational completion record, not a financial write lock. Only a `CLOSED`
+month is amendment-controlled: changes through the tenth of the following
+month apply normally; later changes require a reason and increment the
+closed-month warning/audit counter.
 
 **Execution**
 
-- Single-month and multi-month sheet writes use the same changed-week
-  comparison in the JVM persistence transaction.
-- An unconfirmed request writes neither the canonical ledger nor warning data.
-- The public BFF does not accept a naked `allow=true` override. It stores the
-  JVM-issued challenge on the pinned stage run and accepts only that challenge
-  ID on retry. The ID is a JVM-signed, ten-minute token bound to tenant,
-  project, target revision, exact settled-week revisions, and a one-time nonce.
-  The JVM then re-reads every completion document and requires the target
-  revision and exact set of `(yearMonth, weekNo, completionRevision)` to match.
-  A newly locked week or changed revision produces a new `409` without writes;
-  an unlocked or expired confirmation returns an explicit retry response rather
-  than a server error.
-- The signer uses the required `JVM_WEEKLY_CASHFLOW_SETTLED_WEEK_CONFIRMATION_KEY`
-  (32+ characters), separate from the BFF/JVM authentication token. Stage and
-  production fail JVM startup if the key is absent or weak.
-- The BFF includes the confirmation hash in its semantic apply hash and
-  fail-closes if the JVM response omits, duplicates, or changes any confirmed
-  scope or warning counter.
-- A confirmed request keeps the weekly completion `LOCKED`, overwrites only
-  financially changed weeks, increments `postSettlementChangeWarningCount`,
-  and stores actor UID, source revision, idempotency key, and timestamp.
-- Each changed settled week also writes one idempotent
-  `cashflow_weekly_settlement_change_warnings` audit document in the same
-  transaction. The JVM response returns the exact affected weeks and counters
-  to the BFF and UI.
+- Single-month and multi-month sheet writes skip weekly `LOCKED` checks in the
+  JVM; the completion record remains available to operations and admin views.
+- The BFF forwards only `closedMonthChangeReason`. A legacy weekly confirmation
+  field is accepted but ignored so an already-open browser tab cannot fail
+  during Stage rollout.
+- The JVM is authoritative for a post-deadline closed-month amendment. It
+  requires the reason, records actor/source/idempotency data, and increments
+  the amendment and warning counters in the same transaction as the ledger
+  write.
+- Both cashflow entry UIs show the reason dialog only after this JVM response;
+  a completed weekly update never produces a write-blocking dialog.
 - The sheet settings screen now loads the saved year-specific link on entry;
   checking the share account no longer performs an unrelated mirror read.
   Project/year hydration uses a request generation guard, validates the
@@ -362,21 +345,18 @@ rule.
 
 **Evaluation**
 
-The storage regression covers no partial writes before confirmation, a
-confirmed changed-week write, retained `LOCKED` status, one warning increment,
-actor/source audit fields, stale completion-revision rejection, and an audit
-document. BFF and both cashflow entry UIs cover the server-issued confirmation
-challenge, compact warning dialog, direct-boolean bypass rejection, retry, and
-saved-link hydration.
+The regression covers a settled-week sheet write without confirmation, plus
+the existing closed-month retry with a reason. BFF and both cashflow entry UIs
+cover the JVM reason response and saved-link hydration.
   authorization/reopen/month precedence 15/15; idempotency/audit/legacy 10/10;
   BFF/TypeScript/error contract 10/10; regression/real input 10/10; and
   documentation/build/gate 5/5. The auditor independently rebuilt 2,910 Vite
   modules in 21.87 seconds. One earlier parallel test run had a transient local
   socket failure under concurrent load; isolated 77/77 and the subsequent
   single-worker 174/174 run did not reproduce it.
-- This closes only the weekly settlement lock phase. UI work and Stage
-  deployment require their own tracked contract and the relevant retrospective
-  phase audits; Live deployment remains prohibited without explicit approval.
+- This closes the weekly-lock removal phase. Stage deployment requires its own
+  tracked verification; Live deployment remains prohibited without explicit
+  approval.
 
 ## 2026-07-23 duplicate-read and JVM error propagation fix
 

--- a/src/app/features/cashflow-sheet-compare/README.md
+++ b/src/app/features/cashflow-sheet-compare/README.md
@@ -220,6 +220,9 @@ network/query work if it:
 
 ### 2026-07-22: weekly settlement lock contract
 
+> Historical decision, superseded by the 2026-07-23 month-close-only contract
+> below. Weekly settlement is now status/audit data and does not block writes.
+
 **Planning**
 
 Weekly settlement previously recorded only an actor and timestamp. It did not
@@ -375,3 +378,27 @@ as a blocking-looking warning in the sheet UI.
 **Evaluation:** 83 focused client, JVM bridge, and sheet-page tests passed. The
 production Vite build transformed 2,910 modules successfully. Docker was not
 used.
+
+## 2026-07-23 applied annual totals and month-close race
+
+**Hypothesis:** annual Projection progress should not re-read and recompute
+separate annual documents when the applied sheet already contains the exact
+annual totals. The annual JVM rows still have to remain because month close
+uses their per-line value/empty states for the prior-year opening balance.
+Also, month status can change from `OPEN` to `CLOSED` after staging, so the JVM
+must remain the final authority and return the affected staged scope.
+
+**Execution:** the dashboard now reads annual `totalIn` from the applied pinned
+sheet revision and uses a `Map` lookup instead of one Firestore read per year.
+The existing JVM annual row persistence remains unchanged for row-preserving
+opening-balance evidence. When the JVM requests a post-deadline reason, it
+returns every affected closed month as structured error details. The BFF maps
+those months to week numbers from the already-pinned candidates. Both cashflow
+entry screens retry that same stage run with the reason; the sheet settings
+screen no longer stages a second copy.
+
+**Evaluation:** focused BFF/JVM/UI regressions passed 206/206 and the full JVM
+module passed 202/202, including a two-month `OPEN`-at-stage then
+`CLOSED`-at-apply retry. The production Vite build transformed 2,910 modules
+successfully. Independent read-only re-audit scored the phase 100/100. Docker
+was not used.


### PR DESCRIPTION
## 변경 내용
- 주간 정산은 상태/이력으로만 유지하고 월 결산을 현금흐름 변경의 단일 통제 계약으로 사용
- Stage와 apply 사이 월 결산 상태가 바뀌면 JVM이 영향 월 전체를 구조화해 반환
- 동일한 고정 시트 Stage run에 변경 사유를 붙여 재시도
- Projection 진행률은 적용된 시트의 연간 합계를 사용하고 JVM 항목별 이월 증빙은 유지

## 검증
- BFF/JVM/UI 집중 테스트 206/206
- JVM 전체 테스트 202/202
- Vite production build 2,910 modules
- 독립 read-only 감사 100/100
- Docker 및 신규 의존성 미사용

## 배포 범위
- Stage 전용
- Live/Production 배포 금지