### PR TITLE
fix(cashflow): validate annual running balances in JVM

### DIFF
--- a/docs/architecture/contracts/2026-07-28-cashflow-formula-validation-contract.md
+++ b/docs/architecture/contracts/2026-07-28-cashflow-formula-validation-contract.md
@@ -138,11 +138,13 @@ calculatedBalance[M,P]
 Excel equivalents:
 
 ```excel
-C33 = B33 + C22 - C32
+C33 = C22 - C32
 D33 = C33 + D22 - D32
 E33 = D33 + E22 - E32
 
-C56 = B56 + C45 - C55
+C56 = C45 - C55
+D56 = C56 + D45 - D55
+E56 = D56 + E45 - E55
 D56 = C56 + D45 - D55
 E56 = D56 + E45 - E55
 ```

--- a/docs/architecture/contracts/2026-07-28-cashflow-formula-validation-contract.md
+++ b/docs/architecture/contracts/2026-07-28-cashflow-formula-validation-contract.md
@@ -141,12 +141,16 @@ Excel equivalents:
 C33 = C22 - C32
 D33 = C33 + D22 - D32
 E33 = D33 + E22 - E32
+BM33 = BL33 + BM22 - BM32
+BN33 = BM33 + BN22 - BN32
+BR33 = BQ33 + BR22 - BR32
 
 C56 = C45 - C55
 D56 = C56 + D45 - D55
 E56 = D56 + E45 - E55
-D56 = C56 + D45 - D55
-E56 = D56 + E45 - E55
+BM56 = BL56 + BM45 - BM55
+BN56 = BM56 + BN45 - BN55
+BR56 = BQ56 + BR45 - BR55
 ```
 
 The JVM must not use a reported sheet balance as the next period's input. It uses its own calculated prior balance. This identifies the first broken period instead of propagating a broken displayed balance as trusted input.
@@ -202,6 +206,9 @@ Excel equivalents:
 BS33 = BS22 - BS32
 BS56 = BS45 - BS55
 ```
+
+`BS` is a grand total, not the next running-balance period. It is therefore
+validated independently and never receives `BR33` or `BR56` as an opening balance.
 
 ### 4.6 Deposit schedule total
 

