### PR TITLE
fix(deploy): gate live maintenance release

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -13,6 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: read
   contents: read
   deployments: write
 
@@ -30,6 +31,17 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       VERCEL_DEPLOY_ALLOWED_AUTHOR_EMAILS: ai@mysc.co.kr
+      VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+      LIVE_FIREBASE_PROJECT_ID: inner-platform-live-20260316
+      BFF_DEPLOY_ENV: live
+      BFF_AUTH_MODE: firebase_required
+      BFF_EDIT_LEASES_ENABLED: 'false'
+      BFF_WORKERS_ENABLED: 'false'
+      BFF_SCHEDULER_OWNER: disabled
+      BFF_MAINTENANCE_READ_ONLY: 'true'
+      BFF_ALLOWED_ORIGINS: https://myscube.myscguard.app
+      JVM_WEEKLY_AUTH_MODE: strict
+      GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON: '{}'
       # Use a production-scoped secret name so a stale repository-level
       # VERCEL_TOKEN cannot be confused with the Production environment token.
       VERCEL_TOKEN: ${{ secrets.VERCEL_DEPLOY_TOKEN_PRODUCTION }}
@@ -46,6 +58,33 @@ jobs:
         with:
           ref: main
           fetch-depth: 1
+
+      - name: Verify dispatched main commit
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}" || {
+            echo "main advanced after dispatch; dispatch the current main commit instead." >&2
+            exit 1
+          }
+
+      - name: Verify CI succeeded for this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          runs="$(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
+            -f head_sha="${GITHUB_SHA}" \
+            -f branch=main \
+            -f event=push \
+            -f per_page=20)"
+          jq -e --arg sha "${GITHUB_SHA}" '
+            [.workflow_runs[]
+              | select(.head_sha == $sha and .status == "completed" and .conclusion == "success")]
+            | length > 0
+          ' <<< "${runs}" >/dev/null || {
+            echo "CI must be green for ${GITHUB_SHA} before production deploy." >&2
+            exit 1
+          }
 
       - name: Verify Vercel deploy author policy
         run: |
@@ -71,6 +110,7 @@ jobs:
           test -n "${VERCEL_TOKEN}" || { echo "Missing secret: VERCEL_DEPLOY_TOKEN_PRODUCTION" >&2; exit 1; }
           test -n "${VERCEL_ORG_ID}" || { echo "Missing secret: VERCEL_ORG_ID" >&2; exit 1; }
           test -n "${VERCEL_PROJECT_ID}" || { echo "Missing secret: VERCEL_PROJECT_ID" >&2; exit 1; }
+          test -n "${VERCEL_AUTOMATION_BYPASS_SECRET}" || { echo "Missing secret: VERCEL_AUTOMATION_BYPASS_SECRET" >&2; exit 1; }
           npx --yes "${VERCEL_CLI_PACKAGE}" whoami --token "${VERCEL_TOKEN}" --scope merryai-devs-projects >/dev/null
 
       - name: Deploy to Vercel production
@@ -78,7 +118,33 @@ jobs:
         run: |
           set -euo pipefail
           output_file="$(mktemp)"
