### PR TITLE
fix(cashflow): batch settlement status reads

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -2613,6 +2613,33 @@ export function mountJvmWeeklyApiRoutes(app, {
     res.status(200).json(result);
   }));
 
+  app.post('/api/v1/cashflow/settlement-statuses/batch', asyncHandler(async (req, res) => {
+    assertWeeklyWorkspaceOrRoleAllowed(req, ROUTE_ROLES.readCore, 'read cashflow settlement statuses', authMode, workspaceEmailDomain);
+    const projectIds = req.body?.projectIds;
+    const yearMonth = readOptionalText(req.body?.yearMonth);
+    if (!Array.isArray(projectIds)
+      || projectIds.length < 1
+      || projectIds.length > 100
+      || projectIds.some((projectId) => typeof projectId !== 'string'
+        || projectId.length < 1
+        || projectId.length > 120
+        || projectId.includes('/')
+        || projectId.trim() !== projectId)
+      || new Set(projectIds).size !== projectIds.length
+      || !/^20\d{2}-(0[1-9]|1[0-2])$/.test(yearMonth)) {
+      throw createHttpError(400, '조회할 프로젝트와 결산 연월을 정확히 입력해 주세요.', 'cashflow_settlement_status_batch_request_invalid');
+    }
+    const result = await proxyJavaWeeklyRequest({
+      context: req.context,
+      method: 'POST',
+      path: '/api/v1/cashflow/settlement-statuses/batch',
+      command: 'read_cashflow_settlement_statuses_batch',
+      body: { projectIds, yearMonth },
+      mutation: false,
+    });
+    res.status(200).json(result);
+  }));
+
   app.post('/api/v1/cashflow/:projectId/settlement-statuses/transition', asyncHandler(async (req, res) => {
     assertWeeklyWorkspaceOrRoleAllowed(req, ['admin', 'finance', 'pm', 'viewer', 'tenant_admin'], 'update cashflow settlement status', authMode, workspaceEmailDomain);
     const projectId = readOptionalText(req.params.projectId);

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -455,6 +455,29 @@ describe('JVM weekly API BFF proxy', () => {
     );
   });
 
+  it('reads up to 100 project settlement statuses with one JVM batch request', async () => {
+    const projectIds = Array.from({ length: 100 }, (_, index) => `project-${index + 1}`);
+    const canonical = {
+      items: [{ projectId: 'project-1', yearMonth: '2026-08', items: [] }],
+      errors: [{ projectId: 'project-2', code: 'STATUS_UNAVAILABLE' }],
+    };
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify(canonical), {
+      status: 200, headers: { 'content-type': 'application/json' },
+    }));
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { env: runtimeEnv });
+
+    await request(app)
+      .post('/api/v1/cashflow/settlement-statuses/batch')
+      .send({ projectIds, yearMonth: '2026-08' })
+      .expect(200, canonical);
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://jvm-weekly.local/api/v1/cashflow/settlement-statuses/batch',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ projectIds, yearMonth: '2026-08' }) }),
+    );
+  });
+
   it('rejects invalid settlement scopes before calling JVMP', async () => {
     const fetchImpl = vi.fn();
     const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { env: runtimeEnv });
@@ -465,6 +488,14 @@ describe('JVM weekly API BFF proxy', () => {
     await request(app)
       .post('/api/v1/cashflow/project-a/settlement-statuses/transition')
       .send({ yearMonth: '2026-08', period: 'WEEK_6', action: 'APPROVE' })
+      .expect(400);
+    await request(app)
+      .post('/api/v1/cashflow/settlement-statuses/batch')
+      .send({ projectIds: ['duplicate', 'duplicate'], yearMonth: '2026-08' })
+      .expect(400);
+    await request(app)
+      .post('/api/v1/cashflow/settlement-statuses/batch')
+      .send({ projectIds: Array.from({ length: 101 }, (_, index) => `project-${index}`), yearMonth: '2026-08' })
       .expect(400);
     expect(fetchImpl).not.toHaveBeenCalled();
   });

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSettlementStatusesBatchRequest.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSettlementStatusesBatchRequest.java
@@ -1,0 +1,29 @@
+package dev.merryai.innerplatform.weekly.api;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record CashflowSettlementStatusesBatchRequest(
+    @NotNull @Size(min = 1, max = MAX_PROJECT_COUNT)
+    List<@NotBlank @Size(max = MAX_PROJECT_ID_LENGTH) String> projectIds,
+    @NotBlank @Pattern(regexp = "20\\d{2}-(0[1-9]|1[0-2])") String yearMonth
+) {
+    public static final int MAX_PROJECT_COUNT = 100;
+    public static final int MAX_PROJECT_ID_LENGTH = 120;
+
+    public List<String> requireUniqueProjectIds() {
+        List<String> normalized = projectIds == null
+            ? List.of()
+            : projectIds.stream().map(id -> id == null ? "" : id.trim()).toList();
+        if (normalized.isEmpty() || normalized.size() > MAX_PROJECT_COUNT
+            || normalized.stream().anyMatch(id -> id.isBlank() || id.length() > MAX_PROJECT_ID_LENGTH || id.contains("/"))
+            || normalized.stream().distinct().count() != normalized.size()) {
+            throw new IllegalArgumentException("projectIds must contain 1 to 100 unique safe project IDs.");
+        }
+        return normalized;
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSettlementStatusesBatchResponse.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSettlementStatusesBatchResponse.java
@@ -1,0 +1,20 @@
+package dev.merryai.innerplatform.weekly.api;
+
+import java.util.List;
+
+public record CashflowSettlementStatusesBatchResponse(
+    List<CashflowSettlementStatusesResponse> items,
+    List<ErrorItem> errors
+) {
+    public static final String STATUS_UNAVAILABLE = "STATUS_UNAVAILABLE";
+
+    public CashflowSettlementStatusesBatchResponse {
+        items = items == null ? List.of() : List.copyOf(items);
+        errors = errors == null ? List.of() : List.copyOf(errors);
+        if (items.size() + errors.size() > CashflowSettlementStatusesBatchRequest.MAX_PROJECT_COUNT) {
+            throw new IllegalArgumentException("Cashflow settlement status batch response exceeds the project limit.");
+        }
+    }
+
+    public record ErrorItem(String projectId, String code) {}
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -399,6 +399,19 @@ public class WeeklyExpenseController {
         );
     }
 
+    @PostMapping("/cashflow/settlement-statuses/batch")
+    public CashflowSettlementStatusesBatchResponse readCashflowSettlementStatusesBatch(
+        @RequestHeader("x-tenant-id") String tenantId,
+        @RequestHeader("x-actor-id") String actorId,
+        @RequestHeader("x-actor-role") String actorRole,
+        @RequestHeader(value = "x-actor-email", required = false) String actorEmail,
+        @Valid @RequestBody CashflowSettlementStatusesBatchRequest request
+    ) {
+        return commandService.readCashflowSettlementStatusesBatch(
+            actorContext(tenantId, actorId, actorRole, actorEmail), request
+        );
+    }
+
     @PostMapping("/cashflow/{projectId}/settlement-statuses/transition")
     public CashflowSettlementStatusesResponse transitionCashflowSettlementStatus(
         @PathVariable String projectId,

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -22,6 +22,8 @@ import dev.merryai.innerplatform.weekly.api.CashflowSheetFormulaPreflightRequest
 import dev.merryai.innerplatform.weekly.api.CashflowSheetFormulaPreflightResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowSnapshotResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowSettlementStatusesResponse;
+import dev.merryai.innerplatform.weekly.api.CashflowSettlementStatusesBatchRequest;
+import dev.merryai.innerplatform.weekly.api.CashflowSettlementStatusesBatchResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowVarianceRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowVarianceResponse;
 import dev.merryai.innerplatform.weekly.api.CloseWeekRequest;
@@ -189,6 +191,31 @@ public class WeeklyExpenseCommandService {
             yearMonth,
             persistence.findCashflowSettlementStatuses(actor.tenantId(), projectId, yearMonth)
         );
+    }
+
+    public CashflowSettlementStatusesBatchResponse readCashflowSettlementStatusesBatch(
+        TrustedActorContext actor,
+        CashflowSettlementStatusesBatchRequest request
+    ) {
+        List<String> projectIds = request.requireUniqueProjectIds();
+        for (String projectId : projectIds) {
+            authorizationService.requireProjectAllowed(CASHFLOW_MONTH_CLOSE_READ_COMMAND, actor, projectId);
+        }
+        Map<String, List<WeeklyExpensePersistence.CashflowSettlementStatusRecord>> recordsByProject =
+            persistence.findCashflowSettlementStatusesBatch(actor.tenantId(), projectIds, request.yearMonth());
+        List<CashflowSettlementStatusesResponse> items = new ArrayList<>();
+        List<CashflowSettlementStatusesBatchResponse.ErrorItem> errors = new ArrayList<>();
+        for (String projectId : projectIds) {
+            List<WeeklyExpensePersistence.CashflowSettlementStatusRecord> records = recordsByProject.get(projectId);
+            if (records == null) {
+                errors.add(new CashflowSettlementStatusesBatchResponse.ErrorItem(
+                    projectId, CashflowSettlementStatusesBatchResponse.STATUS_UNAVAILABLE
+                ));
+            } else {
+                items.add(settlementStatusesResponse(projectId, request.yearMonth(), records));
+            }
+        }
+        return new CashflowSettlementStatusesBatchResponse(items, errors);
     }
 
     public CashflowSettlementStatusesResponse transitionCashflowSettlementStatus(

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -2,6 +2,7 @@ package dev.merryai.innerplatform.weekly.storage;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.core.ApiFuture;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.Timestamp;
 import com.google.cloud.firestore.CollectionReference;
@@ -73,6 +74,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
@@ -307,10 +309,41 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     ) {
         requireYearMonth(yearMonth);
         Map<String, Object> stored = settlementStatusDocument(tenantId, projectId, yearMonth);
+        return settlementStatusRecords(stored);
+    }
+
+    @Override
+    public Map<String, List<CashflowSettlementStatusRecord>> findCashflowSettlementStatusesBatch(
+        String tenantId,
+        List<String> projectIds,
+        String yearMonth
+    ) {
+        requireYearMonth(yearMonth);
+        List<ApiFuture<DocumentSnapshot>> reads = projectIds.stream()
+            .map(projectId -> settlementStatusRef(tenantId, projectId, yearMonth))
+            .map(DocumentReference::get)
+            .toList();
+        Map<String, List<CashflowSettlementStatusRecord>> result = new LinkedHashMap<>();
+        for (int index = 0; index < projectIds.size(); index += 1) {
+            String projectId = projectIds.get(index);
+            try {
+                DocumentSnapshot snapshot = reads.get(index).get();
+                result.put(projectId, settlementStatusRecords(snapshot.exists() ? data(snapshot) : Map.of()));
+            } catch (ExecutionException exception) {
+                // Omit only the failed project so the batch response can isolate its error.
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Firestore settlement status batch read was interrupted.", exception);
+            }
+        }
+        return Map.copyOf(result);
+    }
+
+    private List<CashflowSettlementStatusRecord> settlementStatusRecords(Map<String, Object> stored) {
         Map<String, Object> periods = nestedMap(stored.get("periods"));
         List<CashflowSettlementStatusRecord> result = new ArrayList<>();
         for (String period : List.of("MONTH", "WEEK_1", "WEEK_2", "WEEK_3", "WEEK_4", "WEEK_5")) {
-            result.add(settlementStatusRecord(tenantId, projectId, yearMonth, period, nestedMap(periods.get(period))));
+            result.add(settlementStatusRecord(period, nestedMap(periods.get(period))));
         }
         return List.copyOf(result);
     }
@@ -348,9 +381,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         });
         Map<String, Object> periods = nestedMap(document.get("periods"));
         Map<String, Object> current = nestedMap(periods.get(period));
-        CashflowSettlementStatusRecord effective = settlementStatusRecord(
-            actor.tenantId(), projectId, yearMonth, period, current
-        );
+        CashflowSettlementStatusRecord effective = settlementStatusRecord(period, current);
         String expected = "SUBMIT".equals(action) ? "WAITING_FOR_UPDATE" : "PENDING_APPROVAL";
         String next = "SUBMIT".equals(action) ? "PENDING_APPROVAL" : "APPROVE".equals(action) ? "COMPLETED" : "";
         if (next.isBlank()) throw new IllegalArgumentException("Cashflow settlement action is invalid.");
@@ -362,7 +393,6 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         Map<String, Object> updated = new LinkedHashMap<>(current);
         updated.put("status", next);
         updated.put("revision", Math.addExact(longValue(current.get("revision"), 0), 1));
-        updated.put("valueRevision", settlementValueRevision(actor.tenantId(), projectId, yearMonth, period));
         updated.put("updatedAt", now.toString());
         if ("SUBMIT".equals(action)) {
             updated.put("submittedAt", now.toString());
@@ -381,24 +411,13 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         patch.put("periods", periods);
         patch.put("updatedAt", now.toString());
         set(ref, patch);
-        return settlementStatusRecord(actor.tenantId(), projectId, yearMonth, period, updated);
+        return settlementStatusRecord(period, updated);
     }
 
-    private CashflowSettlementStatusRecord settlementStatusRecord(
-        String tenantId,
-        String projectId,
-        String yearMonth,
-        String period,
-        Map<String, Object> stored
-    ) {
-        String status = effectiveSettlementStatus(
-            text(stored.get("status"), "WAITING_FOR_UPDATE"),
-            text(stored.get("valueRevision"), ""),
-            settlementValueRevision(tenantId, projectId, yearMonth, period)
-        );
+    private CashflowSettlementStatusRecord settlementStatusRecord(String period, Map<String, Object> stored) {
         return new CashflowSettlementStatusRecord(
             period,
-            status,
+            text(stored.get("status"), "WAITING_FOR_UPDATE"),
             text(stored.get("submittedAt"), ""),
             text(stored.get("submittedBy"), ""),
             text(stored.get("approvedAt"), ""),
@@ -407,27 +426,10 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         );
     }
 
-    private String settlementValueRevision(String tenantId, String projectId, String yearMonth, String period) {
-        List<Map<String, Object>> weeks = new ArrayList<>();
-        int from = "MONTH".equals(period) ? 1 : Integer.parseInt(period.substring("WEEK_".length()));
-        int through = "MONTH".equals(period) ? 5 : from;
-        for (int weekNo = from; weekNo <= through; weekNo += 1) {
-            DocumentSnapshot snapshot = get(cashflowWeekRef(tenantId, cashflowWeekId(projectId, yearMonth, weekNo)));
-            if (snapshot.exists()) weeks.add(data(snapshot));
-        }
-        return computeCashflowTargetRevision(weeks);
-    }
-
     static boolean isDesignatedCashflowSettlementApprover(Map<String, Object> project, String actorId) {
         return actorId != null && !actorId.isBlank() && actorId.equals(textValue(
             project == null ? null : project.get("executiveApproverId")
         ));
-    }
-
-    static String effectiveSettlementStatus(String storedStatus, String approvedValueRevision, String currentValueRevision) {
-        return "COMPLETED".equals(storedStatus) && !String.valueOf(approvedValueRevision).equals(currentValueRevision)
-            ? "PENDING_APPROVAL"
-            : storedStatus;
     }
 
     private Map<String, Object> settlementStatusDocument(String tenantId, String projectId, String yearMonth) {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
@@ -28,6 +28,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
@@ -410,6 +411,18 @@ public interface WeeklyExpensePersistence {
             "cashflow_settlement_status_backend_unavailable",
             "Cashflow settlement status reads require the Firestore transaction backend."
         );
+    }
+
+    default Map<String, List<CashflowSettlementStatusRecord>> findCashflowSettlementStatusesBatch(
+        String tenantId,
+        List<String> projectIds,
+        String yearMonth
+    ) {
+        Map<String, List<CashflowSettlementStatusRecord>> result = new LinkedHashMap<>();
+        for (String projectId : projectIds) {
+            result.put(projectId, findCashflowSettlementStatuses(tenantId, projectId, yearMonth));
+        }
+        return Map.copyOf(result);
     }
 
     default CashflowSettlementStatusRecord transitionCashflowSettlementStatus(

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/CashflowSettlementStatusesBatchRequestTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/CashflowSettlementStatusesBatchRequestTest.java
@@ -1,0 +1,29 @@
+package dev.merryai.innerplatform.weekly.api;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CashflowSettlementStatusesBatchRequestTest {
+    @Test
+    void keepsInputOrderForOneHundredUniqueProjects() {
+        List<String> projectIds = IntStream.rangeClosed(1, 100).mapToObj(index -> "project-" + index).toList();
+
+        assertThat(new CashflowSettlementStatusesBatchRequest(projectIds, "2026-08").requireUniqueProjectIds())
+            .containsExactlyElementsOf(projectIds);
+    }
+
+    @Test
+    void rejectsDuplicateAndUnsafeProjects() {
+        assertThatThrownBy(() -> new CashflowSettlementStatusesBatchRequest(
+            List.of("duplicate", "duplicate"), "2026-08"
+        ).requireUniqueProjectIds()).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new CashflowSettlementStatusesBatchRequest(
+            List.of("unsafe/project"), "2026-08"
+        ).requireUniqueProjectIds()).isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/CashflowSettlementStatusPolicyTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/CashflowSettlementStatusPolicyTest.java
@@ -19,16 +19,4 @@ class CashflowSettlementStatusPolicyTest {
         )).isFalse();
     }
 
-    @Test
-    void completedStatusNeedsApprovalWhenValuesChangeAndRecoversWhenRestored() {
-        assertThat(FirestoreInheritedWeeklyExpensePersistence.effectiveSettlementStatus(
-            "COMPLETED", "revision-a", "revision-b"
-        )).isEqualTo("PENDING_APPROVAL");
-        assertThat(FirestoreInheritedWeeklyExpensePersistence.effectiveSettlementStatus(
-            "COMPLETED", "revision-a", "revision-a"
-        )).isEqualTo("COMPLETED");
-        assertThat(FirestoreInheritedWeeklyExpensePersistence.effectiveSettlementStatus(
-            "WAITING_FOR_UPDATE", "", "revision-a"
-        )).isEqualTo("WAITING_FOR_UPDATE");
-    }
 }

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -165,6 +165,29 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
+    void isolatesFailedSettlementStatusReadAndKeepsStoredStatus() {
+        Fixture fixture = fixture(activeMember(), activeLease());
+        String successPath = "orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-08";
+        fixture.documents.put(successPath, Map.of("periods", Map.of(
+            "MONTH", Map.of("status", "COMPLETED", "revision", 3)
+        )));
+        String failedPath = "orgs/tenant-a/cashflow_settlement_statuses/project-b-2026-08";
+        DocumentReference failing = mock(DocumentReference.class);
+        when(failing.getPath()).thenReturn(failedPath);
+        when(failing.get()).thenReturn(ApiFutures.immediateFailedFuture(new RuntimeException("Firestore unavailable")));
+        when(fixture.db.document(failedPath)).thenReturn(failing);
+
+        Map<String, List<WeeklyExpensePersistence.CashflowSettlementStatusRecord>> result =
+            fixture.persistence.findCashflowSettlementStatusesBatch(
+                "tenant-a", List.of("project-a", "project-b"), "2026-08"
+            );
+
+        assertThat(result).containsOnlyKeys("project-a");
+        assertThat(result.get("project-a")).hasSize(6);
+        assertThat(result.get("project-a").getFirst().status()).isEqualTo("COMPLETED");
+    }
+
+    @Test
     void validatesStoredMemberAndLeaseInTheSameTransactionAsCanonicalWrite() {
         Fixture fixture = fixture(activeMember(), activeLease());
 

--- a/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
+++ b/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
@@ -18,7 +18,7 @@ describe('CashflowWeeklyPage settlement status surface', () => {
   it('uses the simple persisted status flow and updates only the affected project state', () => {
     expect(source).toContain('sticky top-0');
     expect(source).toContain('sticky left-0');
-    expect(source).toContain('fetchCashflowSettlementStatusesViaBff');
+    expect(source).toContain('fetchCashflowSettlementStatusesBatchViaBff');
     expect(source).toContain('transitionCashflowSettlementStatusViaBff');
     expect(source).toContain('실무자 업데이트 대기 중');
     expect(source).toContain('조직장 승인 필요');
@@ -33,7 +33,8 @@ describe('CashflowWeeklyPage settlement status surface', () => {
     expect(source).toContain('getProjectRegistrationCicOptions()');
     expect(source).toContain('normalizeProjectDepartment(project.department)');
     expect(source).toContain('filterCashflowProjectsByDepartment(projects, deptFilter)');
-    expect(source).toContain('Promise.allSettled(filteredProjects.map');
+    expect(source).not.toContain('Promise.allSettled(filteredProjects.map');
+    expect(source).toContain('projectIds.slice(index * 100, (index + 1) * 100)');
     expect(source).toContain('{filteredProjects.map((project) => {');
     expect(source).toContain('filteredProjects.length === 0');
     expect(source).toContain('>담당조직</Label>');

--- a/src/app/components/cashflow/CashflowWeeklyPage.tsx
+++ b/src/app/components/cashflow/CashflowWeeklyPage.tsx
@@ -12,7 +12,7 @@ import { useCashflowWeeks } from '../../data/cashflow-weeks-store';
 import { useAuth } from '../../data/auth-store';
 import { useFirebase } from '../../lib/firebase-context';
 import {
-  fetchCashflowSettlementStatusesViaBff,
+  fetchCashflowSettlementStatusesBatchViaBff,
   transitionCashflowSettlementStatusViaBff,
   type CashflowSettlementPeriod,
   type CashflowSettlementStatusItem,
@@ -86,21 +86,20 @@ export function CashflowWeeklyPage() {
     }
     let active = true;
     setStatusesLoading(true);
-    void Promise.allSettled(filteredProjects.map(async (project) => ({
-      projectId: project.id,
-      result: await fetchCashflowSettlementStatusesViaBff({
-        tenantId: orgId, actor: user, projectId: project.id, yearMonth,
-      }),
-    }))).then((results) => {
+    const projectIds = filteredProjects.map((project) => project.id);
+    const batches = Array.from(
+      { length: Math.ceil(projectIds.length / 100) },
+      (_, index) => projectIds.slice(index * 100, (index + 1) * 100),
+    );
+    void Promise.all(batches.map(async (batchProjectIds) => fetchCashflowSettlementStatusesBatchViaBff({
+      tenantId: orgId, actor: user, projectIds: batchProjectIds, yearMonth,
+    }).catch(() => ({
+      items: [],
+      errors: batchProjectIds.map((projectId) => ({ projectId, code: 'STATUS_UNAVAILABLE' as const })),
+    })))).then((results) => {
       if (!active) return;
-      const next: Record<string, CashflowSettlementStatusesResult> = {};
-      const errors: Record<string, string> = {};
-      results.forEach((result, index) => {
-        const projectId = filteredProjects[index]?.id;
-        if (!projectId) return;
-        if (result.status === 'fulfilled') next[projectId] = result.value.result;
-        else errors[projectId] = '결산 상태를 불러오지 못했습니다.';
-      });
+      const next = Object.fromEntries(results.flatMap((result) => result.items).map((item) => [item.projectId, item]));
+      const errors = Object.fromEntries(results.flatMap((result) => result.errors).map((error) => [error.projectId, '결산 상태를 불러오지 못했습니다.']));
       setStatuses(next);
       setStatusErrors(errors);
       setStatusesLoading(false);

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -42,6 +42,7 @@ import {
   fetchCashflowWeeklyUpdateViaBff,
   fetchCashflowWeeklyComplianceViaBff,
   fetchCashflowProjectionActualSummariesViaBff,
+  fetchCashflowSettlementStatusesBatchViaBff,
   fetchCashflowActivityViaBff,
   fetchCashflowAppliedCellChangesViaBff,
   type CashflowCumulativeCloseScope,
@@ -75,6 +76,21 @@ function asMockClient<T extends {
 }
 
 describe('platform-bff-client', () => {
+  it('posts all settlement project IDs in one bounded batch request', async () => {
+    const data = { items: [], errors: [{ projectId: 'p002', code: 'STATUS_UNAVAILABLE' }] };
+    const client = asMockClient({ post: vi.fn(async () => ({ data })), get: vi.fn(), request: vi.fn() });
+    const result = await fetchCashflowSettlementStatusesBatchViaBff({
+      tenantId: 'mysc', actor: { uid: 'admin-1', role: 'admin' },
+      projectIds: ['p001', 'p002'], yearMonth: '2026-08', client,
+    });
+
+    expect(client.post).toHaveBeenCalledTimes(1);
+    expect(client.post).toHaveBeenCalledWith('/api/v1/cashflow/settlement-statuses/batch', expect.objectContaining({
+      body: { projectIds: ['p001', 'p002'], yearMonth: '2026-08' }, retries: 0, timeoutMs: 12000,
+    }));
+    expect(result).toEqual(data);
+  });
+
   it('posts project IDs to the canonical JVM projection-actual summary adapter unchanged', async () => {
     const data = {
       version: '1',

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -1354,6 +1354,11 @@ export interface CashflowSettlementStatusesResult {
   items: CashflowSettlementStatusItem[];
 }
 
+export interface CashflowSettlementStatusesBatchResult {
+  items: CashflowSettlementStatusesResult[];
+  errors: Array<{ projectId: string; code: 'STATUS_UNAVAILABLE' }>;
+}
+
 export interface CashflowProjectionActualSummary {
   projectId: string;
   fromMonth: string;
@@ -2899,6 +2904,26 @@ export async function fetchCashflowSettlementStatusesViaBff(params: {
   const response = await resolveClient(params.client).get<CashflowSettlementStatusesResult>(
     `/api/v1/cashflow/${encodeURIComponent(params.projectId)}/settlement-statuses?yearMonth=${encodeURIComponent(params.yearMonth)}`,
     { tenantId: params.tenantId, actor: toRequestActor(params.actor), retries: 0, timeoutMs: 12000 },
+  );
+  return response.data;
+}
+
+export async function fetchCashflowSettlementStatusesBatchViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectIds: string[];
+  yearMonth: string;
+  client?: PlatformApiClientLike;
+}): Promise<CashflowSettlementStatusesBatchResult> {
+  const response = await resolveClient(params.client).post<CashflowSettlementStatusesBatchResult>(
+    '/api/v1/cashflow/settlement-statuses/batch',
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      body: { projectIds: params.projectIds, yearMonth: params.yearMonth },
+      retries: 0,
+      timeoutMs: 12000,
+    },
   );
   return response.data;
 }


### PR DESCRIPTION
## What / why
- replace per-project settlement status HTTP fan-out with bounded batch requests
- read persisted settlement status documents without cashflow week revision recalculation
- isolate Firestore read failures to the affected project and preserve fail-closed authorization
- chunk views over 100 projects without forcing a page refresh

## Verification
- `npm test -- --run`: 2,644 passed, 241 skipped
- `mvn -q -f server/jvm-weekly-api/pom.xml clean test`: passed
- targeted BFF/frontend: 234 passed
- `npm run build`: passed
- independent QA: PASS
- open-code-review: >100-project issue fixed; contract-intent findings documented