### PR TITLE
feat(cashflow): simplify monthly and weekly settlement status

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -2598,6 +2598,43 @@ export function mountJvmWeeklyApiRoutes(app, {
     res.status(200).json(result);
   }));
 
+  app.get('/api/v1/cashflow/:projectId/settlement-statuses', asyncHandler(async (req, res) => {
+    assertWeeklyWorkspaceOrRoleAllowed(req, ROUTE_ROLES.readCore, 'read cashflow settlement statuses', authMode, workspaceEmailDomain);
+    const projectId = readOptionalText(req.params.projectId);
+    const yearMonth = readOptionalText(req.query.yearMonth);
+    if (!projectId || !/^20\d{2}-(0[1-9]|1[0-2])$/.test(yearMonth)) {
+      throw createHttpError(400, '조회할 결산 연월을 정확히 입력해 주세요.', 'cashflow_settlement_status_scope_invalid');
+    }
+    const result = await proxyJavaWeeklyRequest({
+      context: req.context,
+      method: 'GET',
+      path: `/api/v1/cashflow/${encodeURIComponent(projectId)}/settlement-statuses?yearMonth=${encodeURIComponent(yearMonth)}`,
+    });
+    res.status(200).json(result);
+  }));
+
+  app.post('/api/v1/cashflow/:projectId/settlement-statuses/transition', asyncHandler(async (req, res) => {
+    assertWeeklyWorkspaceOrRoleAllowed(req, ['admin', 'finance', 'pm', 'viewer', 'tenant_admin'], 'update cashflow settlement status', authMode, workspaceEmailDomain);
+    const projectId = readOptionalText(req.params.projectId);
+    const requested = commandBody(req);
+    const yearMonth = readOptionalText(requested.yearMonth);
+    const period = readOptionalText(requested.period).toUpperCase();
+    const action = readOptionalText(requested.action).toUpperCase();
+    if (!projectId
+      || !/^20\d{2}-(0[1-9]|1[0-2])$/.test(yearMonth)
+      || !/^(MONTH|WEEK_[1-5])$/.test(period)
+      || !/^(SUBMIT|APPROVE)$/.test(action)) {
+      throw createHttpError(400, '결산 대상과 처리 상태를 정확히 입력해 주세요.', 'cashflow_settlement_status_transition_invalid');
+    }
+    const result = await proxyMutation(
+      req,
+      `/api/v1/cashflow/${encodeURIComponent(projectId)}/settlement-statuses/transition`,
+      { yearMonth, period, action },
+      { cashflowWrite: true },
+    );
+    res.status(200).json(result);
+  }));
+
   app.get('/api/v1/cashflow/:projectId/weekly-update-compliance', asyncHandler(async (req, res) => {
     assertWeeklyWorkspaceOrRoleAllowed(req, ['admin', 'finance', 'pm', 'auditor', 'viewer', 'tenant_admin', 'support', 'security'], 'read weekly cashflow compliance', authMode, workspaceEmailDomain);
     const projectId = readOptionalText(req.params.projectId);

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -424,6 +424,51 @@ function createApp(fetchImpl, idempotencyService = createIdempotencyService(), c
 }
 
 describe('JVM weekly API BFF proxy', () => {
+  it('proxies the lightweight month and weekly settlement status flow', async () => {
+    const canonical = {
+      projectId: 'project-a',
+      yearMonth: '2026-08',
+      items: [{ period: 'MONTH', status: 'PENDING_APPROVAL', revision: 1 }],
+    };
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify(canonical), {
+      status: 200, headers: { 'content-type': 'application/json' },
+    }));
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { env: runtimeEnv });
+
+    await request(app)
+      .get('/api/v1/cashflow/project-a/settlement-statuses?yearMonth=2026-08')
+      .expect(200, canonical);
+    await request(app)
+      .post('/api/v1/cashflow/project-a/settlement-statuses/transition')
+      .send({ yearMonth: '2026-08', period: 'WEEK_3', action: 'SUBMIT' })
+      .expect(200, canonical);
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      'http://jvm-weekly.local/api/v1/cashflow/project-a/settlement-statuses?yearMonth=2026-08',
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      2,
+      'http://jvm-weekly.local/api/v1/cashflow/project-a/settlement-statuses/transition',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ yearMonth: '2026-08', period: 'WEEK_3', action: 'SUBMIT' }) }),
+    );
+  });
+
+  it('rejects invalid settlement scopes before calling JVMP', async () => {
+    const fetchImpl = vi.fn();
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { env: runtimeEnv });
+
+    await request(app)
+      .get('/api/v1/cashflow/project-a/settlement-statuses?yearMonth=2026-13')
+      .expect(400);
+    await request(app)
+      .post('/api/v1/cashflow/project-a/settlement-statuses/transition')
+      .send({ yearMonth: '2026-08', period: 'WEEK_6', action: 'APPROVE' })
+      .expect(400);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it('forwards the canonical projection-actual batch summary unchanged', async () => {
     const canonical = {
       version: '1',

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSettlementStatusesResponse.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSettlementStatusesResponse.java
@@ -1,0 +1,20 @@
+package dev.merryai.innerplatform.weekly.api;
+
+import java.util.List;
+
+public record CashflowSettlementStatusesResponse(
+    String projectId,
+    String yearMonth,
+    List<Item> items
+) {
+    public record Item(
+        String period,
+        String status,
+        String submittedAt,
+        String submittedBy,
+        String approvedAt,
+        String approvedBy,
+        long revision
+    ) {
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/TransitionCashflowSettlementStatusRequest.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/TransitionCashflowSettlementStatusRequest.java
@@ -1,0 +1,11 @@
+package dev.merryai.innerplatform.weekly.api;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record TransitionCashflowSettlementStatusRequest(
+    @NotBlank @Pattern(regexp = "20\\d{2}-(0[1-9]|1[0-2])") String yearMonth,
+    @NotBlank @Pattern(regexp = "MONTH|WEEK_[1-5]") String period,
+    @NotBlank @Pattern(regexp = "SUBMIT|APPROVE") String action
+) {
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -385,6 +385,34 @@ public class WeeklyExpenseController {
         );
     }
 
+    @GetMapping("/cashflow/{projectId}/settlement-statuses")
+    public CashflowSettlementStatusesResponse readCashflowSettlementStatuses(
+        @PathVariable String projectId,
+        @RequestParam("yearMonth") String yearMonth,
+        @RequestHeader("x-tenant-id") String tenantId,
+        @RequestHeader("x-actor-id") String actorId,
+        @RequestHeader("x-actor-role") String actorRole,
+        @RequestHeader(value = "x-actor-email", required = false) String actorEmail
+    ) {
+        return commandService.readCashflowSettlementStatuses(
+            actorContext(tenantId, actorId, actorRole, actorEmail), projectId, yearMonth
+        );
+    }
+
+    @PostMapping("/cashflow/{projectId}/settlement-statuses/transition")
+    public CashflowSettlementStatusesResponse transitionCashflowSettlementStatus(
+        @PathVariable String projectId,
+        @RequestHeader("x-tenant-id") String tenantId,
+        @RequestHeader("x-actor-id") String actorId,
+        @RequestHeader("x-actor-role") String actorRole,
+        @RequestHeader(value = "x-actor-email", required = false) String actorEmail,
+        @Valid @RequestBody TransitionCashflowSettlementStatusRequest request
+    ) {
+        return commandService.transitionCashflowSettlementStatus(
+            actorContext(tenantId, actorId, actorRole, actorEmail), projectId, request
+        );
+    }
+
     @GetMapping("/cashflow/{projectId}/month-close/dashboard-source")
     public CashflowMonthDashboardSourceResponse readCashflowMonthDashboardSource(
         @PathVariable String projectId,

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -21,6 +21,7 @@ import dev.merryai.innerplatform.weekly.api.CashflowProjectionActualSummaryBatch
 import dev.merryai.innerplatform.weekly.api.CashflowSheetFormulaPreflightRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetFormulaPreflightResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowSnapshotResponse;
+import dev.merryai.innerplatform.weekly.api.CashflowSettlementStatusesResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowVarianceRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowVarianceResponse;
 import dev.merryai.innerplatform.weekly.api.CloseWeekRequest;
@@ -50,6 +51,7 @@ import dev.merryai.innerplatform.weekly.api.SaveDraftResponse;
 import dev.merryai.innerplatform.weekly.api.SubmitWeekRequest;
 import dev.merryai.innerplatform.weekly.api.SubmitWeekResponse;
 import dev.merryai.innerplatform.weekly.api.TrustedActorContext;
+import dev.merryai.innerplatform.weekly.api.TransitionCashflowSettlementStatusRequest;
 import dev.merryai.innerplatform.weekly.api.UpsertProjectionRequest;
 import dev.merryai.innerplatform.weekly.api.UpsertProjectionResponse;
 import dev.merryai.innerplatform.weekly.api.WeeklyExpenseConflictException;
@@ -174,6 +176,60 @@ public class WeeklyExpenseCommandService {
 
     public void requireProjectAllowed(String commandName, TrustedActorContext actor, String projectId) {
         authorizationService.requireProjectAllowed(commandName, actor, projectId);
+    }
+
+    public CashflowSettlementStatusesResponse readCashflowSettlementStatuses(
+        TrustedActorContext actor,
+        String projectId,
+        String yearMonth
+    ) {
+        authorizationService.requireProjectAllowed(CASHFLOW_MONTH_CLOSE_READ_COMMAND, actor, projectId);
+        return settlementStatusesResponse(
+            projectId,
+            yearMonth,
+            persistence.findCashflowSettlementStatuses(actor.tenantId(), projectId, yearMonth)
+        );
+    }
+
+    public CashflowSettlementStatusesResponse transitionCashflowSettlementStatus(
+        TrustedActorContext actor,
+        String projectId,
+        TransitionCashflowSettlementStatusRequest request
+    ) {
+        if ("APPROVE".equals(request.action())) {
+            requireCashflowMonthClosePermission(CLOSE_CASHFLOW_MONTH_COMMAND, actor, projectId);
+        } else {
+            requireCashflowWritePermissionWithoutLeaseRuntime(
+                COMPLETE_CASHFLOW_WEEKLY_UPDATE_COMMAND, actor, projectId
+            );
+        }
+        List<WeeklyExpensePersistence.CashflowSettlementStatusRecord> records = new ArrayList<>(
+            persistence.findCashflowSettlementStatuses(actor.tenantId(), projectId, request.yearMonth())
+        );
+        WeeklyExpensePersistence.CashflowSettlementStatusRecord updated = persistence.transitionCashflowSettlementStatus(
+            actor, projectId, request.yearMonth(), request.period(), request.action()
+        );
+        records.replaceAll(record -> record.period().equals(updated.period()) ? updated : record);
+        return settlementStatusesResponse(
+            projectId,
+            request.yearMonth(),
+            records
+        );
+    }
+
+    private CashflowSettlementStatusesResponse settlementStatusesResponse(
+        String projectId,
+        String yearMonth,
+        List<WeeklyExpensePersistence.CashflowSettlementStatusRecord> records
+    ) {
+        return new CashflowSettlementStatusesResponse(
+            projectId,
+            yearMonth,
+            records.stream().map(record -> new CashflowSettlementStatusesResponse.Item(
+                record.period(), record.status(), record.submittedAt(), record.submittedBy(),
+                record.approvedAt(), record.approvedBy(), record.revision()
+            )).toList()
+        );
     }
 
     public CashflowProjectionActualSummaryBatchResponse readCashflowProjectionActualSummaries(

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -327,6 +327,20 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         if (!("MONTH".equals(period) || period.matches("WEEK_[1-5]"))) {
             throw new IllegalArgumentException("Cashflow settlement period is invalid.");
         }
+        if ("APPROVE".equals(action)) {
+            DocumentReference projectRef = db.document("orgs/" + actor.tenantId() + "/projects/" + projectId);
+            Map<String, Object> project = cachedDocumentIfPresent(projectRef).orElseGet(() -> {
+                DocumentSnapshot snapshot = get(projectRef);
+                return snapshot.exists() ? data(snapshot) : Map.of();
+            });
+            if (!isDesignatedCashflowSettlementApprover(project, actor.id())) {
+                throw leaseError(
+                    403,
+                    "cashflow_settlement_approval_forbidden",
+                    "Only the project's designated executive approver can approve this settlement."
+                );
+            }
+        }
         DocumentReference ref = settlementStatusRef(actor.tenantId(), projectId, yearMonth);
         Map<String, Object> document = cachedDocumentIfPresent(ref).orElseGet(() -> {
             DocumentSnapshot snapshot = get(ref);
@@ -377,11 +391,11 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         String period,
         Map<String, Object> stored
     ) {
-        String status = text(stored.get("status"), "WAITING_FOR_UPDATE");
-        if ("COMPLETED".equals(status)
-            && !text(stored.get("valueRevision"), "").equals(settlementValueRevision(tenantId, projectId, yearMonth, period))) {
-            status = "PENDING_APPROVAL";
-        }
+        String status = effectiveSettlementStatus(
+            text(stored.get("status"), "WAITING_FOR_UPDATE"),
+            text(stored.get("valueRevision"), ""),
+            settlementValueRevision(tenantId, projectId, yearMonth, period)
+        );
         return new CashflowSettlementStatusRecord(
             period,
             status,
@@ -402,6 +416,18 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             if (snapshot.exists()) weeks.add(data(snapshot));
         }
         return computeCashflowTargetRevision(weeks);
+    }
+
+    static boolean isDesignatedCashflowSettlementApprover(Map<String, Object> project, String actorId) {
+        return actorId != null && !actorId.isBlank() && actorId.equals(textValue(
+            project == null ? null : project.get("executiveApproverId")
+        ));
+    }
+
+    static String effectiveSettlementStatus(String storedStatus, String approvedValueRevision, String currentValueRevision) {
+        return "COMPLETED".equals(storedStatus) && !String.valueOf(approvedValueRevision).equals(currentValueRevision)
+            ? "PENDING_APPROVAL"
+            : storedStatus;
     }
 
     private Map<String, Object> settlementStatusDocument(String tenantId, String projectId, String yearMonth) {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -299,6 +299,120 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         return requireCashflowPermission(actor, projectId, true);
     }
 
+    @Override
+    public List<CashflowSettlementStatusRecord> findCashflowSettlementStatuses(
+        String tenantId,
+        String projectId,
+        String yearMonth
+    ) {
+        requireYearMonth(yearMonth);
+        Map<String, Object> stored = settlementStatusDocument(tenantId, projectId, yearMonth);
+        Map<String, Object> periods = nestedMap(stored.get("periods"));
+        List<CashflowSettlementStatusRecord> result = new ArrayList<>();
+        for (String period : List.of("MONTH", "WEEK_1", "WEEK_2", "WEEK_3", "WEEK_4", "WEEK_5")) {
+            result.add(settlementStatusRecord(tenantId, projectId, yearMonth, period, nestedMap(periods.get(period))));
+        }
+        return List.copyOf(result);
+    }
+
+    @Override
+    public CashflowSettlementStatusRecord transitionCashflowSettlementStatus(
+        TrustedActorContext actor,
+        String projectId,
+        String yearMonth,
+        String period,
+        String action
+    ) {
+        requireYearMonth(yearMonth);
+        if (!("MONTH".equals(period) || period.matches("WEEK_[1-5]"))) {
+            throw new IllegalArgumentException("Cashflow settlement period is invalid.");
+        }
+        DocumentReference ref = settlementStatusRef(actor.tenantId(), projectId, yearMonth);
+        Map<String, Object> document = cachedDocumentIfPresent(ref).orElseGet(() -> {
+            DocumentSnapshot snapshot = get(ref);
+            return snapshot.exists() ? data(snapshot) : new LinkedHashMap<>();
+        });
+        Map<String, Object> periods = nestedMap(document.get("periods"));
+        Map<String, Object> current = nestedMap(periods.get(period));
+        CashflowSettlementStatusRecord effective = settlementStatusRecord(
+            actor.tenantId(), projectId, yearMonth, period, current
+        );
+        String expected = "SUBMIT".equals(action) ? "WAITING_FOR_UPDATE" : "PENDING_APPROVAL";
+        String next = "SUBMIT".equals(action) ? "PENDING_APPROVAL" : "APPROVE".equals(action) ? "COMPLETED" : "";
+        if (next.isBlank()) throw new IllegalArgumentException("Cashflow settlement action is invalid.");
+        if (next.equals(effective.status())) return effective;
+        if (!expected.equals(effective.status())) {
+            throw new WeeklyExpenseConflictException("Cashflow settlement status changed. Check the current status and try again.");
+        }
+        Instant now = clock.instant();
+        Map<String, Object> updated = new LinkedHashMap<>(current);
+        updated.put("status", next);
+        updated.put("revision", Math.addExact(longValue(current.get("revision"), 0), 1));
+        updated.put("valueRevision", settlementValueRevision(actor.tenantId(), projectId, yearMonth, period));
+        updated.put("updatedAt", now.toString());
+        if ("SUBMIT".equals(action)) {
+            updated.put("submittedAt", now.toString());
+            updated.put("submittedBy", actor.name().isBlank() ? actor.id() : actor.name());
+            updated.remove("approvedAt");
+            updated.remove("approvedBy");
+        } else {
+            updated.put("approvedAt", now.toString());
+            updated.put("approvedBy", actor.name().isBlank() ? actor.id() : actor.name());
+        }
+        periods.put(period, updated);
+        Map<String, Object> patch = new LinkedHashMap<>();
+        patch.put("tenantId", actor.tenantId());
+        patch.put("projectId", projectId);
+        patch.put("yearMonth", yearMonth);
+        patch.put("periods", periods);
+        patch.put("updatedAt", now.toString());
+        set(ref, patch);
+        return settlementStatusRecord(actor.tenantId(), projectId, yearMonth, period, updated);
+    }
+
+    private CashflowSettlementStatusRecord settlementStatusRecord(
+        String tenantId,
+        String projectId,
+        String yearMonth,
+        String period,
+        Map<String, Object> stored
+    ) {
+        String status = text(stored.get("status"), "WAITING_FOR_UPDATE");
+        if ("COMPLETED".equals(status)
+            && !text(stored.get("valueRevision"), "").equals(settlementValueRevision(tenantId, projectId, yearMonth, period))) {
+            status = "PENDING_APPROVAL";
+        }
+        return new CashflowSettlementStatusRecord(
+            period,
+            status,
+            text(stored.get("submittedAt"), ""),
+            text(stored.get("submittedBy"), ""),
+            text(stored.get("approvedAt"), ""),
+            text(stored.get("approvedBy"), ""),
+            longValue(stored.get("revision"), 0)
+        );
+    }
+
+    private String settlementValueRevision(String tenantId, String projectId, String yearMonth, String period) {
+        List<Map<String, Object>> weeks = new ArrayList<>();
+        int from = "MONTH".equals(period) ? 1 : Integer.parseInt(period.substring("WEEK_".length()));
+        int through = "MONTH".equals(period) ? 5 : from;
+        for (int weekNo = from; weekNo <= through; weekNo += 1) {
+            DocumentSnapshot snapshot = get(cashflowWeekRef(tenantId, cashflowWeekId(projectId, yearMonth, weekNo)));
+            if (snapshot.exists()) weeks.add(data(snapshot));
+        }
+        return computeCashflowTargetRevision(weeks);
+    }
+
+    private Map<String, Object> settlementStatusDocument(String tenantId, String projectId, String yearMonth) {
+        DocumentSnapshot snapshot = get(settlementStatusRef(tenantId, projectId, yearMonth));
+        return snapshot.exists() ? data(snapshot) : Map.of();
+    }
+
+    private DocumentReference settlementStatusRef(String tenantId, String projectId, String yearMonth) {
+        return db.document("orgs/" + tenantId + "/cashflow_settlement_statuses/" + projectId + "-" + yearMonth);
+    }
+
     private String requireCashflowPermission(TrustedActorContext actor, String projectId, boolean monthCloseOnly) {
         if (currentTransaction.get() == null) {
             throw leaseError(

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
@@ -343,6 +343,17 @@ public interface WeeklyExpensePersistence {
     record CashflowWeekScope(String yearMonth, int weekNo) {
     }
 
+    record CashflowSettlementStatusRecord(
+        String period,
+        String status,
+        String submittedAt,
+        String submittedBy,
+        String approvedAt,
+        String approvedBy,
+        long revision
+    ) {
+    }
+
     default <T> T runCommandTransaction(Callable<T> action) {
         try {
             return action.call();
@@ -386,6 +397,32 @@ public interface WeeklyExpensePersistence {
             503,
             "cashflow_month_close_permission_backend_unavailable",
             "Cashflow month-close permission checks require the Firestore transaction backend."
+        );
+    }
+
+    default List<CashflowSettlementStatusRecord> findCashflowSettlementStatuses(
+        String tenantId,
+        String projectId,
+        String yearMonth
+    ) {
+        throw new WeeklyExpenseEditLeaseException(
+            503,
+            "cashflow_settlement_status_backend_unavailable",
+            "Cashflow settlement status reads require the Firestore transaction backend."
+        );
+    }
+
+    default CashflowSettlementStatusRecord transitionCashflowSettlementStatus(
+        TrustedActorContext actor,
+        String projectId,
+        String yearMonth,
+        String period,
+        String action
+    ) {
+        throw new WeeklyExpenseEditLeaseException(
+            503,
+            "cashflow_settlement_status_backend_unavailable",
+            "Cashflow settlement status updates require the Firestore transaction backend."
         );
     }
 

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/CashflowSettlementStatusPolicyTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/CashflowSettlementStatusPolicyTest.java
@@ -1,0 +1,34 @@
+package dev.merryai.innerplatform.weekly.storage;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CashflowSettlementStatusPolicyTest {
+    @Test
+    void onlyTheProjectsDesignatedExecutiveApproverCanApprove() {
+        Map<String, Object> project = Map.of("executiveApproverId", "executive-a");
+
+        assertThat(FirestoreInheritedWeeklyExpensePersistence.isDesignatedCashflowSettlementApprover(
+            project, "executive-a"
+        )).isTrue();
+        assertThat(FirestoreInheritedWeeklyExpensePersistence.isDesignatedCashflowSettlementApprover(
+            project, "finance-admin"
+        )).isFalse();
+    }
+
+    @Test
+    void completedStatusNeedsApprovalWhenValuesChangeAndRecoversWhenRestored() {
+        assertThat(FirestoreInheritedWeeklyExpensePersistence.effectiveSettlementStatus(
+            "COMPLETED", "revision-a", "revision-b"
+        )).isEqualTo("PENDING_APPROVAL");
+        assertThat(FirestoreInheritedWeeklyExpensePersistence.effectiveSettlementStatus(
+            "COMPLETED", "revision-a", "revision-a"
+        )).isEqualTo("COMPLETED");
+        assertThat(FirestoreInheritedWeeklyExpensePersistence.effectiveSettlementStatus(
+            "WAITING_FOR_UPDATE", "", "revision-a"
+        )).isEqualTo("WAITING_FOR_UPDATE");
+    }
+}

--- a/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
+++ b/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
@@ -1,53 +1,31 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import {
-  filterCashflowProjectsByDepartment,
-  findCashflowWeeklyCompliance,
-  isCashflowSettlementCompleted,
-} from './CashflowWeeklyPage';
-import type { CashflowWeeklyComplianceItem } from '../../lib/platform-bff-client';
+import { filterCashflowProjectsByDepartment } from './CashflowWeeklyPage';
 
 const source = readFileSync(resolve(import.meta.dirname, 'CashflowWeeklyPage.tsx'), 'utf8');
 
-describe('CashflowWeeklyPage read-only status surface', () => {
-  it('shows only the selected-month weekly difference in exact won', () => {
+describe('CashflowWeeklyPage settlement status surface', () => {
+  it('shows the requested month and weekly status columns without the old summary', () => {
     expect(source).toContain('title="전사 현금흐름 현황"');
-    expect(source).toContain('projectionTotals: week.projectionTotals || emptyTotals()');
-    expect(source).toContain('actualTotals: week.actualTotals || emptyTotals()');
-    expect(source).toContain('const difference = projection.net - actual.net');
-    expect(source).toContain('Projection·Actual·차이');
-    expect(source).not.toContain('CashflowCanonicalSummary');
-    expect(source).not.toContain('누적 Projection-Actual 정산');
-    expect(source).not.toContain('주차 상세');
-    expect(source).toContain('Projection-Actual 차이');
-    expect(source).toContain("difference.toLocaleString('ko-KR')");
-    expect(source).toContain('text-[16px] font-bold');
-    expect(source).not.toContain('formatKoreanWonCompact');
-    expect(source).not.toContain('>Projection 순액<');
-    expect(source).not.toContain('>Actual 순액<');
-    expect(source).not.toContain('monthlyDifference');
+    expect(source).toContain('>월 결산</th>');
+    expect(source).toContain('>현금흐름(링크)</th>');
+    expect(source).toContain('<div>{week.weekNo}주</div>');
+    expect(source).not.toContain('>요약<');
+    expect(source).not.toContain('Projection-Actual 차이');
   });
 
-  it('keeps the project summary visible and uses weekly settlement completion states', () => {
+  it('uses the simple persisted status flow and updates only the affected project state', () => {
     expect(source).toContain('sticky top-0');
     expect(source).toContain('sticky left-0');
-    expect(source).toContain('>요약<');
-    expect(source).toContain('fetchCashflowWeeklyComplianceViaBff');
-    expect(source).toContain("status === 'ON_TIME' || status === 'COMPLETED_LATE'");
-    expect(source).toContain("week.status === 'MISSED'");
-    expect(source).toContain("'완료 대기'");
-    expect(source).toContain("settlementCompleted ? '완료' : '미완료'");
-    expect(source).toContain("completedSettlementCount === monthWeeks.length ? '완료' : '미완료'");
-    expect(source).not.toContain('결산 완료');
-    expect(source).not.toContain('D-7');
-    expect(source).not.toContain('최종 확정과 수정 잠금은 프로젝트별 월 결산 승인에서 처리합니다.');
-    expect(source).toContain("toLocaleString('ko-KR')");
-    expect(source).toContain('limit: 50');
-    expect(source).toContain('이전 이력 더 불러오기');
-    expect(source).toContain('page.nextCursor === current.nextCursor');
-    expect(source).not.toContain('fetchCashflowMonthCloseViaBff');
-    expect(source).toContain("settlementCompleted ? 'bg-emerald-50 dark:bg-emerald-950/30'");
+    expect(source).toContain('fetchCashflowSettlementStatusesViaBff');
+    expect(source).toContain('transitionCashflowSettlementStatusViaBff');
+    expect(source).toContain('실무자 업데이트 대기 중');
+    expect(source).toContain('조직장 승인 필요');
+    expect(source).toContain('정산 완료');
+    expect(source).toContain("user?.uid === project.executiveApproverId");
+    expect(source).toContain("setStatuses((current) => ({ ...current, [projectId]: result }))");
+    expect(source).not.toContain('window.location.reload');
   });
 
   it('filters both visible rows and compliance requests by normalized department', () => {
@@ -72,31 +50,7 @@ describe('CashflowWeeklyPage read-only status surface', () => {
     expect(filterCashflowProjectsByDepartment(projects, '없는 조직')).toEqual([]);
   });
 
-  it('marks only the exact completed year-month and week as completed', () => {
-    const compliance = (yearMonth: string, weekNo: number, status: CashflowWeeklyComplianceItem['status']): CashflowWeeklyComplianceItem => ({
-      yearMonth,
-      weekNo,
-      status,
-      deadline: '',
-      completedAt: null,
-      completedBy: null,
-      operationId: null,
-      auditId: null,
-      updateResult: null,
-    });
-    const items = [
-      compliance('2026-07', 1, 'ON_TIME'),
-      compliance('2026-08', 1, 'COMPLETED_LATE'),
-      compliance('2026-08', 2, 'MISSED'),
-    ];
-
-    expect(isCashflowSettlementCompleted(findCashflowWeeklyCompliance(items, '2026-08', 1)?.status)).toBe(true);
-    expect(isCashflowSettlementCompleted(findCashflowWeeklyCompliance(items, '2026-08', 2)?.status)).toBe(false);
-    expect(isCashflowSettlementCompleted(findCashflowWeeklyCompliance(items, '2026-08', 3)?.status)).toBe(false);
-    expect(isCashflowSettlementCompleted(findCashflowWeeklyCompliance(items, '2026-07', 1)?.status)).toBe(true);
-  });
-
-  it('is read-only and routes detailed work to the project cashflow screen', () => {
+  it('routes detailed work to the project cashflow screen', () => {
     expect(source).not.toContain('useCashflowEditLease');
     expect(source).not.toContain('updateVarianceFlag');
     expect(source).not.toContain('EditLeaseDialogs');

--- a/src/app/components/cashflow/CashflowWeeklyPage.tsx
+++ b/src/app/components/cashflow/CashflowWeeklyPage.tsx
@@ -1,40 +1,62 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { BarChart3, ChevronLeft, ChevronRight, ExternalLink } from 'lucide-react';
+import { toast } from 'sonner';
 import { PageHeader } from '../layout/PageHeader';
 import { Card, CardContent } from '../ui/card';
 import { Button } from '../ui/button';
-import { Badge } from '../ui/badge';
 import { Label } from '../ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
-import { AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '../ui/alert-dialog';
 import { useAppStore } from '../../data/store';
 import { useCashflowWeeks } from '../../data/cashflow-weeks-store';
 import { useAuth } from '../../data/auth-store';
 import { useFirebase } from '../../lib/firebase-context';
-import { fetchCashflowWeeklyComplianceViaBff, type CashflowWeeklyComplianceItem, type CashflowWeeklyCompliancePage } from '../../lib/platform-bff-client';
+import {
+  fetchCashflowSettlementStatusesViaBff,
+  transitionCashflowSettlementStatusViaBff,
+  type CashflowSettlementPeriod,
+  type CashflowSettlementStatusItem,
+  type CashflowSettlementStatusesResult,
+} from '../../lib/platform-bff-client';
 import { getMonthMondayWeeks } from '../../platform/cashflow-weeks';
 import { getProjectRegistrationCicOptions, normalizeProjectDepartment } from '../../platform/project-cic';
-import type { CashflowWeekTotals } from '../../data/types';
-
-function emptyTotals(): CashflowWeekTotals {
-  return { totalIn: 0, totalOut: 0, net: 0 };
-}
 
 export function filterCashflowProjectsByDepartment<T extends { department?: unknown }>(projects: T[], department: string): T[] {
   return projects.filter((project) => department === 'ALL' || normalizeProjectDepartment(project.department) === department);
 }
 
-export function findCashflowWeeklyCompliance(
-  items: CashflowWeeklyComplianceItem[],
-  yearMonth: string,
-  weekNo: number,
-): CashflowWeeklyComplianceItem | undefined {
-  return items.find((item) => item.yearMonth === yearMonth && item.weekNo === weekNo);
+function statusItem(result: CashflowSettlementStatusesResult | undefined, period: CashflowSettlementPeriod) {
+  return result?.items.find((item) => item.period === period);
 }
 
-export function isCashflowSettlementCompleted(status?: CashflowWeeklyComplianceItem['status']): boolean {
-  return status === 'ON_TIME' || status === 'COMPLETED_LATE';
+function SettlementStatusButton({
+  item,
+  loading,
+  canApprove,
+  onAction,
+}: {
+  item?: CashflowSettlementStatusItem;
+  loading: boolean;
+  canApprove: boolean;
+  onAction: (action: 'SUBMIT' | 'APPROVE') => void;
+}) {
+  const status = item?.status || 'WAITING_FOR_UPDATE';
+  if (status === 'COMPLETED') {
+    return <span className="inline-flex min-h-8 items-center rounded-md bg-emerald-50 px-2.5 font-semibold text-emerald-700">정산 완료</span>;
+  }
+  const action = status === 'PENDING_APPROVAL' ? 'APPROVE' : 'SUBMIT';
+  return (
+    <Button
+      type="button"
+      size="sm"
+      variant="outline"
+      className="min-h-8 whitespace-normal text-[11px]"
+      disabled={loading || (action === 'APPROVE' && !canApprove)}
+      onClick={() => onAction(action)}
+    >
+      {loading ? '처리 중…' : status === 'PENDING_APPROVAL' ? '조직장 승인 필요' : '실무자 업데이트 대기 중'}
+    </Button>
+  );
 }
 
 export function CashflowWeeklyPage() {
@@ -42,13 +64,12 @@ export function CashflowWeeklyPage() {
   const { projects } = useAppStore();
   const { user } = useAuth();
   const { orgId } = useFirebase();
-  const { yearMonth, weeks, isLoading, goPrevMonth, goNextMonth } = useCashflowWeeks();
+  const { yearMonth, isLoading, goPrevMonth, goNextMonth } = useCashflowWeeks();
   const monthWeeks = useMemo(() => getMonthMondayWeeks(yearMonth), [yearMonth]);
-  const [canonicalHistory, setCanonicalHistory] = useState<Record<string, CashflowWeeklyCompliancePage>>({});
-  const [historyErrors, setHistoryErrors] = useState<Record<string, string>>({});
-  const [historyLoading, setHistoryLoading] = useState(false);
-  const [detailProjectId, setDetailProjectId] = useState('');
-  const [detailLoading, setDetailLoading] = useState(false);
+  const [statuses, setStatuses] = useState<Record<string, CashflowSettlementStatusesResult>>({});
+  const [statusErrors, setStatusErrors] = useState<Record<string, string>>({});
+  const [statusesLoading, setStatusesLoading] = useState(false);
+  const [actionKey, setActionKey] = useState('');
   const [deptFilter, setDeptFilter] = useState('ALL');
   const departments = useMemo(() => Array.from(new Set([
     ...getProjectRegistrationCicOptions(),
@@ -58,64 +79,52 @@ export function CashflowWeeklyPage() {
 
   useEffect(() => {
     if (!user?.idToken || filteredProjects.length === 0) {
-      setCanonicalHistory({});
-      setHistoryErrors({});
-      setHistoryLoading(false);
+      setStatuses({});
+      setStatusErrors({});
+      setStatusesLoading(false);
       return;
     }
     let active = true;
-    setHistoryLoading(true);
+    setStatusesLoading(true);
     void Promise.allSettled(filteredProjects.map(async (project) => ({
       projectId: project.id,
-      page: await fetchCashflowWeeklyComplianceViaBff({ tenantId: orgId, actor: user, projectId: project.id, limit: 50 }),
+      result: await fetchCashflowSettlementStatusesViaBff({
+        tenantId: orgId, actor: user, projectId: project.id, yearMonth,
+      }),
     }))).then((results) => {
       if (!active) return;
-      const next: Record<string, CashflowWeeklyCompliancePage> = {};
+      const next: Record<string, CashflowSettlementStatusesResult> = {};
       const errors: Record<string, string> = {};
       results.forEach((result, index) => {
         const projectId = filteredProjects[index]?.id;
         if (!projectId) return;
-        if (result.status === 'fulfilled') next[projectId] = result.value.page;
-        else errors[projectId] = '주간 정산 이력을 불러오지 못했습니다.';
+        if (result.status === 'fulfilled') next[projectId] = result.value.result;
+        else errors[projectId] = '결산 상태를 불러오지 못했습니다.';
       });
-      setCanonicalHistory(next);
-      setHistoryErrors(errors);
-      setHistoryLoading(false);
+      setStatuses(next);
+      setStatusErrors(errors);
+      setStatusesLoading(false);
     });
     return () => { active = false; };
   }, [filteredProjects, orgId, user, yearMonth]);
 
-  async function loadMoreHistory(projectId: string) {
-    const current = canonicalHistory[projectId];
-    if (!user?.idToken || !current?.nextCursor || detailLoading) return;
-    setDetailLoading(true);
+  async function transition(projectId: string, period: CashflowSettlementPeriod, action: 'SUBMIT' | 'APPROVE') {
+    if (!user?.idToken) return;
+    const key = `${projectId}:${period}`;
+    setActionKey(key);
     try {
-      const page = await fetchCashflowWeeklyComplianceViaBff({ tenantId: orgId, actor: user, projectId, limit: 50, cursor: current.nextCursor });
-      if (page.nextCursor && (page.nextCursor === current.nextCursor || current.items.length >= 5_000)) {
-        setHistoryErrors((value) => ({ ...value, [projectId]: '이력 페이지가 반복되어 추가 조회를 중단했습니다.' }));
-        return;
-      }
-      setCanonicalHistory((value) => ({ ...value, [projectId]: { ...page, items: [...current.items, ...page.items] } }));
-    } catch {
-      setHistoryErrors((value) => ({ ...value, [projectId]: '추가 주간 정산 이력을 불러오지 못했습니다.' }));
+      const result = await transitionCashflowSettlementStatusViaBff({
+        tenantId: orgId, actor: user, projectId, yearMonth, period, action,
+      });
+      setStatuses((current) => ({ ...current, [projectId]: result }));
+      setStatusErrors((current) => ({ ...current, [projectId]: '' }));
+      toast.success(action === 'APPROVE' ? '정산을 승인했습니다.' : '조직장 승인 대기로 변경했습니다.');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : '결산 상태를 변경하지 못했습니다.');
     } finally {
-      setDetailLoading(false);
+      setActionKey('');
     }
   }
-
-  const byProjectWeek = useMemo(() => {
-    const map = new Map<string, {
-      projectionTotals: CashflowWeekTotals;
-      actualTotals: CashflowWeekTotals;
-    }>();
-    for (const week of weeks.filter((item) => item.yearMonth === yearMonth)) {
-      map.set(`${week.projectId}:${week.weekNo}`, {
-        projectionTotals: week.projectionTotals || emptyTotals(),
-        actualTotals: week.actualTotals || emptyTotals(),
-      });
-    }
-    return map;
-  }, [weeks, yearMonth]);
 
   function openProject(projectId: string) {
     navigate(`/cashflow/projects/${projectId}?ym=${encodeURIComponent(yearMonth)}&view=compare#projection-actual-comparison`);
@@ -127,7 +136,7 @@ export function CashflowWeeklyPage() {
         icon={BarChart3}
         iconGradient="linear-gradient(135deg, #0d9488 0%, #14b8a6 100%)"
         title="전사 현금흐름 현황"
-        description={`프로젝트별 Projection·Actual·차이 · ${yearMonth}`}
+        description={`프로젝트별 월·주 정산 상태 · ${yearMonth}`}
         actions={(
           <div className="flex items-center gap-2">
             <Button variant="outline" size="sm" className="h-8 gap-1.5 text-[12px]" onClick={goPrevMonth}>
@@ -147,9 +156,7 @@ export function CashflowWeeklyPage() {
             <SelectTrigger><SelectValue /></SelectTrigger>
             <SelectContent>
               <SelectItem value="ALL">전체 조직</SelectItem>
-              {departments.map((department) => (
-                <SelectItem key={department} value={department}>{department}</SelectItem>
-              ))}
+              {departments.map((department) => <SelectItem key={department} value={department}>{department}</SelectItem>)}
             </SelectContent>
           </Select>
         </div>
@@ -159,84 +166,67 @@ export function CashflowWeeklyPage() {
       <Card className="overflow-hidden">
         <CardContent className="p-0">
           <div className="max-h-[calc(100vh-190px)] overflow-auto">
-            <table className="w-full min-w-[1260px] border-separate border-spacing-0 text-[11px]">
+            <table className="w-full min-w-[1320px] border-separate border-spacing-0 text-[11px]">
               <thead>
                 <tr className="bg-muted/30">
                   <th className="sticky left-0 top-0 z-40 min-w-[220px] border-b bg-slate-50 px-4 py-2 text-left font-bold">프로젝트</th>
                   <th className="sticky left-[220px] top-0 z-40 min-w-[120px] border-b bg-slate-50 px-3 py-2 text-left font-bold">담당자</th>
-                  <th className="sticky left-[340px] top-0 z-40 min-w-[210px] border-b border-r bg-slate-50 px-3 py-2 text-left font-bold">요약</th>
+                  <th className="sticky top-0 z-30 min-w-[150px] border-b bg-slate-50 px-3 py-2 text-center font-bold">월 결산</th>
+                  <th className="sticky top-0 z-30 min-w-[140px] border-b bg-slate-50 px-3 py-2 text-center font-bold">현금흐름(링크)</th>
                   {monthWeeks.map((week) => (
                     <th key={week.weekNo} className="sticky top-0 z-30 min-w-[170px] border-b bg-slate-50 px-3 py-2 text-center font-bold">
-                      <div>{week.label}</div>
+                      <div>{week.weekNo}주</div>
                       <div className="mt-0.5 text-[10px] text-muted-foreground">{week.weekStart}~{week.weekEnd}</div>
                     </th>
                   ))}
-                  <th className="sticky top-0 z-30 min-w-[120px] border-b bg-slate-50 px-4 py-2 text-right font-bold">현금흐름</th>
                 </tr>
               </thead>
               <tbody>
                 {filteredProjects.map((project) => {
-                  const projectWeeks = monthWeeks.map((week) => byProjectWeek.get(`${project.id}:${week.weekNo}`));
-                  const projectHistory = canonicalHistory[project.id];
-                  const projectStatuses = projectHistory?.items || [];
-                  const completedSettlementCount = monthWeeks.filter((week) => {
-                    const status = projectStatuses.find((item) => item.yearMonth === yearMonth && item.weekNo === week.weekNo)?.status;
-                    return status === 'ON_TIME' || status === 'COMPLETED_LATE';
-                  }).length;
+                  const projectStatuses = statuses[project.id];
+                  const canApprove = user?.uid === project.executiveApproverId;
                   return (
-                  <tr key={project.id} className="border-t border-border/30 transition-colors hover:bg-muted/20">
-                    <td className="sticky left-0 z-20 bg-white px-4 py-3">
-                      <p className="truncate font-semibold">{project.name}</p>
-                      <p className="truncate text-[10px] text-muted-foreground">{project.department} · {project.clientOrg}</p>
-                    </td>
-                    <td className="sticky left-[220px] z-20 bg-white px-3 py-3 font-medium">{project.managerName}</td>
-                    <td className="sticky left-[340px] z-20 border-r bg-white px-3 py-3">
-                      <div className="space-y-1.5">
-                        <div className="flex items-center justify-between gap-2">
-                          <span className="text-muted-foreground">상태</span>
-                          <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
-                            {historyLoading && !projectHistory ? '확인 중' : historyErrors[project.id] ? '조회 오류' : completedSettlementCount === monthWeeks.length ? '완료' : '미완료'} {projectHistory ? `${completedSettlementCount}/${monthWeeks.length}` : ''}
-                          </Badge>
-                        </div>
-                        {projectHistory ? <div className="flex items-center justify-between gap-2 text-[10px]"><span className="text-muted-foreground">누적 준수</span><span>기한 내 {projectHistory.onTimeCount.toLocaleString('ko-KR')} · 미준수 {projectHistory.missedCount.toLocaleString('ko-KR')}</span></div> : null}
-                        <button type="button" className="text-[10px] font-semibold text-teal-700 underline underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-700" onClick={() => setDetailProjectId(project.id)}>주간 정산 자세히</button>
-                      </div>
-                    </td>
-                    {monthWeeks.map((week) => {
-                      const status = byProjectWeek.get(`${project.id}:${week.weekNo}`);
-                      const projection = status?.projectionTotals || emptyTotals();
-                      const actual = status?.actualTotals || emptyTotals();
-                      const difference = projection.net - actual.net;
-                      const compliance = findCashflowWeeklyCompliance(projectStatuses, yearMonth, week.weekNo);
-                      const settlementCompleted = isCashflowSettlementCompleted(compliance?.status);
-                      return (
-                        <td key={week.weekNo} className={`px-3 py-3 ${settlementCompleted ? 'bg-emerald-50 dark:bg-emerald-950/30' : 'bg-red-50 dark:bg-red-950/30'}`}>
-                          <div className="space-y-1.5">
-                            <Badge variant="outline" className="h-5 px-1.5 text-[10px]">
-                              {!projectHistory ? historyLoading ? '확인 중' : '조회 오류' : settlementCompleted ? '완료' : '미완료'}
-                            </Badge>
-                            <div className="border-t border-border/40 pt-2">
-                              <div className="text-[12px] font-semibold text-muted-foreground">Projection-Actual 차이</div>
-                              <div className={`mt-1 text-[16px] font-bold tabular-nums ${difference < 0 ? 'text-red-700' : 'text-slate-800'}`}>
-                                {difference.toLocaleString('ko-KR')}원
-                              </div>
-                            </div>
-                          </div>
-                        </td>
-                      );
-                    })}
-                    <td className="px-4 py-3 text-right">
-                      <Button size="sm" variant="outline" className="h-8 gap-1.5 text-[11px]" onClick={() => openProject(project.id)}>
-                        <ExternalLink className="h-3.5 w-3.5" /> 현금흐름 보기
-                      </Button>
-                    </td>
-                  </tr>
+                    <tr key={project.id} className="border-t border-border/30 transition-colors hover:bg-muted/20">
+                      <td className="sticky left-0 z-20 bg-white px-4 py-3">
+                        <p className="truncate font-semibold">{project.name}</p>
+                        <p className="truncate text-[10px] text-muted-foreground">{project.department} · {project.clientOrg}</p>
+                      </td>
+                      <td className="sticky left-[220px] z-20 bg-white px-3 py-3 font-medium">{project.managerName}</td>
+                      <td className="px-3 py-3 text-center">
+                        {statusErrors[project.id] ? <span className="text-red-700">조회 오류</span> : statusesLoading && !projectStatuses ? <span className="text-muted-foreground">확인 중…</span> : (
+                          <SettlementStatusButton
+                            item={statusItem(projectStatuses, 'MONTH')}
+                            loading={actionKey === `${project.id}:MONTH`}
+                            canApprove={canApprove}
+                            onAction={(action) => void transition(project.id, 'MONTH', action)}
+                          />
+                        )}
+                      </td>
+                      <td className="px-3 py-3 text-center">
+                        <Button size="sm" variant="outline" className="h-8 gap-1.5 text-[11px]" onClick={() => openProject(project.id)}>
+                          <ExternalLink className="h-3.5 w-3.5" /> 현금흐름 보기
+                        </Button>
+                      </td>
+                      {monthWeeks.map((week) => {
+                        const period = `WEEK_${week.weekNo}` as CashflowSettlementPeriod;
+                        return (
+                          <td key={week.weekNo} className="px-3 py-3 text-center">
+                            {statusErrors[project.id] ? <span className="text-red-700">조회 오류</span> : statusesLoading && !projectStatuses ? <span className="text-muted-foreground">확인 중…</span> : (
+                              <SettlementStatusButton
+                                item={statusItem(projectStatuses, period)}
+                                loading={actionKey === `${project.id}:${period}`}
+                                canApprove={canApprove}
+                                onAction={(action) => void transition(project.id, period, action)}
+                              />
+                            )}
+                          </td>
+                        );
+                      })}
+                    </tr>
                   );
                 })}
                 {filteredProjects.length === 0 ? (
-                  <tr>
-                    <td className="px-4 py-8 text-center text-[12px] text-muted-foreground" colSpan={monthWeeks.length + 4}>프로젝트가 없습니다.</td>
-                  </tr>
+                  <tr><td className="px-4 py-8 text-center text-[12px] text-muted-foreground" colSpan={9}>프로젝트가 없습니다.</td></tr>
                 ) : null}
               </tbody>
             </table>
@@ -244,29 +234,6 @@ export function CashflowWeeklyPage() {
           {isLoading ? <div className="border-t border-border/40 px-4 py-3 text-[11px] text-muted-foreground">불러오는 중…</div> : null}
         </CardContent>
       </Card>
-
-      <AlertDialog open={Boolean(detailProjectId)} onOpenChange={(open) => { if (!open) setDetailProjectId(''); }}>
-        <AlertDialogContent className="w-[calc(100vw-2rem)] max-w-[900px]">
-          <AlertDialogHeader>
-            <AlertDialogTitle>{projects.find((project) => project.id === detailProjectId)?.name || '프로젝트'} 주간 정산 이력</AlertDialogTitle>
-            <AlertDialogDescription>JVM 프로젝트 원장의 모든 주차별 준수 상태입니다.</AlertDialogDescription>
-          </AlertDialogHeader>
-          <div className="max-h-[60dvh] overflow-auto rounded-md border" role="region" aria-label="프로젝트 주간 정산 전체 이력" tabIndex={0}>
-            {(canonicalHistory[detailProjectId]?.items || []).length > 0 ? (
-              <table className="w-full min-w-[820px] border-collapse text-[11px]">
-                <caption className="sr-only">대상 주차, 마감기한, 완료 여부, 준수 상태, 처리 결과, 완료시각, 완료자</caption>
-                <thead className="sticky top-0 bg-slate-50"><tr><th className="px-3 py-2 text-left">대상 주차</th><th className="px-3 py-2 text-left">마감기한</th><th className="px-3 py-2 text-left">완료 여부</th><th className="px-3 py-2 text-left">준수 상태</th><th className="px-3 py-2 text-left">처리 결과</th><th className="px-3 py-2 text-left">완료시각</th><th className="px-3 py-2 text-left">완료자</th></tr></thead>
-                <tbody>{(canonicalHistory[detailProjectId]?.items || []).map((week) => {
-                  const completed = week.status === 'ON_TIME' || week.status === 'COMPLETED_LATE';
-                  return <tr key={`${week.yearMonth}:${week.weekNo}:${week.operationId || week.status}`} className="border-t"><th className="px-3 py-2 text-left">{week.yearMonth} {week.weekNo}주차</th><td className="px-3 py-2">{new Date(week.deadline).toLocaleString('ko-KR')}</td><td className="px-3 py-2 font-semibold">{completed ? '완료' : '미완료'}</td><td className="px-3 py-2">{week.status === 'ON_TIME' ? '기한 내 완료' : week.status === 'COMPLETED_LATE' ? '기한 후 완료·미준수' : week.status === 'MISSED' ? '기한 경과·미준수' : '완료 대기'}</td><td className="px-3 py-2">{week.updateResult === 'CHANGED' ? '변경사항 반영 완료' : week.updateResult === 'NO_CHANGES' ? '변경사항 없음' : '-'}</td><td className="px-3 py-2">{week.completedAt ? new Date(week.completedAt).toLocaleString('ko-KR') : '-'}</td><td className="px-3 py-2 break-all">{week.completedBy || '-'}</td></tr>;
-                })}</tbody>
-              </table>
-            ) : historyLoading ? <p role="status" className="p-8 text-center text-[12px] text-muted-foreground">주간 정산 이력을 불러오는 중입니다.</p> : historyErrors[detailProjectId] ? <div role="alert" className="p-8 text-center text-[12px] text-red-700">{historyErrors[detailProjectId]}</div> : <p className="p-8 text-center text-[12px] text-muted-foreground">저장된 주간 정산 이력이 없습니다.</p>}
-          </div>
-          {canonicalHistory[detailProjectId]?.nextCursor ? <Button type="button" variant="outline" disabled={detailLoading} onClick={() => void loadMoreHistory(detailProjectId)}>{detailLoading ? '추가 이력 불러오는 중…' : '이전 이력 더 불러오기'}</Button> : null}
-          <AlertDialogFooter><AlertDialogCancel>닫기</AlertDialogCancel></AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </div>
   );
 }

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -1335,6 +1335,25 @@ export interface CashflowWeeklyCompliancePage {
   missedCount: number;
 }
 
+export type CashflowSettlementPeriod = 'MONTH' | `WEEK_${1 | 2 | 3 | 4 | 5}`;
+export type CashflowSettlementStatus = 'WAITING_FOR_UPDATE' | 'PENDING_APPROVAL' | 'COMPLETED';
+
+export interface CashflowSettlementStatusItem {
+  period: CashflowSettlementPeriod;
+  status: CashflowSettlementStatus;
+  submittedAt: string;
+  submittedBy: string;
+  approvedAt: string;
+  approvedBy: string;
+  revision: number;
+}
+
+export interface CashflowSettlementStatusesResult {
+  projectId: string;
+  yearMonth: string;
+  items: CashflowSettlementStatusItem[];
+}
+
 export interface CashflowProjectionActualSummary {
   projectId: string;
   fromMonth: string;
@@ -2866,6 +2885,42 @@ export async function fetchCashflowWeeklyComplianceViaBff(params: {
   const response = await resolveClient(params.client).get<CashflowWeeklyCompliancePage>(
     `/api/v1/cashflow/${encodeURIComponent(params.projectId)}/weekly-update-compliance?${query.toString()}`,
     { tenantId: params.tenantId, actor: toRequestActor(params.actor), retries: 0, timeoutMs: 12000 },
+  );
+  return response.data;
+}
+
+export async function fetchCashflowSettlementStatusesViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectId: string;
+  yearMonth: string;
+  client?: PlatformApiClientLike;
+}): Promise<CashflowSettlementStatusesResult> {
+  const response = await resolveClient(params.client).get<CashflowSettlementStatusesResult>(
+    `/api/v1/cashflow/${encodeURIComponent(params.projectId)}/settlement-statuses?yearMonth=${encodeURIComponent(params.yearMonth)}`,
+    { tenantId: params.tenantId, actor: toRequestActor(params.actor), retries: 0, timeoutMs: 12000 },
+  );
+  return response.data;
+}
+
+export async function transitionCashflowSettlementStatusViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectId: string;
+  yearMonth: string;
+  period: CashflowSettlementPeriod;
+  action: 'SUBMIT' | 'APPROVE';
+  client?: PlatformApiClientLike;
+}): Promise<CashflowSettlementStatusesResult> {
+  const response = await resolveClient(params.client).post<CashflowSettlementStatusesResult>(
+    `/api/v1/cashflow/${encodeURIComponent(params.projectId)}/settlement-statuses/transition`,
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      body: { yearMonth: params.yearMonth, period: params.period, action: params.action },
+      retries: 0,
+      timeoutMs: 12000,
+    },
   );
   return response.data;
 }


### PR DESCRIPTION
## What
- replace the heavy weekly compliance summary on /cashflow/weekly with one persisted month/week status flow
- reorder columns to 프로젝트 | 담당자 | 월 결산 | 현금흐름(링크) | 1주~5주 and remove the old 요약/detail UI
- persist WAITING_FOR_UPDATE → PENDING_APPROVAL → COMPLETED in JVMP
- require the canonical project writer for submission and the designated executive approver for approval
- return completed scopes to approval-needed when their cashflow value revision changes
- update only the affected project row after actions; no forced page refresh

## Verification
- npm test: 2,642 passed, 241 skipped
- npm run build: passed
- mvn -q -f server/jvm-weekly-api/pom.xml test: passed
- targeted BFF/UI tests: 179 passed

## Ops
- no existing production records are changed or deleted
- new JVMP collection: cashflow_settlement_statuses
- production deploy must run from main via GitHub Actions