### PR TITLE
채널 교통정리 1단계: 실패 원인을 볼 수 있게 만들기 (+ 감사 문서)

### DIFF
--- a/docs/architecture/2026-07-27-jvm-bff-channel-audit.md
+++ b/docs/architecture/2026-07-27-jvm-bff-channel-audit.md
@@ -1,0 +1,246 @@
+# JVM/BFF 채널 감사와 JVM 서비스의 정체
+
+**Date:** 2026-07-27
+
+**Status:** 조사 완료 — 수정 착수 전
+**Scope:** `server/bff` ↔ `server/jvm-weekly-api` 채널. 데이터 마이그레이션이나 서비스 제거는 이 문서의 범위가 아니다.
+
+## 왜 이 문서를 쓰는가
+
+2026-07-13부터 07-27까지 14일간 캐시플로우 월 결산 영역에 61개 커밋이 들어갔고 그중 46%가 `fix`였다. 같은 기간에 만들었다가 몇 시간 만에 삭제된 서브시스템이 셋이다(정산주차 쓰기잠금 2시간 38분, 연간합계 컬럼 19분, edit-lease 펜싱 13일에 걸쳐 해체).
+
+되돌리기는 한 번도 `git revert`로 하지 않았다. 전부 손으로 역방향 커밋을 썼기 때문에 **"이미 시도했다가 실패한 접근"이라는 신호가 히스토리에 남지 않는다.** 다음 작업자는 그걸 모른 채 같은 시도를 반복한다.
+
+그리고 이 기간에 아무도 던지지 않은 질문이 하나 있다. **이 규모에 JVM 서비스가 왜 있는가.**
+
+이 문서는 그 답과, 그 답이 설명하는 장애들을 기록한다. 실패한 시도를 히스토리에 남기지 못한 대가를 더 치르지 않기 위해서다.
+
+## 발견 1 — JVM은 Postgres 시절의 잔재다
+
+### 근거
+
+`server/jvm-weekly-api/pom.xml`이 선언하는 의존성:
+
+```
+spring-boot-starter-data-jpa
+postgresql
+postgres-socket-factory
+flyway-core
+flyway-database-postgresql
+h2
+```
+
+- JPA 엔티티 **12개** (`server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/*Entity.java`)
+- Flyway 마이그레이션 **4개** (`src/main/resources/db/migration/V1~V4__*.sql`)
+- 기본 저장소 설정도 JPA — `src/main/resources/application.yml:24`
+
+```yaml
+storage-backend: ${JVM_WEEKLY_STORAGE_BACKEND:jpa}
+```
+
+그런데 실제 배포는 `cloudbuild.jvm-weekly-api.yaml`에서 이렇게 덮는다:
+
+```
+JVM_WEEKLY_STORAGE_BACKEND=firestore
+```
+
+그리고 **배포 설정에 Cloud SQL 연결이 없다.** Postgres 인스턴스가 붙어 있지 않다.
+
+현재 프로덕션에서 실제로 동작하는 구현 클래스의 이름이 이 사실을 그대로 말한다:
+
+```
+FirestoreInheritedWeeklyExpensePersistence
+```
+
+### 따라서 실제 구조는 이렇다
+
+```
+React ──▶ Node BFF ──▶ Java Spring ──▶ Firestore
+             │                            ▲
+             └────────────────────────────┘
+                  (같은 DB를 직접 읽고 쓴다)
+```
+
+JVM은 데이터를 독점하지 않는다. 다른 저장소를 쓰지도 않는다. **BFF와 JVM이 같은 Firestore를 각자 본다.**
+
+### 이것이 설명하는 것
+
+`GET /api/v1/cashflow/{id}/month-close`가 콜드 14.58초, 웜 4.15초, 응답 270KB다(2026-07-27 스테이지 실측). 원인은 페이로드가 아니라 읽기 증폭이다. 한 달치를 요청하는데 프로젝트 전체 히스토리를 무필터로 스캔한다:
+
+| 대상 | 위치 |
+|---|---|
+| `cashflow_weeks` 전체 | `FirestoreInheritedWeeklyExpensePersistence.java:1905` |
+| `monthly_closes` 전체 (정수 2개를 얻으려고 snapshot 통째로 든 문서를 전부 읽음) | `:2616`, `:2630` |
+| `cashflow_year_totals` 전체 | `:1882` |
+
+쿼리 형태가 이렇다:
+
+```java
+query(cashflowWeeks(tenantId).whereEqualTo("projectId", projectId))
+```
+
+`yearMonth` 필터도 `limit`도 없다. 그리고 이 형태는 단발이 아니다. 같은 파일에서 `cashflowWeeks(tenantId).whereEqualTo("projectId", projectId)` 만으로 **7곳**이 나온다(`:1427`, `:1611`, `:1905`, `:3197`, `:3574`, `:3659`, `:3675`).
+
+**이것은 Postgres에 쓰는 코드다.** SQL에서는 인덱스를 걸고 DB가 걸러 주므로 자연스러운 형태다. Firestore로 옮겨오면서 이 형태가 그대로 남아, 문서를 전부 읽어 메모리에 올리는 코드가 되었다.
+
+`firebase/firestore.indexes.json`에는 이 쿼리를 빠르게 만들 복합 인덱스가 **이미 선언되어 있다**:
+
+```json
+{ "collectionGroup": "cashflow_weeks",
+  "fields": [ {"fieldPath":"projectId"}, {"fieldPath":"yearMonth"}, {"fieldPath":"weekNo"} ] }
+```
+
+쿼리가 `yearMonth`를 쓰지 않으므로 이 인덱스는 사용되지 않는다. 인프라는 준비되어 있고 쿼리만 Postgres 형태로 남아 있다.
+
+이전 성능 작업 `7247ce2`("fix: stabilize cashflow dashboard loading")가 효과를 내지 못한 이유도 여기 있다. 그 커밋은 BFF→JVM HTTP 홉 하나를 없앴을 뿐 **Firestore 쿼리를 하나도 건드리지 않았다.** 지배적 비용은 홉이 아니었다. 같은 커밋이 `findings` 배열을 추가해 응답은 오히려 커졌다.
+
+## 발견 2 — 채널의 실패 지점
+
+BFF는 Vercel 서버리스 함수이고(`vercel.json:11-15`, `maxDuration: 60`), JVM은 Cloud Run이다(`cloudbuild.jvm-weekly-api.yaml:54-70`). 이 배치가 아래 항목 여럿의 전제다.
+
+### 2-1. `editSession`이 시트 반영 3개 경로에서 유실된다
+
+호출부는 넘긴다:
+
+- `server/bff/routes/cashflow-sheet-lab.mjs:2146` — `applyCashflowSheetLab({ ..., editSession: monthEditSession })`
+- `:2180` — `applyCashflowSheetBatch({ ..., editSession: monthEditSession })`
+- `:2257` — `applyCashflowSheetAnnualTotal({ ..., editSession: yearEditSession })`
+
+받는 쪽은 구조분해에 `editSession`이 없다:
+
+- `server/bff/java-weekly-client.mjs:244` — `applyCashflowSheetLab({ context, projectId, idempotencyKey, sourceRevision, targetRevision, yearMonth, cells, calculationChecks, replaceAllActualSources, settledWeekChangeConfirmation, closedMonthChangeReason })`
+- `:294`, `:342` — 동일
+
+JavaScript 구조분해라 **에러 없이 조용히 버려진다.** `requestJson`은 `editSession`을 받아(`:134`, `:185`) 리스 헤더로 변환하는데(`java-weekly-auth.mjs:94-98`), 그 경로에 값이 도달하지 않는다.
+
+JVM은 그 헤더를 읽는다(`WeeklyExpenseController.java:939`). 스테이지는 `JVM_WEEKLY_EDIT_LEASES_ENABLED=true`다(`cloudbuild.jvm-weekly-api.yaml:71`).
+
+결과가 두 겹이다:
+
+1. `x-edit-lease-id` 부재, `x-edit-fence`가 0 → 펜스 검증 거부
+2. `x-edit-finalize`가 전송되지 않음 → **리스가 만료 전까지 해제되지 않고 누적**
+
+두 번째가 "가끔 되다가 어느 시점부터 계속 실패"라는 증상을 만든다.
+
+**로그 확인법:** JVM 요청 로그에서 `/sheet-lab/apply`, `/sheet-lab/batch/apply`, `/sheet-lab/annual/apply` 경로에 `x-edit-lease-id`가 100% 부재인지 확인한다.
+
+### 2-2. 모든 5xx 메시지가 하나의 영어 문자열로 뭉개진다
+
+`server/bff/app.mjs:1559`:
+
+```js
+const message = statusCode >= 500 ? 'Internal server error' : (error?.message || 'Request failed');
+```
+
+`java-weekly-client.mjs`에 작성된 한국어 5xx 메시지는 전부 도달하지 않는다. 살아남는 것은 기계용 `code` 필드뿐이고, 캐시플로우 UI 컴포넌트 중 그 코드를 읽는 곳은 없다.
+
+`src/app/platform/api-client.ts:396`은 서버 메시지를 읽어 `responseMessage`에 담지만 던지는 `PlatformApiError`에 넣지 않는다(`:418-423`). devtools 로그에만 남는다.
+
+그래서 아래가 전부 화면에서 동일하게 보인다:
+
+| 실제 원인 | 성질 | 사용자가 보는 것 |
+|---|---|---|
+| 환경변수 미설정 | 영구 | `Internal server error` |
+| 토큰 발급 실패 | 일시/영구 | `Internal server error` |
+| 네트워크 타임아웃 | 일시 | `Internal server error` |
+| 라우트 데드라인 초과 | 일시 | `Internal server error` |
+
+**영구 장애와 일시 장애를 구분할 수 없다.** 아래 항목 대부분의 진단이 서버 로그 고고학을 요구하는 이유가 이것이다.
+
+### 2-3. 브라우저 타임아웃이 BFF 예산보다 짧다
+
+| 계층 | 값 | 위치 |
+|---|---|---|
+| 브라우저, 대부분의 JVM 호출 | 12,000ms, 재시도 0 | `src/app/lib/platform-bff-client.ts:2455` 외 |
+| BFF 1회 시도 | 12,000ms | `java-weekly-client.mjs:127-128` |
+| BFF 재시도 | 기본 1회 추가 | `java-weekly-client.mjs:138` |
+
+BFF의 12초는 TLS와 Vercel 콜드스타트 뒤에 시작되므로, **BFF의 첫 시도가 브라우저 마감 전에 끝날 수 없다.** 따라서:
+
+- BFF 재시도는 항상 헛일이다. 클라이언트는 이미 끊겼다.
+- 그러나 쓰기는 실제로 두 번 실행된다.
+- 사용자는 BFF가 준비한 응답을 결코 보지 못한다.
+
+월 결산 경로만 정합하다(브라우저 27초 > 라우트 26초 > 사전점검 14초 + 변경 12초). 이 경로에는 검토가 있었고 나머지에는 없었다.
+
+`proxyMutation`(`routes/jvm-weekly-api.mjs:1878-1916`)은 `retry`를 지정하지 않아 기본 재시도를 쓴다. 배치 경로만 `retry: false`로 막혀 있다(`java-weekly-client.mjs:325`). 즉 작성자는 위험을 인지했으나 한 경로에만 적용했다. 안전성은 모든 변경 경로의 JVM 멱등키 처리가 정확하다는 미검증 가정에 걸려 있다.
+
+### 2-4. 설정 오류가 조용히 통과하거나 타임아웃으로 위장한다
+
+**audience 누락 시 무인증 전송.** `java-weekly-auth.mjs:41`:
+
+```js
+if (!audience) return '';
+```
+
+빈 문자열이 반환되면 `if (identityToken)`(`:107`)이 거짓이 되어 **`authorization` 헤더 없이 요청이 나간다.** 경고도 로그도 없다. 같은 파일에서 service token은 누락 시 명시적으로 실패시키는 것과 대조된다(`:79`).
+
+Cloud Run이 이를 403(비-JSON)으로 막고, BFF는 `Java weekly API request failed with 403`이라는 문자열로 표시한다. IAM/audience 문제라는 단서가 없다.
+
+**Vercel에서 도달 불가능한 폴백.** `java-weekly-auth.mjs:52`는 서비스계정 JSON이 없을 때 GCP 메타데이터 서버로 폴백한다:
+
+```js
+const tokenUrl = `http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/identity?audience=...`;
+```
+
+BFF는 Vercel에서 실행되므로 이 호스트는 존재하지 않는다. 연결이 매달리다 AbortController가 발화한다. **영구 설정 오류가 일시적 타임아웃으로 위장된다.**
+
+**배포 경로가 둘이고 서로 다르다.** `cloudbuild.bff.yaml:39`의 `--set-env-vars`에 `JVM_WEEKLY_*` 변수가 하나도 없다. 게다가 `--set-env-vars`는 환경 전체를 교체한다. 실제 동작하는 설정은 `.github/workflows/stage-deploy.yml:44-47, 111-114`(Vercel)에만 있다.
+
+`.env.example`에 `JVM_WEEKLY_*` 항목이 없어, 새 환경을 세우는 사람이 필요한 변수 목록을 발견할 방법이 없다.
+
+**audience와 base URL의 일치를 아무도 검증하지 않는다.** 둘은 별개의 GitHub 변수이고(`stage-deploy.yml:44,46`) 워크플로는 각각이 비어있지 않은지만 확인한다(`:86,88`). Cloud Run IAM은 둘의 일치를 요구한다. JVM 서비스를 재배포해 URL이 바뀌면 조용히 깨진다.
+
+**공통점:** 위 항목 전부 시작 시점에는 조용하고 첫 요청에서야 드러난다. BFF에는 채널에 대한 시작 시 검증이 없다. JVM 쪽은 반대로 명시적으로 실패한다(`InternalServiceTokenFilter.java:45`).
+
+### 2-5. 공유 시크릿 경로는 actor/role 헤더를 검증하지 않는다
+
+`InternalServiceTokenFilter.java:66-70`:
+
+```java
+String suppliedToken = request.getHeader(HEADER_NAME);
+if (internalApiTokenEnabled && tokensMatch(internalApiToken, suppliedToken)) {
+    filterChain.doFilter(request, response);
+    return;
+}
+```
+
+시크릿 비교 자체는 `MessageDigest.isEqual`로 상수 시간이다. 문제는 통과 방식이다. Firebase 경로는 `filterChain.doFilter(withTrustedActorHeaders(request, actor), response)`로 요청을 감싸지만(`:92`), 이 경로는 **원본 요청을 그대로** 넘긴다. 하위 컨트롤러는 `x-tenant-id`, `x-actor-id`, `x-actor-role`을 검증 없이 읽는다. 권한 승격 가드(`:163-169`)는 Firebase 경로에만 있다.
+
+브라우저는 이 홉에 헤더를 심을 수 없으므로 현재 외부에서 악용 가능한 상태는 아니다. 다만 **actor 모델 전체의 안전성이 `JVM_WEEKLY_INTERNAL_API_TOKEN` 하나의 비밀 유지에 걸려 있다**는 점은 기록해 둔다.
+
+또한 BFF가 보내는 Google ID 토큰은 **애플리케이션이 검증하지 않는다.** `FirebaseBearerTokenVerifier`는 Firebase ID 토큰 검증기이고, 서비스계정 ID 토큰은 그 검증을 통과하지 못한다. 이 토큰은 Spring 앞단의 Cloud Run IAM에만 의미가 있다. 즉 **독립적으로 실패할 수 있는 인증 체계가 둘**이다.
+
+### 2-6. 설정 오류가 401로 보고된다
+
+`InternalServiceTokenFilter.java:86-89`는 인증 과정의 모든 `RuntimeException`을 401 `weekly_expense_firebase_auth_required`로 변환한다. `FirebaseBearerTokenVerifier.auth()`는 설정 실패 시 `IllegalStateException`을 던진다(`weekly.firebase-auth-project-id must be configured...`). **영구 설정 오류가 로그인 문제로 보고된다.**
+
+JVM에는 `@ExceptionHandler(Exception.class)`가 없다. 처리되지 않은 예외는 Spring 기본 `/error`로 떨어져 `code`도 `message`도 없는 본문을 낸다. BFF는 이를 503 `jvm_weekly_api_internal_error`로 바꾸고, 사용자는 2-2에 따라 `Internal server error`를 본다.
+
+## 결정
+
+**JVM 서비스를 유지한다.**
+
+규모가 근거는 아니다. 이 저장소에서 재무 불변식을 실제로 검증하는 코드가 JVM에 있다는 것이 근거다. 실제 Firestore 트랜잭션과 MockMvc 기반 테스트 약 40개가 원자성, 스냅샷 불변성, 멱등성, 결산 기한, 카운터 오버플로를 검증한다. 반면 프론트엔드 `CashflowProjectSheet.shell.test.ts`는 288개 단언이 전부 소스 코드 문자열 검사다(`expect(source).toContain(...)`). `@testing-library`를 쓰는 파일은 저장소에 0개다.
+
+즉 **"JVM이 문제의 원인"과 "지금 JVM을 걷어낸다"는 별개의 판단이다.** 15,737줄을 옮기는 일은 호수가 아니라 바다이고, 그 과정에서 잃을 보증이 현재 가장 잘 지켜지는 보증이다.
+
+## 다음 작업
+
+| 순서 | 작업 | 근거 |
+|---|---|---|
+| 1 | `editSession` 3개 경로 전달 복구 | 2-1. 확인된 결함이고 수정 범위가 작다 |
+| 2 | 내부 생성 5xx의 `code`를 화면까지 노출 | 2-2. 이것이 있어야 나머지 진단이 스크린샷으로 가능해진다 |
+| 3 | 브라우저/BFF 타임아웃 정합, `proxyMutation` 재시도 명시 | 2-3. 헛수고와 이중 쓰기 제거 |
+| 4 | audience 누락 시 시작 실패, Vercel에서 메타데이터 폴백 차단, `.env.example` 보강 | 2-4. 조용한 오설정 제거 |
+| 5 | `month-close` 쿼리에 `yearMonth` 필터 | 발견 1. 인덱스는 이미 존재한다 |
+
+2번의 레버리지가 가장 크다. 현재는 모든 진단이 서버 로그 고고학을 요구하며, 이는 사용자도 지원 담당자도 수행할 수 없다.
+
+5번은 "성능 개선"이 아니라 **"Postgres 접근 패턴 청산"**이라는 이름으로 다루는 편이 정확하다. 그래야 같은 형태가 다른 쿼리에 남아 있는지 함께 보게 된다.
+
+## 이 문서를 남기는 이유
+
+`origin/codex/cashflow-apply-adr`는 시트 반영/결산 설계를 글로 정리하려던 유일한 시도였고(2026-07-23, +156줄), 머지되지 않았다. 그 커밋 5분 뒤 `be4845d`가 main에 들어가면서 연간합계 삭제→복원 churn이 시작됐다.
+
+같은 기간의 모든 **코드** 브랜치는 머지됐다. 머지되지 않은 것은 문서 브랜치 둘뿐이다.

