### PR TITLE
fix(cashflow): accept pristine legacy open month

### DIFF
--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -2661,6 +2661,17 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     ) {
         boolean legacyOpen = !close.containsKey("contractVersion")
             && "OPEN".equals(text(close.get("status"), ""));
+        boolean pristineLegacyOpen = legacyOpen
+            && !close.containsKey("revision")
+            && !close.containsKey("reopenCount")
+            && Collections.disjoint(close.keySet(), Set.of(
+                "snapshot", "snapshotHash", "previousSnapshot", "previousSnapshotHash",
+                "latestVersionId", "late", "closedAt", "closedByUid", "closedByName",
+                "reopenRequest", "reopenDecision", "reopenContext",
+                "amendmentCount", "postDeadlineAmendmentWarningCount", "lastAmendmentAt",
+                "lastAmendmentByUid", "lastAmendmentByName", "lastAmendmentReason",
+                "lastAmendmentDeadline", "lastAmendmentPostDeadline", "lastAmendmentEvidence"
+            ));
         if ((!legacyOpen && !CASHFLOW_MONTH_CLOSE_CONTRACT_VERSION.equals(text(close.get("contractVersion"), "")))
             || !tenantId.equals(text(close.get("tenantId"), ""))
             || !projectId.equals(text(close.get("projectId"), ""))
@@ -2669,8 +2680,10 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                 "Cashflow month close document is not canonical; Stage overwrite migration is required."
             );
         }
-        canonicalMonthCounter(close, "revision");
-        canonicalMonthCounter(close, "reopenCount");
+        if (!pristineLegacyOpen) {
+            canonicalMonthCounter(close, "revision");
+            canonicalMonthCounter(close, "reopenCount");
+        }
         String status = text(close.get("status"), "");
         if (Set.of("OPEN", "CLOSED", "REOPEN_REQUESTED").contains(status)) return status;
         throw new WeeklyExpenseConflictException(

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -756,16 +756,15 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
-    void monthlyApplyAcceptsLegacyOpenMonthCloseWithoutContractVersion() {
+    void monthlyApplyAcceptsPristineLegacyOpenMonthCloseWithoutCounters() {
         Fixture fixture = fixture(activeMember(), activeLease());
-        fixture.documents.put(monthClosePath("project-a", "2026-07"), Map.of(
+        Map<String, Object> legacyOpen = Map.of(
             "tenantId", "tenant-a",
             "projectId", "project-a",
             "yearMonth", "2026-07",
-            "status", "OPEN",
-            "revision", 0L,
-            "reopenCount", 0L
-        ));
+            "status", "OPEN"
+        );
+        fixture.documents.put(monthClosePath("project-a", "2026-07"), legacyOpen);
         String targetRevision = FirestoreInheritedWeeklyExpensePersistence.computeCashflowTargetRevision(List.of());
 
         CashflowSheetLabApplyResponse response = fixture.persistence.runCommandTransaction(() -> commandService(
@@ -780,6 +779,49 @@ class FirestoreCashflowLeaseGuardTest {
         assertThat(response.savedProjectionLineCount()).isEqualTo(80);
         assertThat(response.savedActualLineCount()).isEqualTo(80);
         assertThat(fixture.documents.keySet()).anyMatch(path -> path.contains("/cashflow_weeks/"));
+        assertThat(fixture.documents.get(monthClosePath("project-a", "2026-07"))).isEqualTo(legacyOpen);
+    }
+
+    @Test
+    void monthlyApplyRejectsPartialLegacyCountersAndLegacyHistory() {
+        List<Map<String, Object>> invalidCloses = List.of(
+            Map.of("revision", 0L),
+            Map.of("reopenCount", 0L),
+            Map.of("snapshotHash", "sha256:legacy"),
+            Map.of("closedAt", "2026-07-31T00:00:00Z"),
+            Map.of("reopenRequest", Map.of()),
+            Map.of("reopenDecision", Map.of()),
+            Map.of("latestVersionId", "project-a-2026-07-r1"),
+            Map.of("late", false),
+            Map.of("reopenContext", Map.of()),
+            Map.of("lastAmendmentAt", "2026-07-31T00:00:00Z")
+        );
+        String targetRevision = FirestoreInheritedWeeklyExpensePersistence.computeCashflowTargetRevision(List.of());
+
+        for (Map<String, Object> invalid : invalidCloses) {
+            Fixture fixture = fixture(activeMember(), activeLease());
+            Map<String, Object> legacyOpen = new LinkedHashMap<>(Map.of(
+                "tenantId", "tenant-a",
+                "projectId", "project-a",
+                "yearMonth", "2026-07",
+                "status", "OPEN"
+            ));
+            legacyOpen.putAll(invalid);
+            fixture.documents.put(monthClosePath("project-a", "2026-07"), legacyOpen);
+
+            assertThatThrownBy(() -> fixture.persistence.runCommandTransaction(() -> commandService(
+                fixture.persistence
+            ).applyCashflowSheetLab(
+                ACTOR,
+                "project-a",
+                SESSION,
+                monthlyRequest("invalid-legacy-open", targetRevision, "")
+            )))
+                .isInstanceOf(WeeklyExpenseConflictException.class)
+                .hasMessageContaining("non-negative whole numbers");
+            assertThat(fixture.documents.keySet()).noneMatch(path -> path.contains("/cashflow_weeks/"));
+            assertThat(fixture.documents.get(monthClosePath("project-a", "2026-07"))).isEqualTo(legacyOpen);
+        }
     }
 
     @Test


### PR DESCRIPTION
## What
- allow only pristine legacy OPEN month-close documents with both counters absent
- keep partial counters, malformed counters, and any close/reopen/amendment history fail-closed
- preserve the original monthly_close document without migration writes

## Why
Live cashflow sheet apply reached JVM but returned weekly_expense_conflict before replacement because legacy OPEN documents predate revision/reopenCount.

## Verification
- targeted TDD: 3 passed
- JVM full suite: 269 passed
- independent QA: GO
- no Live/Stage DB or Google Sheet mutation