-          npx --yes "${VERCEL_CLI_PACKAGE}" deploy --prod --yes --token "${VERCEL_TOKEN}" 2>&1 | tee "${output_file}"
+          commit_sha="$(git rev-parse HEAD)"
+          npx --yes "${VERCEL_CLI_PACKAGE}" deploy --prod --yes --skip-domain --token "${VERCEL_TOKEN}" \
+            --build-env VITE_PLATFORM_API_ENABLED=true \
+            --build-env VITE_FIRESTORE_CORE_ENABLED=false \
+            --build-env VITE_FIREBASE_PROJECT_ID="${LIVE_FIREBASE_PROJECT_ID}" \
+            --env BFF_DEPLOY_ENV="${BFF_DEPLOY_ENV}" \
+            --env BFF_AUTH_MODE="${BFF_AUTH_MODE}" \
+            --env BFF_EDIT_LEASES_ENABLED="${BFF_EDIT_LEASES_ENABLED}" \
+            --env BFF_WORKERS_ENABLED="${BFF_WORKERS_ENABLED}" \
+            --env BFF_SCHEDULER_OWNER="${BFF_SCHEDULER_OWNER}" \
+            --env BFF_MAINTENANCE_READ_ONLY="${BFF_MAINTENANCE_READ_ONLY}" \
+            --env BFF_ALLOWED_ORIGINS="${BFF_ALLOWED_ORIGINS}" \
+            --env FIREBASE_PROJECT_ID="${LIVE_FIREBASE_PROJECT_ID}" \
+            --env BFF_FIREBASE_AUTH_PROJECT_ID="${LIVE_FIREBASE_PROJECT_ID}" \
+            --env BFF_LIVE_FIREBASE_PROJECT_ID="${LIVE_FIREBASE_PROJECT_ID}" \
+            --env JVM_WEEKLY_FIRESTORE_PROJECT_ID="${LIVE_FIREBASE_PROJECT_ID}" \
+            --env JVM_WEEKLY_AUTH_MODE="${JVM_WEEKLY_AUTH_MODE}" \
+            --env GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON="${GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON}" \
+            --env SLACK_ALERT_WEBHOOK_URL= \
+            --env SLACK_ALERT_BOT_TOKEN= \
+            --env SLACK_ALERT_CHANNEL_ID= \
+            --env PROJECT_REGISTRATION_SLACK_WEBHOOK_URL= \
+            --env PROJECT_REGISTRATION_SLACK_BOT_TOKEN= \
+            --env PROJECT_REGISTRATION_SLACK_CHANNEL_ID= \
+            --meta maintenanceReadOnly=true \
+            --meta githubCommitSha="${commit_sha}" \
+            2>&1 | tee "${output_file}"
           deployment_url="$(grep -Eo 'https://[A-Za-z0-9.-]+\.vercel\.app' "${output_file}" | tail -n 1 || true)"
           if [ -z "${deployment_url}" ]; then
             echo "Could not parse Vercel deployment URL" >&2
@@ -87,6 +153,52 @@ jobs:
           deployment_host="${deployment_url#https://}"
           echo "deployment_url=${deployment_url}" >> "${GITHUB_OUTPUT}"
           echo "deployment_host=${deployment_host}" >> "${GITHUB_OUTPUT}"
+
+      - name: Verify production maintenance surface before alias
+        env:
+          DEPLOYMENT_URL: ${{ steps.vercel_deploy.outputs.deployment_url }}
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          const base = process.env.DEPLOYMENT_URL;
+          const expectedProject = process.env.LIVE_FIREBASE_PROJECT_ID;
+          const request = async (path, init) => {
+            const response = await fetch(`${base}${path}`, {
+              ...init,
+              headers: {
+                ...init?.headers,
+                'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
+              },
+            });
+            const body = await response.json().catch(() => ({}));
+            return { response, body };
+          };
+
+          const health = await request('/api/v1/health');
+          if (health.response.status !== 200
+            || health.body.projectId !== expectedProject
+            || health.body.authMode !== 'firebase_required'
+            || health.body.firestoreEmulator !== false) {
+            throw new Error(`unsafe production health: ${health.response.status} ${JSON.stringify(health.body)}`);
+          }
+
+          const mutation = await request('/api/v1/__maintenance_probe__', { method: 'POST' });
+          if (mutation.response.status !== 503 || mutation.body.error !== 'stage_maintenance_read_only') {
+            throw new Error(`maintenance guard missing: ${mutation.response.status} ${JSON.stringify(mutation.body)}`);
+          }
+
+          for (const path of [
+            '/api/internal/workers/outbox/run',
+            '/api/internal/workers/work-queue/run',
+            '/api/internal/workers/payroll/run',
+            '/api/internal/workers/client-errors/run',
+          ]) {
+            const worker = await request(path);
+            if (worker.response.status !== 503 || worker.body.error !== 'worker_scheduler_disabled') {
+              throw new Error(`worker guard missing at ${path}: ${worker.response.status} ${JSON.stringify(worker.body)}`);
+            }
+          }
+          NODE
 
       - name: Promote canonical production alias
         env:

--- a/scripts/assert_vercel_edge_route_policy.mjs
+++ b/scripts/assert_vercel_edge_route_policy.mjs
@@ -64,6 +64,15 @@ function unexpectedFrom(actual, expected) {
   return actual.map(normalizeHost).filter((host) => !expectedSet.has(host));
 }
 
