### PR TITLE
chore(runtime): remove retired Stage references

### DIFF
--- a/.github/ISSUE_TEMPLATE/operations_firestore_automation.yml
+++ b/.github/ISSUE_TEMPLATE/operations_firestore_automation.yml
@@ -30,7 +30,7 @@ body:
     id: project
     attributes:
       label: 대상 프로젝트 ID
-      placeholder: 예) mysc-bmp-14173451
+      placeholder: 예) inner-platform-live-20260316
     validations:
       required: true
   - type: textarea
@@ -78,4 +78,3 @@ body:
           required: true
         - label: 수동 작업(Firebase Console/IAM)이 필요한 경우 담당자를 지정했습니다.
           required: true
-

--- a/scripts/assert_vercel_edge_route_policy.mjs
+++ b/scripts/assert_vercel_edge_route_policy.mjs
@@ -4,8 +4,6 @@ import fs from "node:fs";
 
 const CANONICAL_PRODUCTION_ORIGIN = "https://myscube.myscguard.app";
 const CANONICAL_PRODUCTION_DESTINATION = `${CANONICAL_PRODUCTION_ORIGIN}/:path*`;
-const INTERNAL_STAGE_HOST = "inner-platform-internal-stage-merryai-devs-projects.vercel.app";
-const LEGACY_STAGE_HOST = "inner-platform-stage-merryai-devs-projects.vercel.app";
 const ROUTE_VERSION_ALIAS = "inner-platform-f52434-routes-merryai-devs-projects.vercel.app";
 const REQUIRED_PROTECTED_OR_REDIRECT_HOSTS = [
   "submit-mysc.com",
@@ -80,12 +78,10 @@ export function isVercelProtectedRedirect(status, location) {
 
 export function evaluateVercelEdgeRoutePolicy({
   vercelConfig,
-  stageWorkflowText,
   smokeScriptText,
 }) {
   const failures = [];
   const warnings = [];
-  const stageHosts = uniqueSorted([INTERNAL_STAGE_HOST, LEGACY_STAGE_HOST]);
   const routeHosts = productionRedirectHosts(vercelConfig);
   const smokeHosts = extractDefaultDirectHosts(smokeScriptText);
   const requiredDirectHosts = uniqueSorted(REQUIRED_PRODUCTION_DIRECT_HOSTS);
@@ -94,16 +90,6 @@ export function evaluateVercelEdgeRoutePolicy({
     ...REQUIRED_PROTECTED_OR_REDIRECT_HOSTS,
     ROUTE_VERSION_ALIAS,
   ]);
-
-  const routedStageHosts = routeHosts.filter((host) => stageHosts.includes(host));
-  if (routedStageHosts.length) {
-    failures.push(`Stage hosts must not redirect to ${CANONICAL_PRODUCTION_ORIGIN}: ${routedStageHosts.join(", ")}`);
-  }
-
-  const smokeStageHosts = smokeHosts.filter((host) => stageHosts.includes(host));
-  if (smokeStageHosts.length) {
-    failures.push(`Stage hosts must not be included in production direct-origin smoke hosts: ${smokeStageHosts.join(", ")}`);
-  }
 
   const missingProductionRoutes = missingFrom(routeHosts, requiredDirectHosts);
   if (missingProductionRoutes.length) {

--- a/scripts/audit-project-organization-labels.ts
+++ b/scripts/audit-project-organization-labels.ts
@@ -3,7 +3,7 @@
  * Read-only audit for organization labels stored in project data.
  *
  * Usage:
- *   npm run firestore:audit:organization-labels -- --org mysc --firebase-project mysc-bmp-14173451
+ *   npm run firestore:audit:organization-labels -- --org mysc --firebase-project inner-platform-live-20260316
  *   npm run firestore:audit:organization-labels -- --org mysc --firebase-project inner-platform-live-20260316 --format json --fail-on-issues
  *   npm run firestore:audit:organization-labels -- --org mysc --firebase-project inner-platform-live-20260316 --database reh2607151200 --format json --fail-on-issues
  */

--- a/scripts/security_control_plane/security_control_plane/cli.py
+++ b/scripts/security_control_plane/security_control_plane/cli.py
@@ -15,8 +15,6 @@ from .sink import write_report_to_firestore
 
 DEFAULT_FIREBASE_PROJECTS = [
     "inner-platform-live-20260316",
-    "inner-platform-qa-20260310",
-    "mysc-bmp-14173451",
     "startup-acceleration-platform",
     "startup-diagnosis-platform",
     "submit-mysc-20260507",

--- a/server/bff/java-weekly-client.test.mjs
+++ b/server/bff/java-weekly-client.test.mjs
@@ -84,7 +84,7 @@ describe('Java weekly cashflow client', () => {
       FIREBASE_PROJECT_ID: 'other-project',
       JVM_WEEKLY_FIRESTORE_PROJECT_ID: 'other-project',
     })],
-    ['Stage using the Live data project', liveEnv({ BFF_DEPLOY_ENV: 'stage' })],
+    ['unsupported runtime using the Live data project', liveEnv({ BFF_DEPLOY_ENV: 'unsupported' })],
   ])('fails before network for %s', async (_case, env) => {
     const fetchImpl = vi.fn();
     const client = createJavaWeeklyClient({ env, fetchImpl });
@@ -541,14 +541,14 @@ describe('Java weekly cashflow client', () => {
     expect(loggerRan).toBe(true);
   });
 
-  it('uses the Stage invoker credential instead of the GCP metadata server', async () => {
+  it('uses the configured Live invoker credential instead of the GCP metadata server', async () => {
     const fetchImpl = vi.fn(async () => ({
       ok: true,
       status: 200,
       body: responseBody({ ok: true, projectId: 'project-a' }),
     }));
-    const serviceAccountJson = JSON.stringify({ client_email: 'stage-invoker@example.iam.gserviceaccount.com' });
-    const resolveIdentityToken = vi.fn(async () => 'stage-id-token');
+    const serviceAccountJson = JSON.stringify({ client_email: 'live-invoker@example.iam.gserviceaccount.com' });
+    const resolveIdentityToken = vi.fn(async () => 'live-id-token');
     const client = createJavaWeeklyClient({
       env: liveEnv({
         JVM_WEEKLY_API_ID_TOKEN_AUDIENCE: 'https://live-jvm.example',
@@ -561,7 +561,7 @@ describe('Java weekly cashflow client', () => {
     await client.applyCashflowSheetLab({
       context,
       projectId: 'project-a',
-      idempotencyKey: 'apply-stage-invoker-1',
+      idempotencyKey: 'apply-live-invoker-1',
       ...monthlyContract,
     });
 
@@ -571,7 +571,7 @@ describe('Java weekly cashflow client', () => {
       signal: expect.any(AbortSignal),
     });
     expect(fetchImpl).toHaveBeenCalledOnce();
-    expect(fetchImpl.mock.calls[0][1].headers.authorization).toBe('Bearer stage-id-token');
+    expect(fetchImpl.mock.calls[0][1].headers.authorization).toBe('Bearer live-id-token');
   });
 
   it('returns a clear retryable service error when JVM transport remains unavailable', async () => {
@@ -628,7 +628,7 @@ describe('Java weekly cashflow client', () => {
     const client = createJavaWeeklyClient({
       env: liveEnv({
         JVM_WEEKLY_API_ID_TOKEN_AUDIENCE: 'https://live-jvm.example',
-        JVM_WEEKLY_API_SERVICE_ACCOUNT_JSON: JSON.stringify({ client_email: 'stage-invoker@example.iam.gserviceaccount.com' }),
+        JVM_WEEKLY_API_SERVICE_ACCOUNT_JSON: JSON.stringify({ client_email: 'live-invoker@example.iam.gserviceaccount.com' }),
       }),
       fetchImpl,
       jvmWeeklyApiIdentityTokenResolver: resolveIdentityToken,

--- a/server/bff/project-request-contract-storage.test.ts
+++ b/server/bff/project-request-contract-storage.test.ts
@@ -20,8 +20,8 @@ describe('project-request-contract-storage', () => {
     };
 
     const service = createProjectRequestContractStorageService({
-      projectId: 'mysc-bmp-14173451',
-      bucketName: 'mysc-bmp-14173451.firebasestorage.app',
+      projectId: 'example-project',
+      bucketName: 'example-project.firebasestorage.app',
       storage,
     });
 
@@ -34,7 +34,7 @@ describe('project-request-contract-storage', () => {
       contentBase64: Buffer.from('fake-pdf', 'utf8').toString('base64'),
     });
 
-    expect(storage.bucket).toHaveBeenCalledWith('mysc-bmp-14173451.firebasestorage.app');
+    expect(storage.bucket).toHaveBeenCalledWith('example-project.firebasestorage.app');
     expect(save).toHaveBeenCalled();
     expect(result.path).toContain('orgs/mysc/project-request-contracts/u001/');
     expect(result.downloadURL).toContain('firebasestorage.googleapis.com');

--- a/server/bff/runtime-safety.test.ts
+++ b/server/bff/runtime-safety.test.ts
@@ -124,7 +124,7 @@ describe('BFF runtime safety', () => {
     expect(() => assertBffRuntimeSafety(config)).toThrow(`approved live origins: ${LIVE_ORIGIN}`);
   });
 
-  it('supports explicit live origin overrides for staged cutovers', () => {
+  it('supports explicit live origin overrides for controlled cutovers', () => {
     const config = buildConfig({
       projectId: LIVE_PROJECT_ID,
       allowedOrigins: [LIVE_ORIGIN, LEGACY_VERCEL_LIVE_ORIGIN],

--- a/server/jvm-weekly-api/README.md
+++ b/server/jvm-weekly-api/README.md
@@ -46,7 +46,7 @@ Optional environment:
 - `JVM_WEEKLY_FIREBASE_AUTH_PROJECT_ID`: Firebase Auth project whose ID tokens are accepted for browser-direct calls
 - `JVM_WEEKLY_FIRESTORE_PROJECT_ID`: Firestore project used when `JVM_WEEKLY_STORAGE_BACKEND=firestore`
 - `JVM_WEEKLY_FIREBASE_PROJECT_ID`: legacy fallback for both Firebase Auth and Firestore when the split envs are not set
-- `JVM_WEEKLY_ALLOWED_ORIGINS`: comma-separated browser origins allowed by CORS; defaults to fixed stage and live origins
+- `JVM_WEEKLY_ALLOWED_ORIGINS`: comma-separated browser origins allowed by CORS; defaults to the canonical Live origin
 
 The runtime configuration fixes `weekly.legacy-week-close-enabled` to `false`.
 Only the isolated test profile sets it to `true` so the historical command service remains regression-tested.
@@ -92,9 +92,9 @@ The command body does not define actor or tenant authority.
 `JVM_WEEKLY_FIRESTORE_PROJECT_ID` controls Firestore storage. Do not fix login by
 implicitly moving storage to a different Firebase project.
 
-The Java API is deployed as a private Cloud Run service. Stage BFF calls carry
+The Java API is deployed as a private Cloud Run service. Live BFF calls carry
 an audience-bound Google ID token from the configured invoker credential; the
-service account has only `roles/run.invoker` on this Stage service. Firebase token
+service account has only `roles/run.invoker` on this Live service. Firebase token
 verification, CORS, command authorization, idempotency, validation, and JPA
 transactions remain the runtime boundary.
 

--- a/server/vercel-edge-route-policy.test.ts
+++ b/server/vercel-edge-route-policy.test.ts
@@ -28,14 +28,6 @@ function smokeScript(hosts: string[]) {
   return `const defaultDirectHosts = [\n${hosts.map((host) => `  "${host}",`).join('\n')}\n];`;
 }
 
-const stageWorkflow = `
-env:
-  STAGE_CANONICAL_HOST: inner-platform-internal-stage-merryai-devs-projects.vercel.app
-steps:
-  - name: Verify stage surface
-    run: curl "https://\${STAGE_CANONICAL_HOST}/"
-`;
-
 describe('Vercel edge route policy', () => {
   it('accepts only recognized removed deployment responses', () => {
     expect(isRemovedVercelDeployment(404, '')).toBe(true);
@@ -52,10 +44,9 @@ describe('Vercel edge route policy', () => {
     expect(isVercelProtectedRedirect(302, 'https://example.com/sso-api?url=x')).toBe(false);
   });
 
-  it('accepts production direct-origin redirects while keeping stage outside the production security domain', () => {
+  it('accepts the exact production direct-origin redirect set', () => {
     const result = evaluateVercelEdgeRoutePolicy({
       vercelConfig: vercelConfig(baseRedirectHosts),
-      stageWorkflowText: stageWorkflow,
       smokeScriptText: smokeScript([
         ...baseRedirectHosts,
         'inner-platform-f52434-routes-merryai-devs-projects.vercel.app',
@@ -68,13 +59,12 @@ describe('Vercel edge route policy', () => {
     expect(result).toMatchObject({ ok: true, failures: [] });
   });
 
-  it('blocks internal stage alias redirects to the production security domain', () => {
+  it('blocks any unexpected redirect into the production security domain', () => {
     const result = evaluateVercelEdgeRoutePolicy({
       vercelConfig: vercelConfig([
         ...baseRedirectHosts,
-        'inner-platform-internal-stage-merryai-devs-projects.vercel.app',
+        'unexpected-preview.example.com',
       ]),
-      stageWorkflowText: stageWorkflow,
       smokeScriptText: smokeScript([
         ...baseRedirectHosts,
         'inner-platform-f52434-routes-merryai-devs-projects.vercel.app',
@@ -85,13 +75,12 @@ describe('Vercel edge route policy', () => {
     });
 
     expect(result.ok).toBe(false);
-    expect(result.failures.join('\n')).toContain('Stage hosts must not redirect');
+    expect(result.failures.join('\n')).toContain('Unexpected production direct-origin redirects');
   });
 
   it('keeps the strict smoke host list aligned with production direct-origin redirects', () => {
     const result = evaluateVercelEdgeRoutePolicy({
       vercelConfig: vercelConfig(baseRedirectHosts),
-      stageWorkflowText: stageWorkflow,
       smokeScriptText: smokeScript([
         ...baseRedirectHosts.filter((host) => host !== 'inner-platform-k2x121b33-merryai-devs-projects.vercel.app'),
         'inner-platform-f52434-routes-merryai-devs-projects.vercel.app',

--- a/src/app/lib/firebase.test.ts
+++ b/src/app/lib/firebase.test.ts
@@ -74,22 +74,22 @@ describe('selectFirebaseConfig', () => {
 describe('Firebase auth domain proxy', () => {
   it('keeps the configured Firebase auth domain on local development hosts', () => {
     expect(resolveFirebaseAuthDomain(
-      'mysc-bmp-14173451.firebaseapp.com',
+      'example-project.firebaseapp.com',
       {
         VITE_FIREBASE_AUTH_PROXY_HOSTS: 'inner-platform-git-dev-merryai-devs-projects.vercel.app',
       },
       { hostname: 'localhost' },
-    )).toBe('mysc-bmp-14173451.firebaseapp.com');
+    )).toBe('example-project.firebaseapp.com');
   });
 
   it('keeps the configured Firebase auth domain on fixed auth hosts unless proxy is explicitly configured', () => {
     expect(resolveFirebaseAuthDomain(
-      'mysc-bmp-14173451.firebaseapp.com',
+      'example-project.firebaseapp.com',
       {
         VITE_FIREBASE_AUTH_ALLOWED_HOSTS: 'inner-platform-git-dev-merryai-devs-projects.vercel.app',
       },
       { hostname: 'inner-platform-git-dev-merryai-devs-projects.vercel.app' },
-    )).toBe('mysc-bmp-14173451.firebaseapp.com');
+    )).toBe('example-project.firebaseapp.com');
   });
 
   it('uses the current app host as authDomain only for explicit proxy hosts', () => {
@@ -100,22 +100,22 @@ describe('Firebase auth domain proxy', () => {
     };
 
     expect(resolveFirebaseAuthDomain(
-      'mysc-bmp-14173451.firebaseapp.com',
+      'example-project.firebaseapp.com',
       env,
       { hostname: 'inner-platform-git-dev-merryai-devs-projects.vercel.app' },
     )).toBe('inner-platform-git-dev-merryai-devs-projects.vercel.app');
 
     expect(resolveFirebaseAuthDomain(
-      'mysc-bmp-14173451.firebaseapp.com',
+      'example-project.firebaseapp.com',
       env,
       { hostname: 'inner-platform-random123-merryai-devs-projects.vercel.app' },
-    )).toBe('mysc-bmp-14173451.firebaseapp.com');
+    )).toBe('example-project.firebaseapp.com');
   });
 
   it('applies authDomain proxy selection when reading env config', () => {
     const selected = readFirebaseConfigFromEnv({
       VITE_FIREBASE_API_KEY: 'env-api-key',
-      VITE_FIREBASE_AUTH_DOMAIN: 'mysc-bmp-14173451.firebaseapp.com',
+      VITE_FIREBASE_AUTH_DOMAIN: 'example-project.firebaseapp.com',
       VITE_FIREBASE_PROJECT_ID: 'env-project',
       VITE_FIREBASE_STORAGE_BUCKET: 'env-bucket',
       VITE_FIREBASE_MESSAGING_SENDER_ID: 'env-msg',

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -668,8 +668,8 @@ describe('platform-bff-client', () => {
     const originalWindow = globalThis.window;
     vi.stubGlobal('window', {
       location: {
-        origin: 'https://inner-platform-stage-merryai-devs-projects.vercel.app',
-        hostname: 'inner-platform-stage-merryai-devs-projects.vercel.app',
+        origin: 'https://inner-platform-preview-merryai-devs-projects.vercel.app',
+        hostname: 'inner-platform-preview-merryai-devs-projects.vercel.app',
       },
     });
 
@@ -678,7 +678,7 @@ describe('platform-bff-client', () => {
       VITE_PLATFORM_API_BASE_URL: 'https://innerplatform-jvm-weekly-api-c3pm5gv7ia-du.a.run.app',
     })).toEqual({
       enabled: true,
-      baseUrl: 'https://inner-platform-stage-merryai-devs-projects.vercel.app',
+      baseUrl: 'https://inner-platform-preview-merryai-devs-projects.vercel.app',
     });
 
     vi.stubGlobal('window', originalWindow);

--- a/src/app/platform/deployment-surface.test.ts
+++ b/src/app/platform/deployment-surface.test.ts
@@ -8,9 +8,10 @@ describe('deployment surface visibility', () => {
     expect(shouldShowCashflowSheetLab('myscube.myscguard.app')).toBe(true);
   });
 
-  it('keeps all known hosts aligned for cashflow sheet lab route availability', () => {
-    expect(isLiveMyscguardHost('inner-platform-stage-merryai-devs-projects.vercel.app')).toBe(false);
-    expect(shouldShowCashflowSheetLab('inner-platform-stage-merryai-devs-projects.vercel.app')).toBe(true);
+  it('does not classify preview or unknown hosts as live', () => {
+    expect(isLiveMyscguardHost('inner-platform-preview-merryai-devs-projects.vercel.app')).toBe(false);
+    expect(isLiveMyscguardHost('unknown.myscguard.app')).toBe(false);
+    expect(shouldShowCashflowSheetLab('inner-platform-preview-merryai-devs-projects.vercel.app')).toBe(true);
     expect(shouldShowCashflowSheetLab('inner-platform-7lwazqaf6-merryai-devs-projects.vercel.app')).toBe(true);
     expect(shouldShowCashflowSheetLab('localhost')).toBe(true);
   });

--- a/src/app/platform/deployment-surface.ts
+++ b/src/app/platform/deployment-surface.ts
@@ -20,9 +20,7 @@ function readCurrentHostname(): string {
 
 export function isLiveMyscguardHost(hostname = readCurrentHostname()): boolean {
   const normalized = normalizeHostname(hostname);
-  if (!normalized) return false;
-  if (LIVE_MYSCGUARD_HOSTS.has(normalized)) return true;
-  return normalized.endsWith('.myscguard.app') && !normalized.includes('stage');
+  return LIVE_MYSCGUARD_HOSTS.has(normalized);
 }
 
 export function shouldShowCashflowSheetLab(_hostname = readCurrentHostname()): boolean {


### PR DESCRIPTION
## What
- remove retired Stage/QA projects from the default security scan read path
- make Live hostname detection exact allowlist only
- remove retired Stage host-specific route policy and keep stricter exact production allowlists
- replace Stage/legacy fixtures and align JVM documentation with Live-only runtime

## Safety
- no DB or Google Sheet mutation
- no deployment workflow changes
- cashflow staged review snapshots remain unchanged

## Verification
- Vitest: 2,603 passed, 241 skipped
- targeted changed-path tests: 160 passed
- security control plane Python tests: 5 passed
- `npm run policy:verify`
- `npm run build`
- independent strict Live-only QA: PASS
