### PR TITLE
fix(cashflow): replay concurrent sheet apply completion

### DIFF
--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -1977,14 +1977,19 @@ async function reserveCashflowSheetApply({
     if (readOptionalText(stageRun.projectId) !== readOptionalText(projectId)) {
       throw createHttpError(404, '시트 검토 run을 찾을 수 없습니다.', 'cashflow_sheet_stage_run_not_found');
     }
+    const publicationSnap = await transaction.get(publicationRef);
+    const publication = publicationSnap.exists ? (publicationSnap.data() || {}) : {};
     const status = readOptionalText(stageRun.status);
     if (status === 'APPLIED') {
       assertApplyRequestMatches(stageRun, applyRequestHash);
-      if (stageRun.applyResponse) return { replay: stageRun.applyResponse, resume: false, stageRun };
-      throw createHttpError(409, '이미 반영된 시트 검토 run입니다.', 'cashflow_sheet_stage_run_applied');
+      const replay = appliedCashflowSheetResponse(stageRun, publication, {
+        projectId,
+        stagedRunId,
+        applyRequestHash,
+      });
+      if (replay) return { replay, resume: false, stageRun };
+      throw createHttpError(409, '이미 반영된 시트 검토 run의 완료 근거가 일치하지 않습니다.', 'cashflow_sheet_stage_run_applied');
     }
-    const publicationSnap = await transaction.get(publicationRef);
-    const publication = publicationSnap.exists ? (publicationSnap.data() || {}) : {};
     if (
       readOptionalText(publication.status).toUpperCase() === 'APPLYING'
       && readOptionalText(publication.stagedRunId) !== stagedRunId
@@ -2174,10 +2179,60 @@ function yearApplyIdempotencyKey({ idempotencyKey, stagedRunId, year }) {
   return `cf-sheet-year-${stableHash({ idempotencyKey, stagedRunId, year }).slice(0, 48)}`;
 }
 
+function appliedCashflowSheetResponse(run, publication, {
+  projectId,
+  stagedRunId,
+  idempotencyKey = '',
+  applyRequestHash,
+}) {
+  const response = run?.applyResponse;
+  const sourceRevision = readOptionalText(run?.sourceRevision);
+  const targetRevision = readOptionalText(response?.resultingTargetRevision);
+  const valid = readOptionalText(run?.status) === 'APPLIED'
+    && readOptionalText(run?.projectId) === projectId
+    && (!idempotencyKey || readOptionalText(run?.appliedIdempotencyKey) === idempotencyKey)
+    && readOptionalText(run.applyRequestHash) === applyRequestHash
+    && response?.ok === true
+    && readOptionalText(response?.projectId) === projectId
+    && readOptionalText(response?.stagedRunId) === stagedRunId
+    && readOptionalText(response?.sourceRevision) === sourceRevision
+    && Boolean(targetRevision)
+    && readOptionalText(publication?.status).toUpperCase() === 'APPLIED'
+    && readOptionalText(publication?.projectId) === projectId
+    && readOptionalText(publication?.stagedRunId) === stagedRunId
+    && readOptionalText(publication?.sourceRevision) === sourceRevision
+    && readOptionalText(publication?.appliedTargetRevision) === targetRevision;
+  return valid ? response : null;
+}
+
+async function readAppliedCashflowSheetResponse({
+  db,
+  tenantId,
+  projectId,
+  stagedRunId,
+  idempotencyKey = '',
+  applyRequestHash,
+}) {
+  const runRef = db.doc(`orgs/${tenantId}/${CASHFLOW_SHEET_STAGE_RUNS_COLLECTION_ID}/${stagedRunId}`);
+  const publicationRef = db.doc(`orgs/${tenantId}/cashflow_sheet_publications/${projectId}`);
+  return db.runTransaction(async (transaction) => {
+    const [runSnap, publicationSnap] = await Promise.all([
+      transaction.get(runRef),
+      transaction.get(publicationRef),
+    ]);
+    return appliedCashflowSheetResponse(
+      runSnap.exists ? (runSnap.data() || {}) : {},
+      publicationSnap.exists ? (publicationSnap.data() || {}) : {},
+      { projectId, stagedRunId, idempotencyKey, applyRequestHash },
+    );
+  });
+}
+
 async function checkpointCashflowSheetApplyOperation({
   db,
   runRef,
   publicationRef,
+  projectId,
   stagedRunId,
   idempotencyKey,
   applyRequestHash,
@@ -2198,6 +2253,12 @@ async function checkpointCashflowSheetApplyOperation({
       || readOptionalText(publication.status).toUpperCase() !== 'APPLYING'
       || readOptionalText(publication.stagedRunId) !== stagedRunId
     ) {
+      if (appliedCashflowSheetResponse(run, publication, {
+        projectId,
+        stagedRunId,
+        idempotencyKey,
+        applyRequestHash,
+      })) return;
       throw createHttpError(409, '시트 반영 작업 상태가 변경되었습니다.', 'cashflow_sheet_apply_operation_conflict');
     }
     transaction.set(runRef, {
@@ -2543,7 +2604,14 @@ async function applyStagedCashflowSheetLab({
   });
   if (replaying) {
     assertApplyRequestMatches(stageRun, applyRequestHash);
-    if (stageRun.applyResponse) return stageRun.applyResponse;
+    const replay = await readAppliedCashflowSheetResponse({
+      db,
+      tenantId,
+      projectId,
+      stagedRunId,
+      applyRequestHash,
+    });
+    if (replay) return replay;
     throw createHttpError(409, '이미 반영된 시트 검토 run입니다.', 'cashflow_sheet_stage_run_applied');
   }
   if (resuming) assertApplyRequestMatches(stageRun, applyRequestHash);
@@ -2764,6 +2832,7 @@ async function applyStagedCashflowSheetLab({
       db,
       runRef: reservation.runRef,
       publicationRef: reservation.publicationRef,
+      projectId,
       stagedRunId,
       idempotencyKey: effectiveIdempotencyKey,
       applyRequestHash,
@@ -3214,32 +3283,47 @@ async function applyStagedCashflowSheetLab({
       .filter((year) => !candidateYears.includes(year))
       .sort((left, right) => left - right),
   });
-  await db.runTransaction(async (transaction) => {
-    const currentRunSnap = await transaction.get(reservation.runRef);
-    const currentRun = currentRunSnap.exists ? (currentRunSnap.data() || {}) : {};
-    const publicationSnap = await transaction.get(reservation.publicationRef);
-    const publication = publicationSnap.exists ? (publicationSnap.data() || {}) : {};
-    if (
-      readOptionalText(currentRun.status) !== 'APPLYING'
-      || readOptionalText(currentRun.appliedIdempotencyKey) !== effectiveIdempotencyKey
-      || readOptionalText(currentRun.applyRequestHash) !== applyRequestHash
-      || readOptionalText(publication.status).toUpperCase() !== 'APPLYING'
-      || readOptionalText(publication.stagedRunId) !== stagedRunId
-    ) {
-      throw createHttpError(409, '시트 반영 완료 상태가 변경되었습니다. 다시 확인해 주세요.', 'cashflow_sheet_apply_completion_conflict');
-    }
-    transaction.set(reservation.runRef, runCompletionPatch, { merge: true });
-    transaction.set(mirrorRef, mirrorCompletionPatch, { merge: true });
-    transaction.set(reservation.publicationRef, stripUndefinedDeep({
+  let finalizedResponse = response;
+  try {
+    await db.runTransaction(async (transaction) => {
+      const currentRunSnap = await transaction.get(reservation.runRef);
+      const currentRun = currentRunSnap.exists ? (currentRunSnap.data() || {}) : {};
+      const publicationSnap = await transaction.get(reservation.publicationRef);
+      const publication = publicationSnap.exists ? (publicationSnap.data() || {}) : {};
+      if (
+        readOptionalText(currentRun.status) !== 'APPLYING'
+        || readOptionalText(currentRun.appliedIdempotencyKey) !== effectiveIdempotencyKey
+        || readOptionalText(currentRun.applyRequestHash) !== applyRequestHash
+        || readOptionalText(publication.status).toUpperCase() !== 'APPLYING'
+        || readOptionalText(publication.stagedRunId) !== stagedRunId
+      ) {
+        throw createHttpError(409, '시트 반영 완료 상태가 변경되었습니다. 다시 확인해 주세요.', 'cashflow_sheet_apply_completion_conflict');
+      }
+      transaction.set(reservation.runRef, runCompletionPatch, { merge: true });
+      transaction.set(mirrorRef, mirrorCompletionPatch, { merge: true });
+      transaction.set(reservation.publicationRef, stripUndefinedDeep({
+        projectId,
+        status: 'APPLIED',
+        stagedRunId,
+        sourceRevision: stageRun.sourceRevision,
+        appliedTargetRevision: targetRevision,
+        appliedAt: now,
+        applyFailure: null,
+      }), { merge: true });
+    });
+  } catch (error) {
+    if (error?.code !== 'cashflow_sheet_apply_completion_conflict') throw error;
+    const replay = await readAppliedCashflowSheetResponse({
+      db,
+      tenantId,
       projectId,
-      status: 'APPLIED',
       stagedRunId,
-      sourceRevision: stageRun.sourceRevision,
-      appliedTargetRevision: targetRevision,
-      appliedAt: now,
-      applyFailure: null,
-    }), { merge: true });
-  });
+      idempotencyKey: effectiveIdempotencyKey,
+      applyRequestHash,
+    });
+    if (!replay) throw error;
+    finalizedResponse = replay;
+  }
   try {
     await markCashflowChangeCandidatesStatus({
       db,
@@ -3255,7 +3339,7 @@ async function applyStagedCashflowSheetLab({
       ...routeErrorDetails(error),
     }, 'warn');
   }
-  return response;
+  return finalizedResponse;
 }
 
 async function stagePinnedCashflowSheetLab({

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -3641,6 +3641,104 @@ describe('cashflow sheet lab route', () => {
       .toMatchObject({ status: 'APPLIED' });
   });
 
+  it('replays the applied response when two requests finish the same staged run together', async () => {
+    let releaseBoth;
+    let callCount = 0;
+    const returnedAuditIds = [];
+    const bothStarted = new Promise((resolve) => { releaseBoth = resolve; });
+    const resultingTargetRevision = `sha256:${'6'.repeat(64)}`;
+    const javaWeeklyClient = {
+      applyCashflowSheetLab: vi.fn(async (input) => {
+        const callNumber = ++callCount;
+        if (callNumber === 2) releaseBoth();
+        await bothStarted;
+        const auditId = `audit-${callNumber}`;
+        returnedAuditIds.push(auditId);
+        return { ...javaApplyResponse(input, resultingTargetRevision), auditId };
+      }),
+    };
+    const staged = await stageJanuaryApply(javaWeeklyClient, 'concurrent-completion');
+    const payload = {
+      stageRunId: staged.stage.body.runId,
+      idempotencyKey: 'apply-concurrent-completion',
+    };
+
+    const responses = await Promise.all([
+      request(staged.app).post('/api/v1/projects/project-a/cashflow-sheet-lab/apply').send(payload),
+      request(staged.app).post('/api/v1/projects/project-a/cashflow-sheet-lab/apply').send(payload),
+    ]);
+
+    expect(responses.map((response) => response.status)).toEqual([200, 200]);
+    expect(responses[0].body).toEqual(responses[1].body);
+    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(2);
+    expect(returnedAuditIds.sort()).toEqual(['audit-1', 'audit-2']);
+    expect(javaWeeklyClient.applyCashflowSheetLab.mock.calls[0][0].idempotencyKey)
+      .toBe(javaWeeklyClient.applyCashflowSheetLab.mock.calls[1][0].idempotencyKey);
+    const storedRun = staged.db.__getDocument(`orgs/tenant-a/cashflow_sheet_stage_runs/${staged.stage.body.runId}`);
+    expect(storedRun).toMatchObject({ status: 'APPLIED', applyResponse: responses[0].body });
+    expect(responses[0].body).toEqual(storedRun.applyResponse);
+  });
+
+  it('replays the applied response when a concurrent request checkpoints after completion', async () => {
+    let releaseSecond;
+    let secondStarted;
+    let callCount = 0;
+    const returnedAuditIds = [];
+    const secondMayFinish = new Promise((resolve) => { releaseSecond = resolve; });
+    const secondHasStarted = new Promise((resolve) => { secondStarted = resolve; });
+    const resultingTargetRevision = `sha256:${'5'.repeat(64)}`;
+    const javaWeeklyClient = {
+      applyCashflowSheetLab: vi.fn(async (input) => {
+        const callNumber = ++callCount;
+        if (callNumber === 2) {
+          secondStarted();
+          await secondMayFinish;
+        } else {
+          await secondHasStarted;
+        }
+        const auditId = `audit-${callNumber}`;
+        returnedAuditIds.push(auditId);
+        return { ...javaApplyResponse(input, resultingTargetRevision), auditId };
+      }),
+    };
+    const staged = await stageJanuaryApply(javaWeeklyClient, 'late-checkpoint');
+    const payload = { stageRunId: staged.stage.body.runId, idempotencyKey: 'apply-late-checkpoint' };
+
+    const first = request(staged.app).post('/api/v1/projects/project-a/cashflow-sheet-lab/apply').send(payload)
+      .then((response) => response);
+    const second = request(staged.app).post('/api/v1/projects/project-a/cashflow-sheet-lab/apply').send(payload)
+      .then((response) => response);
+    const firstResponse = await first;
+    releaseSecond();
+    const secondResponse = await second;
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    expect(returnedAuditIds.sort()).toEqual(['audit-1', 'audit-2']);
+    expect(secondResponse.body).toEqual(firstResponse.body);
+    expect(secondResponse.body).toEqual(staged.db
+      .__getDocument(`orgs/tenant-a/cashflow_sheet_stage_runs/${staged.stage.body.runId}`).applyResponse);
+  });
+
+  it('does not replay an applied response when publication completion evidence differs', async () => {
+    const javaWeeklyClient = {
+      applyCashflowSheetLab: vi.fn(async (input) => javaApplyResponse(input, `sha256:${'4'.repeat(64)}`)),
+    };
+    const staged = await stageJanuaryApply(javaWeeklyClient, 'invalid-applied-evidence');
+    const payload = { stageRunId: staged.stage.body.runId, idempotencyKey: 'apply-invalid-evidence' };
+    await request(staged.app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
+      .send(payload)
+      .expect(200);
+    staged.db.__getDocument('orgs/tenant-a/cashflow_sheet_publications/project-a').appliedTargetRevision = `sha256:${'3'.repeat(64)}`;
+
+    await request(staged.app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
+      .send(payload)
+      .expect(409)
+      .expect((response) => expect(response.body.code).toBe('cashflow_sheet_stage_run_applied'));
+  });
+
   it.each([
     ['malformed status', () => ({ status: 'APPLIED' }), 'MISMATCH'],
     ['wrong project', (input, sourceRevision, targetRevision) => javaOperationApplied(input, {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -471,15 +471,20 @@ public class WeeklyExpenseController {
         if (cumulative == null) {
             cumulative = new WeeklyExpensePersistence.CashflowCumulativeCloseHead("OPEN", "2023-01", "", "", 0);
         }
-        CashflowProjectionActualSummaryBatchResponse summaryResponse = commandService
-            .readCashflowProjectionActualSummaries(
-                actor, new CashflowProjectionActualSummaryBatchRequest(List.of(projectId))
-            );
-        if (summaryResponse == null || summaryResponse.items().size() != 1
-            || !projectId.equals(summaryResponse.items().getFirst().projectId())) {
-            throw new WeeklyExpenseConflictException("Canonical projection-actual summary is unavailable.");
+        CashflowProjectionActualSummaryBatchResponse.Item projectionActualSummary;
+        if (source != null) {
+            projectionActualSummary = commandService.readCashflowProjectionActualSummary(actor, projectId, source);
+        } else {
+            CashflowProjectionActualSummaryBatchResponse summaryResponse = commandService
+                .readCashflowProjectionActualSummaries(
+                    actor, new CashflowProjectionActualSummaryBatchRequest(List.of(projectId))
+                );
+            if (summaryResponse == null || summaryResponse.items().size() != 1
+                || !projectId.equals(summaryResponse.items().getFirst().projectId())) {
+                throw new WeeklyExpenseConflictException("Canonical projection-actual summary is unavailable.");
+            }
+            projectionActualSummary = summaryResponse.items().getFirst();
         }
-        CashflowProjectionActualSummaryBatchResponse.Item projectionActualSummary = summaryResponse.items().getFirst();
         return new CashflowMonthDashboardSourceResponse(
             monthClose,
             cashflow,

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -204,15 +204,7 @@ public class WeeklyExpenseCommandService {
                 WeeklyExpensePersistence.CashflowLedgerSource source = persistence.findCashflowLedgerSource(
                     actor.tenantId(), projectId, CashflowProjectionActualSummaryCalculator.FROM_MONTH, boundary.yearMonth()
                 );
-                CashflowProjectionActualSummaryCalculator.Summary summary =
-                    CashflowProjectionActualSummaryCalculator.calculate(projectId, source.projection(), source.actual(), boundary);
-                items.add(new CashflowProjectionActualSummaryBatchResponse.Item(
-                    summary.projectId(), summary.fromMonth(),
-                    new CashflowProjectionActualSummaryBatchResponse.ComparisonAsOfWeek(
-                        summary.comparisonAsOfWeek().yearMonth(), summary.comparisonAsOfWeek().weekNo()
-                    ),
-                    summary.settlementDifferenceAmount(), summary.settlementMatches()
-                ));
+                items.add(toProjectionActualSummary(projectId, source, boundary));
             } catch (WeeklyExpenseForbiddenException denied) {
                 throw denied;
             } catch (RuntimeException unavailable) {
@@ -222,6 +214,36 @@ public class WeeklyExpenseCommandService {
             }
         }
         return new CashflowProjectionActualSummaryBatchResponse("1", items, errors);
+    }
+
+    @Transactional(readOnly = true)
+    public CashflowProjectionActualSummaryBatchResponse.Item readCashflowProjectionActualSummary(
+        TrustedActorContext actor,
+        String projectId,
+        WeeklyExpensePersistence.CashflowLedgerSource source
+    ) {
+        authorizationService.requireProjectAllowed(CASHFLOW_READ_COMMAND, actor, projectId);
+        return toProjectionActualSummary(
+            projectId,
+            source,
+            CashflowProjectionActualSummaryCalculator.currentFinanceWeek(Clock.systemUTC())
+        );
+    }
+
+    private CashflowProjectionActualSummaryBatchResponse.Item toProjectionActualSummary(
+        String projectId,
+        WeeklyExpensePersistence.CashflowLedgerSource source,
+        CashflowProjectionActualSummaryCalculator.FinanceWeek boundary
+    ) {
+        CashflowProjectionActualSummaryCalculator.Summary summary =
+            CashflowProjectionActualSummaryCalculator.calculate(projectId, source.projection(), source.actual(), boundary);
+        return new CashflowProjectionActualSummaryBatchResponse.Item(
+            summary.projectId(), summary.fromMonth(),
+            new CashflowProjectionActualSummaryBatchResponse.ComparisonAsOfWeek(
+                summary.comparisonAsOfWeek().yearMonth(), summary.comparisonAsOfWeek().weekNo()
+            ),
+            summary.settlementDifferenceAmount(), summary.settlementMatches()
+        );
     }
 
     @Transactional(readOnly = true)

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.same;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -1542,17 +1543,18 @@ class WeeklyExpenseControllerTest {
             "2026-07-20", "2026-07-10", true,
             null, null, null, null, null, null, null, null, null, null, null
         ));
+        WeeklyExpensePersistence.CashflowLedgerSource dashboardSource =
+            new WeeklyExpensePersistence.CashflowLedgerSource(List.of(), List.of(), List.of(2024));
         when(dashboardPersistence.findCashflowLedgerSource("tenant-month-dashboard", "project-month-dashboard"))
-            .thenReturn(new WeeklyExpensePersistence.CashflowLedgerSource(List.of(), List.of(), List.of(2024)));
-        when(dashboardCommandService.readCashflowProjectionActualSummaries(
-            any(), any(CashflowProjectionActualSummaryBatchRequest.class)
-        )).thenReturn(new CashflowProjectionActualSummaryBatchResponse("1", List.of(
-            new CashflowProjectionActualSummaryBatchResponse.Item(
+            .thenReturn(dashboardSource);
+        when(dashboardCommandService.readCashflowProjectionActualSummary(
+            any(), eq("project-month-dashboard"), same(dashboardSource)
+        ))
+            .thenReturn(new CashflowProjectionActualSummaryBatchResponse.Item(
                 "project-month-dashboard", "2023-01",
                 new CashflowProjectionActualSummaryBatchResponse.ComparisonAsOfWeek("2026-07", 4),
                 new java.math.BigDecimal("18371453"), false
-            )
-        )));
+            ));
         Map<String, String> completeAnnualStates = new LinkedHashMap<>();
         CashflowLineCatalog.ALL_LINES.forEach(line -> completeAnnualStates.put(line, "EMPTY"));
         completeAnnualStates.put("SALES_IN", "VALUE");
@@ -1615,6 +1617,12 @@ class WeeklyExpenseControllerTest {
         });
         assertThat(response.projectionActualSummary().settlementDifferenceAmount())
             .isEqualByComparingTo("18371453");
+        verify(dashboardPersistence, times(1))
+            .findCashflowLedgerSource("tenant-month-dashboard", "project-month-dashboard");
+        verify(dashboardCommandService).readCashflowProjectionActualSummary(
+            any(), eq("project-month-dashboard"), same(dashboardSource)
+        );
+        verify(dashboardCommandService, never()).readCashflowProjectionActualSummaries(any(), any());
     }
 
     @Test

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowProjectionActualSummaryServiceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowProjectionActualSummaryServiceTest.java
@@ -129,6 +129,27 @@ class CashflowProjectionActualSummaryServiceTest {
         )).isInstanceOf(IllegalArgumentException.class);
     }
 
+    @Test
+    void directSummaryFromTheDashboardSourceMatchesTheBatchSummary() {
+        WeeklyExpensePersistence persistence = mock(WeeklyExpensePersistence.class);
+        WeeklyExpenseAuthorizationService authorization = mock(WeeklyExpenseAuthorizationService.class);
+        WeeklyExpenseCommandService service = service(persistence, authorization);
+        WeeklyExpenseProjectionEntity projection = new WeeklyExpenseProjectionEntity(
+            "tenant-a", "project-a", "2023-01", 1, "SALES_IN"
+        );
+        projection.setAmount(BigDecimal.TEN);
+        WeeklyExpensePersistence.CashflowLedgerSource source =
+            new WeeklyExpensePersistence.CashflowLedgerSource(List.of(projection), List.of(), List.of(2023));
+        when(persistence.findCashflowLedgerSource(eq("tenant-a"), eq("project-a"), eq("2023-01"), anyString()))
+            .thenReturn(source);
+
+        CashflowProjectionActualSummaryBatchResponse.Item batch = service.readCashflowProjectionActualSummaries(
+            ACTOR, new CashflowProjectionActualSummaryBatchRequest(List.of("project-a"))
+        ).items().getFirst();
+
+        assertThat(service.readCashflowProjectionActualSummary(ACTOR, "project-a", source)).isEqualTo(batch);
+    }
+
     private static WeeklyExpenseCommandService service(
         WeeklyExpensePersistence persistence,
         WeeklyExpenseAuthorizationService authorization


### PR DESCRIPTION
## What
- replay the persisted winner when concurrent sheet applies finish together
- fail closed unless run, publication, and response completion evidence match
- reuse the already-loaded JVM cashflow ledger source for projection/actual summary

## Why
A successful JVM apply could be followed by a BFF completion/checkpoint conflict, surfacing 409/503 even though the sheet data was already committed.

## Verification
- cashflow sheet route: 87/87
- focused concurrent replay: 3/3
- JVM full test suite: passed
- npm test: passed before final test-only assertion; full rerun in progress
- npm run build: passed
- BFF Firestore emulator integration: in progress

## Ops
- no DB migration or direct data mutation
- deploy through main Production Deploy workflow only
- JVM artifact deployment uses the separate JVM Production Deploy workflow