### PR TITLE
fix(cashflow): initialize pinned source before review effect

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -43,6 +43,15 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain('!monthCloseProgress.complete');
   });
 
+  it('initializes the pinned source before effects read its revision', () => {
+    const declaration = source.indexOf('const monthClosePinnedSource = useMemo');
+    const revisionEffect = source.indexOf(
+      '[yearMonth, monthClosePinnedSource?.sourceRevision, monthClosePinnedSource?.targetRevisionAtFetch]',
+    );
+    expect(declaration).toBeGreaterThan(-1);
+    expect(revisionEffect).toBeGreaterThan(declaration);
+  });
+
   it('prefills immutable sheet-authored deposit facts for the compact month close', () => {
     expect(source).toContain('dashboard?.sheetDepositScheduleRows');
     expect(source).toContain('taxInvoiceIssuedDate: row.taxInvoiceIssuedDate');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -375,10 +375,6 @@ export function CashflowProjectSheet({
     setMonthCloseReviewDirty(false);
   }, [projectId]);
 
-  useEffect(() => {
-    setMonthCloseHumanReviewed(false);
-  }, [yearMonth, monthClosePinnedSource?.sourceRevision, monthClosePinnedSource?.targetRevisionAtFetch]);
-
   const discardChangesAndLeave = useCallback(async (): Promise<void> => {
     if (blocker.state !== 'blocked') return;
     setExitBusy(true);
@@ -728,6 +724,10 @@ export function CashflowProjectSheet({
       })),
     };
   }, [cashflowSheetMirror, monthCloseResult?.dashboard, projectId, yearMonth]);
+
+  useEffect(() => {
+    setMonthCloseHumanReviewed(false);
+  }, [yearMonth, monthClosePinnedSource?.sourceRevision, monthClosePinnedSource?.targetRevisionAtFetch]);
 
   useEffect(() => {
     const sourceRows = monthCloseResult?.dashboard?.sheetDepositScheduleRows || [];


### PR DESCRIPTION
## 문제
- 현금흐름 화면 진입 시 Cannot access S before initialization 런타임 오류 발생

## 원인
- monthClosePinnedSource 선언 전에 결산 확인 초기화 effect가 해당 값을 참조

## 수정
- effect를 pinned source 초기화 이후로 이동
- 선언 순서를 고정하는 회귀 테스트 추가

## 검증
- CashflowProjectSheet shell tests 42개 통과
- npm run build 통과

Stage 전용 배포 대상이며 Live에는 배포하지 않습니다.
