### PR TITLE
feat(cashflow): color weekly settlement status

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -1122,7 +1122,7 @@ function monthsBetween(startYearMonth, endYearMonth) {
 }
 
 async function readCashflowDeadlineSummary({ db, tenantId, projectId, comparisonBoundary }) {
-  if (!db?.collection) return { trackingStartedAt: null, missedCount: 0, completedCount: 0, current: null, completedWeeks: [] };
+  if (!db?.collection) return { trackingStartedAt: null, missedCount: 0, completedCount: 0, current: null, completedWeeks: [], weeklyStatuses: [] };
   const [runSnap, completionSnap] = await Promise.all([
     db.collection(`orgs/${tenantId}/cashflow_sheet_stage_runs`)
       .where('projectId', '==', projectId)
@@ -1161,7 +1161,7 @@ async function readCashflowDeadlineSummary({ db, tenantId, projectId, comparison
     .filter((value) => /^20\d{2}-(0[1-9]|1[0-2])$/.test(value.yearMonth) && Number.isInteger(value.weekNo) && value.weekNo >= 1 && value.weekNo <= 5)
     .sort((left, right) => left.yearMonth.localeCompare(right.yearMonth) || left.weekNo - right.weekNo);
   const trackingStartedAt = [...runs, ...completionDates].sort()[0] || null;
-  if (!trackingStartedAt) return { trackingStartedAt: null, missedCount: 0, completedCount: 0, current: null, completedWeeks };
+  if (!trackingStartedAt) return { trackingStartedAt: null, missedCount: 0, completedCount: 0, current: null, completedWeeks, weeklyStatuses: [] };
   const asOfDate = readOptionalText(comparisonBoundary?.asOfDate);
   const startYearMonth = trackingStartedAt.slice(0, 7);
   const endYearMonth = asOfDate.slice(0, 7);
@@ -1173,6 +1173,7 @@ async function readCashflowDeadlineSummary({ db, tenantId, projectId, comparison
   let missedCount = 0;
   let completedCount = 0;
   let current = null;
+  const weeklyStatuses = [];
   for (const week of weeks) {
     const deadlineMs = thursdayDeadlineMs(week);
     const startMs = Date.parse(`${week.weekStart}T00:00:00+09:00`);
@@ -1181,6 +1182,8 @@ async function readCashflowDeadlineSummary({ db, tenantId, projectId, comparison
     const completionMs = recordedAt ? Date.parse(recordedAt) : Number.NaN;
     const completedOnTime = Number.isFinite(completionMs) && completionMs >= startMs && completionMs <= deadlineMs;
     const deadlinePassed = asOfMs >= deadlineMs;
+    const status = completedOnTime ? 'COMPLETED' : recordedAt ? 'COMPLETED_LATE' : deadlinePassed ? 'MISSED' : 'PENDING';
+    weeklyStatuses.push({ yearMonth: week.yearMonth, weekNo: week.weekNo, status });
     if (completedOnTime) completedCount += 1;
     if (deadlinePassed && !completedOnTime) missedCount += 1;
     if (week.yearMonth === comparisonBoundary?.asOfWeek?.yearMonth && week.weekNo === comparisonBoundary?.asOfWeek?.weekNo) {
@@ -1190,27 +1193,11 @@ async function readCashflowDeadlineSummary({ db, tenantId, projectId, comparison
         deadline: new Date(deadlineMs).toISOString(),
         completedAt: recordedAt,
         completedBy: readOptionalText(completion?.completedByEmail) || readOptionalText(completion?.completedByUid) || null,
-        status: completedOnTime ? 'COMPLETED' : recordedAt ? 'COMPLETED_LATE' : deadlinePassed ? 'MISSED' : 'PENDING',
+        status,
       };
     }
   }
-  return { trackingStartedAt, missedCount, completedCount, current, completedWeeks };
-}
-
-async function readCashflowMonthCloseStatuses({ db, tenantId, projectId }) {
-  if (!db?.collection) return [];
-  const snapshot = await db.collection(`orgs/${tenantId}/monthly_closes`)
-    .where('projectId', '==', projectId)
-    .limit(500)
-    .get();
-  return snapshot.docs
-    .map((doc) => doc.data() || {})
-    .map((value) => ({
-      yearMonth: readOptionalText(value.yearMonth),
-      status: readOptionalText(value.status).toUpperCase() || 'OPEN',
-    }))
-    .filter((value) => /^20\d{2}-(0[1-9]|1[0-2])$/.test(value.yearMonth))
-    .sort((left, right) => left.yearMonth.localeCompare(right.yearMonth));
+  return { trackingStartedAt, missedCount, completedCount, current, completedWeeks, weeklyStatuses };
 }
 
 function sheetControlBlockers(sheetFacts) {
@@ -1421,14 +1408,9 @@ async function composeCashflowMonthDashboard({ db, req, projectId, yearMonth, cl
   const legacyEvidenceOnly = snapshotCompatibility.status === 'LEGACY_EVIDENCE_ONLY';
   const tenantId = readOptionalText(req.context?.tenantId);
   const deadlineSummaryPromise = readCashflowDeadlineSummary({ db, tenantId, projectId, comparisonBoundary });
-  const [monthCloseStatuses, projectDocument, mirror] = closedSnapshot
-    ? await Promise.all([
-      readCashflowMonthCloseStatuses({ db, tenantId, projectId }),
-      Promise.resolve(null),
-      Promise.resolve(null),
-    ])
+  const [projectDocument, mirror] = closedSnapshot
+    ? [null, null]
     : await Promise.all([
-      readCashflowMonthCloseStatuses({ db, tenantId, projectId }),
       readDocument(db, `orgs/${tenantId}/projects/${projectId}`),
       readDocument(db, `orgs/${tenantId}/cashflow_sheet_mirrors/${projectId}`),
     ]);
@@ -1595,7 +1577,6 @@ async function composeCashflowMonthDashboard({ db, req, projectId, yearMonth, cl
     openingBalances: authoritativeOpeningBalances,
     snapshotCompatibility,
     deadlineSummary,
-    monthCloseStatuses,
     postCloseAdjustment: closedSnapshot ? postCloseAdjustment(close, closedSnapshot) : null,
     draftRevision: null,
     totals: { projection, actual, difference },

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -702,6 +702,9 @@ describe('JVM weekly API BFF proxy', () => {
         expect(response.body.dashboard.deadlineSummary.completedWeeks).toEqual(expect.arrayContaining([
           expect.objectContaining({ yearMonth: '2026-07', weekNo: 3, completedBy: 'pm@example.com' }),
         ]));
+        expect(response.body.dashboard.deadlineSummary.weeklyStatuses).toEqual(expect.arrayContaining([
+          expect.objectContaining({ yearMonth: '2026-07', weekNo: 3, status: 'COMPLETED' }),
+        ]));
       });
   });
 

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -125,15 +125,15 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain('week.weekStart.slice(5)');
   });
 
-  it('groups each month with an explicit close band and marks completed weekly settlements without extra requests', () => {
-    expect(source).toContain('const monthCloseStatusByMonth = new Map');
-    expect(source).toContain('const settledWeekKeys = new Set');
-    expect(source).toContain('const monthGroups = visibleWeeks.reduce');
-    expect(source).toContain('colSpan={month.weeks.length}');
-    expect(source).toContain("'월 결산 완료'");
-    expect(source).toContain("'주간 정산 완료'");
-    expect(source).toContain("input.monthCloseStatus === 'CLOSED'");
-    expect(source).toContain("? 'bg-slate-200'");
+  it('uses server weekly settlement status to color the whole weekly column without monthly status bands', () => {
+    expect(source).toContain('const weeklyStatusByWeek = new Map');
+    expect(source).toContain('weeklySettlementSurface(input.weeklyStatus)');
+    expect(source).toContain("return 'bg-emerald-50'");
+    expect(source).toContain("return 'bg-red-50'");
+    expect(source).toContain("return 'bg-yellow-50'");
+    expect(source).toContain("? '정산 완료'");
+    expect(source).not.toContain('월 결산 전');
+    expect(source).not.toContain('monthCloseStatusByMonth');
   });
 
   it('keeps explicit zero ledger values distinct from unentered cells outside the as-of comparison range', () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -109,6 +109,13 @@ function weeklyCompletionStatusLabel(status?: 'COMPLETED' | 'COMPLETED_LATE' | '
   return '완료 대기';
 }
 
+function weeklySettlementSurface(status?: string): string {
+  if (status === 'COMPLETED' || status === 'COMPLETED_LATE') return 'bg-emerald-50';
+  if (status === 'MISSED') return 'bg-red-50';
+  if (status === 'PENDING') return 'bg-yellow-50';
+  return '';
+}
+
 function logCashflowSettlement(input: {
   phase: 'start' | 'success' | 'error' | 'info';
   operation: string;
@@ -1519,17 +1526,13 @@ export function CashflowProjectSheet({
     lineId: CashflowSheetLineId;
     isThisWeek: boolean;
     isAltRow: boolean;
-    monthCloseStatus?: string;
+    weeklyStatus?: string;
   }) {
     const persisted = getServerReadCell({ ...input, mode: 'projection' });
     const projection = getBoardEffectiveAmount({ targetYearMonth: input.targetYearMonth, mode: 'projection', weekNo: input.weekNo, lineId: input.lineId });
     const actual = getBoardEffectiveAmount({ targetYearMonth: input.targetYearMonth, mode: 'actual', weekNo: input.weekNo, lineId: input.lineId });
     const shouldHighlightMismatch = persisted.mismatch;
-    const bgClass = input.monthCloseStatus === 'CLOSED'
-      ? 'bg-slate-200'
-      : input.monthCloseStatus === 'REOPEN_REQUESTED'
-        ? 'bg-[#EAF0F5]'
-        : input.isThisWeek ? 'bg-[#EAF0F5]' : input.isAltRow ? 'bg-slate-50' : 'bg-white';
+    const bgClass = weeklySettlementSurface(input.weeklyStatus) || (input.isThisWeek ? 'bg-[#EAF0F5]' : input.isAltRow ? 'bg-slate-50' : 'bg-white');
     const isCollapsedEmpty = projection === 0 && actual === 0 && !persisted.hasValue;
 
     return (
@@ -1551,16 +1554,12 @@ export function CashflowProjectSheet({
     lineId: CashflowSheetLineId;
     isThisWeek: boolean;
     isAltRow: boolean;
-    monthCloseStatus?: string;
+    weeklyStatus?: string;
   }) {
     const persisted = getServerReadCell({ ...input, mode: 'actual' });
     const projection = getBoardEffectiveAmount({ targetYearMonth: input.targetYearMonth, mode: 'projection', weekNo: input.weekNo, lineId: input.lineId });
     const actual = getBoardEffectiveAmount({ targetYearMonth: input.targetYearMonth, mode: 'actual', weekNo: input.weekNo, lineId: input.lineId });
-    const bgClass = input.monthCloseStatus === 'CLOSED'
-      ? 'bg-slate-200'
-      : input.monthCloseStatus === 'REOPEN_REQUESTED'
-        ? 'bg-[#EAF0F5]'
-        : input.isThisWeek ? 'bg-[#EAF0F5]' : input.isAltRow ? 'bg-slate-50' : 'bg-white';
+    const bgClass = weeklySettlementSurface(input.weeklyStatus) || (input.isThisWeek ? 'bg-[#EAF0F5]' : input.isAltRow ? 'bg-slate-50' : 'bg-white');
     const isCollapsedEmpty = projection === 0 && actual === 0 && !persisted.hasValue;
 
     return (
@@ -1582,22 +1581,18 @@ export function CashflowProjectSheet({
     mode: 'projection' | 'actual';
     isThisWeek?: boolean;
     isAltRow?: boolean;
-    monthCloseStatus?: string;
+    weeklyStatus?: string;
     emphasis?: 'income' | 'expense' | 'balance';
     stickyRight?: boolean;
     rowTone?: 'income' | 'expense';
   }) {
-    const bgClass = input.monthCloseStatus === 'CLOSED'
-      ? 'bg-slate-200'
-      : input.monthCloseStatus === 'REOPEN_REQUESTED'
-        ? 'bg-[#EAF0F5]'
-      : input.emphasis
+    const bgClass = weeklySettlementSurface(input.weeklyStatus) || (input.emphasis
       ? 'bg-[#EAF0F5]'
       : input.isThisWeek
         ? 'bg-[#EAF0F5]'
         : input.isAltRow
           ? 'bg-slate-50'
-          : 'bg-white';
+          : 'bg-white');
     const valueClass = input.emphasis ? 'text-slate-950' : 'text-slate-800';
     return (
       <td key={input.keyName} className={`min-w-[84px] border-l-[6px] border-l-white px-1 py-1 align-middle ${input.stickyRight ? 'sticky right-0 z-20 shadow-[-12px_0_24px_rgba(15,23,42,0.08)]' : ''} ${bgClass}`}>
@@ -1634,25 +1629,10 @@ export function CashflowProjectSheet({
       .sort((left, right) => left - right);
     const previousAnnualYears = annualYears.filter((year) => year < selectedYear);
     const followingAnnualYears = annualYears.filter((year) => year > selectedYear);
-    const monthCloseStatusByMonth = new Map(
-      (monthCloseResult?.dashboard?.monthCloseStatuses || []).map((item) => [item.yearMonth, item.status]),
+    const weeklyStatusByWeek = new Map(
+      (monthCloseResult?.dashboard?.deadlineSummary?.weeklyStatuses || [])
+        .map((week) => [`${week.yearMonth}:${week.weekNo}`, week.status]),
     );
-    if (!monthCloseStatusByMonth.has(yearMonth) && monthCloseResult?.status) {
-      monthCloseStatusByMonth.set(yearMonth, monthCloseResult.status);
-    }
-    const settledWeekKeys = new Set(
-      (monthCloseResult?.dashboard?.deadlineSummary?.completedWeeks || [])
-        .map((week) => `${week.yearMonth}:${week.weekNo}`),
-    );
-    const monthGroups = visibleWeeks.reduce<Array<{ yearMonth: string; weeks: typeof visibleWeeks }>>((groups, week) => {
-      const current = groups.at(-1);
-      if (!current || current.yearMonth !== week.yearMonth) {
-        groups.push({ yearMonth: week.yearMonth, weeks: [week] });
-      } else {
-        current.weeks.push(week);
-      }
-      return groups;
-    }, []);
     const annualTotalFor = (year: number, mode: 'projection' | 'actual') => {
       const jvmSource = monthCloseResult?.dashboard?.openingBalances?.selectedYear === selectedYear
         ? monthCloseResult.dashboard.openingBalances[mode]?.sources?.find((source) => source.year === year)
@@ -1799,10 +1779,10 @@ export function CashflowProjectSheet({
           {previousAnnualYears.map((year) => renderAnnualLineCell(mode, lineId, year, rowIndex % 2 === 1))}
           {visibleWeeks.map((week) => {
             const isThisWeek = todayYearMonth === week.yearMonth && todayIso >= week.weekStart && todayIso <= week.weekEnd;
-            const monthCloseStatus = monthCloseStatusByMonth.get(week.yearMonth);
+            const weeklyStatus = weeklyStatusByWeek.get(`${week.yearMonth}:${week.weekNo}`);
             return mode === 'projection'
-              ? renderProjectionCell({ targetYearMonth: week.yearMonth, weekNo: week.weekNo, lineId, isThisWeek, isAltRow: rowIndex % 2 === 1, monthCloseStatus })
-              : renderActualCell({ targetYearMonth: week.yearMonth, weekNo: week.weekNo, lineId, isThisWeek, isAltRow: rowIndex % 2 === 1, monthCloseStatus });
+              ? renderProjectionCell({ targetYearMonth: week.yearMonth, weekNo: week.weekNo, lineId, isThisWeek, isAltRow: rowIndex % 2 === 1, weeklyStatus })
+              : renderActualCell({ targetYearMonth: week.yearMonth, weekNo: week.weekNo, lineId, isThisWeek, isAltRow: rowIndex % 2 === 1, weeklyStatus });
           })}
           {followingAnnualYears.map((year) => renderAnnualLineCell(mode, lineId, year, rowIndex % 2 === 1))}
           {renderSummaryCell({
@@ -1835,7 +1815,7 @@ export function CashflowProjectSheet({
             value: derived[mode].weekTotals[index]?.[kind] || 0,
             mode,
             isThisWeek: todayYearMonth === week.yearMonth && todayIso >= week.weekStart && todayIso <= week.weekEnd,
-            monthCloseStatus: monthCloseStatusByMonth.get(week.yearMonth),
+            weeklyStatus: weeklyStatusByWeek.get(`${week.yearMonth}:${week.weekNo}`),
             emphasis,
             rowTone,
           }))}
@@ -1855,57 +1835,45 @@ export function CashflowProjectSheet({
       <table className="w-full border-separate border-spacing-0 text-[12px]" style={{ minWidth: `${192 + (boardColumnCount - 1) * 84}px` }}>
         <thead className="sticky top-0 z-40 bg-white/95 text-slate-600 backdrop-blur shadow-[0_10px_24px_rgba(15,23,42,0.06)]">
           <tr>
-            <th rowSpan={3} className="sticky left-0 z-50 w-[192px] min-w-[192px] border-r-[6px] border-r-white bg-white px-3 py-2 text-left text-[12px] font-bold text-slate-800">
+            <th rowSpan={2} className="sticky left-0 z-50 w-[192px] min-w-[192px] border-r-[6px] border-r-white bg-white px-3 py-2 text-left text-[12px] font-bold text-slate-800">
               항목
             </th>
             {previousAnnualYears.map((year) => (
-              <th rowSpan={3} key={`${mode}-${year}-before`} data-cashflow-board-column="true" className="min-w-[84px] border-l-[6px] border-l-white bg-slate-100 px-1 py-2 text-center align-middle font-semibold">
+              <th rowSpan={2} key={`${mode}-${year}-before`} data-cashflow-board-column="true" className="min-w-[84px] border-l-[6px] border-l-white bg-slate-100 px-1 py-2 text-center align-middle font-semibold">
                 <div className="text-[12px] font-bold text-slate-800">{year}년</div>
                 <div className="text-[12px] font-normal text-slate-400">누적</div>
               </th>
             ))}
-            {monthGroups.map((month) => {
-              const status = monthCloseStatusByMonth.get(month.yearMonth);
-              const monthLabel = `${Number(month.yearMonth.slice(5, 7))}월`;
+            {visibleWeeks.map((week) => {
+              const status = weeklyStatusByWeek.get(`${week.yearMonth}:${week.weekNo}`);
+              const label = status === 'COMPLETED' || status === 'COMPLETED_LATE'
+                ? '정산 완료'
+                : status === 'MISSED' ? '미정산' : status === 'PENDING' ? '정산 대기' : '';
               return (
-                <th colSpan={month.weeks.length} key={`${mode}-${month.yearMonth}-month-close`} className={`border-l-[6px] border-l-white px-2 py-1.5 text-left align-middle ${status === 'CLOSED' ? 'bg-slate-700 text-white' : status === 'REOPEN_REQUESTED' ? 'bg-[#17324D] text-white' : 'bg-slate-100 text-slate-500'}`}>
-                  <div className="flex items-center justify-between gap-2 whitespace-nowrap">
-                    <span className="font-bold">{status === 'CLOSED' ? '월 결산 완료' : status === 'REOPEN_REQUESTED' ? '재오픈 검토 중' : '월 결산 전'}</span>
-                    <span className={`text-[11px] font-medium ${status === 'CLOSED' || status === 'REOPEN_REQUESTED' ? 'text-white/75' : 'text-slate-400'}`}>{monthLabel}</span>
-                  </div>
+                <th key={`${mode}-${week.yearMonth}-${week.weekNo}-weekly-close`} data-cashflow-board-column="true" className={`min-w-[84px] border-l-[6px] border-l-white px-1 py-1 text-center align-middle ${weeklySettlementSurface(status) || 'bg-white'}`}>
+                  <span className={`inline-flex items-center gap-1 whitespace-nowrap text-[11px] font-semibold ${status === 'MISSED' ? 'text-red-700' : status ? 'text-slate-700' : 'text-slate-300'}`}>
+                    <CheckCircle2 className={`h-3 w-3 ${status === 'MISSED' ? 'text-red-600' : status ? 'text-[#17324D]' : 'text-slate-300'}`} />
+                    {label}
+                  </span>
                 </th>
               );
             })}
             {followingAnnualYears.map((year) => (
-              <th rowSpan={3} key={`${mode}-${year}-after`} data-cashflow-board-column="true" className="min-w-[84px] border-l-[6px] border-l-white bg-slate-100 px-1 py-2 text-center align-middle font-semibold">
+              <th rowSpan={2} key={`${mode}-${year}-after`} data-cashflow-board-column="true" className="min-w-[84px] border-l-[6px] border-l-white bg-slate-100 px-1 py-2 text-center align-middle font-semibold">
                 <div className="text-[12px] font-bold text-slate-800">{year}년</div>
                 <div className="text-[12px] font-normal text-slate-400">합계</div>
               </th>
             ))}
-            <th rowSpan={3} className="sticky right-0 z-50 min-w-[84px] border-l-[6px] border-l-white bg-white px-1 py-2 text-left text-[12px] font-bold text-slate-800 shadow-[-12px_0_24px_rgba(15,23,42,0.08)]">
+            <th rowSpan={2} className="sticky right-0 z-50 min-w-[84px] border-l-[6px] border-l-white bg-white px-1 py-2 text-left text-[12px] font-bold text-slate-800 shadow-[-12px_0_24px_rgba(15,23,42,0.08)]">
               Total
             </th>
           </tr>
           <tr>
             {visibleWeeks.map((week) => {
-              const completed = settledWeekKeys.has(`${week.yearMonth}:${week.weekNo}`);
-              const status = monthCloseStatusByMonth.get(week.yearMonth);
-              return (
-                <th key={`${mode}-${week.yearMonth}-${week.weekNo}-weekly-close`} data-cashflow-board-column="true" className={`min-w-[84px] border-l-[6px] border-l-white px-1 py-1 text-center align-middle ${status === 'CLOSED' ? 'bg-slate-200' : status === 'REOPEN_REQUESTED' ? 'bg-[#EAF0F5]' : 'bg-white'}`}>
-                  <span className={`inline-flex items-center gap-1 whitespace-nowrap text-[11px] font-semibold ${completed ? 'text-slate-700' : 'text-slate-400'}`}>
-                    <CheckCircle2 className={`h-3 w-3 ${completed ? 'text-[#17324D]' : 'text-slate-300'}`} />
-                    {completed ? '주간 정산 완료' : '주간 정산 전'}
-                  </span>
-                </th>
-              );
-            })}
-          </tr>
-          <tr>
-            {visibleWeeks.map((week) => {
               const isThisWeek = todayYearMonth === week.yearMonth && todayIso >= week.weekStart && todayIso <= week.weekEnd;
-              const status = monthCloseStatusByMonth.get(week.yearMonth);
+              const status = weeklyStatusByWeek.get(`${week.yearMonth}:${week.weekNo}`);
               return (
-                <th key={`${mode}-${week.yearMonth}-${week.weekNo}`} data-cashflow-board-column="true" className={`min-w-[84px] border-l-[6px] border-l-white px-1 py-1.5 text-center align-top font-semibold ${status === 'CLOSED' ? 'bg-slate-200' : status === 'REOPEN_REQUESTED' ? 'bg-[#EAF0F5]' : isThisWeek ? 'bg-[#EAF0F5]' : 'bg-slate-50'}`}>
+                <th key={`${mode}-${week.yearMonth}-${week.weekNo}`} data-cashflow-board-column="true" className={`min-w-[84px] border-l-[6px] border-l-white px-1 py-1.5 text-center align-top font-semibold ${weeklySettlementSurface(status) || (isThisWeek ? 'bg-[#EAF0F5]' : 'bg-slate-50')}`}>
                   <span className="block truncate text-[12px] font-bold leading-5 text-slate-800">{week.label}</span>
                 </th>
               );

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -866,6 +866,11 @@ export interface CashflowDeadlineSummary {
     completedAt: string | null;
     completedBy?: string | null;
   }>;
+  weeklyStatuses?: Array<{
+    yearMonth: string;
+    weekNo: number;
+    status: 'COMPLETED' | 'COMPLETED_LATE' | 'MISSED' | 'PENDING';
+  }>;
   current: {
     yearMonth: string;
     weekNo: number;
@@ -918,10 +923,6 @@ export interface CashflowMonthCloseDashboard {
     missingEvidence: Array<'OPENING_BALANCES' | 'LEDGER_WEEKS'>;
   };
   deadlineSummary: CashflowDeadlineSummary;
-  monthCloseStatuses?: Array<{
-    yearMonth: string;
-    status: 'OPEN' | 'CLOSED' | 'REOPEN_REQUESTED' | string;
-  }>;
   postCloseAdjustment: {
     reason: string;
     changedCount: number;


### PR DESCRIPTION
## 변경\n- 주간 정산 상태를 서버 기준으로 주차별 신호등 표시\n- 완료 초록 / 기한 전 미정산 노랑 / 기한 후 미정산 빨강\n- 월별 결산 상태 띠 제거\n\n## 검증\n- node --check server/bff/routes/jvm-weekly-api.mjs\n- npx tsc --noEmit --pretty false\n- npx vitest run src/app/components/cashflow/CashflowProjectSheet.shell.test.ts server/bff/routes/jvm-weekly-api.test.mjs