### PR TITLE
fix(cashflow): align cumulative month close revisions

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -132,18 +132,49 @@ function cashflowCloseHash(value) {
   return `sha256:${createHash('sha256').update(stableStringify(value)).digest('hex')}`;
 }
 
+export function buildCashflowMonthCloseRevisionChanges(previousCells, currentCells) {
+  const key = (cell) => `${cell.mode}|${cell.weekNo}|${cell.cashflowLine}`;
+  const previousByKey = new Map((previousCells || []).map((cell) => [key(cell), cell]));
+  const currentByKey = new Map((currentCells || []).map((cell) => [key(cell), cell]));
+  const orderedKeys = [
+    ...currentByKey.keys(),
+    ...[...previousByKey.keys()].filter((cellKey) => !currentByKey.has(cellKey)),
+  ];
+
+  return orderedKeys.flatMap((cellKey) => {
+    const before = previousByKey.get(cellKey);
+    const current = currentByKey.get(cellKey);
+    if (before && current && before.cellState === current.cellState && before.amount === current.amount) return [];
+    const identity = current || before;
+    const previousAmount = before && typeof before.amount === 'number' ? before.amount : null;
+    const currentAmount = current && typeof current.amount === 'number' ? current.amount : null;
+    return [{
+      mode: identity.mode,
+      weekNo: identity.weekNo,
+      cashflowLine: identity.cashflowLine,
+      previousState: before?.cellState || 'MISSING',
+      previousAmount,
+      currentState: current?.cellState || 'MISSING',
+      currentAmount,
+      amountDelta: previousAmount === null || currentAmount === null ? null : currentAmount - previousAmount,
+    }];
+  });
+}
+
 function cashflowMonthCloseRequestAuditPath(tenantId, requestId, revision, action) {
   return `orgs/${tenantId}/cashflow_month_close_request_audits/${requestId}-r${revision}-${action}`;
 }
 
 function cashflowMonthCloseRequestView(record, partyNames = {}) {
   if (record.contractVersion === CASHFLOW_CUMULATIVE_CLOSE_CONTRACT) {
+    const throughMonth = readOptionalText(record.throughMonth) || record.yearMonth;
     return {
       documentType: 'MONTHLY_CLOSE',
       contractVersion: record.contractVersion,
       requestId: record.requestId,
       projectId: record.projectId,
       yearMonth: record.yearMonth,
+      throughMonth,
       fromMonth: record.fromMonth,
       status: record.status,
       revision: record.revision,
@@ -168,7 +199,7 @@ function cashflowMonthCloseRequestView(record, partyNames = {}) {
       lockRange: {
         fromMonth: record.fromMonth,
         fromWeekNo: 1,
-        throughMonth: record.yearMonth,
+        throughMonth,
         throughWeekNo: 5,
       },
       reconciliationEvidence: objectValue(record.reconciliationEvidence),
@@ -1340,12 +1371,19 @@ function monthsBetween(startYearMonth, endYearMonth) {
   return result;
 }
 
+function previousYearMonth(yearMonth) {
+  const month = new Date(`${yearMonth}-01T00:00:00Z`);
+  month.setUTCMonth(month.getUTCMonth() - 1);
+  return month.toISOString().slice(0, 7);
+}
+
 function cumulativeCloseMonths(yearMonth) {
-  const months = monthsBetween(CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH, yearMonth);
+  const throughMonth = previousYearMonth(yearMonth);
+  const months = monthsBetween(CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH, throughMonth);
   if (
-    yearMonth < CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH
+    throughMonth < CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH
     || months.length === 0
-    || months.at(-1) !== yearMonth
+    || months.at(-1) !== throughMonth
   ) {
     throw createHttpError(
       400,
@@ -1358,6 +1396,7 @@ function cumulativeCloseMonths(yearMonth) {
 
 function buildCumulativeCloseScope(yearMonth, evidence = null) {
   const months = cumulativeCloseMonths(yearMonth);
+  const throughMonth = months.at(-1);
   const nestedSource = objectValue(evidence?.source) || {};
   const sourceField = (...keys) => {
     for (const key of keys) {
@@ -1372,11 +1411,11 @@ function buildCumulativeCloseScope(yearMonth, evidence = null) {
   return {
     contractVersion: CASHFLOW_CUMULATIVE_CLOSE_CONTRACT,
     fromMonth: CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH,
-    throughMonth: yearMonth,
+    throughMonth,
     lockRange: {
       fromMonth: CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH,
       fromWeekNo: 1,
-      throughMonth: yearMonth,
+      throughMonth,
       throughWeekNo: 5,
     },
     monthCount,
@@ -2762,6 +2801,7 @@ export function mountJvmWeeklyApiRoutes(app, {
         projectId,
         rawProjectId,
         cashflow,
+        sourceCloseStatus: readOptionalText(sourceClose.status),
         closeBody,
         reviewWarnings,
         monthSnapshot,
@@ -2927,8 +2967,8 @@ export function mountJvmWeeklyApiRoutes(app, {
     let annualSummaries;
     let payloadFingerprint;
     let auditAction;
-    const buildRevisionEvidence = (requestRevision) => {
-      const revisionShards = cumulativeMonths.map((monthKey) => cumulativeMonthCloseShard({
+    const buildRevisionEvidence = (requestRevision, evidenceMonths = cumulativeMonths) => {
+      const revisionShards = evidenceMonths.map((monthKey) => cumulativeMonthCloseShard({
         requestId,
         requestRevision,
         projectId: prepared.rawProjectId,
@@ -2995,11 +3035,23 @@ export function mountJvmWeeklyApiRoutes(app, {
           || !Number.isSafeInteger(Number(existing.revision)) || Number(existing.revision) < 1) {
           throw createHttpError(409, '이미 이 월의 결산 요청이 존재합니다.', 'cashflow_month_close_request_conflict');
         }
-        const replayEvidence = buildRevisionEvidence(Number(existing.revision));
+        let replayEvidence = buildRevisionEvidence(Number(existing.revision));
+        const legacyBuildingEvidence = existing.status === 'BUILDING'
+          && !readOptionalText(existing.throughMonth)
+          && !readOptionalText(existing.requestFingerprint)
+          && existing.requestId === requestId
+          && existing.projectId === prepared.rawProjectId
+          && existing.yearMonth === yearMonth
+          ? buildRevisionEvidence(
+            Number(existing.revision),
+            monthsBetween(CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH, existing.yearMonth),
+          )
+          : null;
         const legacyBuildingReplay = existing.status === 'BUILDING'
+          && legacyBuildingEvidence !== null
           && !readOptionalText(existing.requestFingerprint)
           && existing.createIdempotencyKey === req.context.idempotencyKey
-          && existing.payloadFingerprint === replayEvidence.payloadFingerprint
+          && existing.payloadFingerprint === legacyBuildingEvidence?.payloadFingerprint
           && existing.requestId === requestId
           && existing.tenantId === req.context.tenantId
           && existing.projectId === prepared.rawProjectId
@@ -3007,6 +3059,7 @@ export function mountJvmWeeklyApiRoutes(app, {
           && existing.requestedByUid === readOptionalText(req.context.actorId)
           && existing.approverUid === approverUid
           && Number(existing.expectedRevision) === prepared.closeBody.expectedRevision;
+        if (legacyBuildingReplay) replayEvidence = legacyBuildingEvidence;
         if (
           existing.createIdempotencyKey === req.context.idempotencyKey
           && (existing.requestFingerprint === requestFingerprint || legacyBuildingReplay)
@@ -3018,11 +3071,34 @@ export function mountJvmWeeklyApiRoutes(app, {
           revision = Number(existing.revision);
           ({ shards, manifest, totals, annualSummaries, payloadFingerprint } = replayEvidence);
           auditAction = revision === 1 ? 'REQUESTED' : 'RESUBMITTED';
-        } else if (existing.status !== 'REJECTED') {
+        } else if (!['REJECTED', 'REOPENED'].includes(existing.status)
+          && !(existing.status === 'APPROVED' && prepared.sourceCloseStatus === 'OPEN')) {
           throw createHttpError(409, '이미 이 월의 결산 요청이 존재합니다.', 'cashflow_month_close_request_conflict');
         } else {
           revision = Number(existing.revision) + 1;
           auditAction = 'RESUBMITTED';
+          const existingThroughMonth = readOptionalText(existing.throughMonth);
+          if (existingThroughMonth && existingThroughMonth !== cumulativeMonths.at(-1)) {
+            throw createHttpError(
+              409,
+              '저장된 누적 월 결산 범위가 현재 계약과 다릅니다.',
+              'cashflow_month_close_request_horizon_invalid',
+            );
+          }
+          const legacyMonthCount = monthsBetween(CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH, yearMonth).length;
+          if (!existingThroughMonth && Number(existing.monthCount) !== legacyMonthCount) {
+            throw createHttpError(
+              409,
+              '저장된 레거시 누적 월 결산 범위를 확인할 수 없습니다.',
+              'cashflow_month_close_request_horizon_invalid',
+            );
+          }
+          if (!existingThroughMonth) {
+            ({ shards, manifest, totals, annualSummaries, payloadFingerprint } = buildRevisionEvidence(
+              revision,
+              monthsBetween(CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH, yearMonth),
+            ));
+          }
         }
       } else {
         revision = 1;
@@ -3046,6 +3122,7 @@ export function mountJvmWeeklyApiRoutes(app, {
         tenantId: req.context.tenantId,
         projectId: prepared.rawProjectId,
         yearMonth,
+        ...(shards.at(-1)?.yearMonth === yearMonth ? {} : { throughMonth: shards.at(-1)?.yearMonth }),
         fromMonth: CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH,
         status: 'PENDING',
         revision,
@@ -3107,7 +3184,7 @@ export function mountJvmWeeklyApiRoutes(app, {
 
   async function verifyCumulativeRequestShards(tenantId, record) {
     const shards = [];
-    for (const yearMonth of monthsBetween(record.fromMonth, record.yearMonth)) {
+    for (const yearMonth of monthsBetween(record.fromMonth, readOptionalText(record.throughMonth) || record.yearMonth)) {
       const snapshot = await db.doc(cashflowMonthCloseRequestMonthPath(
         tenantId, record.requestId, record.revision, yearMonth,
       )).get();
@@ -3347,7 +3424,7 @@ export function mountJvmWeeklyApiRoutes(app, {
         throw createHttpError(403, '이 월 결산 요청을 조회할 권한이 없습니다.', 'cashflow_month_close_request_forbidden');
       }
     }
-    const allMonths = monthsBetween(record.fromMonth, record.yearMonth);
+    const allMonths = monthsBetween(record.fromMonth, readOptionalText(record.throughMonth) || record.yearMonth);
     const start = cursor ? allMonths.findIndex((month) => month >= cursor) : 0;
     const pageMonths = allMonths.slice(start < 0 ? allMonths.length : start, (start < 0 ? allMonths.length : start) + limit);
     const months = [];
@@ -3371,6 +3448,61 @@ export function mountJvmWeeklyApiRoutes(app, {
       months,
       nextCursor: nextIndex < allMonths.length ? allMonths[nextIndex] : null,
     });
+  }));
+
+  app.get('/api/v1/cashflow/:projectId/month-close/requests/:requestId/revision-diff', asyncHandler(async (req, res) => {
+    if (!db?.doc) throw createHttpError(503, '월 결산 요청 저장소에 연결하지 못했습니다.', 'cashflow_month_close_request_store_unavailable');
+    const projectId = readOptionalText(req.params.projectId);
+    const requestId = readOptionalText(req.params.requestId);
+    const actorId = readOptionalText(req.context.actorId);
+    await readActiveCashflowMember({ db, tenantId: req.context.tenantId, actorId });
+    const requestSnapshot = await db.doc(cashflowMonthCloseRequestPath(req.context.tenantId, requestId)).get();
+    const record = requestSnapshot.exists ? requestSnapshot.data() || {} : null;
+    if (!record || record.projectId !== projectId || record.contractVersion !== CASHFLOW_CUMULATIVE_CLOSE_CONTRACT) {
+      throw createHttpError(404, '월 결산 요청을 찾을 수 없습니다.', 'cashflow_month_close_request_not_found');
+    }
+    if (![record.requestedByUid, record.approverUid].includes(actorId)) {
+      throw createHttpError(403, '이 월 결산 요청을 조회할 권한이 없습니다.', 'cashflow_month_close_request_forbidden');
+    }
+    if (record.approverUid === actorId) {
+      const canonicalApproverUid = await readCanonicalCashflowApprover({
+        db, tenantId: req.context.tenantId, projectId, requesterUid: record.requestedByUid,
+      });
+      if (canonicalApproverUid !== actorId) {
+        throw createHttpError(403, '이 월 결산 요청을 조회할 권한이 없습니다.', 'cashflow_month_close_request_forbidden');
+      }
+    }
+    const currentRevision = Number(record.revision);
+    const throughMonth = readOptionalText(record.throughMonth) || record.yearMonth;
+    if (!Number.isSafeInteger(currentRevision) || currentRevision < 1) {
+      throw createHttpError(409, '월 결산 요청 revision이 올바르지 않습니다.', 'cashflow_month_close_request_evidence_invalid');
+    }
+    const readShard = async (revision) => {
+      const snapshot = await db.doc(cashflowMonthCloseRequestMonthPath(
+        req.context.tenantId, requestId, revision, throughMonth,
+      )).get();
+      const stored = snapshot.exists ? snapshot.data() || {} : null;
+      const { shardHash, ...base } = stored || {};
+      if (!stored
+        || stored.requestId !== requestId
+        || stored.projectId !== projectId
+        || Number(stored.requestRevision) !== revision
+        || stored.yearMonth !== throughMonth
+        || stored.cells?.length !== 160
+        || shardHash !== cashflowCloseHash(base)) {
+        throw createHttpError(409, '저장된 revision 비교 근거가 손상되었습니다.', 'cashflow_month_close_request_evidence_tampered');
+      }
+      return stored;
+    };
+    const current = await readShard(currentRevision);
+    if (currentRevision === 1) {
+      res.status(200).json({ requestId, yearMonth: throughMonth, currentRevision, previousRevision: null, changes: [] });
+      return;
+    }
+    const previousRevision = currentRevision - 1;
+    const previous = await readShard(previousRevision);
+    const changes = buildCashflowMonthCloseRevisionChanges(previous.cells, current.cells);
+    res.status(200).json({ requestId, yearMonth: throughMonth, currentRevision, previousRevision, changes });
   }));
 
   app.post('/api/v1/cashflow/:projectId/month-close/requests', asyncHandler(async (req, res) => {
@@ -4006,13 +4138,48 @@ export function mountJvmWeeklyApiRoutes(app, {
 
   app.post('/api/v1/cashflow/:projectId/month-close/reopen-decision', createJavaMutatingProxyRoute(async (req) => {
     assertWeeklyWorkspaceOrRoleAllowed(req, ['admin', 'finance'], 'decide cashflow month reopen', authMode, workspaceEmailDomain);
-    const projectId = encodeURIComponent(readOptionalText(req.params.projectId));
+    const rawProjectId = readOptionalText(req.params.projectId);
+    const projectId = encodeURIComponent(rawProjectId);
     const result = await proxyMutation(
       req,
       `/api/v1/cashflow/${projectId}/month-close/reopen-decision`,
       commandBody(req),
       { cashflowWrite: true },
     );
+    const decision = readOptionalText(req.body?.decision).toUpperCase();
+    const yearMonth = readOptionalText(req.body?.yearMonth);
+    if (decision === 'APPROVE') {
+      if (readOptionalText(result?.projectId) !== rawProjectId
+        || readOptionalText(result?.yearMonth) !== yearMonth
+        || readOptionalText(result?.status) !== 'OPEN') {
+        throw createHttpError(502, 'JVM 월 결산 재개 결과를 확인할 수 없습니다.', 'cashflow_jvm_invalid_response');
+      }
+      try {
+        if (db?.doc && db?.runTransaction) {
+          const requestId = `${rawProjectId}-${yearMonth}`;
+          const requestRef = db.doc(cashflowMonthCloseRequestPath(req.context.tenantId, requestId));
+          await db.runTransaction(async (transaction) => {
+            const snapshot = await transaction.get(requestRef);
+            if (!snapshot.exists) return;
+            const current = snapshot.data() || {};
+            if (current.contractVersion !== CASHFLOW_CUMULATIVE_CLOSE_CONTRACT
+              || current.requestId !== requestId
+              || current.projectId !== rawProjectId
+              || current.yearMonth !== yearMonth
+              || current.status === 'REOPENED'
+              || !['APPROVED', 'APPROVING', 'UNCERTAIN'].includes(current.status)) return;
+            transaction.set(requestRef, {
+              ...current,
+              status: 'REOPENED',
+              reopenedAt: now().toISOString(),
+              reopenDecisionIdempotencyKey: req.context.idempotencyKey,
+            });
+          });
+        }
+      } catch {
+        // The JVM reopen is authoritative; a workflow read-model failure cannot undo it.
+      }
+    }
     return { status: 200, body: result };
   }));
 

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -1,7 +1,61 @@
 import express from 'express';
 import request from 'supertest';
+import { createHash } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
-import { buildCashflowManagementChecks, cashflowMonthCloseDeadline, mountJvmWeeklyApiRoutes } from './jvm-weekly-api.mjs';
+import {
+  buildCashflowManagementChecks,
+  buildCashflowMonthCloseRevisionChanges,
+  cashflowMonthCloseDeadline,
+  mountJvmWeeklyApiRoutes,
+} from './jvm-weekly-api.mjs';
+
+describe('cashflow month-close revision diff', () => {
+  it('preserves EMPTY, ZERO, VALUE, amount changes, and missing keys', () => {
+    const cell = (cashflowLine, cellState, amount) => ({
+      mode: 'projection', weekNo: 1, cashflowLine, cellState, ...(amount === undefined ? {} : { amount }),
+    });
+    const previous = [
+      cell('EMPTY_TO_ZERO', 'EMPTY'),
+      cell('ZERO_TO_EMPTY', 'ZERO', 0),
+      cell('EMPTY_TO_VALUE', 'EMPTY'),
+      cell('VALUE_TO_EMPTY', 'VALUE', 10),
+      cell('ZERO_TO_VALUE', 'ZERO', 0),
+      cell('VALUE_TO_ZERO', 'VALUE', 20),
+      cell('VALUE_AMOUNT', 'VALUE', 30),
+      cell('REMOVED_KEY', 'VALUE', 40),
+    ];
+    const current = [
+      cell('EMPTY_TO_ZERO', 'ZERO', 0),
+      cell('ZERO_TO_EMPTY', 'EMPTY'),
+      cell('EMPTY_TO_VALUE', 'VALUE', 10),
+      cell('VALUE_TO_EMPTY', 'EMPTY'),
+      cell('ZERO_TO_VALUE', 'VALUE', 20),
+      cell('VALUE_TO_ZERO', 'ZERO', 0),
+      cell('VALUE_AMOUNT', 'VALUE', 35),
+      cell('ADDED_KEY', 'VALUE', 50),
+    ];
+
+    const changes = buildCashflowMonthCloseRevisionChanges(previous, current);
+
+    expect(changes).toEqual(expect.arrayContaining([
+      expect.objectContaining({ cashflowLine: 'EMPTY_TO_ZERO', previousState: 'EMPTY', currentState: 'ZERO', previousAmount: null, currentAmount: 0, amountDelta: null }),
+      expect.objectContaining({ cashflowLine: 'ZERO_TO_EMPTY', previousState: 'ZERO', currentState: 'EMPTY', previousAmount: 0, currentAmount: null, amountDelta: null }),
+      expect.objectContaining({ cashflowLine: 'EMPTY_TO_VALUE', previousState: 'EMPTY', currentState: 'VALUE', previousAmount: null, currentAmount: 10, amountDelta: null }),
+      expect.objectContaining({ cashflowLine: 'VALUE_TO_EMPTY', previousState: 'VALUE', currentState: 'EMPTY', previousAmount: 10, currentAmount: null, amountDelta: null }),
+      expect.objectContaining({ cashflowLine: 'ZERO_TO_VALUE', previousState: 'ZERO', currentState: 'VALUE', previousAmount: 0, currentAmount: 20, amountDelta: 20 }),
+      expect.objectContaining({ cashflowLine: 'VALUE_TO_ZERO', previousState: 'VALUE', currentState: 'ZERO', previousAmount: 20, currentAmount: 0, amountDelta: -20 }),
+      expect.objectContaining({ cashflowLine: 'VALUE_AMOUNT', previousState: 'VALUE', currentState: 'VALUE', previousAmount: 30, currentAmount: 35, amountDelta: 5 }),
+      expect.objectContaining({ cashflowLine: 'ADDED_KEY', previousState: 'MISSING', currentState: 'VALUE', previousAmount: null, currentAmount: 50, amountDelta: null }),
+      expect.objectContaining({ cashflowLine: 'REMOVED_KEY', previousState: 'VALUE', currentState: 'MISSING', previousAmount: 40, currentAmount: null, amountDelta: null }),
+    ]));
+    expect(changes).toHaveLength(9);
+  });
+});
+import { stableStringify } from '../utils.mjs';
+
+function cashflowEvidenceHash(value) {
+  return `sha256:${createHash('sha256').update(stableStringify(value)).digest('hex')}`;
+}
 
 function createIdempotencyService() {
   return {
@@ -636,16 +690,16 @@ describe('JVM weekly API BFF proxy', () => {
         expect(response.body.dashboard.cumulativeCloseScope).toEqual({
           contractVersion: 'cashflow-cumulative-close-v2',
           fromMonth: '2023-01',
-          throughMonth: '2026-08',
+          throughMonth: '2026-07',
           lockRange: {
             fromMonth: '2023-01',
             fromWeekNo: 1,
-            throughMonth: '2026-08',
+            throughMonth: '2026-07',
             throughWeekNo: 5,
           },
-          monthCount: 44,
-          weekCount: 220,
-          cellCount: 7040,
+          monthCount: 43,
+          weekCount: 215,
+          cellCount: 6880,
           source: {
             sourceRevision: source.sourceRevision,
             targetRevision: source.targetRevision,
@@ -662,7 +716,7 @@ describe('JVM weekly API BFF proxy', () => {
   it.each([
     ['invalid format', '2026-13'],
     ['before the cumulative baseline', '2022-12'],
-    ['beyond the bounded cumulative range', '2043-01'],
+    ['beyond the bounded cumulative range', '2043-02'],
   ])('rejects %s before reading the JVM month-close source', async (_label, yearMonth) => {
     const fetchImpl = vi.fn();
     const { app } = createApp(fetchImpl, createIdempotencyService());
@@ -2211,10 +2265,10 @@ describe('JVM weekly API BFF proxy', () => {
           source: { kind: 'MONTH_CLOSE_SNAPSHOT', sourceRevision: `sha256:${'f'.repeat(64)}` },
           cumulativeCloseScope: {
             fromMonth: '2023-01',
-            throughMonth: '2026-06',
-            monthCount: 42,
-            weekCount: 210,
-            cellCount: 6720,
+            throughMonth: '2026-05',
+            monthCount: 41,
+            weekCount: 205,
+            cellCount: 6560,
             source: {
               sourceRevision: `sha256:${'f'.repeat(64)}`,
               targetRevision: `sha256:${'a'.repeat(64)}`,
@@ -3502,6 +3556,30 @@ describe('JVM weekly API BFF proxy', () => {
       .expect((response) => expect(response.body.code).toBe('cashflow_month_close_member_inactive'));
   });
 
+  it('keeps the original through month when reading a legacy cumulative request without throughMonth', async () => {
+    const source = fullMonthCloseSource();
+    source.documents.set('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-08', {
+      contractVersion: 'cashflow-cumulative-close-v2',
+      requestId: 'project-a-2026-08', projectId: 'project-a', yearMonth: '2026-08',
+      fromMonth: '2023-01', status: 'PENDING', revision: 1,
+      monthCount: 44, weekCount: 220, cellCount: 7040,
+      manifestHash: `sha256:${'a'.repeat(64)}`,
+      requestedByUid: 'pm-1', approverUid: 'finance-1',
+    });
+    const requester = createApp(vi.fn(), createIdempotencyService(), {
+      actorId: 'pm-1', actorRole: 'pm',
+    }, { env: runtimeEnv, db: source.db }).app;
+
+    await request(requester)
+      .get('/api/v1/cashflow/project-a/month-close/requests/current?yearMonth=2026-08')
+      .expect(200)
+      .expect((response) => expect(response.body.request).toMatchObject({
+        throughMonth: '2026-08',
+        lockRange: { throughMonth: '2026-08' },
+        monthCount: 44,
+      }));
+  });
+
   it('lets only the saved designated approver review and closes only after approval', async () => {
     const source = fullMonthCloseSource();
     const fetchImpl = vi.fn(async (url, init) => ({
@@ -3930,6 +4008,7 @@ describe('JVM weekly API BFF proxy', () => {
     const closeCalls = fetchImpl.mock.calls.filter(([url, init]) => url.endsWith('/month-close') && init.method === 'POST');
     expect(closeCalls).toHaveLength(1);
     expect(JSON.parse(closeCalls[0][1].body).idempotencyKey).toBe('cashflow-month-close-approval:project-a-2026-06:r3');
+
   });
 
   it('approves from stored evidence when live publication and dashboard sources change or disappear', async () => {
@@ -4014,7 +4093,7 @@ describe('JVM weekly API BFF proxy', () => {
     expect(closeBody.cells).toEqual(snapshotCells);
   });
 
-  it('rejects, resubmits, and replays a verified 44-month cumulative v2 request without live evidence', async () => {
+  it('recovers a legacy 44-month BUILDING request, then rejects and resubmits the previous-month cumulative v2 request', async () => {
     const source = fullMonthCloseSource();
     const runTransaction = source.db.runTransaction;
     let transactionTail = Promise.resolve();
@@ -4037,6 +4116,10 @@ describe('JVM weekly API BFF proxy', () => {
     let closedMonthClose = null;
     let dashboardSourceUnavailable = false;
     const fetchImpl = vi.fn(async (url, init) => {
+      if (url.endsWith('/month-close/reopen-decision')) {
+        closedMonthClose = { ...closedMonthClose, status: 'OPEN', revision: 2 };
+        return { ok: true, status: 200, text: async () => JSON.stringify(closedMonthClose) };
+      }
       if (url.includes('/dashboard-source')) {
         if (dashboardSourceUnavailable) throw new Error('live dashboard source drifted after persistence');
         return {
@@ -4053,7 +4136,7 @@ describe('JVM weekly API BFF proxy', () => {
         closedMonthClose = {
           ok: true, projectId: 'project-a', requestId: 'project-a-2026-08', requestRevision: closeBody.requestRevision,
           manifestHash: closeBody.manifestHash, yearMonth: '2026-08', status: 'CLOSED',
-          revision: 1, rootHash: closeBody.manifestHash, headRevision: 44, auditId: `audit-cumulative-${closeBody.requestRevision}`,
+          revision: 1, rootHash: closeBody.manifestHash, headRevision: 43, auditId: `audit-cumulative-${closeBody.requestRevision}`,
         };
         return { ok: true, status: 200, text: async () => JSON.stringify(closedMonthClose) };
       }
@@ -4119,29 +4202,72 @@ describe('JVM weekly API BFF proxy', () => {
       .send(createPayload)
       .expect(202);
     expect(created.body).toMatchObject({
-      documentType: 'MONTHLY_CLOSE', contractVersion: 'cashflow-cumulative-close-v2', status: 'PENDING', monthCount: 44,
-      weekCount: 220, cellCount: 7040,
-      fromMonth: '2023-01', yearMonth: '2026-08', revision: 1,
+      documentType: 'MONTHLY_CLOSE', contractVersion: 'cashflow-cumulative-close-v2', status: 'PENDING', monthCount: 43,
+      weekCount: 215, cellCount: 6880,
+      fromMonth: '2023-01', yearMonth: '2026-08', throughMonth: '2026-07', revision: 1,
       source: { spreadsheetId: 'spreadsheet-a', selectedSheetName: 'cashflow(사용내역 연동)' },
       totals: { projection: 0, actual: 0, difference: 0 },
       annualSummaries: [
         { year: 2023, monthCount: 12, projection: 0, actual: 0, difference: 0 },
         { year: 2024, monthCount: 12, projection: 0, actual: 0, difference: 0 },
         { year: 2025, monthCount: 12, projection: 0, actual: 0, difference: 0 },
-        { year: 2026, monthCount: 8, projection: 0, actual: 0, difference: 0 },
+        { year: 2026, monthCount: 7, projection: 0, actual: 0, difference: 0 },
       ],
     });
     expect(created.body.monthSnapshot).toBeNull();
     let shardDocs = [...source.documents.entries()].filter(([path]) => path.includes('/cashflow_month_close_request_months/'));
-    expect(shardDocs).toHaveLength(44);
+    expect(shardDocs).toHaveLength(43);
     expect(shardDocs.every(([, shard]) => shard.cells.length === 160)).toBe(true);
-    expect(shardDocs.reduce((count, [, shard]) => count + shard.cells.length, 0)).toBe(7040);
+    expect(shardDocs.reduce((count, [, shard]) => count + shard.cells.length, 0)).toBe(6880);
     expect(source.documents.get('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r1-requested')).toMatchObject({
       action: 'REQUESTED', revision: 1, actorUid: 'pm-1', manifestHash: created.body.manifestHash,
     });
+    await request(requester)
+      .get('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/revision-diff')
+      .expect(200)
+      .expect((response) => expect(response.body).toEqual({
+        requestId: 'project-a-2026-08', yearMonth: '2026-07',
+        currentRevision: 1, previousRevision: null, changes: [],
+      }));
 
     const requestPath = 'orgs/tenant-a/cashflow_month_close_requests/project-a-2026-08';
-    const legacyBuilding = { ...source.documents.get(requestPath), status: 'BUILDING' };
+    const canonicalRequestRecord = { ...source.documents.get(requestPath) };
+    const requestedAuditPath = 'orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r1-requested';
+    const canonicalRequestedAudit = { ...source.documents.get(requestedAuditPath) };
+    const legacyAugustBase = {
+      ...Object.fromEntries(Object.entries(shardDocs.find(([, shard]) => shard.yearMonth === '2026-07')[1])
+        .filter(([key]) => key !== 'shardHash')),
+      yearMonth: '2026-08',
+    };
+    const legacyAugustShard = { ...legacyAugustBase, shardHash: cashflowEvidenceHash(legacyAugustBase) };
+    const legacyManifest = {
+      contractVersion: 'cashflow-cumulative-close-v2',
+      requestId: 'project-a-2026-08',
+      requestRevision: 1,
+      projectId: 'project-a',
+      fromMonth: '2023-01',
+      yearMonth: '2026-08',
+      months: [...shardDocs.map(([, shard]) => ({ yearMonth: shard.yearMonth, shardHash: shard.shardHash })), {
+        yearMonth: '2026-08', shardHash: legacyAugustShard.shardHash,
+      }],
+    };
+    const legacyManifestHash = cashflowEvidenceHash(legacyManifest);
+    const legacyBuilding = {
+      ...source.documents.get(requestPath),
+      status: 'BUILDING',
+      manifestHash: legacyManifestHash,
+      monthCount: 44,
+      weekCount: 220,
+      cellCount: 7040,
+      payloadFingerprint: cashflowEvidenceHash({
+        contractVersion: 'cashflow-cumulative-close-v2',
+        approverUid: 'finance-1',
+        yearMonth: '2026-08',
+        expectedRevision: 0,
+        manifestHash: legacyManifestHash,
+      }),
+    };
+    delete legacyBuilding.throughMonth;
     delete legacyBuilding.requestFingerprint;
     source.documents.set(requestPath, legacyBuilding);
     for (const path of [...source.documents.keys()]) {
@@ -4159,7 +4285,44 @@ describe('JVM weekly API BFF proxy', () => {
     expect(legacyRecovery.status, JSON.stringify(legacyRecovery.body)).toBe(202);
     shardDocs = [...source.documents.entries()].filter(([path]) => path.includes('/cashflow_month_close_request_months/'));
     expect(shardDocs).toHaveLength(44);
-    expect(source.documents.get(requestPath)).toMatchObject({ status: 'PENDING', requestFingerprint: expect.any(String) });
+    expect(source.documents.get(requestPath)).toMatchObject({
+      status: 'PENDING', monthCount: 44,
+      manifestHash: legacyManifestHash, requestFingerprint: expect.any(String),
+    });
+    expect(source.documents.get(requestPath).throughMonth).toBeUndefined();
+    source.documents.set(requestPath, { ...source.documents.get(requestPath), status: 'REJECTED' });
+    await request(legacyRequester)
+      .post('/api/v1/cashflow/project-a/month-close/requests')
+      .set('idempotency-key', 'legacy-cumulative-resubmit')
+      .send(createPayload)
+      .expect(202)
+      .expect((response) => expect(response.body).toMatchObject({
+        status: 'PENDING', revision: 2, monthCount: 44,
+      }));
+    expect(source.documents.get(requestPath).throughMonth).toBeUndefined();
+    expect([...source.documents.keys()].filter((path) => (
+      path.includes('/cashflow_month_close_request_months/project-a-2026-08-r2-')
+    ))).toHaveLength(44);
+    source.documents.set(requestPath, {
+      ...source.documents.get(requestPath), status: 'REJECTED', throughMonth: '2026-08', monthCount: 43,
+    });
+    await request(legacyRequester)
+      .post('/api/v1/cashflow/project-a/month-close/requests')
+      .set('idempotency-key', 'invalid-explicit-legacy-horizon')
+      .send(createPayload)
+      .expect(409)
+      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_request_horizon_invalid'));
+    expect([...source.documents.keys()].filter((path) => (
+      path.includes('/cashflow_month_close_request_months/project-a-2026-08-r3-')
+    ))).toHaveLength(0);
+    for (const path of [...source.documents.keys()]) {
+      if (path.includes('/cashflow_month_close_request_months/project-a-2026-08-r2-')
+        || path.endsWith('/project-a-2026-08-r2-resubmitted')) source.documents.delete(path);
+    }
+    source.documents.delete('orgs/tenant-a/cashflow_month_close_request_months/project-a-2026-08-r1-2026-08');
+    source.documents.set(requestPath, canonicalRequestRecord);
+    source.documents.set(requestedAuditPath, canonicalRequestedAudit);
+    shardDocs = [...source.documents.entries()].filter(([path]) => path.includes('/cashflow_month_close_request_months/'));
 
     const firstShard = shardDocs[0][1];
     firstShard.cells[0].amount = 1;
@@ -4173,6 +4336,9 @@ describe('JVM weekly API BFF proxy', () => {
     }, { env: runtimeEnv, db: source.db }).app;
     await request(unrelated)
       .get('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/months?limit=1')
+      .expect(403);
+    await request(unrelated)
+      .get('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/revision-diff')
       .expect(403);
 
     await request(requester)
@@ -4230,13 +4396,20 @@ describe('JVM weekly API BFF proxy', () => {
     expect(resubmitAttempts.find(({ status }) => status === 409)?.body.code).toBe('cashflow_month_close_request_conflict');
     const resubmitted = resubmitAttempts.find(({ status }) => status === 202);
     const winningResubmitKey = resubmitAttempts[0].status === 202 ? 'cumulative-v2-resubmit-a' : 'cumulative-v2-resubmit-b';
-    expect(resubmitted.body).toMatchObject({ status: 'PENDING', revision: 2, monthCount: 44 });
+    expect(resubmitted.body).toMatchObject({ status: 'PENDING', revision: 2, monthCount: 43 });
     expect(resubmitted.body.manifestHash).not.toBe(created.body.manifestHash);
     expect(source.documents.get('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r2-resubmitted')).toMatchObject({
       action: 'RESUBMITTED', revision: 2, actorUid: 'pm-1', manifestHash: resubmitted.body.manifestHash,
     });
     expect([...r1Shards].every(([path, json]) => JSON.stringify(source.documents.get(path)) === json)).toBe(true);
-    expect([...source.documents.keys()].filter((path) => path.includes('/cashflow_month_close_request_months/project-a-2026-08-r2-'))).toHaveLength(44);
+    expect([...source.documents.keys()].filter((path) => path.includes('/cashflow_month_close_request_months/project-a-2026-08-r2-'))).toHaveLength(43);
+    await request(approver)
+      .get('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/revision-diff')
+      .expect(200)
+      .expect((response) => expect(response.body).toEqual({
+        requestId: 'project-a-2026-08', yearMonth: '2026-07',
+        currentRevision: 2, previousRevision: 1, changes: [],
+      }));
     const dashboardSourceCallCount = fetchImpl.mock.calls.filter(([url]) => url.includes('/dashboard-source')).length;
     dashboardSourceUnavailable = true;
     await request(requester)
@@ -4327,12 +4500,28 @@ describe('JVM weekly API BFF proxy', () => {
         .expect((response) => expect(response.body.request).toMatchObject({ status: 'APPROVED', revision: 2 }));
       expect(closePostCount()).toBe(1);
     }
-    source.documents.set(requestPath, { ...source.documents.get(requestPath), status: 'UNCERTAIN' });
     await request(approver)
       .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
       .set('idempotency-key', 'unsafe-reject-after-approval-start')
       .send({ decision: 'REJECT', reason: '취소', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
       .expect(409);
+
+    const reopenRunTransaction = source.db.runTransaction;
+    source.db.runTransaction = vi.fn()
+      .mockRejectedValueOnce(new Error('workflow read model unavailable'))
+      .mockImplementation(reopenRunTransaction);
+    await request(approver)
+      .post('/api/v1/cashflow/project-a/month-close/reopen-decision')
+      .set('idempotency-key', 'reopen-with-post-hook-failure')
+      .send({ yearMonth: '2026-08', expectedRevision: 2, decision: 'APPROVE', reason: '복구 후 재결산' })
+      .expect(200);
+    expect(source.documents.get(requestPath).status).toBe('APPROVED');
+    const afterReopen = await request(requester)
+      .post('/api/v1/cashflow/project-a/month-close/requests')
+      .set('idempotency-key', 'cumulative-v2-after-missed-reopen-hook')
+      .send({ ...createPayload, expectedRevision: 2 });
+    expect(afterReopen.status, JSON.stringify(afterReopen.body)).toBe(202);
+    expect(afterReopen.body).toMatchObject({ status: 'PENDING', revision: 3 });
   });
 
   it('blocks the legacy direct month-close mutation route', async () => {
@@ -4617,6 +4806,114 @@ describe('JVM weekly API BFF proxy', () => {
       });
     },
   );
+
+  it.each(['APPROVED', 'APPROVING', 'UNCERTAIN'])(
+    'marks a %s cumulative request REOPENED after the JVM reopens it', async (status) => {
+    const source = fullMonthCloseSource();
+    const requestPath = 'orgs/tenant-a/cashflow_month_close_requests/project-a-2026-08';
+    source.documents.set(requestPath, {
+      contractVersion: 'cashflow-cumulative-close-v2',
+      requestId: 'project-a-2026-08',
+      projectId: 'project-a',
+      yearMonth: '2026-08',
+      throughMonth: '2026-07',
+      status,
+      revision: 1,
+    });
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ projectId: 'project-a', yearMonth: '2026-08', status: 'OPEN' }),
+    }));
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {
+      actorId: 'finance-1', actorRole: 'finance',
+    }, { env: runtimeEnv, db: source.db, now: () => new Date('2026-08-03T03:00:00.000Z') });
+
+    await request(app)
+      .post('/api/v1/cashflow/project-a/month-close/reopen-decision')
+      .set('idempotency-key', 'reopen-approved-cumulative')
+      .send({ yearMonth: '2026-08', expectedRevision: 2, decision: 'APPROVE', reason: '수정 후 재결산' })
+      .expect(200);
+
+    expect(source.documents.get(requestPath)).toMatchObject({
+      status: 'REOPENED',
+      reopenDecisionIdempotencyKey: 'reopen-approved-cumulative',
+      reopenedAt: '2026-08-03T03:00:00.000Z',
+    });
+  });
+
+  it('keeps a successful JVM reopen successful when the colocated request is not cumulative', async () => {
+    const source = fullMonthCloseSource();
+    const requestPath = 'orgs/tenant-a/cashflow_month_close_requests/project-a-2026-08';
+    source.documents.set(requestPath, { contractVersion: 'cashflow-month-close-v1', status: 'APPROVED' });
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ projectId: 'project-a', yearMonth: '2026-08', status: 'OPEN' }),
+    }));
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {
+      actorId: 'finance-1', actorRole: 'finance',
+    }, { env: runtimeEnv, db: source.db });
+
+    await request(app)
+      .post('/api/v1/cashflow/project-a/month-close/reopen-decision')
+      .set('idempotency-key', 'reopen-non-cumulative')
+      .send({ yearMonth: '2026-08', expectedRevision: 2, decision: 'APPROVE', reason: '수정' })
+      .expect(200);
+
+    expect(source.documents.get(requestPath)).toEqual({
+      contractVersion: 'cashflow-month-close-v1', status: 'APPROVED',
+    });
+  });
+
+  it.each([
+    ['document reference creation', { doc: () => { throw new Error('doc unavailable'); }, runTransaction: vi.fn() }],
+    ['workflow transaction', { doc: vi.fn(() => ({ path: 'request' })), runTransaction: vi.fn().mockRejectedValue(new Error('transaction unavailable')) }],
+  ])('keeps a successful JVM reopen successful when %s fails', async (_label, db) => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ projectId: 'project-a', yearMonth: '2026-08', status: 'OPEN' }),
+    }));
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {
+      actorId: 'finance-1', actorRole: 'finance',
+    }, { env: runtimeEnv, db });
+
+    await request(app)
+      .post('/api/v1/cashflow/project-a/month-close/reopen-decision')
+      .set('idempotency-key', `reopen-post-hook-${_label}`)
+      .send({ yearMonth: '2026-08', expectedRevision: 2, decision: 'APPROVE', reason: '수정' })
+      .expect(200)
+      .expect((response) => expect(response.body).toMatchObject({
+        projectId: 'project-a', yearMonth: '2026-08', status: 'OPEN',
+      }));
+  });
+
+  it.each([
+    [{ projectId: 'project-b', yearMonth: '2026-08', status: 'OPEN' }, 'projectId'],
+    [{ projectId: 'project-a', yearMonth: '2026-07', status: 'OPEN' }, 'yearMonth'],
+    [{ projectId: 'project-a', yearMonth: '2026-08', status: 'CLOSED' }, 'status'],
+  ])('rejects a mismatched JVM reopen %s response before updating the workflow request', async (result) => {
+    const db = { doc: vi.fn(), runTransaction: vi.fn() };
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(result),
+    }));
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {
+      actorId: 'finance-1', actorRole: 'finance',
+    }, { env: runtimeEnv, db });
+
+    await request(app)
+      .post('/api/v1/cashflow/project-a/month-close/reopen-decision')
+      .set('idempotency-key', 'reopen-invalid-jvm-result')
+      .send({ yearMonth: '2026-08', expectedRevision: 2, decision: 'APPROVE', reason: '수정' })
+      .expect(502)
+      .expect((response) => expect(response.body.code).toBe('cashflow_jvm_invalid_response'));
+
+    expect(db.doc).not.toHaveBeenCalled();
+    expect(db.runTransaction).not.toHaveBeenCalled();
+  });
 
   it.each([
     [{ ...runtimeEnv, BFF_DEPLOY_ENV: 'preview' }, 'unsafe_bff_runtime'],

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -1009,12 +1009,13 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         requireCashflowSheetPublicationReady(actor.tenantId(), projectId);
         YearMonth targetMonth = requireYearMonth(request.yearMonth());
         LocalDate today = cashflowMonthCloseBusinessDate();
-        if (!targetMonth.isBefore(YearMonth.from(today))) {
-            throw new WeeklyExpenseConflictException("Cashflow month close is available after the target month ends.");
-        }
         ValidatedCumulativeClose cumulative = request.cumulativeV2()
             ? requireCumulativeCloseApproval(actor, projectId, request)
             : null;
+        YearMonth closeThrough = cumulative == null ? targetMonth : requireYearMonth(cumulative.throughMonth());
+        if (!closeThrough.isBefore(YearMonth.from(today))) {
+            throw new WeeklyExpenseConflictException("Cashflow month close is available after the target month ends.");
+        }
         Map<String, Object> approval = cumulative == null
             ? requireMonthCloseApproval(actor, projectId, request.yearMonth())
             : Map.of();
@@ -1022,6 +1023,17 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         List<CashflowSheetLabApplyRequest.Cell> cells = cumulative == null
             ? CashflowSheetLabApplyRequest.requireCompleteMonth(request.cells())
             : cumulative.cells();
+        List<CashflowClosedMonthAmendment> legacyTransitionAmendments = List.of();
+        if (cumulative != null && cumulative.legacyHeadTransition()) {
+            legacyTransitionAmendments = authorizeCashflowSheetMonthAmendments(
+                actor,
+                projectId,
+                List.of(cumulative.throughMonth()),
+                cumulative.sourceRevision(),
+                "누적 결산 계약 전환",
+                request.idempotencyKey()
+            );
+        }
         List<CloseCashflowMonthRequest.DepositScheduleRow> depositScheduleRows;
         List<CloseCashflowMonthRequest.Confirmation> confirmations;
         ValidatedCloseSource source;
@@ -1064,10 +1076,23 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             actor.tenantId(),
             projectId,
             sourceSheetKey,
-            request.yearMonth(),
+            cumulative == null ? request.yearMonth() : cumulative.throughMonth(),
             cumulative == null ? request.targetRevision() : cumulative.targetRevision(),
             cells
         );
+        if (!legacyTransitionAmendments.isEmpty()) {
+            recordCashflowSheetMonthAmendments(
+                actor,
+                projectId,
+                legacyTransitionAmendments,
+                cumulative.sourceRevision(),
+                cumulative.targetRevision(),
+                replacement.resultingTargetRevision(),
+                Map.of(),
+                "누적 결산 계약 전환",
+                request.idempotencyKey()
+            );
+        }
         Instant now = clock.instant();
         Map<String, Object> snapshot = cumulative == null
             ? buildMonthCloseSnapshot(
@@ -1144,7 +1169,8 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             head.put("projectId", projectId);
             head.put("status", "CLOSED");
             head.put("fromMonth", CASHFLOW_CUMULATIVE_BASELINE.toString());
-            head.put("closedThrough", request.yearMonth());
+            head.put("closedThrough", cumulative.throughMonth());
+            head.put("settlementMonth", request.yearMonth());
             head.put("rootHash", request.manifestHash());
             head.put("revision", cumulative.headRevision());
             head.put("requestId", request.requestId());
@@ -1617,7 +1643,11 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         requireYearMonth(request.yearMonth());
         Map<String, Object> cumulativeHead = cumulativeCloseHead(actor.tenantId(), projectId);
         boolean cumulative = !cumulativeHead.isEmpty();
-        if (cumulative && !request.yearMonth().equals(text(cumulativeHead.get("closedThrough"), ""))) {
+        String cumulativeSettlementMonth = text(
+            cumulativeHead.get("settlementMonth"),
+            text(cumulativeHead.get("closedThrough"), "")
+        );
+        if (cumulative && !request.yearMonth().equals(cumulativeSettlementMonth)) {
             throw new WeeklyExpenseConflictException("Only the latest cumulative close horizon can be reopened.");
         }
         DocumentReference closeRef = db.document(monthlyClosePath(actor.tenantId(), projectId, request.yearMonth()));
@@ -1674,7 +1704,11 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         requireYearMonth(request.yearMonth());
         Map<String, Object> cumulativeHead = cumulativeCloseHead(actor.tenantId(), projectId);
         boolean cumulative = !cumulativeHead.isEmpty();
-        if (cumulative && (!request.yearMonth().equals(text(cumulativeHead.get("closedThrough"), ""))
+        String cumulativeSettlementMonth = text(
+            cumulativeHead.get("settlementMonth"),
+            text(cumulativeHead.get("closedThrough"), "")
+        );
+        if (cumulative && (!request.yearMonth().equals(cumulativeSettlementMonth)
             || !"REOPEN_REQUESTED".equals(text(cumulativeHead.get("status"), "")))) {
             throw new WeeklyExpenseConflictException("Only the latest requested cumulative close horizon can be decided.");
         }
@@ -1698,13 +1732,16 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         Instant now = clock.instant();
         Map<DocumentReference, Map<String, Object>> weeklyReopenPatches = new LinkedHashMap<>();
         if (approved) {
+            String dataYearMonth = cumulative
+                ? text(cumulativeHead.get("closedThrough"), request.yearMonth())
+                : request.yearMonth();
             DocumentReference[] weeklyCompletionRefs = java.util.stream.IntStream.rangeClosed(
                     1,
                     CashflowSheetLabApplyRequest.FINANCE_WEEK_COUNT
                 )
                 .mapToObj(weekNo -> db.document(cashflowWeeklyUpdateCompletionPath(
                     actor.tenantId(),
-                    projectId + "-" + request.yearMonth() + "-w" + weekNo
+                    projectId + "-" + dataYearMonth + "-w" + weekNo
                 )))
                 .toArray(DocumentReference[]::new);
             for (DocumentSnapshot weeklyCompletion : getAll(weeklyCompletionRefs)) {
@@ -1712,7 +1749,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                 Map<String, Object> completion = data(weeklyCompletion);
                 int weekNo = intValue(completion.get("weekNo"), 0);
                 if (!projectId.equals(text(completion.get("projectId"), ""))
-                    || !request.yearMonth().equals(text(completion.get("yearMonth"), ""))
+                    || !dataYearMonth.equals(text(completion.get("yearMonth"), ""))
                     || weekNo < 1
                     || weekNo > CashflowSheetLabApplyRequest.FINANCE_WEEK_COUNT) {
                     throw new WeeklyExpenseConflictException("Stored weekly cashflow completion scope is invalid.");
@@ -1750,7 +1787,16 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             headPatch.put("status", "CLOSED");
             headPatch.put("revision", Math.addExact(longValue(cumulativeHead.get("revision"), 0), 1));
             if (approved) {
-                headPatch.put("closedThrough", YearMonth.parse(request.yearMonth()).minusMonths(1).toString());
+                String currentClosedThrough = text(cumulativeHead.get("closedThrough"), request.yearMonth());
+                String currentSettlementMonth = text(cumulativeHead.get("settlementMonth"), "");
+                String reopenedThrough = YearMonth.parse(currentClosedThrough).minusMonths(1).toString();
+                headPatch.put(
+                    "closedThrough",
+                    reopenedThrough
+                );
+                if (currentSettlementMonth.isBlank() || currentSettlementMonth.equals(currentClosedThrough)) {
+                    headPatch.put("settlementMonth", reopenedThrough);
+                }
             }
             headPatch.put("reopenDecision", decision);
             headPatch.put("updatedAt", now.toString());
@@ -2839,10 +2885,16 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             throw new WeeklyExpenseConflictException("Cumulative close request header evidence does not match approval.");
         }
         YearMonth target = YearMonth.parse(request.yearMonth());
-        if (target.isBefore(CASHFLOW_CUMULATIVE_BASELINE)) {
+        String storedThroughMonth = text(header.get("throughMonth"), "");
+        YearMonth throughMonth = YearMonth.parse(storedThroughMonth.isBlank() ? target.toString() : storedThroughMonth);
+        YearMonth expectedThroughMonth = storedThroughMonth.isBlank() ? target : target.minusMonths(1);
+        if (throughMonth.isBefore(CASHFLOW_CUMULATIVE_BASELINE)) {
             throw new WeeklyExpenseConflictException("Cumulative close cannot precede the 2023-01 baseline.");
         }
-        long monthCount = java.time.temporal.ChronoUnit.MONTHS.between(CASHFLOW_CUMULATIVE_BASELINE, target) + 1;
+        if (!throughMonth.equals(expectedThroughMonth)) {
+            throw new WeeklyExpenseConflictException("Cumulative close through month does not match the settlement contract.");
+        }
+        long monthCount = java.time.temporal.ChronoUnit.MONTHS.between(CASHFLOW_CUMULATIVE_BASELINE, throughMonth) + 1;
         List<String> months = java.util.stream.LongStream.range(0, monthCount)
             .mapToObj(CASHFLOW_CUMULATIVE_BASELINE::plusMonths)
             .map(YearMonth::toString)
@@ -2889,7 +2941,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                 throw new WeeklyExpenseConflictException("Cumulative close month shard hash mismatch: " + yearMonth);
             }
             manifestMonths.add(Map.of("yearMonth", yearMonth, "shardHash", shardHash));
-            if (yearMonth.equals(request.yearMonth())) {
+            if (yearMonth.equals(throughMonth.toString())) {
                 selectedCells = cumulativeCells(canonicalCells);
                 selectedSource = source;
             }
@@ -2907,15 +2959,27 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         }
         Map<String, Object> currentHead = cumulativeCloseHead(actor.tenantId(), projectId);
         String closedThrough = text(currentHead.get("closedThrough"), "");
-        if (!closedThrough.isBlank() && !YearMonth.parse(closedThrough).isBefore(target)) {
-            throw new WeeklyExpenseConflictException("Cumulative close horizon must extend the current horizon.");
+        boolean legacyHeadTransition = false;
+        if (!closedThrough.isBlank()) {
+            YearMonth previousHorizon = YearMonth.parse(closedThrough);
+            String settlementMonth = text(currentHead.get("settlementMonth"), "");
+            boolean legacyHead = settlementMonth.isBlank()
+                || YearMonth.parse(settlementMonth).equals(previousHorizon);
+            legacyHeadTransition = legacyHead && previousHorizon.equals(throughMonth);
+            boolean extendsHorizon = legacyHead
+                ? previousHorizon.isBefore(target)
+                : previousHorizon.isBefore(throughMonth);
+            if (!extendsHorizon) {
+                throw new WeeklyExpenseConflictException("Cumulative close horizon must extend the current horizon.");
+            }
         }
         long headRevision = Math.addExact(longValue(currentHead.get("revision"), 0), 1);
         String sourceRevision = text(selectedSource.get("sourceRevision"), request.manifestHash());
         String targetRevision = text(selectedSource.get("targetRevision"), request.manifestHash());
         return new ValidatedCumulativeClose(
-            selectedCells, selectedSource, sourceRevision, targetRevision, headRevision,
-            text(header.get("approvalId"), ""), text(header.get("operationId"), ""), manifestMonths
+            selectedCells, selectedSource, sourceRevision, targetRevision, throughMonth.toString(), headRevision,
+            text(header.get("approvalId"), ""), text(header.get("operationId"), ""), manifestMonths,
+            legacyHeadTransition
         );
     }
 
@@ -3021,10 +3085,12 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         Map<String, Object> source,
         String sourceRevision,
         String targetRevision,
+        String throughMonth,
         long headRevision,
         String approvalId,
         String operationId,
-        List<Map<String, Object>> manifestMonths
+        List<Map<String, Object>> manifestMonths,
+        boolean legacyHeadTransition
     ) {}
 
     private List<Map<String, Object>> reviewWarnings(Object value) {

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -3758,8 +3758,8 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
-    void cumulativeCloseValidatesFortyFourImmutableMonthShardsAndPublishesHeadAtomically() {
-        Fixture fixture = fixture(activeMember(), activeLease(), true, LocalDate.parse("2026-09-01"));
+    void cumulativeCloseUsesThePreviousMonthDataAndPublishesHeadAtomically() {
+        Fixture fixture = fixture(activeMember(), activeLease(), true, LocalDate.parse("2026-08-01"));
         CloseCashflowMonthRequest request = cumulativeCloseRequest(fixture, "2026-08", "cumulative-44");
 
         CashflowMonthCloseResponse response = fixture.persistence.runCommandTransaction(() -> commandService(
@@ -3771,11 +3771,64 @@ class FirestoreCashflowLeaseGuardTest {
         assertThat(response.requestRevision()).isEqualTo(1);
         assertThat(response.rootHash()).isEqualTo(request.manifestHash());
         assertThat(response.headRevision()).isEqualTo(1);
-        assertThat(fixture.getAllSizes).contains(44);
+        assertThat(fixture.getAllSizes).contains(43);
         assertThat(fixture.documents.get("orgs/tenant-a/cashflow_cumulative_close_heads/project-a"))
-            .containsEntry("closedThrough", "2026-08")
+            .containsEntry("closedThrough", "2026-07")
             .containsEntry("rootHash", request.manifestHash())
             .containsEntry("revision", 1L);
+    }
+
+    @Test
+    void cumulativeCloseAdvancesFromALegacyHeadWithoutManualMigration() {
+        Fixture fixture = fixture(activeMember(), activeLease(), true, LocalDate.parse("2026-10-01"));
+        fixture.documents.put("orgs/tenant-a/cashflow_cumulative_close_heads/project-a", Map.of(
+            "contractVersion", "cashflow-cumulative-close-v2",
+            "tenantId", "tenant-a",
+            "projectId", "project-a",
+            "status", "CLOSED",
+            "closedThrough", "2026-08",
+            "rootHash", SOURCE_REVISION,
+            "revision", 1L
+        ));
+        CloseCashflowMonthRequest request = cumulativeCloseRequest(fixture, "2026-09", "legacy-head-next-close");
+
+        fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
+            .closeCashflowMonth(ACTOR, "project-a", SESSION, request));
+
+        assertThat(fixture.documents.get("orgs/tenant-a/cashflow_cumulative_close_heads/project-a"))
+            .containsEntry("settlementMonth", "2026-09")
+            .containsEntry("closedThrough", "2026-08")
+            .containsEntry("revision", 2L);
+        assertThat(fixture.documents.entrySet())
+            .filteredOn(entry -> entry.getKey().contains("/cashflow_month_amendments/"))
+            .singleElement()
+            .satisfies(entry -> assertThat(entry.getValue())
+                .containsEntry("yearMonth", "2026-08")
+                .containsEntry("closeSnapshotHash", SOURCE_REVISION)
+                .containsEntry("sourceRevision", SOURCE_REVISION)
+                .containsKeys("targetRevision", "resultingTargetRevision")
+                .containsEntry("reason", "누적 결산 계약 전환"));
+    }
+
+    @Test
+    void cumulativeCloseStillRejectsANonExtendingNewFormatHead() {
+        Fixture fixture = fixture(activeMember(), activeLease(), true, LocalDate.parse("2026-09-01"));
+        fixture.documents.put("orgs/tenant-a/cashflow_cumulative_close_heads/project-a", Map.of(
+            "contractVersion", "cashflow-cumulative-close-v2",
+            "tenantId", "tenant-a",
+            "projectId", "project-a",
+            "status", "CLOSED",
+            "settlementMonth", "2026-08",
+            "closedThrough", "2026-07",
+            "rootHash", SOURCE_REVISION,
+            "revision", 1L
+        ));
+        CloseCashflowMonthRequest request = cumulativeCloseRequest(fixture, "2026-08", "new-head-same-close");
+
+        assertThatThrownBy(() -> fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
+            .closeCashflowMonth(ACTOR, "project-a", SESSION, request)))
+            .isInstanceOf(WeeklyExpenseConflictException.class)
+            .hasMessageContaining("horizon must extend");
     }
 
     @Test
@@ -3849,6 +3902,125 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
+    void legacyCumulativeRequestWithoutThroughMonthKeepsItsOriginalHorizon() {
+        Fixture fixture = fixture(activeMember(), activeLease(), true, LocalDate.parse("2026-09-01"));
+        CloseCashflowMonthRequest request = cumulativeCloseRequest(fixture, "2026-08", "legacy-cumulative", true);
+
+        fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
+            .closeCashflowMonth(ACTOR, "project-a", SESSION, request));
+
+        assertThat(fixture.documents.get("orgs/tenant-a/cashflow_cumulative_close_heads/project-a"))
+            .containsEntry("closedThrough", "2026-08");
+    }
+
+    @Test
+    void legacyCumulativeRevisionTwoClosesItsPreservedFortyFourMonthHorizon() {
+        Fixture fixture = fixture(activeMember(), activeLease(), true, LocalDate.parse("2026-09-01"));
+        CloseCashflowMonthRequest request = cumulativeCloseRequest(
+            fixture, "2026-08", "legacy-cumulative-r2", true, 2
+        );
+
+        CashflowMonthCloseResponse response = fixture.persistence.runCommandTransaction(() -> commandService(
+            fixture.persistence
+        ).closeCashflowMonth(ACTOR, "project-a", SESSION, request));
+
+        assertThat(response.requestRevision()).isEqualTo(2);
+        assertThat(fixture.getAllSizes).contains(44);
+        assertThat(fixture.documents.get("orgs/tenant-a/cashflow_cumulative_close_heads/project-a"))
+            .containsEntry("closedThrough", "2026-08");
+    }
+
+    @Test
+    void newSettlementAdvancesAfterALegacyRequestClosedByTheCurrentCode() {
+        Fixture fixture = fixture(activeMember(), activeLease(), true, LocalDate.parse("2026-10-01"));
+        CloseCashflowMonthRequest legacy = cumulativeCloseRequest(
+            fixture, "2026-08", "legacy-current-code", true
+        );
+        fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
+            .closeCashflowMonth(ACTOR, "project-a", SESSION, legacy));
+        assertThat(fixture.documents.get("orgs/tenant-a/cashflow_cumulative_close_heads/project-a"))
+            .containsEntry("settlementMonth", "2026-08")
+            .containsEntry("closedThrough", "2026-08");
+
+        String currentTargetRevision = FirestoreInheritedWeeklyExpensePersistence.computeCashflowTargetRevision(
+            fixture.documents.entrySet().stream()
+                .filter(entry -> entry.getKey().contains("/cashflow_weeks/"))
+                .map(Map.Entry::getValue)
+                .toList()
+        );
+        CloseCashflowMonthRequest next = cumulativeCloseRequest(
+            fixture, "2026-09", "new-after-legacy-current-code", false, 1, currentTargetRevision
+        );
+        fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
+            .closeCashflowMonth(ACTOR, "project-a", SESSION, next));
+
+        assertThat(fixture.documents.get("orgs/tenant-a/cashflow_cumulative_close_heads/project-a"))
+            .containsEntry("settlementMonth", "2026-09")
+            .containsEntry("closedThrough", "2026-08")
+            .containsEntry("revision", 2L);
+        assertThat(fixture.documents.keySet()).anyMatch(path -> path.contains("/cashflow_month_amendments/"));
+    }
+
+    @Test
+    void legacyRequestClosedByCurrentCodeCanBeReopenedAndClosedAgain() {
+        Fixture fixture = fixture(activeMember(), activeLease(), true, LocalDate.parse("2026-09-01"));
+        CloseCashflowMonthRequest first = cumulativeCloseRequest(
+            fixture, "2026-08", "legacy-before-reopen", true
+        );
+        fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
+            .closeCashflowMonth(ACTOR, "project-a", SESSION, first));
+        fixture.persistence.runCommandTransaction(() -> fixture.persistence.requestCashflowMonthReopen(
+            ACTOR, "project-a", new RequestCashflowMonthReopenRequest(
+                "legacy-reopen-request", "2026-08", 1, "레거시 결산 정정"
+            )
+        ));
+        fixture.persistence.runCommandTransaction(() -> fixture.persistence.decideCashflowMonthReopen(
+            ACTOR, "project-a", new DecideCashflowMonthReopenRequest(
+                "legacy-reopen-decision", "2026-08", 2, "APPROVE", "정정 승인"
+            )
+        ));
+        assertThat(fixture.documents.get("orgs/tenant-a/cashflow_cumulative_close_heads/project-a"))
+            .containsEntry("settlementMonth", "2026-07")
+            .containsEntry("closedThrough", "2026-07");
+
+        String currentTargetRevision = FirestoreInheritedWeeklyExpensePersistence.computeCashflowTargetRevision(
+            fixture.documents.entrySet().stream()
+                .filter(entry -> entry.getKey().contains("/cashflow_weeks/"))
+                .map(Map.Entry::getValue)
+                .toList()
+        );
+        CloseCashflowMonthRequest base = cumulativeCloseRequest(
+            fixture, "2026-08", "legacy-after-reopen", true, 2, currentTargetRevision
+        );
+        CloseCashflowMonthRequest reclose = new CloseCashflowMonthRequest(
+            base.idempotencyKey(), base.sourceRevision(), base.targetRevision(), base.yearMonth(), 3,
+            base.expectedDraftRevision(), base.humanReviewed(), base.depositScheduleRows(), base.cells(),
+            base.confirmations(), base.managementChecks(), base.managementConfirmations(), base.openingBalances(),
+            base.deadlineSummary(), base.requestId(), base.requestRevision(), base.manifestHash()
+        );
+
+        fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
+            .closeCashflowMonth(ACTOR, "project-a", SESSION, reclose));
+
+        assertThat(fixture.documents.get("orgs/tenant-a/cashflow_cumulative_close_heads/project-a"))
+            .containsEntry("settlementMonth", "2026-08")
+            .containsEntry("closedThrough", "2026-08")
+            .containsEntry("revision", 4L);
+    }
+
+    @Test
+    void legacyCumulativeRequestCannotCloseItsTargetMonthEarly() {
+        Fixture fixture = fixture(activeMember(), activeLease(), true, LocalDate.parse("2026-08-01"));
+        CloseCashflowMonthRequest request = cumulativeCloseRequest(fixture, "2026-08", "legacy-cumulative-early", true);
+
+        assertThatThrownBy(() -> fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
+            .closeCashflowMonth(ACTOR, "project-a", SESSION, request)))
+            .isInstanceOf(WeeklyExpenseConflictException.class)
+            .hasMessageContaining("after the target month ends");
+        assertThat(fixture.documents).doesNotContainKey("orgs/tenant-a/cashflow_cumulative_close_heads/project-a");
+    }
+
+    @Test
     void cumulativeReopenOnlyRetreatsTheLatestHorizonAndKeepsRootEvidence() {
         Fixture fixture = fixture(activeMember(), Map.of());
         fixture.documents.put("orgs/tenant-a/cashflow_cumulative_close_heads/project-a", Map.of(
@@ -3877,6 +4049,34 @@ class FirestoreCashflowLeaseGuardTest {
             .containsEntry("closedThrough", "2026-07")
             .containsEntry("rootHash", SOURCE_REVISION)
             .containsEntry("status", "CLOSED");
+    }
+
+    @Test
+    void cumulativeReopenUsesSettlementMonthAndReopensTheStoredDataMonth() {
+        Fixture fixture = fixture(activeMember(), Map.of());
+        fixture.documents.put("orgs/tenant-a/cashflow_cumulative_close_heads/project-a", Map.of(
+            "contractVersion", "cashflow-cumulative-close-v2", "tenantId", "tenant-a", "projectId", "project-a",
+            "status", "CLOSED", "settlementMonth", "2026-08", "closedThrough", "2026-07",
+            "rootHash", SOURCE_REVISION, "revision", 1L
+        ));
+        fixture.documents.put(monthClosePath("project-a", "2026-08"), Map.of(
+            "contractVersion", "cashflow-month-close-v1", "tenantId", "tenant-a", "projectId", "project-a",
+            "yearMonth", "2026-08", "status", "CLOSED", "revision", 1L, "reopenCount", 0L,
+            "snapshotHash", SOURCE_REVISION
+        ));
+        String completionPath = "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w1";
+        fixture.documents.put(completionPath, lockedWeeklyCompletion("2026-07", 1, 1));
+
+        fixture.persistence.runCommandTransaction(() -> fixture.persistence.requestCashflowMonthReopen(
+            ACTOR, "project-a", new RequestCashflowMonthReopenRequest("reopen-request", "2026-08", 1, "정정")
+        ));
+        fixture.persistence.runCommandTransaction(() -> fixture.persistence.decideCashflowMonthReopen(
+            ACTOR, "project-a", new DecideCashflowMonthReopenRequest("reopen-decision", "2026-08", 2, "APPROVE", "승인")
+        ));
+
+        assertThat(fixture.documents.get("orgs/tenant-a/cashflow_cumulative_close_heads/project-a"))
+            .containsEntry("closedThrough", "2026-06");
+        assertThat(fixture.documents.get(completionPath)).containsEntry("status", "OPEN");
     }
 
     @Test
@@ -3909,6 +4109,43 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     private static CloseCashflowMonthRequest cumulativeCloseRequest(Fixture fixture, String yearMonth, String requestId) {
+        return cumulativeCloseRequest(fixture, yearMonth, requestId, false);
+    }
+
+    private static CloseCashflowMonthRequest cumulativeCloseRequest(
+        Fixture fixture,
+        String yearMonth,
+        String requestId,
+        boolean legacy
+    ) {
+        return cumulativeCloseRequest(fixture, yearMonth, requestId, legacy, 1);
+    }
+
+    private static CloseCashflowMonthRequest cumulativeCloseRequest(
+        Fixture fixture,
+        String yearMonth,
+        String requestId,
+        boolean legacy,
+        int revision
+    ) {
+        return cumulativeCloseRequest(
+            fixture,
+            yearMonth,
+            requestId,
+            legacy,
+            revision,
+            "sha256:298012959db83e193536ff7f60735889252ceaa4325de6944465e2dd197fcb44"
+        );
+    }
+
+    private static CloseCashflowMonthRequest cumulativeCloseRequest(
+        Fixture fixture,
+        String yearMonth,
+        String requestId,
+        boolean legacy,
+        int revision,
+        String targetRevision
+    ) {
         List<String> lines = List.of(
             "MYSC_PREPAY_IN", "MYSC_PREPAY_LABOR_IN", "MYSC_PREPAY_INPUT_VAT_IN", "SALES_IN",
             "SALES_VAT_IN", "TEAM_SUPPORT_IN", "BANK_INTEREST_IN", "MYSC_PREPAY_DIRECT_OUT",
@@ -3916,7 +4153,7 @@ class FirestoreCashflowLeaseGuardTest {
             "MYSC_PROFIT_OUT", "SALES_VAT_OUT", "TEAM_SUPPORT_OUT", "BANK_INTEREST_OUT"
         );
         List<Map<String, Object>> manifestMonths = new ArrayList<>();
-        java.time.YearMonth target = java.time.YearMonth.parse(yearMonth);
+        java.time.YearMonth target = java.time.YearMonth.parse(yearMonth).minusMonths(legacy ? 0 : 1);
         long count = java.time.temporal.ChronoUnit.MONTHS.between(java.time.YearMonth.of(2023, 1), target) + 1;
         for (long offset = 0; offset < count; offset++) {
             String month = java.time.YearMonth.of(2023, 1).plusMonths(offset).toString();
@@ -3936,12 +4173,12 @@ class FirestoreCashflowLeaseGuardTest {
             }
             Map<String, Object> source = Map.of(
                 "sourceRevision", SOURCE_REVISION,
-                "targetRevision", "sha256:298012959db83e193536ff7f60735889252ceaa4325de6944465e2dd197fcb44"
+                "targetRevision", targetRevision
             );
             Map<String, Object> hashInput = new LinkedHashMap<>();
             hashInput.put("contractVersion", "cashflow-cumulative-close-v2");
             hashInput.put("requestId", requestId);
-            hashInput.put("requestRevision", 1L);
+            hashInput.put("requestRevision", (long) revision);
             hashInput.put("projectId", "project-a");
             hashInput.put("yearMonth", month);
             hashInput.put("cells", cells);
@@ -3950,7 +4187,7 @@ class FirestoreCashflowLeaseGuardTest {
             Map<String, Object> shard = new LinkedHashMap<>(hashInput);
             shard.put("shardHash", shardHash);
             fixture.documents.put(
-                "orgs/tenant-a/cashflow_month_close_request_months/" + requestId + "-r1-" + month,
+                "orgs/tenant-a/cashflow_month_close_request_months/" + requestId + "-r" + revision + "-" + month,
                 shard
             );
             manifestMonths.add(Map.of("yearMonth", month, "shardHash", shardHash));
@@ -3958,20 +4195,20 @@ class FirestoreCashflowLeaseGuardTest {
         Map<String, Object> manifest = new LinkedHashMap<>();
         manifest.put("contractVersion", "cashflow-cumulative-close-v2");
         manifest.put("requestId", requestId);
-        manifest.put("requestRevision", 1L);
+        manifest.put("requestRevision", (long) revision);
         manifest.put("projectId", "project-a");
         manifest.put("fromMonth", "2023-01");
         manifest.put("yearMonth", yearMonth);
         manifest.put("months", manifestMonths);
         String manifestHash = fixture.persistence.hashCanonicalJson(manifest);
-        fixture.documents.put("orgs/tenant-a/cashflow_month_close_requests/" + requestId, Map.ofEntries(
+        Map<String, Object> header = new LinkedHashMap<>(Map.ofEntries(
             Map.entry("contractVersion", "cashflow-cumulative-close-v2"),
             Map.entry("requestId", requestId),
             Map.entry("projectId", "project-a"),
             Map.entry("yearMonth", yearMonth),
             Map.entry("fromMonth", "2023-01"),
             Map.entry("status", "APPROVING"),
-            Map.entry("revision", 1L),
+            Map.entry("revision", (long) revision),
             Map.entry("manifestHash", manifestHash),
             Map.entry("monthCount", count),
             Map.entry("approverUid", "pm-1"),
@@ -3979,10 +4216,12 @@ class FirestoreCashflowLeaseGuardTest {
             Map.entry("approvalId", "approval-" + requestId),
             Map.entry("operationId", "operation-" + requestId)
         ));
+        if (!legacy) header.put("throughMonth", target.toString());
+        fixture.documents.put("orgs/tenant-a/cashflow_month_close_requests/" + requestId, header);
         return new CloseCashflowMonthRequest(
             "idem-" + requestId, "", "", yearMonth, 0, 0, false,
             List.of(), List.of(), List.of(), List.of(), List.of(), null, null,
-            requestId, 1, manifestHash
+            requestId, revision, manifestHash
         );
     }
 

--- a/src/app/components/approval/AdminApprovalPage.shell.test.ts
+++ b/src/app/components/approval/AdminApprovalPage.shell.test.ts
@@ -84,7 +84,8 @@ describe('AdminApprovalPage shell contract', () => {
     expect(monthlySource).toContain('저장 시트 링크 없음');
     expect(monthlySource).toContain('selectedSource.spreadsheetTitle');
     expect(monthlySource).toContain('selectedSource.selectedSheetName');
-    expect(monthlySource).toContain('annualSummaries');
+    expect(monthlySource).not.toContain('annualSummaries');
+    expect(monthlySource).not.toContain('복구 상태');
     expect(monthlySource).toContain('CumulativeSettlementMonthDetails');
     expect(monthlySource).toContain('expectedManifestHash: action.request.manifestHash');
     expect(monthlySource).toContain('승인하면 이 범위의 모든 주차가 수정 불가 상태가 됩니다.');

--- a/src/app/components/approval/CumulativeSettlementMonthDetails.revision-diff.test.ts
+++ b/src/app/components/approval/CumulativeSettlementMonthDetails.revision-diff.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import type { CashflowMonthCloseRevisionDiff } from '../../lib/platform-bff-client';
+import { matchesCashflowMonthCloseRevisionDiff } from './CumulativeSettlementMonthDetails';
+
+const request = {
+  requestId: 'project-a-2026-08',
+  revision: 2,
+  throughMonth: '2026-07',
+  lockRange: { fromMonth: '2023-01', fromWeekNo: 1, throughMonth: '2026-07', throughWeekNo: 5 },
+};
+
+function result(overrides: Partial<CashflowMonthCloseRevisionDiff> = {}): CashflowMonthCloseRevisionDiff {
+  return {
+    requestId: request.requestId,
+    yearMonth: request.throughMonth,
+    currentRevision: request.revision,
+    previousRevision: 1,
+    changes: [],
+    ...overrides,
+  };
+}
+
+describe('matchesCashflowMonthCloseRevisionDiff', () => {
+  it('accepts only the selected request revision and through-month response', () => {
+    expect(matchesCashflowMonthCloseRevisionDiff(request, result())).toBe(true);
+    expect(matchesCashflowMonthCloseRevisionDiff(request, result({ requestId: 'another-request' }))).toBe(false);
+    expect(matchesCashflowMonthCloseRevisionDiff(request, result({ currentRevision: 1 }))).toBe(false);
+    expect(matchesCashflowMonthCloseRevisionDiff(request, result({ yearMonth: '2026-08' }))).toBe(false);
+    expect(matchesCashflowMonthCloseRevisionDiff({
+      ...request,
+      lockRange: { ...request.lockRange, throughMonth: '2026-06' },
+    }, result())).toBe(false);
+  });
+
+  it('uses lockRange throughMonth for legacy responses without a top-level throughMonth', () => {
+    expect(matchesCashflowMonthCloseRevisionDiff({ ...request, throughMonth: undefined }, result())).toBe(true);
+  });
+});

--- a/src/app/components/approval/CumulativeSettlementMonthDetails.tsx
+++ b/src/app/components/approval/CumulativeSettlementMonthDetails.tsx
@@ -1,11 +1,13 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Loader2, RefreshCw } from 'lucide-react';
 import { CASHFLOW_SHEET_LINE_LABELS, type CashflowSheetLineId } from '../../data/types';
 import {
   fetchCashflowMonthCloseRequestMonthsViaBff,
+  fetchCashflowMonthCloseRevisionDiffViaBff,
   type CashflowMonthCloseMonthShard,
   type CashflowMonthCloseMonthShardPage,
   type CashflowMonthCloseRequest,
+  type CashflowMonthCloseRevisionDiff,
 } from '../../lib/platform-bff-client';
 import { resolveApiErrorMessage } from '../../platform/api-error-message';
 import { CASHFLOW_ALL_LINES } from '../../platform/cashflow-sheet';
@@ -35,16 +37,18 @@ function monthsBetween(fromMonth: string, throughMonth: string) {
 }
 
 function expectedRequestMonths(request: CashflowMonthCloseRequest) {
+  const throughMonth = request.throughMonth || request.lockRange?.throughMonth;
   if (
     !request.fromMonth
+    || !throughMonth
     || !request.lockRange
     || request.lockRange.fromMonth !== request.fromMonth
-    || request.lockRange.throughMonth !== request.yearMonth
+    || request.lockRange.throughMonth !== throughMonth
     || request.lockRange.fromWeekNo !== 1
     || request.lockRange.throughWeekNo !== 5
     || !Number.isSafeInteger(request.monthCount)
   ) throw new Error('누적 결산 문서의 고정 범위가 요청 header와 일치하지 않습니다.');
-  const expected = monthsBetween(request.fromMonth, request.yearMonth);
+  const expected = monthsBetween(request.fromMonth, throughMonth);
   if (expected.length !== request.monthCount) throw new Error('누적 결산 문서의 월 수가 요청 header와 일치하지 않습니다.');
   return expected;
 }
@@ -173,6 +177,26 @@ function MonthTable({ shard, mode }: { shard: CashflowMonthCloseMonthShard; mode
   );
 }
 
+function revisionValue(state: 'VALUE' | 'ZERO' | 'EMPTY' | 'MISSING', amount: number | null) {
+  if (state === 'MISSING') return '키 누락';
+  if (state === 'EMPTY') return '미입력';
+  return formatMoney(amount ?? 0);
+}
+
+export function matchesCashflowMonthCloseRevisionDiff(
+  request: Pick<CashflowMonthCloseRequest, 'requestId' | 'revision' | 'throughMonth' | 'lockRange'>,
+  result: CashflowMonthCloseRevisionDiff,
+) {
+  const throughMonth = request.throughMonth || request.lockRange?.throughMonth;
+  if (request.throughMonth && request.lockRange?.throughMonth && request.throughMonth !== request.lockRange.throughMonth) {
+    return false;
+  }
+  return result.requestId === request.requestId
+    && result.currentRevision === request.revision
+    && Boolean(throughMonth)
+    && result.yearMonth === throughMonth;
+}
+
 export function CumulativeSettlementMonthDetails({
   tenantId,
   actor,
@@ -188,6 +212,8 @@ export function CumulativeSettlementMonthDetails({
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [revisionDiff, setRevisionDiff] = useState<CashflowMonthCloseRevisionDiff | null>(null);
+  const [revisionDiffError, setRevisionDiffError] = useState('');
   const generationRef = useRef(0);
 
   const load = useCallback(async (
@@ -244,14 +270,21 @@ export function CumulativeSettlementMonthDetails({
     return () => { generationRef.current += 1; };
   }, [load, onReadyChange]);
 
-  const years = useMemo(() => {
-    const groups = new Map<string, CashflowMonthCloseMonthShard[]>();
-    months.forEach((month) => {
-      const year = month.yearMonth.slice(0, 4);
-      groups.set(year, [...(groups.get(year) || []), month]);
-    });
-    return [...groups.entries()].sort(([left], [right]) => left.localeCompare(right));
-  }, [months]);
+  useEffect(() => {
+    let active = true;
+    setRevisionDiff(null);
+    setRevisionDiffError('');
+    if (!actor.idToken) return () => { active = false; };
+    void fetchCashflowMonthCloseRevisionDiffViaBff({ tenantId, actor, projectId: request.projectId, requestId: request.requestId })
+      .then((result) => {
+        if (active && matchesCashflowMonthCloseRevisionDiff(request, result)) setRevisionDiff(result);
+      })
+      .catch((loadError) => { if (active) setRevisionDiffError(resolveApiErrorMessage(loadError, '직전 revision 비교를 불러오지 못했습니다.')); });
+    return () => { active = false; };
+  }, [actor, request.projectId, request.requestId, request.revision, request.throughMonth, request.lockRange?.throughMonth, tenantId]);
+
+  const targetMonth = request.lockRange?.throughMonth || request.throughMonth;
+  const targetShard = months.find((month) => month.yearMonth === targetMonth);
 
   if (loading && months.length === 0) {
     return <div className="flex min-h-[120px] items-center justify-center gap-2 border border-slate-300 text-[12px] text-slate-500" aria-busy="true"><Loader2 className="h-4 w-4 animate-spin" />월별 저장 문서를 불러오고 있습니다.</div>;
@@ -274,26 +307,28 @@ export function CumulativeSettlementMonthDetails({
           <Loader2 className="h-3.5 w-3.5 animate-spin" />월별 저장 문서 검증 중 · {months.length.toLocaleString()}/{request.monthCount?.toLocaleString()}개월
         </p>
       ) : null}
-      {years.map(([year, yearMonths]) => (
-        <details key={year} className="border border-slate-300 bg-white" open={years.length === 1}>
-          <summary className="cursor-pointer bg-slate-100 px-4 py-3 text-[13px] font-bold text-slate-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#174a7c]">
-            {year}년 · {yearMonths.length}개월 불러옴
-          </summary>
-          <div className="space-y-3 p-3">
-            {yearMonths.map((month) => (
-              <details key={month.yearMonth} className="border border-slate-200">
-                <summary className="cursor-pointer px-3 py-2 text-[12px] font-semibold text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-[#174a7c]">
-                  {month.yearMonth} · 제출 시점 저장본
-                </summary>
-                <div className="border-t border-slate-200 p-3">
-                  <MonthTable shard={month} mode="projection" />
-                  <MonthTable shard={month} mode="actual" />
-                </div>
-              </details>
-            ))}
-          </div>
-        </details>
-      ))}
+      {targetShard ? <div className="space-y-3 border border-slate-300 bg-white p-3">
+        <p className="text-[12px] font-semibold text-slate-800">{request.yearMonth} 월 결산 · 데이터 기준 {targetShard.yearMonth}</p>
+        <MonthTable shard={targetShard} mode="projection" />
+        <MonthTable shard={targetShard} mode="actual" />
+      </div> : null}
+      {revisionDiff ? <section className="border border-slate-300 bg-white p-3" aria-label={`${revisionDiff.yearMonth} 직전 revision 대비 변경사항`}>
+        <h6 className="text-[12px] font-bold text-[#001e46]">{revisionDiff.yearMonth} 직전 revision 대비 변경사항</h6>
+        {revisionDiff.previousRevision === null ? <p className="mt-2 text-[11px] text-slate-600">최초 제출본이라 비교할 이전 revision이 없습니다.</p>
+          : revisionDiff.changes.length === 0 ? <p className="mt-2 text-[11px] text-slate-600">{revisionDiff.yearMonth}에는 revision {revisionDiff.previousRevision} 대비 변경사항이 없습니다.</p>
+            : <div className="mt-2 overflow-x-auto"><table className="w-full min-w-[760px] border-collapse text-[11px]"><caption className="sr-only">{revisionDiff.yearMonth} 한 달의 직전 revision 대비 변경사항</caption>
+              <thead className="bg-slate-100"><tr><th className="border px-2 py-2 text-left">구분</th><th className="border px-2 py-2 text-left">항목</th><th className="border px-2 py-2 text-right">주차</th><th className="border px-2 py-2 text-right">이전</th><th className="border px-2 py-2 text-right">이번</th><th className="border px-2 py-2 text-right">증감</th></tr></thead>
+              <tbody>{revisionDiff.changes.map((change) => <tr key={`${change.mode}:${change.weekNo}:${change.cashflowLine}`}>
+                <td className="border px-2 py-2">{change.mode === 'projection' ? 'Projection' : 'Actual'}</td>
+                <th className="border px-2 py-2 text-left font-medium">{CASHFLOW_SHEET_LINE_LABELS[change.cashflowLine as CashflowSheetLineId] || change.cashflowLine}</th>
+                <td className="border px-2 py-2 text-right">{change.weekNo}주차</td>
+                <td className="border px-2 py-2 text-right">{revisionValue(change.previousState, change.previousAmount)}</td>
+                <td className="border px-2 py-2 text-right">{revisionValue(change.currentState, change.currentAmount)}</td>
+                <td className="border px-2 py-2 text-right">{change.amountDelta === null ? '—' : formatMoney(change.amountDelta)}</td>
+              </tr>)}</tbody>
+            </table></div>}
+      </section> : null}
+      {revisionDiffError ? <p className="border border-amber-200 bg-amber-50 p-3 text-[11px] text-amber-900">{revisionDiffError} 현재 저장본 검증과 승인은 계속할 수 있습니다.</p> : null}
       {error ? <div role="alert" className="border border-red-200 bg-red-50 p-3 text-[12px] text-red-800">{error} <span className="font-semibold">검증 완료 {months.length.toLocaleString()}/{request.monthCount?.toLocaleString()}개월</span> <Button type="button" variant="outline" size="sm" className="ml-2" onClick={() => void load(nextCursor || undefined, months, generationRef.current)}><RefreshCw className="mr-1 h-3.5 w-3.5" />다시 시도</Button></div> : null}
       {!loading && !error && nextCursor === null && months.length === request.monthCount ? (
         <p className="text-center text-[11px] text-slate-500" aria-live="polite">월별 저장 문서 {months.length.toLocaleString()}건을 모두 불러왔습니다.</p>

--- a/src/app/components/approval/MonthlySettlementApprovalSection.test.ts
+++ b/src/app/components/approval/MonthlySettlementApprovalSection.test.ts
@@ -88,7 +88,7 @@ describe('MonthlySettlementApprovalSection cumulative totals', () => {
     });
   });
 
-  it('builds persisted request, review, and recovery history without exposing UIDs', () => {
+  it('builds persisted request and review history without exposing recovery internals or UIDs', () => {
     const request = {
       documentType: 'MONTHLY_CLOSE', requestId: 'request-1', projectId: 'project-a', yearMonth: '2026-07',
       status: 'UNCERTAIN', revision: 1, requestedByUid: 'uid-requester', requestedByName: '변민욱(보람)',
@@ -103,9 +103,23 @@ describe('MonthlySettlementApprovalSection cumulative totals', () => {
     expect(entries).toEqual([
       expect.objectContaining({ kind: 'REQUESTED', actorName: '변민욱(보람)', at: '2026-07-30T07:27:41.384Z' }),
       expect.objectContaining({ kind: 'REVIEWED', actorName: '(AX) AI', at: '2026-07-30T07:30:00.000Z', detail: '확인 중' }),
-      expect.objectContaining({ kind: 'RECOVERY', actorName: '(AX) AI' }),
     ]);
+    expect(JSON.stringify(entries)).not.toContain('복구');
     expect(JSON.stringify(entries)).not.toContain('uid-requester');
     expect(JSON.stringify(entries)).not.toContain('uid-approver');
+  });
+
+  it('labels reopened month-close history for non-developer users', () => {
+    const request = {
+      documentType: 'MONTHLY_CLOSE', requestId: 'request-1', projectId: 'project-a', yearMonth: '2026-08',
+      status: 'REOPENED', revision: 2, requestedByUid: 'uid-requester', requestedAt: '2026-09-01T00:00:00.000Z',
+      approverUid: 'uid-approver', reviewedByUid: 'uid-approver', reviewedAt: '2026-09-02T00:00:00.000Z',
+      decisionReason: null, reviewWarnings: [], monthSnapshot: null,
+      lockRange: { fromMonth: '2023-01', fromWeekNo: 1, throughMonth: '2026-07', throughWeekNo: 5 }, monthCount: 43,
+    } as Parameters<typeof buildMonthCloseHistoryEntries>[0];
+
+    expect(buildMonthCloseHistoryEntries(request, [])).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'REVIEWED', detail: '재오픈' }),
+    ]));
   });
 });

--- a/src/app/components/approval/MonthlySettlementApprovalSection.tsx
+++ b/src/app/components/approval/MonthlySettlementApprovalSection.tsx
@@ -46,6 +46,7 @@ const REQUEST_STATUS_LABELS: Record<CashflowMonthCloseRequest['status'], string>
   UNCERTAIN: '서버 결과 확인 필요',
   APPROVED: '승인',
   REJECTED: '반려',
+  REOPENED: '재오픈',
 };
 
 export function formatMoney(value: number | null | undefined) {
@@ -90,7 +91,7 @@ export function resolveRequestPartyName(explicitName: string | null | undefined,
 
 export function buildMonthCloseHistoryEntries(request: CashflowMonthCloseRequest, members: OrgMember[]) {
   const summary = `${request.yearMonth} 월 결산 승인 요청 · ${request.lockRange ? `${request.lockRange.fromMonth} ${request.lockRange.fromWeekNo}주차 ~ ${request.lockRange.throughMonth} ${request.lockRange.throughWeekNo}주차 · ${request.monthCount?.toLocaleString()}개월` : '제출 시점 저장본'}`;
-  const entries: Array<{ kind: 'REQUESTED' | 'REVIEWED' | 'RECOVERY'; actorName: string; at: string; detail: string }> = [{
+  const entries: Array<{ kind: 'REQUESTED' | 'REVIEWED'; actorName: string; at: string; detail: string }> = [{
     kind: 'REQUESTED',
     actorName: resolveRequestPartyName(request.requestedByName, members, request.requestedByUid),
     at: request.requestedAt,
@@ -101,12 +102,6 @@ export function buildMonthCloseHistoryEntries(request: CashflowMonthCloseRequest
     actorName: resolveRequestPartyName(request.reviewedByName || request.approverName, members, request.reviewedByUid || request.approverUid),
     at: request.reviewedAt || request.requestedAt,
     detail: request.decisionReason || REQUEST_STATUS_LABELS[request.status],
-  });
-  if (['APPROVING', 'UNCERTAIN'].includes(request.status)) entries.push({
-    kind: 'RECOVERY' as const,
-    actorName: resolveRequestPartyName(request.approverName, members, request.approverUid),
-    at: request.reviewedAt || request.requestedAt,
-    detail: request.status === 'UNCERTAIN' ? '서버 결과를 조회해 중복 마감 없이 복구합니다.' : '저장된 승인 작업을 동일한 요청으로 재개합니다.',
   });
   return entries;
 }
@@ -435,7 +430,7 @@ export function MonthlySettlementApprovalSection({
                 <div className="border border-t-0 border-slate-400 text-[12px]">
                   {buildMonthCloseHistoryEntries(selectedRequest, members).map((entry) => (
                     <div key={`${entry.kind}:${entry.at}`} className="grid gap-1 border-t border-slate-300 px-3 py-3 first:border-t-0 sm:grid-cols-[120px_1fr]">
-                      <strong>{entry.kind === 'REQUESTED' ? '요청' : entry.kind === 'REVIEWED' ? '검토' : '복구 상태'}</strong>
+                      <strong>{entry.kind === 'REQUESTED' ? '요청' : '검토'}</strong>
                       <span><span className="font-semibold">{entry.actorName}</span> · {formatDateTime(entry.at)}<br />{entry.detail}</span>
                     </div>
                   ))}
@@ -498,19 +493,6 @@ export function MonthlySettlementApprovalSection({
                           <p className="mt-2 text-right text-[14px] font-semibold tabular-nums">{formatMoney(selectedRequest.totals?.[mode])}</p>
                         </div>
                       ))}
-                    </div>
-                  </section>
-
-                  <section>
-                    <h4 className="border-b-2 border-slate-700 pb-2 text-[14px] font-bold">연도별 요약</h4>
-                    <div className="overflow-x-auto border border-t-0 border-slate-300" role="region" aria-label="누적 결산 연도별 요약" tabIndex={0}>
-                      <table className="w-full min-w-[1080px] border-collapse text-[11px]">
-                        <caption className="sr-only">연도별 Projection, Actual, 차이의 셀 금액 합계</caption>
-                        <thead className="bg-slate-100"><tr><th className="px-3 py-2 text-left">연도</th><th className="px-3 py-2 text-right">포함 월</th>{(['Projection 합계', 'Actual 합계', '차이'] as const).map((label) => <th key={label} className="px-3 py-2 text-right">{label}</th>)}</tr></thead>
-                        <tbody>{(selectedRequest.annualSummaries || []).map((annual) => (
-                          <tr key={annual.year} className="border-t border-slate-200"><th className="px-3 py-2 text-left">{annual.year}년</th><td className="px-3 py-2 text-right">{annual.monthCount}개월</td>{(['projection', 'actual', 'difference'] as const).map((mode) => <td key={mode} className="px-3 py-2 text-right tabular-nums">{formatMoney(annual[mode])}</td>)}</tr>
-                        ))}</tbody>
-                      </table>
                     </div>
                   </section>
 

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -58,7 +58,8 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toMatch(/>해당 없음<\/Button>/);
     expect(source).not.toContain('!monthCloseProgress.complete');
     expect(source).toContain('monthCloseResult?.dashboard?.cumulativeCloseScope');
-    expect(source).toContain('scope?.throughMonth === selectedMonth');
+    expect(source).toContain('const throughMonth = previousYearMonth(selectedMonth)');
+    expect(source).toContain('scope?.throughMonth === throughMonth');
     expect(source).toContain('prepared.dashboard?.cumulativeCloseScope');
     expect(source).toContain('cumulativeRequestScope.fromMonth} ~ {cumulativeRequestScope.throughMonth');
     expect(source).toContain('서버 고정 범위');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -93,13 +93,21 @@ import { loadCashflowActivitySourcesSequentially } from './cashflow-activity-loa
 
 const CASHFLOW_STANDARD_ANNUAL_YEARS = [2024, 2025, 2027, 2028, 2029, 2030, 2031, 2032] as const;
 
+function previousYearMonth(yearMonth: string): string {
+  if (!/^\d{4}-(0[1-9]|1[0-2])$/.test(yearMonth)) return '';
+  const month = new Date(`${yearMonth}-01T00:00:00Z`);
+  month.setUTCMonth(month.getUTCMonth() - 1);
+  return month.toISOString().slice(0, 7);
+}
+
 function fmt(n: number): string {
   return n.toLocaleString('ko-KR');
 }
 
 function isCumulativeCloseScopeReady(scope: CashflowCumulativeCloseScope | null | undefined, selectedMonth: string): scope is CashflowCumulativeCloseScope {
-  return scope?.throughMonth === selectedMonth
-    && scope.lockRange.throughMonth === selectedMonth
+  const throughMonth = previousYearMonth(selectedMonth);
+  return scope?.throughMonth === throughMonth
+    && scope.lockRange.throughMonth === throughMonth
     && scope.lockRange.fromMonth === scope.fromMonth
     && scope.lockRange.fromWeekNo === 1
     && scope.lockRange.throughWeekNo === 5;
@@ -2697,6 +2705,8 @@ export function CashflowProjectSheet({
                         ? monthCloseRequest.status === 'UNCERTAIN' ? '서버 처리 결과를 다시 확인하고 있습니다.' : '지정 조직장의 검토를 기다리고 있습니다.'
                         : monthCloseRequest?.status === 'REJECTED'
                           ? `반려됨${monthCloseRequest.decisionReason ? ` · ${monthCloseRequest.decisionReason}` : ''}`
+                        : monthCloseRequest?.status === 'REOPENED'
+                          ? '재오픈됨 · 수정 후 월 결산을 다시 요청해 주세요.'
                       : monthClosePreparation.status === 'READY'
                         ? `${yearMonth} 결산 승인을 요청하면 조직장 승인 전까지 확정되지 않습니다.`
                         : monthClosePreparation.title}
@@ -2712,7 +2722,7 @@ export function CashflowProjectSheet({
                         onClick={handleOpenMonthCloseReview}
                       >
                         <CheckCircle2 className="mr-1 h-3 w-3" />
-                        {monthCloseError || !monthCloseResult ? '월 결산 점검' : monthCloseRequest?.status === 'REJECTED' ? '월 결산 재요청' : '월 결산 요청'}
+                        {monthCloseError || !monthCloseResult ? '월 결산 점검' : ['REJECTED', 'REOPENED'].includes(monthCloseRequest?.status || '') ? '월 결산 재요청' : '월 결산 요청'}
                       </Button>
                     ) : null}
                     {!monthCloseError && canRequestMonthReopen && monthCloseResult?.status === 'CLOSED' ? (
@@ -3064,6 +3074,8 @@ export function CashflowProjectSheet({
           ? '조직장 승인 대기'
           : monthCloseRequest?.status === 'REJECTED'
             ? '월 결산 반려'
+            : monthCloseRequest?.status === 'REOPENED'
+              ? '재결산 필요'
       : '결산 전';
   const monthCloseStatusClass = monthCloseError
     ? 'border border-red-200 bg-red-50 text-red-700'

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -1071,7 +1071,7 @@ export interface CloseCashflowMonthPayload {
   closeInput: CashflowMonthCloseDraftInput;
 }
 
-export type CashflowMonthCloseRequestStatus = 'BUILDING' | 'PENDING' | 'APPROVING' | 'UNCERTAIN' | 'APPROVED' | 'REJECTED';
+export type CashflowMonthCloseRequestStatus = 'BUILDING' | 'PENDING' | 'APPROVING' | 'UNCERTAIN' | 'APPROVED' | 'REJECTED' | 'REOPENED';
 
 export interface CashflowMonthCloseStoredSource {
   sourceRevision: string | null;
@@ -1162,6 +1162,7 @@ export interface CashflowMonthCloseRequest {
   requestId: string;
   projectId: string;
   yearMonth: string;
+  throughMonth?: string;
   status: CashflowMonthCloseRequestStatus;
   revision: number;
   fromMonth?: string;
@@ -1184,6 +1185,23 @@ export interface CashflowMonthCloseRequest {
   decisionReason: string | null;
   reviewWarnings: Array<{ code: string; message: string; details?: unknown }>;
   monthSnapshot: CashflowMonthCloseMonthSnapshot | null;
+}
+
+export interface CashflowMonthCloseRevisionDiff {
+  requestId: string;
+  yearMonth: string;
+  currentRevision: number;
+  previousRevision: number | null;
+  changes: Array<{
+    mode: 'projection' | 'actual';
+    weekNo: number;
+    cashflowLine: string;
+    previousState: CashflowMonthCloseMonthSnapshotCell['cellState'] | 'MISSING';
+    previousAmount: number | null;
+    currentState: CashflowMonthCloseMonthSnapshotCell['cellState'] | 'MISSING';
+    currentAmount: number | null;
+    amountDelta: number | null;
+  }>;
 }
 
 export interface ReviewCashflowMonthCloseRequestPayload {
@@ -3045,6 +3063,25 @@ export async function fetchCashflowMonthCloseRequestMonthsViaBff(params: {
   if (params.cursor) query.set('cursor', params.cursor);
   const response = await resolveClient(params.client).get<CashflowMonthCloseMonthShardPage>(
     `/api/v1/cashflow/${encodeURIComponent(params.projectId)}/month-close/requests/${encodeURIComponent(params.requestId)}/months?${query.toString()}`,
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      retries: 0,
+      timeoutMs: 12000,
+    },
+  );
+  return response.data;
+}
+
+export async function fetchCashflowMonthCloseRevisionDiffViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectId: string;
+  requestId: string;
+  client?: PlatformApiClientLike;
+}): Promise<CashflowMonthCloseRevisionDiff> {
+  const response = await resolveClient(params.client).get<CashflowMonthCloseRevisionDiff>(
+    `/api/v1/cashflow/${encodeURIComponent(params.projectId)}/month-close/requests/${encodeURIComponent(params.requestId)}/revision-diff`,
     {
       tenantId: params.tenantId,
       actor: toRequestActor(params.actor),


### PR DESCRIPTION
## What
- align settlement-month and locked-through-month contracts across frontend, BFF, and JVM
- preserve legacy/current close, reopen, and reclose flows with immutable amendment evidence
- add revision-diff identity guards and REOPENED recovery UI
- make stale BFF APPROVED records recoverable only when the JVM source is OPEN

## Verification
- BFF: 173/173 passed
- JVM Maven suite: passed
- frontend targeted QA: 85/85 passed
- production build: passed
- independent QA: blocker/major 0
- Claude adversarial review: PASS, blocking 0

## Ops
- no database mutation
- deploy through main Production Deploy workflows only
- rollback baseline: a490f33c93923a27354308a7c4db863fb314271c