### PR TITLE
feat(policy): JVM 권한맵을 역할의 단일 원본으로 고정

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,10 +65,11 @@
     "security:firebase:whitehat": "node scripts/firebase_whitehat_demo.mjs",
     "pii:rotate": "node scripts/pii_rotate_fields.mjs",
     "pii:setup:vercel": "bash scripts/pii_setup_vercel_local.sh",
-    "policy:verify": "node scripts/verify_rbac_policy.mjs && node scripts/assert_vercel_edge_route_policy.mjs && node scripts/verify_privacy_by_design_policy.mjs",
+    "policy:verify": "node scripts/verify_rbac_policy.mjs && node scripts/extract_jvm_command_roles.mjs && node scripts/assert_vercel_edge_route_policy.mjs && node scripts/verify_privacy_by_design_policy.mjs",
     "etl:build:staging-json": "npx tsx scripts/etl/build-staging-json.ts",
     "etl:sync:staging": "npx tsx scripts/etl/sync-staging-to-firestore.ts",
-    "prepare": "husky"
+    "prepare": "husky",
+    "policy:jvm-roles:write": "node scripts/extract_jvm_command_roles.mjs --write"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",

--- a/policies/jvm-command-roles.json
+++ b/policies/jvm-command-roles.json
@@ -1,0 +1,262 @@
+{
+  "$comment": "생성물이다. 직접 고치지 말고 JVM 권한맵을 고친 뒤 npm run policy:jvm-roles:write 를 실행한다.",
+  "source": "server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseAuthorizationService.java",
+  "roles": [
+    "admin",
+    "auditor",
+    "finance",
+    "pm",
+    "security",
+    "support",
+    "tenant_admin",
+    "viewer"
+  ],
+  "commands": {
+    "AUDIT_EXPORT_CREATE_COMMAND": {
+      "command": "weeklyExpense.auditExport.create",
+      "roles": [
+        "admin",
+        "finance"
+      ]
+    },
+    "BANK_IMPORT_APPLY_ITEMS_COMMAND": {
+      "command": "weeklyExpense.bankStatement.applyItems",
+      "roles": [
+        "admin",
+        "finance",
+        "pm"
+      ]
+    },
+    "BANK_IMPORT_BATCH_COMMAND": {
+      "command": "weeklyExpense.bankStatement.importBatch",
+      "roles": [
+        "admin",
+        "finance",
+        "pm"
+      ]
+    },
+    "BANK_IMPORT_LIST_LINES_COMMAND": {
+      "command": "weeklyExpense.bankStatement.listLines",
+      "roles": [
+        "admin",
+        "auditor",
+        "finance",
+        "pm",
+        "security",
+        "support",
+        "tenant_admin",
+        "viewer"
+      ]
+    },
+    "CASHFLOW_MONTH_CLOSE_READ_COMMAND": {
+      "command": "cashflowMonth.read",
+      "roles": [
+        "admin",
+        "auditor",
+        "finance",
+        "pm",
+        "security",
+        "support",
+        "tenant_admin",
+        "viewer"
+      ]
+    },
+    "CASHFLOW_READ_COMMAND": {
+      "command": "weeklyExpense.cashflow.read",
+      "roles": [
+        "admin",
+        "auditor",
+        "finance",
+        "pm",
+        "security",
+        "support",
+        "tenant_admin",
+        "viewer"
+      ]
+    },
+    "CASHFLOW_SHEET_LAB_APPLY_COMMAND": {
+      "command": "weeklyExpense.cashflowSheetLab.apply",
+      "roles": [
+        "admin",
+        "finance",
+        "pm",
+        "tenant_admin",
+        "viewer"
+      ]
+    },
+    "CASHFLOW_VARIANCE_COMMAND": {
+      "command": "cashflowVariance.update",
+      "roles": [
+        "admin",
+        "finance",
+        "pm",
+        "tenant_admin"
+      ]
+    },
+    "CELLS_COPY_COMMAND": {
+      "command": "weeklyExpense.cells.copy",
+      "roles": [
+        "admin",
+        "finance",
+        "pm"
+      ]
+    },
+    "CELLS_CUT_COMMAND": {
+      "command": "weeklyExpense.cells.cut",
+      "roles": [
+        "admin",
+        "finance",
+        "pm"
+      ]
+    },
+    "CELLS_PASTE_COMMAND": {
+      "command": "weeklyExpense.cells.paste",
+      "roles": [
+        "admin",
+        "finance",
+        "pm"
+      ]
+    },
+    "CELL_PATCH_COMMAND": {
+      "command": "weeklyExpense.cell.patch",
+      "roles": [
+        "admin",
+        "finance",
+        "pm"
+      ]
+    },
+    "CLOSE_CASHFLOW_MONTH_COMMAND": {
+      "command": "cashflowMonth.close",
+      "roles": [
+        "admin",
+        "finance",
+        "pm",
+        "tenant_admin",
+        "viewer"
+      ]
+    },
+    "CLOSE_WEEK_COMMAND": {
+      "command": "weeklyExpense.closeWeek",
+      "roles": [
+        "admin",
+        "finance"
+      ]
+    },
+    "COMPLETE_CASHFLOW_WEEKLY_UPDATE_COMMAND": {
+      "command": "cashflowWeeklyUpdate.complete",
+      "roles": [
+        "admin",
+        "finance",
+        "pm",
+        "tenant_admin",
+        "viewer"
+      ]
+    },
+    "DECIDE_CASHFLOW_MONTH_REOPEN_COMMAND": {
+      "command": "cashflowMonth.decideReopen",
+      "roles": [
+        "admin",
+        "finance"
+      ]
+    },
+    "READ_CASHFLOW_WEEKLY_UPDATE_COMMAND": {
+      "command": "cashflowWeeklyUpdate.read",
+      "roles": [
+        "admin",
+        "auditor",
+        "finance",
+        "pm",
+        "security",
+        "support",
+        "tenant_admin",
+        "viewer"
+      ]
+    },
+    "REOPEN_CASHFLOW_WEEKLY_UPDATE_COMMAND": {
+      "command": "cashflowWeeklyUpdate.reopen",
+      "roles": [
+        "admin",
+        "finance",
+        "pm",
+        "tenant_admin",
+        "viewer"
+      ]
+    },
+    "REQUEST_CASHFLOW_MONTH_REOPEN_COMMAND": {
+      "command": "cashflowMonth.requestReopen",
+      "roles": [
+        "admin",
+        "finance",
+        "pm",
+        "tenant_admin",
+        "viewer"
+      ]
+    },
+    "ROW_DELETE_COMMAND": {
+      "command": "weeklyExpense.row.delete",
+      "roles": [
+        "admin",
+        "finance",
+        "pm"
+      ]
+    },
+    "ROW_INSERT_COMMAND": {
+      "command": "weeklyExpense.row.insert",
+      "roles": [
+        "admin",
+        "finance",
+        "pm"
+      ]
+    },
+    "SAVE_DRAFT_COMMAND": {
+      "command": "weeklyExpense.saveDraft",
+      "roles": [
+        "admin",
+        "finance",
+        "pm"
+      ]
+    },
+    "SHEET_READ_COMMAND": {
+      "command": "weeklyExpense.sheet.read",
+      "roles": [
+        "admin",
+        "auditor",
+        "finance",
+        "pm",
+        "security",
+        "support",
+        "tenant_admin",
+        "viewer"
+      ]
+    },
+    "SUBMIT_WEEK_COMMAND": {
+      "command": "weeklyExpense.submitWeek",
+      "roles": [
+        "admin",
+        "finance",
+        "pm"
+      ]
+    },
+    "UPSERT_PROJECTION_COMMAND": {
+      "command": "weeklyExpense.projection.upsert",
+      "roles": [
+        "admin",
+        "finance",
+        "pm"
+      ]
+    },
+    "WEEKLY_STATUS_READ_COMMAND": {
+      "command": "weeklyExpense.status.read",
+      "roles": [
+        "admin",
+        "auditor",
+        "finance",
+        "pm",
+        "security",
+        "support",
+        "tenant_admin",
+        "viewer"
+      ]
+    }
+  }
+}

