### PR TITLE
fix: 캐시플로우에 시트 연동 오류 표시

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -324,6 +324,14 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('toDevtoolsError');
   });
 
+  it('shows a saved sheet structure error and its failing cells in the cashflow dashboard', () => {
+    expect(source).toContain('시트 연동 오류: ');
+    expect(source).toContain('cashflowSheetMirror.lastRefreshError.diagnostics');
+    expect(source).toContain('diagnostic.sourceCell');
+    expect(source).toContain('시트 설정');
+    expect(source).not.toContain('min-w-0 truncate">시트 연동 오류');
+  });
+
   it('locks the cashflow screen with the shared sheet sync overlay while a sheet refresh is running', () => {
     expect(source).toContain('CashflowSheetSyncOverlay');
     expect(source).toContain('inert={sheetRefreshLoading || undefined}');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -2384,8 +2384,22 @@ export function CashflowProjectSheet({
           </section>
 
           {cashflowSheetMirror?.lastRefreshError?.message ? (
-            <div className="flex items-center justify-between gap-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-800">
-              <span className="min-w-0 truncate">시트 연동 오류: {cashflowSheetMirror.lastRefreshError.message}</span>
+            <div className="flex items-start justify-between gap-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-800">
+              <div className="min-w-0">
+                <span className="font-semibold">시트 연동 오류: </span>{cashflowSheetMirror.lastRefreshError.message}
+                {cashflowSheetMirror.lastRefreshError.diagnostics?.length ? (
+                  <ul className="mt-2 space-y-1 border-t border-red-200 pt-2">
+                    {cashflowSheetMirror.lastRefreshError.diagnostics.map((diagnostic, index) => (
+                      <li key={`${diagnostic.code}-${diagnostic.sourceCell || index}`}>
+                        {diagnostic.sourceCell ? `${diagnostic.sourceCell} · ` : ''}{diagnostic.message}
+                      </li>
+                    ))}
+                    {(cashflowSheetMirror.lastRefreshError.diagnosticCount || 0) > cashflowSheetMirror.lastRefreshError.diagnostics.length ? (
+                      <li>외 {(cashflowSheetMirror.lastRefreshError.diagnosticCount || 0) - cashflowSheetMirror.lastRefreshError.diagnostics.length}건</li>
+                    ) : null}
+                  </ul>
+                ) : null}
+              </div>
               <Button
                 type="button"
                 size="sm"


### PR DESCRIPTION
## 변경\n- 캐시플로우 대시보드에서 시트 연동 오류를 줄이지 않고 표시합니다.\n- 구조 오류면 실패 셀과 원인도 함께 표시합니다.\n- 시트 설정으로 바로 이동할 수 있습니다.\n\n## 검증\n- CashflowProjectSheet shell: 41 passed\n- npm run build: passed