### PR TITLE
fix(cashflow): preserve month-close approval idempotency

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -3826,7 +3826,9 @@ export function mountJvmWeeklyApiRoutes(app, {
       await verifyCumulativeRequestShards(req.context.tenantId, initialRecord);
       const approvalId = `cashflow-month-close:${requestId}:r${expectedRevision}`;
       const operationId = approvalId;
-      const jvmIdempotencyKey = `cashflow-month-close-approval:${requestId}:r${expectedRevision}`;
+      const jvmIdempotencyKey = resumesApproval
+        ? initialRecord.reviewIdempotencyKey
+        : req.context.idempotencyKey;
       const closeBody = {
         idempotencyKey: jvmIdempotencyKey,
         requestId,

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -4463,8 +4463,9 @@ describe('JVM weekly API BFF proxy', () => {
     const approvalBody = JSON.parse(fetchImpl.mock.calls.find(
       ([url, init]) => url.endsWith('/month-close') && init.method === 'POST',
     )[1].body);
+    expect(approvalBody.idempotencyKey).toBe(source.documents.get(requestPath).reviewIdempotencyKey);
     expect(approvalBody).toEqual({
-      idempotencyKey: 'cashflow-month-close-approval:project-a-2026-08:r2',
+      idempotencyKey: 'cumulative-v2-approve',
       requestId: 'project-a-2026-08', requestRevision: 2, manifestHash: resubmitted.body.manifestHash,
       yearMonth: '2026-08', expectedRevision: 0,
     });
@@ -4500,6 +4501,24 @@ describe('JVM weekly API BFF proxy', () => {
         .expect((response) => expect(response.body.request).toMatchObject({ status: 'APPROVED', revision: 2 }));
       expect(closePostCount()).toBe(1);
     }
+    closedMonthClose = null;
+    dashboardSourceUnavailable = true;
+    source.documents.set(requestPath, {
+      ...source.documents.get(requestPath),
+      status: 'UNCERTAIN',
+      reviewIdempotencyKey: 'prior-uncertain-repost',
+    });
+    await request(approver)
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
+      .set('idempotency-key', 'resume-uncertain-repost')
+      .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
+      .expect(200);
+    const repostBody = JSON.parse(fetchImpl.mock.calls.filter(
+      ([url, init]) => url.endsWith('/month-close') && init.method === 'POST',
+    ).at(-1)[1].body);
+    expect(repostBody.idempotencyKey).toBe('prior-uncertain-repost');
+    expect(closePostCount()).toBe(2);
+    dashboardSourceUnavailable = false;
     await request(approver)
       .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
       .set('idempotency-key', 'unsafe-reject-after-approval-start')


### PR DESCRIPTION
## What\n- forward the original review idempotency key to the JVM cumulative month-close mutation\n- reuse the stored key when APPROVING/UNCERTAIN approval resumes\n- cover the reconcile-failure crash window with a regression test\n\n## Why\nPrevents 409 conflicts on the initial approval while preserving exactly-once behavior when a retry arrives with a different HTTP key.\n\n## Verification\n- npm test -- server/bff/routes/jvm-weekly-api.test.mjs src/app/components/approval/AdminApprovalPage.shell.test.ts (175 passed)\n- npm test -- --reporter=dot (2,631 passed, 241 skipped)\n- npm run build (passed)\n- independent QA stage-gate: PASS