### PR TITLE
fix(cashflow): simplify weekly settlement completion

### DIFF
--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -1553,34 +1553,6 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             WeekDocParts parts = parseCashflowWeekId(projectId, weekSnapshot.getId());
             projectWeeks.put(weekSnapshot.getId(), week);
         }
-        List<Map<String, Object>> missingCells = new ArrayList<>();
-        for (CashflowWeekScope scope : consecutiveFinanceWeeks(request.yearMonth(), request.weekNo(), 16)) {
-            Map<String, Object> candidate = projectWeeks.getOrDefault(
-                cashflowWeekId(projectId, scope.yearMonth(), scope.weekNo()),
-                Map.of()
-            );
-            Map<String, Object> projection = nestedMap(candidate.get("projection"));
-            for (String lineId : CASHFLOW_CUMULATIVE_LINES) {
-                if (projection.containsKey(lineId) && projection.get(lineId) != null) continue;
-                missingCells.add(Map.of(
-                    "yearMonth", scope.yearMonth(),
-                    "weekNo", scope.weekNo(),
-                    "lineId", lineId
-                ));
-            }
-        }
-        if (!missingCells.isEmpty()) {
-            throw new WeeklyExpenseEditLeaseException(
-                409,
-                "cashflow_projection_window_incomplete",
-                "대상 주차와 그 이후 15개 재무주차의 Projection 값을 모두 입력해 주세요.",
-                Map.of(
-                    "requiredWeekCount", 16,
-                    "requiredCellCount", 256,
-                    "missingCells", List.copyOf(missingCells)
-                )
-            );
-        }
         if (lockedCompletion != null) {
             return toWeeklyCompletionRecord(
                 projectId, request.yearMonth(), request.weekNo(), lockedCompletion, true

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -2067,89 +2067,6 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
-    void lockedWeeklyReplayStillRejectsOneMissingCellInTheSixteenthFinanceWeek() {
-        Fixture fixture = fixture(activeMember(), Map.of());
-        putCompleteProjectionWindow(fixture, "2026-07", 3);
-        WeeklyExpenseCommandService service = commandService(fixture.persistence);
-        fixture.persistence.runCommandTransaction(() -> service.completeCashflowWeeklyUpdate(
-            ACTOR,
-            "project-a",
-            new CompleteCashflowWeeklyUpdateRequest(
-                "weekly-window-lock", "2026-07", 3, "2026-07-16T09:00:00Z"
-            )
-        ));
-        String sixteenthWeekPath = "orgs/tenant-a/cashflow_weeks/project-a-2026-10-w3";
-        Map<String, Object> sixteenthWeek = new LinkedHashMap<>(fixture.documents.get(sixteenthWeekPath));
-        Map<String, Object> projection = new LinkedHashMap<>((Map<String, Object>) sixteenthWeek.get("projection"));
-        projection.remove("SALES_IN");
-        sixteenthWeek.put("projection", projection);
-        fixture.documents.put(sixteenthWeekPath, sixteenthWeek);
-
-        Throwable failure = catchThrowable(() -> fixture.persistence.runCommandTransaction(() ->
-            service.completeCashflowWeeklyUpdate(
-                ACTOR,
-                "project-a",
-                new CompleteCashflowWeeklyUpdateRequest(
-                    "weekly-window-replay", "2026-07", 3, "2026-07-16T10:00:00Z"
-                )
-            )
-        ));
-
-        assertThat(failure).isInstanceOf(WeeklyExpenseEditLeaseException.class);
-        WeeklyExpenseEditLeaseException incomplete = (WeeklyExpenseEditLeaseException) failure;
-        assertThat(incomplete.code()).isEqualTo("cashflow_projection_window_incomplete");
-        assertThat(incomplete.details())
-            .containsEntry("requiredWeekCount", 16)
-            .containsEntry("requiredCellCount", 256);
-        assertThat((List<Map<String, Object>>) incomplete.details().get("missingCells"))
-            .containsExactly(Map.of("yearMonth", "2026-10", "weekNo", 3, "lineId", "SALES_IN"));
-    }
-
-    @Test
-    void liveLegacyTwelveLineProjectionFailsClosedWithoutPartialWrites() {
-        Fixture fixture = fixture(activeMember(), Map.of());
-        putCompleteProjectionWindow(fixture, "2026-07", 3);
-        List<String> liveMissingLines = List.of(
-            "MYSC_PREPAY_DIRECT_OUT",
-            "MYSC_PREPAY_INPUT_VAT_IN",
-            "MYSC_PREPAY_LABOR_IN",
-            "MYSC_PREPAY_LABOR_OUT"
-        );
-        fixture.documents.entrySet().stream()
-            .filter(entry -> entry.getKey().contains("/cashflow_weeks/"))
-            .forEach(entry -> {
-                Map<String, Object> document = entry.getValue();
-                Map<String, Object> projection = new LinkedHashMap<>(
-                    (Map<String, Object>) document.get("projection")
-                );
-                liveMissingLines.forEach(projection::remove);
-                document.put("projection", projection);
-            });
-
-        Throwable failure = catchThrowable(() -> fixture.persistence.runCommandTransaction(() ->
-            commandService(fixture.persistence).completeCashflowWeeklyUpdate(
-                ACTOR,
-                "project-a",
-                new CompleteCashflowWeeklyUpdateRequest(
-                    "live-legacy-window", "2026-07", 3, "2026-07-16T09:00:00Z"
-                )
-            )
-        ));
-
-        assertThat(failure).isInstanceOf(WeeklyExpenseEditLeaseException.class);
-        WeeklyExpenseEditLeaseException incomplete = (WeeklyExpenseEditLeaseException) failure;
-        assertThat(incomplete.code()).isEqualTo("cashflow_projection_window_incomplete");
-        assertThat((List<Map<String, Object>>) incomplete.details().get("missingCells"))
-            .hasSize(64)
-            .extracting(cell -> cell.get("lineId"))
-            .containsOnlyElementsOf(liveMissingLines);
-        assertThat(fixture.documents.keySet())
-            .noneMatch(path -> path.contains("/cashflow_weekly_update_completions/")
-                || path.contains("/cashflow_weekly_update_completion_versions/")
-                || path.contains("/weekly_api_audit_events/"));
-    }
-
-    @Test
     void lockedCashflowWeekRemainsOperationalStatusWhileProjectionChanges() {
         Fixture fixture = fixture(activeMember(), Map.of());
         fixture.documents.put(
@@ -2581,36 +2498,16 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
-    void weeklyCompletionChecksSixteenWeeksAcrossYearBoundaryAndTreatsNullAsEmptyButZeroAsWritten() {
+    void weeklyCompletionTracksStatusWithoutRequiringProjectionValues() {
         Fixture fixture = fixture(activeMember(), Map.of());
-        putCompleteProjectionWindow(fixture, "2026-12", 4);
-        String nullPath = "orgs/tenant-a/cashflow_weeks/project-a-2027-01-w2";
-        Map<String, Object> nullWeek = new LinkedHashMap<>(fixture.documents.get(nullPath));
-        Map<String, Object> projection = new LinkedHashMap<>((Map<String, Object>) nullWeek.get("projection"));
-        projection.put("SALES_IN", null);
-        nullWeek.put("projection", projection);
-        fixture.documents.put(nullPath, nullWeek);
         CompleteCashflowWeeklyUpdateRequest request = new CompleteCashflowWeeklyUpdateRequest(
             "window-cross-year", "2026-12", 4, "2026-12-24T14:59:00Z", "NO_CHANGES"
         );
 
-        Throwable failure = catchThrowable(() -> fixture.persistence.runCommandTransaction(() -> commandService(
-            fixture.persistence
-        ).completeCashflowWeeklyUpdate(ACTOR, "project-a", request)));
-        assertThat(failure).isInstanceOf(WeeklyExpenseEditLeaseException.class);
-        WeeklyExpenseEditLeaseException incomplete = (WeeklyExpenseEditLeaseException) failure;
-        assertThat(incomplete.code()).isEqualTo("cashflow_projection_window_incomplete");
-        assertThat(incomplete.details())
-            .containsEntry("requiredWeekCount", 16)
-            .containsEntry("requiredCellCount", 256);
-        assertThat((List<Map<String, Object>>) incomplete.details().get("missingCells"))
-            .contains(Map.of("yearMonth", "2027-01", "weekNo", 2, "lineId", "SALES_IN"));
-
-        projection.put("SALES_IN", 0L);
-        fixture.documents.put(nullPath, nullWeek);
         CashflowWeeklyUpdateCompletionResponse completed = fixture.persistence.runCommandTransaction(() -> commandService(
             fixture.persistence
         ).completeCashflowWeeklyUpdate(ACTOR, "project-a", request));
+        assertThat(completed.status()).isEqualTo("LOCKED");
         assertThat(completed.updateResult()).isEqualTo("NO_CHANGES");
         assertThat(completed.complianceStatus()).isEqualTo("ON_TIME");
     }

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -377,10 +377,13 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain("updateResult: weeklyUpdateResult");
     expect(source).toContain("['CHANGED', '변경사항 반영 완료'");
     expect(source).toContain("['NO_CHANGES', '변경사항 없음'");
-    expect(source).toContain('그 이후 15개 재무주차(총 16주·256칸)');
+    expect(source).toContain('이번 주차의 처리 결과만 선택해 정산 상태를 업데이트합니다.');
+    expect(source).toContain('무시하고 반영');
+    expect(source).not.toContain('선택한 결과로 완료');
+    expect(source).not.toContain('그 이후 15개 재무주차(총 16주·256칸)');
     expect(source).not.toContain('ZERO(0원)는 작성값이며 EMPTY(미입력)는 완료할 수 없습니다.');
     expect(source).not.toContain('Cashflow weekly lock no longer matches');
-    expect(source).toContain('weeklyProjectionMissingCells(error)');
+    expect(source).not.toContain('weeklyProjectionMissingCells(error)');
     expect(source).toContain('fetchCashflowWeeklyComplianceViaBff');
     expect(source).toContain("week.status === 'ON_TIME'");
     expect(source).toContain("week.status === 'COMPLETED_LATE'");
@@ -549,8 +552,9 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain("const totalActual = projectLineTotalFor('actual', lineId)");
   });
 
-  it('spells out every JVM 15-week missing Projection cell', () => {
-    expect(source).toContain("{cell.yearMonth} {cell.weekNo}주차 · {CASHFLOW_SHEET_LINE_LABELS[cell.lineId as CashflowSheetLineId] || cell.lineId}이 미작성입니다.");
+  it('does not expose the retired Projection completeness gate', () => {
+    expect(source).not.toContain('서버가 확인한 EMPTY 항목');
+    expect(source).not.toContain('Projection 미입력 주차와 항목');
   });
 
   it('renders annual carry-forward and future totals around the selected year weekly ledger', () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -128,20 +128,6 @@ function formatSheetAppliedAt(value?: string | null): string {
   }).format(date);
 }
 
-type WeeklyProjectionMissingCell = { yearMonth: string; weekNo: number; lineId: string };
-
-function weeklyProjectionMissingCells(error: unknown): WeeklyProjectionMissingCell[] {
-  const details = (error as { body?: { details?: { missingCells?: unknown } } })?.body?.details;
-  return Array.isArray(details?.missingCells)
-    ? details.missingCells.filter((cell): cell is WeeklyProjectionMissingCell => Boolean(
-      cell && typeof cell === 'object'
-      && /^20\d{2}-(0[1-9]|1[0-2])$/.test(String((cell as WeeklyProjectionMissingCell).yearMonth))
-      && Number.isInteger(Number((cell as WeeklyProjectionMissingCell).weekNo))
-      && typeof (cell as WeeklyProjectionMissingCell).lineId === 'string',
-    ))
-    : [];
-}
-
 function decodeActivityActor(value?: string): string {
   const text = String(value || '').trim();
   if (!text) return '';
@@ -386,7 +372,6 @@ export function CashflowProjectSheet({
   const [weeklyCompletionOpen, setWeeklyCompletionOpen] = useState(false);
   const [weeklyUpdateResult, setWeeklyUpdateResult] = useState<'CHANGED' | 'NO_CHANGES' | ''>('');
   const [weeklyCompletionError, setWeeklyCompletionError] = useState('');
-  const [weeklyMissingCells, setWeeklyMissingCells] = useState<WeeklyProjectionMissingCell[]>([]);
   const [weeklyHistoryOpen, setWeeklyHistoryOpen] = useState(false);
   const [weeklyComplianceHistory, setWeeklyComplianceHistory] = useState<CashflowWeeklyComplianceItem[]>([]);
   const [weeklyComplianceHistoryLoading, setWeeklyComplianceHistoryLoading] = useState(false);
@@ -759,7 +744,6 @@ export function CashflowProjectSheet({
       await loadCashflowMonthClose();
       setWeeklyCompletionOpen(false);
       setWeeklyCompletionError('');
-      setWeeklyMissingCells([]);
       setWeeklyUpdateResult('');
       logCashflowSettlement({
         phase: 'success',
@@ -785,7 +769,6 @@ export function CashflowProjectSheet({
       });
       const message = resolveApiErrorMessage(error, '주간 정산 완료 상태를 저장하지 못했습니다.');
       setWeeklyCompletionError(message);
-      setWeeklyMissingCells(weeklyProjectionMissingCells(error));
       toast.error(message);
     } finally {
       setWeeklyCompletionBusy(false);
@@ -2677,7 +2660,6 @@ export function CashflowProjectSheet({
                       disabled={weeklyCompletionBusy || monthCloseLoading || Boolean(monthCloseResult?.dashboard?.deadlineSummary?.current?.completedAt)}
                       onClick={() => {
                         setWeeklyCompletionError('');
-                        setWeeklyMissingCells([]);
                         setWeeklyUpdateResult('');
                         setWeeklyCompletionOpen(true);
                       }}
@@ -3134,19 +3116,9 @@ export function CashflowProjectSheet({
         <AlertDialogContent className="w-[calc(100vw-2rem)] max-w-[620px]">
           <AlertDialogHeader>
             <AlertDialogTitle>주간 정산 완료</AlertDialogTitle>
-            <AlertDialogDescription>
-              대상 {monthCloseResult?.dashboard?.deadlineSummary?.current?.yearMonth || yearMonth} {monthCloseResult?.dashboard?.deadlineSummary?.current?.weekNo || '-'}주차와 그 이후 15개 재무주차(총 16주·256칸)의 모든 Projection 항목이 작성되어 있어야 합니다.
-            </AlertDialogDescription>
+            <AlertDialogDescription>이번 주차의 처리 결과만 선택해 정산 상태를 업데이트합니다.</AlertDialogDescription>
           </AlertDialogHeader>
           {weeklyCompletionError ? <div role="alert" className="rounded-md border border-red-200 bg-red-50 p-3 text-[12px] leading-5 text-red-800">{weeklyCompletionError}</div> : null}
-          {weeklyMissingCells.length > 0 ? (
-            <details open className="max-h-[260px] overflow-auto rounded-md border border-red-300 bg-red-50 p-3 text-[12px]">
-              <summary className="cursor-pointer font-bold text-red-950">서버가 확인한 EMPTY 항목 {weeklyMissingCells.length.toLocaleString()}건</summary>
-              <ul className="mt-2 space-y-1" aria-label="Projection 미입력 주차와 항목">
-                {weeklyMissingCells.map((cell) => <li key={`${cell.yearMonth}:${cell.weekNo}:${cell.lineId}`}>{cell.yearMonth} {cell.weekNo}주차 · {CASHFLOW_SHEET_LINE_LABELS[cell.lineId as CashflowSheetLineId] || cell.lineId}이 미작성입니다.</li>)}
-              </ul>
-            </details>
-          ) : null}
           <fieldset className="space-y-2">
             <legend className="mb-2 text-[13px] font-bold text-slate-900">이번 주차 처리 결과를 하나 선택해 주세요.</legend>
             {([
@@ -3162,7 +3134,7 @@ export function CashflowProjectSheet({
           <AlertDialogFooter>
             <AlertDialogCancel disabled={weeklyCompletionBusy}>취소</AlertDialogCancel>
             <Button type="button" disabled={weeklyCompletionBusy || !weeklyUpdateResult} onClick={() => void handleCompleteWeeklyUpdate()}>
-              {weeklyCompletionBusy ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <ClipboardCheck className="mr-1.5 h-3.5 w-3.5" />}선택한 결과로 완료
+              {weeklyCompletionBusy ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <ClipboardCheck className="mr-1.5 h-3.5 w-3.5" />}무시하고 반영
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>


### PR DESCRIPTION
## What
- remove the retired 16-week/256-cell Projection completeness blocker from weekly settlement completion
- keep weekly settlement as status/audit tracking only
- change the confirmation action to `무시하고 반영` and remove obsolete EMPTY details

## Verification
- `mvn -q -f server/jvm-weekly-api/pom.xml -Dtest=FirestoreCashflowLeaseGuardTest test`
- `npm test -- --run server/bff/routes/jvm-weekly-api.test.mjs` (175 passed)
- `npm test -- --run src/app/components/cashflow/CashflowProjectSheet.shell.test.ts` (57 passed)
- `npm run build`
- independent QA: PASS