### PR TITLE
feat(cashflow): add latency phase observability

### DIFF
--- a/server/bff/cashflow-performance.mjs
+++ b/server/bff/cashflow-performance.mjs
@@ -1,0 +1,98 @@
+import { performance } from 'node:perf_hooks';
+
+const SAFE_TEXT = /^[a-zA-Z0-9_.:-]+$/;
+
+function safeText(value, fallback = 'unknown') {
+  const text = typeof value === 'string' ? value.trim().slice(0, 128) : '';
+  return text && SAFE_TEXT.test(text) ? text : fallback;
+}
+
+function safeDuration(value) {
+  return Math.max(0, Math.round(Number(value) || 0));
+}
+
+function safeErrorCode(value) {
+  const code = safeText(value, 'unknown');
+  return /^(?:cashflow_|java_|jvm_)[a-z0-9_]+$/.test(code)
+    || ['AbortError', 'Error', 'TypeError'].includes(code)
+    ? code
+    : 'unknown';
+}
+
+function defaultLogger(payload) {
+  if (process.env.NODE_ENV === 'test') return;
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(payload));
+}
+
+export function createCashflowPerformanceTrace({
+  requestId,
+  operation,
+  logger = defaultLogger,
+  now = () => performance.now(),
+} = {}) {
+  const startedAt = now();
+
+  const emit = (phase, details = {}) => {
+    const payload = {
+      severity: details.outcome === 'error' ? 'WARNING' : 'INFO',
+      message: 'cashflow.performance',
+      requestId: safeText(requestId),
+      operation: safeText(operation),
+      phase: safeText(phase),
+      ...(Number.isSafeInteger(details.attempt) ? { attempt: details.attempt } : {}),
+      ...(details.outcome ? { outcome: safeText(details.outcome) } : {}),
+      ...(Number.isInteger(details.statusCode) ? { statusCode: details.statusCode } : {}),
+      ...(typeof details.retryable === 'boolean' ? { retryable: details.retryable } : {}),
+      ...(details.errorCode ? { errorCode: safeErrorCode(details.errorCode) } : {}),
+      durationMs: safeDuration(details.durationMs),
+      totalMs: safeDuration(now() - startedAt),
+    };
+    if (logger === defaultLogger && process.env.NODE_ENV === 'test') return;
+    setImmediate(() => {
+      try {
+        logger(payload);
+      } catch {
+        // Diagnostics must never affect the request being measured.
+      }
+    }).unref?.();
+  };
+
+  const measure = async (phase, task, details = {}) => {
+    const phaseStartedAt = now();
+    try {
+      const result = await task();
+      emit(phase, { ...details, outcome: 'ok', durationMs: now() - phaseStartedAt });
+      return result;
+    } catch (error) {
+      emit(phase, {
+        ...details,
+        outcome: 'error',
+        statusCode: error?.statusCode,
+        errorCode: error?.code || error?.name,
+        durationMs: now() - phaseStartedAt,
+      });
+      throw error;
+    }
+  };
+
+  const measureSync = (phase, task, details = {}) => {
+    const phaseStartedAt = now();
+    try {
+      const result = task();
+      emit(phase, { ...details, outcome: 'ok', durationMs: now() - phaseStartedAt });
+      return result;
+    } catch (error) {
+      emit(phase, {
+        ...details,
+        outcome: 'error',
+        statusCode: error?.statusCode,
+        errorCode: error?.code || error?.name,
+        durationMs: now() - phaseStartedAt,
+      });
+      throw error;
+    }
+  };
+
+  return { emit, measure, measureSync };
+}

