### PR TITLE
fix(cashflow): align month close Firestore transaction

### DIFF
--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CloseCashflowMonthRequest.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CloseCashflowMonthRequest.java
@@ -1,7 +1,9 @@
 package dev.merryai.innerplatform.weekly.api;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import dev.merryai.innerplatform.weekly.domain.CashflowLineCatalog;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -37,7 +39,7 @@ public record CloseCashflowMonthRequest(
     List<Confirmation> confirmations,
     @Valid @NotNull @Size(max = 4) List<ManagementCheck> managementChecks,
     @Valid @NotNull @Size(max = 4) List<ManagementConfirmation> managementConfirmations,
-    @Valid @NotNull CashflowOpeningBalancesResponse openingBalances,
+    @Valid CashflowOpeningBalancesResponse openingBalances,
     @Valid DeadlineSummary deadlineSummary,
     @Size(max = 160) String requestId,
     @PositiveOrZero long requestRevision,
@@ -162,6 +164,12 @@ public record CloseCashflowMonthRequest(
 
     public boolean cumulativeV2() {
         return !requestId.isBlank() || !manifestHash.isBlank();
+    }
+
+    @AssertTrue(message = "Legacy cashflow month close requires openingBalances.")
+    @JsonIgnore
+    public boolean isOpeningBalancesContractValid() {
+        return cumulativeV2() || openingBalances != null;
     }
 
     public static CashflowOpeningBalancesResponse requireOpeningBalances(

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/PermissiveWeeklyProjectExistenceRepository.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/PermissiveWeeklyProjectExistenceRepository.java
@@ -4,7 +4,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Repository;
 
 @Repository
-@ConditionalOnProperty(name = "weekly.storage-backend", havingValue = "jpa", matchIfMissing = true)
+@ConditionalOnProperty(name = "weekly.storage-backend", havingValue = "jpa")
 public class PermissiveWeeklyProjectExistenceRepository implements WeeklyProjectExistenceRepository {
     @Override
     public boolean exists(String tenantId, String projectId) {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -88,7 +88,6 @@ import dev.merryai.innerplatform.weekly.domain.SpreadsheetValueType;
 import dev.merryai.innerplatform.weekly.storage.WeeklyExpensePersistence;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -177,7 +176,6 @@ public class WeeklyExpenseCommandService {
         authorizationService.requireProjectAllowed(commandName, actor, projectId);
     }
 
-    @Transactional(readOnly = true)
     public CashflowProjectionActualSummaryBatchResponse readCashflowProjectionActualSummaries(
         TrustedActorContext actor,
         CashflowProjectionActualSummaryBatchRequest request
@@ -215,7 +213,6 @@ public class WeeklyExpenseCommandService {
         return new CashflowProjectionActualSummaryBatchResponse("1", items, errors);
     }
 
-    @Transactional(readOnly = true)
     public CashflowProjectionActualSummaryBatchResponse.Item readCashflowProjectionActualSummary(
         TrustedActorContext actor,
         String projectId,
@@ -245,7 +242,6 @@ public class WeeklyExpenseCommandService {
         );
     }
 
-    @Transactional(readOnly = true)
     public WeeklyExpenseSheetResponse readSheet(TrustedActorContext actor, String projectId, String sheetKey) {
         authorizationService.requireProjectAllowed(SHEET_READ_COMMAND, actor, projectId);
         Optional<WeeklyExpenseSheetEntity> found = persistence.findSheetForUpdate(actor.tenantId(), projectId, sheetKey);
@@ -255,7 +251,6 @@ public class WeeklyExpenseCommandService {
         return toSheetResponse(projectId, found.get(), recentAuditEvents(actor.tenantId(), projectId));
     }
 
-    @Transactional(readOnly = true)
     public WeeklyExpenseSheetsResponse listSheets(TrustedActorContext actor, String projectId) {
         authorizationService.requireProjectAllowed(SHEET_READ_COMMAND, actor, projectId);
         List<WeeklyExpenseSheetResponse> sheets = persistence.findSheets(actor.tenantId(), projectId).stream()
@@ -264,7 +259,6 @@ public class WeeklyExpenseCommandService {
         return new WeeklyExpenseSheetsResponse(true, projectId, sheets, recentAuditEvents(actor.tenantId(), projectId));
     }
 
-    @Transactional(readOnly = true)
     public CashflowSheetOperationStatusResponse readCashflowSheetOperationStatus(
         TrustedActorContext actor,
         String projectId,
@@ -405,7 +399,6 @@ public class WeeklyExpenseCommandService {
         return "";
     }
 
-    @Transactional
     public SaveDraftResponse saveDraft(
         TrustedActorContext actor,
         String projectId,
@@ -468,7 +461,6 @@ public class WeeklyExpenseCommandService {
         return response;
     }
 
-    @Transactional(readOnly = true)
     public BankStatementImportLinesResponse listBankStatementImportLines(
         TrustedActorContext actor,
         String projectId,
@@ -509,7 +501,6 @@ public class WeeklyExpenseCommandService {
         );
     }
 
-    @Transactional
     public ImportBankStatementBatchResponse importBankStatementBatch(
         TrustedActorContext actor,
         String projectId,
@@ -634,7 +625,6 @@ public class WeeklyExpenseCommandService {
         return response;
     }
 
-    @Transactional
     public ApplyBankStatementItemsResponse applyBankStatementItems(
         TrustedActorContext actor,
         String projectId,
@@ -774,7 +764,6 @@ public class WeeklyExpenseCommandService {
         return response;
     }
 
-    @Transactional
     public UpsertProjectionResponse upsertProjection(
         TrustedActorContext actor,
         String projectId,
@@ -834,7 +823,6 @@ public class WeeklyExpenseCommandService {
         return response;
     }
 
-    @Transactional(readOnly = true)
     public CashflowMonthCloseResponse readCashflowMonthClose(
         TrustedActorContext actor,
         String projectId,
@@ -849,7 +837,6 @@ public class WeeklyExpenseCommandService {
         );
     }
 
-    @Transactional
     public CashflowVarianceResponse updateCashflowVariance(
         TrustedActorContext actor,
         String projectId,
@@ -918,7 +905,6 @@ public class WeeklyExpenseCommandService {
         }
     }
 
-    @Transactional
     public CashflowMonthCloseResponse closeCashflowMonth(
         TrustedActorContext actor,
         String projectId,
@@ -981,7 +967,6 @@ public class WeeklyExpenseCommandService {
         return response;
     }
 
-    @Transactional
     public CashflowWeeklyUpdateCompletionResponse completeCashflowWeeklyUpdate(
         TrustedActorContext actor,
         String projectId,
@@ -1055,7 +1040,6 @@ public class WeeklyExpenseCommandService {
         return response;
     }
 
-    @Transactional(readOnly = true)
     public CashflowWeeklyUpdateCompletionResponse readCashflowWeeklyUpdate(
         TrustedActorContext actor,
         String projectId,
@@ -1068,7 +1052,6 @@ public class WeeklyExpenseCommandService {
         return weeklyCompletionResponse(READ_CASHFLOW_WEEKLY_UPDATE_COMMAND, record);
     }
 
-    @Transactional(readOnly = true)
     public CashflowWeeklyComplianceHistoryResponse readCashflowWeeklyComplianceHistory(
         TrustedActorContext actor,
         String projectId,
@@ -1090,7 +1073,6 @@ public class WeeklyExpenseCommandService {
         );
     }
 
-    @Transactional(readOnly = true)
     public CashflowAppliedCellChangesResponse readCashflowAppliedCellChanges(
         TrustedActorContext actor,
         String projectId,
@@ -1273,7 +1255,6 @@ public class WeeklyExpenseCommandService {
     private record AppliedCellChangeCandidate(CashflowAppliedCellChangesResponse.Item item, int ordinal) {
     }
 
-    @Transactional
     public CashflowWeeklyUpdateCompletionResponse reopenCashflowWeeklyUpdate(
         TrustedActorContext actor,
         String projectId,
@@ -1336,7 +1317,6 @@ public class WeeklyExpenseCommandService {
         return response;
     }
 
-    @Transactional
     public CashflowMonthCloseResponse requestCashflowMonthReopen(
         TrustedActorContext actor,
         String projectId,
@@ -1391,7 +1371,6 @@ public class WeeklyExpenseCommandService {
         return response;
     }
 
-    @Transactional
     public CashflowMonthCloseResponse decideCashflowMonthReopen(
         TrustedActorContext actor,
         String projectId,
@@ -1447,7 +1426,6 @@ public class WeeklyExpenseCommandService {
         return response;
     }
 
-    @Transactional
     public CashflowSheetLabApplyResponse applyCashflowSheetLab(
         TrustedActorContext actor,
         String projectId,
@@ -1606,7 +1584,6 @@ public class WeeklyExpenseCommandService {
         return response;
     }
 
-    @Transactional
     public CashflowSheetBatchApplyResponse applyCashflowSheetBatch(
         TrustedActorContext actor,
         String projectId,
@@ -1997,7 +1974,6 @@ public class WeeklyExpenseCommandService {
         return values;
     }
 
-    @Transactional
     public CashflowSheetAnnualApplyResponse applyCashflowSheetAnnualTotal(
         TrustedActorContext actor,
         String projectId,
@@ -2095,7 +2071,6 @@ public class WeeklyExpenseCommandService {
         return response;
     }
 
-    @Transactional
     public SubmitWeekResponse submitWeek(
         TrustedActorContext actor,
         String projectId,
@@ -2222,7 +2197,6 @@ public class WeeklyExpenseCommandService {
         return response;
     }
 
-    @Transactional
     public CloseWeekResponse closeWeek(
         TrustedActorContext actor,
         String projectId,
@@ -2312,7 +2286,6 @@ public class WeeklyExpenseCommandService {
         return response;
     }
 
-    @Transactional
     public CreateAuditExportResponse createAuditExport(
         TrustedActorContext actor,
         String projectId,
@@ -2399,7 +2372,6 @@ public class WeeklyExpenseCommandService {
         return response;
     }
 
-    @Transactional
     public CellCommandResponse patchCells(
         TrustedActorContext actor,
         String projectId,
@@ -2444,7 +2416,6 @@ public class WeeklyExpenseCommandService {
         );
     }
 
-    @Transactional
     public CellCommandResponse copyCells(
         TrustedActorContext actor,
         String projectId,
@@ -2490,7 +2461,6 @@ public class WeeklyExpenseCommandService {
         );
     }
 
-    @Transactional
     public CellCommandResponse pasteCells(
         TrustedActorContext actor,
         String projectId,
@@ -2546,7 +2516,6 @@ public class WeeklyExpenseCommandService {
         );
     }
 
-    @Transactional
     public CellCommandResponse cutCells(
         TrustedActorContext actor,
         String projectId,
@@ -2594,7 +2563,6 @@ public class WeeklyExpenseCommandService {
         );
     }
 
-    @Transactional
     public RowCommandResponse insertRows(
         TrustedActorContext actor,
         String projectId,
@@ -2641,7 +2609,6 @@ public class WeeklyExpenseCommandService {
         );
     }
 
-    @Transactional
     public RowCommandResponse deleteRows(
         TrustedActorContext actor,
         String projectId,

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreStorageBackendEnvironmentPostProcessor.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreStorageBackendEnvironmentPostProcessor.java
@@ -22,7 +22,7 @@ public class FirestoreStorageBackendEnvironmentPostProcessor implements Environm
 
     @Override
     public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
-        String backend = environment.getProperty("weekly.storage-backend", "jpa").trim();
+        String backend = environment.getProperty("weekly.storage-backend", "firestore").trim();
         if (!"firestore".equalsIgnoreCase(backend)) return;
 
         Set<String> excludes = new LinkedHashSet<>();

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/JpaWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/JpaWeeklyExpensePersistence.java
@@ -21,14 +21,16 @@ import dev.merryai.innerplatform.weekly.repository.WeeklyExpenseSheetRepository;
 import dev.merryai.innerplatform.weekly.repository.WeeklyExpenseWeeklyStatusRepository;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 
 @Repository
-@ConditionalOnProperty(name = "weekly.storage-backend", havingValue = "jpa", matchIfMissing = true)
+@ConditionalOnProperty(name = "weekly.storage-backend", havingValue = "jpa")
 public class JpaWeeklyExpensePersistence implements WeeklyExpensePersistence {
     private final WeeklyExpenseSheetRepository sheetRepository;
     private final WeeklyExpenseIdempotencyRepository idempotencyRepository;
@@ -60,6 +62,12 @@ public class JpaWeeklyExpensePersistence implements WeeklyExpensePersistence {
         this.auditExportRepository = auditExportRepository;
         this.bankImportBatchRepository = bankImportBatchRepository;
         this.bankImportLineRepository = bankImportLineRepository;
+    }
+
+    @Override
+    @Transactional
+    public <T> T runCommandTransaction(Callable<T> action) {
+        return WeeklyExpensePersistence.super.runCommandTransaction(action);
     }
 
     @Override

--- a/server/jvm-weekly-api/src/main/resources/application-local.yml
+++ b/server/jvm-weekly-api/src/main/resources/application-local.yml
@@ -8,7 +8,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+    open-in-view: false
 weekly:
+  storage-backend: ${JVM_WEEKLY_STORAGE_BACKEND:jpa}
   internal-api-token-enabled: ${JVM_WEEKLY_INTERNAL_API_TOKEN_ENABLED:false}
   internal-api-token: ${JVM_WEEKLY_INTERNAL_API_TOKEN:local-weekly-api-token}
   cashflow-settled-week-confirmation-key: ${JVM_WEEKLY_CASHFLOW_SETTLED_WEEK_CONFIRMATION_KEY:local-cashflow-settled-week-confirmation-key-32}

--- a/server/jvm-weekly-api/src/main/resources/application.yml
+++ b/server/jvm-weekly-api/src/main/resources/application.yml
@@ -4,23 +4,13 @@ spring:
   jackson:
     deserialization:
       fail-on-unknown-properties: true
-  datasource:
-    url: ${JVM_WEEKLY_DATABASE_URL:jdbc:postgresql://localhost:5432/innerplatform_weekly}
-    username: ${JVM_WEEKLY_DATABASE_USER:innerplatform}
-    password: ${JVM_WEEKLY_DATABASE_PASSWORD:innerplatform}
-  flyway:
-    enabled: true
-  jpa:
-    hibernate:
-      ddl-auto: validate
-    open-in-view: false
 server:
   port: ${WEEKLY_API_PORT:8088}
 weekly:
   deploy-env: ${JVM_WEEKLY_DEPLOY_ENV:local}
   legacy-week-close-enabled: false
   cashflow-edit-leases-enabled: ${JVM_WEEKLY_EDIT_LEASES_ENABLED:false}
-  storage-backend: ${JVM_WEEKLY_STORAGE_BACKEND:jpa}
+  storage-backend: ${JVM_WEEKLY_STORAGE_BACKEND:firestore}
   internal-api-token-enabled: ${JVM_WEEKLY_INTERNAL_API_TOKEN_ENABLED:false}
   internal-api-token: ${JVM_WEEKLY_INTERNAL_API_TOKEN:}
   cashflow-settled-week-confirmation-key: ${JVM_WEEKLY_CASHFLOW_SETTLED_WEEK_CONFIRMATION_KEY:}

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/CloseCashflowMonthRequestTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/CloseCashflowMonthRequestTest.java
@@ -1,5 +1,8 @@
 package dev.merryai.innerplatform.weekly.api;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -12,6 +15,36 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class CloseCashflowMonthRequestTest {
+    private final Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+
+    @Test
+    void cumulativeV2CompactContractDoesNotRequireLegacyOpeningBalances() {
+        CloseCashflowMonthRequest request = compactCumulativeRequest();
+
+        assertThat(request.cumulativeV2()).isTrue();
+        assertThat(validator.validate(request)).isEmpty();
+    }
+
+    @Test
+    void contractValidationFlagIsNotPartOfTheJvmJsonPayload() throws Exception {
+        String json = new ObjectMapper().writeValueAsString(compactCumulativeRequest());
+
+        assertThat(json).doesNotContain("openingBalancesContractValid");
+    }
+
+    @Test
+    void legacyContractStillRequiresOpeningBalances() {
+        CloseCashflowMonthRequest request = new CloseCashflowMonthRequest(
+            "legacy-close", "", "", "2026-01", 0, 0, true,
+            List.of(), List.of(), List.of(), List.of(), List.of(), null, null
+        );
+
+        assertThat(request.cumulativeV2()).isFalse();
+        assertThat(validator.validate(request))
+            .extracting(violation -> violation.getPropertyPath().toString())
+            .contains("openingBalancesContractValid");
+    }
+
     @Test
     void monthCloseRejectsAnUnattestedHumanReview() {
         assertThatThrownBy(() -> CloseCashflowMonthRequest.requireHumanReviewed(false))
@@ -118,6 +151,28 @@ class CloseCashflowMonthRequestTest {
             states.put(line, line.equals(valueLine) ? "VALUE" : "EMPTY");
         }
         return states;
+    }
+
+    private static CloseCashflowMonthRequest compactCumulativeRequest() {
+        return new CloseCashflowMonthRequest(
+            "cumulative-close",
+            "",
+            "",
+            "2026-08",
+            0,
+            0,
+            false,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "project-a-2026-08",
+            2,
+            "sha256:" + "a".repeat(64)
+        );
     }
 
     private static List<CloseCashflowMonthRequest.DepositScheduleRow> validNotApplicableRows() {

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreStorageBackendEnvironmentPostProcessorTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreStorageBackendEnvironmentPostProcessorTest.java
@@ -29,8 +29,26 @@ class FirestoreStorageBackendEnvironmentPostProcessorTest {
     }
 
     @Test
-    void leavesJpaAutoconfigurationAloneByDefault() {
+    void excludesJpaAutoconfigurationByDefault() {
         StandardEnvironment environment = new StandardEnvironment();
+
+        new FirestoreStorageBackendEnvironmentPostProcessor()
+            .postProcessEnvironment(environment, new SpringApplication());
+
+        String excludes = environment.getProperty("spring.autoconfigure.exclude", "");
+        assertThat(excludes).contains("DataSourceAutoConfiguration");
+        assertThat(excludes).contains("HibernateJpaAutoConfiguration");
+        assertThat(excludes).contains("FlywayAutoConfiguration");
+        assertThat(environment.getProperty("spring.flyway.enabled")).isEqualTo("false");
+    }
+
+    @Test
+    void leavesJpaAutoconfigurationAloneWhenJpaIsExplicit() {
+        StandardEnvironment environment = new StandardEnvironment();
+        TestPropertySourceUtils.addInlinedPropertiesToEnvironment(
+            environment,
+            "weekly.storage-backend=jpa"
+        );
 
         new FirestoreStorageBackendEnvironmentPostProcessor()
             .postProcessEnvironment(environment, new SpringApplication());

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/JpaWeeklyExpensePersistenceTransactionTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/JpaWeeklyExpensePersistenceTransactionTest.java
@@ -1,0 +1,28 @@
+package dev.merryai.innerplatform.weekly.storage;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class JpaWeeklyExpensePersistenceTransactionTest {
+    @Autowired
+    private JpaWeeklyExpensePersistence persistence;
+
+    @Test
+    void opensSpringTransactionAtPersistenceBoundary() {
+        assertThat(TransactionSynchronizationManager.isActualTransactionActive()).isFalse();
+
+        boolean transactionActive = persistence.runCommandTransaction(
+            TransactionSynchronizationManager::isActualTransactionActive
+        );
+
+        assertThat(transactionActive).isTrue();
+        assertThat(TransactionSynchronizationManager.isActualTransactionActive()).isFalse();
+    }
+}

--- a/server/jvm-weekly-api/src/test/resources/application-test.yml
+++ b/server/jvm-weekly-api/src/test/resources/application-test.yml
@@ -6,9 +6,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: validate
+    open-in-view: false
   flyway:
     enabled: true
 weekly:
+  storage-backend: jpa
   deploy-env: live
   legacy-week-close-enabled: true
   cashflow-edit-leases-enabled: true

--- a/src/app/components/approval/AdminApprovalPage.shell.test.ts
+++ b/src/app/components/approval/AdminApprovalPage.shell.test.ts
@@ -47,6 +47,9 @@ describe('AdminApprovalPage shell contract', () => {
     expect(monthlySource).toContain("request.documentType === 'MONTHLY_CLOSE'");
     expect(monthlySource).toContain('문서 열기');
     expect(monthlySource).toContain('월 결산 승인서');
+    expect(monthlySource).toContain('w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)]');
+    expect(monthlySource).toContain('sm:w-[calc(100vw-2rem)] sm:max-w-[calc(100vw-2rem)]');
+    expect(monthlySource).toContain('<DialogContent className="max-w-sm">');
     expect(monthlySource).not.toContain('월 결산 검토 및 승인서');
     expect(monthlySource).toContain('MYSCube · MONTHLY CLOSE');
     expect(monthlySource).toContain('기안');

--- a/src/app/components/approval/MonthlySettlementApprovalSection.tsx
+++ b/src/app/components/approval/MonthlySettlementApprovalSection.tsx
@@ -400,13 +400,13 @@ export function MonthlySettlementApprovalSection({
       )}
 
       <Dialog open={Boolean(selectedRequest)} onOpenChange={(open) => { if (!open) { setSelectedRequest(null); setWarningsAcknowledged(false); setCumulativeEvidenceReady(false); } }}>
-        <DialogContent className="max-h-[calc(100dvh-2rem)] max-w-[1180px] overflow-y-auto rounded-none border border-slate-300 bg-slate-100 p-3 sm:p-6">
+        <DialogContent className="max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] overflow-y-auto rounded-none border border-slate-300 bg-slate-100 p-3 sm:max-h-[calc(100dvh-2rem)] sm:w-[calc(100vw-2rem)] sm:max-w-[calc(100vw-2rem)] sm:p-6">
           <DialogHeader className="sr-only">
             <DialogTitle>월 결산 승인서</DialogTitle>
             <DialogDescription>제출 당시 저장된 월 결산 자료를 검토하고 승인 또는 반려합니다.</DialogDescription>
           </DialogHeader>
           {selectedRequest ? (
-            <article className="mx-auto w-full max-w-[1080px] border border-slate-300 bg-white p-5 shadow-sm sm:p-8">
+            <article className="mx-auto w-full border border-slate-300 bg-white p-5 shadow-sm sm:p-8">
               <header className="border-b-2 border-slate-700 pb-5">
                 <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_320px]">
                   <div className="flex min-h-[138px] flex-col justify-center">


### PR DESCRIPTION
## Summary
- cumulative-v2 월 결산 요청에서는 `openingBalances`를 선택적으로 허용하고 legacy-v1 검증은 유지합니다.
- 운영 기본 저장소를 Firestore로 고정하고 JPA는 local/test 프로필로 한정합니다.
- 트랜잭션 경계를 persistence 구현으로 이동해 Firestore와 JPA의 의미를 분리합니다.
- 관리자 월 결산 승인서를 전체 viewport로 표시합니다.

## Verification
- JVM: 274 tests passed
- UI shell: 2 tests passed
- Production frontend build passed
- `git diff --check` passed

## Risk and rollout
- Database migration or direct data mutation: none
- Deploy order: JVM workflow first, then Vercel candidate, then Live alias
- Live canary will verify the cumulative month-close path before frontend alias promotion.