### PR TITLE
fix(cashflow): 확인할 항목 카드 제거 및 진행률 배지 상태 라벨 정정

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -98,10 +98,20 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('getPinnedDerivedAmount(mode, week.yearMonth, week.weekNo, kind)');
   });
 
-  it('keeps the ready placeholder out of the issue count', () => {
+  it('drops the inbox card but keeps the issue count badge', () => {
     expect(source).not.toContain("inbox.push({ id: 'all-clear'");
     expect(source).toContain('{opsSummary.status.count}건');
-    expect(source).toContain('visibleInbox.length === 0');
+    expect(source).not.toContain('visibleInbox');
+    expect(source).not.toContain('text-muted-foreground">확인할 항목</div>');
+    expect(source).not.toContain('xl:max-h-[126px]');
+  });
+
+  it('labels rate tiles by loading, over, under, and OK', () => {
+    expect(source).toContain('function rateStatusLabel');
+    expect(source).toContain("if (monthCloseLoading || !monthCloseResult?.dashboard) return '확인 중';");
+    expect(source).toContain("if (percent === 100) return 'OK';");
+    expect(source).toContain("return percent > 100 ? '초과' : '미달';");
+    expect(source).not.toContain("rate.percent === 100 ? 'OK' : '확인 중'");
   });
 
   it('keeps Projection then ACTUAL row order and uses navy for difference rows', () => {
@@ -122,7 +132,6 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('text-card-foreground">월 결산');
     expect(source).toContain('text-secondary-foreground">{check.title}');
     expect(source).toContain('text-muted-foreground">프로젝트 전체 기간 · BFF/JVM 서버 판정');
-    expect(source).toContain('divide-y divide-border');
     expect(source).toContain('bg-accent px-2.5 py-1 font-semibold text-accent-foreground');
     expect(source).toContain('space-y-5 bg-background p-4');
     expect(source).not.toMatch(/FFF7DE|E4C974|D6A92C|FCE8A8/);

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1460,28 +1460,15 @@ export function CashflowProjectSheet({
     const dashboard = monthCloseResult?.dashboard;
     const blockers = dashboard?.validation?.blockers || [];
     const warnings = dashboard?.validation?.warnings || [];
-    const inbox = [
-      ...blockers.map((item) => ({ id: `blocker-${item.code}`, tone: 'danger' as CashflowOpsTone, title: item.message, detail: item.code })),
-      ...warnings.map((item) => ({ id: `warning-${item.code}`, tone: 'warning' as CashflowOpsTone, title: item.message, detail: item.code })),
-      ...(dashboard && (dashboard.summary?.settlementIncompleteWeeks?.length || 0) > 0
-        ? [{
-            id: 'projection-actual-diff',
-            tone: 'warning' as CashflowOpsTone,
-            title: `Projection/Actual 확인이 필요한 주차 ${dashboard.summary.settlementIncompleteWeeks.length}건`,
-            detail: dashboard.summary.settlementIncompleteWeeks
-              .slice(0, 5)
-              .map((week) => `${week.yearMonth} ${week.weekNo}주차`)
-              .join(', '),
-          }]
-        : []),
-    ];
-    if (!dashboard && !monthCloseLoading) {
-      inbox.push({ id: 'dashboard-unavailable', tone: 'danger', title: '월 결산 서버 상태를 불러오지 못했습니다.', detail: monthCloseError || '잠시 후 다시 시도해 주세요.' });
-    }
-    const issueCount = inbox.length;
-    const kind = blockers.length > 0 || (!dashboard && !monthCloseLoading)
+    const settlementIncompleteCount = dashboard?.summary?.settlementIncompleteWeeks?.length || 0;
+    const dashboardUnavailable = !dashboard && !monthCloseLoading;
+    const issueCount = blockers.length
+      + warnings.length
+      + (settlementIncompleteCount > 0 ? 1 : 0)
+      + (dashboardUnavailable ? 1 : 0);
+    const kind = blockers.length > 0 || dashboardUnavailable
       ? 'blocked' as const
-      : warnings.length > 0 || (dashboard?.summary?.settlementIncompleteWeeks?.length || 0) > 0
+      : warnings.length > 0 || settlementIncompleteCount > 0
         ? 'review' as const
         : 'ready' as const;
     const tone: CashflowOpsTone = kind === 'blocked' ? 'danger' : kind === 'review' ? 'warning' : 'success';
@@ -1503,9 +1490,8 @@ export function CashflowProjectSheet({
         actual: rate(dashboard?.summary?.actualProgressPercent || 0),
         confirmation: rate(dashboard?.summary?.settlementProgressPercent || 0),
       },
-      inbox,
     };
-  }, [monthCloseError, monthCloseLoading, monthCloseResult?.dashboard]);
+  }, [monthCloseLoading, monthCloseResult?.dashboard]);
 
   function diffTextClass(diff: number): string {
     return diff === 0 ? 'text-slate-400' : 'text-slate-800';
@@ -2175,12 +2161,10 @@ export function CashflowProjectSheet({
     return 'bg-secondary';
   }
 
-  function opsTextClass(tone: CashflowOpsTone): string {
-    if (tone === 'danger') return 'text-red-700';
-    if (tone === 'warning') return 'text-accent-foreground';
-    if (tone === 'success') return 'text-secondary-foreground';
-    if (tone === 'info') return 'text-primary';
-    return 'text-secondary-foreground';
+  function rateStatusLabel(percent: number): string {
+    if (monthCloseLoading || !monthCloseResult?.dashboard) return '확인 중';
+    if (percent === 100) return 'OK';
+    return percent > 100 ? '초과' : '미달';
   }
 
   function renderRateTile(label: string, rate: { percent: number }) {
@@ -2207,7 +2191,7 @@ export function CashflowProjectSheet({
           <span className={`text-[22px] font-bold leading-6 tabular-nums ${tone.value}`}>
             {rate.percent}%
           </span>
-          <span className={`truncate text-right text-[12px] font-semibold leading-4 ${tone.value}`}>{rate.percent === 100 ? 'OK' : '확인 중'}</span>
+          <span className={`truncate text-right text-[12px] font-semibold leading-4 ${tone.value}`}>{rateStatusLabel(rate.percent)}</span>
         </div>
         <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-muted">
           <div className={`h-full rounded-full ${tone.bar}`} style={{ width: `${Math.min(100, Math.max(0, rate.percent))}%` }} />
@@ -2217,70 +2201,21 @@ export function CashflowProjectSheet({
     );
   }
 
-  function renderOperationsSummary(input: {
-    hiddenInboxCount: number;
-    visibleInbox: typeof opsSummary.inbox;
-  }) {
+  function renderOperationsSummary() {
     return (
-      <div className="grid gap-2.5 xl:grid-cols-[minmax(0,1fr)_240px]">
-        <div className="grid gap-2 md:grid-cols-3">
-          {renderRateTile('Projection', opsSummary.rates.projection)}
-          {renderRateTile('Actual', opsSummary.rates.actual)}
-          {renderRateTile('결산', opsSummary.rates.confirmation)}
-        </div>
-
-        <div className="min-w-0 overflow-hidden rounded-md border border-border bg-card shadow-none xl:max-h-[126px]">
-          <div className="flex items-center justify-between gap-2 px-3 py-2">
-            <div className="min-w-0">
-              <div className="text-[12px] font-semibold text-muted-foreground">확인할 항목</div>
-              <div className={`mt-0.5 text-[12px] font-bold tabular-nums ${opsTextClass(opsSummary.status.tone)}`}>
-                {opsSummary.status.count}건
-              </div>
-            </div>
-          </div>
-          <div className="divide-y divide-border">
-            {input.visibleInbox.length === 0 ? (
-              <div className="grid grid-cols-[14px_minmax(0,1fr)] gap-1.5 px-3 py-1.5">
-                <div className="flex h-4 items-center justify-center">
-                  <span className={`h-1.5 w-1.5 rounded-full ${opsDotClass('success')}`} />
-                </div>
-                <div className="min-w-0">
-                  <div className={`truncate text-[12px] font-bold leading-4 ${opsTextClass('success')}`}>확인할 항목이 없습니다.</div>
-                  <div className="mt-0.5 truncate text-[12px] leading-4 text-muted-foreground">서버 검증 기준으로 준비되었습니다.</div>
-                </div>
-              </div>
-            ) : input.visibleInbox.map((item) => (
-              <div key={item.id} className="grid grid-cols-[14px_minmax(0,1fr)] gap-1.5 px-3 py-1.5">
-                <div className="flex h-4 items-center justify-center">
-                  <span className={`h-1.5 w-1.5 rounded-full ${opsDotClass(item.tone)}`} />
-                </div>
-                <div className="min-w-0">
-                  <div className={`truncate text-[12px] font-bold leading-4 ${opsTextClass(item.tone)}`}>{item.title}</div>
-                  <div className="mt-0.5 truncate text-[12px] leading-4 text-muted-foreground">{item.detail}</div>
-                </div>
-              </div>
-            ))}
-            {input.hiddenInboxCount > 0 && (
-              <div className="px-2 py-1 text-[12px] font-semibold text-muted-foreground">
-                외 {input.hiddenInboxCount}건
-              </div>
-            )}
-          </div>
-        </div>
+      <div className="grid gap-2 md:grid-cols-3">
+        {renderRateTile('Projection', opsSummary.rates.projection)}
+        {renderRateTile('Actual', opsSummary.rates.actual)}
+        {renderRateTile('결산', opsSummary.rates.confirmation)}
       </div>
     );
   }
 
   function renderOperationsPanel() {
-    const visibleInbox = opsSummary.inbox.slice(0, 4);
-    const hiddenInboxCount = Math.max(0, opsSummary.status.count - visibleInbox.length);
     const statusBadgeLabel = opsSummary.status.kind === 'ready'
       ? opsSummary.status.label
       : `확인 항목 ${opsSummary.status.count}건`;
-    const dashboardSummary = renderOperationsSummary({
-      hiddenInboxCount,
-      visibleInbox,
-    });
+    const dashboardSummary = renderOperationsSummary();
     return (
       <Card className="overflow-hidden rounded-lg border border-border bg-card shadow-sm">
         <CardContent className="space-y-3 p-4">


### PR DESCRIPTION
스테이지(`/portal/cashflow`)에서 직접 확인한 두 가지 UI 결함을 고칩니다.

## 1. 확인할 항목 카드 제거

카드에 `xl:max-h-[126px]` + `overflow-hidden` 이 걸려 있어 항목 3건 중 1건만 온전히 읽혔습니다. 2번째는 `PROJECT_SHEET_ACCOUNT_THR...` 로 잘리고 3번째는 아예 보이지 않았습니다.

카드를 통째로 제거하고, `opsSummary.inbox` 배열을 만들지 않은 채 `issueCount`를 직접 계산하도록 바꿨습니다. 헤더의 `확인 항목 N건` 배지는 그대로 유지되어 건수는 계속 보입니다.

카드에서만 쓰이던 `opsTextClass()` 헬퍼도 함께 제거했습니다.

**알려진 트레이드오프**: 서버 `warnings` 와 `월 결산 서버 상태를 불러오지 못했습니다` 메시지는 이제 UI에 노출되지 않습니다. `blockers` 는 월 결산 시도 시 에러로 계속 표면화됩니다.

## 2. 진행률 배지 상태 라벨

`rate.percent === 100 ? 'OK' : '확인 중'` 이라, 계산이 끝났지만 100%가 아닌 값도 "아직 확인 중"으로 읽혔습니다. 스테이지에서 Projection 370.97%(계약금액 1억 vs Projection 3.71억)가 `확인 중` 으로 표시되어, 실무자가 계약금액 불일치를 로딩 상태로 오해할 수 있었습니다.

```ts
function rateStatusLabel(percent: number): string {
  if (monthCloseLoading || !monthCloseResult?.dashboard) return '확인 중';
  if (percent === 100) return 'OK';
  return percent > 100 ? '초과' : '미달';
}
```

`dashboard` 가 없을 때도 `확인 중` 으로 둡니다. 서버 데이터가 없으면 percent가 `|| 0` 으로 0이 되는데, 이를 `미달` 로 표시하면 사실과 다르기 때문입니다.

## 검증

| 항목 | 결과 |
|---|---|
| 타입체크 | 기존 206건 → 206건, 신규 에러 0 (stash 대조) |
| `vitest run src/app/components/cashflow/` | 91/91 통과 |
| 전체 `vitest run` | 2350 통과 |
| `npm run policy:verify` | 통과 |
| `vite build` | 통과 |

삭제한 카드를 검증하던 셸 테스트 2건을 새 계약(카드 부재 + 4단계 라벨)에 맞게 재작성했습니다.

브라우저 육안 확인은 하지 못했습니다. 스테이지는 `main` 머지 후 Stage Deploy로만 배포되고, 로컬 dev 서버도 실제 Google 로그인이 필요하기 때문입니다.

## 범위 밖 (별도 처리 필요)

- `/api/v1/cashflow/{id}/month-close` 가 콜드 14.58초 / 웜 4.15초. 원인은 `yearMonth` 필터 없는 전체 스캔(`FirestoreInheritedWeeklyExpensePersistence.java:1904`, `:2615`, `:1881`). 해당 복합 인덱스는 이미 선언되어 있으나 쿼리가 사용하지 않습니다.
- `opsSubtleBgClass()` 는 이 PR 이전부터 사용처가 없는 죽은 코드입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)