### PR TITLE
fix: 시트 구조 오류 위치 표시

### DIFF
--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -2897,11 +2897,14 @@ export function mountCashflowSheetLabRoutes(app, {
       const template = analyzeCashflowSheetTemplate(preview.matrix);
       assertConfiguredWeekRangeExistsInTemplate(template, weekRange);
       if (!template.supported) {
-        throw createHttpError(
+        throw Object.assign(createHttpError(
           400,
           '지원하지 않는 cashflow 시트 구조라 연동할 수 없습니다.',
           'cashflow_sheet_template_unsupported',
-        );
+        ), {
+          diagnostics: template.reasons.slice(0, 20),
+          diagnosticCount: template.reasons.length,
+        });
       }
 
       const targetSnapshot = await readCashflowWeeksSnapshot(db, tenantId, projectId);
@@ -2953,11 +2956,16 @@ export function mountCashflowSheetLabRoutes(app, {
       res.status(200).json(completedMirror);
     } catch (error) {
       const normalized = normalizeRouteError(error);
+      const diagnostics = Array.isArray(normalized?.diagnostics) ? normalized.diagnostics : [];
       const lastRefreshError = {
         code: normalized?.code || normalized?.name || 'error',
         message: normalized?.message || '시트 연동에 실패했습니다.',
         statusCode: normalized?.statusCode || 500,
         at: attemptedAt,
+        ...(diagnostics.length > 0 ? {
+          diagnostics,
+          diagnosticCount: Number(normalized?.diagnosticCount) || diagnostics.length,
+        } : {}),
       };
       const mirror = previousMirror?.sourceRevision
         ? {

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -1034,6 +1034,43 @@ describe('cashflow sheet lab route', () => {
     expect(response.body.sourceRevision).toBeUndefined();
   });
 
+  it('returns the exact cells that make a cashflow sheet structure unsupported', async () => {
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        cashflowSheetLab: { value: 'spreadsheet-a', sheetName: 'cashflow(사용내역 연동)' },
+      },
+    });
+    const matrix = buildMatrix();
+    matrix[12][4] = 'broken-week-header';
+    const app = createApp({
+      db,
+      googleSheetsService: {
+        previewSpreadsheet: vi.fn(async () => ({
+          spreadsheetId: 'spreadsheet-a',
+          selectedSheetName: 'cashflow(사용내역 연동)',
+          availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
+          matrix,
+        })),
+      },
+    });
+
+    const response = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'mirror-unsupported-template' })
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      status: 'ERROR',
+      lastRefreshError: {
+        code: 'cashflow_sheet_template_unsupported',
+        diagnostics: expect.arrayContaining([
+          expect.objectContaining({ code: 'cashflow_week_header_invalid', sourceCell: 'E13' }),
+        ]),
+      },
+    });
+  });
+
   it('replays an explicit mirror refresh idempotently without rereading Google', async () => {
     const db = createDb({
       project: {

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
@@ -128,6 +128,8 @@ describe('CashflowSheetLabPage shell', () => {
     expect(pageSource).toContain('시트 값 가져오기');
     expect(pageSource).toContain('시트 값 다시 가져오기');
     expect(pageSource).toContain("mirror?.lastRefreshError?.message");
+    expect(pageSource).toContain('mirror.lastRefreshError.diagnostics');
+    expect(pageSource).toContain('diagnostic.sourceCell');
     expect(pageSource).toContain('시트 연동 오류');
     expect(pageSource).not.toContain('시트 고정본 ·');
     expect(pageSource).not.toContain('검토 범위');

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
@@ -1090,6 +1090,19 @@ export function CashflowSheetLabPage({
               {mirror?.lastRefreshError?.message ? (
                 <div className="border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-900">
                   <span className="font-bold">시트 연동 오류</span> · {mirror.lastRefreshError.message}
+                  {mirror.lastRefreshError.diagnostics?.length ? (
+                    <ul className="mt-2 space-y-1 border-t border-red-200 pt-2">
+                      {mirror.lastRefreshError.diagnostics.map((diagnostic, index) => (
+                        <li key={`${diagnostic.code}-${diagnostic.sourceCell || index}`}>
+                          {diagnostic.sourceCell ? `${diagnostic.sourceCell} · ` : ''}{diagnostic.message}
+                          <span className="ml-1 text-red-700">({diagnostic.code})</span>
+                        </li>
+                      ))}
+                      {(mirror.lastRefreshError.diagnosticCount || 0) > mirror.lastRefreshError.diagnostics.length ? (
+                        <li>외 {(mirror.lastRefreshError.diagnosticCount || 0) - mirror.lastRefreshError.diagnostics.length}건</li>
+                      ) : null}
+                    </ul>
+                  ) : null}
                 </div>
               ) : null}
             </div>

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -378,7 +378,20 @@ export interface CashflowSheetLabMirrorResult {
   activeWeekRange?: CashflowSheetLabApplyResult['activeWeekRange'] & { activeWeeks?: unknown[] };
   lastRefreshAttemptAt?: string;
   lastRefreshIdempotencyKey?: string;
-  lastRefreshError?: { code: string; message: string; statusCode?: number; at?: string } | null;
+  lastRefreshError?: {
+    code: string;
+    message: string;
+    statusCode?: number;
+    at?: string;
+    diagnosticCount?: number;
+    diagnostics?: Array<{
+      code: string;
+      message: string;
+      mode?: 'projection' | 'actual';
+      sourceCell?: string;
+      lineIds?: string[];
+    }>;
+  } | null;
 }
 
 function isCashflowSheetLabMirrorResult(


### PR DESCRIPTION
## 변경\n- 지원하지 않는 cashflow 시트 구조일 때 실패한 셀과 규칙을 저장합니다.\n- 시트 연동 오류 아래에 셀 주소, 설명, 진단 코드를 표시합니다.\n- 진단은 최대 20건만 노출하고 전체 건수를 함께 표시합니다.\n\n## 검증\n- targeted Vitest: 82 passed\n- npm run build: passed\n\n## 범위\n- 파서 규칙과 시트 값 반영 계약은 변경하지 않았습니다.