--- a/server/bff/cashflow-performance.test.mjs
+++ b/server/bff/cashflow-performance.test.mjs
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createCashflowPerformanceTrace } from './cashflow-performance.mjs';
+
+const flushLogs = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('cashflow performance trace', () => {
+  it('records only safe timing metadata with one request id', async () => {
+    const events = [];
+    const ticks = [0, 2, 8, 9];
+    const trace = createCashflowPerformanceTrace({
+      requestId: 'req-1',
+      operation: 'cashflow.read',
+      logger: (event) => events.push(event),
+      now: () => ticks.shift() ?? 9,
+    });
+
+    await expect(trace.measure('upstream_ttfb', async () => ({ secret: 'not-logged' }), { attempt: 1 }))
+      .resolves.toEqual({ secret: 'not-logged' });
+    await flushLogs();
+
+    expect(events).toEqual([{
+      severity: 'INFO',
+      message: 'cashflow.performance',
+      requestId: 'req-1',
+      operation: 'cashflow.read',
+      phase: 'upstream_ttfb',
+      attempt: 1,
+      outcome: 'ok',
+      durationMs: 6,
+      totalMs: 9,
+    }]);
+    expect(JSON.stringify(events)).not.toContain('not-logged');
+  });
+
+  it('preserves the measured result when the logger throws', async () => {
+    const trace = createCashflowPerformanceTrace({
+      requestId: 'req-2',
+      operation: 'cashflow.read',
+      logger: () => { throw new Error('logger failed'); },
+    });
+
+    await expect(trace.measure('body_read', async () => 'same-result')).resolves.toBe('same-result');
+    await flushLogs();
+  });
+
+  it('logs a safe error code and rethrows the original error', async () => {
+    const events = [];
+    const error = Object.assign(new Error('contains private workbook value'), {
+      code: 'jvm_weekly_api_unreachable',
+      statusCode: 503,
+    });
+    const trace = createCashflowPerformanceTrace({
+      requestId: 'req-3',
+      operation: 'cashflow.read',
+      logger: (event) => events.push(event),
+    });
+
+    await expect(trace.measure('auth_headers', async () => { throw error; })).rejects.toBe(error);
+    await flushLogs();
+    expect(events[0]).toMatchObject({
+      outcome: 'error',
+      statusCode: 503,
+      errorCode: 'jvm_weekly_api_unreachable',
+    });
+    expect(JSON.stringify(events)).not.toContain('private workbook value');
+  });
+
+  it('keeps a slow logger outside the measured request path', async () => {
+    let logged = false;
+    const trace = createCashflowPerformanceTrace({
+      requestId: 'req-4',
+      operation: 'cashflow.read',
+      logger: () => {
+        const until = Date.now() + 20;
+        while (Date.now() < until) {}
+        logged = true;
+      },
+    });
+
+    await expect(trace.measure('body_read', async () => 'same-result')).resolves.toBe('same-result');
+    expect(logged).toBe(false);
+    await flushLogs();
+    expect(logged).toBe(true);
+  });
+});

--- a/server/bff/java-weekly-client.mjs
+++ b/server/bff/java-weekly-client.mjs
@@ -3,6 +3,7 @@ import {
   buildJavaWeeklyTrustedHeaders,
   resolveJavaWeeklyApiServiceAccountJson,
 } from './java-weekly-auth.mjs';
