### PR TITLE
fix: expose participation dashboard outside LAB mode

### DIFF
--- a/src/app/platform/shell-lab-visibility.test.ts
+++ b/src/app/platform/shell-lab-visibility.test.ts
@@ -44,7 +44,6 @@ describe('shell LAB visibility', () => {
       '/payroll',
       '/budget-summary',
       '/expense-management',
-      '/participation',
       '/koica-personnel',
       '/personnel-changes',
       '/approvals',
@@ -78,6 +77,7 @@ describe('shell LAB visibility', () => {
     expect(shouldShowShellRoute('/projects/migration-audit', 'admin', 'nav', { labEnabled: false })).toBe(true);
     expect(shouldShowShellRoute('/management-planning/project-codes', 'admin', 'nav', { labEnabled: false })).toBe(true);
     expect(shouldShowShellRoute('/cashflow', 'admin', 'nav', { labEnabled: false })).toBe(true);
+    expect(shouldShowShellRoute('/participation', 'admin', 'nav', { labEnabled: false })).toBe(true);
     expect(shouldShowShellRoute('/users', 'admin', 'nav', { labEnabled: false })).toBe(true);
   });
 

--- a/src/app/platform/shell-lab-visibility.ts
+++ b/src/app/platform/shell-lab-visibility.ts
@@ -21,7 +21,6 @@ export const ADMIN_LAB_ROUTES = [
   '/payroll',
   '/budget-summary',
   '/expense-management',
-  '/participation',
   '/koica-personnel',
   '/personnel-changes',
   '/approvals',


### PR DESCRIPTION
원인: 참여율 대시보드가 관리자 LAB 전용 경로에 남아 있어 LAB OFF 상태에서 메뉴가 숨겨졌습니다. 수정: participation 경로를 LAB 전용 목록에서 제거하고 관리자 권한 정책은 유지했습니다. 검증: LAB OFF 표시 회귀 테스트를 포함해 관련 테스트 25개가 통과했습니다.