### PR TITLE
fix(cashflow): recover uncertain month-close approvals

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -3884,6 +3884,19 @@ export function mountJvmWeeklyApiRoutes(app, {
       let monthClose;
       if (resumesApproval) monthClose = await reconcileStoredClose();
       if (!monthClose) {
+        if (initialRecord.status === 'UNCERTAIN') {
+          await db.runTransaction(async (transaction) => {
+            const snapshot = await transaction.get(requestRef);
+            const current = snapshot.exists ? snapshot.data() || {} : null;
+            if (!current || !['UNCERTAIN', 'APPROVING'].includes(current.status)
+              || current.operationId !== operationId || current.reviewedByUid !== req.context.actorId
+              || current.reviewIdempotencyKey !== jvmIdempotencyKey
+              || current.manifestHash !== expectedManifestHash || Number(current.revision) !== expectedRevision) {
+              throw createHttpError(409, '월 결산 승인 상태가 변경되었습니다.', 'cashflow_month_close_request_revision_stale');
+            }
+            if (current.status === 'UNCERTAIN') transaction.set(requestRef, { ...current, status: 'APPROVING' });
+          });
+        }
         try {
           monthClose = assertCumulativeCloseResult(await proxyMutation(
             req,

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -4133,6 +4133,11 @@ describe('JVM weekly API BFF proxy', () => {
       }
       if (init.method === 'POST') {
         const closeBody = JSON.parse(init.body);
+        if (closeBody.requestId) {
+          expect(source.documents.get(
+            `orgs/tenant-a/cashflow_month_close_requests/${closeBody.requestId}`,
+          )?.status).toBe('APPROVING');
+        }
         closedMonthClose = {
           ok: true, projectId: 'project-a', requestId: 'project-a-2026-08', requestRevision: closeBody.requestRevision,
           manifestHash: closeBody.manifestHash, yearMonth: '2026-08', status: 'CLOSED',


### PR DESCRIPTION
## What
- atomically restore cumulative month-close requests from UNCERTAIN to APPROVING before JVM retry
- preserve the stored operation and idempotency evidence
- keep the portal UI lifecycle unchanged; no polling or forced refresh

## Why
The JVM correctly requires an APPROVING request header. Retries previously reposted while the header remained UNCERTAIN, causing the approval 409 and leaving the portal on server confirmation.

## Verification
- npm test -- server/bff/routes/jvm-weekly-api.test.mjs (173 passed)
- npm run bff:test:integration
- npm run build
- git diff --check