### PR TITLE
feat(cashflow): show weekly and monthly settlement state

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -1122,7 +1122,7 @@ function monthsBetween(startYearMonth, endYearMonth) {
 }
 
 async function readCashflowDeadlineSummary({ db, tenantId, projectId, comparisonBoundary }) {
-  if (!db?.collection) return { trackingStartedAt: null, missedCount: 0, completedCount: 0, current: null };
+  if (!db?.collection) return { trackingStartedAt: null, missedCount: 0, completedCount: 0, current: null, completedWeeks: [] };
   const [runSnap, completionSnap] = await Promise.all([
     db.collection(`orgs/${tenantId}/cashflow_sheet_stage_runs`)
       .where('projectId', '==', projectId)
@@ -1151,8 +1151,17 @@ async function readCashflowDeadlineSummary({ db, tenantId, projectId, comparison
     .map((value) => readOptionalText(value.completedAt))
     .filter((value) => Number.isFinite(Date.parse(value)))
     .sort();
+  const completedWeeks = completionRows
+    .map((value) => ({
+      yearMonth: readOptionalText(value.yearMonth),
+      weekNo: Number(value.weekNo),
+      completedAt: readOptionalText(value.completedAt) || null,
+      completedBy: readOptionalText(value.completedByEmail) || readOptionalText(value.completedByUid) || null,
+    }))
+    .filter((value) => /^20\d{2}-(0[1-9]|1[0-2])$/.test(value.yearMonth) && Number.isInteger(value.weekNo) && value.weekNo >= 1 && value.weekNo <= 5)
+    .sort((left, right) => left.yearMonth.localeCompare(right.yearMonth) || left.weekNo - right.weekNo);
   const trackingStartedAt = [...runs, ...completionDates].sort()[0] || null;
-  if (!trackingStartedAt) return { trackingStartedAt: null, missedCount: 0, completedCount: 0, current: null };
+  if (!trackingStartedAt) return { trackingStartedAt: null, missedCount: 0, completedCount: 0, current: null, completedWeeks };
   const asOfDate = readOptionalText(comparisonBoundary?.asOfDate);
   const startYearMonth = trackingStartedAt.slice(0, 7);
   const endYearMonth = asOfDate.slice(0, 7);
@@ -1185,7 +1194,23 @@ async function readCashflowDeadlineSummary({ db, tenantId, projectId, comparison
       };
     }
   }
-  return { trackingStartedAt, missedCount, completedCount, current };
+  return { trackingStartedAt, missedCount, completedCount, current, completedWeeks };
+}
+
+async function readCashflowMonthCloseStatuses({ db, tenantId, projectId }) {
+  if (!db?.collection) return [];
+  const snapshot = await db.collection(`orgs/${tenantId}/monthly_closes`)
+    .where('projectId', '==', projectId)
+    .limit(500)
+    .get();
+  return snapshot.docs
+    .map((doc) => doc.data() || {})
+    .map((value) => ({
+      yearMonth: readOptionalText(value.yearMonth),
+      status: readOptionalText(value.status).toUpperCase() || 'OPEN',
+    }))
+    .filter((value) => /^20\d{2}-(0[1-9]|1[0-2])$/.test(value.yearMonth))
+    .sort((left, right) => left.yearMonth.localeCompare(right.yearMonth));
 }
 
 function sheetControlBlockers(sheetFacts) {
@@ -1395,9 +1420,15 @@ async function composeCashflowMonthDashboard({ db, req, projectId, yearMonth, cl
   };
   const legacyEvidenceOnly = snapshotCompatibility.status === 'LEGACY_EVIDENCE_ONLY';
   const tenantId = readOptionalText(req.context?.tenantId);
-  const [projectDocument, mirror] = closedSnapshot
-    ? [null, null]
+  const deadlineSummaryPromise = readCashflowDeadlineSummary({ db, tenantId, projectId, comparisonBoundary });
+  const [monthCloseStatuses, projectDocument, mirror] = closedSnapshot
+    ? await Promise.all([
+      readCashflowMonthCloseStatuses({ db, tenantId, projectId }),
+      Promise.resolve(null),
+      Promise.resolve(null),
+    ])
     : await Promise.all([
+      readCashflowMonthCloseStatuses({ db, tenantId, projectId }),
       readDocument(db, `orgs/${tenantId}/projects/${projectId}`),
       readDocument(db, `orgs/${tenantId}/cashflow_sheet_mirrors/${projectId}`),
     ]);
@@ -1460,9 +1491,13 @@ async function composeCashflowMonthDashboard({ db, req, projectId, yearMonth, cl
       pinnedSheetCells: mirror?.cells,
       projectionOpeningBalance: safeAmount(authoritativeOpeningBalances?.projection?.amount),
     });
+  const liveDeadlineSummary = await deadlineSummaryPromise;
   const deadlineSummary = closedSnapshot
-    ? closedSnapshot?.deadlineSummary || { trackingStartedAt: null, missedCount: 0, completedCount: 0, current: null }
-    : await readCashflowDeadlineSummary({ db, tenantId, projectId, comparisonBoundary });
+    ? {
+      ...(closedSnapshot?.deadlineSummary || liveDeadlineSummary),
+      completedWeeks: liveDeadlineSummary.completedWeeks,
+    }
+    : liveDeadlineSummary;
   const blockers = [];
   if (readOptionalText(close?.status) !== 'OPEN') {
     blockers.push({ code: 'MONTH_NOT_OPEN', message: '결산 또는 재오픈 검토 중인 월은 수정할 수 없습니다.' });
@@ -1560,6 +1595,7 @@ async function composeCashflowMonthDashboard({ db, req, projectId, yearMonth, cl
     openingBalances: authoritativeOpeningBalances,
     snapshotCompatibility,
     deadlineSummary,
+    monthCloseStatuses,
     postCloseAdjustment: closedSnapshot ? postCloseAdjustment(close, closedSnapshot) : null,
     draftRevision: null,
     totals: { projection, actual, difference },

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -695,9 +695,14 @@ describe('JVM weekly API BFF proxy', () => {
     await request(app)
       .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
       .expect(200)
-      .expect((response) => expect(response.body.dashboard.deadlineSummary.current).toMatchObject({
-        yearMonth: '2026-07', weekNo: 3, status: 'COMPLETED',
-      }));
+      .expect((response) => {
+        expect(response.body.dashboard.deadlineSummary.current).toMatchObject({
+          yearMonth: '2026-07', weekNo: 3, status: 'COMPLETED',
+        });
+        expect(response.body.dashboard.deadlineSummary.completedWeeks).toEqual(expect.arrayContaining([
+          expect.objectContaining({ yearMonth: '2026-07', weekNo: 3, completedBy: 'pm@example.com' }),
+        ]));
+      });
   });
 
   it('forwards an explicit weekly scope and a reasoned reopen without an edit lease', async () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -125,6 +125,17 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain('week.weekStart.slice(5)');
   });
 
+  it('groups each month with an explicit close band and marks completed weekly settlements without extra requests', () => {
+    expect(source).toContain('const monthCloseStatusByMonth = new Map');
+    expect(source).toContain('const settledWeekKeys = new Set');
+    expect(source).toContain('const monthGroups = visibleWeeks.reduce');
+    expect(source).toContain('colSpan={month.weeks.length}');
+    expect(source).toContain("'월 결산 완료'");
+    expect(source).toContain("'주간 정산 완료'");
+    expect(source).toContain("input.monthCloseStatus === 'CLOSED'");
+    expect(source).toContain("? 'bg-slate-200'");
+  });
+
   it('keeps explicit zero ledger values distinct from unentered cells outside the as-of comparison range', () => {
     expect(source).toContain('Object.prototype.hasOwnProperty.call(amounts, params.lineId)');
     expect(source).not.toContain("? Boolean(comparisonLine?.projectionHadValue)");

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1519,12 +1519,17 @@ export function CashflowProjectSheet({
     lineId: CashflowSheetLineId;
     isThisWeek: boolean;
     isAltRow: boolean;
+    monthCloseStatus?: string;
   }) {
     const persisted = getServerReadCell({ ...input, mode: 'projection' });
     const projection = getBoardEffectiveAmount({ targetYearMonth: input.targetYearMonth, mode: 'projection', weekNo: input.weekNo, lineId: input.lineId });
     const actual = getBoardEffectiveAmount({ targetYearMonth: input.targetYearMonth, mode: 'actual', weekNo: input.weekNo, lineId: input.lineId });
     const shouldHighlightMismatch = persisted.mismatch;
-    const bgClass = input.isThisWeek ? 'bg-[#EAF0F5]' : input.isAltRow ? 'bg-slate-50' : 'bg-white';
+    const bgClass = input.monthCloseStatus === 'CLOSED'
+      ? 'bg-slate-200'
+      : input.monthCloseStatus === 'REOPEN_REQUESTED'
+        ? 'bg-[#EAF0F5]'
+        : input.isThisWeek ? 'bg-[#EAF0F5]' : input.isAltRow ? 'bg-slate-50' : 'bg-white';
     const isCollapsedEmpty = projection === 0 && actual === 0 && !persisted.hasValue;
 
     return (
@@ -1546,11 +1551,16 @@ export function CashflowProjectSheet({
     lineId: CashflowSheetLineId;
     isThisWeek: boolean;
     isAltRow: boolean;
+    monthCloseStatus?: string;
   }) {
     const persisted = getServerReadCell({ ...input, mode: 'actual' });
     const projection = getBoardEffectiveAmount({ targetYearMonth: input.targetYearMonth, mode: 'projection', weekNo: input.weekNo, lineId: input.lineId });
     const actual = getBoardEffectiveAmount({ targetYearMonth: input.targetYearMonth, mode: 'actual', weekNo: input.weekNo, lineId: input.lineId });
-    const bgClass = input.isThisWeek ? 'bg-[#EAF0F5]' : input.isAltRow ? 'bg-slate-50' : 'bg-white';
+    const bgClass = input.monthCloseStatus === 'CLOSED'
+      ? 'bg-slate-200'
+      : input.monthCloseStatus === 'REOPEN_REQUESTED'
+        ? 'bg-[#EAF0F5]'
+        : input.isThisWeek ? 'bg-[#EAF0F5]' : input.isAltRow ? 'bg-slate-50' : 'bg-white';
     const isCollapsedEmpty = projection === 0 && actual === 0 && !persisted.hasValue;
 
     return (
@@ -1572,11 +1582,16 @@ export function CashflowProjectSheet({
     mode: 'projection' | 'actual';
     isThisWeek?: boolean;
     isAltRow?: boolean;
+    monthCloseStatus?: string;
     emphasis?: 'income' | 'expense' | 'balance';
     stickyRight?: boolean;
     rowTone?: 'income' | 'expense';
   }) {
-    const bgClass = input.emphasis
+    const bgClass = input.monthCloseStatus === 'CLOSED'
+      ? 'bg-slate-200'
+      : input.monthCloseStatus === 'REOPEN_REQUESTED'
+        ? 'bg-[#EAF0F5]'
+      : input.emphasis
       ? 'bg-[#EAF0F5]'
       : input.isThisWeek
         ? 'bg-[#EAF0F5]'
@@ -1619,6 +1634,25 @@ export function CashflowProjectSheet({
       .sort((left, right) => left - right);
     const previousAnnualYears = annualYears.filter((year) => year < selectedYear);
     const followingAnnualYears = annualYears.filter((year) => year > selectedYear);
+    const monthCloseStatusByMonth = new Map(
+      (monthCloseResult?.dashboard?.monthCloseStatuses || []).map((item) => [item.yearMonth, item.status]),
+    );
+    if (!monthCloseStatusByMonth.has(yearMonth) && monthCloseResult?.status) {
+      monthCloseStatusByMonth.set(yearMonth, monthCloseResult.status);
+    }
+    const settledWeekKeys = new Set(
+      (monthCloseResult?.dashboard?.deadlineSummary?.completedWeeks || [])
+        .map((week) => `${week.yearMonth}:${week.weekNo}`),
+    );
+    const monthGroups = visibleWeeks.reduce<Array<{ yearMonth: string; weeks: typeof visibleWeeks }>>((groups, week) => {
+      const current = groups.at(-1);
+      if (!current || current.yearMonth !== week.yearMonth) {
+        groups.push({ yearMonth: week.yearMonth, weeks: [week] });
+      } else {
+        current.weeks.push(week);
+      }
+      return groups;
+    }, []);
     const annualTotalFor = (year: number, mode: 'projection' | 'actual') => {
       const jvmSource = monthCloseResult?.dashboard?.openingBalances?.selectedYear === selectedYear
         ? monthCloseResult.dashboard.openingBalances[mode]?.sources?.find((source) => source.year === year)
@@ -1765,9 +1799,10 @@ export function CashflowProjectSheet({
           {previousAnnualYears.map((year) => renderAnnualLineCell(mode, lineId, year, rowIndex % 2 === 1))}
           {visibleWeeks.map((week) => {
             const isThisWeek = todayYearMonth === week.yearMonth && todayIso >= week.weekStart && todayIso <= week.weekEnd;
+            const monthCloseStatus = monthCloseStatusByMonth.get(week.yearMonth);
             return mode === 'projection'
-              ? renderProjectionCell({ targetYearMonth: week.yearMonth, weekNo: week.weekNo, lineId, isThisWeek, isAltRow: rowIndex % 2 === 1 })
-              : renderActualCell({ targetYearMonth: week.yearMonth, weekNo: week.weekNo, lineId, isThisWeek, isAltRow: rowIndex % 2 === 1 });
+              ? renderProjectionCell({ targetYearMonth: week.yearMonth, weekNo: week.weekNo, lineId, isThisWeek, isAltRow: rowIndex % 2 === 1, monthCloseStatus })
+              : renderActualCell({ targetYearMonth: week.yearMonth, weekNo: week.weekNo, lineId, isThisWeek, isAltRow: rowIndex % 2 === 1, monthCloseStatus });
           })}
           {followingAnnualYears.map((year) => renderAnnualLineCell(mode, lineId, year, rowIndex % 2 === 1))}
           {renderSummaryCell({
@@ -1800,6 +1835,7 @@ export function CashflowProjectSheet({
             value: derived[mode].weekTotals[index]?.[kind] || 0,
             mode,
             isThisWeek: todayYearMonth === week.yearMonth && todayIso >= week.weekStart && todayIso <= week.weekEnd,
+            monthCloseStatus: monthCloseStatusByMonth.get(week.yearMonth),
             emphasis,
             rowTone,
           }))}
@@ -1819,34 +1855,61 @@ export function CashflowProjectSheet({
       <table className="w-full border-separate border-spacing-0 text-[12px]" style={{ minWidth: `${192 + (boardColumnCount - 1) * 84}px` }}>
         <thead className="sticky top-0 z-40 bg-white/95 text-slate-600 backdrop-blur shadow-[0_10px_24px_rgba(15,23,42,0.06)]">
           <tr>
-            <th className="sticky left-0 z-50 w-[192px] min-w-[192px] border-r-[6px] border-r-white bg-white px-3 py-2 text-left text-[12px] font-bold text-slate-800">
+            <th rowSpan={3} className="sticky left-0 z-50 w-[192px] min-w-[192px] border-r-[6px] border-r-white bg-white px-3 py-2 text-left text-[12px] font-bold text-slate-800">
               항목
             </th>
             {previousAnnualYears.map((year) => (
-              <th key={`${mode}-${year}-before`} data-cashflow-board-column="true" className="min-w-[84px] border-l-[6px] border-l-white bg-slate-100 px-1 py-2 text-center align-top font-semibold">
+              <th rowSpan={3} key={`${mode}-${year}-before`} data-cashflow-board-column="true" className="min-w-[84px] border-l-[6px] border-l-white bg-slate-100 px-1 py-2 text-center align-middle font-semibold">
                 <div className="text-[12px] font-bold text-slate-800">{year}년</div>
                 <div className="text-[12px] font-normal text-slate-400">누적</div>
               </th>
             ))}
-            {visibleWeeks.map((week) => {
-              const isThisWeek = todayYearMonth === week.yearMonth && todayIso >= week.weekStart && todayIso <= week.weekEnd;
+            {monthGroups.map((month) => {
+              const status = monthCloseStatusByMonth.get(month.yearMonth);
+              const monthLabel = `${Number(month.yearMonth.slice(5, 7))}월`;
               return (
-              <th key={`${mode}-${week.yearMonth}-${week.weekNo}`} data-cashflow-board-column="true" className={`min-w-[84px] border-l-[6px] border-l-white px-1 py-2 text-center align-top font-semibold ${isThisWeek ? 'bg-[#EAF0F5]' : 'bg-slate-50'}`}>
-                  <div className="min-h-5">
-                    <span className="block truncate text-[12px] font-bold leading-5 text-slate-800">{week.label}</span>
+                <th colSpan={month.weeks.length} key={`${mode}-${month.yearMonth}-month-close`} className={`border-l-[6px] border-l-white px-2 py-1.5 text-left align-middle ${status === 'CLOSED' ? 'bg-slate-700 text-white' : status === 'REOPEN_REQUESTED' ? 'bg-[#17324D] text-white' : 'bg-slate-100 text-slate-500'}`}>
+                  <div className="flex items-center justify-between gap-2 whitespace-nowrap">
+                    <span className="font-bold">{status === 'CLOSED' ? '월 결산 완료' : status === 'REOPEN_REQUESTED' ? '재오픈 검토 중' : '월 결산 전'}</span>
+                    <span className={`text-[11px] font-medium ${status === 'CLOSED' || status === 'REOPEN_REQUESTED' ? 'text-white/75' : 'text-slate-400'}`}>{monthLabel}</span>
                   </div>
                 </th>
               );
             })}
             {followingAnnualYears.map((year) => (
-              <th key={`${mode}-${year}-after`} data-cashflow-board-column="true" className="min-w-[84px] border-l-[6px] border-l-white bg-slate-100 px-1 py-2 text-center align-top font-semibold">
+              <th rowSpan={3} key={`${mode}-${year}-after`} data-cashflow-board-column="true" className="min-w-[84px] border-l-[6px] border-l-white bg-slate-100 px-1 py-2 text-center align-middle font-semibold">
                 <div className="text-[12px] font-bold text-slate-800">{year}년</div>
                 <div className="text-[12px] font-normal text-slate-400">합계</div>
               </th>
             ))}
-            <th className="sticky right-0 z-50 min-w-[84px] border-l-[6px] border-l-white bg-white px-1 py-2 text-left text-[12px] font-bold text-slate-800 shadow-[-12px_0_24px_rgba(15,23,42,0.08)]">
+            <th rowSpan={3} className="sticky right-0 z-50 min-w-[84px] border-l-[6px] border-l-white bg-white px-1 py-2 text-left text-[12px] font-bold text-slate-800 shadow-[-12px_0_24px_rgba(15,23,42,0.08)]">
               Total
             </th>
+          </tr>
+          <tr>
+            {visibleWeeks.map((week) => {
+              const completed = settledWeekKeys.has(`${week.yearMonth}:${week.weekNo}`);
+              const status = monthCloseStatusByMonth.get(week.yearMonth);
+              return (
+                <th key={`${mode}-${week.yearMonth}-${week.weekNo}-weekly-close`} data-cashflow-board-column="true" className={`min-w-[84px] border-l-[6px] border-l-white px-1 py-1 text-center align-middle ${status === 'CLOSED' ? 'bg-slate-200' : status === 'REOPEN_REQUESTED' ? 'bg-[#EAF0F5]' : 'bg-white'}`}>
+                  <span className={`inline-flex items-center gap-1 whitespace-nowrap text-[11px] font-semibold ${completed ? 'text-slate-700' : 'text-slate-400'}`}>
+                    <CheckCircle2 className={`h-3 w-3 ${completed ? 'text-[#17324D]' : 'text-slate-300'}`} />
+                    {completed ? '주간 정산 완료' : '주간 정산 전'}
+                  </span>
+                </th>
+              );
+            })}
+          </tr>
+          <tr>
+            {visibleWeeks.map((week) => {
+              const isThisWeek = todayYearMonth === week.yearMonth && todayIso >= week.weekStart && todayIso <= week.weekEnd;
+              const status = monthCloseStatusByMonth.get(week.yearMonth);
+              return (
+                <th key={`${mode}-${week.yearMonth}-${week.weekNo}`} data-cashflow-board-column="true" className={`min-w-[84px] border-l-[6px] border-l-white px-1 py-1.5 text-center align-top font-semibold ${status === 'CLOSED' ? 'bg-slate-200' : status === 'REOPEN_REQUESTED' ? 'bg-[#EAF0F5]' : isThisWeek ? 'bg-[#EAF0F5]' : 'bg-slate-50'}`}>
+                  <span className="block truncate text-[12px] font-bold leading-5 text-slate-800">{week.label}</span>
+                </th>
+              );
+            })}
           </tr>
         </thead>
         <tbody>

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -860,6 +860,12 @@ export interface CashflowDeadlineSummary {
   trackingStartedAt: string | null;
   missedCount: number;
   completedCount: number;
+  completedWeeks?: Array<{
+    yearMonth: string;
+    weekNo: number;
+    completedAt: string | null;
+    completedBy?: string | null;
+  }>;
   current: {
     yearMonth: string;
     weekNo: number;
@@ -912,6 +918,10 @@ export interface CashflowMonthCloseDashboard {
     missingEvidence: Array<'OPENING_BALANCES' | 'LEDGER_WEEKS'>;
   };
   deadlineSummary: CashflowDeadlineSummary;
+  monthCloseStatuses?: Array<{
+    yearMonth: string;
+    status: 'OPEN' | 'CLOSED' | 'REOPEN_REQUESTED' | string;
+  }>;
   postCloseAdjustment: {
     reason: string;
     changedCount: number;


### PR DESCRIPTION
## 변경\n- 월별 결산 상태를 하나의 상태 맵으로 조회\n- 표 헤더에 월 결산/주간 정산 상태 표시\n- 월 결산 완료 월은 전체 셀을 짙은 회색으로 표시\n\n## 검증\n- node --check server/bff/routes/jvm-weekly-api.mjs\n- npx vitest run src/app/components/cashflow/CashflowProjectSheet.shell.test.ts server/bff/routes/jvm-weekly-api.test.mjs\n\nStage 배포는 main 병합 후 GitHub Actions로만 실행합니다.