### PR TITLE
fix(cashflow): batch project authorization reads

### DIFF
--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/FirestoreWeeklyProjectExistenceRepository.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/FirestoreWeeklyProjectExistenceRepository.java
@@ -3,12 +3,21 @@ package dev.merryai.innerplatform.weekly.service;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.FirestoreOptions;
+import com.google.cloud.firestore.DocumentReference;
+import com.google.cloud.firestore.DocumentSnapshot;
 import com.google.cloud.firestore.QuerySnapshot;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Repository;
 
 import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 @Repository
 @ConditionalOnProperty(name = "weekly.storage-backend", havingValue = "firestore")
@@ -45,6 +54,33 @@ public class FirestoreWeeklyProjectExistenceRepository implements WeeklyProjectE
             return hasExistingProjectScopedData(tenant, project);
         } catch (Exception error) {
             return false;
+        }
+    }
+
+    @Override
+    public Set<String> existingProjectIds(String tenantId, List<String> projectIds) {
+        String tenant = text(tenantId);
+        if (tenant.isBlank() || projectIds == null || projectIds.isEmpty()) return Set.of();
+        try {
+            DocumentReference[] refs = projectIds.stream()
+                .map(projectId -> db.document("orgs/" + tenant + "/projects/" + text(projectId)))
+                .toArray(DocumentReference[]::new);
+            List<DocumentSnapshot> snapshots = db.getAll(refs).get();
+            Set<String> result = new LinkedHashSet<>();
+            Map<String, Future<Boolean>> legacyChecks = new LinkedHashMap<>();
+            try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+                for (int index = 0; index < projectIds.size(); index += 1) {
+                    String projectId = text(projectIds.get(index));
+                    if (snapshots.get(index).exists()) result.add(projectId);
+                    else legacyChecks.put(projectId, executor.submit(() -> hasExistingProjectScopedData(tenant, projectId)));
+                }
+                for (Map.Entry<String, Future<Boolean>> entry : legacyChecks.entrySet()) {
+                    if (entry.getValue().get()) result.add(entry.getKey());
+                }
+            }
+            return Set.copyOf(result);
+        } catch (Exception error) {
+            return Set.of();
         }
     }
 

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseAuthorizationService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseAuthorizationService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.Locale;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -121,6 +122,24 @@ public class WeeklyExpenseAuthorizationService {
             return;
         }
         throw new WeeklyExpenseForbiddenException("Actor is not assigned to this project.");
+    }
+
+    public void requireProjectsAllowed(String commandName, TrustedActorContext actor, List<String> projectIds) {
+        requireAllowed(commandName, actor);
+        if (projectIds == null || projectIds.isEmpty()
+            || !projectExistenceRepository.existingProjectIds(actor.tenantId(), projectIds).containsAll(projectIds)) {
+            throw new WeeklyExpenseForbiddenException("Project does not exist in this workspace.");
+        }
+        String role = actor.role() == null ? "" : actor.role().trim().toLowerCase(Locale.ROOT);
+        if ((isWorkspaceMode() && "workspace_user".equals(role) && WORKSPACE_COMMANDS.contains(commandName))
+            || TENANT_WIDE_PROJECT_ROLES.contains(role)) {
+            return;
+        }
+        for (String projectId : projectIds) {
+            if (!projectAccessRepository.hasProjectAccess(actor, projectId)) {
+                throw new WeeklyExpenseForbiddenException("Actor is not assigned to this project.");
+            }
+        }
     }
 
     private boolean isWorkspaceMode() {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -198,9 +198,7 @@ public class WeeklyExpenseCommandService {
         CashflowSettlementStatusesBatchRequest request
     ) {
         List<String> projectIds = request.requireUniqueProjectIds();
-        for (String projectId : projectIds) {
-            authorizationService.requireProjectAllowed(CASHFLOW_MONTH_CLOSE_READ_COMMAND, actor, projectId);
-        }
+        authorizationService.requireProjectsAllowed(CASHFLOW_MONTH_CLOSE_READ_COMMAND, actor, projectIds);
         Map<String, List<WeeklyExpensePersistence.CashflowSettlementStatusRecord>> recordsByProject =
             persistence.findCashflowSettlementStatusesBatch(actor.tenantId(), projectIds, request.yearMonth());
         List<CashflowSettlementStatusesResponse> items = new ArrayList<>();

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyProjectExistenceRepository.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyProjectExistenceRepository.java
@@ -1,7 +1,19 @@
 package dev.merryai.innerplatform.weekly.service;
 
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
 public interface WeeklyProjectExistenceRepository {
     boolean exists(String tenantId, String projectId);
+
+    default Set<String> existingProjectIds(String tenantId, List<String> projectIds) {
+        Set<String> result = new LinkedHashSet<>();
+        for (String projectId : projectIds) {
+            if (exists(tenantId, projectId)) result.add(projectId);
+        }
+        return Set.copyOf(result);
+    }
 
     default boolean existsCanonicalProject(String tenantId, String projectId) {
         return false;

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseAuthorizationServiceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseAuthorizationServiceTest.java
@@ -4,10 +4,42 @@ import dev.merryai.innerplatform.weekly.api.TrustedActorContext;
 import dev.merryai.innerplatform.weekly.api.WeeklyExpenseForbiddenException;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class WeeklyExpenseAuthorizationServiceTest {
+    @Test
+    void tenantWideBatchAuthorizationUsesOneExistenceLookup() {
+        int[] batchCalls = {0};
+        WeeklyProjectExistenceRepository projects = new WeeklyProjectExistenceRepository() {
+            @Override
+            public boolean exists(String tenantId, String projectId) {
+                throw new AssertionError("batch authorization must not use sequential existence reads");
+            }
+
+            @Override
+            public Set<String> existingProjectIds(String tenantId, List<String> projectIds) {
+                batchCalls[0] += 1;
+                return Set.copyOf(projectIds);
+            }
+        };
+        WeeklyExpenseAuthorizationService service = new WeeklyExpenseAuthorizationService(
+            (actor, projectId) -> false, projects, "strict"
+        );
+        TrustedActorContext admin = new TrustedActorContext("tenant-a", "admin-1", "admin@example.com", "admin");
+
+        assertThatCode(() -> service.requireProjectsAllowed(
+            WeeklyExpenseCommandService.CASHFLOW_MONTH_CLOSE_READ_COMMAND,
+            admin,
+            List.of("project-a", "project-b")
+        )).doesNotThrowAnyException();
+        assertThat(batchCalls[0]).isEqualTo(1);
+    }
+
     @Test
     void pmCanMutateOnlyAssignedProject() {
         WeeklyExpenseAuthorizationService service = new WeeklyExpenseAuthorizationService(


### PR DESCRIPTION
## Root cause
The settlement status endpoint batched status reads but still performed up to 100 sequential project-existence authorization reads, exceeding the frontend 12s timeout.

## Fix
- authorize project existence with one Firestore `getAll`
- preserve fail-closed authorization
- run supported legacy-only fallback checks concurrently
- leave mutation/audit paths unchanged

## Verification
- targeted Java authorization/storage tests: passed
- BFF/frontend targeted tests: 234 passed
- production build: passed
- independent QA: PASS
- open-code-review legacy fallback finding addressed