### PR TITLE
fix(cashflow): harden explicit close review

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -1745,9 +1745,6 @@ async function composeCashflowMonthDashboard({ db, req, projectId, yearMonth, cl
 }
 
 async function composeCashflowMonthCloseBody({ db, req, projectId, cashflow, openingBalances, comparisonBoundary }) {
-  if (!db?.doc) {
-    throw createHttpError(503, '월 결산 자료를 보관하는 저장소에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.', 'cashflow_month_close_source_unavailable');
-  }
   const tenantId = readOptionalText(req.context?.tenantId);
   const requested = commandBody(req);
   const yearMonth = readOptionalText(requested.yearMonth);
@@ -1758,6 +1755,12 @@ async function composeCashflowMonthCloseBody({ db, req, projectId, cashflow, ope
   }
   if (!closeInput || readOptionalText(closeInput.yearMonth) !== yearMonth) {
     throw createHttpError(400, 'Cashflow month close review input is required.', 'cashflow_month_close_request_invalid');
+  }
+  if (closeInput.humanReviewed !== true) {
+    throw createHttpError(409, '시트값과 결산 항목을 직접 확인한 뒤 결산해 주세요.', 'cashflow_month_close_human_review_required');
+  }
+  if (!db?.doc) {
+    throw createHttpError(503, '월 결산 자료를 보관하는 저장소에 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.', 'cashflow_month_close_source_unavailable');
   }
 
   const [mirrorSnap, projectSnap] = await Promise.all([
@@ -1805,6 +1808,7 @@ async function composeCashflowMonthCloseBody({ db, req, projectId, cashflow, ope
     yearMonth,
     expectedRevision,
     expectedDraftRevision: 0,
+    humanReviewed: true,
     sourceRevision: closeInput.sourceRevision,
     targetRevision: closeInput.targetRevision,
     depositScheduleRows: closeInput.depositScheduleRows,

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -122,6 +122,7 @@ function fullMonthCloseSource({ mirrorStatus = 'FRESH', controlMatches = true, c
   }));
   const closeInput = {
     yearMonth: '2026-06', sourceRevision, targetRevision,
+    humanReviewed: true,
     depositScheduleRows,
     cells: cells.map(({ lineId, state, yearMonth: _yearMonth, direction: _direction, ...cell }) => ({
       ...cell, cashflowLine: lineId, cellState: state,
@@ -1868,7 +1869,7 @@ describe('JVM weekly API BFF proxy', () => {
         yearMonth: '2026-06',
         expectedRevision: 0,
         expectedOpeningBalances: { selectedYear: 2026 },
-        closeInput: { yearMonth: '2026-06' },
+        closeInput: { yearMonth: '2026-06', humanReviewed: true },
       })
       .expect(504)
       .expect((response) => {
@@ -1876,6 +1877,36 @@ describe('JVM weekly API BFF proxy', () => {
       });
 
     expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('rejects a month close that has not been explicitly reviewed by a person', async () => {
+    const source = fullMonthCloseSource();
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(monthDashboardSource({
+        ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0,
+        reopenCount: 0, projectWarningCount: 0, snapshot: {},
+      })),
+    }));
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { env: stageEnv, db: source.db });
+    const read = await request(app)
+      .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
+      .expect(200);
+
+    await request(app)
+      .post('/api/v1/cashflow/project-a/month-close')
+      .set('idempotency-key', 'month-close-human-review-required')
+      .send({
+        yearMonth: '2026-06',
+        expectedRevision: 0,
+        expectedOpeningBalances: read.body.dashboard.openingBalances,
+        closeInput: { ...source.closeInput, humanReviewed: false, managementChecks: read.body.dashboard.managementChecks },
+      })
+      .expect(409)
+      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_human_review_required'));
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
   it.each(['viewer', 'pm', 'finance', 'admin'])('forwards a reviewed %s month close without edit-lease headers', async (actorRole) => {
@@ -1933,6 +1964,7 @@ describe('JVM weekly API BFF proxy', () => {
       yearMonth: '2026-06',
       expectedRevision: 3,
       expectedDraftRevision: 0,
+      humanReviewed: true,
       sourceRevision: `sha256:${'c'.repeat(64)}`,
       targetRevision: `sha256:${'d'.repeat(64)}`,
       openingBalances: {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CloseCashflowMonthRequest.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CloseCashflowMonthRequest.java
@@ -28,6 +28,7 @@ public record CloseCashflowMonthRequest(
     String yearMonth,
     @PositiveOrZero long expectedRevision,
     @PositiveOrZero long expectedDraftRevision,
+    boolean humanReviewed,
     @Valid @NotNull @Size(min = CashflowSheetLabApplyRequest.FINANCE_WEEK_COUNT, max = CashflowSheetLabApplyRequest.FINANCE_WEEK_COUNT)
     List<DepositScheduleRow> depositScheduleRows,
     @Valid @NotNull @Size(min = CashflowSheetLabApplyRequest.EXPECTED_CELL_COUNT, max = CashflowSheetLabApplyRequest.EXPECTED_CELL_COUNT)
@@ -327,6 +328,12 @@ public record CloseCashflowMonthRequest(
             }
         }
         return List.copyOf(byKey.values());
+    }
+
+    public static void requireHumanReviewed(boolean humanReviewed) {
+        if (!humanReviewed) {
+            throw new IllegalArgumentException("Cashflow month close requires an explicit human review.");
+        }
     }
 
     public static List<ManagementCheck> requireCompleteManagementChecks(List<ManagementCheck> checks) {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -422,6 +422,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             LocalDate deadline = YearMonth.parse(yearMonth).plusMonths(1).atDay(10);
             boolean postDeadline = businessDate.date().isAfter(deadline);
             long closeRevision = canonicalMonthCounter(close, "revision");
+            addMonthCounters(closeRevision, 1);
             String closeSnapshotHash = text(close.get("snapshotHash"), "");
             if (!closeSnapshotHash.matches("sha256:[a-f0-9]{64}")) {
                 throw new WeeklyExpenseConflictException(
@@ -466,6 +467,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         for (CashflowClosedMonthAmendment amendment : amendments == null ? List.<CashflowClosedMonthAmendment>of() : amendments) {
             Map<String, Object> evidence = new LinkedHashMap<>();
             evidence.put("closeRevision", amendment.closeRevision());
+            evidence.put("resultingCloseRevision", addMonthCounters(amendment.closeRevision(), 1));
             evidence.put("closeSnapshotHash", amendment.closeSnapshotHash());
             evidence.put("sourceRevision", sourceRevision);
             evidence.put("targetRevision", targetRevision);
@@ -477,6 +479,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                     : calculationChecksByMonth.getOrDefault(amendment.yearMonth(), List.of()))
             );
             Map<String, Object> closePatch = new LinkedHashMap<>();
+            closePatch.put("revision", addMonthCounters(amendment.closeRevision(), 1));
             closePatch.put("amendmentCount", amendment.amendmentCount());
             closePatch.put("postDeadlineAmendmentWarningCount", amendment.warningCount());
             closePatch.put("lastAmendmentAt", now.toString());
@@ -494,6 +497,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             amendmentDocument.put("projectId", projectId);
             amendmentDocument.put("yearMonth", amendment.yearMonth());
             amendmentDocument.put("closeRevision", amendment.closeRevision());
+            amendmentDocument.put("resultingCloseRevision", addMonthCounters(amendment.closeRevision(), 1));
             amendmentDocument.put("closeSnapshotHash", amendment.closeSnapshotHash());
             amendmentDocument.put("deadline", amendment.deadline());
             amendmentDocument.put("postDeadline", amendment.postDeadline());
@@ -940,6 +944,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         }
 
         List<CashflowSheetLabApplyRequest.Cell> cells = CashflowSheetLabApplyRequest.requireCompleteMonth(request.cells());
+        CloseCashflowMonthRequest.requireHumanReviewed(request.humanReviewed());
         List<CloseCashflowMonthRequest.DepositScheduleRow> depositScheduleRows = CloseCashflowMonthRequest
             .requireCompleteDepositSchedule(request.depositScheduleRows());
         List<CloseCashflowMonthRequest.Confirmation> confirmations = CloseCashflowMonthRequest
@@ -2772,6 +2777,12 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
 
         Map<String, Object> snapshot = new LinkedHashMap<>();
         snapshot.put("version", 1);
+        snapshot.put("humanReview", Map.of(
+            "confirmed", true,
+            "confirmedByUid", actor.id(),
+            "confirmedByName", actor.name(),
+            "confirmedAt", now.toString()
+        ));
         snapshot.put("project", project);
         snapshot.put("sheetFacts", source.sheetFacts());
         snapshot.put("depositScheduleRows", depositSnapshot);

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/CloseCashflowMonthRequestTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/CloseCashflowMonthRequestTest.java
@@ -12,6 +12,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class CloseCashflowMonthRequestTest {
     @Test
+    void monthCloseRejectsAnUnattestedHumanReview() {
+        assertThatThrownBy(() -> CloseCashflowMonthRequest.requireHumanReviewed(false))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("explicit human review");
+    }
+
+    @Test
     void depositScheduleRejectsImpossibleCalendarDate() {
         List<CloseCashflowMonthRequest.DepositScheduleRow> rows = validNotApplicableRows();
         rows.set(0, new CloseCashflowMonthRequest.DepositScheduleRow(

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -768,6 +768,7 @@ class FirestoreCashflowLeaseGuardTest {
         assertThat(response.months()).extracting(CashflowSheetBatchApplyResponse.MonthResult::yearMonth)
             .containsExactly("2026-07", "2026-08");
         assertThat(fixture.documents.get("orgs/tenant-a/monthly_closes/project-a-2026-08"))
+            .containsEntry("revision", 2L)
             .containsEntry("amendmentCount", 1L)
             .containsEntry("postDeadlineAmendmentWarningCount", 0L)
             .containsEntry("lastAmendmentPostDeadline", false);
@@ -1031,12 +1032,14 @@ class FirestoreCashflowLeaseGuardTest {
         ));
         assertThat(closedResponse.yearMonth()).isEqualTo("2026-07");
         assertThat(closed.documents.get("orgs/tenant-a/monthly_closes/project-a-2026-07"))
+            .containsEntry("revision", 2L)
             .containsEntry("amendmentCount", 1L)
             .containsEntry("postDeadlineAmendmentWarningCount", 0L)
             .hasEntrySatisfying("lastAmendmentEvidence", value -> {
                 Map<String, Object> evidence = (Map<String, Object>) value;
                 assertThat(evidence)
                     .containsEntry("closeRevision", 1L)
+                    .containsEntry("resultingCloseRevision", 2L)
                     .containsEntry("closeSnapshotHash", "sha256:" + "f".repeat(64))
                     .containsEntry("sourceRevision", SOURCE_REVISION)
                     .containsEntry("targetRevision", "sha256:298012959db83e193536ff7f60735889252ceaa4325de6944465e2dd197fcb44");
@@ -2184,6 +2187,7 @@ class FirestoreCashflowLeaseGuardTest {
             pinned.yearMonth(),
             pinned.expectedRevision(),
             pinned.expectedDraftRevision(),
+            pinned.humanReviewed(),
             pinned.depositScheduleRows(),
             changedCells,
             pinned.confirmations(),
@@ -2240,6 +2244,7 @@ class FirestoreCashflowLeaseGuardTest {
             base.yearMonth(),
             base.expectedRevision(),
             base.expectedDraftRevision(),
+            base.humanReviewed(),
             base.depositScheduleRows(),
             base.cells(),
             base.confirmations(),
@@ -2974,6 +2979,7 @@ class FirestoreCashflowLeaseGuardTest {
             month.yearMonth(),
             expectedRevision,
             expectedDraftRevision,
+            true,
             depositScheduleRows,
             month.cells(),
             confirmations,

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -31,13 +31,15 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain('applyCashflowMonthCloseProjectionDrafts');
   });
 
-  it('closes the month from one compact confirmation while preserving the server snapshot contract', () => {
+  it('requires an explicit human review before the compact month close is enabled', () => {
     expect(source).toContain('결산 기준을 먼저 점검한 뒤, 준비된 경우에만 이 달의 수정을 잠급니다.');
     expect(source).toContain('월 결산 확정');
     expect(source).toContain('monthCloseResult?.dashboard?.managementChecks');
     expect(source).not.toContain('캐시플로 항목 사람 확인');
     expect(source).not.toContain('세금계산서·입금 일정</h3>');
-    expect(source).toContain("decision: hasDepositValue ? 'CONFIRMED' : 'NOT_APPLICABLE'");
+    expect(source).toContain('monthCloseHumanReviewed');
+    expect(source).toContain('humanReviewed: monthCloseHumanReviewed');
+    expect(source).toContain('직접 확인했습니다');
     expect(source).not.toContain('!monthCloseProgress.complete');
   });
 

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -889,10 +889,7 @@ export function CashflowProjectSheet({
         decisions,
         depositScheduleRows,
         managementChecks,
-        managementDecisions: Object.fromEntries(managementChecks.map((check) => [
-          check.id,
-          managementDecisions[check.id] || 'CONFIRMED',
-        ])),
+        managementDecisions,
         deadlineSummary: monthCloseResult?.dashboard?.deadlineSummary || {
           trackingStartedAt: null,
           missedCount: 0,

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -311,6 +311,7 @@ export function CashflowProjectSheet({
   const [qaClockSetting, setQaClockSetting] = useState<CashflowMonthCloseQaDateTimeSetting | null>(null);
   const [weeklyCompletionBusy, setWeeklyCompletionBusy] = useState(false);
   const [monthCloseReviewOpen, setMonthCloseReviewOpen] = useState(false);
+  const [monthCloseHumanReviewed, setMonthCloseHumanReviewed] = useState(false);
   const [managementDecisions, setManagementDecisions] = useState<CashflowManagementDecisionMap>({});
   const [monthCloseDepositRows, setMonthCloseDepositRows] = useState<CashflowMonthCloseDepositReviewRow[]>(
     () => createEmptyCashflowMonthCloseDepositRows(),
@@ -370,8 +371,13 @@ export function CashflowProjectSheet({
     setMonthCloseResult(null);
     setManagementDecisions({});
     setMonthCloseDepositRows(createEmptyCashflowMonthCloseDepositRows());
+    setMonthCloseHumanReviewed(false);
     setMonthCloseReviewDirty(false);
   }, [projectId]);
+
+  useEffect(() => {
+    setMonthCloseHumanReviewed(false);
+  }, [yearMonth, monthClosePinnedSource?.sourceRevision, monthClosePinnedSource?.targetRevisionAtFetch]);
 
   const discardChangesAndLeave = useCallback(async (): Promise<void> => {
     if (blocker.state !== 'blocked') return;
@@ -879,6 +885,7 @@ export function CashflowProjectSheet({
       monthCloseInput = buildCashflowMonthCloseDraftInput({
         mirror: monthClosePinnedSource,
         yearMonth,
+        humanReviewed: monthCloseHumanReviewed,
         decisions,
         depositScheduleRows,
         managementChecks,
@@ -984,6 +991,7 @@ export function CashflowProjectSheet({
     loadCashflowMonthClose,
     monthCloseCellsState,
     monthCloseDepositRows,
+    monthCloseHumanReviewed,
     managementDecisions,
     monthCloseResult,
     orgId,
@@ -2789,6 +2797,20 @@ export function CashflowProjectSheet({
             결산 후에는 재오픈 승인을 받기 전까지 이 월을 수정할 수 없습니다.
           </div>
 
+          <label className="flex items-start gap-2 rounded-md border border-slate-200 bg-white px-3 py-3 text-[13px] leading-5 text-slate-800">
+            <input
+              type="checkbox"
+              checked={monthCloseHumanReviewed}
+              disabled={monthCloseBusy || monthClosePreparation.status !== 'READY'}
+              onChange={(event) => setMonthCloseHumanReviewed(event.target.checked)}
+              className="mt-1 h-4 w-4 rounded border-slate-300 text-[#17324D]"
+            />
+            <span>
+              시트 고정본의 현금흐름·입금 일정과 주요 관리 항목을 직접 확인했습니다.
+              이 확인은 결산 스냅샷에 제 이름과 서버 시각으로 기록됩니다.
+            </span>
+          </label>
+
           <AlertDialogFooter>
             <AlertDialogCancel disabled={monthCloseBusy}>닫기</AlertDialogCancel>
             {monthClosePreparation.actionLabel ? (
@@ -2803,7 +2825,7 @@ export function CashflowProjectSheet({
               </Button>
             ) : null}
             <AlertDialogAction
-              disabled={!canFinalizeMonth || monthCloseBusy || monthClosePreparation.status !== 'READY' || monthCloseResult?.status !== 'OPEN'}
+              disabled={!canFinalizeMonth || !monthCloseHumanReviewed || monthCloseBusy || monthClosePreparation.status !== 'READY' || monthCloseResult?.status !== 'OPEN'}
               onClick={(event) => {
                 event.preventDefault();
                 void handleFinalizeMonthClose();

--- a/src/app/components/cashflow/cashflow-month-close.test.ts
+++ b/src/app/components/cashflow/cashflow-month-close.test.ts
@@ -228,6 +228,28 @@ describe('cashflow month close contract', () => {
     expect(result.managementConfirmations).toHaveLength(4);
   });
 
+  it('does not turn an unreviewed management check into an automatic confirmation', () => {
+    const source = mirror();
+    const cells = normalizeCashflowMonthCloseCells(source, '2026-07');
+    const decisions = Object.fromEntries(cells.map((cell) => [
+      cashflowMonthCloseConfirmationKey(cell),
+      requiredCashflowMonthCloseDecision(cell),
+    ]));
+    expect(() => buildCashflowMonthCloseDraftInput({
+      mirror: source,
+      yearMonth: '2026-07',
+      humanReviewed: true,
+      decisions,
+      depositScheduleRows: createEmptyCashflowMonthCloseDepositRows().map((row) => ({
+        ...row,
+        decision: 'NOT_APPLICABLE' as const,
+      })),
+      managementChecks,
+      managementDecisions: { ...managementDecisions, 'labor-transfer': undefined },
+      deadlineSummary,
+    })).toThrow('확인 또는 해당 없음');
+  });
+
   it('rejects an invalid or incomplete pinned mirror', () => {
     const source = mirror();
     source.cells = source.cells?.slice(0, -1);

--- a/src/app/components/cashflow/cashflow-month-close.test.ts
+++ b/src/app/components/cashflow/cashflow-month-close.test.ts
@@ -128,12 +128,31 @@ describe('cashflow month close contract', () => {
     expect(() => buildCashflowMonthCloseDraftInput({
       mirror: mirror(),
       yearMonth: '2026-07',
+      humanReviewed: true,
       decisions: {},
       depositScheduleRows: createEmptyCashflowMonthCloseDepositRows(),
       managementChecks,
       managementDecisions: {},
       deadlineSummary,
     })).toThrow('확인');
+  });
+
+  it('does not turn a server-derived cell state into a confirmation without an explicit review', () => {
+    const cells = normalizeCashflowMonthCloseCells(mirror(), '2026-07');
+    const decisions = Object.fromEntries(cells.map((cell) => [
+      cashflowMonthCloseConfirmationKey(cell),
+      requiredCashflowMonthCloseDecision(cell),
+    ]));
+    expect(() => buildCashflowMonthCloseDraftInput({
+      mirror: mirror(),
+      yearMonth: '2026-07',
+      humanReviewed: false,
+      decisions,
+      depositScheduleRows: createEmptyCashflowMonthCloseDepositRows().map((row) => ({ ...row, decision: 'NOT_APPLICABLE' as const })),
+      managementChecks,
+      managementDecisions,
+      deadlineSummary,
+    })).toThrow('직접 확인');
   });
 
   it('keeps untouched deposit rows incomplete until a human chooses an action', () => {
@@ -165,6 +184,7 @@ describe('cashflow month close contract', () => {
     const result = buildCashflowMonthCloseDraftInput({
       mirror: source,
       yearMonth: '2026-07',
+      humanReviewed: true,
       decisions,
       projectionDrafts: { [key]: '12,345' },
       depositScheduleRows: createEmptyCashflowMonthCloseDepositRows().map((row) => ({
@@ -190,6 +210,7 @@ describe('cashflow month close contract', () => {
     const result = buildCashflowMonthCloseDraftInput({
       mirror: source,
       yearMonth: '2026-07',
+      humanReviewed: true,
       decisions,
       depositScheduleRows: createEmptyCashflowMonthCloseDepositRows().map((row) => ({
         ...row,

--- a/src/app/components/cashflow/cashflow-month-close.ts
+++ b/src/app/components/cashflow/cashflow-month-close.ts
@@ -244,6 +244,7 @@ function normalizeDepositRows(
 export function buildCashflowMonthCloseDraftInput(input: {
   mirror: CashflowSheetLabMirrorResult | null;
   yearMonth: string;
+  humanReviewed: boolean;
   decisions: CashflowMonthCloseDecisionMap;
   depositScheduleRows: CashflowMonthCloseDepositReviewRow[];
   projectionDrafts?: Record<string, string>;
@@ -251,6 +252,9 @@ export function buildCashflowMonthCloseDraftInput(input: {
   managementDecisions: CashflowManagementDecisionMap;
   deadlineSummary: CashflowDeadlineSummary;
 }): CashflowMonthCloseDraftInput {
+  if (!input.humanReviewed) {
+    throw new Error('시트값과 결산 항목을 직접 확인한 뒤 결산 확인을 선택해 주세요.');
+  }
   const cells = applyCashflowMonthCloseProjectionDrafts(
     normalizeCashflowMonthCloseCells(input.mirror, input.yearMonth),
     input.projectionDrafts || {},
@@ -284,6 +288,7 @@ export function buildCashflowMonthCloseDraftInput(input: {
     sourceRevision: input.mirror.sourceRevision,
     targetRevision: input.mirror.targetRevisionAtFetch,
     yearMonth: input.yearMonth,
+    humanReviewed: true,
     depositScheduleRows: normalizeDepositRows(input.depositScheduleRows),
     cells,
     confirmations,

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -848,6 +848,7 @@ export interface CashflowMonthCloseDraftInput {
   sourceRevision: string;
   targetRevision: string;
   yearMonth: string;
+  humanReviewed: boolean;
   depositScheduleRows: CashflowMonthCloseDepositScheduleRow[];
   cells: CashflowMonthCloseCell[];
   confirmations: CashflowMonthCloseConfirmation[];


### PR DESCRIPTION
## 변경 내용
- 월 결산의 사람 확인을 명시적 체크로만 인정
- 주요 관리 항목의 미확인 상태를 자동 확인하지 않도록 수정
- 결산 후 변경 시 월 결산 revision 증가 및 감사 정보 기록

## 검증
- Frontend cashflow targeted tests: 53 passed
- JVM targeted tests: passed
- Independent review: unsafe BFF direct-to-JVM shortcut was not included

## 배포 범위
- Stage only
- Live/production deployment excluded