### PR TITLE
fix(cashflow): mint JVM probe token via GitHub OIDC

### DIFF
--- a/.github/workflows/jvm-production-deploy.yml
+++ b/.github/workflows/jvm-production-deploy.yml
@@ -58,9 +58,12 @@ jobs:
           ' <<< "${runs}" >/dev/null
 
       - uses: google-github-actions/auth@v3
+        id: auth
         with:
           workload_identity_provider: ${{ vars.GCP_WIF_PROVIDER_LIVE }}
           service_account: ${{ vars.GCP_JVM_DEPLOYER_SERVICE_ACCOUNT_LIVE }}
+          token_format: id_token
+          id_token_audience: ${{ vars.JVM_WEEKLY_API_ID_TOKEN_AUDIENCE_LIVE }}
 
       - uses: google-github-actions/setup-gcloud@v3
 
@@ -114,14 +117,14 @@ jobs:
       - name: Verify candidate against legacy live read
         env:
           CANDIDATE_URL: ${{ steps.candidate.outputs.url }}
+          ID_TOKEN: ${{ steps.auth.outputs.id_token }}
         run: |
-          id_token="$(gcloud auth print-identity-token --audiences="${JVM_WEEKLY_API_ID_TOKEN_AUDIENCE}")"
           curl --fail --silent --show-error \
-            -H "Authorization: Bearer ${id_token}" \
+            -H "Authorization: Bearer ${ID_TOKEN}" \
             "${CANDIDATE_URL}/api/v1/health" \
             | jq -e '.ok == true and .service == "jvm-weekly-api"' >/dev/null
           curl --fail --silent --show-error \
-            -H "Authorization: Bearer ${id_token}" \
+            -H "Authorization: Bearer ${ID_TOKEN}" \
             -H "x-inner-platform-service-token: ${JVM_WEEKLY_INTERNAL_API_TOKEN}" \
             -H 'x-tenant-id: mysc' \
             -H 'x-actor-id: github-jvm-deployer' \
@@ -141,15 +144,16 @@ jobs:
             --set-tags "candidate=${REVISION}"
 
       - name: Verify canonical service after promotion
+        env:
+          ID_TOKEN: ${{ steps.auth.outputs.id_token }}
         run: |
           canonical_url="$(gcloud run services describe "${SERVICE}" --project "${PROJECT_ID}" --region "${REGION}" --format='value(status.url)')"
-          id_token="$(gcloud auth print-identity-token --audiences="${JVM_WEEKLY_API_ID_TOKEN_AUDIENCE}")"
           curl --fail --silent --show-error \
-            -H "Authorization: Bearer ${id_token}" \
+            -H "Authorization: Bearer ${ID_TOKEN}" \
             "${canonical_url}/api/v1/health" \
             | jq -e '.ok == true and .service == "jvm-weekly-api"' >/dev/null
           curl --fail --silent --show-error \
-            -H "Authorization: Bearer ${id_token}" \
+            -H "Authorization: Bearer ${ID_TOKEN}" \
             -H "x-inner-platform-service-token: ${JVM_WEEKLY_INTERNAL_API_TOKEN}" \
             -H 'x-tenant-id: mysc' \
             -H 'x-actor-id: github-jvm-deployer' \

--- a/server/jvm-weekly-api/live-deploy-workflow.test.ts
+++ b/server/jvm-weekly-api/live-deploy-workflow.test.ts
@@ -12,6 +12,9 @@ describe('JVM production deploy workflow', () => {
     expect(workflow.indexOf('/month-close/dashboard-source')).toBeGreaterThan(workflow.indexOf('--no-traffic'));
     expect(workflow.indexOf('update-traffic')).toBeGreaterThan(workflow.indexOf('/month-close/dashboard-source'));
     expect(workflow).toContain('workload_identity_provider');
+    expect(workflow).toContain('token_format: id_token');
+    expect(workflow).toContain('ID_TOKEN: ${{ steps.auth.outputs.id_token }}');
+    expect(workflow).not.toContain('gcloud auth print-identity-token');
     expect(workflow).toContain('actions: read');
     expect(workflow).toContain("java-version: '21'");
     expect(workflow).not.toContain('service_account_key');


### PR DESCRIPTION
## What\n- request the Cloud Run audience ID token directly from the existing keyless GitHub OIDC auth step\n- reuse that masked token for candidate and canonical read-only probes\n\n## Why\nThe candidate deployed successfully, but gcloud cannot mint an audience token from an external-account credential. Live traffic was not changed.\n\n## Verification\n- npx vitest run server/jvm-weekly-api/live-deploy-workflow.test.ts\n- git diff --check\n\nNo DB, mirror, or sheet writes.