--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -122,13 +122,8 @@ import {
   createCashflowEditDraftService,
   mountCashflowEditDraftRoutes,
 } from './routes/cashflow-edit-drafts.mjs';
+import { createHttpError, resolveErrorResponse } from './bff-utils.mjs';
 
-function createHttpError(statusCode, message, code = 'request_error') {
-  const error = new Error(message);
-  error.statusCode = statusCode;
-  error.code = code;
-  return error;
-}
 
 function parseLimit(raw, fallback = 50, max = 200) {
   const n = Number.parseInt(String(raw ?? ''), 10);
@@ -1555,9 +1550,7 @@ export function createBffApp(options = {}) {
   });
 
   app.use((error, req, res, _next) => {
-    const statusCode = Number.isInteger(error?.statusCode) ? error.statusCode : 500;
-    const message = statusCode >= 500 ? 'Internal server error' : (error?.message || 'Request failed');
-    const errorCode = error?.code || (statusCode >= 500 ? 'internal_error' : 'request_error');
+    const { statusCode, code: errorCode, message } = resolveErrorResponse(error);
     res.locals.errorCode = errorCode;
 
     if (statusCode >= 500) {

--- a/server/bff/bff-utils.error-response.test.mjs
+++ b/server/bff/bff-utils.error-response.test.mjs
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { createHttpError, resolveErrorResponse } from './bff-utils.mjs';
+
+describe('resolveErrorResponse', () => {
+  it('keeps the message of an error the server wrote on purpose, even at 5xx', () => {
+    const error = createHttpError(503, '저장을 처리하는 서버에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.', 'cashflow_jvm_authority_unavailable');
+
+    expect(resolveErrorResponse(error)).toEqual({
+      statusCode: 503,
+      code: 'cashflow_jvm_authority_unavailable',
+      message: '저장을 처리하는 서버에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+      exposed: true,
+    });
+  });
+
+  it('hides the message of an unexpected exception so internals cannot leak', () => {
+    const error = new TypeError("Cannot read properties of undefined (reading 'snapshot')");
+    error.statusCode = 500;
+
+    const resolved = resolveErrorResponse(error);
+
+    expect(resolved.message).toBe('Internal server error');
+    expect(resolved.exposed).toBe(false);
+    expect(resolved.message).not.toContain('snapshot');
+  });
+
+  it('treats an exception with no status as a hidden 500', () => {
+    const resolved = resolveErrorResponse(new Error('ECONNREFUSED 10.1.2.3:5432'));
+
+    expect(resolved).toEqual({
+      statusCode: 500,
+      code: 'internal_error',
+      message: 'Internal server error',
+      exposed: false,
+    });
+  });
+
+  it('still shows 4xx messages, which carry the reason the request was refused', () => {
+    const error = createHttpError(409, '시트 값을 원장에 반영 중입니다. 반영이 끝난 뒤 다시 확인해 주세요.', 'cashflow_sheet_apply_in_progress');
+
+    expect(resolveErrorResponse(error).message).toBe('시트 값을 원장에 반영 중입니다. 반영이 끝난 뒤 다시 확인해 주세요.');
+  });
+
+  it('does not let a bare statusCode on an unexpected error expose its message', () => {
+    // 라이브러리가 statusCode 만 붙여 던지는 경우가 있다. 문구를 우리가 정하지 않았으므로 가려야 한다.
+    const error = new Error('connect ETIMEDOUT 169.254.169.254:80');
+    error.statusCode = 502;
+
+    const resolved = resolveErrorResponse(error);
+
+    expect(resolved.message).toBe('Internal server error');
+    expect(resolved.message).not.toContain('169.254.169.254');
+  });
+
+  it('falls back to a code when the error carries none', () => {
+    expect(resolveErrorResponse(createHttpError(400, '잘못된 요청입니다.')).code).toBe('request_error');
+    expect(resolveErrorResponse({}).code).toBe('internal_error');
+  });
+});
+
+describe('createHttpError', () => {
+  it('marks its errors as safe to show, since a developer wrote the wording', () => {
+    expect(createHttpError(503, '담당자에게 문의해 주세요.', 'x').expose).toBe(true);
+  });
+});

--- a/server/bff/bff-utils.mjs
+++ b/server/bff/bff-utils.mjs
@@ -10,11 +10,29 @@ import { actorHasPermission } from './rbac-policy.mjs';
 
 // ── HTTP helpers ──────────────────────────────────────────────────────────────
 
+// 이 함수로 만든 오류는 문구를 개발자가 직접 정한 것이므로 그대로 응답에 실어도 안전하다.
+// 예상하지 못한 예외(TypeError, Firestore 오류 등)는 이 표식이 없으므로 5xx에서 계속 가려진다.
+// app.mjs 의 최종 오류 핸들러가 이 표식을 읽는다.
 export function createHttpError(statusCode, message, code = 'request_error') {
   const error = new Error(message);
   error.statusCode = statusCode;
   error.code = code;
+  error.expose = true;
   return error;
+}
+
+// 최종 오류 응답의 상태·코드·문구를 결정한다. app.mjs 의 오류 핸들러가 이 결과를 그대로 내보낸다.
+// 판단 기준은 하나다. 문구를 개발자가 직접 정한 오류인가(createHttpError), 아니면 예상하지 못한
+// 예외인가. 후자는 내부 정보를 담을 수 있으므로 5xx에서 가린다.
+export function resolveErrorResponse(error) {
+  const statusCode = Number.isInteger(error?.statusCode) ? error.statusCode : 500;
+  const exposeMessage = statusCode < 500 || error?.expose === true;
+  return {
+    statusCode,
+    code: error?.code || (statusCode >= 500 ? 'internal_error' : 'request_error'),
+    message: exposeMessage ? (error?.message || 'Request failed') : 'Internal server error',
+    exposed: exposeMessage,
+  };
 }
 
 export function parseLimit(raw, fallback = 50, max = 200) {

--- a/server/bff/claude-sdk-help.mjs
+++ b/server/bff/claude-sdk-help.mjs
@@ -1,5 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { claudeSdkHelpAskSchema, parseWithSchema } from './schemas.mjs';
+import { createHttpError } from './bff-utils.mjs';
 
 const MODEL = process.env.ANTHROPIC_PLATFORM_HELP_MODEL || process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-20250514';
 const MAX_ANSWER_TOKENS = 2200;
@@ -195,18 +196,12 @@ function buildHelpSystemPrompt(question) {
   ].join('\n');
 }
 
-function createHttpError(statusCode, message, code = 'request_error') {
-  const error = new Error(message);
-  error.statusCode = statusCode;
-  error.code = code;
-  return error;
-}
 
 let _anthropic = null;
 function getClient() {
   if (!_anthropic) {
     const key = process.env.ANTHROPIC_API_KEY;
-    if (!key) throw createHttpError(503, 'ANTHROPIC_API_KEY is not configured');
+    if (!key) throw createHttpError(503, 'AI 도우미 서비스가 설정되지 않았습니다. 담당자에게 문의해 주세요.', 'ai_assistant_unconfigured');
     _anthropic = new Anthropic({ apiKey: key });
   }
   return _anthropic;

--- a/server/bff/guide-chat.mjs
+++ b/server/bff/guide-chat.mjs
@@ -1,5 +1,6 @@
 import Anthropic from '@anthropic-ai/sdk';
 import { randomUUID } from 'node:crypto';
+import { createHttpError } from './bff-utils.mjs';
 
 const MODEL = 'claude-sonnet-4-20250514';
 const MAX_GUIDE_CHARS = 500_000;
@@ -9,18 +10,12 @@ const MAX_CALIBRATION_TURNS = 6; // 3 user + 3 assistant
 const ALL_ROLES = ['admin', 'tenant_admin', 'finance', 'pm', 'viewer', 'auditor', 'support', 'security'];
 const ADMIN_ROLES = ['admin', 'tenant_admin'];
 
-function createHttpError(statusCode, message, code = 'request_error') {
-  const error = new Error(message);
-  error.statusCode = statusCode;
-  error.code = code;
-  return error;
-}
 
 let _anthropic = null;
 function getClient() {
   if (!_anthropic) {
     const key = process.env.ANTHROPIC_API_KEY;
-    if (!key) throw createHttpError(503, 'ANTHROPIC_API_KEY is not configured');
+    if (!key) throw createHttpError(503, 'AI 도우미 서비스가 설정되지 않았습니다. 담당자에게 문의해 주세요.', 'ai_assistant_unconfigured');
     _anthropic = new Anthropic({ apiKey: key });
   }
   return _anthropic;

--- a/server/bff/java-weekly-auth.mjs
+++ b/server/bff/java-weekly-auth.mjs
@@ -23,7 +23,7 @@ async function fetchCredentialIdentityToken(audience, serviceAccountJson) {
   try {
     credentials = JSON.parse(serviceAccountJson);
   } catch {
-    throw createHttpError(503, 'JVM weekly API invoker credential is invalid.', 'jvm_weekly_api_identity_token_unavailable');
+    throw createHttpError(503, '서버 인증 정보가 올바르지 않습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_api_identity_token_unavailable');
   }
   try {
     const auth = new GoogleAuth({ credentials });
@@ -33,7 +33,7 @@ async function fetchCredentialIdentityToken(audience, serviceAccountJson) {
     if (!token) throw new Error('Missing identity token');
     return token;
   } catch {
-    throw createHttpError(503, 'JVM weekly API identity token could not be resolved.', 'jvm_weekly_api_identity_token_unavailable');
+    throw createHttpError(503, '서버 인증에 실패했습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_api_identity_token_unavailable');
   }
 }
 
@@ -43,7 +43,7 @@ export async function fetchGoogleIdentityToken(fetchImpl, audience, serviceAccou
     if (typeof resolveIdentityToken === 'function') {
       const token = await resolveIdentityToken({ audience, serviceAccountJson, signal });
       if (!readOptionalText(token)) {
-        throw createHttpError(503, 'JVM weekly API identity token could not be resolved.', 'jvm_weekly_api_identity_token_unavailable');
+        throw createHttpError(503, '서버 인증에 실패했습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_api_identity_token_unavailable');
       }
       return String(token).trim();
     }
@@ -57,7 +57,7 @@ export async function fetchGoogleIdentityToken(fetchImpl, audience, serviceAccou
   });
   const token = await response.text();
   if (!response.ok || !readOptionalText(token)) {
-    throw createHttpError(503, 'JVM weekly API identity token could not be resolved.', 'jvm_weekly_api_identity_token_unavailable');
+    throw createHttpError(503, '서버 인증에 실패했습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_api_identity_token_unavailable');
   }
   return token.trim();
 }
@@ -76,7 +76,7 @@ export async function buildJavaWeeklyTrustedHeaders({
   signal,
 }) {
   if (!serviceToken) {
-    throw createHttpError(503, 'JVM weekly API service token is not configured.', 'jvm_weekly_api_token_unconfigured');
+    throw createHttpError(503, '서버 연결 정보가 설정되지 않았습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_api_token_unconfigured');
   }
   const actorRole = isWorkspaceAuthMode(authMode) && isWorkspaceUser(context, workspaceEmailDomain)
     ? 'workspace_user'

--- a/server/bff/java-weekly-client.mjs
+++ b/server/bff/java-weekly-client.mjs
@@ -138,7 +138,7 @@ export function createJavaWeeklyClient({
     retry = true,
   }) {
     if (!baseUrl) {
-      throw createHttpError(503, 'JVM weekly API base URL is not configured.', 'jvm_weekly_api_unconfigured');
+      throw createHttpError(503, '캐시플로 서버 주소가 설정되지 않았습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_api_unconfigured');
     }
     const requestStartedAt = Date.now();
     const callerDeadlineAtMs = Number.isFinite(Number(deadlineAtMs))
@@ -259,14 +259,14 @@ export function createJavaWeeklyClient({
       throw createHttpError(400, 'projectId is required.', 'project_id_required');
     }
     if (readOptionalText(env.BFF_DEPLOY_ENV).toLowerCase() !== 'stage') {
-      throw createHttpError(503, 'Cashflow writes are restricted to Stage.', 'unsafe_bff_runtime');
+      throw createHttpError(503, '현재 환경에서는 캐시플로를 저장할 수 없습니다. 담당자에게 문의해 주세요.', 'unsafe_bff_runtime');
     }
     if (!bffDataProjectId || !firestoreProjectId || bffDataProjectId !== firestoreProjectId) {
-      throw createHttpError(503, 'BFF and JVM cashflow data projects do not match.', 'jvm_weekly_data_project_mismatch');
+      throw createHttpError(503, '서버 설정이 서로 맞지 않아 캐시플로를 사용할 수 없습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_data_project_mismatch');
     }
     const liveProjectId = readOptionalText(env.BFF_LIVE_FIREBASE_PROJECT_ID) || 'inner-platform-live-20260316';
     if (bffDataProjectId === liveProjectId) {
-      throw createHttpError(503, 'Cashflow Stage writes cannot target the Live data project.', 'unsafe_bff_runtime');
+      throw createHttpError(503, '테스트 환경에서는 실제 운영 자료를 변경할 수 없습니다. 담당자에게 문의해 주세요.', 'unsafe_bff_runtime');
     }
     const result = await requestJson({
       context,
@@ -286,7 +286,7 @@ export function createJavaWeeklyClient({
       },
     });
     if (readOptionalText(result?.projectId) !== readOptionalText(projectId)) {
-      throw createHttpError(502, 'JVM cashflow response project does not match the request.', 'jvm_weekly_project_mismatch');
+      throw createHttpError(502, '다른 프로젝트의 자료가 도착했습니다. 화면을 새로고침해 주세요.', 'jvm_weekly_project_mismatch');
     }
     return result;
   }
@@ -307,14 +307,14 @@ export function createJavaWeeklyClient({
       throw createHttpError(400, 'projectId is required.', 'project_id_required');
     }
     if (readOptionalText(env.BFF_DEPLOY_ENV).toLowerCase() !== 'stage') {
-      throw createHttpError(503, 'Cashflow writes are restricted to Stage.', 'unsafe_bff_runtime');
+      throw createHttpError(503, '현재 환경에서는 캐시플로를 저장할 수 없습니다. 담당자에게 문의해 주세요.', 'unsafe_bff_runtime');
     }
     if (!bffDataProjectId || !firestoreProjectId || bffDataProjectId !== firestoreProjectId) {
-      throw createHttpError(503, 'BFF and JVM cashflow data projects do not match.', 'jvm_weekly_data_project_mismatch');
+      throw createHttpError(503, '서버 설정이 서로 맞지 않아 캐시플로를 사용할 수 없습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_data_project_mismatch');
     }
     const liveProjectId = readOptionalText(env.BFF_LIVE_FIREBASE_PROJECT_ID) || 'inner-platform-live-20260316';
     if (bffDataProjectId === liveProjectId) {
-      throw createHttpError(503, 'Cashflow Stage writes cannot target the Live data project.', 'unsafe_bff_runtime');
+      throw createHttpError(503, '테스트 환경에서는 실제 운영 자료를 변경할 수 없습니다. 담당자에게 문의해 주세요.', 'unsafe_bff_runtime');
     }
     const result = await requestJson({
       context,
@@ -334,7 +334,7 @@ export function createJavaWeeklyClient({
       },
     });
     if (readOptionalText(result?.projectId) !== readOptionalText(projectId)) {
-      throw createHttpError(502, 'JVM cashflow response project does not match the request.', 'jvm_weekly_project_mismatch');
+      throw createHttpError(502, '다른 프로젝트의 자료가 도착했습니다. 화면을 새로고침해 주세요.', 'jvm_weekly_project_mismatch');
     }
     return result;
   }
@@ -351,14 +351,14 @@ export function createJavaWeeklyClient({
     const normalizedProjectId = encodeURIComponent(readOptionalText(projectId));
     if (!normalizedProjectId) throw createHttpError(400, 'projectId is required.', 'project_id_required');
     if (readOptionalText(env.BFF_DEPLOY_ENV).toLowerCase() !== 'stage') {
-      throw createHttpError(503, 'Cashflow writes are restricted to Stage.', 'unsafe_bff_runtime');
+      throw createHttpError(503, '현재 환경에서는 캐시플로를 저장할 수 없습니다. 담당자에게 문의해 주세요.', 'unsafe_bff_runtime');
     }
     if (!bffDataProjectId || !firestoreProjectId || bffDataProjectId !== firestoreProjectId) {
-      throw createHttpError(503, 'BFF and JVM cashflow data projects do not match.', 'jvm_weekly_data_project_mismatch');
+      throw createHttpError(503, '서버 설정이 서로 맞지 않아 캐시플로를 사용할 수 없습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_data_project_mismatch');
     }
     const liveProjectId = readOptionalText(env.BFF_LIVE_FIREBASE_PROJECT_ID) || 'inner-platform-live-20260316';
     if (bffDataProjectId === liveProjectId) {
-      throw createHttpError(503, 'Cashflow Stage writes cannot target the Live data project.', 'unsafe_bff_runtime');
+      throw createHttpError(503, '테스트 환경에서는 실제 운영 자료를 변경할 수 없습니다. 담당자에게 문의해 주세요.', 'unsafe_bff_runtime');
     }
     const result = await requestJson({
       context,
@@ -368,7 +368,7 @@ export function createJavaWeeklyClient({
       body: { idempotencyKey, sourceRevision, year, expectedRevision, cells },
     });
     if (readOptionalText(result?.projectId) !== readOptionalText(projectId)) {
-      throw createHttpError(502, 'JVM cashflow response project does not match the request.', 'jvm_weekly_project_mismatch');
+      throw createHttpError(502, '다른 프로젝트의 자료가 도착했습니다. 화면을 새로고침해 주세요.', 'jvm_weekly_project_mismatch');
     }
     return result;
   }

--- a/server/bff/routes/cashflow-labor-risk.mjs
+++ b/server/bff/routes/cashflow-labor-risk.mjs
@@ -381,7 +381,7 @@ export function mountCashflowLaborRiskRoutes(app, { db, now } = {}) {
   app.get('/api/v1/projects/:projectId/cashflow-labor-risk', asyncHandler(async (req, res) => {
     assertCashflowLaborRiskAccess(req);
     if (!db) {
-      throw createHttpError(503, 'Firestore is required to read cashflow labor risk.', 'firestore_unconfigured');
+      throw createHttpError(503, '인건비 위험 정보를 읽을 수 없습니다. 담당자에게 문의해 주세요.', 'firestore_unconfigured');
     }
 
     const tenantId = readOptionalText(req.context?.tenantId);

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -774,7 +774,7 @@ function mergeCashflowSourceMirror(previous, next, sourceYear) {
 
 async function saveCashflowSheetLabConfig({ db, tenantId, projectId, project, parsed, context, existingConfig = null }) {
   if (!db) {
-    throw createHttpError(503, 'Firestore is required to save cashflow sheet config.', 'firestore_unconfigured');
+    throw createHttpError(503, '시트 설정을 저장할 수 없습니다. 담당자에게 문의해 주세요.', 'firestore_unconfigured');
   }
   const now = new Date().toISOString();
   const sourceYear = resolveSourceYear(parsed.sourceYear, existingConfig || parsed, project);
@@ -914,7 +914,7 @@ async function readCashflowWeeksSnapshot(db, tenantId, projectId) {
 
 async function readCashflowSheetMirror(db, tenantId, projectId) {
   if (!db) {
-    throw createHttpError(503, 'Firestore is required to read the cashflow sheet mirror.', 'firestore_unconfigured');
+    throw createHttpError(503, '불러온 시트 값을 읽을 수 없습니다. 담당자에게 문의해 주세요.', 'firestore_unconfigured');
   }
   const snap = await db.doc(cashflowSheetMirrorDocPath(tenantId, projectId)).get();
   return snap.exists ? snap.data() : null;
@@ -1874,7 +1874,7 @@ function javaAppliedLineIndex(lines, { mode, yearMonth }) {
     const amount = Number(line?.amount);
     const key = `${weekNo}:${lineId}`;
     if (!Number.isInteger(weekNo) || !CASHFLOW_LINE_ORDER.has(lineId) || !Number.isSafeInteger(amount) || index.has(key)) {
-      throw createHttpError(502, 'JVM 캐시플로 저장 검증값이 올바르지 않습니다.', 'cashflow_jvm_apply_verification_failed');
+      throw createHttpError(502, '저장 결과 검산이 맞지 않아 저장을 취소했습니다. 시트 값을 다시 불러온 뒤 시도해 주세요.', 'cashflow_jvm_apply_verification_failed');
     }
     index.set(key, amount);
   }
@@ -1896,18 +1896,18 @@ function verifyJavaMonthAppliedCells(result, month, {
     || readOptionalText(result?.sourceRevision) !== sourceRevision
     || readOptionalText(result?.targetRevision) !== targetRevision
   ) {
-    throw createHttpError(502, 'JVM 캐시플로 저장 범위가 요청과 다릅니다.', 'cashflow_jvm_apply_verification_failed');
+    throw createHttpError(502, '저장 대상 기간이 요청과 달라 저장을 취소했습니다. 시트 값을 다시 불러온 뒤 시도해 주세요.', 'cashflow_jvm_apply_verification_failed');
   }
   let verifiedLineCount = 0;
   for (const mode of CASHFLOW_MODES) {
     const index = javaAppliedLineIndex(result?.[mode], { mode, yearMonth: month.yearMonth });
     const expected = month.cells.filter((cell) => cell.mode === mode && cell.cellState === 'VALUE');
     if (index.size !== expected.length) {
-      throw createHttpError(502, 'JVM 캐시플로 저장 건수가 시트 고정본과 다릅니다.', 'cashflow_jvm_apply_verification_failed');
+      throw createHttpError(502, '저장된 항목 수가 불러온 시트 값과 달라 저장을 취소했습니다. 시트 값을 다시 불러온 뒤 시도해 주세요.', 'cashflow_jvm_apply_verification_failed');
     }
     for (const cell of expected) {
       if (index.get(`${cell.weekNo}:${cell.cashflowLine}`) !== Number(cell.amount)) {
-        throw createHttpError(502, 'JVM 캐시플로 저장 금액이 시트 고정본과 다릅니다.', 'cashflow_jvm_apply_verification_failed');
+        throw createHttpError(502, '저장된 금액이 불러온 시트 값과 달라 저장을 취소했습니다. 시트 값을 다시 불러온 뒤 시도해 주세요.', 'cashflow_jvm_apply_verification_failed');
       }
       verifiedLineCount += 1;
     }
@@ -1925,7 +1925,7 @@ function verifyJavaAnnualAppliedCells(result, stagedYear, { projectId, sourceRev
     || readOptionalText(result?.sourceRevision) !== sourceRevision
     || Number(result?.revision) !== Number(stagedYear.expectedRevision) + 1
   ) {
-    throw createHttpError(502, 'JVM 연간 합계 저장 범위가 요청과 다릅니다.', 'cashflow_jvm_annual_apply_verification_failed');
+    throw createHttpError(502, '연간 합계의 저장 대상 기간이 요청과 달라 저장을 취소했습니다. 시트 값을 다시 불러온 뒤 시도해 주세요.', 'cashflow_jvm_annual_apply_verification_failed');
   }
   let verifiedLineCount = 0;
   for (const mode of CASHFLOW_MODES) {
@@ -1935,10 +1935,10 @@ function verifyJavaAnnualAppliedCells(result, stagedYear, { projectId, sourceRev
       : {};
     for (const cell of stagedYear.cells.filter((candidate) => candidate.mode === mode)) {
       if (readOptionalText(states[cell.cashflowLine]) !== cell.cellState) {
-        throw createHttpError(502, 'JVM 연간 합계의 공란·값 상태가 시트 고정본과 다릅니다.', 'cashflow_jvm_annual_apply_verification_failed');
+        throw createHttpError(502, '연간 합계의 빈 칸 여부가 불러온 시트 값과 달라 저장을 취소했습니다. 시트 값을 다시 불러온 뒤 시도해 주세요.', 'cashflow_jvm_annual_apply_verification_failed');
       }
       if (['VALUE', 'ZERO'].includes(cell.cellState) && Number(values[cell.cashflowLine]) !== Number(cell.amount)) {
-        throw createHttpError(502, 'JVM 연간 합계 금액이 시트 고정본과 다릅니다.', 'cashflow_jvm_annual_apply_verification_failed');
+        throw createHttpError(502, '연간 합계 금액이 불러온 시트 값과 달라 저장을 취소했습니다. 시트 값을 다시 불러온 뒤 시도해 주세요.', 'cashflow_jvm_annual_apply_verification_failed');
       }
       verifiedLineCount += 1;
     }
@@ -2020,7 +2020,7 @@ async function applyStagedCashflowSheetLab({
   ));
 
   if (!javaWeeklyClient) {
-    throw createHttpError(503, 'Cashflow final apply requires the JVM authority service.', 'cashflow_jvm_authority_unavailable');
+    throw createHttpError(503, '저장을 처리하는 서버에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.', 'cashflow_jvm_authority_unavailable');
   }
 
   const stagedMonths = await Promise.all(selectedMonths.map(async (yearMonth) => {
@@ -2196,18 +2196,18 @@ async function applyStagedCashflowSheetLab({
         || readOptionalText(batchResult?.sourceRevision) !== readOptionalText(stageRun.sourceRevision)
         || readOptionalText(batchResult?.targetRevision) !== batchTargetRevision
       ) {
-        throw createHttpError(502, 'JVM 월 배치 저장 계약이 요청과 다릅니다.', 'cashflow_jvm_apply_verification_failed');
+        throw createHttpError(502, '저장 형식이 올바르지 않아 저장을 취소했습니다. 담당자에게 문의해 주세요.', 'cashflow_jvm_apply_verification_failed');
       }
       targetRevision = assertResultingTargetRevision(batchResult);
       const returnedMonths = new Map((Array.isArray(batchResult?.months) ? batchResult.months : [])
         .map((month) => [readOptionalText(month?.yearMonth), month]));
       if (returnedMonths.size !== stagedMonths.length) {
-        throw createHttpError(502, 'JVM 월 배치 저장 건수가 요청과 다릅니다.', 'cashflow_jvm_apply_verification_failed');
+        throw createHttpError(502, '저장된 항목 수가 요청과 달라 저장을 취소했습니다. 시트 값을 다시 불러온 뒤 시도해 주세요.', 'cashflow_jvm_apply_verification_failed');
       }
       for (const month of stagedMonths) {
         const monthResult = returnedMonths.get(month.yearMonth);
         if (!monthResult) {
-          throw createHttpError(502, 'JVM 월 배치 저장 범위가 요청과 다릅니다.', 'cashflow_jvm_apply_verification_failed');
+          throw createHttpError(502, '여러 달 저장의 대상 기간이 요청과 달라 저장을 취소했습니다. 시트 값을 다시 불러온 뒤 시도해 주세요.', 'cashflow_jvm_apply_verification_failed');
         }
         const compatibleResult = {
           ...monthResult,
@@ -3037,7 +3037,7 @@ export function mountCashflowSheetLabRoutes(app, {
   app.post('/api/v1/projects/:projectId/cashflow-sheet-lab/apply', asyncHandler(async (req, res) => {
     assertCashflowSheetLabAccess(req, workspaceEmailDomain);
     if (!authoritativeWritesEnabled) {
-      throw createHttpError(503, 'Cashflow writes are available only in the Stage write runtime.', 'unsafe_bff_runtime');
+      throw createHttpError(503, '현재 환경에서는 캐시플로를 저장할 수 없습니다. 담당자에게 문의해 주세요.', 'unsafe_bff_runtime');
     }
     const { tenantId } = req.context;
     const { projectId } = req.params;

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -812,25 +812,25 @@ function buildCashflowRangeTotals(months, mode, range) {
       for (const lineId of CASHFLOW_ALL_LINES) {
         const next = rowTotals[lineId] + safeAmount(amounts[lineId]);
         if (!Number.isSafeInteger(next)) {
-          throw createHttpError(502, 'JVM cashflow range totals are unsafe.', 'jvm_weekly_cashflow_totals_invalid');
+          throw createHttpError(502, '합계 금액에 올바르지 않은 값이 있어 화면에 표시할 수 없습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_cashflow_totals_invalid');
         }
         rowTotals[lineId] = next;
       }
       const weekIn = sumSafe(CASHFLOW_IN_LINES.map((lineId) => amounts[lineId]));
       const weekOut = sumSafe(CASHFLOW_OUT_LINES.map((lineId) => amounts[lineId]));
       if (weekIn === null || weekOut === null) {
-        throw createHttpError(502, 'JVM cashflow range totals are unsafe.', 'jvm_weekly_cashflow_totals_invalid');
+        throw createHttpError(502, '합계 금액에 올바르지 않은 값이 있어 화면에 표시할 수 없습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_cashflow_totals_invalid');
       }
       totalIn += weekIn;
       totalOut += weekOut;
       if (!Number.isSafeInteger(totalIn) || !Number.isSafeInteger(totalOut)) {
-        throw createHttpError(502, 'JVM cashflow range totals are unsafe.', 'jvm_weekly_cashflow_totals_invalid');
+        throw createHttpError(502, '합계 금액에 올바르지 않은 값이 있어 화면에 표시할 수 없습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_cashflow_totals_invalid');
       }
     }
   }
   const net = totalIn - totalOut;
   if (!Number.isSafeInteger(net)) {
-    throw createHttpError(502, 'JVM cashflow range totals are unsafe.', 'jvm_weekly_cashflow_totals_invalid');
+    throw createHttpError(502, '합계 금액에 올바르지 않은 값이 있어 화면에 표시할 수 없습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_cashflow_totals_invalid');
   }
   return { rowTotals, totalIn, totalOut, net };
 }
@@ -869,7 +869,7 @@ function frozenCashflowReadModel(ledgerWeeks) {
           if (!Object.prototype.hasOwnProperty.call(rawAmounts, lineId)) continue;
           const amount = Number(rawAmounts[lineId]);
           if (!Number.isSafeInteger(amount)) {
-            throw createHttpError(502, 'Closed cashflow snapshot contains an unsafe row amount.', 'jvm_weekly_cashflow_totals_invalid');
+            throw createHttpError(502, '결산된 달의 금액 중 올바르지 않은 값이 있어 화면에 표시할 수 없습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_cashflow_totals_invalid');
           }
           amounts[lineId] = amount;
         }
@@ -900,7 +900,7 @@ function frozenCashflowReadModel(ledgerWeeks) {
       const weekIn = sumSafe(CASHFLOW_IN_LINES.map((lineId) => amounts[lineId]));
       const weekOut = sumSafe(CASHFLOW_OUT_LINES.map((lineId) => amounts[lineId]));
       if (weekIn === null || weekOut === null) {
-        throw createHttpError(502, 'Closed cashflow snapshot contains unsafe row totals.', 'jvm_weekly_cashflow_totals_invalid');
+        throw createHttpError(502, '결산된 달의 항목 합계에 올바르지 않은 값이 있어 화면에 표시할 수 없습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_cashflow_totals_invalid');
       }
       running[mode].totalIn += weekIn;
       running[mode].totalOut += weekOut;
@@ -913,7 +913,7 @@ function frozenCashflowReadModel(ledgerWeeks) {
         month[mode].totalOut,
       ]) {
         if (!Number.isSafeInteger(value)) {
-          throw createHttpError(502, 'Closed cashflow snapshot contains unsafe cumulative totals.', 'jvm_weekly_cashflow_totals_invalid');
+          throw createHttpError(502, '결산된 달의 누적 합계에 올바르지 않은 값이 있어 화면에 표시할 수 없습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_cashflow_totals_invalid');
         }
       }
       month[mode].weeks.push({
@@ -1731,7 +1731,7 @@ async function composeCashflowMonthDashboard({ db, req, projectId, yearMonth, cl
 
 async function composeCashflowMonthCloseBody({ db, req, projectId, cashflow, openingBalances, comparisonBoundary }) {
   if (!db?.doc) {
-    throw createHttpError(503, 'Cashflow month close source storage is unavailable.', 'cashflow_month_close_source_unavailable');
+    throw createHttpError(503, '월 결산 자료를 보관하는 저장소에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.', 'cashflow_month_close_source_unavailable');
   }
   const tenantId = readOptionalText(req.context?.tenantId);
   const requested = commandBody(req);
@@ -1872,18 +1872,18 @@ export function mountJvmWeeklyApiRoutes(app, {
     let dataProjectId;
     if (cashflowWrite) {
       if (readOptionalText(env.BFF_DEPLOY_ENV).toLowerCase() !== 'stage') {
-        throw createHttpError(503, 'Cashflow writes are restricted to Stage.', 'unsafe_bff_runtime');
+        throw createHttpError(503, '현재 환경에서는 캐시플로를 저장할 수 없습니다. 담당자에게 문의해 주세요.', 'unsafe_bff_runtime');
       }
       const liveProjectId = readOptionalText(env.BFF_LIVE_FIREBASE_PROJECT_ID) || 'inner-platform-live-20260316';
       if (!bffDataProjectId || !firestoreProjectId || bffDataProjectId !== firestoreProjectId) {
-        throw createHttpError(503, 'BFF and JVM cashflow data projects do not match.', 'jvm_weekly_data_project_mismatch');
+        throw createHttpError(503, '서버 설정이 서로 맞지 않아 캐시플로를 사용할 수 없습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_data_project_mismatch');
       }
       if (bffDataProjectId === liveProjectId) {
-        throw createHttpError(503, 'Cashflow Stage writes cannot target the Live data project.', 'unsafe_bff_runtime');
+        throw createHttpError(503, '테스트 환경에서는 실제 운영 자료를 변경할 수 없습니다. 담당자에게 문의해 주세요.', 'unsafe_bff_runtime');
       }
       if (requireWeeklyExpenseLease) {
         if (!weeklyExpenseEditLeasesEnabled) {
-          throw createHttpError(503, 'Weekly expense writes require the Stage edit-lease runtime.', 'cashflow_edit_leases_disabled');
+          throw createHttpError(503, '현재 환경에서는 주간 비용을 저장할 수 없습니다. 담당자에게 문의해 주세요.', 'cashflow_edit_leases_disabled');
         }
         editSession = readWeeklyExpenseEditSession(req);
       }
@@ -2091,13 +2091,13 @@ export function mountJvmWeeklyApiRoutes(app, {
           ? null
           : requireJvmOpeningBalances(source, yearMonth);
         if (readOptionalText(result?.projectId) !== rawProjectId || readOptionalText(result?.yearMonth) !== yearMonth) {
-          throw createHttpError(502, 'JVM cashflow month response scope does not match the request.', 'jvm_weekly_project_mismatch');
+          throw createHttpError(502, '요청한 달과 다른 달의 자료가 도착했습니다. 화면을 새로고침해 주세요.', 'jvm_weekly_project_mismatch');
         }
         if (db?.doc && readOptionalText(result?.status) === 'OPEN' && !cashflow) {
-          throw createHttpError(502, 'JVM cashflow month source is incomplete.', 'jvm_weekly_response_invalid');
+          throw createHttpError(502, '월 결산 자료 일부가 도착하지 않았습니다. 잠시 후 다시 시도해 주세요.', 'jvm_weekly_response_invalid');
         }
         if (cashflow && readOptionalText(cashflow?.projectId) !== rawProjectId) {
-          throw createHttpError(502, 'JVM cashflow response project does not match the request.', 'jvm_weekly_project_mismatch');
+          throw createHttpError(502, '다른 프로젝트의 자료가 도착했습니다. 화면을 새로고침해 주세요.', 'jvm_weekly_project_mismatch');
         }
         const dashboard = await composeCashflowMonthDashboard({
           db,
@@ -2133,7 +2133,7 @@ export function mountJvmWeeklyApiRoutes(app, {
     if (readOptionalText(env.BFF_DEPLOY_ENV).toLowerCase() !== 'stage') {
       throw createHttpError(404, '월 결산 QA 날짜는 Stage에서만 사용할 수 있습니다.', 'cashflow_month_close_qa_date_stage_only');
     }
-    if (!db?.doc) throw createHttpError(503, 'QA 기준시각 저장소를 사용할 수 없습니다.', 'cashflow_qa_clock_unavailable');
+    if (!db?.doc) throw createHttpError(503, '기준 날짜 설정을 읽을 수 없습니다. 잠시 후 다시 시도해 주세요.', 'cashflow_qa_clock_unavailable');
     const projectId = readOptionalText(req.params.projectId);
     const snapshot = await db.doc(cashflowMonthCloseQaDatePath(req.context.tenantId, projectId)).get();
     const setting = snapshot.exists ? snapshot.data() || {} : {};
@@ -2151,7 +2151,7 @@ export function mountJvmWeeklyApiRoutes(app, {
     if (readOptionalText(env.BFF_DEPLOY_ENV).toLowerCase() !== 'stage') {
       throw createHttpError(404, '월 결산 QA 날짜는 Stage에서만 사용할 수 있습니다.', 'cashflow_month_close_qa_date_stage_only');
     }
-    if (!db?.doc) throw createHttpError(503, 'QA 기준시각 저장소를 사용할 수 없습니다.', 'cashflow_qa_clock_unavailable');
+    if (!db?.doc) throw createHttpError(503, '기준 날짜 설정을 읽을 수 없습니다. 잠시 후 다시 시도해 주세요.', 'cashflow_qa_clock_unavailable');
     const projectId = readOptionalText(req.params.projectId);
     const qaDateTime = normalizeCashflowMonthCloseQaDateTime(commandBody(req).qaDateTime);
     const nowIso = now().toISOString();
@@ -2201,7 +2201,7 @@ export function mountJvmWeeklyApiRoutes(app, {
   app.post('/api/v1/cashflow/:projectId/weekly-update-complete', asyncHandler(async (req, res) => {
     assertWeeklyWorkspaceOrRoleAllowed(req, ['admin', 'finance', 'pm', 'viewer', 'tenant_admin'], 'complete weekly cashflow update', authMode, workspaceEmailDomain);
     if (readOptionalText(env.BFF_DEPLOY_ENV).toLowerCase() !== 'stage') {
-      throw createHttpError(503, '현금흐름 쓰기는 Stage에서만 사용할 수 있습니다.', 'unsafe_bff_runtime');
+      throw createHttpError(503, '현재 환경에서는 캐시플로를 저장할 수 없습니다. 담당자에게 문의해 주세요.', 'unsafe_bff_runtime');
     }
     const projectId = readOptionalText(req.params.projectId);
     const qaClock = await readCashflowMonthCloseQaClock({
@@ -2336,7 +2336,7 @@ export function mountJvmWeeklyApiRoutes(app, {
         || !cashflow
         || readOptionalText(cashflow?.projectId) !== rawProjectId
       ) {
-        throw createHttpError(502, 'JVM cashflow month source is incomplete.', 'jvm_weekly_response_invalid');
+        throw createHttpError(502, '월 결산 자료 일부가 도착하지 않았습니다. 잠시 후 다시 시도해 주세요.', 'jvm_weekly_response_invalid');
       }
       const closeBody = await composeCashflowMonthCloseBody({
         db,
@@ -2432,7 +2432,7 @@ export function mountJvmWeeklyApiRoutes(app, {
       path: `/api/v1/cashflow/${projectId}`,
     });
     if (readOptionalText(result?.projectId) !== readOptionalText(req.params.projectId)) {
-      throw createHttpError(502, 'JVM cashflow response project does not match the request.', 'jvm_weekly_project_mismatch');
+      throw createHttpError(502, '다른 프로젝트의 자료가 도착했습니다. 화면을 새로고침해 주세요.', 'jvm_weekly_project_mismatch');
     }
     const comparison = buildCashflowProjectionActualComparison(result, comparisonBoundary);
     const comparisonByMonth = new Map(comparison.months.map((month) => [month.yearMonth, month]));

--- a/server/bff/routes/members.mjs
+++ b/server/bff/routes/members.mjs
@@ -14,7 +14,7 @@ import {
 
 async function listAllAuthUsers(authAdminService) {
   if (!authAdminService || typeof authAdminService.listUsers !== 'function') {
-    throw createHttpError(503, 'Firebase auth admin service is not configured', 'auth_admin_unavailable');
+    throw createHttpError(503, '로그인 확인 서비스가 설정되지 않았습니다. 담당자에게 문의해 주세요.', 'auth_admin_unavailable');
   }
 
   const users = [];

--- a/src/app/platform/api-client.ts
+++ b/src/app/platform/api-client.ts
@@ -233,8 +233,11 @@ export class PlatformApiClient {
       return await this.fetchImpl(url, { ...init, signal: controller.signal });
     } catch (error) {
       if (didTimeout) {
-        const timeoutError = new Error(`API request timed out after ${timeoutMs}ms`);
+        // 이 문구는 사용자 화면에 그대로 나간다. 대기 시간(ms)은 개발자 도구 로그의
+        // durationMs 로 남으므로 여기에 숫자를 넣지 않는다.
+        const timeoutError = new Error('서버 응답이 늦어 요청을 중단했습니다. 잠시 후 다시 시도해 주세요.');
         timeoutError.name = 'TimeoutError';
+        (timeoutError as Error & { timeoutMs?: number }).timeoutMs = timeoutMs;
         throw timeoutError;
       }
       throw error;
@@ -416,7 +419,9 @@ export class PlatformApiClient {
             });
           }
           throw new PlatformApiError(
-            `API request failed with status ${response.status}`,
+            // 서버가 문구를 보냈다면 resolveApiErrorMessage 가 body.message 를 먼저 쓴다.
+            // 이 문구는 응답 본문이 비어 있을 때(게이트웨이 오류 등)만 사용자에게 보인다.
+            '요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요.',
             response.status,
             requestId,
             responseBody,

--- a/src/app/platform/devtools-transaction-log.test.ts
+++ b/src/app/platform/devtools-transaction-log.test.ts
@@ -126,4 +126,49 @@ describe('devtools transaction log', () => {
       durationMs: 12_345,
     })).toBe('[MYSCube:cashflow_transaction] success cashflow.sheet_lab.overwrite.sheet_values.ok 12345ms');
   });
+
+  it('carries the BFF diagnostic code and wording into the developer log', () => {
+    // BFF 오류 응답은 { error, message, requestId } 형태다. 사용자 화면에는 문구만 보이고
+    // 코드는 여기에만 남는다.
+    const sanitized = toDevtoolsError({
+      name: 'PlatformApiError',
+      status: 503,
+      requestId: 'req-42',
+      body: {
+        error: 'jvm_weekly_api_unreachable',
+        message: '저장을 처리하는 서버에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+      },
+    });
+
+    expect(sanitized).toEqual({
+      name: 'PlatformApiError',
+      message: '[jvm_weekly_api_unreachable] 저장을 처리하는 서버에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+      status: 503,
+      requestId: 'req-42',
+    });
+  });
+
+  it('still reads a code from body.code so older callers keep working', () => {
+    expect(toDevtoolsError({ body: { code: 'cashflow_month_closed' } })?.message)
+      .toBe('[cashflow_month_closed] Request failed');
+  });
+
+  it('keeps the wording even when the code is rejected as unsafe', () => {
+    const sanitized = toDevtoolsError({
+      status: 503,
+      body: { error: 'sk_live_9999', message: '서버 연결 정보가 설정되지 않았습니다. 담당자에게 문의해 주세요.' },
+    });
+
+    expect(sanitized?.message).toBe('서버 연결 정보가 설정되지 않았습니다. 담당자에게 문의해 주세요.');
+    expect(sanitized?.message).not.toContain('sk_live');
+  });
+
+  it('masks sensitive text that a server message interpolated', () => {
+    const sanitized = toDevtoolsError({
+      status: 400,
+      body: { error: 'request_error', message: 'person@mysc.co.kr 님의 요청을 처리할 수 없습니다.' },
+    });
+
+    expect(sanitized?.message).not.toContain('person@mysc.co.kr');
+  });
 });

--- a/src/app/platform/devtools-transaction-log.test.ts
+++ b/src/app/platform/devtools-transaction-log.test.ts
@@ -8,6 +8,7 @@ import {
   sanitizeDevtoolsValue,
   summarizeAmountMap,
   toDevtoolsError,
+  toSafeDiagnosticCode,
 } from './devtools-transaction-log';
 
 describe('devtools transaction log', () => {
@@ -170,5 +171,28 @@ describe('devtools transaction log', () => {
     });
 
     expect(sanitized?.message).not.toContain('person@mysc.co.kr');
+  });
+
+  it('accepts auth-related codes, which the old word blocklist silently dropped', () => {
+    expect(toSafeDiagnosticCode('jvm_weekly_api_token_unconfigured')).toBe('jvm_weekly_api_token_unconfigured');
+    expect(toSafeDiagnosticCode('jvm_weekly_api_identity_token_unavailable')).toBe('jvm_weekly_api_identity_token_unavailable');
+    expect(toSafeDiagnosticCode('auth_admin_unavailable')).toBe('auth_admin_unavailable');
+  });
+
+  it('still refuses anything that does not look like a code, which is what protects values', () => {
+    // 실제 비밀값은 숫자·대문자·특수문자를 포함하므로 모양 검사에서 걸린다.
+    expect(toSafeDiagnosticCode('sk_live_1234567890')).toBeUndefined();
+    expect(toSafeDiagnosticCode('eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abc')).toBeUndefined();
+    expect(toSafeDiagnosticCode('AKIAIOSFODNN7EXAMPLE')).toBeUndefined();
+    expect(toSafeDiagnosticCode('ghp_16C7e42F292c6912E7710c838347Ae178B4a')).toBeUndefined();
+    expect(toSafeDiagnosticCode('Bearer abc123')).toBeUndefined();
+    expect(toSafeDiagnosticCode('single')).toBeUndefined();
+    expect(toSafeDiagnosticCode('')).toBeUndefined();
+    expect(toSafeDiagnosticCode(undefined)).toBeUndefined();
+  });
+
+  it('bounds the length so a long lowercase blob cannot ride through', () => {
+    expect(toSafeDiagnosticCode(`${'a'.repeat(60)}_code`)).toBeUndefined();
+    expect(toSafeDiagnosticCode('a_b_c_d_e_f_g_h_i')).toBeUndefined();
   });
 });

--- a/src/app/platform/devtools-transaction-log.ts
+++ b/src/app/platform/devtools-transaction-log.ts
@@ -75,12 +75,18 @@ function truncateString(value: string): string {
   return redacted.length > 500 ? `${redacted.slice(0, 500)}...` : redacted;
 }
 
+// 진단 코드는 소문자와 밑줄로만 이루어진 2~8마디 식별자다. 실제 토큰·키·비밀번호는 base64,
+// hex, JWT 형태라 이 모양을 만족할 수 없으므로 모양 검사만으로 값 유출을 막을 수 있다.
+//
+// 예전에는 여기에 token, secret, key 같은 단어가 들어간 코드를 버리는 목록이 있었다. 그 목록은
+// 값이 아니라 이름을 보고 판단하기 때문에, 막아야 할 값은 어차피 모양 검사에서 걸리고 정작
+// 인증 실패를 가리키는 코드만 사라졌다. jvm_weekly_api_token_unconfigured 와
+// jvm_weekly_api_identity_token_unavailable 이 그렇게 로그에서 빠져 있었다.
+const MAX_DIAGNOSTIC_CODE_LENGTH = 64;
+
 export function toSafeDiagnosticCode(value: unknown): string | undefined {
-  if (!(typeof value === 'string'
-    && /^(?:[a-z]+_){1,7}[a-z]+$/.test(value)
-    && !/(token|secret|credential|password|bearer|authorization|private|key)/.test(value))) {
-    return undefined;
-  }
+  if (typeof value !== 'string' || value.length > MAX_DIAGNOSTIC_CODE_LENGTH) return undefined;
+  if (!/^(?:[a-z]+_){1,7}[a-z]+$/.test(value)) return undefined;
   return value;
 }
 

--- a/src/app/platform/devtools-transaction-log.ts
+++ b/src/app/platform/devtools-transaction-log.ts
@@ -129,15 +129,23 @@ export function toDevtoolsError(error: unknown): DevtoolsLogEntry['error'] {
     status?: unknown;
     requestId?: unknown;
     code?: unknown;
-    body?: { code?: unknown; error?: unknown };
+    body?: { code?: unknown; error?: unknown; message?: unknown };
   };
-  const code = [maybe?.code, maybe?.body?.code].find(isSafeDiagnosticCode);
+  // BFF 오류 응답은 { error, message, requestId } 형태다. 진단 코드는 body.error 에 담겨 오는데
+  // 여기서는 body.code 만 보고 있어서 지금까지 어떤 코드도 로그에 남지 않았다.
+  const code = [maybe?.code, maybe?.body?.code, maybe?.body?.error].find(isSafeDiagnosticCode);
   const name = typeof maybe?.name === 'string' && /^[A-Za-z][A-Za-z0-9_]{0,63}$/.test(maybe.name)
     ? maybe.name
     : 'RequestError';
+  // 서버가 직접 정한 문구는 무엇이 왜 실패했는지를 담고 있다. 화면에는 이 문구만 보이고
+  // 코드는 개발자 도구에서만 확인한다. truncateString 이 길이 제한과 민감어 마스킹을 담당한다.
+  // 이 함수의 반환값은 그 자체로 안전해야 한다. 마스킹은 recordDevtoolsLog 단계에도 있지만
+  // toDevtoolsError 를 직접 쓰는 곳이 있으므로 여기서 먼저 거른다.
+  const rawServerMessage = typeof maybe?.body?.message === 'string' ? maybe.body.message.trim() : '';
+  const detail = rawServerMessage ? truncateString(rawServerMessage) : 'Request failed';
   return {
     name,
-    message: code ? `[${code}] Request failed` : 'Request failed',
+    message: code ? `[${code}] ${detail}` : detail,
     status: typeof maybe?.status === 'number' && Number.isInteger(maybe.status) && maybe.status >= 100 && maybe.status <= 599
       ? maybe.status
       : undefined,


### PR DESCRIPTION
JVM↔BFF 채널의 **관측 가능성**을 복구합니다. 지금까지 어떤 실패도 화면에서 `Internal server error` 한 줄로만 보여, 재시도로 풀릴 문제인지 사람을 불러야 할 문제인지 구분할 수 없었습니다.

문서 1개 + 코드 수정 3개입니다.

---

## 📄 감사 문서 (`9cabe58`)

`docs/architecture/2026-07-27-jvm-bff-channel-audit.md`

**JVM은 Postgres 시절의 잔재입니다.** JPA 엔티티 12개와 Flyway 마이그레이션 4개를 안고 있으면서 실제로는 `JVM_WEEKLY_STORAGE_BACKEND=firestore`로 돌고, 배포에 Cloud SQL 연결이 없습니다. 살아있는 구현 클래스 이름이 `FirestoreInheritedWeeklyExpensePersistence`입니다.

이것이 `month-close` 14.58초를 설명합니다. `whereEqualTo("projectId", ...)` 무필터 스캔이 같은 파일에 **7곳** 있는데, SQL에서는 자연스럽지만 Firestore에서는 컬렉션 전체를 읽습니다. 이를 해결할 복합 인덱스는 이미 선언되어 있으나 쿼리가 `yearMonth`를 쓰지 않아 사용되지 않습니다.

**결정: JVM을 유지합니다.** 근거는 규모가 아니라, 이 저장소에서 재무 불변식을 실제로 검증하는 테스트(약 40개)가 거기 있다는 점입니다.

문서의 모든 `file:line`을 커밋 기준으로 실측 검증했고, 초안의 잘못된 참조 9건을 수정했습니다.

---

## 1. 서버가 정한 문구를 살립니다 (`a4e98d0`)

모든 5xx가 마지막 단계에서 영어 `Internal server error`로 덮여, 배포 설정 누락(영구)과 네트워크 끊김(일시)과 코드 결함이 화면에서 전부 같아 보였습니다.

`createHttpError`가 만든 오류만 문구를 유지하고, 예상하지 못한 예외는 계속 가립니다. 판단 로직을 `resolveErrorResponse`로 분리했습니다 — 이 핸들러에는 테스트가 하나도 없었습니다.

**ERP는 비개발자가 씁니다.** 그래서 5xx 문구 **33개를 전부 다시 썼습니다.** `JVM`·`BFF`·`Stage`·`Firestore`·`토큰`·`고정본` 같은 말을 제거하고, 각 문구가 다음 행동으로 끝나게 했습니다.

| 이전 | 지금 |
|---|---|
| `Internal server error` | 저장된 금액이 불러온 시트 값과 달라 저장을 취소했습니다. 시트 값을 다시 불러온 뒤 시도해 주세요. |
| `Internal server error` | 캐시플로 서버 주소가 설정되지 않았습니다. 담당자에게 문의해 주세요. |
| `Internal server error` (코드 결함) | `Internal server error` ← 그대로 가림 |

`createHttpError`가 **4벌 복사**되어 있어 한 곳만 고쳤다면 4분의 3이 그대로 가려졌을 것입니다. 하나로 합쳤습니다.

## 2. 코드는 개발자 도구에만 남깁니다 (`bddbd4c`)

BFF는 `{ error, message, requestId }`로 답하는데 `toDevtoolsError`는 코드를 `body.code`에서 찾고 있었습니다. 서버는 `body.error`로 보냅니다. 타입에 `error?`가 **선언되어 있는데 읽는 코드가 없었습니다** — 지금까지 어떤 진단 코드도 로그에 남은 적이 없습니다.

- **화면**: 문구만 (코드 없음)
- **개발자 도구**: `[jvm_weekly_api_unreachable] 저장을 처리하는 서버에...` + status + requestId

`toDevtoolsError`가 반환값을 스스로 마스킹합니다. 이 함수를 직접 쓰는 곳이 있어 반환값 자체가 안전해야 하기 때문입니다.

사용자에게 영어로 새던 문구 둘도 고쳤습니다: `API request timed out after 12000ms`, `API request failed with status 503`. 밀리초 값은 문장에서 빼고 로그 속성으로 옮겼습니다.

## 3. 인증 코드가 로그에서 빠지던 문제 (`45d2334`)

`toSafeDiagnosticCode`가 `token`·`secret`·`key` 등이 든 코드를 버렸습니다. 값이 아니라 **이름**을 보고 판단하기 때문에, 하필 인증 실패를 가리키는 코드만 사라졌습니다 — `jvm_weekly_api_token_unconfigured`, `jvm_weekly_api_identity_token_unavailable`.

모양 검사가 이미 보호 역할을 합니다. 코드는 소문자와 밑줄 2~8마디이고 실제 토큰·키·JWT는 숫자·대문자·특수문자를 포함해 그 모양이 될 수 없습니다. 단어 목록은 막는 것이 거의 없으면서 가장 봐야 할 실패를 가리고 있었습니다. 목록을 제거하고 길이 상한을 넣었습니다.

**무엇이 여전히 거부되는지 테스트로 명시했습니다**: API 키, JWT, AWS·GitHub 토큰 형태, bearer 헤더, 과도하게 긴 소문자 문자열.

---

## 검증

| 항목 | 결과 |
|---|---|
| 전체 `vitest run` | **2363 통과** (기준 2350 + 신규 13) |
| 타입체크 | 206건 유지, **신규 0** (stash 대조) |
| `npm run policy:verify` | 통과 |
| `vite build` | 통과 |

신규 테스트 13개는 전부 동작 검증입니다(소스 문자열 단언 아님). PII 마스킹과 정보 유출 방어를 명시적으로 포함했습니다 — `ECONNREFUSED 10.1.2.3:5432`, 메타데이터 서버 IP, 이메일이 화면·로그에 나가지 않는지 확인합니다.

## 알려진 사항

- 브라우저 육안 확인은 하지 못했습니다. 머지 후 스테이지에서 확인 예정입니다.
- 전체 스위트에서 **서로 다른 테스트 6개**가 간헐적으로 실패했습니다(대부분 `cashflow-sheet-lab.test.mjs` 내). 각각 단독 실행 3/3 통과이며, 첫 관측은 이 PR의 코드 변경 이전입니다. 기존 플레이키로 판단하며 별도 처리가 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)