### PR TITLE
fix(cashflow): preserve sheet values and close checks

### DIFF
--- a/server/bff/cashflow-sheet-snapshot.mjs
+++ b/server/bff/cashflow-sheet-snapshot.mjs
@@ -313,6 +313,78 @@ function readWholeWon(
   return classified.amount;
 }
 
+function readComputedWholeWon(matrix, rowIndex, columnIndex, emptyValue = null) {
+  const classified = classifyCashflowSheetCell(matrix?.[rowIndex]?.[columnIndex]);
+  if (classified.state === 'EMPTY') return emptyValue;
+  if (classified.state !== 'VALUE' || !Number.isSafeInteger(classified.amount)) return null;
+  return classified.amount;
+}
+
+function buildWeeklyCalculationChecks({ template, matrix }) {
+  return (template?.sections || []).flatMap((section) => {
+    const lineRows = Array.isArray(section?.lineRows) ? section.lineRows : [];
+    const derivedRows = Array.isArray(section?.derivedRows) ? section.derivedRows : [];
+    const derivedByKind = new Map(derivedRows.map((row) => [row.kind, row]));
+    if (
+      !['deposit_total', 'withdrawal_total', 'balance'].every((kind) => derivedByKind.has(kind))
+      || lineRows.some((row) => row.direction !== 'IN' && row.direction !== 'OUT')
+    ) return [];
+    const firstYear = Number(String(section?.weekColumns?.[0]?.yearMonth || '').slice(0, 4));
+    const openingColumn = (section?.annualColumns || [])
+      .filter((column) => Number(column?.year) < firstYear)
+      .sort((left, right) => Number(right.year) - Number(left.year))[0];
+    let priorBalance = openingColumn
+      ? readComputedWholeWon(matrix, derivedByKind.get('balance').rowIndex, openingColumn.columnIndex)
+      : null;
+    return (section?.weekColumns || []).map((week) => {
+      const amounts = lineRows.map((row) => ({
+        direction: row.direction,
+        amount: readComputedWholeWon(matrix, row.rowIndex, week.columnIndex, 0),
+      }));
+      const totalFor = (direction) => {
+        const values = amounts.filter((row) => row.direction === direction).map((row) => row.amount);
+        if (values.some((amount) => amount === null)) return null;
+        try {
+          return values.reduce((sum, amount) => addWholeWon(sum, amount), 0);
+        } catch {
+          return null;
+        }
+      };
+      const depositTotal = readComputedWholeWon(matrix, derivedByKind.get('deposit_total')?.rowIndex, week.columnIndex);
+      const withdrawalTotal = readComputedWholeWon(matrix, derivedByKind.get('withdrawal_total')?.rowIndex, week.columnIndex);
+      const balance = readComputedWholeWon(matrix, derivedByKind.get('balance')?.rowIndex, week.columnIndex);
+      const computedDepositTotal = totalFor('IN');
+      const computedWithdrawalTotal = totalFor('OUT');
+      let computedBalance = null;
+      if (priorBalance !== null && computedDepositTotal !== null && computedWithdrawalTotal !== null) {
+        try {
+          computedBalance = addWholeWon(priorBalance, addWholeWon(computedDepositTotal, -computedWithdrawalTotal));
+        } catch {
+          computedBalance = null;
+        }
+      }
+      const result = {
+        mode: section.mode,
+        yearMonth: week.yearMonth,
+        weekNo: week.weekNo,
+        sourceCells: {
+          depositTotal: toA1(derivedByKind.get('deposit_total')?.rowIndex, week.columnIndex),
+          withdrawalTotal: toA1(derivedByKind.get('withdrawal_total')?.rowIndex, week.columnIndex),
+          balance: toA1(derivedByKind.get('balance')?.rowIndex, week.columnIndex),
+          openingBalance: openingColumn ? toA1(derivedByKind.get('balance').rowIndex, openingColumn.columnIndex) : '',
+        },
+        matches: {
+          depositTotal: depositTotal === null || computedDepositTotal === null ? null : depositTotal === computedDepositTotal,
+          withdrawalTotal: withdrawalTotal === null || computedWithdrawalTotal === null ? null : withdrawalTotal === computedWithdrawalTotal,
+          balance: balance === null || computedBalance === null ? null : balance === computedBalance,
+        },
+      };
+      priorBalance = balance;
+      return result;
+    });
+  });
+}
+
 function controlRow({ matrix, row, weekColumns, issues, controlColumnIndex }) {
   const field = `${row.kind}:${row.lineId || row.derivedKind}`;
   const amounts = weekColumns.map((week) => readWholeWon(
@@ -440,6 +512,7 @@ export function extractCashflowSheetFacts({ template = {}, matrix = [], cells = 
 
   const projectionControls = modeControls('projection');
   const actualControls = modeControls('actual');
+  const weeklyCalculationChecks = buildWeeklyCalculationChecks({ template, matrix });
 
   return {
     metadata: {
@@ -451,6 +524,7 @@ export function extractCashflowSheetFacts({ template = {}, matrix = [], cells = 
     depositScheduleRows,
     annualFinancialTotals: annualSheetFinancialTotals({ depositScheduleRows, projectionControls }),
     annualCashflowTotals: buildAnnualCashflowTotals({ cells, annualCells }),
+    ...(weeklyCalculationChecks.length > 0 ? { weeklyCalculationChecks } : {}),
     cashflowGrandTotals: {
       projection: buildCashflowSheetTotal(totalCells, 'projection'),
       actual: buildCashflowSheetTotal(totalCells, 'actual'),

--- a/server/bff/cashflow-sheet-snapshot.test.mjs
+++ b/server/bff/cashflow-sheet-snapshot.test.mjs
@@ -49,6 +49,48 @@ describe('cashflow sheet pinned snapshot', () => {
     });
   });
 
+  it('keeps monthly derived totals as verification evidence without replacing sheet values', () => {
+    const matrix = Array.from({ length: 30 }, () => Array.from({ length: 8 }, () => ''));
+    const weekColumns = Array.from({ length: 5 }, (_, index) => ({
+      yearMonth: '2026-07', weekNo: index + 1, columnIndex: index + 3,
+    }));
+    const section = (mode, rowOffset) => ({
+      mode,
+      weekColumns,
+      annualColumns: [{ year: 2025, columnIndex: 2 }],
+      lineRows: [
+        { rowIndex: rowOffset, lineId: 'SALES_IN', direction: 'IN' },
+        { rowIndex: rowOffset + 1, lineId: 'DIRECT_COST_OUT', direction: 'OUT' },
+      ],
+      derivedRows: [
+        { rowIndex: rowOffset + 2, kind: 'deposit_total' },
+        { rowIndex: rowOffset + 3, kind: 'withdrawal_total' },
+        { rowIndex: rowOffset + 4, kind: 'balance' },
+      ],
+    });
+    for (const rowOffset of [10, 20]) {
+      matrix[rowOffset + 4][2] = '0';
+      for (let index = 0; index < 5; index += 1) {
+        const column = index + 3;
+        matrix[rowOffset][column] = '100';
+        matrix[rowOffset + 1][column] = '30';
+        matrix[rowOffset + 2][column] = '100';
+        matrix[rowOffset + 3][column] = '30';
+        matrix[rowOffset + 4][column] = String((index + 1) * 70);
+      }
+    }
+    const template = { sections: [section('projection', 10), section('actual', 20)] };
+
+    const valid = extractCashflowSheetFacts({ template, matrix });
+    expect(valid.weeklyCalculationChecks.find((check) => check.mode === 'projection' && check.weekNo === 2)?.matches)
+      .toEqual({ depositTotal: true, withdrawalTotal: true, balance: true });
+
+    matrix[12][4] = '101';
+    const invalid = extractCashflowSheetFacts({ template, matrix });
+    expect(invalid.weeklyCalculationChecks.find((check) => check.mode === 'projection' && check.weekNo === 2)?.matches.depositTotal)
+      .toBe(false);
+  });
+
   it('pins normalized cells and keeps source and target revisions separate', () => {
     const mappings = [
       {

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -625,6 +625,28 @@ function buildActiveWeeksFromTemplate(template, weekRange) {
     .filter(Boolean);
 }
 
+function selectCanonicalAnnualCells(cells = []) {
+  const byYear = new Map();
+  for (const cell of cells) {
+    const year = Number(cell?.year);
+    const sourceYear = Number(cell?.sourceYear);
+    if (!Number.isSafeInteger(year) || !Number.isSafeInteger(sourceYear)) continue;
+    const candidates = byYear.get(year) || new Map();
+    const sourceCells = candidates.get(sourceYear) || [];
+    sourceCells.push(cell);
+    candidates.set(sourceYear, sourceCells);
+    byYear.set(year, candidates);
+  }
+  return [...byYear.entries()].flatMap(([year, candidates]) => {
+    const sourceYear = [...candidates.keys()].sort((left, right) => (
+      Math.abs(left - year) - Math.abs(right - year) || right - left
+    ))[0];
+    return candidates.get(sourceYear) || [];
+  }).sort((left, right) => Number(left.year) - Number(right.year)
+    || readOptionalText(left.mode).localeCompare(readOptionalText(right.mode))
+    || readOptionalText(left.lineId).localeCompare(readOptionalText(right.lineId)));
+}
+
 function mergeCashflowSourceMirror(previous, next, sourceYear) {
   const weeklyYears = [...new Set((next.cells || [])
     .map((cell) => Number(readOptionalText(cell?.yearMonth).slice(0, 4)))
@@ -653,12 +675,10 @@ function mergeCashflowSourceMirror(previous, next, sourceYear) {
       || Number(left.weekNo) - Number(right.weekNo)
       || readOptionalText(left.mode).localeCompare(readOptionalText(right.mode))
       || readOptionalText(left.lineId).localeCompare(readOptionalText(right.lineId)));
-  const annualCells = [
+  const annualCells = selectCanonicalAnnualCells([
     ...previousAnnualCells,
     ...(next.annualCells || []).map((cell) => ({ ...cell, sourceYear })),
-  ].sort((left, right) => Number(left.year) - Number(right.year)
-    || readOptionalText(left.mode).localeCompare(readOptionalText(right.mode))
-    || readOptionalText(left.lineId).localeCompare(readOptionalText(right.lineId)));
+  ]);
   const previousTotalCells = readOptionalText(previous?.sourceRevision)
     ? (previous.totalCells || [])
       .map((cell) => ({ ...cell, sourceYear: Number(cell?.sourceYear) || previousSourceYear }))

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -151,11 +151,13 @@ function buildOfficialMatrix({
   annualYears = [],
   projectionAnnualValue = '',
   actualAnnualValue = '',
+  projectionAnnualValues = {},
+  actualAnnualValues = {},
 } = {}) {
   const matrix = Array.from({ length: 60 }, () => Array(72).fill(''));
   const sourceYear = 2000 + Number.parseInt(String(weekLabels[0] || '26').split('-')[0], 10);
   const annualColumns = officialAnnualColumns(sourceYear);
-  const writeSection = (actual, annualValue) => {
+  const writeSection = (actual, annualValue, annualValues) => {
     const headerRowIndex = actual ? 34 : 11;
     const weekRowIndex = actual ? 35 : 12;
     const lineRowIndexes = actual
@@ -181,7 +183,11 @@ function buildOfficialMatrix({
       });
       for (const year of annualYears) {
         const columnIndex = annualColumns.get(year);
-        if (columnIndex !== undefined) matrix[rowIndex][columnIndex] = year === 2027 ? '' : annualValue;
+        if (columnIndex !== undefined) {
+          matrix[rowIndex][columnIndex] = Object.hasOwn(annualValues, year)
+            ? annualValues[year]
+            : year === 2027 ? '' : annualValue;
+        }
       }
     });
     derivedRows.forEach(([rowIndex, label]) => {
@@ -192,8 +198,8 @@ function buildOfficialMatrix({
     });
   };
   matrix[0][0] = 'title';
-  writeSection(false, projectionAnnualValue);
-  writeSection(true, actualAnnualValue);
+  writeSection(false, projectionAnnualValue, projectionAnnualValues);
+  writeSection(true, actualAnnualValue, actualAnnualValues);
   return matrix;
 }
 
@@ -1303,6 +1309,55 @@ describe('cashflow sheet lab route', () => {
       2027: { sourceYear: 2027, spreadsheetId: 'spreadsheet-2027' },
     });
     expect([...new Set(mirror.body.cells.map((cell) => Number(cell.yearMonth.slice(0, 4))))]).toEqual([2026, 2027]);
+  });
+
+  it('keeps each annual year from one closest sheet source instead of double-counting overlapping 2024/2025 totals', async () => {
+    const db = createDb({
+      project: { id: 'project-a', contractStart: '2024-01-01', contractEnd: '2028-12-31' },
+    });
+    const previewSpreadsheet = vi.fn(async ({ value }) => {
+      const year = String(value).includes('2027') ? 2027 : 2026;
+      const weekLabels = Array.from({ length: 12 }, (_, monthIndex) => (
+        Array.from({ length: 5 }, (_unused, weekIndex) => `${String(year).slice(2)}-${monthIndex + 1}-${weekIndex + 1}`)
+      )).flat();
+      return {
+        spreadsheetId: `spreadsheet-${year}`,
+        selectedSheetName: 'cashflow(사용내역 연동)',
+        availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
+        matrix: buildOfficialMatrix({
+          weekLabels,
+          annualYears: [2025],
+          projectionAnnualValues: { 2025: year === 2026 ? '100' : '200' },
+          actualAnnualValues: { 2025: year === 2026 ? '50' : '80' },
+        }),
+      };
+    });
+    const app = createApp({ db, googleSheetsService: { previewSpreadsheet } });
+
+    for (const year of [2026, 2027]) {
+      await request(app)
+        .put('/api/v1/projects/project-a/cashflow-sheet-lab/config')
+        .send({
+          sourceYear: year,
+          value: `https://docs.google.com/spreadsheets/d/spreadsheet-${year}/edit`,
+          sheetName: 'cashflow(사용내역 연동)',
+          startWeek: `${String(year).slice(2)}-1-1`,
+          endWeek: `${String(year).slice(2)}-12-5`,
+        })
+        .expect(200);
+      await request(app)
+        .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+        .send({ sourceYear: year, idempotencyKey: `refresh-overlap-${year}` })
+        .expect(200);
+    }
+
+    const mirror = await request(app)
+      .get('/api/v1/projects/project-a/cashflow-sheet-lab/mirror')
+      .expect(200);
+    const cells2025 = mirror.body.annualCells.filter((cell) => cell.year === 2025);
+    expect(cells2025).toHaveLength(32);
+    expect(new Set(cells2025.map((cell) => cell.sourceYear))).toEqual(new Set([2026]));
+    expect(mirror.body.sheetFacts.annualCashflowTotals.find((row) => row.year === 2025).projection.totalIn).toBe(700);
   });
 
   it('invalidates the pinned mirror and staged run when the saved sheet config changes', async () => {

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -1221,6 +1221,32 @@ function sheetControlBlockers(sheetFacts) {
   return blockers;
 }
 
+function monthSheetCalculationBlockers(sheetFacts, yearMonth) {
+  if (!Array.isArray(sheetFacts?.weeklyCalculationChecks)) return [];
+  const checks = sheetFacts.weeklyCalculationChecks
+    .filter((check) => readOptionalText(check?.yearMonth) === yearMonth);
+  if (checks.length !== 10) {
+    return [{
+      code: 'SHEET_CALCULATION_CHECK_MISSING',
+      message: '시트 합계·잔액 검산값이 없습니다. 시트값을 다시 불러와 주세요.',
+    }];
+  }
+  const invalid = checks.filter((check) => Object.values(check?.matches || {}).some((match) => match === null));
+  if (invalid.length > 0) {
+    return [{
+      code: 'SHEET_CALCULATION_VALUE_INVALID',
+      message: '월 결산 대상의 입금·출금 합계 또는 잔액 값을 확인해 주세요.',
+      details: invalid.map((check) => ({ mode: check.mode, weekNo: check.weekNo, sourceCells: check.sourceCells })),
+    }];
+  }
+  const mismatches = checks.filter((check) => Object.values(check?.matches || {}).some((match) => match === false));
+  return mismatches.length === 0 ? [] : [{
+    code: 'SHEET_CALCULATION_MISMATCH',
+    message: '월 결산 대상의 시트 합계 또는 잔액이 항목 합계와 다릅니다.',
+    details: mismatches.map((check) => ({ mode: check.mode, weekNo: check.weekNo, matches: check.matches, sourceCells: check.sourceCells })),
+  }];
+}
+
 function sourceDepositRows(sheetFacts, yearMonth) {
   return (Array.isArray(sheetFacts?.depositScheduleRows) ? sheetFacts.depositScheduleRows : [])
     .filter((row) => readOptionalText(row?.yearMonth) === yearMonth)
@@ -1453,6 +1479,7 @@ async function composeCashflowMonthDashboard({ db, req, projectId, yearMonth, cl
       blockers.push({ code: 'SHEET_SOURCE_NOT_APPLIED', message: '불러온 시트값을 원장에 반영해 주세요.' });
     }
     blockers.push(...sheetControlBlockers(sheetFacts));
+    blockers.push(...monthSheetCalculationBlockers(sheetFacts, yearMonth));
     if (!completeMonthCloseCells(cells)) blockers.push({ code: 'SHEET_MONTH_INCOMPLETE', message: '선택한 월의 160개 캐시플로우 값을 다시 불러와 주세요.' });
     if (!projectionMode || !actualMode) blockers.push({ code: 'AMOUNT_OUT_OF_RANGE', message: '지원 범위를 넘는 금액이 있습니다.' });
   }

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -95,7 +95,7 @@ function matchingControlRows(startRow, matches = true) {
   }));
 }
 
-function fullMonthCloseSource({ mirrorStatus = 'FRESH', controlMatches = true, contractAmount = 1000 } = {}) {
+function fullMonthCloseSource({ mirrorStatus = 'FRESH', controlMatches = true, calculationMismatch = false, contractAmount = 1000 } = {}) {
   const sourceRevision = `sha256:${'c'.repeat(64)}`;
   const targetRevision = `sha256:${'d'.repeat(64)}`;
   const cells = [];
@@ -148,6 +148,17 @@ function fullMonthCloseSource({ mirrorStatus = 'FRESH', controlMatches = true, c
       projection: matchingControlRows(14, controlMatches),
       actual: matchingControlRows(37, controlMatches),
     },
+    ...(calculationMismatch ? {
+      weeklyCalculationChecks: Array.from({ length: 10 }, (_, index) => ({
+        mode: index < 5 ? 'projection' : 'actual',
+        yearMonth: '2026-06',
+        weekNo: (index % 5) + 1,
+        sourceCells: {},
+        matches: index === 0
+          ? { depositTotal: false, withdrawalTotal: true, balance: true }
+          : { depositTotal: true, withdrawalTotal: true, balance: true },
+      })),
+    } : {}),
     issues: [],
   };
   const draftId = `v1_${Buffer.from(JSON.stringify(['cashflow', 'project-a', 'pm-1']), 'utf8').toString('base64url')}`;
@@ -1490,6 +1501,29 @@ describe('JVM weekly API BFF proxy', () => {
         })
         .expect(409);
     }
+  });
+
+  it('blocks month close when the pinned sheet total does not equal its item values', async () => {
+    const source = fullMonthCloseSource({ calculationMismatch: true });
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(monthDashboardSource({
+        ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0,
+        reopenCount: 0, projectWarningCount: 0, snapshot: {},
+      })),
+    }));
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { env: stageEnv, db: source.db });
+
+    await request(app)
+      .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
+      .expect(200)
+      .expect((response) => {
+        expect(response.body.dashboard.validation.canClose).toBe(false);
+        expect(response.body.dashboard.validation.blockers).toEqual(expect.arrayContaining([
+          expect.objectContaining({ code: 'SHEET_CALCULATION_MISMATCH' }),
+        ]));
+      });
   });
 
   it('requires explicit reviewed close input before forwarding a month close', async () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -125,6 +125,11 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain('week.weekStart.slice(5)');
   });
 
+  it('keeps explicit zero ledger values distinct from unentered cells outside the as-of comparison range', () => {
+    expect(source).toContain('Object.prototype.hasOwnProperty.call(amounts, params.lineId)');
+    expect(source).not.toContain("? Boolean(comparisonLine?.projectionHadValue)");
+  });
+
   it('places the operations dashboard before comparison and the monthly board', () => {
     const operations = source.indexOf('{renderOperationsPanel()}');
     const comparison = source.indexOf('data-cashflow-block="comparison"');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1496,11 +1496,10 @@ export function CashflowProjectSheet({
     const comparisonLine = month?.comparison?.weeks
       ?.find((candidate) => candidate.weekNo === params.weekNo)
       ?.lines?.find((candidate) => candidate.lineId === params.lineId);
+    const amounts = week?.amounts || {};
     return {
-      amount: Number(week?.amounts[params.lineId] || 0),
-      hasValue: params.mode === 'projection'
-        ? Boolean(comparisonLine?.projectionHadValue)
-        : Boolean(comparisonLine?.actualHadValue),
+      amount: Number(amounts[params.lineId] || 0),
+      hasValue: Object.prototype.hasOwnProperty.call(amounts, params.lineId),
       mismatch: comparisonLine?.mismatch === true,
     };
   }


### PR DESCRIPTION
## 변경\n- 명시적 0과 미입력 원장 상태를 분리해 표시합니다.\n- 중복된 연도 합계는 한 번만 선택하고, 2024·2025 이월은 각각 합산합니다.\n- 월 결산 시에만 입금·출금 합계와 전기이월 포함 잔액을 검산합니다.\n\n## 검증\n- node 구문 검사 및 검산 self-check 통과\n- 전체 Vitest는 GitHub Actions에서 실행합니다.\n\nStage Deploy는 main 병합 후 자동 실행됩니다. Production workflow는 실행하지 않습니다.