### PR TITLE
fix(cashflow): restore legacy live reads

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -353,7 +353,7 @@ async function readCashflowActivityDocuments(db, tenantId, collectionId, project
   let query = db.collection(`orgs/${tenantId}/${collectionId}`)
     .where('projectId', '==', projectId);
   query = collectionId === 'weekly_api_audit_events'
-    ? query.orderBy('createdAt', 'desc').limit(50)
+    ? query.limit(200)
     : query.limit(200);
   const snap = await query.get();
   return snap.docs.map((doc) => ({ id: doc.id, ...(doc.data() || {}) }));

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -763,8 +763,8 @@ describe('JVM weekly API BFF proxy', () => {
         ]);
       });
     expect(activityQueries.find((query) => query.collectionId === 'weekly_api_audit_events')).toMatchObject({
-      orderBy: ['createdAt', 'desc'],
-      limit: 50,
+      orderBy: null,
+      limit: 200,
     });
   });
 

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -887,9 +887,10 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     ) {
         requireYearMonth(yearMonth);
         DocumentSnapshot close = get(db.document(monthlyClosePath(tenantId, projectId, yearMonth)));
-        List<Map<String, Object>> projectCloses = readProjectMonthCloses(tenantId, projectId);
-        Map<String, Object> document = close.exists() ? data(close) : Map.of();
-        if (!document.isEmpty()) canonicalMonthStatus(document, tenantId, projectId, yearMonth);
+        List<Map<String, Object>> projectCloses = readProjectMonthClosesForRead(tenantId, projectId);
+        Map<String, Object> document = close.exists()
+            ? readableMonthClose(data(close), tenantId, projectId, yearMonth)
+            : Map.of();
         return toMonthCloseRecord(tenantId, projectId, yearMonth, document, projectWarningCount(projectCloses));
     }
 
@@ -2675,6 +2676,35 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         );
     }
 
