### PR TITLE
fix(live): restore canonical project reads

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -38,7 +38,7 @@ jobs:
       BFF_EDIT_LEASES_ENABLED: 'false'
       BFF_WORKERS_ENABLED: 'false'
       BFF_SCHEDULER_OWNER: disabled
-      BFF_MAINTENANCE_READ_ONLY: 'true'
+      BFF_MAINTENANCE_READ_ONLY: 'false'
       BFF_ALLOWED_ORIGINS: https://myscube.myscguard.app
       JVM_WEEKLY_AUTH_MODE: strict
       GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON: '{}'
@@ -142,7 +142,7 @@ jobs:
             --env PROJECT_REGISTRATION_SLACK_WEBHOOK_URL= \
             --env PROJECT_REGISTRATION_SLACK_BOT_TOKEN= \
             --env PROJECT_REGISTRATION_SLACK_CHANNEL_ID= \
-            --meta maintenanceReadOnly=true \
+            --meta maintenanceReadOnly=false \
             --meta githubCommitSha="${commit_sha}" \
             2>&1 | tee "${output_file}"
           deployment_url="$(grep -Eo 'https://[A-Za-z0-9.-]+\.vercel\.app' "${output_file}" | tail -n 1 || true)"
@@ -154,7 +154,7 @@ jobs:
           echo "deployment_url=${deployment_url}" >> "${GITHUB_OUTPUT}"
           echo "deployment_host=${deployment_host}" >> "${GITHUB_OUTPUT}"
 
-      - name: Verify production maintenance surface before alias
+      - name: Verify production surface before alias
         env:
           DEPLOYMENT_URL: ${{ steps.vercel_deploy.outputs.deployment_url }}
         run: |
@@ -182,9 +182,12 @@ jobs:
             throw new Error(`unsafe production health: ${health.response.status} ${JSON.stringify(health.body)}`);
           }
 
