### PR TITLE
fix(deploy): enable live BFF traffic

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -43,7 +43,7 @@ jobs:
       BFF_EDIT_LEASES_ENABLED: 'false'
       BFF_WORKERS_ENABLED: 'false'
       BFF_SCHEDULER_OWNER: disabled
-      BFF_MAINTENANCE_READ_ONLY: 'true'
+      BFF_MAINTENANCE_READ_ONLY: 'false'
       BFF_ALLOWED_ORIGINS: https://myscube.myscguard.app
       JVM_WEEKLY_AUTH_MODE: strict
       JVM_WEEKLY_API_BASE_URL: ${{ vars.JVM_WEEKLY_API_BASE_URL_LIVE }}
@@ -159,7 +159,7 @@ jobs:
             --env PROJECT_REGISTRATION_SLACK_WEBHOOK_URL= \
             --env PROJECT_REGISTRATION_SLACK_BOT_TOKEN= \
             --env PROJECT_REGISTRATION_SLACK_CHANNEL_ID= \
-            --meta maintenanceReadOnly=true \
+            --meta maintenanceReadOnly=false \
             --meta githubCommitSha="${commit_sha}" \
             2>&1 | tee "${output_file}"
           deployment_url="$(grep -Eo 'https://[A-Za-z0-9.-]+\.vercel\.app' "${output_file}" | tail -n 1 || true)"
@@ -171,7 +171,7 @@ jobs:
           echo "deployment_url=${deployment_url}" >> "${GITHUB_OUTPUT}"
           echo "deployment_host=${deployment_host}" >> "${GITHUB_OUTPUT}"
 
-      - name: Verify production maintenance surface before alias
+      - name: Verify production surface before alias
         env:
           DEPLOYMENT_URL: ${{ steps.vercel_deploy.outputs.deployment_url }}
         run: |
@@ -200,8 +200,8 @@ jobs:
           }
 
           const mutation = await request('/api/v1/__maintenance_probe__', { method: 'POST' });
-          if (mutation.response.status !== 503 || mutation.body.error !== 'stage_maintenance_read_only') {
-            throw new Error(`maintenance guard missing: ${mutation.response.status} ${JSON.stringify(mutation.body)}`);
+          if (mutation.response.status !== 400 || mutation.body.error === 'stage_maintenance_read_only') {
+            throw new Error(`production maintenance guard still active: ${mutation.response.status} ${JSON.stringify(mutation.body)}`);
           }
 
           for (const path of [

--- a/server/bff/worker-endpoints.test.ts
+++ b/server/bff/worker-endpoints.test.ts
@@ -32,6 +32,26 @@ function createTestApp(options: Parameters<typeof createBffApp>[0] = {}) {
 }
 
 describe('internal worker endpoints (cron)', () => {
+  it('keeps the Live maintenance probe open while workers stay disabled', async () => {
+    const app = createTestApp({
+      projectId: LIVE_PROJECT_ID,
+      allowedOrigins: [LIVE_ORIGIN],
+      env: {
+        BFF_DEPLOY_ENV: 'live',
+        BFF_MAINTENANCE_READ_ONLY: 'false',
+        BFF_WORKERS_ENABLED: 'false',
+      },
+    });
+
+    const mutationProbe = await request(app).post('/api/v1/__maintenance_probe__');
+    expect(mutationProbe.status).toBe(400);
+    expect(mutationProbe.body?.error).not.toBe('stage_maintenance_read_only');
+
+    const workerProbe = await request(app).get('/api/internal/workers/outbox/run');
+    expect(workerProbe.status).toBe(503);
+    expect(workerProbe.body?.error).toBe('worker_scheduler_disabled');
+  });
+
   it('keeps health readable but blocks every mutation during stage maintenance', async () => {
     const app = createTestApp({
       env: {

--- a/server/production-deploy-workflow.test.ts
+++ b/server/production-deploy-workflow.test.ts
@@ -77,13 +77,13 @@ describe('production deployment workflow safety', () => {
     expect(workflowText).toContain('Could not parse Vercel deployment URL');
   });
 
-  it('forces the production artifact into Live maintenance before alias promotion', () => {
+  it('deploys the production artifact with Live reads and writes enabled before alias promotion', () => {
     expect(workflowText).toContain('LIVE_FIREBASE_PROJECT_ID: inner-platform-live-20260316');
     expect(workflowText).toContain('BFF_DEPLOY_ENV: live');
     expect(workflowText).toContain("BFF_EDIT_LEASES_ENABLED: 'false'");
     expect(workflowText).toContain("BFF_WORKERS_ENABLED: 'false'");
     expect(workflowText).toContain('BFF_SCHEDULER_OWNER: disabled');
-    expect(workflowText).toContain("BFF_MAINTENANCE_READ_ONLY: 'true'");
+    expect(workflowText).toContain("BFF_MAINTENANCE_READ_ONLY: 'false'");
     expect(workflowText).toContain('--env FIREBASE_PROJECT_ID="${LIVE_FIREBASE_PROJECT_ID}"');
     expect(workflowText).toContain('--env BFF_FIREBASE_AUTH_PROJECT_ID="${LIVE_FIREBASE_PROJECT_ID}"');
     expect(workflowText).toContain('--env JVM_WEEKLY_FIRESTORE_PROJECT_ID="${LIVE_FIREBASE_PROJECT_ID}"');
@@ -104,7 +104,9 @@ describe('production deployment workflow safety', () => {
     expect(workflowText).toContain('deploy --prod --yes --skip-domain');
     expect(workflowText).toContain('/api/v1/__maintenance_probe__');
     expect(workflowText).toContain('worker_scheduler_disabled');
-    expect(workflowText.indexOf('Verify production maintenance surface before alias')).toBeLessThan(
+    expect(workflowText).toContain('mutation.response.status !== 400');
+    expect(workflowText).toContain("mutation.body.error === 'stage_maintenance_read_only'");
+    expect(workflowText.indexOf('Verify production surface before alias')).toBeLessThan(
       workflowText.indexOf('Promote canonical production alias'),
     );
   });


### PR DESCRIPTION
## What
- disable the Live BFF maintenance read-only gate
- keep Stage maintenance and Live workers disabled
- verify the pre-alias Live probe reaches normal request validation instead of the maintenance 503

## Verification
- `npm test -- --run server/production-deploy-workflow.test.ts server/bff/worker-endpoints.test.ts`
- `npm run build`

## Data safety
- no Firestore, mirror, or Google Sheet writes
- previous Production deployment and JVM bootstrap revision remain rollback points