--- a/scripts/extract_jvm_command_roles.mjs
+++ b/scripts/extract_jvm_command_roles.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * JVM 권한맵을 역할의 단일 원본으로 삼아 JSON으로 추출한다.
+ *
+ * 이 저장소에서는 같은 질문("이 역할이 이 명령을 실행할 수 있나")에 네 곳이 답해 왔고
+ * 서로 어긋나 있었다. 실제로 강제되는 곳은 JVM 하나뿐이므로 그곳을 원본으로 두고,
+ * 나머지는 이 산출물을 참조하거나 이 산출물과 대조한다.
+ *
+ *   node scripts/extract_jvm_command_roles.mjs           # 대조만 한다. 어긋나면 실패
+ *   node scripts/extract_jvm_command_roles.mjs --write   # 산출물을 다시 만든다
+ *
+ * Java 를 정규식으로 읽으므로 형식이 바뀌면 깨진다. 그때는 조용히 빈 값을 내는 대신
+ * 크게 실패해야 하므로, 항목 수가 기대보다 적으면 그 자체를 오류로 본다.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const ROOT = path.resolve(import.meta.dirname, '..');
+const JAVA_ROOT = 'server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service';
+const COMMAND_SERVICE = path.join(ROOT, JAVA_ROOT, 'WeeklyExpenseCommandService.java');
+const AUTH_SERVICE = path.join(ROOT, JAVA_ROOT, 'WeeklyExpenseAuthorizationService.java');
+const OUTPUT = path.join(ROOT, 'policies/jvm-command-roles.json');
+
+// 추출이 조용히 망가지는 것을 막는 하한선. 명령을 지울 일이 생기면 이 값도 함께 낮춘다.
+const MIN_COMMANDS = 20;
+
+function fail(message) {
+  console.error(`[jvm-command-roles] ${message}`);
+  process.exit(1);
+}
+
+function readCommandValues() {
+  const source = readFileSync(COMMAND_SERVICE, 'utf8');
+  const values = new Map();
+  for (const match of source.matchAll(/static final String ([A-Z_]+_COMMAND)\s*=\s*"([^"]+)"/g)) {
+    values.set(match[1], match[2]);
+  }
+  if (values.size < MIN_COMMANDS) {
+    fail(`WeeklyExpenseCommandService 에서 상수를 ${values.size}개만 찾았다. 형식이 바뀌었는지 확인이 필요하다.`);
+  }
+  return values;
+}
+
+function readCommandRoles(commandValues) {
+  const source = readFileSync(AUTH_SERVICE, 'utf8');
+  const commands = {};
+  for (const match of source.matchAll(
+    /Map\.entry\(\s*WeeklyExpenseCommandService\.([A-Z_]+_COMMAND)\s*,\s*Set\.of\(([^)]*)\)/g,
+  )) {
+    const [, constant, rawRoles] = match;
+    const value = commandValues.get(constant);
+    if (!value) fail(`${constant} 의 문자열 값을 찾지 못했다.`);
+    const roles = [...rawRoles.matchAll(/"([a-z_]+)"/g)].map((role) => role[1]).sort();
+    if (roles.length === 0) fail(`${constant} 에 허용 역할이 없다. 파싱이 깨졌을 가능성이 높다.`);
+    commands[constant] = { command: value, roles };
+  }
+  if (Object.keys(commands).length < MIN_COMMANDS) {
+    fail(`권한맵에서 ${Object.keys(commands).length}개만 읽었다. 형식이 바뀌었는지 확인이 필요하다.`);
+  }
+  return commands;
+}
+
+function build() {
+  const commands = readCommandRoles(readCommandValues());
+  const roles = [...new Set(Object.values(commands).flatMap((entry) => entry.roles))].sort();
+  return {
+    $comment: '생성물이다. 직접 고치지 말고 JVM 권한맵을 고친 뒤 npm run policy:jvm-roles:write 를 실행한다.',
+    source: `${JAVA_ROOT}/WeeklyExpenseAuthorizationService.java`,
+    roles,
+    commands: Object.fromEntries(Object.keys(commands).sort().map((key) => [key, commands[key]])),
+  };
+}
+
+const generated = `${JSON.stringify(build(), null, 2)}\n`;
+
+if (process.argv.includes('--write')) {
+  writeFileSync(OUTPUT, generated, 'utf8');
+  console.log(`[jvm-command-roles] wrote ${path.relative(ROOT, OUTPUT)}`);
+  process.exit(0);
+}
+
+let committed;
+try {
+  committed = readFileSync(OUTPUT, 'utf8');
+} catch {
+  fail(`${path.relative(ROOT, OUTPUT)} 가 없다. npm run policy:jvm-roles:write 를 실행한다.`);
+}
+
+if (committed !== generated) {
+  fail(
+    'JVM 권한맵과 생성물이 다르다. 권한을 바꿨다면 npm run policy:jvm-roles:write 를 실행해 함께 커밋한다.\n'
+    + '이 검사가 있어야 권한이 조용히 넓어지는 일을 막을 수 있다.',
+  );
+}
+
+console.log('[jvm-command-roles] ok: 권한맵과 생성물이 일치한다');


