### PR TITLE
feat(cashflow): lock screen during sheet sync

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -185,9 +185,10 @@ describe('CashflowProjectSheet monthly close shell', () => {
   });
 
   it('keeps the sheet refresh loading state open until the successful response is processed', () => {
-    expect(source).toContain('{sheetRefreshLoading ? (');
-    expect(source).toContain('aria-busy="true"');
-    expect(source).toContain('시트 값을 불러오는 중입니다');
+    expect(source).toContain('CashflowSheetSyncOverlay');
+    expect(source).toContain('{sheetRefreshLoading ? <CashflowSheetSyncOverlay operation="refresh" /> : null}');
+    expect(source).toContain('inert={sheetRefreshLoading || undefined}');
+    expect(source).toContain('aria-busy={sheetRefreshLoading}');
     expect(source).not.toContain('setSheetRefreshResult');
     expect(source).not.toContain('setSheetStageDialog');
   });
@@ -277,6 +278,12 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('결산 상태 다시 확인');
     expect(source).toContain('recordDevtoolsLog');
     expect(source).toContain('toDevtoolsError');
+  });
+
+  it('locks the cashflow screen with the shared sheet sync overlay while a sheet refresh is running', () => {
+    expect(source).toContain('CashflowSheetSyncOverlay');
+    expect(source).toContain('inert={sheetRefreshLoading || undefined}');
+    expect(source).toContain('<CashflowSheetSyncOverlay operation="refresh" />');
   });
 
   it('prioritizes local sheet preflight over a failed server refresh and never shows stale reopen actions', () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -71,6 +71,7 @@ import {
   type CashflowMonthCloseDepositReviewRow,
   type CashflowManagementDecisionMap,
 } from './cashflow-month-close';
+import { CashflowSheetSyncOverlay } from './CashflowSheetSyncOverlay';
 
 function fmt(n: number): string {
   return n.toLocaleString('ko-KR');
@@ -2563,7 +2564,8 @@ export function CashflowProjectSheet({
   const legacyCloseEvidence = monthCloseResult?.dashboard?.snapshotCompatibility?.status === 'LEGACY_EVIDENCE_ONLY';
 
   return (
-    <div className="space-y-5 bg-background p-4">
+    <>
+    <div className="space-y-5 bg-background p-4" inert={sheetRefreshLoading || undefined} aria-busy={sheetRefreshLoading}>
       {legacyCloseEvidence ? (
         <div role="status" className="rounded-md border border-slate-300 bg-slate-50 px-4 py-3 text-[12px] leading-5 text-[#17324D]">
           <strong>이전 형식의 월 결산입니다.</strong> 결산 당시 저장된 값은 읽을 수 있지만, 항목별 전년도 이월 근거와 전체 동결 원장은 보관되지 않았습니다. 수정이 필요하면 재오픈 승인 후 시트값을 다시 반영하고 재결산해 주세요.
@@ -2588,20 +2590,6 @@ export function CashflowProjectSheet({
       </section>
 
       {renderUnifiedMonthlyBoard()}
-
-      {sheetRefreshLoading ? (
-        <div className="fixed inset-0 z-[100] grid place-items-start bg-transparent px-4 pt-24" aria-live="polite" aria-busy="true">
-          <div role="status" className="w-full max-w-[420px] rounded-lg border border-slate-200 bg-white px-5 py-4 shadow-xl">
-            <div className="flex items-center gap-2 text-[14px] font-bold text-slate-950">
-              <Loader2 className="h-4 w-4 animate-spin text-[#17324D]" />
-              시트 값을 불러오는 중입니다
-            </div>
-            <div className="mt-1 text-[12px] leading-5 text-slate-600">
-              시트의 최신 값을 고정하고 변경된 항목을 확인하고 있습니다. 완료될 때까지 잠시 기다려 주세요.
-            </div>
-          </div>
-        </div>
-      ) : null}
 
       <AlertDialog open={qaClockOpen} onOpenChange={(open) => { if (!qaClockBusy) setQaClockOpen(open); }}>
         <AlertDialogContent className="w-[calc(100vw-2rem)] max-w-[380px]">
@@ -2917,5 +2905,7 @@ export function CashflowProjectSheet({
         </AlertDialogContent>
       </AlertDialog>
     </div>
+    {sheetRefreshLoading ? <CashflowSheetSyncOverlay operation="refresh" /> : null}
+    </>
   );
 }

--- a/src/app/components/cashflow/CashflowSheetSyncOverlay.tsx
+++ b/src/app/components/cashflow/CashflowSheetSyncOverlay.tsx
@@ -1,0 +1,50 @@
+export type CashflowSheetSyncOperation = 'saving' | 'refresh' | 'staging' | 'applying';
+
+const copy: Record<CashflowSheetSyncOperation, { title: string; detail: string; activeStep: number }> = {
+  saving: {
+    title: '시트 연결 정보를 저장하고 있습니다',
+    detail: '저장하는 동안 화면을 잠시 잠급니다.',
+    activeStep: 0,
+  },
+  refresh: {
+    title: '시트 최신값을 가져오고 있습니다',
+    detail: '시트 값을 읽어 서버 고정본으로 만들고 있습니다.',
+    activeStep: 0,
+  },
+  staging: {
+    title: '시트 변경값을 확인하고 있습니다',
+    detail: '월 결산 이후 변경 여부를 확인하고 있습니다.',
+    activeStep: 1,
+  },
+  applying: {
+    title: '시트 값을 MYSCube에 반영하고 있습니다',
+    detail: '원장 반영이 끝날 때까지 페이지를 닫거나 새로고침하지 마세요.',
+    activeStep: 2,
+  },
+};
+
+const steps = ['시트 읽기', '변경 확인', '원장 반영'];
+
+export function CashflowSheetSyncOverlay({ operation }: { operation: CashflowSheetSyncOperation }) {
+  const current = copy[operation];
+
+  return (
+    <div className="fixed inset-0 z-[120] grid place-items-center bg-[#EAF4FB]/90 px-5 py-8 backdrop-blur-sm" role="dialog" aria-modal="true" aria-labelledby="cashflow-sheet-sync-title">
+      <div role="status" aria-live="assertive" className="w-full max-w-[360px] rounded-2xl border border-white/80 bg-white/95 px-7 py-8 text-center shadow-[0_24px_60px_rgba(23,50,77,0.20)]">
+        <div className="mx-auto flex h-24 items-center justify-center" aria-hidden="true">
+          <div className="cashflow-sync-blob" />
+        </div>
+        <h2 id="cashflow-sheet-sync-title" className="mt-4 text-[17px] font-bold tracking-[-0.02em] text-[#17324D]">{current.title}</h2>
+        <p className="mt-2 text-[13px] leading-5 text-slate-600">{current.detail}</p>
+        <ol className="mt-6 grid grid-cols-3 gap-1.5 text-[11px] font-semibold">
+          {steps.map((step, index) => (
+            <li key={step} className={index < current.activeStep ? 'text-[#17324D]' : index === current.activeStep ? 'text-[#17324D]' : 'text-slate-400'}>
+              <span className={`mx-auto mb-1.5 block h-1.5 rounded-full ${index < current.activeStep ? 'bg-[#17324D]' : index === current.activeStep ? 'bg-[#6B9ED1]' : 'bg-slate-200'}`} />
+              {step}
+            </li>
+          ))}
+        </ol>
+      </div>
+    </div>
+  );
+}

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
@@ -91,6 +91,9 @@ describe('CashflowSheetLabPage shell', () => {
     expect(pageSource.indexOf('const stageIdempotencyKey =')).toBeLessThan(pageSource.indexOf("runWithBffAuthRetry('stage.sheet_values'"));
     expect(pageSource.indexOf('const applyIdempotencyKey =')).toBeLessThan(pageSource.indexOf("runWithBffAuthRetry('apply.sheet_values'"));
     expect(pageSource).toContain('CashflowSheetHeroAnimation');
+    expect(pageSource).toContain('CashflowSheetSyncOverlay');
+    expect(pageSource).toContain('inert={loading || undefined}');
+    expect(pageSource).toContain('operation={loadingOperation}');
     expect(pageSource).toContain('cashflow-tile-float');
     expect(pageSource).not.toContain('motion/react');
     expect(pageSource).toContain('사업비 관리시트 연동');

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
@@ -31,6 +31,7 @@ import { readRecentPortalProjectIds, rememberRecentPortalProject } from '../../p
 import { recordDevtoolsLog } from '../../platform/devtools-transaction-log';
 import { resolvePortalProjectResourcePath } from '../../platform/portal-project-selection';
 import { resolveFinanceWeekForDate } from '../../platform/cashflow-weeks';
+import { CashflowSheetSyncOverlay, type CashflowSheetSyncOperation } from '../../components/cashflow/CashflowSheetSyncOverlay';
 
 function formatError(error: unknown) {
   const apiError = error as { body?: { code?: string; error?: string; message?: string }; requestId?: string; status?: number };
@@ -294,7 +295,8 @@ export function CashflowSheetLabPage({
   const [closedMonthWarning, setClosedMonthWarning] = useState<NonNullable<CashflowSheetLabStageResult['closedMonthDifferences']>>([]);
   const [closedMonthStage, setClosedMonthStage] = useState<CashflowSheetLabStageResult | null>(null);
   const [closedMonthChangeReason, setClosedMonthChangeReason] = useState('');
-  const [loading, setLoading] = useState(false);
+  const [loadingOperation, setLoadingOperation] = useState<CashflowSheetSyncOperation | null>(null);
+  const loading = loadingOperation !== null;
   const [accountLoading, setAccountLoading] = useState(false);
   const [tutorialOpen, setTutorialOpen] = useState(false);
   const [tutorialSlide, setTutorialSlide] = useState(0);
@@ -609,7 +611,7 @@ export function CashflowSheetLabPage({
 
   async function handleSaveSheetConfig() {
     if (!projectId || loading || !spreadsheetId) return;
-    setLoading(true);
+    setLoadingOperation('saving');
     setErrorMessage('');
     setStatusMessage('');
     setReviewedSourceKey('');
@@ -636,14 +638,14 @@ export function CashflowSheetLabPage({
       logCashflowLab('settings.save.error', { projectId, spreadsheetId, ...errorDiagnostics(error) }, 'warn');
       setErrorMessage(formatError(error));
     } finally {
-      setLoading(false);
+      setLoadingOperation(null);
     }
   }
   async function handleRefreshSheetMirror() {
     if (!projectId || loading || !spreadsheetId) return;
     const startedAt = Date.now();
     const refreshIdempotencyKey = `cashflow-sheet-lab-refresh:${projectId}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
-    setLoading(true);
+    setLoadingOperation('refresh');
     setErrorMessage('');
     setStatusMessage('');
     setReviewedSourceKey('');
@@ -711,7 +713,7 @@ export function CashflowSheetLabPage({
         void handleLoadShareAccount();
       }
     } finally {
-      setLoading(false);
+      setLoadingOperation(null);
     }
   }
 
@@ -732,7 +734,7 @@ export function CashflowSheetLabPage({
     let activeStep: 'stage' | 'apply' = stagedOverride ? 'apply' : 'stage';
     let staged = stagedOverride;
     let stageDurationMs = 0;
-    setLoading(true);
+    setLoadingOperation(stagedOverride ? 'applying' : 'staging');
     setErrorMessage('');
     setStatusMessage('');
     if (!stagedOverride) {
@@ -806,6 +808,7 @@ export function CashflowSheetLabPage({
         return;
       }
       activeStep = 'apply';
+      setLoadingOperation('applying');
       const applyStartedAt = Date.now();
       const stagedRunId = staged.runId;
       logCashflowLab('apply.sheet_values.start', {
@@ -889,7 +892,7 @@ export function CashflowSheetLabPage({
         setErrorMessage(formatError(error));
       }
     } finally {
-      setLoading(false);
+      setLoadingOperation(null);
     }
   }
 
@@ -922,7 +925,8 @@ export function CashflowSheetLabPage({
   }
 
   return (
-    <div className="bg-white px-5 py-6 sm:bg-slate-100 sm:px-6">
+    <>
+    <div className="bg-white px-5 py-6 sm:bg-slate-100 sm:px-6" inert={loading || undefined} aria-busy={loading}>
       <section className="mx-auto max-w-[560px] bg-white sm:border sm:border-slate-200 sm:p-8 sm:shadow-sm">
         <header>
           <CashflowSheetHeroAnimation />
@@ -1328,5 +1332,7 @@ export function CashflowSheetLabPage({
         </DialogContent>
       </Dialog>
     </div>
+    {loadingOperation ? <CashflowSheetSyncOverlay operation={loadingOperation} /> : null}
+    </>
   );
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -547,3 +547,34 @@ a,
     scale: 1;
   }
 }
+
+@keyframes cashflow-sync-blob {
+  0%,
+  100% {
+    border-radius: 48% 52% 46% 54% / 54% 44% 56% 46%;
+    rotate: -8deg;
+    scale: 0.94;
+  }
+  50% {
+    border-radius: 56% 44% 55% 45% / 45% 56% 44% 55%;
+    rotate: 8deg;
+    scale: 1.05;
+  }
+}
+
+.cashflow-sync-blob {
+  width: 78px;
+  aspect-ratio: 1;
+  background:
+    radial-gradient(circle at 30% 25%, rgba(211, 228, 255, 0.98) 0 8%, transparent 36%),
+    radial-gradient(circle at 70% 70%, rgba(26, 72, 194, 0.92), transparent 58%),
+    linear-gradient(135deg, #6B9ED1, #17324D 72%);
+  box-shadow: inset 13px 13px 18px rgba(255, 255, 255, 0.46), inset -14px -12px 20px rgba(0, 24, 79, 0.34), 0 13px 28px rgba(23, 50, 77, 0.24);
+  animation: cashflow-sync-blob 2.8s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cashflow-sync-blob {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## 변경 내용\n- 시트 저장·불러오기·검토·반영 동안 전면 로딩 오버레이를 표시합니다.\n- 처리 중 페이지 입력과 클릭을 잠가 중복 실행 및 이탈을 방지합니다.\n- 영상 레퍼런스의 차분한 블루 모핑 로더와 단계 안내를 적용했습니다.\n\n## 검증\n- git diff --check 통과\n- 로컬 node_modules 부재로 빌드는 GitHub CI에서 검증합니다.\n\nStage 전용 배포입니다. Live 배포는 포함하지 않습니다.