### PR TITLE
fix(cashflow): enable aligned live sheet apply

### DIFF
--- a/server/bff/java-weekly-client.mjs
+++ b/server/bff/java-weekly-client.mjs
@@ -59,6 +59,26 @@ export function resolveBffDataProjectId(options = {}, env = process.env) {
     || readOptionalText(env.GOOGLE_CLOUD_PROJECT);
 }
 
+export function assertCashflowMutationRuntime(options = {}, env = process.env) {
+  const deployEnv = readOptionalText(env.BFF_DEPLOY_ENV).toLowerCase();
+  const bffDataProjectId = resolveBffDataProjectId(options, env);
+  const firestoreProjectId = resolveJavaWeeklyFirestoreProjectId(options, env);
+  const liveProjectId = readOptionalText(env.BFF_LIVE_FIREBASE_PROJECT_ID) || 'inner-platform-live-20260316';
+
+  if (!['stage', 'live'].includes(deployEnv)) {
+    throw createHttpError(503, '현재 환경에서는 캐시플로를 저장할 수 없습니다. 담당자에게 문의해 주세요.', 'unsafe_bff_runtime');
+  }
+  if (!bffDataProjectId || !firestoreProjectId || bffDataProjectId !== firestoreProjectId) {
+    throw createHttpError(503, '서버 설정이 서로 맞지 않아 캐시플로를 사용할 수 없습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_data_project_mismatch');
+  }
+  const projectMatchesEnvironment = deployEnv === 'live'
+    ? bffDataProjectId === liveProjectId
+    : bffDataProjectId !== liveProjectId;
+  if (!projectMatchesEnvironment) {
+    throw createHttpError(503, '현재 환경에서는 캐시플로를 저장할 수 없습니다. 담당자에게 문의해 주세요.', 'unsafe_bff_runtime');
+  }
+}
+
 const GENERIC_UPSTREAM_ERROR_CODES = new Set([
   'error',
   'internal_error',
@@ -426,16 +446,7 @@ export function createJavaWeeklyClient({
     if (!normalizedProjectId) {
       throw createHttpError(400, 'projectId is required.', 'project_id_required');
     }
-    if (readOptionalText(env.BFF_DEPLOY_ENV).toLowerCase() !== 'stage') {
-      throw createHttpError(503, '현재 환경에서는 캐시플로를 저장할 수 없습니다. 담당자에게 문의해 주세요.', 'unsafe_bff_runtime');
-    }
-    if (!bffDataProjectId || !firestoreProjectId || bffDataProjectId !== firestoreProjectId) {
-      throw createHttpError(503, '서버 설정이 서로 맞지 않아 캐시플로를 사용할 수 없습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_data_project_mismatch');
-    }
-    const liveProjectId = readOptionalText(env.BFF_LIVE_FIREBASE_PROJECT_ID) || 'inner-platform-live-20260316';
-    if (bffDataProjectId === liveProjectId) {
-      throw createHttpError(503, '테스트 환경에서는 실제 운영 자료를 변경할 수 없습니다. 담당자에게 문의해 주세요.', 'unsafe_bff_runtime');
-    }
+    assertCashflowMutationRuntime({ bffDataProjectId, jvmWeeklyFirestoreProjectId: firestoreProjectId }, env);
     const result = await requestJson({
       context,
       method: 'POST',
@@ -481,16 +492,7 @@ export function createJavaWeeklyClient({
     if (!normalizedProjectId) {
       throw createHttpError(400, 'projectId is required.', 'project_id_required');
     }
-    if (readOptionalText(env.BFF_DEPLOY_ENV).toLowerCase() !== 'stage') {
-      throw createHttpError(503, '현재 환경에서는 캐시플로를 저장할 수 없습니다. 담당자에게 문의해 주세요.', 'unsafe_bff_runtime');
-    }
-    if (!bffDataProjectId || !firestoreProjectId || bffDataProjectId !== firestoreProjectId) {
-      throw createHttpError(503, '서버 설정이 서로 맞지 않아 캐시플로를 사용할 수 없습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_data_project_mismatch');
-    }
-    const liveProjectId = readOptionalText(env.BFF_LIVE_FIREBASE_PROJECT_ID) || 'inner-platform-live-20260316';
-    if (bffDataProjectId === liveProjectId) {
-      throw createHttpError(503, '테스트 환경에서는 실제 운영 자료를 변경할 수 없습니다. 담당자에게 문의해 주세요.', 'unsafe_bff_runtime');
-    }
+    assertCashflowMutationRuntime({ bffDataProjectId, jvmWeeklyFirestoreProjectId: firestoreProjectId }, env);
     const result = await requestJson({
       context,
       method: 'POST',
@@ -579,16 +581,7 @@ export function createJavaWeeklyClient({
   }) {
     const normalizedProjectId = encodeURIComponent(readOptionalText(projectId));
     if (!normalizedProjectId) throw createHttpError(400, 'projectId is required.', 'project_id_required');
-    if (readOptionalText(env.BFF_DEPLOY_ENV).toLowerCase() !== 'stage') {
-      throw createHttpError(503, '현재 환경에서는 캐시플로를 저장할 수 없습니다. 담당자에게 문의해 주세요.', 'unsafe_bff_runtime');
-    }
-    if (!bffDataProjectId || !firestoreProjectId || bffDataProjectId !== firestoreProjectId) {
-      throw createHttpError(503, '서버 설정이 서로 맞지 않아 캐시플로를 사용할 수 없습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_data_project_mismatch');
-    }
-    const liveProjectId = readOptionalText(env.BFF_LIVE_FIREBASE_PROJECT_ID) || 'inner-platform-live-20260316';
-    if (bffDataProjectId === liveProjectId) {
-      throw createHttpError(503, '테스트 환경에서는 실제 운영 자료를 변경할 수 없습니다. 담당자에게 문의해 주세요.', 'unsafe_bff_runtime');
-    }
+    assertCashflowMutationRuntime({ bffDataProjectId, jvmWeeklyFirestoreProjectId: firestoreProjectId }, env);
     const result = await requestJson({
       context,
       method: 'POST',

--- a/server/bff/java-weekly-client.test.mjs
+++ b/server/bff/java-weekly-client.test.mjs
@@ -13,6 +13,18 @@ function stageEnv(overrides = {}) {
   };
 }
 
+function liveEnv(overrides = {}) {
+  return {
+    BFF_DEPLOY_ENV: 'live',
+    FIREBASE_PROJECT_ID: 'live-data-project',
+    BFF_LIVE_FIREBASE_PROJECT_ID: 'live-data-project',
+    JVM_WEEKLY_FIRESTORE_PROJECT_ID: 'live-data-project',
+    JVM_WEEKLY_API_BASE_URL: 'https://live-jvm.example',
+    JVM_WEEKLY_INTERNAL_API_TOKEN: 'service-token',
+    ...overrides,
+  };
+}
+
 const context = {
   tenantId: 'tenant-a',
   actorId: 'pm-1',
@@ -46,6 +58,58 @@ function chunkedResponse(chunks, { status = 200, headers = {} } = {}) {
 }
 
 describe('Java weekly cashflow client', () => {
+  it.each([
+    ['monthly', 'applyCashflowSheetLab', {
+      idempotencyKey: 'live-monthly-1',
+      ...monthlyContract,
+    }, '/sheet-lab/apply'],
+    ['batch', 'applyCashflowSheetBatch', {
+      idempotencyKey: 'live-batch-1',
+      sourceRevision: monthlyContract.sourceRevision,
+      targetRevision: monthlyContract.targetRevision,
+      months: [{ yearMonth: monthlyContract.yearMonth, cells: monthlyContract.cells }],
+    }, '/sheet-lab/batch/apply'],
+    ['annual', 'applyCashflowSheetAnnualTotal', {
+      idempotencyKey: 'live-annual-1',
+      sourceRevision: monthlyContract.sourceRevision,
+      year: 2025,
+      expectedRevision: 3,
+      cells: [{ mode: 'projection', cashflowLine: 'SALES_IN', cellState: 'VALUE', amount: 1000 }],
+    }, '/sheet-lab/annual/apply'],
+  ])('allows aligned Live %s apply to reach the JVM once', async (_case, method, payload, path) => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      body: responseBody({ ok: true, projectId: 'project-a' }),
+    }));
+    const client = createJavaWeeklyClient({ env: liveEnv(), fetchImpl });
+
+    await client[method]({ context, projectId: 'project-a', ...payload });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(fetchImpl.mock.calls[0][0]).toContain(path);
+  });
+
+  it.each([
+    ['unknown runtime', liveEnv({ BFF_DEPLOY_ENV: 'preview' })],
+    ['Live using an unapproved data project', liveEnv({
+      FIREBASE_PROJECT_ID: 'other-project',
+      JVM_WEEKLY_FIRESTORE_PROJECT_ID: 'other-project',
+    })],
+    ['Stage using the Live data project', liveEnv({ BFF_DEPLOY_ENV: 'stage' })],
+  ])('fails before network for %s', async (_case, env) => {
+    const fetchImpl = vi.fn();
+    const client = createJavaWeeklyClient({ env, fetchImpl });
+
+    await expect(client.applyCashflowSheetLab({
+      context,
+      projectId: 'project-a',
+      idempotencyKey: 'blocked-1',
+      ...monthlyContract,
+    })).rejects.toMatchObject({ statusCode: 503, code: 'unsafe_bff_runtime' });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it('forwards an annual total to the dedicated JVM authority endpoint', async () => {
     const fetchImpl = vi.fn(async (url, init) => ({
       ok: true,

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -19,7 +19,7 @@ import {
   cashflowAnnualTotalDocPath,
   summarizeCashflowAnnualMode,
 } from '../cashflow-annual-total.mjs';
-import { createJavaWeeklyClient } from '../java-weekly-client.mjs';
+import { assertCashflowMutationRuntime, createJavaWeeklyClient } from '../java-weekly-client.mjs';
 import { createCashflowPerformanceTrace } from '../cashflow-performance.mjs';
 import { stableStringify } from '../utils.mjs';
 import { getMonthFinanceWeeks } from '../../../src/app/platform/cashflow-week-core.mjs';
@@ -3650,7 +3650,7 @@ export function mountCashflowSheetLabRoutes(app, {
     googleSheetsService,
     cacheTtlMs: sheetPreviewCacheTtlMs,
   });
-  const authoritativeWritesEnabled = readOptionalText(env.BFF_DEPLOY_ENV).toLowerCase() === 'stage'
+  const authoritativeWritesEnabled = ['stage', 'live'].includes(readOptionalText(env.BFF_DEPLOY_ENV).toLowerCase())
     || Boolean(javaWeeklyClient);
   const authoritativeJavaClient = authoritativeWritesEnabled
     ? (javaWeeklyClient || createJavaWeeklyClient({ env, performanceLogger, performanceNow }))
@@ -4002,6 +4002,7 @@ export function mountCashflowSheetLabRoutes(app, {
     if (!authoritativeWritesEnabled) {
       throw createHttpError(503, '현재 환경에서는 캐시플로를 저장할 수 없습니다. 담당자에게 문의해 주세요.', 'unsafe_bff_runtime');
     }
+    if (!javaWeeklyClient) assertCashflowMutationRuntime({}, env);
     const { tenantId } = req.context;
     const { projectId } = req.params;
     const parsed = parseWithSchema(cashflowSheetLabApplySchema, req.body, 'Invalid cashflow sheet lab apply payload');

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -1989,6 +1989,65 @@ describe('cashflow sheet lab route', () => {
     expect(db.__getDocument('orgs/tenant-a/cashflow_weeks/project-a-2026-01-w1')).toBeUndefined();
   });
 
+  it('allows an aligned Live request to reach pinned-stage validation', async () => {
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        cashflowSheetLab: {
+          value: 'saved-spreadsheet-a',
+          sheetName: 'cashflow(사용내역 연동)',
+          startWeek: '26-1-1',
+          endWeek: '26-1-2',
+        },
+      },
+    });
+
+    await request(createApp({
+      db,
+      routeOptions: {
+        env: {
+          BFF_DEPLOY_ENV: 'live',
+          FIREBASE_PROJECT_ID: 'live-data-project',
+          BFF_LIVE_FIREBASE_PROJECT_ID: 'live-data-project',
+          JVM_WEEKLY_FIRESTORE_PROJECT_ID: 'live-data-project',
+          JVM_WEEKLY_API_BASE_URL: 'https://live-jvm.example',
+          JVM_WEEKLY_INTERNAL_API_TOKEN: 'service-token',
+        },
+      },
+    }))
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
+      .send({ idempotencyKey: 'live-apply-001' })
+      .expect(400)
+      .expect((response) => expect(response.body.code).toBe('cashflow_sheet_stage_run_required'));
+
+    expect(db.__getDocument('orgs/tenant-a/cashflow_weeks/project-a-2026-01-w1')).toBeUndefined();
+  });
+
+  it('rejects a misaligned Live runtime before reading project data', async () => {
+    let readCount = 0;
+    const db = createDb({ onGet: async () => { readCount += 1; } });
+
+    await request(createApp({
+      db,
+      routeOptions: {
+        env: {
+          BFF_DEPLOY_ENV: 'live',
+          FIREBASE_PROJECT_ID: 'stage-data-project',
+          BFF_LIVE_FIREBASE_PROJECT_ID: 'live-data-project',
+          JVM_WEEKLY_FIRESTORE_PROJECT_ID: 'stage-data-project',
+          JVM_WEEKLY_API_BASE_URL: 'https://live-jvm.example',
+          JVM_WEEKLY_INTERNAL_API_TOKEN: 'service-token',
+        },
+      },
+    }))
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
+      .send({ idempotencyKey: 'live-apply-misaligned-001' })
+      .expect(503)
+      .expect((response) => expect(response.body.code).toBe('unsafe_bff_runtime'));
+
+    expect(readCount).toBe(0);
+  });
+
   it('rejects direct final apply without a pinned stage run', async () => {
     const db = createDb({
       project: {

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -433,6 +433,7 @@ describe('CashflowProjectSheet monthly close shell', () => {
 
   it('resumes the same staged sheet apply after an uncertain server response', () => {
     expect(source).toContain('getCashflowSheetLabApplyStatusViaBff');
+    expect(source).toContain('isCashflowSheetApplyResultUncertain(finalError)');
     expect(source).toContain("status.status !== 'APPLYING'");
     expect(source).toContain('setLateSheetApply(stage)');
     expect(source).toContain('setSheetApplyResumeRequired(true)');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -66,6 +66,7 @@ import {
   getCashflowSheetLabApplyStatusViaBff,
   getCashflowSheetLabMirrorViaBff,
   getCashflowSheetLabShareAccountViaBff,
+  isCashflowSheetApplyResultUncertain,
   refreshCashflowSheetLabMirrorViaBff,
   stageCashflowSheetLabViaBff,
   type CashflowSheetLabMirrorResult,
@@ -1578,9 +1579,14 @@ export function CashflowProjectSheet({
         setSheetApplyResumeRequired(false);
         return;
       }
-      setLateSheetApply(stage);
-      setLateSheetFormulaAccepted(acceptFormulaMismatches);
-      setSheetApplyResumeRequired(true);
+      if (isCashflowSheetApplyResultUncertain(finalError)) {
+        setLateSheetApply(stage);
+        setLateSheetFormulaAccepted(acceptFormulaMismatches);
+        setSheetApplyResumeRequired(true);
+      } else {
+        setLateSheetApply(null);
+        setSheetApplyResumeRequired(false);
+      }
       toast.error(resolveApiErrorMessage(finalError, '시트 값을 MYSCube 시트에 반영하지 못했습니다.'));
     } finally {
       setSheetStageApplyLoading(false);

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
@@ -10,6 +10,7 @@ import {
   extractSpreadsheetIdFromSheetInput,
   applyCashflowSheetLabViaBff,
   cashflowFormulaMismatchesFromError,
+  isCashflowSheetApplyResultUncertain,
   getCashflowSheetLabApplyStatusViaBff,
   getCashflowSheetLabShareAccountViaBff,
   refreshCashflowSheetLabMirrorViaBff,
@@ -62,11 +63,6 @@ function formatError(error: unknown) {
 function getErrorCode(error: unknown) {
   const apiError = error as { code?: string; body?: { code?: string; error?: string } };
   return apiError?.code || apiError?.body?.code || apiError?.body?.error || '';
-}
-
-function isApplyResultUncertain(error: unknown) {
-  const status = Number((error as { status?: unknown })?.status);
-  return !Number.isInteger(status) || status >= 500;
 }
 
 function getClosedMonthDifferences(error: unknown) {
@@ -983,7 +979,7 @@ export function CashflowSheetLabPage({
         setApplyResumeRequired(false);
         setClosedMonthFormulaAccepted(acceptFormulaMismatches);
         setClosedMonthPendingApprovalAccepted(acceptPendingApprovalDifferences);
-      } else if (activeStep === 'apply' && staged && isApplyResultUncertain(error)) {
+      } else if (activeStep === 'apply' && staged && isCashflowSheetApplyResultUncertain(error)) {
         setClosedMonthStage(staged);
         setClosedMonthChangeReason(stagedOverride ? monthCloseChangeReason.trim() : '');
         setClosedMonthFormulaAccepted(acceptFormulaMismatches);

--- a/src/app/lib/sheets-cashflow-readonly-client.test.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.test.ts
@@ -7,6 +7,7 @@ import {
   getCashflowSheetLabMirrorViaBff,
   getCashflowSheetLabShareAccountViaBff,
   getCashflowSheetLabYearViewViaBff,
+  isCashflowSheetApplyResultUncertain,
   refreshCashflowSheetLabMirrorViaBff,
   saveCashflowSheetLabConfigViaBff,
   stageCashflowSheetLabViaBff,
@@ -30,6 +31,22 @@ function asMockClient(client: {
 }
 
 describe('sheets cashflow readonly client', () => {
+  it('treats only transport-uncertain apply failures as resumable', () => {
+    expect(isCashflowSheetApplyResultUncertain({
+      status: 503,
+      body: { code: 'unsafe_bff_runtime' },
+    })).toBe(false);
+    expect(isCashflowSheetApplyResultUncertain({
+      status: 503,
+      body: { code: 'jvm_weekly_api_unconfigured' },
+    })).toBe(false);
+    expect(isCashflowSheetApplyResultUncertain({
+      status: 503,
+      body: { code: 'cashflow_sheet_operation_uncertain' },
+    })).toBe(true);
+    expect(isCashflowSheetApplyResultUncertain(new TypeError('Failed to fetch'))).toBe(true);
+  });
+
   it('has no retired direct preview or sheet writeback client path', () => {
     expect(clientSource).not.toContain('previewCashflowSheetLabViaBff');
     expect(clientSource).not.toContain('/cashflow-sheet-lab/preview');

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -11,6 +11,14 @@ import {
   type CashflowMutationLease,
 } from './cashflow-edit-lease';
 
+export function isCashflowSheetApplyResultUncertain(error: unknown) {
+  const apiError = error as { status?: unknown; code?: string; body?: { code?: string; error?: string } };
+  const status = Number(apiError?.status);
+  if (!Number.isInteger(status)) return true;
+  const code = apiError?.code || apiError?.body?.code || apiError?.body?.error || '';
+  return code === 'cashflow_sheet_operation_uncertain';
+}
+
 export interface CashflowSheetLabWeekColumn {
   raw: string;
   year: number;


### PR DESCRIPTION
## What
- allow Cashflow Sheet apply in Live only when BFF, JVM, and Firebase project IDs align
- keep Stage/unknown/mismatched runtimes fail-closed before data reads or upstream calls
- distinguish explicit operation uncertainty from policy 503s in both Cashflow screens

## Verification
- targeted: 211 passed
- failed-suite isolated rerun: 168 passed
- BFF integration: 236 passed
- npm run build: passed
- independent QA: GO

No production DB or Google Sheet mutation was performed during verification.