### PR TITLE
fix(deploy): restore sheets service account auth

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -50,7 +50,6 @@ jobs:
       JVM_WEEKLY_API_ID_TOKEN_AUDIENCE: ${{ vars.JVM_WEEKLY_API_ID_TOKEN_AUDIENCE_LIVE }}
       JVM_WEEKLY_INTERNAL_API_TOKEN: ${{ secrets.JVM_WEEKLY_INTERNAL_API_TOKEN_LIVE }}
       JVM_WEEKLY_API_SERVICE_ACCOUNT_JSON: ${{ secrets.JVM_WEEKLY_API_SERVICE_ACCOUNT_JSON_LIVE }}
-      GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON: '{}'
       # Use a production-scoped secret name so a stale repository-level
       # VERCEL_TOKEN cannot be confused with the Production environment token.
       VERCEL_TOKEN: ${{ secrets.VERCEL_DEPLOY_TOKEN_PRODUCTION }}
@@ -152,7 +151,6 @@ jobs:
             --env JVM_WEEKLY_API_ID_TOKEN_AUDIENCE="${JVM_WEEKLY_API_ID_TOKEN_AUDIENCE}" \
             --env JVM_WEEKLY_INTERNAL_API_TOKEN="${JVM_WEEKLY_INTERNAL_API_TOKEN}" \
             --env JVM_WEEKLY_API_SERVICE_ACCOUNT_JSON="${JVM_WEEKLY_API_SERVICE_ACCOUNT_JSON}" \
-            --env GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON="${GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON}" \
             --env SLACK_ALERT_WEBHOOK_URL= \
             --env SLACK_ALERT_BOT_TOKEN= \
             --env SLACK_ALERT_CHANNEL_ID= \

--- a/server/production-deploy-workflow.test.ts
+++ b/server/production-deploy-workflow.test.ts
@@ -95,7 +95,8 @@ describe('production deployment workflow safety', () => {
     expect(workflowText).toContain('--env JVM_WEEKLY_API_ID_TOKEN_AUDIENCE="${JVM_WEEKLY_API_ID_TOKEN_AUDIENCE}"');
     expect(workflowText).toContain('--env JVM_WEEKLY_INTERNAL_API_TOKEN="${JVM_WEEKLY_INTERNAL_API_TOKEN}"');
     expect(workflowText).toContain('--env JVM_WEEKLY_API_SERVICE_ACCOUNT_JSON="${JVM_WEEKLY_API_SERVICE_ACCOUNT_JSON}"');
-    expect(workflowText).toContain('--env GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON="${GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON}"');
+    expect(workflowText).not.toContain("GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON: '{}'");
+    expect(workflowText).not.toContain('--env GOOGLE_DRIVE_SERVICE_ACCOUNT_JSON=');
     expect(workflowText).toContain('--env SLACK_ALERT_WEBHOOK_URL=');
     expect(workflowText).toContain('--build-env VITE_FIRESTORE_CORE_ENABLED=false');
     expect(workflowText).toContain('--build-env VITE_FIREBASE_PROJECT_ID="${LIVE_FIREBASE_PROJECT_ID}"');


### PR DESCRIPTION
## What
- stop Production Deploy from overriding the stored Google Sheets service account with `{}`
- preserve the Vercel Production credential already configured for the project
- add a regression assertion that forbids the empty runtime override

## Verification
- `npx vitest run server/production-deploy-workflow.test.ts server/bff/google-sheets.test.ts` (20 passed)
- cashflow route flaky socket test rerun alone (passed)
- `npm run build`
- workflow YAML parse, `git diff --check`, secret scan

## Safety
- no DB or Google Sheet writes
- no credential values committed or logged
- rollback baseline: production deployment from `06ee1d9a78781c28c3b5c65d88b181edf0a2594a`