--- a/server/bff/cashflow-sheet-snapshot.mjs
+++ b/server/bff/cashflow-sheet-snapshot.mjs
@@ -106,6 +106,7 @@ function snapshotAnnualCell(mapping, matrix) {
   return {
     mode: mapping.mode,
     year: Number(mapping.year),
+    periodKind: mapping.periodKind,
     lineId: mapping.lineId,
     direction: mapping.direction,
     sourceCell: mapping.a1,
@@ -119,6 +120,7 @@ function snapshotAnnualDerivedCell(mapping, matrix) {
   return {
     mode: mapping.mode,
     year: Number(mapping.year),
+    periodKind: mapping.periodKind,
     derivedKind: mapping.derivedKind,
     sourceCell: mapping.a1,
     ...(classified.state === 'VALUE' && classified.amount === 0

--- a/server/bff/cashflow-sheet-snapshot.mjs
+++ b/server/bff/cashflow-sheet-snapshot.mjs
@@ -114,6 +114,19 @@ function snapshotAnnualCell(mapping, matrix) {
   };
 }
 
+function snapshotAnnualDerivedCell(mapping, matrix) {
+  const classified = classifyCashflowSheetCell(matrix?.[mapping.rowIndex]?.[mapping.columnIndex]);
+  return {
+    mode: mapping.mode,
+    year: Number(mapping.year),
+    derivedKind: mapping.derivedKind,
+    sourceCell: mapping.a1,
+    ...(classified.state === 'VALUE' && classified.amount === 0
+      ? { state: 'ZERO', amount: 0 }
+      : classified),
+  };
+}
+
 function snapshotTotalCell(mapping, matrix) {
   const classified = classifyCashflowSheetCell(matrix?.[mapping.rowIndex]?.[mapping.columnIndex]);
   const totalClassified = classified.state === 'VALUE' && classified.amount === 0
@@ -568,6 +581,12 @@ export function createCashflowPinnedSnapshot({
     .flatMap((section) => section.annualMappings || [])
     .map((mapping) => snapshotAnnualCell(mapping, matrix))
     .sort(compareAnnualCells);
+  const annualDerivedCells = (template?.sections || [])
+    .flatMap((section) => section.annualDerivedMappings || [])
+    .map((mapping) => snapshotAnnualDerivedCell(mapping, matrix))
+    .sort((left, right) => Number(left.year) - Number(right.year)
+      || String(left.mode).localeCompare(String(right.mode))
+      || String(left.derivedKind).localeCompare(String(right.derivedKind)));
   const totalCells = (template?.sections || [])
     .flatMap((section) => section.totalMappings || [])
     .map((mapping) => snapshotTotalCell(mapping, matrix))
@@ -575,7 +594,7 @@ export function createCashflowPinnedSnapshot({
       || String(left.kind).localeCompare(String(right.kind))
       || String(left.lineId || left.derivedKind || '').localeCompare(String(right.lineId || right.derivedKind || '')));
   const sheetFacts = extractCashflowSheetFacts({ template, matrix, cells, annualCells, totalCells });
-  const sourceRevision = revisionOf({ spreadsheetId, selectedSheetName, cells, annualCells, totalCells, sheetFacts });
+  const sourceRevision = revisionOf({ spreadsheetId, selectedSheetName, cells, annualCells, annualDerivedCells, totalCells, sheetFacts });
   const summary = cells.reduce((counts, cell) => {
     counts.cellCount += 1;
     if (cell.state === 'VALUE' || cell.state === 'ZERO') counts.valueCount += 1;
@@ -607,6 +626,7 @@ export function createCashflowPinnedSnapshot({
     summary,
     cells,
     annualCells,
+    annualDerivedCells,
     totalCells,
     sheetFacts,
   };

--- a/server/bff/cashflow-sheet-snapshot.test.mjs
+++ b/server/bff/cashflow-sheet-snapshot.test.mjs
@@ -42,6 +42,33 @@ describe('cashflow sheet pinned snapshot', () => {
     expect(zero.sourceRevision).not.toBe(empty.sourceRevision);
   });
 
+  it('pins annual totals and running balances as sheet evidence', () => {
+    const snapshot = createCashflowPinnedSnapshot({
+      projectId: 'project-a',
+      spreadsheetId: 'sheet-a',
+      selectedSheetName: 'cashflow(사용내역 연동)',
+      template: {
+        sections: [{
+          mode: 'projection',
+          annualDerivedMappings: [
+            { mode: 'projection', year: 2024, derivedKind: 'deposit_total', rowIndex: 0, columnIndex: 2, a1: 'C1' },
+            { mode: 'projection', year: 2024, derivedKind: 'withdrawal_total', rowIndex: 1, columnIndex: 2, a1: 'C2' },
+            { mode: 'projection', year: 2024, derivedKind: 'balance', rowIndex: 2, columnIndex: 2, a1: 'C3' },
+            { mode: 'projection', year: 2025, derivedKind: 'balance', rowIndex: 2, columnIndex: 3, a1: 'D3' },
+          ],
+        }],
+      },
+      matrix: [['', '', '100'], ['', '', '30'], ['', '', '70', '170']],
+    });
+
+    expect(snapshot.annualDerivedCells).toEqual([
+      expect.objectContaining({ year: 2024, derivedKind: 'balance', amount: 70, sourceCell: 'C3' }),
+      expect.objectContaining({ year: 2024, derivedKind: 'deposit_total', amount: 100, sourceCell: 'C1' }),
+      expect.objectContaining({ year: 2024, derivedKind: 'withdrawal_total', amount: 30, sourceCell: 'C2' }),
+      expect.objectContaining({ year: 2025, derivedKind: 'balance', amount: 170, sourceCell: 'D3' }),
+    ]);
+  });
+
   it('marks non-numeric sheet contents invalid instead of silently converting them to zero', () => {
     expect(classifyCashflowSheetCell('확인 필요')).toEqual({
       state: 'INVALID',

--- a/server/bff/cashflow-sheet-snapshot.test.mjs
+++ b/server/bff/cashflow-sheet-snapshot.test.mjs
@@ -51,10 +51,10 @@ describe('cashflow sheet pinned snapshot', () => {
         sections: [{
           mode: 'projection',
           annualDerivedMappings: [
-            { mode: 'projection', year: 2024, derivedKind: 'deposit_total', rowIndex: 0, columnIndex: 2, a1: 'C1' },
-            { mode: 'projection', year: 2024, derivedKind: 'withdrawal_total', rowIndex: 1, columnIndex: 2, a1: 'C2' },
-            { mode: 'projection', year: 2024, derivedKind: 'balance', rowIndex: 2, columnIndex: 2, a1: 'C3' },
-            { mode: 'projection', year: 2025, derivedKind: 'balance', rowIndex: 2, columnIndex: 3, a1: 'D3' },
+            { mode: 'projection', year: 2024, periodKind: 'ANNUAL', derivedKind: 'deposit_total', rowIndex: 0, columnIndex: 2, a1: 'C1' },
+            { mode: 'projection', year: 2024, periodKind: 'ANNUAL', derivedKind: 'withdrawal_total', rowIndex: 1, columnIndex: 2, a1: 'C2' },
+            { mode: 'projection', year: 2024, periodKind: 'ANNUAL', derivedKind: 'balance', rowIndex: 2, columnIndex: 2, a1: 'C3' },
+            { mode: 'projection', year: 2025, periodKind: 'ANNUAL', derivedKind: 'balance', rowIndex: 2, columnIndex: 3, a1: 'D3' },
           ],
         }],
       },

--- a/server/bff/cashflow-sheet-template.mjs
+++ b/server/bff/cashflow-sheet-template.mjs
@@ -115,6 +115,7 @@ function annualColumn(matrix, rowIndex, columnIndex) {
   if (!match) return null;
   return {
     year: Number.parseInt(match[1], 10),
+    periodKind: 'ANNUAL',
     columnIndex,
     a1: toA1(rowIndex, columnIndex),
   };
@@ -156,6 +157,7 @@ function fixedSection(matrix, layout, reasons) {
   if (totalColumn) {
     annualColumns.push({
       year: sourceYear,
+      periodKind: 'GRAND_TOTAL',
       columnIndex: totalColumn.columnIndex,
       a1: totalColumn.a1,
     });
@@ -230,6 +232,7 @@ function fixedSection(matrix, layout, reasons) {
     canonicalLabel: lineRow.canonicalLabel,
     direction: lineRow.direction,
     year: column.year,
+    periodKind: column.periodKind,
     rowIndex: lineRow.rowIndex,
     columnIndex: column.columnIndex,
     a1: toA1(lineRow.rowIndex, column.columnIndex),
@@ -240,6 +243,7 @@ function fixedSection(matrix, layout, reasons) {
     derivedKind: row.kind,
     label: row.label,
     year: column.year,
+    periodKind: column.periodKind,
     rowIndex: row.rowIndex,
     columnIndex: column.columnIndex,
     a1: toA1(row.rowIndex, column.columnIndex),

--- a/server/bff/cashflow-sheet-template.mjs
+++ b/server/bff/cashflow-sheet-template.mjs
@@ -235,6 +235,16 @@ function fixedSection(matrix, layout, reasons) {
     a1: toA1(lineRow.rowIndex, column.columnIndex),
     source: 'sheet_annual_total',
   })));
+  const annualDerivedMappings = derivedRows.flatMap((row) => annualColumns.map((column) => ({
+    mode: layout.mode,
+    derivedKind: row.kind,
+    label: row.label,
+    year: column.year,
+    rowIndex: row.rowIndex,
+    columnIndex: column.columnIndex,
+    a1: toA1(row.rowIndex, column.columnIndex),
+    source: 'sheet_annual_derived',
+  })));
   const totalMappings = [
     ...lineRows.map((lineRow) => ({
       mode: layout.mode,
@@ -269,6 +279,7 @@ function fixedSection(matrix, layout, reasons) {
     ignoredRows: [],
     mappings,
     annualMappings,
+    annualDerivedMappings,
     totalMappings,
     missingLineIds: [],
     duplicateLineIds: [],

--- a/server/bff/cashflow-sheet-template.test.mjs
+++ b/server/bff/cashflow-sheet-template.test.mjs
@@ -113,8 +113,10 @@ describe('cashflow official fixed template', () => {
     ]);
     expect(result.sections[0].totalColumn).toMatchObject({ a1: 'BS12' });
     expect(result.sections[0].annualDerivedMappings).toEqual(expect.arrayContaining([
-      expect.objectContaining({ year: 2024, derivedKind: 'balance', a1: 'C33' }),
-      expect.objectContaining({ year: 2025, derivedKind: 'balance', a1: 'D33' }),
+      expect.objectContaining({ year: 2024, periodKind: 'ANNUAL', derivedKind: 'balance', a1: 'C33' }),
+      expect.objectContaining({ year: 2025, periodKind: 'ANNUAL', derivedKind: 'balance', a1: 'D33' }),
+      expect.objectContaining({ year: 2027, periodKind: 'ANNUAL', derivedKind: 'balance', a1: 'BM33' }),
+      expect.objectContaining({ year: 2026, periodKind: 'GRAND_TOTAL', derivedKind: 'balance', a1: 'BS33' }),
     ]));
   });
 

--- a/server/bff/cashflow-sheet-template.test.mjs
+++ b/server/bff/cashflow-sheet-template.test.mjs
@@ -91,6 +91,7 @@ describe('cashflow official fixed template', () => {
     expect(result.mappingCandidates).toHaveLength(1_920);
     expect(result.sections.map((section) => section.weekColumns.length)).toEqual([60, 60]);
     expect(result.sections.map((section) => section.annualMappings.length)).toEqual([144, 144]);
+    expect(result.sections.map((section) => section.annualDerivedMappings.length)).toEqual([27, 27]);
     expect(result.sections.map((section) => section.totalMappings.length)).toEqual([19, 19]);
     expect(result.sections[0].mappings[0]).toMatchObject({
       mode: 'projection',
@@ -111,6 +112,10 @@ describe('cashflow official fixed template', () => {
       [2029, 'BO12'], [2030, 'BP12'], [2031, 'BQ12'], [2032, 'BR12'], [2026, 'BS12'],
     ]);
     expect(result.sections[0].totalColumn).toMatchObject({ a1: 'BS12' });
+    expect(result.sections[0].annualDerivedMappings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ year: 2024, derivedKind: 'balance', a1: 'C33' }),
+      expect.objectContaining({ year: 2025, derivedKind: 'balance', a1: 'D33' }),
+    ]));
   });
 
   it('fails closed instead of guessing when an official coordinate changes', () => {

--- a/server/bff/java-weekly-client.mjs
+++ b/server/bff/java-weekly-client.mjs
@@ -347,6 +347,34 @@ export function createJavaWeeklyClient({
     return result;
   }
 
+  async function validateCashflowSheetFormulas({
+    context,
+    projectId,
+    sourceYear,
+    annualCells,
+    annualDerivedCells,
+    months,
+    acceptFormulaMismatches = false,
+  }) {
+    const normalizedProjectId = encodeURIComponent(readOptionalText(projectId));
+    if (!normalizedProjectId) {
+      throw createHttpError(400, 'projectId is required.', 'project_id_required');
+    }
+    return requestJson({
+      context,
+      method: 'POST',
+      path: `/api/v1/cashflow/${normalizedProjectId}/sheet-lab/formulas/preflight`,
+      dataProjectId: bffDataProjectId,
+      body: {
+        sourceYear,
+        annualCells,
+        annualDerivedCells,
+        months,
+        ...(acceptFormulaMismatches === true ? { acceptFormulaMismatches: true } : {}),
+      },
+    });
+  }
+
   async function applyCashflowSheetAnnualTotal({
     context,
     projectId,
@@ -386,6 +414,7 @@ export function createJavaWeeklyClient({
     getCashflowSnapshot,
     applyCashflowSheetLab,
     applyCashflowSheetBatch,
+    validateCashflowSheetFormulas,
     applyCashflowSheetAnnualTotal,
     authMode,
     workspaceEmailDomain,

--- a/server/bff/java-weekly-client.test.mjs
+++ b/server/bff/java-weekly-client.test.mjs
@@ -166,6 +166,40 @@ describe('Java weekly cashflow client', () => {
     });
   });
 
+  it('forwards annual and weekly formula evidence to the JVM preflight authority', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ ok: true, projectId: 'project-a' }),
+    }));
+    const client = createJavaWeeklyClient({ env: stageEnv(), fetchImpl });
+    const annualCells = [{ year: 2024, mode: 'projection', cashflowLine: 'SALES_IN', cellState: 'ZERO', amount: 0 }];
+    const annualDerivedCells = [{
+      year: 2024, periodKind: 'ANNUAL', mode: 'projection', field: 'balance', amount: 0, sourceCell: 'C33',
+    }];
+    const months = [{ yearMonth: '2026-01', cells: monthlyContract.cells, calculationChecks: [] }];
+
+    await client.validateCashflowSheetFormulas({
+      context,
+      projectId: 'project-a',
+      sourceYear: 2026,
+      annualCells,
+      annualDerivedCells,
+      months,
+      acceptFormulaMismatches: true,
+    });
+
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toContain('/api/v1/cashflow/project-a/sheet-lab/formulas/preflight');
+    expect(JSON.parse(init.body)).toEqual({
+      sourceYear: 2026,
+      annualCells,
+      annualDerivedCells,
+      months,
+      acceptFormulaMismatches: true,
+    });
+  });
+
   it('waits once for a slow batch conflict instead of retrying and masking it as unreachable', async () => {
     vi.useFakeTimers();
     try {

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -679,6 +679,15 @@ function mergeCashflowSourceMirror(previous, next, sourceYear) {
     ...previousAnnualCells,
     ...(next.annualCells || []).map((cell) => ({ ...cell, sourceYear })),
   ]);
+  const previousAnnualDerivedCells = readOptionalText(previous?.sourceRevision)
+    ? (previous.annualDerivedCells || [])
+      .map((cell) => ({ ...cell, sourceYear: Number(cell?.sourceYear) || previousSourceYear }))
+      .filter((cell) => cell.sourceYear !== sourceYear)
+    : [];
+  const annualDerivedCells = selectCanonicalAnnualCells([
+    ...previousAnnualDerivedCells,
+    ...(next.annualDerivedCells || []).map((cell) => ({ ...cell, sourceYear })),
+  ]);
   const previousTotalCells = readOptionalText(previous?.sourceRevision)
     ? (previous.totalCells || [])
       .map((cell) => ({ ...cell, sourceYear: Number(cell?.sourceYear) || previousSourceYear }))
@@ -708,7 +717,7 @@ function mergeCashflowSourceMirror(previous, next, sourceYear) {
       activeWeekRange: next.activeWeekRange,
     },
   };
-  const sourceRevision = `sha256:${stableHash({ sources, cells, annualCells, totalCells })}`;
+  const sourceRevision = `sha256:${stableHash({ sources, cells, annualCells, annualDerivedCells, totalCells })}`;
   const summary = cells.reduce((counts, cell) => {
     counts.cellCount += 1;
     if (['VALUE', 'ZERO'].includes(cell.state)) counts.valueCount += 1;
@@ -750,6 +759,7 @@ function mergeCashflowSourceMirror(previous, next, sourceYear) {
     sourceRevision,
     cells,
     annualCells,
+    annualDerivedCells,
     totalCells,
     yearMonths: [...new Set(cells.map((cell) => readOptionalText(cell.yearMonth)).filter(Boolean))].sort(),
     years: [...new Set([
@@ -1316,6 +1326,68 @@ function monthCalculationChecks(mirror, yearMonth) {
     ? mirror.sheetFacts.weeklyCalculationChecks.filter((check) => readOptionalText(check?.yearMonth) === yearMonth)
     : [];
   return checks.length === 10 ? checks : [];
+}
+
+function cashflowFormulaPreflightInput(mirror) {
+  const sourceYear = Number(mirror?.sourceYear);
+  if (!Number.isSafeInteger(sourceYear)) {
+    throw createHttpError(409, '시트의 기준 연도를 확인할 수 없습니다. 시트 값을 다시 불러와 주세요.', 'cashflow_sheet_formula_evidence_incomplete');
+  }
+  const annualCells = [];
+  const annualYears = [...new Set((mirror?.annualCells || []).map((cell) => Number(cell?.year)))]
+    .filter(Number.isSafeInteger)
+    .sort((left, right) => left - right);
+  for (const year of annualYears) {
+    const validated = validateCompletePinnedYear(
+      year,
+      (mirror.annualCells || []).filter((cell) => Number(cell?.year) === year),
+    );
+    if (!validated.ok) {
+      throw createHttpError(409, `${year}년 연간 원장 행을 확인할 수 없습니다. 시트 값을 다시 불러와 주세요.`, 'cashflow_sheet_formula_evidence_incomplete');
+    }
+    annualCells.push(...validated.cells.map((cell) => ({ year, ...cell })));
+  }
+
+  const fieldByKind = {
+    deposit_total: 'depositTotal',
+    withdrawal_total: 'withdrawalTotal',
+    balance: 'balance',
+  };
+  const annualDerivedCells = (mirror?.annualDerivedCells || []).map((cell) => {
+    const field = fieldByKind[readOptionalText(cell?.derivedKind)];
+    const state = readOptionalText(cell?.state);
+    if (
+      !field
+      || !['ANNUAL', 'GRAND_TOTAL'].includes(readOptionalText(cell?.periodKind))
+      || !CASHFLOW_MODES.includes(readOptionalText(cell?.mode))
+      || !['VALUE', 'ZERO', 'EMPTY'].includes(state)
+      || (['VALUE', 'ZERO'].includes(state) && !Number.isSafeInteger(cell?.amount))
+    ) {
+      throw createHttpError(409, `${readOptionalText(cell?.sourceCell) || '연간 합계'} 셀 값을 숫자로 확인해 주세요.`, 'cashflow_sheet_formula_evidence_incomplete');
+    }
+    return stripUndefinedDeep({
+      year: Number(cell.year),
+      periodKind: cell.periodKind,
+      mode: cell.mode,
+      field,
+      amount: ['VALUE', 'ZERO'].includes(state) ? cell.amount : undefined,
+      sourceCell: readOptionalText(cell.sourceCell) || undefined,
+    });
+  });
+
+  const cellsByMonth = groupPinnedCellsByMonth((mirror?.cells || [])
+    .filter((cell) => Number(readOptionalText(cell?.yearMonth).slice(0, 4)) === sourceYear));
+  const months = [];
+  const yearMonths = [...cellsByMonth.keys()].sort();
+  for (const yearMonth of yearMonths) {
+    const validated = validateCompletePinnedMonth(yearMonth, cellsByMonth.get(yearMonth) || []);
+    const calculationChecks = monthCalculationChecks(mirror, yearMonth);
+    if (!validated.ok || calculationChecks.length !== 10) {
+      throw createHttpError(409, `${yearMonth} 계산 근거를 확인할 수 없습니다. 시트 값을 다시 불러와 주세요.`, 'cashflow_sheet_formula_evidence_incomplete');
+    }
+    months.push({ yearMonth, cells: validated.cells, calculationChecks, apply: false });
+  }
+  return { sourceYear, annualCells, annualDerivedCells, months };
 }
 
 function stageMonthSnapshotDocument({ tenantId, projectId, runId, mirror, yearMonth, cells, calculationChecks, now }) {
@@ -2165,20 +2237,28 @@ async function applyStagedCashflowSheetLab({
     ? stageRun.openingBalanceCells
     : [];
 
+  const mirror = await readCashflowSheetMirror(db, tenantId, projectId);
+  assertFreshCashflowSheetMirror(mirror);
+  if (
+    readOptionalText(mirror?.configRevision) !== readOptionalText(stageRun.configRevision)
+    || readOptionalText(mirror?.sourceRevision) !== readOptionalText(stageRun.sourceRevision)
+  ) {
+    throw createHttpError(409, '검토 후 시트 고정본이 변경되었습니다. 다시 검토해 주세요.', 'cashflow_sheet_mirror_revision_conflict');
+  }
   if (!resuming) {
-    const mirror = await readCashflowSheetMirror(db, tenantId, projectId);
-    assertFreshCashflowSheetMirror(mirror);
-    if (
-      readOptionalText(mirror?.configRevision) !== readOptionalText(stageRun.configRevision)
-      || readOptionalText(mirror?.sourceRevision) !== readOptionalText(stageRun.sourceRevision)
-    ) {
-      throw createHttpError(409, '검토 후 시트 고정본이 변경되었습니다. 다시 검토해 주세요.', 'cashflow_sheet_mirror_revision_conflict');
-    }
     const currentTargetSnapshot = await readCashflowWeeksSnapshot(db, tenantId, projectId);
     if (computeCashflowTargetRevision(currentTargetSnapshot) !== readOptionalText(stageRun.targetRevisionAtFetch)) {
       throw createHttpError(409, '검토 후 캐시플로우 값이 변경되었습니다. 다시 검토해 주세요.', 'cashflow_sheet_target_revision_conflict');
     }
   }
+
+  const preflightInput = cashflowFormulaPreflightInput(mirror);
+  await javaWeeklyClient.validateCashflowSheetFormulas({
+    context,
+    projectId,
+    ...preflightInput,
+    acceptFormulaMismatches,
+  });
 
   const reservation = await reserveCashflowSheetApply({
     db,

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -366,6 +366,14 @@ function createApp({ context = {}, db = createDb(), googleSheetsService, routeOp
     };
     next();
   });
+  if (routeOptions.javaWeeklyClient && !routeOptions.javaWeeklyClient.validateCashflowSheetFormulas) {
+    routeOptions.javaWeeklyClient.validateCashflowSheetFormulas = vi.fn(async (input) => ({
+      ok: true,
+      projectId: input.projectId,
+      annualCheckCount: 0,
+      weeklyCheckCount: 0,
+    }));
+  }
   mountCashflowSheetLabRoutes(app, {
     db,
     googleSheetsService: googleSheetsService || {
@@ -3098,7 +3106,7 @@ describe('cashflow sheet lab route', () => {
       sourceCell: 'BO12',
     };
     const javaWeeklyClient = {
-      applyCashflowSheetLab: vi.fn(async (input) => {
+      validateCashflowSheetFormulas: vi.fn(async (input) => {
         if (!input.acceptFormulaMismatches) {
           throw Object.assign(new Error('formula confirmation required'), {
             statusCode: 409,
@@ -3106,6 +3114,9 @@ describe('cashflow sheet lab route', () => {
             details: { mismatchCount: 1, mismatches: [mismatch] },
           });
         }
+        return { ok: true };
+      }),
+      applyCashflowSheetLab: vi.fn(async (input) => {
         return javaApplyResponse(input, resultingTargetRevision);
       }),
     };
@@ -3142,9 +3153,10 @@ describe('cashflow sheet lab route', () => {
       })
       .expect(200);
 
-    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(2);
-    expect(javaWeeklyClient.applyCashflowSheetLab.mock.calls[0][0].acceptFormulaMismatches).toBe(false);
-    expect(javaWeeklyClient.applyCashflowSheetLab.mock.calls[1][0].acceptFormulaMismatches).toBe(true);
+    expect(javaWeeklyClient.validateCashflowSheetFormulas).toHaveBeenCalledTimes(2);
+    expect(javaWeeklyClient.validateCashflowSheetFormulas.mock.calls[0][0].acceptFormulaMismatches).toBe(false);
+    expect(javaWeeklyClient.validateCashflowSheetFormulas.mock.calls[1][0].acceptFormulaMismatches).toBe(true);
+    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(1);
   });
 
   it('applies a settled-week sheet change without a weekly confirmation', async () => {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSheetFormulaPreflightRequest.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSheetFormulaPreflightRequest.java
@@ -1,0 +1,30 @@
+package dev.merryai.innerplatform.weekly.api;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record CashflowSheetFormulaPreflightRequest(
+    @Min(2000) @Max(2099) int sourceYear,
+    @Valid @NotNull @Size(min = 32, max = 288) List<CashflowOpeningBalanceCell> annualCells,
+    @Valid @NotNull @Size(min = 6, max = 54) List<AnnualDerivedCell> annualDerivedCells,
+    @Valid @NotNull @Size(min = 1, max = 12) List<CashflowSheetBatchApplyRequest.Month> months,
+    boolean acceptFormulaMismatches
+) {
+    public record AnnualDerivedCell(
+        @Min(2000) @Max(2099) int year,
+        @NotBlank @Pattern(regexp = "ANNUAL|GRAND_TOTAL") String periodKind,
+        @NotBlank @Pattern(regexp = "projection|actual") String mode,
+        @NotBlank @Pattern(regexp = "depositTotal|withdrawalTotal|balance") String field,
+        BigDecimal amount,
+        @NotBlank @Size(max = 20) String sourceCell
+    ) {
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSheetFormulaPreflightResponse.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSheetFormulaPreflightResponse.java
@@ -1,0 +1,9 @@
+package dev.merryai.innerplatform.weekly.api;
+
+public record CashflowSheetFormulaPreflightResponse(
+    boolean ok,
+    String projectId,
+    int annualCheckCount,
+    int weeklyCheckCount
+) {
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -623,6 +623,22 @@ public class WeeklyExpenseController {
         );
     }
 
+    @PostMapping("/cashflow/{projectId}/sheet-lab/formulas/preflight")
+    public CashflowSheetFormulaPreflightResponse validateCashflowSheetFormulas(
+        @PathVariable String projectId,
+        @RequestHeader("x-tenant-id") String tenantId,
+        @RequestHeader("x-actor-id") String actorId,
+        @RequestHeader("x-actor-role") String actorRole,
+        @RequestHeader(value = "x-actor-email", required = false) String actorEmail,
+        @Valid @RequestBody CashflowSheetFormulaPreflightRequest request
+    ) {
+        return commandService.validateCashflowSheetFormulas(
+            actorContext(tenantId, actorId, actorRole, actorEmail),
+            projectId,
+            request
+        );
+    }
+
     @PostMapping("/cashflow/{projectId}/sheet-lab/batch/apply")
     public CashflowSheetBatchApplyResponse applyCashflowSheetBatch(
         @PathVariable String projectId,

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowFormulaValidator.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowFormulaValidator.java
@@ -60,6 +60,71 @@ public final class CashflowFormulaValidator {
         return Map.copyOf(balances);
     }
 
+    public static List<AnnualCheck> validateAnnualPeriods(
+        List<OpeningCell> cells,
+        List<ReportedAnnual> reportedAnnuals,
+        Map<String, BigDecimal> openingBalances
+    ) {
+        Map<Integer, List<OpeningCell>> cellsByYear = (cells == null ? List.<OpeningCell>of() : cells).stream()
+            .collect(Collectors.groupingBy(OpeningCell::year, TreeMap::new, Collectors.toList()));
+        Map<String, ReportedAnnual> reportedByKey = new LinkedHashMap<>();
+        for (ReportedAnnual reported : reportedAnnuals == null ? List.<ReportedAnnual>of() : reportedAnnuals) {
+            String mode = normalizeMode(reported.mode());
+            ReportedAnnual canonical = new ReportedAnnual(
+                reported.year(), mode, reported.depositTotal(), reported.withdrawalTotal(), reported.balance(),
+                reported.sourceCells() == null ? Map.of() : Map.copyOf(reported.sourceCells())
+            );
+            if (reportedByKey.putIfAbsent(reported.year() + ":" + mode, canonical) != null) {
+                throw new IllegalArgumentException("Cashflow annual formula input contains duplicate reported periods.");
+            }
+        }
+        Map<String, BigDecimal> balances = new LinkedHashMap<>(Map.of(
+            "projection", requiredWholeWon(openingBalances.getOrDefault("projection", BigDecimal.ZERO), "opening balance"),
+            "actual", requiredWholeWon(openingBalances.getOrDefault("actual", BigDecimal.ZERO), "opening balance")
+        ));
+        List<AnnualCheck> results = new ArrayList<>();
+        for (Map.Entry<Integer, List<OpeningCell>> yearEntry : cellsByYear.entrySet()) {
+            int year = yearEntry.getKey();
+            Map<String, Cell> sourceByKey = new LinkedHashMap<>();
+            for (OpeningCell source : yearEntry.getValue()) {
+                String mode = normalizeMode(source.mode());
+                String lineId = CashflowLineCatalog.canonicalize(source.lineId());
+                if (!List.of("projection", "actual").contains(mode) || !CashflowLineCatalog.ALL_LINES.contains(lineId)) {
+                    throw new IllegalArgumentException("Cashflow annual formula input contains an unsupported cell.");
+                }
+                Cell canonical = new Cell(mode, 1, lineId, source.state(), source.amount());
+                amount(canonical);
+                if (sourceByKey.putIfAbsent(key(mode, 1, lineId), canonical) != null) {
+                    throw new IllegalArgumentException("Cashflow annual formula input contains duplicate cells.");
+                }
+            }
+            if (sourceByKey.size() != CashflowLineCatalog.ALL_LINES.size() * 2) {
+                throw new IllegalArgumentException("Cashflow annual formula input must contain every source row.");
+            }
+            for (String mode : List.of("projection", "actual")) {
+                ReportedAnnual reported = reportedByKey.get(year + ":" + mode);
+                if (reported == null) {
+                    throw new IllegalArgumentException("Cashflow annual formula input must contain every reported period.");
+                }
+                BigDecimal depositTotal = total(sourceByKey, mode, 1, CashflowLineCatalog.IN_LINES);
+                BigDecimal withdrawalTotal = total(sourceByKey, mode, 1, CashflowLineCatalog.OUT_LINES);
+                BigDecimal balance = balances.get(mode).add(depositTotal).subtract(withdrawalTotal);
+                results.add(new AnnualCheck(
+                    year, mode, balances.get(mode), depositTotal, withdrawalTotal, balance,
+                    matches(reported.depositTotal(), depositTotal),
+                    matches(reported.withdrawalTotal(), withdrawalTotal),
+                    matches(reported.balance(), balance),
+                    reported.sourceCells()
+                ));
+                balances.put(mode, balance);
+            }
+        }
+        if (reportedByKey.size() != results.size()) {
+            throw new IllegalArgumentException("Cashflow annual formula input contains an unsupported reported period.");
+        }
+        return List.copyOf(results);
+    }
+
     public static List<WeeklyCheck> validateMonth(
         List<Cell> cells,
         List<ReportedWeek> reportedWeeks,
@@ -201,6 +266,30 @@ public final class CashflowFormulaValidator {
     }
 
     public record OpeningCell(int year, String mode, String lineId, String state, BigDecimal amount) {
+    }
+
+    public record ReportedAnnual(
+        int year,
+        String mode,
+        BigDecimal depositTotal,
+        BigDecimal withdrawalTotal,
+        BigDecimal balance,
+        Map<String, String> sourceCells
+    ) {
+    }
+
+    public record AnnualCheck(
+        int year,
+        String mode,
+        BigDecimal openingBalance,
+        BigDecimal depositTotal,
+        BigDecimal withdrawalTotal,
+        BigDecimal balance,
+        Boolean depositTotalMatches,
+        Boolean withdrawalTotalMatches,
+        Boolean balanceMatches,
+        Map<String, String> sourceCells
+    ) {
     }
 
     public record ReportedWeek(

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowFormulaValidator.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowFormulaValidator.java
@@ -110,7 +110,9 @@ public final class CashflowFormulaValidator {
                 BigDecimal withdrawalTotal = total(sourceByKey, mode, 1, CashflowLineCatalog.OUT_LINES);
                 BigDecimal balance = balances.get(mode).add(depositTotal).subtract(withdrawalTotal);
                 results.add(new AnnualCheck(
-                    year, mode, balances.get(mode), depositTotal, withdrawalTotal, balance,
+                    year, mode, balances.get(mode),
+                    reported.depositTotal(), reported.withdrawalTotal(), reported.balance(),
+                    depositTotal, withdrawalTotal, balance,
                     matches(reported.depositTotal(), depositTotal),
                     matches(reported.withdrawalTotal(), withdrawalTotal),
                     matches(reported.balance(), balance),
@@ -250,7 +252,7 @@ public final class CashflowFormulaValidator {
     }
 
     private static Boolean matches(BigDecimal reported, BigDecimal calculated) {
-        if (reported == null) return null;
+        if (reported == null) return false;
         return requiredWholeWon(reported, "reported value").compareTo(calculated) == 0;
     }
 
@@ -282,6 +284,9 @@ public final class CashflowFormulaValidator {
         int year,
         String mode,
         BigDecimal openingBalance,
+        BigDecimal reportedDepositTotal,
+        BigDecimal reportedWithdrawalTotal,
+        BigDecimal reportedBalance,
         BigDecimal depositTotal,
         BigDecimal withdrawalTotal,
         BigDecimal balance,

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -13,6 +13,8 @@ import dev.merryai.innerplatform.weekly.api.CashflowSheetBatchApplyRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetBatchApplyResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetAnnualApplyRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetAnnualApplyResponse;
+import dev.merryai.innerplatform.weekly.api.CashflowSheetFormulaPreflightRequest;
+import dev.merryai.innerplatform.weekly.api.CashflowSheetFormulaPreflightResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowSnapshotResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowVarianceRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowVarianceResponse;
@@ -55,6 +57,7 @@ import dev.merryai.innerplatform.weekly.domain.CellValidationIssue;
 import dev.merryai.innerplatform.weekly.domain.CellAddress;
 import dev.merryai.innerplatform.weekly.domain.CellValidationStatus;
 import dev.merryai.innerplatform.weekly.domain.CashflowLineCatalog;
+import dev.merryai.innerplatform.weekly.domain.CashflowFormulaValidator;
 import dev.merryai.innerplatform.weekly.domain.ClipboardCell;
 import dev.merryai.innerplatform.weekly.domain.ClipboardPayload;
 import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseActualEntity;
@@ -1404,8 +1407,144 @@ public class WeeklyExpenseCommandService {
         return response;
     }
 
+    public CashflowSheetFormulaPreflightResponse validateCashflowSheetFormulas(
+        TrustedActorContext actor,
+        String projectId,
+        CashflowSheetFormulaPreflightRequest request
+    ) {
+        requireCashflowWritePermission(CASHFLOW_SHEET_LAB_APPLY_COMMAND, actor, projectId);
+        requireCompleteAnnualFormulaEvidence(request);
+        var cellsByMonth = CashflowSheetBatchApplyRequest.requireCompleteMonths(request.months());
+        if (cellsByMonth.keySet().stream().anyMatch(yearMonth -> !yearMonth.startsWith(request.sourceYear() + "-"))) {
+            throw new IllegalArgumentException("Cashflow formula preflight months must belong to the source year.");
+        }
+
+        List<CashflowFormulaValidator.OpeningCell> annualCells = request.annualCells().stream()
+            .map(cell -> new CashflowFormulaValidator.OpeningCell(
+                cell.year(), cell.mode(), cell.cashflowLine(), cell.cellState(), cell.amount()
+            ))
+            .toList();
+        List<CashflowFormulaValidator.AnnualCheck> annualChecks = new ArrayList<>();
+        Map<String, BigDecimal> balances = Map.of("projection", BigDecimal.ZERO, "actual", BigDecimal.ZERO);
+        List<CashflowFormulaValidator.AnnualCheck> priorChecks = CashflowFormulaValidator.validateAnnualPeriods(
+            annualCells.stream().filter(cell -> cell.year() < request.sourceYear()).toList(),
+            reportedAnnuals(request, "ANNUAL", true),
+            balances
+        );
+        annualChecks.addAll(priorChecks);
+        balances = annualClosingBalances(priorChecks, balances);
+        boolean completeSourceYear = cellsByMonth.firstKey().equals(request.sourceYear() + "-01")
+            && cellsByMonth.lastKey().equals(request.sourceYear() + "-12")
+            && cellsByMonth.size() == 12;
+        if (!cellsByMonth.firstKey().endsWith("-01")) balances = Map.of();
+
+        Map<String, List<Map<String, Object>>> weeklyChecksByMonth = new LinkedHashMap<>();
+        Map<String, CashflowSheetBatchApplyRequest.Month> monthsByKey = request.months().stream()
+            .collect(java.util.stream.Collectors.toMap(CashflowSheetBatchApplyRequest.Month::yearMonth, month -> month));
+        for (Map.Entry<String, List<CashflowSheetLabApplyRequest.Cell>> monthEntry : cellsByMonth.entrySet()) {
+            CashflowSheetBatchApplyRequest.Month month = monthsByKey.get(monthEntry.getKey());
+            List<Map<String, Object>> checks = CashflowSheetLabApplyRequest.recalculateCalculationChecks(
+                month.yearMonth(), monthEntry.getValue(), month.calculationChecks(), balances
+            );
+            weeklyChecksByMonth.put(month.yearMonth(), checks);
+            balances = CashflowSheetLabApplyRequest.closingBalances(checks);
+        }
+
+        List<CashflowFormulaValidator.AnnualCheck> futureChecks = completeSourceYear
+            ? CashflowFormulaValidator.validateAnnualPeriods(
+                annualCells.stream().filter(cell -> cell.year() > request.sourceYear()).toList(),
+                reportedAnnuals(request, "ANNUAL", false),
+                balances
+            )
+            : List.of();
+        annualChecks.addAll(futureChecks);
+        List<CashflowFormulaValidator.AnnualCheck> grandTotalChecks = CashflowFormulaValidator.validateAnnualPeriods(
+            annualCells.stream().filter(cell -> cell.year() == request.sourceYear()).toList(),
+            reportedAnnuals(request, "GRAND_TOTAL", false),
+            Map.of("projection", BigDecimal.ZERO, "actual", BigDecimal.ZERO)
+        );
+        annualChecks.addAll(grandTotalChecks);
+
+        requireFormulaMismatchConfirmation(weeklyChecksByMonth, annualChecks, request.acceptFormulaMismatches());
+        return new CashflowSheetFormulaPreflightResponse(
+            true,
+            projectId,
+            annualChecks.size(),
+            weeklyChecksByMonth.values().stream().mapToInt(List::size).sum()
+        );
+    }
+
+    private void requireCompleteAnnualFormulaEvidence(CashflowSheetFormulaPreflightRequest request) {
+        Set<Integer> years = request.annualCells().stream()
+            .map(cell -> cell.year())
+            .collect(java.util.stream.Collectors.toSet());
+        Set<String> keys = new java.util.HashSet<>();
+        for (CashflowSheetFormulaPreflightRequest.AnnualDerivedCell cell : request.annualDerivedCells()) {
+            String expectedKind = cell.year() == request.sourceYear() ? "GRAND_TOTAL" : "ANNUAL";
+            if (!years.contains(cell.year()) || !expectedKind.equals(cell.periodKind())
+                || !keys.add(cell.year() + ":" + cell.mode() + ":" + cell.field())) {
+                throw new IllegalArgumentException("Cashflow annual formula evidence is invalid.");
+            }
+        }
+        if (keys.size() != years.size() * 2 * 3) {
+            throw new IllegalArgumentException("Cashflow annual formula evidence is incomplete.");
+        }
+    }
+
+    private List<CashflowFormulaValidator.ReportedAnnual> reportedAnnuals(
+        CashflowSheetFormulaPreflightRequest request,
+        String periodKind,
+        boolean beforeSourceYear
+    ) {
+        Map<String, Map<String, CashflowSheetFormulaPreflightRequest.AnnualDerivedCell>> byPeriod = new LinkedHashMap<>();
+        request.annualDerivedCells().stream()
+            .filter(cell -> cell.periodKind().equals(periodKind))
+            .filter(cell -> "GRAND_TOTAL".equals(periodKind)
+                ? cell.year() == request.sourceYear()
+                : beforeSourceYear ? cell.year() < request.sourceYear() : cell.year() > request.sourceYear())
+            .forEach(cell -> byPeriod
+                .computeIfAbsent(cell.year() + ":" + cell.mode(), ignored -> new LinkedHashMap<>())
+                .put(cell.field(), cell));
+        return byPeriod.entrySet().stream().map(entry -> {
+            Map<String, CashflowSheetFormulaPreflightRequest.AnnualDerivedCell> fields = entry.getValue();
+            if (!fields.keySet().equals(Set.of("depositTotal", "withdrawalTotal", "balance"))) {
+                throw new IllegalArgumentException("Cashflow annual formula evidence is incomplete.");
+            }
+            CashflowSheetFormulaPreflightRequest.AnnualDerivedCell balance = fields.get("balance");
+            Map<String, String> sourceCells = new LinkedHashMap<>();
+            sourceCells.put("depositTotal", fields.get("depositTotal").sourceCell());
+            sourceCells.put("withdrawalTotal", fields.get("withdrawalTotal").sourceCell());
+            sourceCells.put("balance", balance.sourceCell());
+            return new CashflowFormulaValidator.ReportedAnnual(
+                balance.year(),
+                balance.mode(),
+                fields.get("depositTotal").amount(),
+                fields.get("withdrawalTotal").amount(),
+                balance.amount(),
+                sourceCells
+            );
+        }).toList();
+    }
+
+    private Map<String, BigDecimal> annualClosingBalances(
+        List<CashflowFormulaValidator.AnnualCheck> checks,
+        Map<String, BigDecimal> fallback
+    ) {
+        Map<String, BigDecimal> balances = new LinkedHashMap<>(fallback);
+        checks.forEach(check -> balances.put(check.mode(), check.balance()));
+        return Map.copyOf(balances);
+    }
+
     private void requireFormulaMismatchConfirmation(
         Map<String, List<Map<String, Object>>> checksByMonth,
+        boolean accepted
+    ) {
+        requireFormulaMismatchConfirmation(checksByMonth, List.of(), accepted);
+    }
+
+    private void requireFormulaMismatchConfirmation(
+        Map<String, List<Map<String, Object>>> checksByMonth,
+        List<CashflowFormulaValidator.AnnualCheck> annualChecks,
         boolean accepted
     ) {
         if (accepted) return;
@@ -1430,6 +1569,30 @@ public class WeeklyExpenseCommandService {
                 }
             }
         }
+        for (CashflowFormulaValidator.AnnualCheck check : annualChecks) {
+            Map<String, Boolean> matches = Map.of(
+                "depositTotal", check.depositTotalMatches(),
+                "withdrawalTotal", check.withdrawalTotalMatches(),
+                "balance", check.balanceMatches()
+            );
+            Map<String, BigDecimal> reported = annualReportedValues(check);
+            Map<String, BigDecimal> calculated = Map.of(
+                "depositTotal", check.depositTotal(),
+                "withdrawalTotal", check.withdrawalTotal(),
+                "balance", check.balance()
+            );
+            for (String field : List.of("depositTotal", "withdrawalTotal", "balance")) {
+                if (!Boolean.FALSE.equals(matches.get(field))) continue;
+                Map<String, Object> mismatch = new LinkedHashMap<>();
+                mismatch.put("year", check.year());
+                mismatch.put("mode", check.mode());
+                mismatch.put("field", field);
+                mismatch.put("reported", reported.get(field));
+                mismatch.put("calculated", calculated.get(field));
+                if (check.sourceCells().get(field) != null) mismatch.put("sourceCell", check.sourceCells().get(field));
+                mismatches.add(java.util.Collections.unmodifiableMap(mismatch));
+            }
+        }
         if (mismatches.isEmpty()) return;
         throw new WeeklyExpenseEditLeaseException(
             409,
@@ -1440,6 +1603,14 @@ public class WeeklyExpenseCommandService {
                 "mismatches", List.copyOf(mismatches)
             )
         );
+    }
+
+    private Map<String, BigDecimal> annualReportedValues(CashflowFormulaValidator.AnnualCheck check) {
+        Map<String, BigDecimal> values = new LinkedHashMap<>();
+        values.put("depositTotal", check.reportedDepositTotal());
+        values.put("withdrawalTotal", check.reportedWithdrawalTotal());
+        values.put("balance", check.reportedBalance());
+        return values;
     }
 
     @Transactional

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowFormulaValidatorTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowFormulaValidatorTest.java
@@ -103,6 +103,57 @@ class CashflowFormulaValidatorTest {
             .hasMessageContaining("every source row");
     }
 
+    @Test
+    void validatesAnnualBalancesAsAContinuousChainWithoutTrustingWrongReportedBalances() {
+        List<CashflowFormulaValidator.OpeningCell> cells = completeOpeningCells(2024, 2025);
+        replaceOpening(cells, 2024, "projection", "SALES_IN", "VALUE", 100);
+        replaceOpening(cells, 2025, "projection", "DIRECT_COST_OUT", "VALUE", 30);
+        List<CashflowFormulaValidator.ReportedAnnual> reported = reportedAnnuals(2024, 2025);
+        replaceReportedAnnual(reported, 2024, "projection", 100, 0, 1);
+        replaceReportedAnnual(reported, 2025, "projection", 0, 30, 2);
+
+        List<CashflowFormulaValidator.AnnualCheck> checks = CashflowFormulaValidator.validateAnnualPeriods(
+            cells,
+            reported,
+            Map.of()
+        );
+
+        CashflowFormulaValidator.AnnualCheck year2024 = annualCheck(checks, 2024, "projection");
+        assertThat(year2024.balance()).isEqualByComparingTo("100");
+        assertThat(year2024.balanceMatches()).isFalse();
+        CashflowFormulaValidator.AnnualCheck year2025 = annualCheck(checks, 2025, "projection");
+        assertThat(year2025.openingBalance()).isEqualByComparingTo("100");
+        assertThat(year2025.balance()).isEqualByComparingTo("70");
+        assertThat(year2025.balanceMatches()).isFalse();
+    }
+
+    @Test
+    void carriesTheCalculatedAnnualBalanceIntoTheFirstWeeklyPeriod() {
+        List<CashflowFormulaValidator.OpeningCell> annualCells = completeOpeningCells(2024, 2025);
+        replaceOpening(annualCells, 2024, "projection", "SALES_IN", "VALUE", 1_000_000);
+        replaceOpening(annualCells, 2025, "projection", "TEAM_SUPPORT_IN", "VALUE", 1_000_000);
+        List<CashflowFormulaValidator.AnnualCheck> annualChecks = CashflowFormulaValidator.validateAnnualPeriods(
+            annualCells,
+            reportedAnnuals(2024, 2025),
+            Map.of()
+        );
+        Map<String, BigDecimal> opening = Map.of(
+            "projection", annualCheck(annualChecks, 2025, "projection").balance(),
+            "actual", annualCheck(annualChecks, 2025, "actual").balance()
+        );
+        List<CashflowFormulaValidator.Cell> weeklyCells = completeCells();
+        replace(weeklyCells, "projection", 1, "SALES_IN", "VALUE", 100);
+
+        CashflowFormulaValidator.WeeklyCheck firstWeek = check(
+            CashflowFormulaValidator.validateMonth(weeklyCells, reportedWeeks(0), opening),
+            "projection",
+            1
+        );
+
+        assertThat(firstWeek.openingBalance()).isEqualByComparingTo("2000000");
+        assertThat(firstWeek.balance()).isEqualByComparingTo("2000100");
+    }
+
     private static List<CashflowFormulaValidator.Cell> completeCells() {
         List<CashflowFormulaValidator.Cell> cells = new ArrayList<>();
         for (String mode : List.of("projection", "actual")) {
@@ -125,6 +176,50 @@ class CashflowFormulaValidatorTest {
             }
         }
         return cells;
+    }
+
+    private static List<CashflowFormulaValidator.ReportedAnnual> reportedAnnuals(int... years) {
+        List<CashflowFormulaValidator.ReportedAnnual> reported = new ArrayList<>();
+        for (int year : years) {
+            for (String mode : List.of("projection", "actual")) {
+                reported.add(new CashflowFormulaValidator.ReportedAnnual(
+                    year, mode, BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO, Map.of()
+                ));
+            }
+        }
+        return reported;
+    }
+
+    private static void replaceReportedAnnual(
+        List<CashflowFormulaValidator.ReportedAnnual> reported,
+        int year,
+        String mode,
+        long depositTotal,
+        long withdrawalTotal,
+        long balance
+    ) {
+        for (int index = 0; index < reported.size(); index += 1) {
+            CashflowFormulaValidator.ReportedAnnual value = reported.get(index);
+            if (value.year() == year && value.mode().equals(mode)) {
+                reported.set(index, new CashflowFormulaValidator.ReportedAnnual(
+                    year, mode, BigDecimal.valueOf(depositTotal), BigDecimal.valueOf(withdrawalTotal),
+                    BigDecimal.valueOf(balance), Map.of()
+                ));
+                return;
+            }
+        }
+        throw new IllegalArgumentException("Test annual report not found.");
+    }
+
+    private static CashflowFormulaValidator.AnnualCheck annualCheck(
+        List<CashflowFormulaValidator.AnnualCheck> checks,
+        int year,
+        String mode
+    ) {
+        return checks.stream()
+            .filter(check -> check.year() == year && check.mode().equals(mode))
+            .findFirst()
+            .orElseThrow();
     }
 
     private static void replaceOpening(

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowFormulaValidatorTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowFormulaValidatorTest.java
@@ -54,6 +54,20 @@ class CashflowFormulaValidatorTest {
     }
 
     @Test
+    void treatsAMissingDerivedFormulaAsAMismatch() {
+        List<CashflowFormulaValidator.Cell> cells = completeCells();
+        List<CashflowFormulaValidator.ReportedWeek> reported = reportedWeeks(0);
+        CashflowFormulaValidator.ReportedWeek first = reported.getFirst();
+        reported.set(0, new CashflowFormulaValidator.ReportedWeek(
+            first.mode(), first.weekNo(), first.openingBalance(), null,
+            first.withdrawalTotal(), first.balance(), first.sourceCells()
+        ));
+
+        assertThat(check(CashflowFormulaValidator.validateMonth(cells, reported), "projection", 1)
+            .depositTotalMatches()).isFalse();
+    }
+
+    @Test
     void keepsExplicitZeroValidAndRejectsDecimalWon() {
         List<CashflowFormulaValidator.Cell> cells = completeCells();
         replace(cells, "projection", 1, "SALES_IN", "ZERO", 0);
@@ -152,6 +166,34 @@ class CashflowFormulaValidatorTest {
 
         assertThat(firstWeek.openingBalance()).isEqualByComparingTo("2000000");
         assertThat(firstWeek.balance()).isEqualByComparingTo("2000100");
+    }
+
+    @Test
+    void carriesFutureAnnualBalancesButCalculatesTheGrandTotalIndependently() {
+        List<CashflowFormulaValidator.OpeningCell> futureCells = completeOpeningCells(2027, 2028);
+        replaceOpening(futureCells, 2027, "projection", "SALES_IN", "VALUE", 50);
+        replaceOpening(futureCells, 2028, "projection", "DIRECT_COST_OUT", "VALUE", 20);
+        List<CashflowFormulaValidator.AnnualCheck> future = CashflowFormulaValidator.validateAnnualPeriods(
+            futureCells,
+            reportedAnnuals(2027, 2028),
+            Map.of("projection", BigDecimal.valueOf(100), "actual", BigDecimal.ZERO)
+        );
+
+        assertThat(annualCheck(future, 2027, "projection").balance()).isEqualByComparingTo("150");
+        assertThat(annualCheck(future, 2028, "projection").openingBalance()).isEqualByComparingTo("150");
+        assertThat(annualCheck(future, 2028, "projection").balance()).isEqualByComparingTo("130");
+
+        List<CashflowFormulaValidator.OpeningCell> totalCells = completeOpeningCells(2026);
+        replaceOpening(totalCells, 2026, "projection", "SALES_IN", "VALUE", 200);
+        replaceOpening(totalCells, 2026, "projection", "DIRECT_COST_OUT", "VALUE", 50);
+        List<CashflowFormulaValidator.AnnualCheck> total = CashflowFormulaValidator.validateAnnualPeriods(
+            totalCells,
+            reportedAnnuals(2026),
+            Map.of("projection", BigDecimal.ZERO, "actual", BigDecimal.ZERO)
+        );
+
+        assertThat(annualCheck(total, 2026, "projection").openingBalance()).isEqualByComparingTo("0");
+        assertThat(annualCheck(total, 2026, "projection").balance()).isEqualByComparingTo("150");
     }
 
     private static List<CashflowFormulaValidator.Cell> completeCells() {

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowSheetMonthlyApplyServiceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowSheetMonthlyApplyServiceTest.java
@@ -6,6 +6,9 @@ import dev.merryai.innerplatform.weekly.api.CashflowSheetBatchApplyRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetBatchApplyResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetLabApplyRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetLabApplyResponse;
+import dev.merryai.innerplatform.weekly.api.CashflowSheetFormulaPreflightRequest;
+import dev.merryai.innerplatform.weekly.api.CashflowSheetFormulaPreflightResponse;
+import dev.merryai.innerplatform.weekly.api.CashflowOpeningBalanceCell;
 import dev.merryai.innerplatform.weekly.api.TrustedActorContext;
 import dev.merryai.innerplatform.weekly.api.WeeklyExpenseEditLeaseException;
 import dev.merryai.innerplatform.weekly.domain.CashflowLineCatalog;
@@ -320,6 +323,28 @@ class CashflowSheetMonthlyApplyServiceTest {
     }
 
     @Test
+    void rejectsAnnualFormulaMismatchBeforeAnyCanonicalWriteAndAllowsExplicitConfirmation() {
+        WeeklyExpensePersistence persistence = mock(WeeklyExpensePersistence.class);
+        when(persistence.requireCashflowWritePermission(ACTOR, "project-a")).thenReturn("pm");
+        CashflowSheetFormulaPreflightRequest rejected = formulaPreflightRequest(false);
+
+        assertThatThrownBy(() -> service(persistence).validateCashflowSheetFormulas(ACTOR, "project-a", rejected))
+            .isInstanceOf(WeeklyExpenseEditLeaseException.class)
+            .hasMessageContaining("시트 합산 수식");
+        verify(persistence, never()).replaceCashflowSheetMonths(any(), any(), any(), any(), any());
+        verify(persistence, never()).replaceCashflowSheetYearTotal(any(), any(), any(), any());
+
+        CashflowSheetFormulaPreflightResponse accepted = service(persistence).validateCashflowSheetFormulas(
+            ACTOR,
+            "project-a",
+            formulaPreflightRequest(true)
+        );
+        assertThat(accepted.ok()).isTrue();
+        assertThat(accepted.annualCheckCount()).isEqualTo(18);
+        assertThat(accepted.weeklyCheckCount()).isEqualTo(120);
+    }
+
+    @Test
     void rejectsAnIncompleteMonthBeforeLeaseOrCanonicalWrites() {
         WeeklyExpensePersistence persistence = mock(WeeklyExpensePersistence.class);
         when(persistence.requireCashflowWritePermission(ACTOR, "project-a")).thenReturn("pm");
@@ -476,6 +501,44 @@ class CashflowSheetMonthlyApplyServiceTest {
             }
         }
         return List.copyOf(checks);
+    }
+
+    private static CashflowSheetFormulaPreflightRequest formulaPreflightRequest(boolean accepted) {
+        List<CashflowOpeningBalanceCell> annualCells = new ArrayList<>();
+        List<CashflowSheetFormulaPreflightRequest.AnnualDerivedCell> derived = new ArrayList<>();
+        for (int year = 2024; year <= 2032; year += 1) {
+            String periodKind = year == 2026 ? "GRAND_TOTAL" : "ANNUAL";
+            for (String mode : List.of("projection", "actual")) {
+                for (String lineId : CashflowLineCatalog.ALL_LINES) {
+                    annualCells.add(new CashflowOpeningBalanceCell(year, mode, lineId, "ZERO", BigDecimal.ZERO));
+                }
+                for (String field : List.of("depositTotal", "withdrawalTotal", "balance")) {
+                    BigDecimal amount = year == 2024 && mode.equals("projection") && field.equals("balance")
+                        ? BigDecimal.ONE
+                        : BigDecimal.ZERO;
+                    derived.add(new CashflowSheetFormulaPreflightRequest.AnnualDerivedCell(
+                        year, periodKind, mode, field, amount, year + ":" + field
+                    ));
+                }
+            }
+        }
+        List<CashflowSheetBatchApplyRequest.Month> months = new ArrayList<>();
+        for (int month = 1; month <= 12; month += 1) {
+            String yearMonth = "2026-" + String.format("%02d", month);
+            months.add(new CashflowSheetBatchApplyRequest.Month(
+                yearMonth,
+                calculationChecks(yearMonth),
+                emptyCells(),
+                false
+            ));
+        }
+        return new CashflowSheetFormulaPreflightRequest(2026, annualCells, derived, months, accepted);
+    }
+
+    private static List<CashflowSheetLabApplyRequest.Cell> emptyCells() {
+        return completeCells(5).stream().map(cell -> new CashflowSheetLabApplyRequest.Cell(
+            cell.mode(), cell.weekNo(), cell.cashflowLine(), "EMPTY", null, cell.sourceCell(), cell.sourceLabel()
+        )).toList();
     }
 
     private static List<CashflowSheetLabApplyRequest.Cell> completeCells(int weekCount) {

--- a/src/app/components/cashflow/CashflowFormulaMismatchDialog.tsx
+++ b/src/app/components/cashflow/CashflowFormulaMismatchDialog.tsx
@@ -17,9 +17,12 @@ const fieldLabels: Record<CashflowFormulaMismatch['field'], string> = {
   balance: '잔액',
 };
 
-function weekLabel(issue: CashflowFormulaMismatch): string {
-  const [year, month] = issue.yearMonth.split('-');
-  return `${year.slice(-2)}-${Number(month)}-${issue.weekNo}`;
+function periodLabel(issue: CashflowFormulaMismatch): string {
+  if (issue.yearMonth && issue.weekNo) {
+    const [year, month] = issue.yearMonth.split('-');
+    return `${year.slice(-2)}-${Number(month)}-${issue.weekNo}`;
+  }
+  return issue.year ? `${issue.year}년` : '연간 합계';
 }
 
 function amount(value: number | null): string {
@@ -45,16 +48,16 @@ export function CashflowFormulaMismatchDialog({
           <AlertDialogTitle>시트 합계 수식이 다릅니다</AlertDialogTitle>
           <AlertDialogDescription className="leading-5">
             {first
-              ? `${weekLabel(first)} ${first.mode === 'projection' ? 'Projection' : 'Actual'}의 ${fieldLabels[first.field]}가 시트 행 금액의 합과 다릅니다.`
+              ? `${periodLabel(first)} ${first.mode === 'projection' ? 'Projection' : 'Actual'}의 ${fieldLabels[first.field]}가 시트 행 금액의 합과 다릅니다.`
               : ''}
             {' '}시트의 합계 수식을 고친 뒤 다시 불러오는 것을 권장합니다.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <div className="max-h-48 space-y-2 overflow-y-auto rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[13px] text-slate-800">
           {issues.slice(0, 5).map((issue, index) => (
-            <div key={`${issue.yearMonth}:${issue.mode}:${issue.weekNo}:${issue.field}:${index}`}>
+            <div key={`${issue.year || issue.yearMonth}:${issue.mode}:${issue.weekNo || 0}:${issue.field}:${index}`}>
               <div className="font-semibold">
-                {weekLabel(issue)} · {issue.mode === 'projection' ? 'Projection' : 'Actual'} · {fieldLabels[issue.field]}
+                {periodLabel(issue)} · {issue.mode === 'projection' ? 'Projection' : 'Actual'} · {fieldLabels[issue.field]}
               </div>
               <div className="text-slate-600">
                 시트 {amount(issue.reported)} · 다시 계산 {amount(issue.calculated)}

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -84,6 +84,16 @@ export interface CashflowSheetLabTemplateSection {
     year: number;
     source: 'sheet_annual_total';
   }>;
+  annualDerivedMappings: Array<{
+    mode: 'projection' | 'actual';
+    derivedKind: 'deposit_total' | 'withdrawal_total' | 'balance';
+    label: string;
+    year: number;
+    rowIndex: number;
+    columnIndex: number;
+    a1: string;
+    source: 'sheet_annual_derived';
+  }>;
   missingLineIds: string[];
   duplicateLineIds: string[];
 }

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -89,6 +89,7 @@ export interface CashflowSheetLabTemplateSection {
     derivedKind: 'deposit_total' | 'withdrawal_total' | 'balance';
     label: string;
     year: number;
+    periodKind: 'ANNUAL' | 'GRAND_TOTAL';
     rowIndex: number;
     columnIndex: number;
     a1: string;
@@ -540,9 +541,10 @@ export interface CashflowSheetLabStageResult {
 }
 
 export interface CashflowFormulaMismatch {
-  yearMonth: string;
+  yearMonth?: string;
+  year?: number;
   mode: 'projection' | 'actual';
-  weekNo: number;
+  weekNo?: number;
   field: 'depositTotal' | 'withdrawalTotal' | 'balance';
   reported: number | null;
   calculated: number | null;


### PR DESCRIPTION
## 변경\n- C/D 및 BM~BR 연도 잔액을 JVM에서 연속 검증\n- BS Total은 입금 합계-출금 합계로 독립 검증\n- 시트 반영 전 JVM preflight 409 경고 및 원자성 보장\n- 연간 오류 위치를 사용자 문구로 표시\n\n## 검증\n- BFF cashflow 테스트 113건 통과\n- JVM 전체 테스트 통과\n- production build 통과\n\nStage 전용 hotfix이며 Production 배포는 포함하지 않습니다.