+import { createCashflowPerformanceTrace } from './cashflow-performance.mjs';
 
 export {
   buildJavaWeeklyTrustedHeaders,
@@ -162,6 +163,8 @@ export function createJavaWeeklyClient({
   jvmWeeklyFirestoreProjectId,
   jvmWeeklyApiTimeoutMs,
   jvmWeeklyApiMaxResponseBytes,
+  performanceLogger,
+  performanceNow,
 } = {}) {
   const baseUrl = resolveJavaWeeklyApiBaseUrl({ jvmWeeklyApiBaseUrl }, env);
   const serviceToken = resolveJavaWeeklyApiServiceToken({ jvmWeeklyApiServiceToken }, env);
@@ -204,6 +207,12 @@ export function createJavaWeeklyClient({
     const requestStartedAt = Date.now();
     const endpoint = safeEndpoint(baseUrl);
     const commandName = readOptionalText(command) || method.toLowerCase();
+    const trace = createCashflowPerformanceTrace({
+      requestId: context?.requestId,
+      operation: commandName,
+      ...(performanceLogger ? { logger: performanceLogger } : {}),
+      ...(performanceNow ? { now: performanceNow } : {}),
+    });
     const metadata = (attempt, upstreamStatus, retryable, mutationOutcome) => ({
       endpoint,
       command: commandName,
@@ -214,6 +223,11 @@ export function createJavaWeeklyClient({
       mutationOutcome,
     });
     if (!baseUrl) {
+      trace.emit('request_rejected', {
+        outcome: 'error',
+        statusCode: 503,
+        errorCode: 'jvm_weekly_api_unconfigured',
+      });
       throw attachTransportMetadata(
         createHttpError(503, '캐시플로 서버 주소가 설정되지 않았습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_api_unconfigured'),
         metadata(0, undefined, false, mutation ? 'not_started' : 'failed'),
@@ -234,6 +248,7 @@ export function createJavaWeeklyClient({
       metadata(attempt, undefined, true, mutationOutcome),
     );
     const send = async (attempt) => {
+      trace.emit('attempt_start', { attempt, outcome: 'started' });
       const remainingMs = requestDeadlineAtMs - Date.now();
       if (remainingMs <= 0) {
         if (callerDeadlineReached()) throw callerDeadlineError(attempt, mutation ? 'not_started' : 'failed');
@@ -256,7 +271,7 @@ export function createJavaWeeklyClient({
       });
       timeout.unref?.();
       const attemptPromise = (async () => {
-        const headers = await buildJavaWeeklyTrustedHeaders({
+        const headers = await trace.measure('auth_headers', () => buildJavaWeeklyTrustedHeaders({
           fetchImpl,
           context,
           serviceToken,
@@ -268,16 +283,20 @@ export function createJavaWeeklyClient({
           editSession,
           dataProjectId,
           signal: controller.signal,
-        });
+        }), { attempt });
         sent = true;
-        const response = await fetchImpl(`${baseUrl.replace(/\/$/, '')}${path}`, {
+        const response = await trace.measure('upstream_ttfb', () => fetchImpl(`${baseUrl.replace(/\/$/, '')}${path}`, {
           method,
           headers,
           body: method === 'GET' ? undefined : JSON.stringify(body || {}),
           signal: controller.signal,
-        });
+        }), { attempt });
         upstreamStatus = response.status;
-        const parsed = await readJsonResponse(response, maxResponseBytes);
+        const parsed = await trace.measure(
+          'body_read',
+          () => readJsonResponse(response, maxResponseBytes),
+          { attempt, statusCode: response.status },
+        );
         if (!response.ok) {
           throw attachTransportMetadata(
             readJavaError(response.status, parsed.payload),
@@ -293,8 +312,21 @@ export function createJavaWeeklyClient({
         return parsed.payload;
       })();
       try {
-        return await Promise.race([attemptPromise, timeoutPromise]);
+        const result = await Promise.race([attemptPromise, timeoutPromise]);
+        trace.emit('attempt_complete', {
+          attempt,
+          outcome: 'ok',
+          statusCode: upstreamStatus,
+        });
+        return result;
       } catch (error) {
+        trace.emit('attempt_complete', {
+          attempt,
+          outcome: 'error',
+          statusCode: error?.statusCode || upstreamStatus,
+          retryable: !Number.isInteger(error?.statusCode) || Boolean(error?.transportFailure),
+          errorCode: error?.code || error?.name,
+        });
         if (Number.isInteger(error?.statusCode)) {
           if (!Number.isInteger(error.attempt)) {
             attachTransportMetadata(
@@ -326,6 +358,12 @@ export function createJavaWeeklyClient({
       if (!error?.transportFailure) throw error;
       if (callerDeadlineReached()) throw callerDeadlineError(1, error.mutationOutcome);
       if (!retryAllowed) throw error;
+      trace.emit('retry_scheduled', {
+        attempt: 2,
+        outcome: 'retry',
+        retryable: true,
+        errorCode: error?.code || error?.name,
+      });
       try {
         return await send(2);
       } catch (retryError) {

--- a/server/bff/java-weekly-client.test.mjs
+++ b/server/bff/java-weekly-client.test.mjs
@@ -414,6 +414,79 @@ describe('Java weekly cashflow client', () => {
     expect(fetchImpl.mock.calls[1][1].body).toBe(fetchImpl.mock.calls[0][1].body);
   });
 
+  it('separates auth, TTFB, body read, and retry timing without logging request data', async () => {
+    const events = [];
+    const fetchImpl = vi.fn()
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: responseBody({ ok: true, projectId: 'project-a', privateAmount: 987654321 }),
+      });
+    const client = createJavaWeeklyClient({
+      env: stageEnv(),
+      fetchImpl,
+      performanceLogger: (event) => events.push(event),
+    });
+
+    await client.applyCashflowSheetLab({
+      context: { ...context, requestId: 'req-performance-1' },
+      projectId: 'project-a',
+      idempotencyKey: 'apply-performance-1',
+      ...monthlyContract,
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(events.every((event) => event.requestId === 'req-performance-1')).toBe(true);
+    expect(events.filter((event) => event.phase === 'attempt_start').map((event) => event.attempt)).toEqual([1, 2]);
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({ phase: 'auth_headers', attempt: 1, outcome: 'ok' }),
+      expect.objectContaining({ phase: 'upstream_ttfb', attempt: 1, outcome: 'error' }),
+      expect.objectContaining({ phase: 'retry_scheduled', attempt: 2, retryable: true }),
+      expect.objectContaining({ phase: 'upstream_ttfb', attempt: 2, outcome: 'ok' }),
+      expect.objectContaining({ phase: 'body_read', attempt: 2, outcome: 'ok', statusCode: 200 }),
+      expect.objectContaining({ phase: 'attempt_complete', attempt: 2, outcome: 'ok', statusCode: 200 }),
+    ]));
+    const serialized = JSON.stringify(events);
+    expect(serialized).not.toContain('project-a');
+    expect(serialized).not.toContain('apply-performance-1');
+    expect(serialized).not.toContain('987654321');
+    expect(serialized).not.toContain('service-token');
+  });
+
+  it('starts the retry before a slow performance logger runs', async () => {
+    let loggerRan = false;
+    const fetchImpl = vi.fn()
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        body: responseBody({ ok: true, projectId: 'project-a' }),
+      });
+    const client = createJavaWeeklyClient({
+      env: stageEnv(),
+      fetchImpl,
+      performanceLogger: () => {
+        loggerRan = true;
+        const until = Date.now() + 20;
+        while (Date.now() < until) {}
+      },
+    });
+
+    await expect(client.applyCashflowSheetLab({
+      context,
+      projectId: 'project-a',
+      idempotencyKey: 'apply-slow-logger',
+      ...monthlyContract,
+    })).resolves.toMatchObject({ ok: true });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(loggerRan).toBe(false);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(loggerRan).toBe(true);
+  });
+
   it('uses the Stage invoker credential instead of the GCP metadata server', async () => {
     const fetchImpl = vi.fn(async () => ({
       ok: true,

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -20,6 +20,7 @@ import {
   summarizeCashflowAnnualMode,
 } from '../cashflow-annual-total.mjs';
 import { createJavaWeeklyClient } from '../java-weekly-client.mjs';
+import { createCashflowPerformanceTrace } from '../cashflow-performance.mjs';
 import { stableStringify } from '../utils.mjs';
 import { getMonthFinanceWeeks } from '../../../src/app/platform/cashflow-week-core.mjs';
 import {
@@ -3632,6 +3633,8 @@ export function mountCashflowSheetLabRoutes(app, {
   javaWeeklyClient,
   workspaceEmailDomain = 'mysc.co.kr',
   sheetPreviewCacheTtlMs = DEFAULT_SHEET_PREVIEW_CACHE_TTL_MS,
+  performanceLogger,
+  performanceNow,
 } = {}) {
   if (enabled === false) {
     app.use('/api/v1/projects/:projectId/cashflow-sheet-lab', (_req, res) => {
@@ -3650,7 +3653,7 @@ export function mountCashflowSheetLabRoutes(app, {
   const authoritativeWritesEnabled = readOptionalText(env.BFF_DEPLOY_ENV).toLowerCase() === 'stage'
     || Boolean(javaWeeklyClient);
   const authoritativeJavaClient = authoritativeWritesEnabled
-    ? (javaWeeklyClient || createJavaWeeklyClient({ env }))
+    ? (javaWeeklyClient || createJavaWeeklyClient({ env, performanceLogger, performanceNow }))
     : null;
   const systemAccountEmail = resolveSystemAccountEmail(googleSheetsService);
 
@@ -3699,6 +3702,12 @@ export function mountCashflowSheetLabRoutes(app, {
 
   app.post('/api/v1/projects/:projectId/cashflow-sheet-lab/mirror/refresh', asyncHandler(async (req, res) => {
     assertCashflowSheetLabAccess(req, workspaceEmailDomain);
+    const trace = createCashflowPerformanceTrace({
+      requestId: req.context?.requestId || req.requestId,
+      operation: 'cashflow.sheet_mirror.refresh',
+      ...(performanceLogger ? { logger: performanceLogger } : {}),
+      ...(performanceNow ? { now: performanceNow } : {}),
+    });
     const { tenantId } = req.context;
     const { projectId } = req.params;
     const parsed = parseWithSchema(
@@ -3706,7 +3715,10 @@ export function mountCashflowSheetLabRoutes(app, {
       req.body,
       'Invalid cashflow sheet mirror refresh payload',
     );
-    const project = await readProjectDocument(db, tenantId, projectId);
+    const project = await trace.measure(
+      'project_read',
+      () => readProjectDocument(db, tenantId, projectId),
+    );
     const sourceYear = resolveSourceYear(parsed.sourceYear, parsed, project);
     const source = resolvePreviewSource(
       { ...parsed, sourceYear },
@@ -3714,7 +3726,10 @@ export function mountCashflowSheetLabRoutes(app, {
     );
     const weekRange = normalizeWeekRange(source);
     const configRevision = computeCashflowSheetConfigRevision({ ...source, ...weekRange });
-    const previousMirror = await readCashflowSheetMirror(db, tenantId, projectId);
+    const previousMirror = await trace.measure(
+      'mirror_read',
+      () => readCashflowSheetMirror(db, tenantId, projectId),
+    );
     const refreshRequestHash = stableHash({
       sourceYear,
       value: source.value,
@@ -3729,16 +3744,19 @@ export function mountCashflowSheetLabRoutes(app, {
     ) {
       throw createHttpError(409, '같은 idempotencyKey에 다른 시트 연동 요청을 사용할 수 없습니다.', 'idempotency_key_reused');
     }
-    const refreshRun = await beginCashflowSheetRefreshRun({
-      db,
-      tenantId,
-      projectId,
-      idempotencyKey: parsed.idempotencyKey,
-      requestHash: refreshRequestHash,
-      configRevision,
-      attemptedAt,
-      context: req.context,
-    });
+    const refreshRun = await trace.measure(
+      'refresh_reserve',
+      () => beginCashflowSheetRefreshRun({
+        db,
+        tenantId,
+        projectId,
+        idempotencyKey: parsed.idempotencyKey,
+        requestHash: refreshRequestHash,
+        configRevision,
+        attemptedAt,
+        context: req.context,
+      }),
+    );
     if (refreshRun.replay) {
       res.status(200).json(refreshRun.replay);
       return;
@@ -3768,13 +3786,19 @@ export function mountCashflowSheetLabRoutes(app, {
     });
 
     try {
-      const preview = await loadSheetPreview({
-        value: source.value,
-        sheetName: source.sheetName,
-        bypassCache: true,
-      });
+      const preview = await trace.measure(
+        'google_sheet_fetch',
+        () => loadSheetPreview({
+          value: source.value,
+          sheetName: source.sheetName,
+          bypassCache: true,
+        }),
+      );
       assertCashflowUsageLinkedSheet(preview);
-      const template = analyzeCashflowSheetTemplate(preview.matrix);
+      const template = trace.measureSync(
+        'sheet_parse_validate',
+        () => analyzeCashflowSheetTemplate(preview.matrix),
+      );
       assertConfiguredWeekRangeExistsInTemplate(template, weekRange);
       if (!template.supported) {
         throw Object.assign(createHttpError(
@@ -3787,9 +3811,12 @@ export function mountCashflowSheetLabRoutes(app, {
         });
       }
 
-      const targetSnapshot = await readCashflowWeeksSnapshot(db, tenantId, projectId);
+      const targetSnapshot = await trace.measure(
+        'target_snapshot_read',
+        () => readCashflowWeeksSnapshot(db, tenantId, projectId),
+      );
       const mappings = template.mappingCandidates.filter((mapping) => isInWeekRange(mapping, weekRange));
-      const mirror = createCashflowPinnedSnapshot({
+      const mirror = trace.measureSync('mirror_build', () => createCashflowPinnedSnapshot({
         projectId,
         spreadsheetId: preview.spreadsheetId,
         spreadsheetTitle: preview.spreadsheetTitle,
@@ -3804,7 +3831,7 @@ export function mountCashflowSheetLabRoutes(app, {
           email: req.context?.actorEmail,
           role: req.context?.actorRole || 'workspace_user',
         },
-      });
+      }));
       mirror.activeWeekRange = {
         startWeek: weekRange.startWeek,
         endWeek: weekRange.endWeek,
@@ -3817,16 +3844,19 @@ export function mountCashflowSheetLabRoutes(app, {
       mirror.lastRefreshIdempotencyKey = parsed.idempotencyKey;
       mirror.lastRefreshRequestHash = refreshRequestHash;
       const mergedMirror = mergeCashflowSourceMirror(previousMirror, mirror, sourceYear);
-      const completedMirror = await completeCashflowSheetRefreshRun({
-        db,
-        tenantId,
-        projectId,
-        runRef: refreshRun.runRef,
-        requestHash: refreshRequestHash,
-        generation: refreshRun.generation,
-        response: mergedMirror,
-        completedAt: new Date().toISOString(),
-      });
+      const completedMirror = await trace.measure(
+        'mirror_publish',
+        () => completeCashflowSheetRefreshRun({
+          db,
+          tenantId,
+          projectId,
+          runRef: refreshRun.runRef,
+          requestHash: refreshRequestHash,
+          generation: refreshRun.generation,
+          response: mergedMirror,
+          completedAt: new Date().toISOString(),
+        }),
+      );
       logCashflowSheetLab('mirror.refresh.ok', req, {
         projectId,
         sourceRevision: completedMirror.sourceRevision,
@@ -3865,16 +3895,19 @@ export function mountCashflowSheetLabRoutes(app, {
           lastRefreshIdempotencyKey: parsed.idempotencyKey,
           lastRefreshRequestHash: refreshRequestHash,
         };
-      const completedMirror = await completeCashflowSheetRefreshRun({
-        db,
-        tenantId,
-        projectId,
-        runRef: refreshRun.runRef,
-        requestHash: refreshRequestHash,
-        generation: refreshRun.generation,
-        response: mirror,
-        completedAt: new Date().toISOString(),
-      });
+      const completedMirror = await trace.measure(
+        'mirror_publish_error',
+        () => completeCashflowSheetRefreshRun({
+          db,
+          tenantId,
+          projectId,
+          runRef: refreshRun.runRef,
+          requestHash: refreshRequestHash,
+          generation: refreshRun.generation,
+          response: mirror,
+          completedAt: new Date().toISOString(),
+        }),
+      );
       logCashflowSheetLab('mirror.refresh.failed', req, {
         projectId,
         mirrorStatus: completedMirror.status,
@@ -4016,13 +4049,19 @@ export function mountCashflowSheetLabRoutes(app, {
 
   app.post('/api/v1/projects/:projectId/cashflow-sheet-lab/stage', asyncHandler(async (req, res) => {
     assertCashflowSheetLabAccess(req, workspaceEmailDomain);
+    const trace = createCashflowPerformanceTrace({
+      requestId: req.context?.requestId || req.requestId,
+      operation: 'cashflow.sheet_stage',
+      ...(performanceLogger ? { logger: performanceLogger } : {}),
+      ...(performanceNow ? { now: performanceNow } : {}),
+    });
     const { tenantId } = req.context;
     const { projectId } = req.params;
     const parsed = parseWithSchema(cashflowSheetLabStageSchema, req.body, 'Invalid cashflow sheet lab stage payload');
     await readProjectDocument(db, tenantId, projectId);
 
     try {
-      const result = await stagePinnedCashflowSheetLab({
+      const result = await trace.measure('stage_total', () => stagePinnedCashflowSheetLab({
         db,
         tenantId,
         projectId,
@@ -4031,7 +4070,7 @@ export function mountCashflowSheetLabRoutes(app, {
         logger: (event, details = {}, level = 'info') => {
           logCashflowSheetLab(`stage.${event}`, req, details, level);
         },
-      });
+      }));
       res.status(200).json(result);
     } catch (error) {
       logCashflowSheetLab('stage.error', req, {

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -625,6 +625,7 @@ describe('cashflow sheet lab route', () => {
   });
 
   it('reads Google Sheets only on explicit mirror refresh and pins the result', async () => {
+    const performanceEvents = [];
     const db = createDb({
       project: {
         id: 'project-a',
@@ -645,7 +646,11 @@ describe('cashflow sheet lab route', () => {
       availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
       matrix: buildMatrix(),
     }));
-    const app = createApp({ db, googleSheetsService: { previewSpreadsheet } });
+    const app = createApp({
+      db,
+      googleSheetsService: { previewSpreadsheet },
+      routeOptions: { performanceLogger: (event) => performanceEvents.push(event) },
+    });
 
     const beforeRefresh = await request(app)
       .get('/api/v1/projects/project-a/cashflow-sheet-lab/mirror')
@@ -673,6 +678,18 @@ describe('cashflow sheet lab route', () => {
     expect(pinned.body.cells).toHaveLength(32);
     expect(previewSpreadsheet).toHaveBeenCalledTimes(1);
     expect(db.__getDocument().cashflowSheetLab.activeWeeks).toBeUndefined();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(performanceEvents).toEqual(expect.arrayContaining([
+      expect.objectContaining({ phase: 'project_read', operation: 'cashflow.sheet_mirror.refresh' }),
+      expect.objectContaining({ phase: 'mirror_read', operation: 'cashflow.sheet_mirror.refresh' }),
+      expect.objectContaining({ phase: 'refresh_reserve', operation: 'cashflow.sheet_mirror.refresh' }),
+      expect.objectContaining({ phase: 'google_sheet_fetch', operation: 'cashflow.sheet_mirror.refresh' }),
+      expect.objectContaining({ phase: 'sheet_parse_validate', operation: 'cashflow.sheet_mirror.refresh' }),
+      expect.objectContaining({ phase: 'target_snapshot_read', operation: 'cashflow.sheet_mirror.refresh' }),
+      expect.objectContaining({ phase: 'mirror_build', operation: 'cashflow.sheet_mirror.refresh' }),
+      expect.objectContaining({ phase: 'mirror_publish', operation: 'cashflow.sheet_mirror.refresh' }),
+    ]));
+    expect(performanceEvents.every((event) => event.requestId === 'req-1')).toBe(true);
   });
 
   it('stores weekly values and annual totals without requiring a missing future year', async () => {

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -11,6 +11,7 @@ import {
   resolveJavaWeeklyApiServiceAccountJson,
 } from '../java-weekly-auth.mjs';
 import { createJavaWeeklyClient } from '../java-weekly-client.mjs';
+import { createCashflowPerformanceTrace } from '../cashflow-performance.mjs';
 import {
   buildCashflowProjectionActualComparison,
   resolveCashflowComparisonAsOf,
@@ -2182,6 +2183,8 @@ export function mountJvmWeeklyApiRoutes(app, {
   jvmWeeklyFirestoreProjectId,
   jvmWeeklyApiTimeoutMs,
   cashflowMonthCloseRouteTimeoutMs,
+  performanceLogger,
+  performanceNow,
   now = () => new Date(),
 } = {}) {
   const baseUrl = resolveJavaWeeklyApiBaseUrl({ jvmWeeklyApiBaseUrl }, env);
@@ -2225,6 +2228,8 @@ export function mountJvmWeeklyApiRoutes(app, {
     jvmWeeklyWorkspaceEmailDomain: workspaceEmailDomain,
     jvmWeeklyFirestoreProjectId: firestoreProjectId,
     jvmWeeklyApiTimeoutMs,
+    performanceLogger,
+    performanceNow,
   });
 
   function proxyJavaWeeklyRequest(options) {
@@ -2442,6 +2447,12 @@ export function mountJvmWeeklyApiRoutes(app, {
   }));
 
   app.get('/api/v1/cashflow/:projectId/month-close', asyncHandler(async (req, res) => {
+    const trace = createCashflowPerformanceTrace({
+      requestId: req.context?.requestId || req.requestId,
+      operation: 'cashflow.month_close.read',
+      ...(performanceLogger ? { logger: performanceLogger } : {}),
+      ...(performanceNow ? { now: performanceNow } : {}),
+    });
     const body = await withCashflowMonthCloseDeadline(async () => {
       assertWeeklyWorkspaceOrRoleAllowed(req, ROUTE_ROLES.readCore, 'read cashflow month close', authMode, workspaceEmailDomain);
       const rawProjectId = readOptionalText(req.params.projectId);
@@ -2467,17 +2478,26 @@ export function mountJvmWeeklyApiRoutes(app, {
         asOfMs: qaClock.now.getTime(),
       };
       for (let attempt = 0; attempt < 2; attempt += 1) {
-        const publicationBefore = await readCashflowSheetPublicationState({
-          db,
-          tenantId: req.context.tenantId,
-          projectId: rawProjectId,
-        });
+        const traceAttempt = attempt + 1;
+        const publicationBefore = await trace.measure(
+          'publication_before',
+          () => readCashflowSheetPublicationState({
+            db,
+            tenantId: req.context.tenantId,
+            projectId: rawProjectId,
+          }),
+          { attempt: traceAttempt },
+        );
         assertCashflowSheetPublicationReady(publicationBefore);
-        const source = await proxyJavaWeeklyRequest({
-          context: req.context,
-          method: 'GET',
-          path: `/api/v1/cashflow/${projectId}/month-close/dashboard-source?yearMonth=${encodeURIComponent(yearMonth)}`,
-        });
+        const source = await trace.measure(
+          'jvm_dashboard',
+          () => proxyJavaWeeklyRequest({
+            context: req.context,
+            method: 'GET',
+            path: `/api/v1/cashflow/${projectId}/month-close/dashboard-source?yearMonth=${encodeURIComponent(yearMonth)}`,
+          }),
+          { attempt: traceAttempt },
+        );
         const result = objectValue(source?.monthClose);
         const cashflow = objectValue(source?.cashflow);
         const snapshotCompatibility = objectValue(source?.snapshotCompatibility) || {
@@ -2509,25 +2529,37 @@ export function mountJvmWeeklyApiRoutes(app, {
           || typeof projectionActualSummary?.settlementMatches !== 'boolean') {
           throw createHttpError(502, 'JVM 누적 Projection-Actual 요약을 확인할 수 없습니다.', 'jvm_weekly_response_invalid');
         }
-        const weeklyCompliance = await readWeeklyCompliance(req.context, rawProjectId);
-        const dashboard = await composeCashflowMonthDashboard({
-          db,
-          req,
-          projectId: rawProjectId,
-          yearMonth,
-          close: result,
-          cashflow,
-          openingBalances,
-          comparisonBoundary,
-          weeklyCompliance,
-          projectionActualSummary,
-          weeklyComplianceBoundary,
-        });
-        const publicationAfter = await readCashflowSheetPublicationState({
-          db,
-          tenantId: req.context.tenantId,
-          projectId: rawProjectId,
-        });
+        const weeklyCompliance = await trace.measure(
+          'jvm_compliance',
+          () => readWeeklyCompliance(req.context, rawProjectId),
+          { attempt: traceAttempt },
+        );
+        const dashboard = await trace.measure(
+          'dashboard_compose',
+          () => composeCashflowMonthDashboard({
+            db,
+            req,
+            projectId: rawProjectId,
+            yearMonth,
+            close: result,
+            cashflow,
+            openingBalances,
+            comparisonBoundary,
+            weeklyCompliance,
+            projectionActualSummary,
+            weeklyComplianceBoundary,
+          }),
+          { attempt: traceAttempt },
+        );
+        const publicationAfter = await trace.measure(
+          'publication_after',
+          () => readCashflowSheetPublicationState({
+            db,
+            tenantId: req.context.tenantId,
+            projectId: rawProjectId,
+          }),
+          { attempt: traceAttempt },
+        );
         assertCashflowSheetPublicationReady(publicationAfter);
         if (publicationBefore.fingerprint === publicationAfter.fingerprint) {
           return { ...result, dashboard };

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -569,6 +569,7 @@ describe('JVM weekly API BFF proxy', () => {
   });
 
   it('reads a cashflow month-close through the JVM with the requested yearMonth', async () => {
+    const performanceEvents = [];
     const fetchImpl = vi.fn(async () => ({
       ok: true,
       status: 200,
@@ -582,7 +583,7 @@ describe('JVM weekly API BFF proxy', () => {
     const { app } = createApp(fetchImpl, createIdempotencyService(), {
       actorId: 'auditor-1',
       actorRole: 'auditor',
-    });
+    }, { performanceLogger: (event) => performanceEvents.push(event) });
 
     await request(app)
       .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
@@ -602,6 +603,15 @@ describe('JVM weekly API BFF proxy', () => {
     );
     expect(fetchImpl.mock.calls[0][1].method).toBe('GET');
     expect(fetchImpl.mock.calls[0][1].body).toBeUndefined();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(performanceEvents).toEqual(expect.arrayContaining([
+      expect.objectContaining({ operation: 'cashflow.month_close.read', phase: 'publication_before' }),
+      expect.objectContaining({ operation: 'cashflow.month_close.read', phase: 'jvm_dashboard' }),
+      expect.objectContaining({ operation: 'cashflow.month_close.read', phase: 'jvm_compliance' }),
+      expect.objectContaining({ operation: 'cashflow.month_close.read', phase: 'dashboard_compose' }),
+      expect.objectContaining({ operation: 'cashflow.month_close.read', phase: 'publication_after' }),
+    ]));
+    expect(performanceEvents.every((event) => event.requestId === 'req-1')).toBe(true);
   });
 
   it('publishes the server-owned cumulative close scope and pinned sheet source for 2026-08', async () => {


### PR DESCRIPTION
## What\n- add structured BFF-to-JVM cashflow phase timing logs\n- separate auth, TTFB, body-read, retry, mirror/stage, and month-close phases\n- keep logging off the request critical path and restrict logged error codes\n\n## Why\nIdentify whether Live cashflow latency comes from upstream connection, JVM response, response-body transfer, mirror refresh, or publication reads before changing timeouts.\n\n## Verification\n- targeted BFF tests: 292/292 passed\n- production build passed\n- diff check and secret scan passed\n- independent QA: GO\n\n## Ops\n- no timeout, retry, DB, mirror, or Google Sheet behavior changes\n- no database or sheet migration\n- production deployment must run through the GitHub Actions Production Deploy workflow