+    private Map<String, Object> readableMonthClose(
+        Map<String, Object> close,
+        String tenantId,
+        String projectId,
+        String yearMonth
+    ) {
+        if (close.isEmpty()) return close;
+        String storedContract = text(close.get("contractVersion"), "");
+        String storedTenant = text(close.get("tenantId"), "");
+        String storedProject = text(close.get("projectId"), "");
+        String storedMonth = text(close.get("yearMonth"), "");
+        if ((!storedContract.isBlank() && !CASHFLOW_MONTH_CLOSE_CONTRACT_VERSION.equals(storedContract))
+            || (!storedTenant.isBlank() && !tenantId.equals(storedTenant))
+            || (!storedProject.isBlank() && !projectId.equals(storedProject))
+            || (!storedMonth.isBlank() && !yearMonth.equals(storedMonth))) {
+            canonicalMonthStatus(close, tenantId, projectId, yearMonth);
+        }
+        Map<String, Object> readable = new LinkedHashMap<>(close);
+        readable.put("contractVersion", CASHFLOW_MONTH_CLOSE_CONTRACT_VERSION);
+        readable.put("tenantId", tenantId);
+        readable.put("projectId", projectId);
+        readable.put("yearMonth", yearMonth);
+        readable.put("status", text(close.get("status"), "OPEN").toUpperCase(Locale.ROOT));
+        readable.putIfAbsent("revision", 0L);
+        readable.putIfAbsent("reopenCount", 0L);
+        canonicalMonthStatus(readable, tenantId, projectId, yearMonth);
+        return readable;
+    }
+
     private void requireMutableMonthStatus(String status) {
         if ("OPEN".equals(status)) return;
         if ("CLOSED".equals(status) || "REOPEN_REQUESTED".equals(status)) {
@@ -3197,6 +3227,23 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             requireYearMonth(yearMonth);
             canonicalMonthStatus(close, tenantId, projectId, yearMonth);
             closes.add(close);
+        }
+        return closes;
+    }
+
+    private List<Map<String, Object>> readProjectMonthClosesForRead(String tenantId, String projectId) {
+        QuerySnapshot snapshot = query(db.collection("orgs/" + tenantId + "/monthly_closes")
+            .whereEqualTo("projectId", projectId));
+        List<Map<String, Object>> closes = new ArrayList<>();
+        for (DocumentSnapshot document : snapshot.getDocuments()) {
+            Map<String, Object> close = data(document);
+            String yearMonth = text(close.get("yearMonth"), "");
+            if (yearMonth.isBlank()) {
+                String prefix = projectId + "-";
+                yearMonth = document.getId().startsWith(prefix) ? document.getId().substring(prefix.length()) : "";
+            }
+            requireYearMonth(yearMonth);
+            closes.add(readableMonthClose(close, tenantId, projectId, yearMonth));
         }
         return closes;
     }

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -3480,6 +3480,42 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
+    void monthCloseReadAcceptsLegacyOpenDocument() {
+        Fixture fixture = fixture(activeMember(), activeLease());
+        fixture.documents.put(
+            monthClosePath("project-a", "2026-06"),
+            new LinkedHashMap<>(Map.of("status", "OPEN"))
+        );
+
+        WeeklyExpensePersistence.CashflowMonthCloseRecord result = fixture.persistence.runCommandTransaction(() ->
+            fixture.persistence.findCashflowMonthClose("tenant-a", "project-a", "2026-06")
+        );
+        assertThat(result.status()).isEqualTo("OPEN");
+        assertThat(result.revision()).isZero();
+    }
+
+    @Test
+    void monthCloseWritesStillRejectAnotherLegacyMonth() {
+        Fixture fixture = fixture(activeMember(), activeLease());
+        fixture.documents.put(monthClosePath("project-a", "2026-05"), new LinkedHashMap<>(Map.of(
+            "projectId", "project-a",
+            "yearMonth", "2026-05",
+            "status", "CLOSED"
+        )));
+        fixture.documents.put(monthClosePath("project-a", "2026-06"), closedMonth("2026-06", 1, 0));
+
+        assertThatThrownBy(() -> fixture.persistence.runCommandTransaction(() ->
+            fixture.persistence.requestCashflowMonthReopen(
+                ACTOR,
+                "project-a",
+                new RequestCashflowMonthReopenRequest("legacy-write-guard", "2026-06", 1, "증빙 재확인")
+            )
+        ))
+            .isInstanceOf(WeeklyExpenseConflictException.class)
+            .hasMessageContaining("canonical");
+    }
+
+    @Test
     void projectWarningCountAndRevisionIncrementFailClosedOnOverflow() {
         Fixture warningFixture = fixture(activeMember(), activeLease());
         warningFixture.documents.put(

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -553,6 +553,9 @@ describe('CashflowProjectSheet monthly close shell', () => {
   });
 
   it('renders annual carry-forward and future totals around the selected year weekly ledger', () => {
+    expect(source).toContain('canonicalAnnualYears');
+    expect(source).toContain('canonicalCashflowAnnualYears');
+    expect(source).toContain('canonicalAnnualTotalFor');
     expect(source).toContain('const previousAnnualYears = annualYears.filter((year) => year < selectedYear)');
     expect(source).toContain('const followingAnnualYears = annualYears.filter((year) => year > selectedYear)');
     expect(source).toContain('const renderAnnualSummaryCell');
@@ -565,6 +568,11 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain("'값 없음'");
     expect(source).toContain('>미입력</');
     expect(source).toContain("cell.difference === null ? '미입력'");
+  });
+
+  it('never renders synthetic zero cashflow values after the canonical read fails', () => {
+    expect(source).toContain('shouldHideCashflowValuesAfterLoadError');
+    expect(source).toContain('현금흐름 데이터를 불러오지 못했습니다.');
   });
 
   it('aligns the Projection - Actual table to the same annual, weekly, and Total contract as the cashflow board', () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -75,6 +75,7 @@ import {
 } from '../../lib/sheets-cashflow-readonly-client';
 import {
   buildCashflowMonthCloseDraftInput,
+  canonicalCashflowAnnualYears,
   carryForwardCashflowRunningBalances,
   createEmptyCashflowMonthCloseDepositRows,
   isCashflowMonthCloseRequestLocked,
@@ -83,6 +84,8 @@ import {
   resolveCashflowComparisonScope,
   resolveCashflowEvidenceScope,
   shouldApplyCashflowMonthCloseRequestResult,
+  shouldHideCashflowValuesAfterLoadError,
+  summarizeCanonicalCashflowYear,
   type CashflowMonthCloseDepositReviewRow,
 } from './cashflow-month-close';
 import { CashflowSheetSyncOverlay } from './CashflowSheetSyncOverlay';
@@ -1704,15 +1707,19 @@ export function CashflowProjectSheet({
   const mirroredAnnualTotals = useMemo(() => new Map((cashflowSheetMirror?.sheetFacts?.annualCashflowTotals || [])
     .filter((row) => Number.isSafeInteger(row.year))
     .map((row) => [row.year, row])), [cashflowSheetMirror?.sheetFacts?.annualCashflowTotals]);
+  const canonicalAnnualYears = canonicalCashflowAnnualYears(
+    monthCloseResult?.dashboard?.canonical?.months || [],
+    selectedYear,
+  );
   const annualYears = useMemo(() => {
     const openingBalanceYears = [
       ...(monthCloseResult?.dashboard?.openingBalances?.projection?.sources || []).map((source) => source.year),
       ...(monthCloseResult?.dashboard?.openingBalances?.actual?.sources || []).map((source) => source.year),
     ];
-    return [...new Set([...openingBalanceYears, ...mirroredAnnualTotals.keys()])]
+    return [...new Set([...openingBalanceYears, ...mirroredAnnualTotals.keys(), ...canonicalAnnualYears])]
       .filter((year) => year !== selectedYear)
       .sort((left, right) => left - right);
-  }, [mirroredAnnualTotals, monthCloseResult?.dashboard?.openingBalances, selectedYear]);
+  }, [canonicalAnnualYears, mirroredAnnualTotals, monthCloseResult?.dashboard?.openingBalances, selectedYear]);
   const previousAnnualYears = annualYears.filter((year) => year < selectedYear);
   const followingAnnualYears = annualYears.filter((year) => year > selectedYear);
   const comparisonAsOfWeek = monthCloseResult?.dashboard?.summary?.comparisonAsOfWeek;
@@ -1726,11 +1733,18 @@ export function CashflowProjectSheet({
   const visibleComparisonAnnualYears = comparisonScope.annualYears;
   const previousComparisonAnnualYears = visibleComparisonAnnualYears.filter((year) => year < selectedYear);
   const followingComparisonAnnualYears = visibleComparisonAnnualYears.filter((year) => year > selectedYear);
+  const canonicalAnnualTotalFor = (year: number, mode: 'projection' | 'actual') => summarizeCanonicalCashflowYear(
+    monthCloseResult?.dashboard?.canonical?.months || [],
+    year,
+    mode,
+  );
   const annualTotalFor = (year: number, mode: 'projection' | 'actual') => {
     const pinned = monthCloseResult?.status === 'OPEN'
       ? mirroredAnnualTotals.get(year)?.[mode] || null
       : null;
     if (pinned) return pinned;
+    const canonical = canonicalAnnualTotalFor(year, mode);
+    if (canonical) return canonical;
     const jvmSource = monthCloseResult?.dashboard?.openingBalances?.selectedYear === selectedYear
       ? monthCloseResult.dashboard.openingBalances[mode]?.sources?.find((source) => source.year === year)
       : null;
@@ -2072,6 +2086,16 @@ export function CashflowProjectSheet({
       return (
         <div className="rounded-[18px] border border-slate-200 bg-white px-3 py-8 text-center text-[12px] text-slate-500">
           서버 확정 시트와 기간 합계를 불러오는 중입니다.
+        </div>
+      );
+    }
+    if (shouldHideCashflowValuesAfterLoadError(monthCloseError, Boolean(monthCloseResult?.dashboard?.canonical))) {
+      return (
+        <div className="rounded-[18px] border border-red-200 bg-red-50 px-3 py-8 text-center text-[12px] text-red-700">
+          <p>현금흐름 데이터를 불러오지 못했습니다.</p>
+          <button type="button" className="mt-3 rounded-lg border border-red-300 bg-white px-3 py-1.5 font-semibold" onClick={() => void loadCashflowMonthClose()}>
+            다시 확인
+          </button>
         </div>
       );
     }

--- a/src/app/components/cashflow/cashflow-month-close.test.ts
+++ b/src/app/components/cashflow/cashflow-month-close.test.ts
@@ -4,6 +4,7 @@ import type { CashflowSheetLabMirrorResult } from '../../lib/sheets-cashflow-rea
 import type { CashflowDeadlineSummary, CashflowManagementCheck } from '../../lib/platform-bff-client';
 import {
   buildCashflowMonthCloseDraftInput,
+  canonicalCashflowAnnualYears,
   carryForwardCashflowRunningBalances,
   createEmptyCashflowMonthCloseDepositRows,
   isCashflowMonthCloseRequestLocked,
@@ -14,6 +15,8 @@ import {
   resolveCashflowComparisonScope,
   resolveCashflowEvidenceScope,
   shouldApplyCashflowMonthCloseRequestResult,
+  shouldHideCashflowValuesAfterLoadError,
+  summarizeCanonicalCashflowYear,
 } from './cashflow-month-close';
 
 function mirror(): CashflowSheetLabMirrorResult {
@@ -53,6 +56,29 @@ const deadlineSummary: CashflowDeadlineSummary = {
 };
 
 describe('cashflow month close contract', () => {
+  it('deduplicates prior years and calculates exact canonical annual totals', () => {
+    const months = [
+      { yearMonth: '2024-01', projection: { weeks: [{ amounts: { SALES_IN: 100, DIRECT_COST_OUT: 30 } }] } },
+      { yearMonth: '2024-02', projection: { weeks: [{ amounts: { SALES_IN: 50, DIRECT_COST_OUT: 20 } }] } },
+      { yearMonth: '2025-01', projection: { weeks: [{ amounts: { SALES_IN: 900 } }] } },
+      { yearMonth: '2026-01', projection: { weeks: [{ amounts: { SALES_IN: 9999 } }] } },
+    ];
+
+    expect(canonicalCashflowAnnualYears(months, 2026)).toEqual([2024, 2025]);
+    expect(summarizeCanonicalCashflowYear(months, 2024, 'projection')).toMatchObject({
+      lineAmounts: { SALES_IN: 150, DIRECT_COST_OUT: 50 },
+      lineStates: { SALES_IN: 'VALUE', DIRECT_COST_OUT: 'VALUE', SALES_VAT_IN: 'EMPTY' },
+      totalIn: 150,
+      totalOut: 50,
+      net: 100,
+    });
+  });
+
+  it('hides values only when canonical loading failed without a retained model', () => {
+    expect(shouldHideCashflowValuesAfterLoadError('409 conflict', false)).toBe(true);
+    expect(shouldHideCashflowValuesAfterLoadError('409 conflict', true)).toBe(false);
+    expect(shouldHideCashflowValuesAfterLoadError(null, false)).toBe(false);
+  });
   it('limits Projection-Actual comparison to the server KST finance week', () => {
     const asOfWeek = { yearMonth: '2026-08', weekNo: 3 };
 

--- a/src/app/components/cashflow/cashflow-month-close.ts
+++ b/src/app/components/cashflow/cashflow-month-close.ts
@@ -1,4 +1,5 @@
-import { CASHFLOW_ALL_LINES } from '../../platform/cashflow-sheet';
+import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES } from '../../platform/cashflow-sheet';
+import type { CashflowSheetLineId } from '../../data/types';
 import type {
   CashflowMonthCloseCell,
   CashflowMonthCloseConfirmation,
@@ -22,6 +23,45 @@ export type CashflowMonthCloseDepositReviewRow = Omit<CashflowMonthCloseDepositS
 };
 
 export const CASHFLOW_MONTH_CLOSE_WEEK_NOS = [1, 2, 3, 4, 5] as const;
+
+type CanonicalCashflowMonth = {
+  yearMonth: string;
+  projection?: { weeks?: Array<{ amounts?: Partial<Record<CashflowSheetLineId, number>> }> };
+  actual?: { weeks?: Array<{ amounts?: Partial<Record<CashflowSheetLineId, number>> }> };
+};
+
+export function canonicalCashflowAnnualYears(months: CanonicalCashflowMonth[], selectedYear: number): number[] {
+  return [...new Set(months
+    .map((month) => Number(month.yearMonth.slice(0, 4)))
+    .filter((year) => Number.isSafeInteger(year) && year !== selectedYear))]
+    .sort((left, right) => left - right);
+}
+
+export function summarizeCanonicalCashflowYear(
+  months: CanonicalCashflowMonth[],
+  year: number,
+  mode: 'projection' | 'actual',
+) {
+  const selected = months.filter((month) => Number(month.yearMonth.slice(0, 4)) === year);
+  if (!selected.length) return null;
+  const lineAmounts = Object.fromEntries(CASHFLOW_ALL_LINES.map((lineId) => [
+    lineId,
+    selected.reduce((total, month) => total + (month[mode]?.weeks || [])
+      .reduce((monthTotal, week) => monthTotal + Number(week.amounts?.[lineId] || 0), 0), 0),
+  ])) as Record<CashflowSheetLineId, number>;
+  const lineStates = Object.fromEntries(CASHFLOW_ALL_LINES.map((lineId) => {
+    const hasValue = selected.some((month) => (month[mode]?.weeks || [])
+      .some((week) => Object.prototype.hasOwnProperty.call(week.amounts || {}, lineId)));
+    return [lineId, hasValue ? (lineAmounts[lineId] === 0 ? 'ZERO' : 'VALUE') : 'EMPTY'];
+  })) as Record<CashflowSheetLineId, 'VALUE' | 'ZERO' | 'EMPTY'>;
+  const totalIn = CASHFLOW_IN_LINES.reduce((sum, lineId) => sum + lineAmounts[lineId], 0);
+  const totalOut = CASHFLOW_OUT_LINES.reduce((sum, lineId) => sum + lineAmounts[lineId], 0);
+  return { lineAmounts, lineStates, totalIn, totalOut, net: totalIn - totalOut };
+}
+
+export function shouldHideCashflowValuesAfterLoadError(error: string | null, hasCanonical: boolean): boolean {
+  return Boolean(error) && !hasCanonical;
+}
 
 export function isCashflowComparisonWeekVisible(
   week: { yearMonth: string; weekNo: number },


### PR DESCRIPTION
## What
- read legacy Live month-close documents without mutating them
- keep canonical write guards fail-closed
- restore 2024/2025 annual columns from canonical weekly ledger
- prevent failed reads from rendering synthetic zero values
- remove the undeployed audit composite-index dependency

## Verification
- Vitest targeted: 235/235
- JVM full test suite: pass
- production build: pass
- independent QA: pass

## Ops
- DB/mirror/sheet writes: none
- production deploy via GitHub Actions only