### PR TITLE
fix(ci): run JVM live deploy on Java 21

### DIFF
--- a/.github/workflows/jvm-production-deploy.yml
+++ b/.github/workflows/jvm-production-deploy.yml
@@ -38,6 +38,11 @@ jobs:
           ref: main
           fetch-depth: 1
 
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+
       - name: Verify dispatched main commit
         run: test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
 

--- a/server/jvm-weekly-api/live-deploy-workflow.test.ts
+++ b/server/jvm-weekly-api/live-deploy-workflow.test.ts
@@ -18,6 +18,7 @@ describe('JVM production deploy workflow', () => {
     expect(workflow.indexOf('update-traffic')).toBeGreaterThan(workflow.indexOf('/month-close/dashboard-source'));
     expect(workflow).toContain('workload_identity_provider');
     expect(workflow).toContain('actions: read');
+    expect(workflow).toContain("java-version: '21'");
     expect(workflow).not.toContain('service_account_key');
     expect(workflow).toContain('CASHFLOW_PROJECT_ID: p1773817948751');
     expect(workflow).toContain('CASHFLOW_YEAR_MONTH: 2026-07');


### PR DESCRIPTION
Fix the Live JVM deployment runner to use the project-required Java 21 toolchain.

The previous run stopped during Maven compilation before building or changing candidate/live traffic.

Test: targeted workflow test passes.