### PR TITLE
fix(cashflow): restore legacy month-close confirmation

### DIFF
--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -1499,8 +1499,9 @@ async function readCanonicalClosedCashflowMonths({ db, tenantId, projectId, year
     const snap = await db.doc(`orgs/${tenantId}/monthly_closes/${projectId}-${yearMonth}`).get();
     if (!snap.exists) return;
     const close = snap.data() || {};
+    const legacyOpen = !Object.hasOwn(close, 'contractVersion') && readOptionalText(close.status) === 'OPEN';
     if (
-      readOptionalText(close.contractVersion) !== 'cashflow-month-close-v1'
+      (!legacyOpen && readOptionalText(close.contractVersion) !== 'cashflow-month-close-v1')
       || readOptionalText(close.tenantId) !== tenantId
       || readOptionalText(close.projectId) !== projectId
       || readOptionalText(close.yearMonth) !== yearMonth

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -3797,6 +3797,21 @@ describe('cashflow sheet lab route', () => {
     });
     expect(db.__getDocument(`orgs/tenant-a/cashflow_sheet_stage_runs/${stage.body.runId}`).status).toBe('READY');
 
+    const originalSourceRevision = currentMirror.sourceRevision;
+    currentMirror.sourceRevision = `sha256:${'9'.repeat(64)}`;
+    await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
+      .send({
+        stageRunId: stage.body.runId,
+        idempotencyKey: 'apply-formula-mismatch-stale-confirmation',
+        acceptFormulaMismatches: true,
+      })
+      .expect(409)
+      .expect((response) => expect(response.body.code).toBe('cashflow_sheet_mirror_revision_conflict'));
+    expect(javaWeeklyClient.validateCashflowSheetFormulas).toHaveBeenCalledTimes(1);
+    expect(javaWeeklyClient.applyCashflowSheetLab).not.toHaveBeenCalled();
+    currentMirror.sourceRevision = originalSourceRevision;
+
     await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
       .send({
@@ -3812,6 +3827,95 @@ describe('cashflow sheet lab route', () => {
     expect(javaWeeklyClient.validateCashflowSheetFormulas.mock.calls[0][0].acceptFormulaMismatches).toBe(false);
     expect(javaWeeklyClient.validateCashflowSheetFormulas.mock.calls[1][0].acceptFormulaMismatches).toBe(true);
     expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a monthly close missing only contractVersion as legacy v1 and reaches formula validation', async () => {
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        cashflowSheetLab: {
+          value: 'saved-spreadsheet-a',
+          sheetName: 'cashflow(사용내역 연동)',
+          startWeek: '26-1-1',
+          endWeek: '26-1-5',
+        },
+      },
+      initialDocuments: {
+        'orgs/tenant-a/monthly_closes/project-a-2026-01': {
+          tenantId: 'tenant-a',
+          projectId: 'project-a',
+          yearMonth: '2026-01',
+          status: 'OPEN',
+        },
+      },
+    });
+    const javaWeeklyClient = {
+      validateCashflowSheetFormulas: vi.fn(async () => {
+        throw Object.assign(new Error('formula confirmation required'), {
+          statusCode: 409,
+          code: 'cashflow_formula_mismatch_confirmation_required',
+          details: { mismatchCount: 1, mismatches: [] },
+        });
+      }),
+    };
+    const app = createApp({ db, routeOptions: { javaWeeklyClient } });
+    const mirror = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'refresh-legacy-month-close' })
+      .expect(200);
+    const stage = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-legacy-month-close' })
+      .expect(200);
+
+    await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
+      .send({ stageRunId: stage.body.runId, idempotencyKey: 'apply-legacy-month-close' })
+      .expect(409)
+      .expect((response) => expect(response.body.code).toBe('cashflow_formula_mismatch_confirmation_required'));
+    expect(javaWeeklyClient.validateCashflowSheetFormulas).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['contract version', { contractVersion: 'cashflow-month-close-v0' }],
+    ['blank contract version', { contractVersion: ' ' }],
+    ['legacy closed status', { status: 'CLOSED' }],
+    ['tenant', { tenantId: 'tenant-b' }],
+    ['project', { projectId: 'project-b' }],
+    ['month', { yearMonth: '2026-02' }],
+    ['status', { status: 'INVALID' }],
+  ])('still rejects a monthly close with an invalid %s', async (_field, override) => {
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        cashflowSheetLab: {
+          value: 'saved-spreadsheet-a',
+          sheetName: 'cashflow(사용내역 연동)',
+          startWeek: '26-1-1',
+          endWeek: '26-1-5',
+        },
+      },
+      initialDocuments: {
+        'orgs/tenant-a/monthly_closes/project-a-2026-01': {
+          tenantId: 'tenant-a',
+          projectId: 'project-a',
+          yearMonth: '2026-01',
+          status: 'OPEN',
+          ...override,
+        },
+      },
+    });
+    const app = createApp({ db });
+    const mirror = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: `refresh-invalid-month-close-${_field}` })
+      .expect(200);
+
+    await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: `stage-invalid-month-close-${_field}` })
+      .expect(409)
+      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_contract_invalid'));
   });
 
   it('applies a settled-week sheet change without a weekly confirmation', async () => {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -2659,7 +2659,9 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         String projectId,
         String yearMonth
     ) {
-        if (!CASHFLOW_MONTH_CLOSE_CONTRACT_VERSION.equals(text(close.get("contractVersion"), ""))
+        boolean legacyOpen = !close.containsKey("contractVersion")
+            && "OPEN".equals(text(close.get("status"), ""));
+        if ((!legacyOpen && !CASHFLOW_MONTH_CLOSE_CONTRACT_VERSION.equals(text(close.get("contractVersion"), "")))
             || !tenantId.equals(text(close.get("tenantId"), ""))
             || !projectId.equals(text(close.get("projectId"), ""))
             || !yearMonth.equals(text(close.get("yearMonth"), ""))) {

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowSheetMonthlyApplyServiceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowSheetMonthlyApplyServiceTest.java
@@ -171,6 +171,46 @@ class CashflowSheetMonthlyApplyServiceTest {
 
         verify(persistence, never()).replaceCashflowSheetMonth(any(), any(), any(), any(), any(), any());
         verify(persistence, never()).saveAuditEvent(any());
+
+        CashflowSheetLabApplyRequest accepted = new CashflowSheetLabApplyRequest(
+            "apply-formula-mismatch-accepted",
+            SOURCE_REVISION,
+            TARGET_REVISION,
+            "2026-07",
+            false,
+            null,
+            null,
+            List.of(),
+            calculationChecks("2026-07"),
+            completeCells(5),
+            true
+        );
+        when(persistence.replaceCashflowSheetMonth(
+            eq("tenant-a"), eq("project-a"), eq("cashflow-sheet-lab"), eq("2026-07"), eq(TARGET_REVISION),
+            eq(accepted.cells()), eq(false), isNull(), eq(SOURCE_REVISION), eq("apply-formula-mismatch-accepted")
+        )).thenReturn(new WeeklyExpensePersistence.CashflowSheetMonthReplacement(
+            List.of(), List.of(), List.of(), TARGET_REVISION
+        ));
+        when(persistence.saveAuditEvent(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(persistence.saveIdempotency(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CashflowSheetLabApplyResponse response = service(persistence).applyCashflowSheetLab(
+            ACTOR, "project-a", SESSION, accepted
+        );
+
+        assertThat(response.calculationChecks())
+            .filteredOn(check -> check.mode().equals("projection") && check.weekNo() == 1)
+            .singleElement()
+            .satisfies(check -> {
+                assertThat(check.reported().balance()).isEqualByComparingTo("0");
+                assertThat(check.calculated().depositTotal()).isEqualByComparingTo("700");
+                assertThat(check.calculated().withdrawalTotal()).isEqualByComparingTo("900");
+                assertThat(check.calculated().balance()).isEqualByComparingTo("-200");
+            });
+        verify(persistence).replaceCashflowSheetMonth(
+            eq("tenant-a"), eq("project-a"), eq("cashflow-sheet-lab"), eq("2026-07"), eq(TARGET_REVISION),
+            eq(accepted.cells()), eq(false), isNull(), eq(SOURCE_REVISION), eq("apply-formula-mismatch-accepted")
+        );
     }
 
     @Test

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -756,6 +756,33 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
+    void monthlyApplyAcceptsLegacyOpenMonthCloseWithoutContractVersion() {
+        Fixture fixture = fixture(activeMember(), activeLease());
+        fixture.documents.put(monthClosePath("project-a", "2026-07"), Map.of(
+            "tenantId", "tenant-a",
+            "projectId", "project-a",
+            "yearMonth", "2026-07",
+            "status", "OPEN",
+            "revision", 0L,
+            "reopenCount", 0L
+        ));
+        String targetRevision = FirestoreInheritedWeeklyExpensePersistence.computeCashflowTargetRevision(List.of());
+
+        CashflowSheetLabApplyResponse response = fixture.persistence.runCommandTransaction(() -> commandService(
+            fixture.persistence
+        ).applyCashflowSheetLab(
+            ACTOR,
+            "project-a",
+            SESSION,
+            monthlyRequest("legacy-open-month", targetRevision, "")
+        ));
+
+        assertThat(response.savedProjectionLineCount()).isEqualTo(80);
+        assertThat(response.savedActualLineCount()).isEqualTo(80);
+        assertThat(fixture.documents.keySet()).anyMatch(path -> path.contains("/cashflow_weeks/"));
+    }
+
+    @Test
     void fullYearApplySortsMonthsAndReadsAllSixtyWeeksInOneCommandTransaction() {
         Fixture fixture = fixture(activeMember(), activeLease());
         String targetRevision = FirestoreInheritedWeeklyExpensePersistence.computeCashflowTargetRevision(List.of());

--- a/src/app/components/cashflow/CashflowFormulaMismatchDialog.test.ts
+++ b/src/app/components/cashflow/CashflowFormulaMismatchDialog.test.ts
@@ -1,5 +1,9 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { describeCashflowFormulaMismatch } from './CashflowFormulaMismatchDialog';
+
+const source = readFileSync(fileURLToPath(new URL('./CashflowFormulaMismatchDialog.tsx', import.meta.url)), 'utf8');
 
 describe('CashflowFormulaMismatchDialog', () => {
   it('explains a missing weekly total with the official sheet calculation', () => {
@@ -43,5 +47,12 @@ describe('CashflowFormulaMismatchDialog', () => {
 
     expect(result.expected).toContain('직전 기간의 잔액에 이번 기간 입금 합계를 더하고 출금 합계를 뺀 값');
     expect(result.current).toContain('10원이 표시되어 있습니다.');
+  });
+
+  it('makes the source-value override and platform-calculated totals explicit', () => {
+    expect(source).toContain('시트의 원천 항목값을 가져오고');
+    expect(source).toContain('입금 합계·출금 합계·잔액은 플랫폼 계산값으로 반영합니다');
+    expect(source).toContain('차이를 확인하고 원천값 반영');
+    expect(source).toContain('<AlertDialogCancel disabled={busy} onClick={onCancel}>취소</AlertDialogCancel>');
   });
 });

--- a/src/app/components/cashflow/CashflowFormulaMismatchDialog.tsx
+++ b/src/app/components/cashflow/CashflowFormulaMismatchDialog.tsx
@@ -77,7 +77,7 @@ export function CashflowFormulaMismatchDialog({
             {first
               ? `${periodLabel(first)} ${first.mode === 'projection' ? 'Projection' : 'Actual'}의 ${fieldLabels[first.field]}가 공식 시트 양식의 계산 결과와 다릅니다.`
               : ''}
-            {' '}아래 계산대로 시트를 고친 뒤 다시 불러오는 것을 권장합니다.
+            {' '}아래 계산대로 시트를 고친 뒤 다시 불러오는 것을 권장합니다. 계속하면 시트의 원천 항목값을 가져오고, 입금 합계·출금 합계·잔액은 플랫폼 계산값으로 반영합니다.
           </AlertDialogDescription>
         </AlertDialogHeader>
         <div className="max-h-80 space-y-3 overflow-y-auto rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-[13px] text-slate-800">
@@ -96,7 +96,7 @@ export function CashflowFormulaMismatchDialog({
           <AlertDialogCancel disabled={busy} onClick={onCancel}>취소</AlertDialogCancel>
           <Button type="button" className="bg-[#17324D] hover:bg-slate-800" disabled={busy} onClick={onConfirm}>
             {busy && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
-            그래도 현재 시트값 반영
+            차이를 확인하고 원천값 반영
           </Button>
         </AlertDialogFooter>
       </AlertDialogContent>


### PR DESCRIPTION
## Summary

- Allow only legacy `OPEN` month-close documents without `contractVersion` to reach the existing JVM formula validation flow.
- Keep tenant, project, month, status, revision, and explicit contract-version guards intact.
- Explain that confirmed imports preserve source item values while totals and balance use platform calculations.

## Verification

- BFF cashflow sheet lab: 82/82 passed
- JVM monthly apply service: 12/12 passed
- Formula mismatch dialog: 4/4 passed
- Projects regression rerun: 92/92 passed
- Production build: passed
- Full unit suite: 2,604 passed, one transient socket hang-up passed on isolated rerun
- Independent coverage audit: 92%

## Operations

- No database or Google Sheet data mutation performed.
- Production deployment must use the `Production Deploy` GitHub Actions workflow after merge and green CI.