+export function isRemovedVercelDeployment(status, vercelError) {
+  return status === 404
+    || (status === 410 && ["GONE", "DEPLOYMENT_NOT_FOUND"].includes(String(vercelError || "").toUpperCase()));
+}
+
+export function isVercelProtectedRedirect(status, location) {
+  return status === 302 && String(location || "").startsWith("https://vercel.com/sso-api?");
+}
+
 export function evaluateVercelEdgeRoutePolicy({
   vercelConfig,
   stageWorkflowText,

--- a/scripts/assert_vercel_edge_route_policy.mjs
+++ b/scripts/assert_vercel_edge_route_policy.mjs
@@ -7,6 +7,11 @@ const CANONICAL_PRODUCTION_DESTINATION = `${CANONICAL_PRODUCTION_ORIGIN}/:path*`
 const INTERNAL_STAGE_HOST = "inner-platform-internal-stage-merryai-devs-projects.vercel.app";
 const LEGACY_STAGE_HOST = "inner-platform-stage-merryai-devs-projects.vercel.app";
 const ROUTE_VERSION_ALIAS = "inner-platform-f52434-routes-merryai-devs-projects.vercel.app";
+const REQUIRED_PROTECTED_OR_REDIRECT_HOSTS = [
+  "submit-mysc.com",
+  "inner-platform-merryai-devs-projects.vercel.app",
+  "inner-platform-merryai-dev-merryai-devs-projects.vercel.app",
+];
 
 const REQUIRED_PRODUCTION_DIRECT_HOSTS = [
   "inner-platform.vercel.app",
@@ -84,7 +89,11 @@ export function evaluateVercelEdgeRoutePolicy({
   const routeHosts = productionRedirectHosts(vercelConfig);
   const smokeHosts = extractDefaultDirectHosts(smokeScriptText);
   const requiredDirectHosts = uniqueSorted(REQUIRED_PRODUCTION_DIRECT_HOSTS);
-  const requiredSmokeHosts = uniqueSorted([...REQUIRED_PRODUCTION_DIRECT_HOSTS, ROUTE_VERSION_ALIAS]);
+  const requiredSmokeHosts = uniqueSorted([
+    ...REQUIRED_PRODUCTION_DIRECT_HOSTS,
+    ...REQUIRED_PROTECTED_OR_REDIRECT_HOSTS,
+    ROUTE_VERSION_ALIAS,
+  ]);
 
   const routedStageHosts = routeHosts.filter((host) => stageHosts.includes(host));
   if (routedStageHosts.length) {

--- a/scripts/smoke_cloudflare_edge.mjs
+++ b/scripts/smoke_cloudflare_edge.mjs
@@ -2,6 +2,10 @@
 
 import fs from "node:fs";
 import { spawnSync } from "node:child_process";
+import {
+  isRemovedVercelDeployment,
+  isVercelProtectedRedirect,
+} from "./assert_vercel_edge_route_policy.mjs";
 
 const defaultHosts = [
   "myscube.myscguard.app",
@@ -176,12 +180,16 @@ async function checkDirectOrigin(host) {
       headers: { "user-agent": "MYSCube-edge-smoke/1.0" },
     });
     const location = response.headers.get("location") || "";
+    const vercelError = response.headers.get("x-vercel-error") || "";
     const canonicalRedirect = response.status >= 300 && response.status < 400 && location.startsWith("https://myscube.myscguard.app/");
-    const removedAlias = response.status === 404;
-    return result(`https://${host}/ direct-origin`, canonicalRedirect || removedAlias, {
+    const protectedRedirect = isVercelProtectedRedirect(response.status, location);
+    const removedAlias = isRemovedVercelDeployment(response.status, vercelError);
+    return result(`https://${host}/ direct-origin`, canonicalRedirect || protectedRedirect || removedAlias, {
       status: response.status,
       location,
+      vercelError,
       canonicalRedirect,
+      protectedRedirect,
       removedAlias,
     });
   } catch (error) {

--- a/scripts/smoke_cloudflare_edge.mjs
+++ b/scripts/smoke_cloudflare_edge.mjs
@@ -34,6 +34,9 @@ const defaultDirectHosts = [
   "inner-platform-gq6813nqh-merryai-devs-projects.vercel.app",
   "inner-platform-k2x121b33-merryai-devs-projects.vercel.app",
   "inner-platform-f52434-routes-merryai-devs-projects.vercel.app",
+  "submit-mysc.com",
+  "inner-platform-merryai-devs-projects.vercel.app",
+  "inner-platform-merryai-dev-merryai-devs-projects.vercel.app",
 ];
 const directHosts = (process.env.CLOUDFLARE_EDGE_DIRECT_HOSTS || defaultDirectHosts.join(","))
   .split(",")

--- a/server/production-deploy-workflow.test.ts
+++ b/server/production-deploy-workflow.test.ts
@@ -37,6 +37,7 @@ describe('production deployment workflow safety', () => {
     expect(workflowText).toMatch(/environment:\n\s+name: Production/);
     expect(workflowText).toContain('if [ "${GITHUB_REF}" != "refs/heads/main" ]; then');
     expect(workflowText).toContain('ref: main');
+    expect(workflowText).toContain('test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"');
   });
 
   it('does not interpolate manual workflow inputs directly inside shell run blocks', () => {
@@ -71,6 +72,30 @@ describe('production deployment workflow safety', () => {
     expect(workflowText).toContain('deployment_url="$(grep -Eo');
     expect(workflowText).toContain('| tail -n 1 || true)"');
     expect(workflowText).toContain('Could not parse Vercel deployment URL');
+  });
+
+  it('forces the production artifact into Live maintenance before alias promotion', () => {
+    expect(workflowText).toContain('LIVE_FIREBASE_PROJECT_ID: inner-platform-live-20260316');
+    expect(workflowText).toContain('BFF_DEPLOY_ENV: live');
+    expect(workflowText).toContain("BFF_EDIT_LEASES_ENABLED: 'false'");
+    expect(workflowText).toContain("BFF_WORKERS_ENABLED: 'false'");
+    expect(workflowText).toContain('BFF_SCHEDULER_OWNER: disabled');
+    expect(workflowText).toContain("BFF_MAINTENANCE_READ_ONLY: 'true'");
+    expect(workflowText).toContain('--env FIREBASE_PROJECT_ID="${LIVE_FIREBASE_PROJECT_ID}"');
+    expect(workflowText).toContain('--env BFF_FIREBASE_AUTH_PROJECT_ID="${LIVE_FIREBASE_PROJECT_ID}"');
+    expect(workflowText).toContain('--env JVM_WEEKLY_FIRESTORE_PROJECT_ID="${LIVE_FIREBASE_PROJECT_ID}"');
+    expect(workflowText).toContain('--env GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON="${GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON}"');
+    expect(workflowText).toContain('--env SLACK_ALERT_WEBHOOK_URL=');
+    expect(workflowText).toContain('--build-env VITE_FIRESTORE_CORE_ENABLED=false');
+    expect(workflowText).toContain('--build-env VITE_FIREBASE_PROJECT_ID="${LIVE_FIREBASE_PROJECT_ID}"');
+    expect(workflowText).toContain('VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}');
+    expect(workflowText).toContain("'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET");
+    expect(workflowText).toContain('deploy --prod --yes --skip-domain');
+    expect(workflowText).toContain('/api/v1/__maintenance_probe__');
+    expect(workflowText).toContain('worker_scheduler_disabled');
+    expect(workflowText.indexOf('Verify production maintenance surface before alias')).toBeLessThan(
+      workflowText.indexOf('Promote canonical production alias'),
+    );
   });
 
   it('uses a production-scoped Vercel token secret to avoid repo/environment name shadowing', () => {
@@ -149,9 +174,9 @@ describe('stage release workflow safety', () => {
     expect(stageWorkflowText).not.toContain('RBAC policy verify');
     expect(stageWorkflowText).not.toContain('Stage build');
 
-    expect(workflowText).not.toContain('Verify CI succeeded for this commit');
-    expect(workflowText).not.toContain('gh run list');
-    expect(workflowText).not.toContain('CI must be green before production deploy');
+    expect(workflowText).toContain('Verify CI succeeded for this commit');
+    expect(workflowText).toContain('actions/workflows/ci.yml/runs');
+    expect(workflowText).toContain('CI must be green for ${GITHUB_SHA} before production deploy.');
     expect(workflowText).not.toContain('node scripts/assert-safe-live-deploy.mjs');
     expect(workflowText).not.toContain('Verify production deploy policy');
     expect(workflowText).not.toContain('run: npm ci');

--- a/server/vercel-edge-route-policy.test.ts
+++ b/server/vercel-edge-route-policy.test.ts
@@ -59,6 +59,9 @@ describe('Vercel edge route policy', () => {
       smokeScriptText: smokeScript([
         ...baseRedirectHosts,
         'inner-platform-f52434-routes-merryai-devs-projects.vercel.app',
+        'submit-mysc.com',
+        'inner-platform-merryai-devs-projects.vercel.app',
+        'inner-platform-merryai-dev-merryai-devs-projects.vercel.app',
       ]),
     });
 
@@ -75,6 +78,9 @@ describe('Vercel edge route policy', () => {
       smokeScriptText: smokeScript([
         ...baseRedirectHosts,
         'inner-platform-f52434-routes-merryai-devs-projects.vercel.app',
+        'submit-mysc.com',
+        'inner-platform-merryai-devs-projects.vercel.app',
+        'inner-platform-merryai-dev-merryai-devs-projects.vercel.app',
       ]),
     });
 
@@ -89,6 +95,9 @@ describe('Vercel edge route policy', () => {
       smokeScriptText: smokeScript([
         ...baseRedirectHosts.filter((host) => host !== 'inner-platform-k2x121b33-merryai-devs-projects.vercel.app'),
         'inner-platform-f52434-routes-merryai-devs-projects.vercel.app',
+        'submit-mysc.com',
+        'inner-platform-merryai-devs-projects.vercel.app',
+        'inner-platform-merryai-dev-merryai-devs-projects.vercel.app',
       ]),
     });
 

--- a/server/vercel-edge-route-policy.test.ts
+++ b/server/vercel-edge-route-policy.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { evaluateVercelEdgeRoutePolicy } from '../scripts/assert_vercel_edge_route_policy.mjs';
+import {
+  evaluateVercelEdgeRoutePolicy,
+  isRemovedVercelDeployment,
+  isVercelProtectedRedirect,
+} from '../scripts/assert_vercel_edge_route_policy.mjs';
 
 const baseRedirectHosts = [
   'inner-platform.vercel.app',
@@ -33,6 +37,21 @@ steps:
 `;
 
 describe('Vercel edge route policy', () => {
+  it('accepts only recognized removed deployment responses', () => {
+    expect(isRemovedVercelDeployment(404, '')).toBe(true);
+    expect(isRemovedVercelDeployment(410, 'GONE')).toBe(true);
+    expect(isRemovedVercelDeployment(410, 'deployment_not_found')).toBe(true);
+    expect(isRemovedVercelDeployment(410, '')).toBe(false);
+    expect(isRemovedVercelDeployment(410, 'random')).toBe(false);
+    expect(isRemovedVercelDeployment(200, 'GONE')).toBe(false);
+  });
+
+  it('accepts only the Vercel authentication redirect as deployment protection', () => {
+    expect(isVercelProtectedRedirect(302, 'https://vercel.com/sso-api?url=x')).toBe(true);
+    expect(isVercelProtectedRedirect(307, 'https://vercel.com/sso-api?url=x')).toBe(false);
+    expect(isVercelProtectedRedirect(302, 'https://example.com/sso-api?url=x')).toBe(false);
+  });
+
   it('accepts production direct-origin redirects while keeping stage outside the production security domain', () => {
     const result = evaluateVercelEdgeRoutePolicy({
       vercelConfig: vercelConfig(baseRedirectHosts),


### PR DESCRIPTION
## What
- force Live Vercel artifact into BFF/client maintenance mode
- verify exact-SHA CI, maintenance mutation, and disabled workers before alias promotion
- recognize Vercel protected/removed direct origins without accepting arbitrary 410

## Why
Live maintenance QA must not expose old generated deployment URLs or allow writes before the artifact is promoted.

## Verification
- 65 focused tests passed
- npm run policy:verify passed
- strict edge smoke passed with Cloudflare challenge enabled
- workflow YAML parsed successfully