-          const mutation = await request('/api/v1/__maintenance_probe__', { method: 'POST' });
-          if (mutation.response.status !== 503 || mutation.body.error !== 'stage_maintenance_read_only') {
-            throw new Error(`maintenance guard missing: ${mutation.response.status} ${JSON.stringify(mutation.body)}`);
+          const mutation = await request('/api/v1/__maintenance_probe__', {
+            method: 'POST',
+            headers: { 'idempotency-key': 'production-auth-probe' },
+          });
+          if (mutation.response.status !== 401 || mutation.body.error !== 'missing_bearer_token') {
+            throw new Error(`production write surface is not auth-protected: ${mutation.response.status} ${JSON.stringify(mutation.body)}`);
           }
 
           for (const path of [

--- a/server/production-deploy-workflow.test.ts
+++ b/server/production-deploy-workflow.test.ts
@@ -74,13 +74,13 @@ describe('production deployment workflow safety', () => {
     expect(workflowText).toContain('Could not parse Vercel deployment URL');
   });
 
-  it('forces the production artifact into Live maintenance before alias promotion', () => {
+  it('deploys the production artifact against Live without the migration maintenance gate', () => {
     expect(workflowText).toContain('LIVE_FIREBASE_PROJECT_ID: inner-platform-live-20260316');
     expect(workflowText).toContain('BFF_DEPLOY_ENV: live');
     expect(workflowText).toContain("BFF_EDIT_LEASES_ENABLED: 'false'");
     expect(workflowText).toContain("BFF_WORKERS_ENABLED: 'false'");
     expect(workflowText).toContain('BFF_SCHEDULER_OWNER: disabled');
-    expect(workflowText).toContain("BFF_MAINTENANCE_READ_ONLY: 'true'");
+    expect(workflowText).toContain("BFF_MAINTENANCE_READ_ONLY: 'false'");
     expect(workflowText).toContain('--env FIREBASE_PROJECT_ID="${LIVE_FIREBASE_PROJECT_ID}"');
     expect(workflowText).toContain('--env BFF_FIREBASE_AUTH_PROJECT_ID="${LIVE_FIREBASE_PROJECT_ID}"');
     expect(workflowText).toContain('--env JVM_WEEKLY_FIRESTORE_PROJECT_ID="${LIVE_FIREBASE_PROJECT_ID}"');
@@ -93,7 +93,7 @@ describe('production deployment workflow safety', () => {
     expect(workflowText).toContain('deploy --prod --yes --skip-domain');
     expect(workflowText).toContain('/api/v1/__maintenance_probe__');
     expect(workflowText).toContain('worker_scheduler_disabled');
-    expect(workflowText.indexOf('Verify production maintenance surface before alias')).toBeLessThan(
+    expect(workflowText.indexOf('Verify production surface before alias')).toBeLessThan(
       workflowText.indexOf('Promote canonical production alias'),
     );
   });

--- a/src/app/data/store.project-trash-shell.test.ts
+++ b/src/app/data/store.project-trash-shell.test.ts
@@ -11,10 +11,12 @@ function extractFunction(name: string): string {
 }
 
 describe('project trash local state contract', () => {
-  it('does not seed live Firestore sessions with mock projects before remote data arrives', () => {
-    expect(source).toContain('const usesLocalSeedData = !featureFlags.firestoreCoreEnabled');
+  it('does not seed live BFF or Firestore sessions with mock projects before remote data arrives', () => {
+    expect(source).toContain('const usesLocalSeedData = !platformApiEnabled && !featureFlags.firestoreCoreEnabled');
     expect(source).toContain('useState<Project[]>(() => (usesLocalSeedData ? PROJECTS : []))');
     expect(source).toContain('setProjects(usesLocalSeedData ? PROJECTS : [])');
+    expect(source).toContain('if (platformApiEnabled && bffActor.idToken)');
+    expect(source).toContain('fetchProjectsViaBff({ tenantId: orgId, actor: bffActor })');
   });
 
   it('mirrors trash and restore success into local state even when Firestore is online', () => {

--- a/src/app/data/store.tsx
+++ b/src/app/data/store.tsx
@@ -157,7 +157,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     [platformApiEnabled, firestoreEnabled],
   );
 
-  const usesLocalSeedData = !featureFlags.firestoreCoreEnabled;
+  const usesLocalSeedData = !platformApiEnabled && !featureFlags.firestoreCoreEnabled;
   const [projects, setProjects] = useState<Project[]>(() => (usesLocalSeedData ? PROJECTS : []));
   const [ledgers, setLedgers] = useState<Ledger[]>(() => (usesLocalSeedData ? LEDGERS : []));
   const [transactions, setTransactions] = useState<Transaction[]>(() => (usesLocalSeedData ? TRANSACTIONS : []));
@@ -251,7 +251,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     let cancelled = false;
 
     if (!firestoreEnabled || !db) {
-      setDataSource('local');
+      setDataSource(platformApiEnabled ? 'firestore' : 'local');
       setProjects(usesLocalSeedData ? PROJECTS : []);
       setLedgers(usesLocalSeedData ? LEDGERS : []);
       setTransactions(usesLocalSeedData ? TRANSACTIONS : []);
@@ -260,6 +260,24 @@ export function AppProvider({ children }: { children: ReactNode }) {
       setAuditLogs(usesLocalSeedData ? AUDIT_LOGS : []);
       setParticipationEntries(usesLocalSeedData ? PARTICIPATION_ENTRIES : []);
       setLocalMembers(usesLocalSeedData ? ORG_MEMBERS as Array<OrgMember & Record<string, unknown>> : []);
+
+      if (platformApiEnabled && bffActor.idToken) {
+        fetchProjectsViaBff({ tenantId: orgId, actor: bffActor })
+          .then((nextProjects) => {
+            if (!cancelled) setProjects(nextProjects);
+          })
+          .catch((error) => {
+            reportError(error, {
+              message: '[AppStore] BFF project fetch failed:',
+              options: {
+                level: 'error',
+                tags: { surface: 'app_store', action: 'project_fetch' },
+                extra: { orgId },
+              },
+            });
+          });
+      }
+
       return () => {
         cancelled = true;
       };

--- a/src/app/platform/portal-project-selection.test.ts
+++ b/src/app/platform/portal-project-selection.test.ts
@@ -89,6 +89,18 @@ describe('portal project selection helpers', () => {
     expect(financeResult.searchProjects.map((project) => project.id)).toEqual(['p-assigned', 'p-managed', 'p-other']);
   });
 
+  it('does not expose trashed projects in portal selection', () => {
+    const result = resolvePortalProjectCandidates({
+      role: 'admin',
+      projects: [
+        ...projects,
+        { id: 'p-trashed', name: 'Trashed Project', trashedAt: '2026-07-31T00:00:00.000Z' },
+      ] as unknown as Project[],
+    });
+
+    expect(result.searchProjects.map((project) => project.id)).toEqual(['p-assigned', 'p-managed', 'p-other']);
+  });
+
   it('falls back from active project to primary and then the first candidate', () => {
     expect(resolveActivePortalProjectId({
       activeProjectId: 'missing-project',

--- a/src/app/platform/portal-project-selection.ts
+++ b/src/app/platform/portal-project-selection.ts
@@ -53,7 +53,7 @@ export function resolvePortalProjectCandidates(input: {
   projects: Project[];
 }): PortalProjectCandidateSet {
   const role = normalizeRole(input.role);
-  const projects = dedupeProjects(sortProjects(input.projects || []));
+  const projects = dedupeProjects(sortProjects((input.projects || []).filter((project) => !project.trashedAt)));
 
   if (!role) {
     return {


### PR DESCRIPTION
## What\n- stop seeding the 20-project mock catalog when the platform BFF is enabled\n- load the canonical Live project catalog through the BFF\n- exclude trashed projects from portal selection\n- release the global Live maintenance gate while retaining disabled workers and Live-safe edit lease settings\n\n## Evidence\n- targeted tests: 47/47 and final 28/28\n- BFF integration: 236/236\n- production build: pass\n- full suite: 2590 passed; one JVM test failed only under parallel load and passed alone\n\n## Production verification\n- verify all 69 projects / 60 active / 0 mock IDs in admin and portal\n- verify 21 pending project requests\n- rollback canonical alias immediately if counts or authenticated reads differ