### PR DESCRIPTION
권한이 조용히 넓어지는 것을 CI가 잡도록 합니다. 코드 동작은 바뀌지 않고, 검사와 생성물만 추가합니다.

## 문제

"이 역할이 이 명령을 실행할 수 있나"에 답하는 곳이 **네 군데**이고 서로 다릅니다.

| 층 | 판정 지점 |
|---|---|
| React 화면 | 23곳 `role === '...'` |
| BFF 라우트 | 12곳 역할 목록 |
| JVM 권한맵 | 26개 명령 |
| `rbac-policy.json` | 선언만, **아무도 강제하지 않음** |

실제로 강제되는 곳은 JVM 하나입니다. 트랜잭션 안에서 검사되고 동작 테스트도 붙어 있습니다. 나머지는 손으로 베낀 사본이고 어긋나 있습니다.

## 이것이 실제로 일어났습니다

`CLOSE_CASHFLOW_MONTH_COMMAND` 의 허용 역할이 8일 동안 이렇게 넓어졌습니다.

| 커밋 | 제목 | 결과 |
|---|---|---|
| `829bac9` | feat: finalize monthly close | `pm` |
| `2f628ca` | fix: **align** permissions | `+admin, finance` |
| `9cc5f7d` | feat: **harden** multi-year permissions | **`+viewer`** |
| `09082c9` | feat: **enforce** closed-month amendments | `+tenant_admin` |

