### PR TITLE
fix(cashflow): stabilize sheet-linked settlement close

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -760,12 +760,12 @@ function profitVatAfterDepositCheck(weeks) {
     }
   }
   if (deposits.length === 0) {
-    return managementCheck('profit-vat-after-deposit', 'REVIEW_REQUIRED', '입금 후 MYSC 수익·매출부가세 이관', 'Projection 매출입금이 없습니다. 해당 없음 여부를 사람이 확인해 주세요.');
+    return managementCheck('profit-vat-after-deposit', 'REVIEW_REQUIRED', '입금 후 MYSC 수익·매출부가세 이관(해당 주, 차주)', 'Projection 매출입금이 없습니다. 해당 없음 여부를 사람이 확인해 주세요.');
   }
   return managementCheck(
     'profit-vat-after-deposit',
     due.length > 0 ? 'WARNING' : 'OK',
-    '입금 후 MYSC 수익·매출부가세 이관',
+    '입금 후 MYSC 수익·매출부가세 이관(해당 주, 차주)',
     due.length > 0 ? `입금 주차 또는 다음 주차까지 미이관: ${due.join(', ')}` : 'Projection 매출입금의 같은 주차 또는 다음 주차 이관을 확인했습니다.',
     due,
   );
@@ -2981,46 +2981,60 @@ export function mountJvmWeeklyApiRoutes(app, {
     const yearMonth = readOptionalText(prepared.closeBody.yearMonth);
     const cumulativeMonths = cumulativeCloseMonths(yearMonth);
     const requestId = `${prepared.rawProjectId}-${yearMonth}`;
-    const revision = 1;
     const sourceMonths = new Map((Array.isArray(prepared.cashflow?.readModel?.months) ? prepared.cashflow.readModel.months : [])
       .map((month) => [readOptionalText(month?.yearMonth), month]));
-    const shards = cumulativeMonths.map((monthKey) => (
-      cumulativeMonthCloseShard({
+    const requestRef = db.doc(cashflowMonthCloseRequestPath(req.context.tenantId, requestId));
+    const requestedAt = now().toISOString();
+    const requestFingerprint = cashflowCloseHash(req.body ?? null);
+    let revision;
+    let shards;
+    let manifest;
+    let totals;
+    let annualSummaries;
+    let payloadFingerprint;
+    let auditAction;
+    const buildRevisionEvidence = (requestRevision) => {
+      const revisionShards = cumulativeMonths.map((monthKey) => cumulativeMonthCloseShard({
         requestId,
-        requestRevision: revision,
+        requestRevision,
         projectId: prepared.rawProjectId,
         yearMonth: monthKey,
         month: sourceMonths.get(monthKey),
         source: prepared.shardSource,
-      })
-    ));
-    const manifest = cumulativeMonthCloseManifest({
-      requestId, requestRevision: revision, projectId: prepared.rawProjectId, yearMonth, shards,
-    });
-    const sumMode = (mode, selectedShards = shards) => selectedShards.reduce((sum, shard) => sum + shard.cells
-      .filter((cell) => cell.mode === mode && cell.cellState !== 'EMPTY')
-      .reduce((monthSum, cell) => monthSum + Number(cell.amount), 0), 0);
-    const totals = {
-      projection: sumMode('projection'),
-      actual: sumMode('actual'),
+      }));
+      const revisionManifest = cumulativeMonthCloseManifest({
+        requestId, requestRevision, projectId: prepared.rawProjectId, yearMonth, shards: revisionShards,
+      });
+      const sumMode = (mode, selectedShards = revisionShards) => selectedShards.reduce((sum, shard) => sum + shard.cells
+        .filter((cell) => cell.mode === mode && cell.cellState !== 'EMPTY')
+        .reduce((monthSum, cell) => monthSum + Number(cell.amount), 0), 0);
+      const revisionTotals = {
+        projection: sumMode('projection'),
+        actual: sumMode('actual'),
+      };
+      revisionTotals.difference = revisionTotals.actual - revisionTotals.projection;
+      const revisionAnnualSummaries = [...new Set(revisionShards.map((shard) => Number(shard.yearMonth.slice(0, 4))))].map((year) => {
+        const yearShards = revisionShards.filter((shard) => Number(shard.yearMonth.slice(0, 4)) === year);
+        const projection = sumMode('projection', yearShards);
+        const actual = sumMode('actual', yearShards);
+        return { year, monthCount: yearShards.length, projection, actual, difference: actual - projection };
+      });
+      const fingerprint = cashflowCloseHash({
+        contractVersion: CASHFLOW_CUMULATIVE_CLOSE_CONTRACT,
+        approverUid,
+        yearMonth,
+        expectedRevision: prepared.closeBody.expectedRevision,
+        manifestHash: revisionManifest.manifestHash,
+      });
+      return {
+        shards: revisionShards,
+        manifest: revisionManifest,
+        totals: revisionTotals,
+        annualSummaries: revisionAnnualSummaries,
+        payloadFingerprint: fingerprint,
+      };
     };
-    totals.difference = totals.actual - totals.projection;
-    const annualSummaries = [...new Set(shards.map((shard) => Number(shard.yearMonth.slice(0, 4))))].map((year) => {
-      const yearShards = shards.filter((shard) => Number(shard.yearMonth.slice(0, 4)) === year);
-      const projection = sumMode('projection', yearShards);
-      const actual = sumMode('actual', yearShards);
-      return { year, monthCount: yearShards.length, projection, actual, difference: actual - projection };
-    });
-    const requestRef = db.doc(cashflowMonthCloseRequestPath(req.context.tenantId, requestId));
-    const requestedAt = now().toISOString();
-    const payloadFingerprint = cashflowCloseHash({
-      contractVersion: CASHFLOW_CUMULATIVE_CLOSE_CONTRACT,
-      approverUid,
-      yearMonth,
-      expectedRevision: prepared.closeBody.expectedRevision,
-      manifestHash: manifest.manifestHash,
-    });
-    await db.runTransaction(async (transaction) => {
+    return db.runTransaction(async (transaction) => {
       const [projectSnapshot, approverSnapshot, requesterSnapshot, requestSnapshot] = await Promise.all([
         transaction.get(db.doc(`orgs/${req.context.tenantId}/projects/${prepared.rawProjectId}`)),
         transaction.get(db.doc(`orgs/${req.context.tenantId}/members/${approverUid}`)),
@@ -3043,17 +3057,52 @@ export function mountJvmWeeklyApiRoutes(app, {
         || readOptionalText(requester.status).toUpperCase() !== 'ACTIVE'
       ) throw createHttpError(403, '이 프로젝트의 월 결산을 요청할 권한이 없습니다.', 'cashflow_month_close_project_forbidden');
       if (existing) {
-        if (existing.createIdempotencyKey === req.context.idempotencyKey && existing.payloadFingerprint === payloadFingerprint) return;
-        throw createHttpError(409, '이미 이 월의 결산 요청이 존재합니다.', 'cashflow_month_close_request_conflict');
+        if (existing.contractVersion !== CASHFLOW_CUMULATIVE_CLOSE_CONTRACT
+          || !Number.isSafeInteger(Number(existing.revision)) || Number(existing.revision) < 1) {
+          throw createHttpError(409, '이미 이 월의 결산 요청이 존재합니다.', 'cashflow_month_close_request_conflict');
+        }
+        const replayEvidence = buildRevisionEvidence(Number(existing.revision));
+        if (
+          existing.createIdempotencyKey === req.context.idempotencyKey
+          && existing.requestFingerprint === requestFingerprint
+          && existing.payloadFingerprint === replayEvidence.payloadFingerprint
+        ) {
+          if (!['BUILDING', 'PENDING'].includes(existing.status)) {
+            return existing;
+          }
+          revision = Number(existing.revision);
+          ({ shards, manifest, totals, annualSummaries, payloadFingerprint } = replayEvidence);
+          auditAction = revision === 1 ? 'REQUESTED' : 'RESUBMITTED';
+        } else if (existing.status !== 'REJECTED') {
+          throw createHttpError(409, '이미 이 월의 결산 요청이 존재합니다.', 'cashflow_month_close_request_conflict');
+        } else {
+          revision = Number(existing.revision) + 1;
+          auditAction = 'RESUBMITTED';
+        }
+      } else {
+        revision = 1;
+        auditAction = 'REQUESTED';
       }
-      transaction.set(requestRef, {
+      if (!shards) {
+        ({ shards, manifest, totals, annualSummaries, payloadFingerprint } = buildRevisionEvidence(revision));
+      }
+      const shardRefs = shards.map((shard) => db.doc(cashflowMonthCloseRequestMonthPath(
+        req.context.tenantId, requestId, revision, shard.yearMonth,
+      )));
+      const shardSnapshots = await Promise.all(shardRefs.map((ref) => transaction.get(ref)));
+      shardSnapshots.forEach((snapshot, index) => {
+        if (snapshot.exists && stableStringify(snapshot.data() || {}) !== stableStringify(shards[index])) {
+          throw createHttpError(409, '저장된 누적 월 결산 월 근거가 변경되었습니다.', 'cashflow_month_close_request_evidence_tampered');
+        }
+      });
+      const storedRecord = {
         contractVersion: CASHFLOW_CUMULATIVE_CLOSE_CONTRACT,
         requestId,
         tenantId: req.context.tenantId,
         projectId: prepared.rawProjectId,
         yearMonth,
         fromMonth: CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH,
-        status: 'BUILDING',
+        status: 'PENDING',
         revision,
         manifestHash: manifest.manifestHash,
         monthCount: shards.length,
@@ -3067,46 +3116,31 @@ export function mountJvmWeeklyApiRoutes(app, {
         requestedByUid: readOptionalText(req.context.actorId),
         requestedAt,
         createIdempotencyKey: req.context.idempotencyKey,
+        requestFingerprint,
         payloadFingerprint,
+      };
+      shardSnapshots.forEach((snapshot, index) => {
+        if (!snapshot.exists) transaction.set(shardRefs[index], shards[index]);
       });
-    });
-    for (const shard of shards) {
-      const ref = db.doc(cashflowMonthCloseRequestMonthPath(req.context.tenantId, requestId, revision, shard.yearMonth));
-      const snapshot = await ref.get();
-      if (snapshot.exists && stableStringify(snapshot.data() || {}) !== stableStringify(shard)) {
-        throw createHttpError(409, '저장된 누적 월 결산 월 근거가 변경되었습니다.', 'cashflow_month_close_request_evidence_tampered');
-      }
-      if (!snapshot.exists) await ref.set(shard);
-    }
-    const verifiedShards = [];
-    for (const shard of shards) {
-      const snapshot = await db.doc(cashflowMonthCloseRequestMonthPath(
-        req.context.tenantId, requestId, revision, shard.yearMonth,
-      )).get();
-      const stored = snapshot.exists ? snapshot.data() || {} : null;
-      const { shardHash, ...base } = stored || {};
-      if (!stored || stored.cells?.length !== 160 || shardHash !== cashflowCloseHash(base)) {
-        throw createHttpError(409, '누적 월 결산 월 근거 검증에 실패했습니다.', 'cashflow_month_close_request_evidence_invalid');
-      }
-      verifiedShards.push(stored);
-    }
-    const verifiedManifest = cumulativeMonthCloseManifest({
-      requestId, requestRevision: revision, projectId: prepared.rawProjectId, yearMonth, shards: verifiedShards,
-    });
-    if (verifiedManifest.manifestHash !== manifest.manifestHash) {
-      throw createHttpError(409, '누적 월 결산 manifest 검증에 실패했습니다.', 'cashflow_month_close_request_manifest_invalid');
-    }
-    let storedRecord;
-    await db.runTransaction(async (transaction) => {
-      const snapshot = await transaction.get(requestRef);
-      const current = snapshot.exists ? snapshot.data() || {} : null;
-      if (!current || current.payloadFingerprint !== payloadFingerprint || !['BUILDING', 'PENDING'].includes(current.status)) {
-        throw createHttpError(409, '누적 월 결산 요청 상태가 변경되었습니다.', 'cashflow_month_close_request_conflict');
-      }
-      storedRecord = { ...current, status: 'PENDING' };
       transaction.set(requestRef, storedRecord);
+      transaction.set(
+        db.doc(cashflowMonthCloseRequestAuditPath(
+          req.context.tenantId, requestId, revision, auditAction.toLowerCase(),
+        )),
+        {
+          requestId,
+          projectId: prepared.rawProjectId,
+          yearMonth,
+          action: auditAction,
+          revision,
+          manifestHash: manifest.manifestHash,
+          actorUid: storedRecord.requestedByUid,
+          idempotencyKey: storedRecord.createIdempotencyKey,
+          createdAt: storedRecord.requestedAt,
+        },
+      );
+      return storedRecord;
     });
-    return storedRecord;
   }
 
   function assertCumulativeCloseResult(result, record) {
@@ -3415,6 +3449,45 @@ export function mountJvmWeeklyApiRoutes(app, {
       projectId: rawProjectId,
       requesterUid: req.context.actorId,
     });
+    if (readOptionalText(req.body?.contractVersion) === CASHFLOW_CUMULATIVE_CLOSE_CONTRACT) {
+      const yearMonth = readOptionalText(req.body?.yearMonth);
+      const requestId = `${rawProjectId}-${yearMonth}`;
+      const requestFingerprint = cashflowCloseHash(req.body ?? null);
+      const [requestSnapshot, projectSnapshot] = await Promise.all([
+        db.doc(cashflowMonthCloseRequestPath(req.context.tenantId, requestId)).get(),
+        db.doc(`orgs/${req.context.tenantId}/projects/${rawProjectId}`).get(),
+      ]);
+      const existing = requestSnapshot.exists ? requestSnapshot.data() || {} : null;
+      const project = projectSnapshot.exists ? projectSnapshot.data() || {} : {};
+      const projectVersion = Number.isSafeInteger(project.version) ? project.version : 0;
+      if (
+        existing
+        && existing.createIdempotencyKey === req.context.idempotencyKey
+        && existing.requestFingerprint !== requestFingerprint
+      ) {
+        throw createHttpError(409, '동일한 요청 키의 월 결산 입력이 변경되었습니다.', 'cashflow_month_close_request_conflict');
+      }
+      if (
+        existing
+        && existing.status !== 'BUILDING'
+        && existing.contractVersion === CASHFLOW_CUMULATIVE_CLOSE_CONTRACT
+        && existing.requestId === requestId
+        && existing.projectId === rawProjectId
+        && existing.yearMonth === yearMonth
+        && existing.requestedByUid === readOptionalText(req.context.actorId)
+        && existing.approverUid === approverUid
+        && Boolean(readOptionalText(req.context.idempotencyKey))
+        && existing.createIdempotencyKey === req.context.idempotencyKey
+        && existing.requestFingerprint === requestFingerprint
+        && Number(existing.expectedRevision) === Number(req.body?.expectedRevision)
+        && expectedApproverUid === approverUid
+        && projectVersion === expectedProjectVersion
+        && readOptionalText(project.executiveApproverId) === approverUid
+      ) {
+        res.status(202).json(cashflowMonthCloseRequestView(existing));
+        return;
+      }
+    }
     const prepared = await prepareCashflowMonthClose(req);
     const yearMonth = readOptionalText(prepared.closeBody.yearMonth);
     if (readOptionalText(req.body?.contractVersion) === CASHFLOW_CUMULATIVE_CLOSE_CONTRACT) {
@@ -3603,6 +3676,23 @@ export function mountJvmWeeklyApiRoutes(app, {
       if (expectedManifestHash !== initialRecord.manifestHash) {
         throw createHttpError(409, '누적 월 결산 manifest가 변경되었습니다.', 'cashflow_month_close_request_manifest_invalid');
       }
+      const terminalReplay = (
+        Boolean(readOptionalText(req.context.idempotencyKey))
+        && initialRecord.reviewIdempotencyKey === req.context.idempotencyKey
+        && Number(initialRecord.revision) === expectedRevision
+        && readOptionalText(initialRecord.decisionReason) === reason
+        && ((decision === 'REJECT' && initialRecord.status === 'REJECTED')
+          || (decision === 'APPROVE' && initialRecord.status === 'APPROVED'))
+      );
+      if (terminalReplay) {
+        res.status(200).json({
+          request: cashflowMonthCloseRequestView(initialRecord),
+          ...(decision === 'APPROVE' && objectValue(initialRecord.monthCloseResult)
+            ? { monthClose: initialRecord.monthCloseResult }
+            : {}),
+        });
+        return;
+      }
       const resumesApproval = decision === 'APPROVE' && ['APPROVING', 'UNCERTAIN'].includes(initialRecord.status);
       if (Number(initialRecord.revision) !== expectedRevision || (!resumesApproval && initialRecord.status !== 'PENDING')) {
         throw createHttpError(409, '이미 검토가 시작되었거나 변경된 월 결산 요청입니다.', 'cashflow_month_close_request_already_reviewed');
@@ -3620,7 +3710,9 @@ export function mountJvmWeeklyApiRoutes(app, {
           const current = snapshot.exists ? snapshot.data() || {} : null;
           const reviewer = reviewerSnapshot.exists ? reviewerSnapshot.data() || {} : {};
           if (!current || current.status !== 'PENDING' || current.manifestHash !== expectedManifestHash
+            || Number(current.revision) !== expectedRevision
             || readOptionalText(currentProject.executiveApproverId) !== req.context.actorId
+            || readOptionalText(reviewer.uid) !== req.context.actorId
             || readOptionalText(reviewer.status).toUpperCase() !== 'ACTIVE') {
             throw createHttpError(409, '이미 검토가 끝났거나 변경된 월 결산 요청입니다.', 'cashflow_month_close_request_already_reviewed');
           }
@@ -3629,6 +3721,23 @@ export function mountJvmWeeklyApiRoutes(app, {
             reviewedAt, decisionReason: reason, reviewIdempotencyKey: req.context.idempotencyKey,
           };
           transaction.set(requestRef, rejected);
+          transaction.set(
+            db.doc(cashflowMonthCloseRequestAuditPath(
+              req.context.tenantId, requestId, expectedRevision, 'rejected',
+            )),
+            {
+              requestId,
+              projectId,
+              yearMonth: rejected.yearMonth,
+              action: 'REJECTED',
+              revision: expectedRevision,
+              manifestHash: rejected.manifestHash,
+              actorUid: req.context.actorId,
+              reason,
+              idempotencyKey: req.context.idempotencyKey,
+              createdAt: reviewedAt,
+            },
+          );
         });
         res.status(200).json({ request: cashflowMonthCloseRequestView(rejected) });
         return;
@@ -3658,7 +3767,9 @@ export function mountJvmWeeklyApiRoutes(app, {
           const reviewer = reviewerSnapshot.exists ? reviewerSnapshot.data() || {} : {};
           const current = snapshot.exists ? snapshot.data() || {} : null;
           if (!current || current.status !== 'PENDING' || current.manifestHash !== expectedManifestHash
+            || Number(current.revision) !== expectedRevision
             || readOptionalText(currentProject.executiveApproverId) !== req.context.actorId
+            || readOptionalText(reviewer.uid) !== req.context.actorId
             || readOptionalText(reviewer.status).toUpperCase() !== 'ACTIVE') {
             throw createHttpError(409, '이미 검토가 시작되었거나 변경된 월 결산 요청입니다.', 'cashflow_month_close_request_already_reviewed');
           }
@@ -3714,8 +3825,32 @@ export function mountJvmWeeklyApiRoutes(app, {
           || current.manifestHash !== expectedManifestHash || Number(current.revision) !== expectedRevision) {
           throw createHttpError(409, '월 결산 승인 상태가 변경되었습니다.', 'cashflow_month_close_request_revision_stale');
         }
-        approved = { ...current, status: 'APPROVED', rootHash: monthClose.rootHash, headRevision: monthClose.headRevision };
+        approved = {
+          ...current,
+          status: 'APPROVED',
+          rootHash: monthClose.rootHash,
+          headRevision: monthClose.headRevision,
+          monthCloseResult: monthClose,
+        };
         transaction.set(requestRef, approved);
+        transaction.set(
+          db.doc(cashflowMonthCloseRequestAuditPath(
+            req.context.tenantId, requestId, expectedRevision, 'approved',
+          )),
+          {
+            requestId,
+            projectId,
+            yearMonth: approved.yearMonth,
+            action: 'APPROVED',
+            revision: expectedRevision,
+            manifestHash: approved.manifestHash,
+            actorUid: req.context.actorId,
+            reason: reason || null,
+            idempotencyKey: req.context.idempotencyKey,
+            jvmMutationIdempotencyKey: jvmIdempotencyKey,
+            createdAt: reviewedAt,
+          },
+        );
       });
       res.status(200).json({ request: cashflowMonthCloseRequestView(approved), monthClose });
       return;

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -41,7 +41,7 @@ const managementConfirmations = [
 
 const emptyManagementChecks = [
   { id: 'labor-transfer', status: 'WARNING', title: 'MYSC 인건비 이관', detail: '2026-06 3주차 인건비 미입력' },
-  { id: 'profit-vat-after-deposit', status: 'REVIEW_REQUIRED', title: '입금 후 MYSC 수익·매출부가세 이관', detail: '실제 입금 확인 건이 없습니다. 해당 없음 여부를 사람이 확인해 주세요.' },
+  { id: 'profit-vat-after-deposit', status: 'REVIEW_REQUIRED', title: '입금 후 MYSC 수익·매출부가세 이관(해당 주, 차주)', detail: '실제 입금 확인 건이 없습니다. 해당 없음 여부를 사람이 확인해 주세요.' },
   { id: 'negative-projection-balance', status: 'OK', title: 'Projection 잔액 마이너스', detail: 'Projection 누적 잔액이 0원 이상입니다.' },
   { id: 'future-prepay-over-million', status: 'OK', title: '금주 이후 선입금 요청 100만원 초과', detail: '금주 이후 100만원 초과 요청이 없습니다.' },
 ];
@@ -106,10 +106,24 @@ function matchingControlRows(startRow, matches = true) {
 }
 
 function memoryTransaction(documents) {
-  return async (callback) => callback({
-    get: async (ref) => ref.get(),
-    set: async (ref, value, options) => ref.set(value, options),
-  });
+  return async (callback) => {
+    const staged = new Map();
+    const result = await callback({
+      get: async (ref) => {
+        if (!ref.path) return ref.get();
+        const value = staged.has(ref.path) ? staged.get(ref.path) : documents.get(ref.path);
+        return { exists: value !== undefined, data: () => value };
+      },
+      set: (ref, value, options) => {
+        ref.beforeTransactionSet?.();
+        staged.set(ref.path, options?.merge
+          ? { ...(staged.get(ref.path) || documents.get(ref.path) || {}), ...value }
+          : value);
+      },
+    });
+    for (const [path, value] of staged) documents.set(path, value);
+    return result;
+  };
 }
 
 function memoryDoc(documents, path) {
@@ -1426,7 +1440,7 @@ describe('JVM weekly API BFF proxy', () => {
       }));
   });
 
-  it('passes updateResult and JVM 15-week missing-cell evidence without recalculating it', async () => {
+  it('passes updateResult and JVM 16-week missing-cell evidence without recalculating it', async () => {
     const fetchImpl = vi.fn(async (_url, init) => {
       const body = JSON.parse(init.body);
       expect(body.updateResult).toBe('NO_CHANGES');
@@ -1437,8 +1451,8 @@ describe('JVM weekly API BFF proxy', () => {
           code: 'cashflow_projection_window_incomplete',
           message: 'Projection window is incomplete.',
           details: {
-            requiredWeekCount: 15,
-            requiredCellCount: 240,
+            requiredWeekCount: 16,
+            requiredCellCount: 256,
             missingCells: [{ yearMonth: '2026-05', weekNo: 1, lineId: 'SALES_IN' }],
           },
         }),
@@ -1455,7 +1469,7 @@ describe('JVM weekly API BFF proxy', () => {
       .expect((response) => expect(response.body).toMatchObject({
         code: 'cashflow_projection_window_incomplete',
         details: {
-          requiredWeekCount: 15, requiredCellCount: 240,
+          requiredWeekCount: 16, requiredCellCount: 256,
           missingCells: [{ yearMonth: '2026-05', weekNo: 1, lineId: 'SALES_IN' }],
         },
       }));
@@ -1710,6 +1724,35 @@ describe('JVM weekly API BFF proxy', () => {
       '2026-07 1주차에 매출입금이 있으나 [MYSC 수익·매출부가세] 계획이 Projection에 없습니다.',
       '2026-07 3주차에 매출입금이 있으나 [매출부가세] 계획이 Projection에 없습니다.',
     ]);
+  });
+
+  it('does not warn when profit and sales VAT are planned in either the deposit week or the next week', () => {
+    const checks = buildCashflowManagementChecks({
+      cashflow: {
+        readModel: {
+          months: [{
+            yearMonth: '2026-07',
+            projection: { weeks: [
+              { weekNo: 1, amounts: { SALES_IN: 1_000, MYSC_PROFIT_OUT: 100, SALES_VAT_OUT: 10 } },
+              { weekNo: 2, amounts: { SALES_IN: 2_000 } },
+              { weekNo: 3, amounts: { MYSC_PROFIT_OUT: 200, SALES_VAT_OUT: 20 } },
+            ] },
+            actual: { weeks: [] },
+          }],
+        },
+      },
+      cells: [],
+      yearMonth: '2026-07',
+      depositScheduleRows: [],
+      comparisonBoundary: { asOfWeek: { yearMonth: '2026-07', weekNo: 3 } },
+    });
+
+    const transferCheck = checks.find((check) => check.id === 'profit-vat-after-deposit');
+    expect(transferCheck).toMatchObject({
+      status: 'OK',
+      title: '입금 후 MYSC 수익·매출부가세 이관(해당 주, 차주)',
+    });
+    expect(transferCheck).not.toHaveProperty('findings');
   });
 
   it('monitors labor and post-deposit transfers across the full pinned project period', () => {
@@ -3931,8 +3974,15 @@ describe('JVM weekly API BFF proxy', () => {
     expect(closeBody.cells).toEqual(snapshotCells);
   });
 
-  it('persists and approves a verified 44-month cumulative v2 manifest without embedding shards in the header', async () => {
+  it('rejects, resubmits, and replays a verified 44-month cumulative v2 request without live evidence', async () => {
     const source = fullMonthCloseSource();
+    const runTransaction = source.db.runTransaction;
+    let transactionTail = Promise.resolve();
+    source.db.runTransaction = (callback) => {
+      const result = transactionTail.then(() => runTransaction(callback));
+      transactionTail = result.then(() => undefined, () => undefined);
+      return result;
+    };
     source.closeInput.yearMonth = '2026-08';
     const mirror = source.documents.get('orgs/tenant-a/cashflow_sheet_mirrors/project-a');
     mirror.yearMonths = ['2026-08'];
@@ -3945,8 +3995,10 @@ describe('JVM weekly API BFF proxy', () => {
     }
     const cashflow = { projectId: 'project-a', projection: [], actual: [], readModel: { months } };
     let closedMonthClose = null;
+    let dashboardSourceUnavailable = false;
     const fetchImpl = vi.fn(async (url, init) => {
       if (url.includes('/dashboard-source')) {
+        if (dashboardSourceUnavailable) throw new Error('live dashboard source drifted after persistence');
         return {
           ok: true,
           status: 200,
@@ -3957,10 +4009,11 @@ describe('JVM weekly API BFF proxy', () => {
         };
       }
       if (init.method === 'POST') {
+        const closeBody = JSON.parse(init.body);
         closedMonthClose = {
-          ok: true, projectId: 'project-a', requestId: 'project-a-2026-08', requestRevision: 1,
-          manifestHash: JSON.parse(init.body).manifestHash, yearMonth: '2026-08', status: 'CLOSED',
-          revision: 1, rootHash: JSON.parse(init.body).manifestHash, headRevision: 44, auditId: 'audit-cumulative-1',
+          ok: true, projectId: 'project-a', requestId: 'project-a-2026-08', requestRevision: closeBody.requestRevision,
+          manifestHash: closeBody.manifestHash, yearMonth: '2026-08', status: 'CLOSED',
+          revision: 1, rootHash: closeBody.manifestHash, headRevision: 44, auditId: `audit-cumulative-${closeBody.requestRevision}`,
         };
         return { ok: true, status: 200, text: async () => JSON.stringify(closedMonthClose) };
       }
@@ -3973,12 +4026,11 @@ describe('JVM weekly API BFF proxy', () => {
       if (!path.includes('/cashflow_month_close_request_months/') || !path.endsWith('-2024-01')) return ref;
       return {
         ...ref,
-        set: async (...args) => {
+        beforeTransactionSet: () => {
           if (failShardOnce) {
             failShardOnce = false;
             throw new Error('injected shard write failure');
           }
-          return ref.set(...args);
         },
       };
     };
@@ -3998,11 +4050,29 @@ describe('JVM weekly API BFF proxy', () => {
       .set('idempotency-key', 'cumulative-v2-create')
       .send(createPayload)
       .expect(500);
-    expect(source.documents.get('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-08').status).toBe('BUILDING');
+    expect(source.documents.get('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-08')).toBeUndefined();
+    expect([...source.documents.keys()].filter((path) => path.includes('/cashflow_month_close_request_months/'))).toHaveLength(0);
     await request(requester)
       .get('/api/v1/cashflow/project-a/month-close/requests/current?yearMonth=2026-08')
       .expect(200)
       .expect((response) => expect(response.body.request).toBeNull());
+    const serializedRunTransaction = source.db.runTransaction;
+    const retryConflict = new Error('simulated Firestore transaction retry');
+    let retryOnce = true;
+    source.db.runTransaction = async (callback) => {
+      if (retryOnce) {
+        retryOnce = false;
+        try {
+          await serializedRunTransaction(async (transaction) => {
+            await callback(transaction);
+            throw retryConflict;
+          });
+        } catch (error) {
+          if (error !== retryConflict) throw error;
+        }
+      }
+      return serializedRunTransaction(callback);
+    };
     const created = await request(requester)
       .post('/api/v1/cashflow/project-a/month-close/requests')
       .set('idempotency-key', 'cumulative-v2-create')
@@ -4026,6 +4096,9 @@ describe('JVM weekly API BFF proxy', () => {
     expect(shardDocs).toHaveLength(44);
     expect(shardDocs.every(([, shard]) => shard.cells.length === 160)).toBe(true);
     expect(shardDocs.reduce((count, [, shard]) => count + shard.cells.length, 0)).toBe(7040);
+    expect(source.documents.get('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r1-requested')).toMatchObject({
+      action: 'REQUESTED', revision: 1, actorUid: 'pm-1', manifestHash: created.body.manifestHash,
+    });
 
     const firstShard = shardDocs[0][1];
     firstShard.cells[0].amount = 1;
@@ -4051,25 +4124,131 @@ describe('JVM weekly API BFF proxy', () => {
     const approver = createApp(fetchImpl, createIdempotencyService(), {
       actorId: 'finance-1', actorRole: 'finance',
     }, { env: stageEnv, db: source.db, now: () => new Date('2026-09-10T00:00:00.000Z') }).app;
-    await request(approver)
+    const r1Shards = new Map(shardDocs.map(([path, shard]) => [path, JSON.stringify(shard)]));
+    const rejectedResponse = await request(approver)
       .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
-      .set('idempotency-key', 'cumulative-v2-approve')
-      .send({ decision: 'APPROVE', expectedRevision: 1, expectedManifestHash: created.body.manifestHash })
+      .set('idempotency-key', 'cumulative-v2-reject')
+      .send({ decision: 'REJECT', reason: '누적 근거를 다시 확인해 주세요.', expectedRevision: 1, expectedManifestHash: created.body.manifestHash })
       .expect(200)
       .expect((response) => expect(response.body.request).toMatchObject({
-        status: 'APPROVED', revision: 1, manifestHash: created.body.manifestHash,
+        status: 'REJECTED', revision: 1, manifestHash: created.body.manifestHash,
+        decisionReason: '누적 근거를 다시 확인해 주세요.',
       }));
+    expect(source.documents.get('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r1-rejected')).toMatchObject({
+      action: 'REJECTED', revision: 1, actorUid: 'finance-1', reason: '누적 근거를 다시 확인해 주세요.',
+    });
+    const rejectedReplayBody = {
+      decision: 'REJECT', reason: '누적 근거를 다시 확인해 주세요.',
+      expectedRevision: 1, expectedManifestHash: created.body.manifestHash,
+    };
+    await request(approver)
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
+      .set('idempotency-key', 'cumulative-v2-reject')
+      .send(rejectedReplayBody)
+      .expect(200)
+      .expect((response) => expect(response.body).toEqual(rejectedResponse.body));
+    await request(approver)
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
+      .set('idempotency-key', 'cumulative-v2-reject-duplicate')
+      .send(rejectedReplayBody)
+      .expect(409);
+    await request(requester)
+      .get('/api/v1/cashflow/project-a/month-close/requests/current?yearMonth=2026-08')
+      .expect(200)
+      .expect((response) => expect(response.body.request).toMatchObject({
+        status: 'REJECTED', revision: 1, decisionReason: '누적 근거를 다시 확인해 주세요.',
+      }));
+
+    const resubmitAttempts = await Promise.all(['cumulative-v2-resubmit-a', 'cumulative-v2-resubmit-b'].map((key) => (
+      request(requester)
+        .post('/api/v1/cashflow/project-a/month-close/requests')
+        .set('idempotency-key', key)
+        .send(createPayload)
+    )));
+    expect(resubmitAttempts.map(({ status }) => status).sort()).toEqual([202, 409]);
+    expect(resubmitAttempts.find(({ status }) => status === 409)?.body.code).toBe('cashflow_month_close_request_conflict');
+    const resubmitted = resubmitAttempts.find(({ status }) => status === 202);
+    const winningResubmitKey = resubmitAttempts[0].status === 202 ? 'cumulative-v2-resubmit-a' : 'cumulative-v2-resubmit-b';
+    expect(resubmitted.body).toMatchObject({ status: 'PENDING', revision: 2, monthCount: 44 });
+    expect(resubmitted.body.manifestHash).not.toBe(created.body.manifestHash);
+    expect(source.documents.get('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r2-resubmitted')).toMatchObject({
+      action: 'RESUBMITTED', revision: 2, actorUid: 'pm-1', manifestHash: resubmitted.body.manifestHash,
+    });
+    expect([...r1Shards].every(([path, json]) => JSON.stringify(source.documents.get(path)) === json)).toBe(true);
+    expect([...source.documents.keys()].filter((path) => path.includes('/cashflow_month_close_request_months/project-a-2026-08-r2-'))).toHaveLength(44);
+    const dashboardSourceCallCount = fetchImpl.mock.calls.filter(([url]) => url.includes('/dashboard-source')).length;
+    dashboardSourceUnavailable = true;
+    await request(requester)
+      .post('/api/v1/cashflow/project-a/month-close/requests')
+      .set('idempotency-key', winningResubmitKey)
+      .send(createPayload)
+      .expect(202)
+      .expect((response) => expect(response.body).toMatchObject({ status: 'PENDING', revision: 2, manifestHash: resubmitted.body.manifestHash }));
+    expect(fetchImpl.mock.calls.filter(([url]) => url.includes('/dashboard-source'))).toHaveLength(dashboardSourceCallCount);
+    await request(requester)
+      .post('/api/v1/cashflow/project-a/month-close/requests')
+      .set('idempotency-key', winningResubmitKey)
+      .send({ ...createPayload, closeInput: undefined })
+      .expect(409)
+      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_request_conflict'));
+    await request(requester)
+      .post('/api/v1/cashflow/project-a/month-close/requests')
+      .set('idempotency-key', winningResubmitKey)
+      .send({ ...createPayload, expectedOpeningBalances: { ...createPayload.expectedOpeningBalances, projection: { amount: 1 } } })
+      .expect(409)
+      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_request_conflict'));
+    expect(fetchImpl.mock.calls.filter(([url]) => url.includes('/dashboard-source'))).toHaveLength(dashboardSourceCallCount);
+    dashboardSourceUnavailable = false;
+    await request(approver)
+      .get('/api/v1/cashflow/month-close/requests/pending')
+      .expect(200)
+      .expect((response) => {
+        expect(response.body.count).toBe(1);
+        expect(response.body.items).toHaveLength(1);
+        expect(response.body.items[0]).toMatchObject({ requestId: created.body.requestId, revision: 2 });
+      });
+    await request(approver)
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
+      .set('idempotency-key', 'cumulative-v2-stale-approve')
+      .send({ decision: 'APPROVE', expectedRevision: 1, expectedManifestHash: created.body.manifestHash })
+      .expect(409)
+      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_request_manifest_invalid'));
+    expect(fetchImpl.mock.calls.filter(([url, init]) => url.endsWith('/month-close') && init.method === 'POST')).toHaveLength(0);
+
+    const approvedResponse = await request(approver)
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
+      .set('idempotency-key', 'cumulative-v2-approve')
+      .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
+      .expect(200)
+      .expect((response) => expect(response.body.request).toMatchObject({
+        status: 'APPROVED', revision: 2, manifestHash: resubmitted.body.manifestHash,
+      }));
+    expect(source.documents.get('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r2-approved')).toMatchObject({
+      action: 'APPROVED', revision: 2, actorUid: 'finance-1', manifestHash: resubmitted.body.manifestHash,
+    });
     const approvalBody = JSON.parse(fetchImpl.mock.calls.find(
       ([url, init]) => url.endsWith('/month-close') && init.method === 'POST',
     )[1].body);
     expect(approvalBody).toEqual({
-      idempotencyKey: 'cashflow-month-close-approval:project-a-2026-08:r1',
-      requestId: 'project-a-2026-08', requestRevision: 1, manifestHash: created.body.manifestHash,
+      idempotencyKey: 'cashflow-month-close-approval:project-a-2026-08:r2',
+      requestId: 'project-a-2026-08', requestRevision: 2, manifestHash: resubmitted.body.manifestHash,
       yearMonth: '2026-08', expectedRevision: 0,
     });
     const requestPath = 'orgs/tenant-a/cashflow_month_close_requests/project-a-2026-08';
     const closePostCount = () => fetchImpl.mock.calls.filter(([url, init]) => url.endsWith('/month-close') && init.method === 'POST').length;
     expect(closePostCount()).toBe(1);
+    await request(approver)
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
+      .set('idempotency-key', 'cumulative-v2-approve')
+      .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
+      .expect(200)
+      .expect((response) => expect(response.body).toEqual(approvedResponse.body));
+    expect(closePostCount()).toBe(1);
+    await request(approver)
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
+      .set('idempotency-key', 'cumulative-v2-approve-duplicate')
+      .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
+      .expect(409);
     for (const status of ['APPROVING', 'UNCERTAIN']) {
       source.documents.set(requestPath, {
         ...source.documents.get(requestPath),
@@ -4077,22 +4256,22 @@ describe('JVM weekly API BFF proxy', () => {
         reviewedByUid: 'finance-1',
         reviewedAt: '2026-09-10T00:00:00.000Z',
         reviewIdempotencyKey: `prior-${status.toLowerCase()}`,
-        approvalId: 'cashflow-month-close:project-a-2026-08:r1',
-        operationId: 'cashflow-month-close:project-a-2026-08:r1',
+        approvalId: 'cashflow-month-close:project-a-2026-08:r2',
+        operationId: 'cashflow-month-close:project-a-2026-08:r2',
       });
       await request(approver)
         .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
         .set('idempotency-key', `resume-${status.toLowerCase()}`)
-        .send({ decision: 'APPROVE', expectedRevision: 1, expectedManifestHash: created.body.manifestHash })
+        .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
         .expect(200)
-        .expect((response) => expect(response.body.request).toMatchObject({ status: 'APPROVED', revision: 1 }));
+        .expect((response) => expect(response.body.request).toMatchObject({ status: 'APPROVED', revision: 2 }));
       expect(closePostCount()).toBe(1);
     }
     source.documents.set(requestPath, { ...source.documents.get(requestPath), status: 'UNCERTAIN' });
     await request(approver)
       .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
       .set('idempotency-key', 'unsafe-reject-after-approval-start')
-      .send({ decision: 'REJECT', reason: '취소', expectedRevision: 1, expectedManifestHash: created.body.manifestHash })
+      .send({ decision: 'REJECT', reason: '취소', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
       .expect(409);
   });
 

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -1198,10 +1198,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             || weekNo != intValue(document.get("weekNo"), 0)) {
             throw new WeeklyExpenseConflictException("Stored weekly cashflow completion scope is invalid.");
         }
-        DocumentSnapshot monthClose = get(db.document(monthlyClosePath(tenantId, projectId, yearMonth)));
-        boolean monthClosed = monthClose.exists()
-            && "CLOSED".equals(canonicalMonthStatus(data(monthClose), tenantId, projectId, yearMonth));
-        requireWeeklyCompletionIntegrity(tenantId, projectId, yearMonth, weekNo, document, !monthClosed);
+        requireWeeklyCompletionIntegrity(document);
         return toWeeklyCompletionRecord(projectId, yearMonth, weekNo, document, false);
     }
 
@@ -1382,6 +1379,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             "orgs/" + actor.tenantId() + "/cashflow_weekly_compliance_heads/" + projectId
         );
         DocumentSnapshot complianceHeadSnapshot = get(complianceHeadRef);
+        Map<String, Object> lockedCompletion = null;
         if (snapshot.exists()) {
             Map<String, Object> existing = data(snapshot);
             if (!projectId.equals(text(existing.get("projectId"), ""))
@@ -1390,15 +1388,8 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                 throw new WeeklyExpenseConflictException("Stored weekly cashflow completion scope is invalid.");
             }
             if ("LOCKED".equals(text(existing.get("status"), ""))) {
-                requireWeeklyCompletionIntegrity(
-                    actor.tenantId(),
-                    projectId,
-                    request.yearMonth(),
-                    request.weekNo(),
-                    existing,
-                    true
-                );
-                return toWeeklyCompletionRecord(projectId, request.yearMonth(), request.weekNo(), existing, true);
+                requireWeeklyCompletionIntegrity(existing);
+                lockedCompletion = existing;
             }
         }
 
@@ -1410,7 +1401,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             projectWeeks.put(weekSnapshot.getId(), week);
         }
         List<Map<String, Object>> missingCells = new ArrayList<>();
-        for (CashflowWeekScope scope : consecutiveFinanceWeeks(request.yearMonth(), request.weekNo(), 15)) {
+        for (CashflowWeekScope scope : consecutiveFinanceWeeks(request.yearMonth(), request.weekNo(), 16)) {
             Map<String, Object> candidate = projectWeeks.getOrDefault(
                 cashflowWeekId(projectId, scope.yearMonth(), scope.weekNo()),
                 Map.of()
@@ -1429,12 +1420,17 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             throw new WeeklyExpenseEditLeaseException(
                 409,
                 "cashflow_projection_window_incomplete",
-                "대상 주차부터 15개 재무주차의 Projection 값을 모두 입력해 주세요.",
+                "대상 주차와 그 이후 15개 재무주차의 Projection 값을 모두 입력해 주세요.",
                 Map.of(
-                    "requiredWeekCount", 15,
-                    "requiredCellCount", 240,
+                    "requiredWeekCount", 16,
+                    "requiredCellCount", 256,
                     "missingCells", List.copyOf(missingCells)
                 )
+            );
+        }
+        if (lockedCompletion != null) {
+            return toWeeklyCompletionRecord(
+                projectId, request.yearMonth(), request.weekNo(), lockedCompletion, true
             );
         }
         for (Map.Entry<String, Map<String, Object>> entry : projectWeeks.entrySet()) {
@@ -3559,37 +3555,12 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         );
     }
 
-    private void requireWeeklyCompletionIntegrity(
-        String tenantId,
-        String projectId,
-        String yearMonth,
-        int weekNo,
-        Map<String, Object> completion,
-        boolean compareCurrentLedger
-    ) {
+    private void requireWeeklyCompletionIntegrity(Map<String, Object> completion) {
         if (!"LOCKED".equals(text(completion.get("status"), ""))) return;
         Map<String, Object> lockedSnapshot = nestedMap(completion.get("snapshot"));
         String snapshotHash = text(completion.get("snapshotHash"), "");
         if (lockedSnapshot.isEmpty() || snapshotHash.isBlank() || !snapshotHash.equals(hashCanonicalJson(lockedSnapshot))) {
             throw new WeeklyExpenseConflictException("Cashflow weekly lock snapshot integrity check failed.");
-        }
-        if (!compareCurrentLedger) return;
-        String weekId = cashflowWeekId(projectId, yearMonth, weekNo);
-        DocumentSnapshot currentSnapshot = get(cashflowWeekRef(tenantId, weekId));
-        Map<String, Object> current = currentSnapshot.exists()
-            ? data(currentSnapshot)
-            : baseCashflowWeekDoc(tenantId, projectId, weekId);
-        boolean matches = revisionAmounts(current.get("projection"))
-            .equals(revisionAmounts(lockedSnapshot.get("projection")))
-            && revisionAmounts(current.get("actual"))
-                .equals(revisionAmounts(lockedSnapshot.get("actual")))
-            && revisionAmountSources(current.get("weeklyExpenseActualBySheet"))
-                .equals(revisionAmountSources(lockedSnapshot.get("weeklyExpenseActualBySheet")))
-            && revisionBoolean(current.get("adminClosed")) == revisionBoolean(lockedSnapshot.get("adminClosed"));
-        if (!matches) {
-            throw new WeeklyExpenseConflictException(
-                "Cashflow weekly lock no longer matches the canonical ledger. Do not continue settlement."
-            );
         }
     }
 

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -1889,6 +1889,12 @@ class FirestoreCashflowLeaseGuardTest {
             .anyMatch(path -> path.startsWith(
                 "orgs/tenant-a/cashflow_weekly_update_completion_versions/project-a-2026-07-w3-r1"
             ));
+        assertThat(fixture.documents.keySet().stream()
+            .filter(path -> path.contains("/cashflow_weekly_update_completions/")))
+            .containsExactly("orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w3");
+        assertThat(fixture.documents.keySet().stream()
+            .filter(path -> path.contains("/cashflow_weekly_update_completion_versions/")))
+            .containsExactly("orgs/tenant-a/cashflow_weekly_update_completion_versions/project-a-2026-07-w3-r1");
     }
 
     @Test
@@ -1933,7 +1939,7 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
-    void weeklyLockReadRejectsCanonicalLedgerDrift() {
+    void weeklyLockReadAndReplayAllowCanonicalLedgerDriftWithoutReopen() {
         Fixture fixture = fixture(activeMember(), Map.of());
         String path = "orgs/tenant-a/cashflow_weeks/project-a-2026-07-w3";
         fixture.documents.put(path, new LinkedHashMap<>(Map.of(
@@ -1955,14 +1961,79 @@ class FirestoreCashflowLeaseGuardTest {
             )
         ));
         Map<String, Object> drifted = new LinkedHashMap<>(fixture.documents.get(path));
-        drifted.put("projection", Map.of("SALES_IN", 999L));
+        Map<String, Object> driftedProjection = new LinkedHashMap<>((Map<String, Object>) drifted.get("projection"));
+        driftedProjection.put("SALES_IN", 999L);
+        drifted.put("projection", driftedProjection);
         fixture.documents.put(path, drifted);
+
+        CashflowWeeklyUpdateCompletionResponse read = fixture.persistence.runCommandTransaction(() ->
+            service.readCashflowWeeklyUpdate(READ_ACTOR, "project-a", "2026-07", 3)
+        );
+        CashflowWeeklyUpdateCompletionResponse replay = fixture.persistence.runCommandTransaction(() ->
+            service.completeCashflowWeeklyUpdate(
+                ACTOR,
+                "project-a",
+                new CompleteCashflowWeeklyUpdateRequest(
+                    "weekly-drift-replay", "2026-07", 3, "2026-07-16T10:00:00Z"
+                )
+            )
+        );
+
+        assertThat(read.status()).isEqualTo("LOCKED");
+        assertThat(replay.alreadyCompleted()).isTrue();
+        assertThat(replay.revision()).isEqualTo(1L);
+
+        String completionPath = "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w3";
+        Map<String, Object> tamperedCompletion = new LinkedHashMap<>(fixture.documents.get(completionPath));
+        Map<String, Object> tamperedSnapshot = new LinkedHashMap<>((Map<String, Object>) tamperedCompletion.get("snapshot"));
+        tamperedSnapshot.put("projection", Map.of("SALES_IN", 777L));
+        tamperedCompletion.put("snapshot", tamperedSnapshot);
+        fixture.documents.put(completionPath, tamperedCompletion);
 
         assertThatThrownBy(() -> fixture.persistence.runCommandTransaction(() ->
             service.readCashflowWeeklyUpdate(READ_ACTOR, "project-a", "2026-07", 3)
         ))
             .isInstanceOf(WeeklyExpenseConflictException.class)
-            .hasMessageContaining("canonical ledger");
+            .hasMessageContaining("snapshot integrity");
+    }
+
+    @Test
+    void lockedWeeklyReplayStillRejectsOneMissingCellInTheSixteenthFinanceWeek() {
+        Fixture fixture = fixture(activeMember(), Map.of());
+        putCompleteProjectionWindow(fixture, "2026-07", 3);
+        WeeklyExpenseCommandService service = commandService(fixture.persistence);
+        fixture.persistence.runCommandTransaction(() -> service.completeCashflowWeeklyUpdate(
+            ACTOR,
+            "project-a",
+            new CompleteCashflowWeeklyUpdateRequest(
+                "weekly-window-lock", "2026-07", 3, "2026-07-16T09:00:00Z"
+            )
+        ));
+        String sixteenthWeekPath = "orgs/tenant-a/cashflow_weeks/project-a-2026-10-w3";
+        Map<String, Object> sixteenthWeek = new LinkedHashMap<>(fixture.documents.get(sixteenthWeekPath));
+        Map<String, Object> projection = new LinkedHashMap<>((Map<String, Object>) sixteenthWeek.get("projection"));
+        projection.remove("SALES_IN");
+        sixteenthWeek.put("projection", projection);
+        fixture.documents.put(sixteenthWeekPath, sixteenthWeek);
+
+        Throwable failure = catchThrowable(() -> fixture.persistence.runCommandTransaction(() ->
+            service.completeCashflowWeeklyUpdate(
+                ACTOR,
+                "project-a",
+                new CompleteCashflowWeeklyUpdateRequest(
+                    "weekly-window-replay", "2026-07", 3, "2026-07-16T10:00:00Z"
+                )
+            )
+        ));
+
+        assertThat(failure).isInstanceOf(WeeklyExpenseEditLeaseException.class);
+        WeeklyExpenseEditLeaseException incomplete = (WeeklyExpenseEditLeaseException) failure;
+        assertThat(incomplete.code()).isEqualTo("cashflow_projection_window_incomplete");
+        assertThat(incomplete.details())
+            .containsEntry("requiredWeekCount", 16)
+            .containsEntry("requiredCellCount", 256);
+        assertThat((List<Map<String, Object>>) incomplete.details().get("missingCells"))
+            .containsExactly(Map.of("yearMonth", "2026-10", "weekNo", 3, "lineId", "SALES_IN"));
     }
 
     @Test
@@ -2397,7 +2468,7 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
-    void weeklyCompletionChecksFifteenWeeksAcrossYearBoundaryAndTreatsNullAsEmptyButZeroAsWritten() {
+    void weeklyCompletionChecksSixteenWeeksAcrossYearBoundaryAndTreatsNullAsEmptyButZeroAsWritten() {
         Fixture fixture = fixture(activeMember(), Map.of());
         putCompleteProjectionWindow(fixture, "2026-12", 4);
         String nullPath = "orgs/tenant-a/cashflow_weeks/project-a-2027-01-w2";
@@ -2416,6 +2487,9 @@ class FirestoreCashflowLeaseGuardTest {
         assertThat(failure).isInstanceOf(WeeklyExpenseEditLeaseException.class);
         WeeklyExpenseEditLeaseException incomplete = (WeeklyExpenseEditLeaseException) failure;
         assertThat(incomplete.code()).isEqualTo("cashflow_projection_window_incomplete");
+        assertThat(incomplete.details())
+            .containsEntry("requiredWeekCount", 16)
+            .containsEntry("requiredCellCount", 256);
         assertThat((List<Map<String, Object>>) incomplete.details().get("missingCells"))
             .contains(Map.of("yearMonth", "2027-01", "weekNo", 2, "lineId", "SALES_IN"));
 
@@ -3790,7 +3864,7 @@ class FirestoreCashflowLeaseGuardTest {
     private static void putCompleteProjectionWindow(Fixture fixture, String yearMonth, int weekNo) {
         java.time.YearMonth month = java.time.YearMonth.parse(yearMonth);
         int week = weekNo;
-        for (int index = 0; index < 15; index++) {
+        for (int index = 0; index < 16; index++) {
             String path = "orgs/tenant-a/cashflow_weeks/project-a-" + month + "-w" + week;
             Map<String, Object> document = new LinkedHashMap<>(fixture.documents.getOrDefault(path, Map.of()));
             Map<String, Object> projection = new LinkedHashMap<>((Map<String, Object>) document.getOrDefault("projection", Map.of()));

--- a/src/app/components/approval/AdminApprovalPage.shell.test.ts
+++ b/src/app/components/approval/AdminApprovalPage.shell.test.ts
@@ -35,6 +35,8 @@ describe('AdminApprovalPage shell contract', () => {
     expect(monthlySource).toContain('reviewCashflowMonthCloseRequestViaBff');
     expect(monthlySource).toContain("decision: action.decision");
     expect(monthlySource).toContain('반려 사유 (필수)');
+    expect(monthlySource).toContain('maxLength={1000}');
+    expect(monthlySource).not.toContain('maxLength={2000}');
     expect(monthlySource).toContain('월 결산 승인 대기 항목이 없습니다');
     expect(monthlySource).toContain('결재 전 확인사항');
     expect(monthlySource).toContain('문서 유형');

--- a/src/app/components/approval/MonthlySettlementApprovalSection.tsx
+++ b/src/app/components/approval/MonthlySettlementApprovalSection.tsx
@@ -590,7 +590,7 @@ export function MonthlySettlementApprovalSection({
             <DialogDescription className="text-[11px]">검토한 저장 문서에 대한 처리 의견을 남깁니다.</DialogDescription>
           </DialogHeader>
           {actionError ? <div role="alert" className="border border-red-200 bg-red-50 p-3 text-[12px] text-red-800">{actionError}</div> : null}
-          <Textarea value={reason} onChange={(event) => { setReason(event.target.value); setActionError(''); }} maxLength={2000} aria-label={action?.decision === 'APPROVE' ? '승인 코멘트' : '반려 사유'} className="min-h-[88px] text-[12px]" placeholder={action?.decision === 'APPROVE' ? '승인 코멘트 (선택)' : '반려 사유 (필수)'} />
+          <Textarea value={reason} onChange={(event) => { setReason(event.target.value); setActionError(''); }} maxLength={1000} aria-label={action?.decision === 'APPROVE' ? '승인 코멘트' : '반려 사유'} className="min-h-[88px] text-[12px]" placeholder={action?.decision === 'APPROVE' ? '승인 코멘트 (선택)' : '반려 사유 (필수)'} />
           <DialogFooter>
             <Button variant="outline" size="sm" disabled={busy} onClick={() => setAction(null)}>취소</Button>
             <Button

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -377,9 +377,9 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain("updateResult: weeklyUpdateResult");
     expect(source).toContain("['CHANGED', '변경사항 반영 완료'");
     expect(source).toContain("['NO_CHANGES', '변경사항 없음'");
-    expect(source).toContain('향후 15개 재무주차');
+    expect(source).toContain('그 이후 15개 재무주차(총 16주·256칸)');
     expect(source).not.toContain('ZERO(0원)는 작성값이며 EMPTY(미입력)는 완료할 수 없습니다.');
-    expect(source).toContain('이미 완료한 주차의 값이 시트 반영으로 변경되었습니다. 해당 주차를 재오픈한 뒤 변경 내용을 확인하고 다시 완료해 주세요.');
+    expect(source).not.toContain('Cashflow weekly lock no longer matches');
     expect(source).toContain('weeklyProjectionMissingCells(error)');
     expect(source).toContain('fetchCashflowWeeklyComplianceViaBff');
     expect(source).toContain("week.status === 'ON_TIME'");

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -836,10 +836,7 @@ export function CashflowProjectSheet({
         durationMs: Date.now() - startedAt,
         error,
       });
-      const serverMessage = resolveApiErrorMessage(error, '주간 정산 완료 상태를 저장하지 못했습니다.');
-      const message = serverMessage.includes('Cashflow weekly lock no longer matches')
-        ? '이미 완료한 주차의 값이 시트 반영으로 변경되었습니다. 해당 주차를 재오픈한 뒤 변경 내용을 확인하고 다시 완료해 주세요.'
-        : serverMessage;
+      const message = resolveApiErrorMessage(error, '주간 정산 완료 상태를 저장하지 못했습니다.');
       setWeeklyCompletionError(message);
       setWeeklyMissingCells(weeklyProjectionMissingCells(error));
       toast.error(message);
@@ -3172,7 +3169,7 @@ export function CashflowProjectSheet({
           <AlertDialogHeader>
             <AlertDialogTitle>주간 정산 완료</AlertDialogTitle>
             <AlertDialogDescription>
-              대상 {monthCloseResult?.dashboard?.deadlineSummary?.current?.yearMonth || yearMonth} {monthCloseResult?.dashboard?.deadlineSummary?.current?.weekNo || '-'}주차부터 향후 15개 재무주차의 모든 Projection 항목이 작성되어 있어야 합니다.
+              대상 {monthCloseResult?.dashboard?.deadlineSummary?.current?.yearMonth || yearMonth} {monthCloseResult?.dashboard?.deadlineSummary?.current?.weekNo || '-'}주차와 그 이후 15개 재무주차(총 16주·256칸)의 모든 Projection 항목이 작성되어 있어야 합니다.
             </AlertDialogDescription>
           </AlertDialogHeader>
           {weeklyCompletionError ? <div role="alert" className="rounded-md border border-red-200 bg-red-50 p-3 text-[12px] leading-5 text-red-800">{weeklyCompletionError}</div> : null}

--- a/src/app/components/portal/PortalBudget.import-layout.test.ts
+++ b/src/app/components/portal/PortalBudget.import-layout.test.ts
@@ -22,6 +22,15 @@ describe('PortalBudget manual editing surface contract', () => {
     expect(codeBookSurface).not.toContain('<TabsTrigger value="csv"');
     expect(portalLayoutSource).toContain("{ to: '/portal/budget', icon: BarChart3, label: '예산총괄' }");
     expect(routesSource).toContain("{ path: 'budget', element: <S C={PortalBudget} /> }");
+    expect(portalBudgetSource).toContain('최종 수정예산');
+    expect(portalBudgetSource).not.toContain('>수정 예산<');
+    expect(portalBudgetSource).toContain('formatBudgetContractPeriod(myProject.contractStart, myProject.contractEnd)');
+    expect(portalBudgetSource).toContain("return '계약기간 미등록'");
+    expect(portalBudgetSource).not.toContain('badge={`${meta.year}년`}');
+    expect(portalBudgetSource).not.toContain('fmtPercent(r.ratio)');
+    expect(portalBudgetSource).not.toContain('fmtPercent(group.burnRate)');
+    expect(portalBudgetSource).not.toContain('fmtPercent(subItem.burnRate)');
+    expect(portalBudgetSource).not.toContain('fmtPercent(leaf.burnRate)');
   });
 
   it('keeps the adjacent admin summary editing description', () => {

--- a/src/app/components/portal/PortalBudget.tsx
+++ b/src/app/components/portal/PortalBudget.tsx
@@ -71,6 +71,13 @@ function groupIdForEntry(name: string): string {
   return normalizeBudgetLabel(name) || '기타';
 }
 
+function formatBudgetContractPeriod(start: string, end: string): string {
+  const startYear = /^\d{4}/.exec(start)?.[0] || '';
+  const endYear = /^\d{4}/.exec(end)?.[0] || '';
+  if (!startYear && !endYear) return '계약기간 미등록';
+  return startYear && endYear && startYear !== endYear ? `${startYear}–${endYear}` : `${startYear || endYear}년`;
+}
+
 // 소진율 색상
 function burnColor(rate: number): string {
   if (rate >= 0.8) return '#e11d48';
@@ -597,7 +604,6 @@ export function PortalBudget() {
   const meta = myProject ? {
     projectId: myProject.id,
     projectName: myProject.name,
-    year: new Date(myProject.contractStart).getFullYear(),
     funder: myProject.clientOrg,
     basis: BASIS_LABELS[myProject.basis] || myProject.basis,
     totalBudget: myProject.contractAmount,
@@ -1357,16 +1363,14 @@ export function PortalBudget() {
   }, [budgetCodeViews]);
 
   const auxRows = useMemo(() => {
-    const effectiveTotal = total.effectiveBudget || 0;
     return budgetCodeViews.map((group) => {
       const effective = group.effectiveBudget;
       return {
         label: group.budgetCode || '기타',
         amount: effective,
-        ratio: effectiveTotal > 0 ? effective / effectiveTotal : 0,
       };
     });
-  }, [budgetCodeViews, total.effectiveBudget]);
+  }, [budgetCodeViews]);
 
   const updateDraftLeafField = useCallback((
     rowKey: string,
@@ -1400,7 +1404,7 @@ export function PortalBudget() {
           iconGradient="linear-gradient(135deg, #0d9488 0%, #059669 100%)"
           title="예산 편집"
           description={myProject ? myProject.name : '예산 현황'}
-          badge={`${meta.year}년`}
+          badge={formatBudgetContractPeriod(myProject.contractStart, myProject.contractEnd)}
           headingVisible={false}
           actions={(
             <div className="flex items-center gap-2">
@@ -2084,7 +2088,6 @@ export function PortalBudget() {
                   <span>{r.label}</span>
                   <div className="flex items-center gap-4" style={{ fontVariantNumeric: 'tabular-nums' }}>
                     <span style={{ fontWeight: 500 }}>{fmtKRW(r.amount)}원</span>
-                    <span className="text-muted-foreground w-[50px] text-right">{fmtPercent(r.ratio)}</span>
                   </div>
                 </div>
               ))}
@@ -2141,19 +2144,8 @@ export function PortalBudget() {
                   <div className="flex items-center gap-3 text-[10px]" style={{ fontVariantNumeric: 'tabular-nums' }}>
                     <span className="text-muted-foreground">예산 <strong className="text-foreground">{fmtShort(group.effectiveBudget)}</strong></span>
                     <span className="text-muted-foreground">집행 <strong style={{ color: group.spent > 0 ? '#e11d48' : undefined }}>{fmtShort(group.spent)}</strong></span>
-                    <span style={{ fontWeight: 600, color: burnColor(group.burnRate) }}>{fmtPercent(group.burnRate)}</span>
                   </div>
                 </button>
-
-                {/* 그룹 진행바 */}
-                <div className="px-4 pt-1.5 pb-0.5">
-                  <div className="w-full h-1.5 rounded-full bg-muted overflow-hidden">
-                    <div className="h-full rounded-full" style={{
-                      width: `${Math.min(group.burnRate * 100, 100)}%`,
-                      background: burnColor(group.burnRate),
-                    }} />
-                  </div>
-                </div>
 
                 {/* 항목 테이블 */}
                 {!isCollapsed && group.subItems.length > 0 && (
@@ -2163,9 +2155,8 @@ export function PortalBudget() {
                         <tr className="bg-muted/30">
                           <th className="px-4 py-2 text-left" style={{ fontWeight: 600, minWidth: 140 }}>세목 / 세세목</th>
                           <th className="px-3 py-2 text-right" style={{ fontWeight: 600, minWidth: 90 }}>최초 예산</th>
-                          <th className="px-3 py-2 text-right" style={{ fontWeight: 600, minWidth: 90 }}>수정 예산</th>
+                          <th className="px-3 py-2 text-right" style={{ fontWeight: 600, minWidth: 90 }}>최종 수정예산</th>
                           <th className="px-3 py-2 text-right" style={{ fontWeight: 600, minWidth: 90 }}>소진금액</th>
-                          <th className="px-3 py-2 text-right" style={{ fontWeight: 600, minWidth: 50 }}>소진율</th>
                           <th className="px-3 py-2 text-right" style={{ fontWeight: 600, minWidth: 90 }}>잔액</th>
                           <th className="px-4 py-2 text-left hidden lg:table-cell" style={{ fontWeight: 600, minWidth: 120 }}>특이사항</th>
                         </tr>
@@ -2185,7 +2176,7 @@ export function PortalBudget() {
                                 ? `세세목 최초예산 합계 ${fmtKRW(subItem.leafInitialBudgetTotal)}원이 세목 최초예산 ${fmtKRW(subItem.targetInitialBudget)}원과 다릅니다.`
                                 : '',
                               subItem.hasRevisedBudgetMismatch
-                                ? `세세목 수정예산 합계 ${fmtKRW(subItem.leafRevisedBudgetTotal)}원이 세목 수정예산 ${fmtKRW(subItem.targetRevisedBudget)}원과 다릅니다.`
+                                ? `세세목 최종 수정예산 합계 ${fmtKRW(subItem.leafRevisedBudgetTotal)}원이 세목 최종 수정예산 ${fmtKRW(subItem.targetRevisedBudget)}원과 다릅니다.`
                                 : '',
                             ].filter(Boolean);
                             return (
@@ -2240,11 +2231,6 @@ export function PortalBudget() {
                                     <td className="px-3 py-2.5 text-right" style={{ fontVariantNumeric: 'tabular-nums', color: subItem.spent > 0 ? '#e11d48' : undefined }}>
                                       {fmtKRW(subItem.spent)}
                                     </td>
-                                    <td className="px-3 py-2.5 text-right">
-                                      <span className="inline-flex items-center justify-center min-w-[40px] px-1.5 py-0.5 rounded text-[9px]" style={{ fontWeight: 600, color: burnColor(subItem.burnRate), background: `${burnColor(subItem.burnRate)}10` }}>
-                                        {fmtPercent(subItem.burnRate)}
-                                      </span>
-                                    </td>
                                     <td className="px-3 py-2.5 text-right" style={{ fontVariantNumeric: 'tabular-nums', color: '#059669' }}>
                                       {fmtKRW(subItem.balance)}
                                     </td>
@@ -2271,7 +2257,7 @@ export function PortalBudget() {
                                   </tr>
                                 {!subCollapsed && warningMessages.length > 0 ? (
                                   <tr className="border-t border-border/20 bg-rose-50/60">
-                                    <td colSpan={7} className="px-4 py-2 text-[10px] text-rose-600">
+                                    <td colSpan={6} className="px-4 py-2 text-[10px] text-rose-600">
                                       {warningMessages.join(' ')}
                                     </td>
                                   </tr>
@@ -2332,11 +2318,6 @@ export function PortalBudget() {
                                       </td>
                                       <td className="px-3 py-2.5 text-right" style={{ fontVariantNumeric: 'tabular-nums', color: leaf.spent > 0 ? '#e11d48' : undefined }}>
                                         {fmtKRW(leaf.spent)}
-                                      </td>
-                                      <td className="px-3 py-2.5 text-right">
-                                        <span className="inline-flex items-center justify-center min-w-[40px] px-1.5 py-0.5 rounded text-[9px]" style={{ fontWeight: 600, color: burnColor(leaf.burnRate), background: `${burnColor(leaf.burnRate)}10` }}>
-                                          {fmtPercent(leaf.burnRate)}
-                                        </span>
                                       </td>
                                       <td className="px-3 py-2.5 text-right" style={{ fontVariantNumeric: 'tabular-nums', color: '#059669' }}>
                                         {fmtKRW(leaf.balance)}
@@ -2425,11 +2406,6 @@ export function PortalBudget() {
                               <td className="px-3 py-2.5 text-right" style={{ fontVariantNumeric: 'tabular-nums', color: leaf.spent > 0 ? '#e11d48' : undefined }}>
                                 {fmtKRW(leaf.spent)}
                               </td>
-                              <td className="px-3 py-2.5 text-right">
-                                <span className="inline-flex items-center justify-center min-w-[40px] px-1.5 py-0.5 rounded text-[9px]" style={{ fontWeight: 600, color: burnColor(leaf.burnRate), background: `${burnColor(leaf.burnRate)}10` }}>
-                                  {fmtPercent(leaf.burnRate)}
-                                </span>
-                              </td>
                               <td className="px-3 py-2.5 text-right" style={{ fontVariantNumeric: 'tabular-nums', color: '#059669' }}>
                                 {fmtKRW(leaf.balance)}
                               </td>
@@ -2493,9 +2469,8 @@ export function PortalBudget() {
                     ['세목', selectedRow.subCode || '—'],
                     ['세세목', selectedRow.subSubCode || '—'],
                     ['최초 예산', fmtKRW(selectedRow.initialBudget) + '원'],
-                    ['수정 예산', selectedRow.revisedBudget > 0 ? fmtKRW(selectedRow.revisedBudget) + '원' : '—'],
+                    ['최종 수정예산', selectedRow.revisedBudget > 0 ? fmtKRW(selectedRow.revisedBudget) + '원' : '—'],
                     ['소진금액', fmtKRW(selectedRow.spent) + '원'],
-                    ['소진율', fmtPercent(selectedRow.burnRate)],
                     ['잔액', fmtKRW(selectedRow.balance) + '원'],
                   ].map(([l, v]) => (
                     <div key={l as string}>
@@ -2514,19 +2489,6 @@ export function PortalBudget() {
                   </div>
                 )}
 
-                <div>
-                  <p className="text-[10px] text-muted-foreground mb-1">소진율</p>
-                  <div className="w-full h-3 rounded-full bg-muted overflow-hidden">
-                    <div className="h-full rounded-full transition-all" style={{
-                      width: `${Math.min(selectedRow.burnRate * 100, 100)}%`,
-                      background: burnColor(selectedRow.burnRate),
-                    }} />
-                  </div>
-                  <div className="flex justify-between mt-1 text-[9px] text-muted-foreground" style={{ fontVariantNumeric: 'tabular-nums' }}>
-                    <span>{fmtPercent(selectedRow.burnRate)}</span>
-                    <span>잔액 {fmtKRW(selectedRow.balance)}원</span>
-                  </div>
-                </div>
               </div>
             )}
           </DialogContent>


### PR DESCRIPTION
## What
- stabilize Google Sheet-linked weekly settlement validation across 16 finance weeks
- make cumulative month-close request/resubmit evidence atomic and replay-safe
- clarify budget period and revised-budget labels while removing item-level burn-rate clutter
- clarify profit/VAT transfer check as deposit week or next week

## Verification
- npm test: 2586 passed, 241 skipped
- npm run bff:test:integration: 236 passed
- mvn test: passed
- npm run build: passed
- local browser QA: contract-period fallback, final revised-budget label, no item burn-rate column

## Ops
- Stage only after merge; Production Deploy workflow is not triggered
- before Live: verify no BUILDING/legacy fingerprint records and run max 7040-cell Stage canary