`9cc5f7d` 는 제목이 harden 이지만 순수한 완화입니다. 아무것도 실패하지 않았습니다. 지켜보는 것이 없었기 때문입니다.

이 검사가 있었다면 세 번 다 CI에서 걸렸을 것입니다. 변경 자체를 막는 것이 아니라 **생성물 재생성을 요구해 diff에 드러나게** 합니다.

## 무엇을 추가하나

`policies/jvm-command-roles.json` — 26개 명령의 허용 역할을 JVM 권한맵에서 추출한 생성물입니다.

```json
"CLOSE_CASHFLOW_MONTH_COMMAND": {
  "command": "cashflowMonth.close",
  "roles": ["admin", "finance", "pm", "tenant_admin", "viewer"]
}
```

`npm run policy:verify` 가 권한맵과 생성물을 대조하고, 다르면 실패합니다. 권한을 바꿨다면 `npm run policy:jvm-roles:write` 로 재생성해 함께 커밋합니다.

부수 효과로 **26개 명령의 권한을 한 파일에서 볼 수 있게** 됩니다. 지금은 Java 파일을 읽어야 알 수 있습니다.

## 검증

드리프트 감지가 실제로 작동하는지 시험했습니다.

| 단계 | 결과 |
|---|---|
| 일치 상태 | `ok: 권한맵과 생성물이 일치한다` |
| `DECIDE_REOPEN` 에 `pm` 을 몰래 추가 | **종료코드 1로 실패** |
| 원복 | 다시 통과 |

`npm run policy:verify` 통과, `server/bff` 679 통과, 최신 main 과 충돌 0.

추출기는 Java 를 정규식으로 읽으므로 형식이 바뀌면 깨집니다. 그때 조용히 빈 맵을 내고 통과하는 대신 **항목 수가 기대보다 적으면 그 자체를 오류로** 처리합니다.

## 범위에 대한 정직한 메모

이 검사의 현재 실익은 크지 않습니다. 이 제품의 역할은 `admin, finance, pm, viewer` 네 개뿐이고, 층간 불일치는 대부분 **제품에 존재하지 않는 역할**(`tenant_admin`, `auditor`, `support`, `security`)에서만 발생합니다.

그래서 함께 검토했던 capability API 도입과 BFF 목록 파생은 **과투자로 판단해 보류**했습니다. 이 PR은 유지 비용이 명령어 한 번뿐이고 권한 변경을 눈에 보이게 만드는 값이 있어 남깁니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)