### PR TITLE
fix(cashflow): align settlement submission and approval states

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -2653,6 +2653,9 @@ export function mountJvmWeeklyApiRoutes(app, {
       || !/^(SUBMIT|APPROVE)$/.test(action)) {
       throw createHttpError(400, '결산 대상과 처리 상태를 정확히 입력해 주세요.', 'cashflow_settlement_status_transition_invalid');
     }
+    if (action === 'SUBMIT') {
+      throw createHttpError(403, '실무자 포털에서 정산을 완료한 뒤에만 제출할 수 있습니다.', 'cashflow_settlement_submit_forbidden');
+    }
     const result = await proxyMutation(
       req,
       `/api/v1/cashflow/${encodeURIComponent(projectId)}/settlement-statuses/transition`,
@@ -2677,6 +2680,7 @@ export function mountJvmWeeklyApiRoutes(app, {
   app.post('/api/v1/cashflow/projection-actual-summary/batch', asyncHandler(async (req, res) => {
     assertWeeklyWorkspaceOrRoleAllowed(req, ROUTE_ROLES.readCore, 'read cashflow projection-actual summary', authMode, workspaceEmailDomain);
     const projectIds = req.body?.projectIds;
+    const yearMonth = readOptionalText(req.body?.yearMonth);
     if (!Array.isArray(projectIds)
       || projectIds.length < 1
       || projectIds.length > 10
@@ -2685,7 +2689,8 @@ export function mountJvmWeeklyApiRoutes(app, {
         || projectId.length > 120
         || projectId.includes('/')
         || projectId.trim() !== projectId)
-      || new Set(projectIds).size !== projectIds.length) {
+      || new Set(projectIds).size !== projectIds.length
+      || (yearMonth && !/^20\d{2}-(0[1-9]|1[0-2])$/.test(yearMonth))) {
       throw createHttpError(400, '현금흐름 요약 조회 범위가 올바르지 않습니다.', 'cashflow_projection_actual_summary_request_invalid');
     }
     const result = await proxyJavaWeeklyRequest({
@@ -2693,7 +2698,7 @@ export function mountJvmWeeklyApiRoutes(app, {
       method: 'POST',
       path: '/api/v1/cashflow/projection-actual-summary/batch',
       command: 'read_cashflow_projection_actual_summaries',
-      body: { projectIds },
+      body: { projectIds, ...(yearMonth ? { yearMonth } : {}) },
       mutation: false,
     });
     res.status(200).json(result);
@@ -3073,11 +3078,13 @@ export function mountJvmWeeklyApiRoutes(app, {
       };
     };
     return db.runTransaction(async (transaction) => {
-      const [projectSnapshot, approverSnapshot, requesterSnapshot, requestSnapshot] = await Promise.all([
+      const settlementStatusRef = db.doc(`orgs/${req.context.tenantId}/cashflow_settlement_statuses/${prepared.rawProjectId}-${yearMonth}`);
+      const [projectSnapshot, approverSnapshot, requesterSnapshot, requestSnapshot, settlementStatusSnapshot] = await Promise.all([
         transaction.get(db.doc(`orgs/${req.context.tenantId}/projects/${prepared.rawProjectId}`)),
         transaction.get(db.doc(`orgs/${req.context.tenantId}/members/${approverUid}`)),
         transaction.get(db.doc(`orgs/${req.context.tenantId}/members/${readOptionalText(req.context.actorId)}`)),
         transaction.get(requestRef),
+        transaction.get(settlementStatusRef),
       ]);
       const project = projectSnapshot.exists ? projectSnapshot.data() || {} : {};
       const approver = approverSnapshot.exists ? approverSnapshot.data() || {} : {};
@@ -3209,6 +3216,30 @@ export function mountJvmWeeklyApiRoutes(app, {
         if (!snapshot.exists) transaction.set(shardRefs[index], shards[index]);
       });
       transaction.set(requestRef, storedRecord);
+      const settlementStatus = settlementStatusSnapshot.exists ? settlementStatusSnapshot.data() || {} : {};
+      const settlementPeriods = settlementStatus.periods && typeof settlementStatus.periods === 'object'
+        ? settlementStatus.periods : {};
+      const monthStatus = settlementPeriods.MONTH && typeof settlementPeriods.MONTH === 'object'
+        ? settlementPeriods.MONTH : {};
+      if (!readOptionalText(monthStatus.status) || readOptionalText(monthStatus.status) === 'WAITING_FOR_UPDATE') {
+        transaction.set(settlementStatusRef, {
+          tenantId: req.context.tenantId,
+          projectId: prepared.rawProjectId,
+          yearMonth,
+          periods: {
+            ...settlementPeriods,
+            MONTH: {
+              status: 'PENDING_APPROVAL',
+              revision: Number.isSafeInteger(Number(monthStatus.revision)) ? Number(monthStatus.revision) + 1 : 1,
+              submittedAt: requestedAt,
+              submittedBy: readOptionalText(requester.name) || readOptionalText(req.context.actorId),
+              approvedAt: '',
+              approvedBy: '',
+            },
+          },
+          updatedAt: requestedAt,
+        }, { merge: true });
+      }
       transaction.set(
         db.doc(cashflowMonthCloseRequestAuditPath(
           req.context.tenantId, requestId, revision, auditAction.toLowerCase(),
@@ -3655,14 +3686,16 @@ export function mountJvmWeeklyApiRoutes(app, {
     const projectRef = db.doc(`orgs/${req.context.tenantId}/projects/${prepared.rawProjectId}`);
     const approverRef = db.doc(`orgs/${req.context.tenantId}/members/${approverUid}`);
     const requesterRef = db.doc(`orgs/${req.context.tenantId}/members/${readOptionalText(req.context.actorId)}`);
+    const settlementStatusRef = db.doc(`orgs/${req.context.tenantId}/cashflow_settlement_statuses/${prepared.rawProjectId}-${yearMonth}`);
     const requestedAt = now().toISOString();
     let storedRecord;
     await db.runTransaction(async (transaction) => {
-      const [projectSnapshot, approverSnapshot, requesterSnapshot, snapshot] = await Promise.all([
+      const [projectSnapshot, approverSnapshot, requesterSnapshot, snapshot, settlementStatusSnapshot] = await Promise.all([
         transaction.get(projectRef),
         transaction.get(approverRef),
         transaction.get(requesterRef),
         transaction.get(requestRef),
+        transaction.get(settlementStatusRef),
       ]);
       const currentProject = projectSnapshot.exists ? projectSnapshot.data() || {} : {};
       const currentApprover = approverSnapshot.exists ? approverSnapshot.data() || {} : {};
@@ -3683,6 +3716,30 @@ export function mountJvmWeeklyApiRoutes(app, {
       ) {
         throw createHttpError(403, '이 프로젝트의 월 결산을 요청할 권한이 없습니다.', 'cashflow_month_close_project_forbidden');
       }
+      const settlementStatus = settlementStatusSnapshot.exists ? settlementStatusSnapshot.data() || {} : {};
+      const settlementPeriods = objectValue(settlementStatus.periods) || {};
+      const monthStatus = objectValue(settlementPeriods.MONTH) || {};
+      const holdMonthForApproval = () => {
+        const status = readOptionalText(monthStatus.status);
+        if (status && status !== 'WAITING_FOR_UPDATE') return;
+        transaction.set(settlementStatusRef, {
+          tenantId: req.context.tenantId,
+          projectId: prepared.rawProjectId,
+          yearMonth,
+          periods: {
+            ...settlementPeriods,
+            MONTH: {
+              status: 'PENDING_APPROVAL',
+              revision: Number.isSafeInteger(Number(monthStatus.revision)) ? Number(monthStatus.revision) + 1 : 1,
+              submittedAt: requestedAt,
+              submittedBy: readOptionalText(currentRequester.name) || readOptionalText(req.context.actorId),
+              approvedAt: '',
+              approvedBy: '',
+            },
+          },
+          updatedAt: requestedAt,
+        }, { merge: true });
+      };
       if (snapshot.exists) {
         const existing = snapshot.data() || {};
         if (
@@ -3715,6 +3772,7 @@ export function mountJvmWeeklyApiRoutes(app, {
           };
           assertCashflowMonthCloseRequestSize(storedRecord);
           transaction.set(requestRef, storedRecord);
+          holdMonthForApproval();
           transaction.set(
             db.doc(cashflowMonthCloseRequestAuditPath(req.context.tenantId, requestId, revision, 'resubmitted')),
             {
@@ -3752,6 +3810,7 @@ export function mountJvmWeeklyApiRoutes(app, {
       };
       assertCashflowMonthCloseRequestSize(storedRecord);
       transaction.set(requestRef, storedRecord);
+      holdMonthForApproval();
       transaction.set(
         db.doc(cashflowMonthCloseRequestAuditPath(req.context.tenantId, requestId, 0, 'requested')),
         {
@@ -3815,7 +3874,29 @@ export function mountJvmWeeklyApiRoutes(app, {
     }
     const projectRef = db.doc(`orgs/${req.context.tenantId}/projects/${projectId}`);
     const reviewerRef = db.doc(`orgs/${req.context.tenantId}/members/${req.context.actorId}`);
+    const settlementStatusRef = db.doc(`orgs/${req.context.tenantId}/cashflow_settlement_statuses/${projectId}-${initialRecord.yearMonth}`);
     const reviewedAt = now().toISOString();
+    const completeMonthSettlement = (transaction, snapshot) => {
+      const status = snapshot.exists ? snapshot.data() || {} : {};
+      const periods = objectValue(status.periods) || {};
+      const month = objectValue(periods.MONTH) || {};
+      transaction.set(settlementStatusRef, {
+        tenantId: req.context.tenantId,
+        projectId,
+        yearMonth: initialRecord.yearMonth,
+        periods: {
+          ...periods,
+          MONTH: {
+            ...month,
+            status: 'COMPLETED',
+            revision: Number.isSafeInteger(Number(month.revision)) ? Number(month.revision) + 1 : 1,
+            approvedAt: reviewedAt,
+            approvedBy: req.context.actorId,
+          },
+        },
+        updatedAt: reviewedAt,
+      }, { merge: true });
+    };
     if (initialRecord.contractVersion === CASHFLOW_CUMULATIVE_CLOSE_CONTRACT) {
       const expectedManifestHash = readOptionalText(req.body?.expectedManifestHash);
       if (expectedManifestHash !== initialRecord.manifestHash) {
@@ -3965,7 +4046,10 @@ export function mountJvmWeeklyApiRoutes(app, {
       }
       let approved;
       await db.runTransaction(async (transaction) => {
-        const snapshot = await transaction.get(requestRef);
+        const [snapshot, settlementSnapshot] = await Promise.all([
+          transaction.get(requestRef),
+          transaction.get(settlementStatusRef),
+        ]);
         const current = snapshot.exists ? snapshot.data() || {} : null;
         if (!current || !['APPROVING', 'UNCERTAIN'].includes(current.status)
           || current.operationId !== operationId || current.reviewedByUid !== req.context.actorId
@@ -3980,6 +4064,7 @@ export function mountJvmWeeklyApiRoutes(app, {
           monthCloseResult: monthClose,
         };
         transaction.set(requestRef, approved);
+        completeMonthSettlement(transaction, settlementSnapshot);
         transaction.set(
           db.doc(cashflowMonthCloseRequestAuditPath(
             req.context.tenantId, requestId, expectedRevision, 'approved',
@@ -4145,7 +4230,10 @@ export function mountJvmWeeklyApiRoutes(app, {
     }
     let approved;
     await db.runTransaction(async (transaction) => {
-      const snapshot = await transaction.get(requestRef);
+      const [snapshot, settlementSnapshot] = await Promise.all([
+        transaction.get(requestRef),
+        transaction.get(settlementStatusRef),
+      ]);
       const current = snapshot.exists ? snapshot.data() || {} : null;
       if (
         !current
@@ -4160,6 +4248,7 @@ export function mountJvmWeeklyApiRoutes(app, {
       delete approved.publicationFingerprint;
       delete approved.reconciliationEvidence;
       transaction.set(requestRef, approved);
+      completeMonthSettlement(transaction, settlementSnapshot);
       transaction.set(
         db.doc(cashflowMonthCloseRequestAuditPath(req.context.tenantId, requestId, reviewRevision, 'approved')),
         {

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -440,7 +440,7 @@ describe('JVM weekly API BFF proxy', () => {
       .expect(200, canonical);
     await request(app)
       .post('/api/v1/cashflow/project-a/settlement-statuses/transition')
-      .send({ yearMonth: '2026-08', period: 'WEEK_3', action: 'SUBMIT' })
+      .send({ yearMonth: '2026-08', period: 'WEEK_3', action: 'APPROVE' })
       .expect(200, canonical);
 
     expect(fetchImpl).toHaveBeenNthCalledWith(
@@ -451,8 +451,20 @@ describe('JVM weekly API BFF proxy', () => {
     expect(fetchImpl).toHaveBeenNthCalledWith(
       2,
       'http://jvm-weekly.local/api/v1/cashflow/project-a/settlement-statuses/transition',
-      expect.objectContaining({ method: 'POST', body: JSON.stringify({ yearMonth: '2026-08', period: 'WEEK_3', action: 'SUBMIT' }) }),
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ yearMonth: '2026-08', period: 'WEEK_3', action: 'APPROVE' }) }),
     );
+  });
+
+  it('blocks an administrator from submitting an uncompleted settlement', async () => {
+    const fetchImpl = vi.fn();
+    const { app } = createApp(fetchImpl, createIdempotencyService(), { actorRole: 'admin' }, { env: runtimeEnv });
+
+    await request(app)
+      .post('/api/v1/cashflow/project-a/settlement-statuses/transition')
+      .send({ yearMonth: '2026-08', period: 'WEEK_3', action: 'SUBMIT' })
+      .expect(403)
+      .expect((response) => expect(response.body.code).toBe('cashflow_settlement_submit_forbidden'));
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
   it('reads up to 100 project settlement statuses with one JVM batch request', async () => {
@@ -520,7 +532,7 @@ describe('JVM weekly API BFF proxy', () => {
 
     const response = await request(app)
       .post('/api/v1/cashflow/projection-actual-summary/batch')
-      .send({ projectIds: ['project-a', 'project-b'] })
+      .send({ projectIds: ['project-a', 'project-b'], yearMonth: '2026-11' })
       .expect(200);
 
     expect(response.body).toEqual(canonical);
@@ -528,7 +540,7 @@ describe('JVM weekly API BFF proxy', () => {
     const [url, init] = fetchImpl.mock.calls[0];
     expect(String(url)).toBe('http://jvm-weekly.local/api/v1/cashflow/projection-actual-summary/batch');
     expect(init.method).toBe('POST');
-    expect(JSON.parse(init.body)).toEqual({ projectIds: ['project-a', 'project-b'] });
+    expect(JSON.parse(init.body)).toEqual({ projectIds: ['project-a', 'project-b'], yearMonth: '2026-11' });
     expect(new Headers(init.headers).get('x-tenant-id')).toBe('tenant-a');
   });
 
@@ -2637,6 +2649,8 @@ describe('JVM weekly API BFF proxy', () => {
     expect(created.body.reviewWarnings).toEqual(expect.arrayContaining([
       expect.objectContaining({ code: 'SHEET_SOURCE_NOT_APPLIED' }),
     ]));
+    expect(source.documents.get('orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-06'))
+      .toMatchObject({ periods: { MONTH: { status: 'PENDING_APPROVAL', revision: 1 } } });
 
     const approver = createApp(fetchImpl, createIdempotencyService(), {
       actorId: 'finance-1', actorRole: 'finance',
@@ -2647,6 +2661,8 @@ describe('JVM weekly API BFF proxy', () => {
       .send({ decision: 'APPROVE', expectedRevision: 0 })
       .expect(200)
       .expect((result) => expect(result.body.request.status).toBe('APPROVED'));
+    expect(source.documents.get('orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-06'))
+      .toMatchObject({ periods: { MONTH: { status: 'COMPLETED', revision: 2, approvedBy: 'finance-1' } } });
   });
 
   it('creates and approves a warning-backed request when the mirror document is missing but closeInput has 160 cells', async () => {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowProjectionActualSummaryBatchRequest.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowProjectionActualSummaryBatchRequest.java
@@ -2,16 +2,22 @@ package dev.merryai.innerplatform.weekly.api;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 import java.util.List;
 
 public record CashflowProjectionActualSummaryBatchRequest(
     @NotNull @Size(min = 1, max = MAX_PROJECT_COUNT)
-    List<@NotBlank @Size(max = MAX_PROJECT_ID_LENGTH) String> projectIds
+    List<@NotBlank @Size(max = MAX_PROJECT_ID_LENGTH) String> projectIds,
+    @Pattern(regexp = "20\\d{2}-(0[1-9]|1[0-2])") String yearMonth
 ) {
     public static final int MAX_PROJECT_COUNT = 10;
     public static final int MAX_PROJECT_ID_LENGTH = 120;
+
+    public CashflowProjectionActualSummaryBatchRequest(List<String> projectIds) {
+        this(projectIds, null);
+    }
 
     public List<String> requireUniqueProjectIds() {
         List<String> normalized = projectIds == null

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowProjectionActualSummaryBatchResponse.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowProjectionActualSummaryBatchResponse.java
@@ -26,11 +26,54 @@ public record CashflowProjectionActualSummaryBatchResponse(
         String projectId,
         String fromMonth,
         ComparisonAsOfWeek comparisonAsOfWeek,
+        BigDecimal projectionAmount,
+        BigDecimal actualAmount,
+        BigDecimal projectionActualDifferenceAmount,
         BigDecimal settlementDifferenceAmount,
-        boolean settlementMatches
-    ) {}
+        boolean settlementMatches,
+        List<PeriodSummary> periods
+    ) {
+        public Item {
+            periods = periods == null ? List.of() : List.copyOf(periods);
+        }
+
+        public Item(
+            String projectId,
+            String fromMonth,
+            ComparisonAsOfWeek comparisonAsOfWeek,
+            BigDecimal projectionAmount,
+            BigDecimal actualAmount,
+            BigDecimal projectionActualDifferenceAmount,
+            BigDecimal settlementDifferenceAmount,
+            boolean settlementMatches
+        ) {
+            this(projectId, fromMonth, comparisonAsOfWeek, projectionAmount, actualAmount,
+                projectionActualDifferenceAmount, settlementDifferenceAmount, settlementMatches, List.of());
+        }
+
+        public Item(
+            String projectId,
+            String fromMonth,
+            ComparisonAsOfWeek comparisonAsOfWeek,
+            BigDecimal settlementDifferenceAmount,
+            boolean settlementMatches
+        ) {
+            this(
+                projectId, fromMonth, comparisonAsOfWeek,
+                BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO,
+                settlementDifferenceAmount, settlementMatches, List.of()
+            );
+        }
+    }
 
     public record ComparisonAsOfWeek(String yearMonth, int weekNo) {}
+
+    public record PeriodSummary(
+        String period,
+        BigDecimal projectionAmount,
+        BigDecimal actualAmount,
+        BigDecimal projectionActualDifferenceAmount
+    ) {}
 
     public record ErrorItem(String projectId, String code) {}
 }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowProjectionActualSummaryCalculator.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowProjectionActualSummaryCalculator.java
@@ -22,7 +22,8 @@ public final class CashflowProjectionActualSummaryCalculator {
         List<WeeklyExpenseActualEntity> actual,
         Clock clock
     ) {
-        return calculate(projectId, projection, actual, currentFinanceWeek(clock));
+        FinanceWeek boundary = currentFinanceWeek(clock);
+        return calculate(projectId, projection, actual, boundary, boundary.yearMonth());
     }
 
     public static Summary calculate(
@@ -31,29 +32,86 @@ public final class CashflowProjectionActualSummaryCalculator {
         List<WeeklyExpenseActualEntity> actual,
         FinanceWeek boundary
     ) {
+        return calculate(projectId, projection, actual, boundary, boundary.yearMonth());
+    }
+
+    public static Summary calculate(
+        String projectId,
+        List<WeeklyExpenseProjectionEntity> projection,
+        List<WeeklyExpenseActualEntity> actual,
+        FinanceWeek boundary,
+        String selectedYearMonth
+    ) {
         Map<CellKey, BigDecimal> projectionAmounts = new LinkedHashMap<>();
         Map<CellKey, BigDecimal> actualAmounts = new LinkedHashMap<>();
+        Map<CellKey, BigDecimal> selectedProjectionAmounts = new LinkedHashMap<>();
+        Map<CellKey, BigDecimal> selectedActualAmounts = new LinkedHashMap<>();
         for (WeeklyExpenseProjectionEntity line : projection == null
             ? List.<WeeklyExpenseProjectionEntity>of() : projection) {
             requireProject(projectId, line.getProjectId());
             add(projectionAmounts, line.getYearMonth(), line.getWeekNo(), line.getCashflowLine(), line.getAmount(), boundary);
+            addSelected(selectedProjectionAmounts, line.getYearMonth(), line.getWeekNo(), line.getCashflowLine(), line.getAmount(), selectedYearMonth);
         }
         for (WeeklyExpenseActualEntity line : actual == null ? List.<WeeklyExpenseActualEntity>of() : actual) {
             requireProject(projectId, line.getProjectId());
             add(actualAmounts, line.getYearMonth(), line.getWeekNo(), line.getCashflowLine(), line.getAmount(), boundary);
+            addSelected(selectedActualAmounts, line.getYearMonth(), line.getWeekNo(), line.getCashflowLine(), line.getAmount(), selectedYearMonth);
         }
+        BigDecimal projectionTotal = BigDecimal.ZERO;
+        BigDecimal actualTotal = BigDecimal.ZERO;
         BigDecimal difference = BigDecimal.ZERO;
         for (String yearMonth : monthsThrough(boundary.yearMonth())) {
             int throughWeek = yearMonth.equals(boundary.yearMonth()) ? boundary.weekNo() : 5;
             for (int weekNo = 1; weekNo <= throughWeek; weekNo += 1) {
                 for (String lineId : CashflowLineCatalog.ALL_LINES) {
                     CellKey key = new CellKey(yearMonth, weekNo, lineId);
-                    difference = difference.add(projectionAmounts.getOrDefault(key, BigDecimal.ZERO)
-                        .subtract(actualAmounts.getOrDefault(key, BigDecimal.ZERO)).abs());
+                    BigDecimal projectionAmount = projectionAmounts.getOrDefault(key, BigDecimal.ZERO);
+                    BigDecimal actualAmount = actualAmounts.getOrDefault(key, BigDecimal.ZERO);
+                    projectionTotal = projectionTotal.add(projectionAmount);
+                    actualTotal = actualTotal.add(actualAmount);
+                    difference = difference.add(projectionAmount.subtract(actualAmount).abs());
                 }
             }
         }
-        return new Summary(projectId, FROM_MONTH, boundary, difference, difference.signum() == 0);
+        List<PeriodSummary> periods = java.util.stream.IntStream.rangeClosed(1, 5)
+            .mapToObj(weekNo -> periodSummary("WEEK_" + weekNo, weekNo, weekNo, selectedProjectionAmounts, selectedActualAmounts))
+            .toList();
+        List<PeriodSummary> withMonth = new java.util.ArrayList<>();
+        withMonth.add(periodSummary("MONTH", 1, 5, selectedProjectionAmounts, selectedActualAmounts));
+        withMonth.addAll(periods);
+        return new Summary(
+            projectId, FROM_MONTH, boundary, projectionTotal, actualTotal,
+            projectionTotal.subtract(actualTotal), difference, difference.signum() == 0, withMonth
+        );
+    }
+
+    private static void addSelected(
+        Map<CellKey, BigDecimal> target, String yearMonth, int weekNo, String rawLineId,
+        BigDecimal amount, String selectedYearMonth
+    ) {
+        String lineId = CashflowLineCatalog.canonicalize(rawLineId);
+        if (!selectedYearMonth.equals(yearMonth) || weekNo < 1 || weekNo > 5
+            || !CashflowLineCatalog.ALL_LINES.contains(lineId)) return;
+        target.merge(new CellKey(yearMonth, weekNo, lineId), amount == null ? BigDecimal.ZERO : amount, BigDecimal::add);
+    }
+
+    private static PeriodSummary periodSummary(
+        String period, int fromWeek, int throughWeek,
+        Map<CellKey, BigDecimal> projection, Map<CellKey, BigDecimal> actual
+    ) {
+        BigDecimal projectionTotal = BigDecimal.ZERO;
+        BigDecimal actualTotal = BigDecimal.ZERO;
+        for (Map.Entry<CellKey, BigDecimal> entry : projection.entrySet()) {
+            if (entry.getKey().weekNo() >= fromWeek && entry.getKey().weekNo() <= throughWeek) {
+                projectionTotal = projectionTotal.add(entry.getValue());
+            }
+        }
+        for (Map.Entry<CellKey, BigDecimal> entry : actual.entrySet()) {
+            if (entry.getKey().weekNo() >= fromWeek && entry.getKey().weekNo() <= throughWeek) {
+                actualTotal = actualTotal.add(entry.getValue());
+            }
+        }
+        return new PeriodSummary(period, projectionTotal, actualTotal, projectionTotal.subtract(actualTotal));
     }
 
     public static FinanceWeek currentFinanceWeek(Clock clock) {
@@ -114,8 +172,19 @@ public final class CashflowProjectionActualSummaryCalculator {
         String projectId,
         String fromMonth,
         FinanceWeek comparisonAsOfWeek,
+        BigDecimal projectionAmount,
+        BigDecimal actualAmount,
+        BigDecimal projectionActualDifferenceAmount,
         BigDecimal settlementDifferenceAmount,
-        boolean settlementMatches
+        boolean settlementMatches,
+        List<PeriodSummary> periods
     ) {
     }
+
+    public record PeriodSummary(
+        String period,
+        BigDecimal projectionAmount,
+        BigDecimal actualAmount,
+        BigDecimal projectionActualDifferenceAmount
+    ) {}
 }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -224,9 +224,7 @@ public class WeeklyExpenseCommandService {
         if ("APPROVE".equals(request.action())) {
             requireCashflowMonthClosePermission(CLOSE_CASHFLOW_MONTH_COMMAND, actor, projectId);
         } else {
-            requireCashflowWritePermissionWithoutLeaseRuntime(
-                COMPLETE_CASHFLOW_WEEKLY_UPDATE_COMMAND, actor, projectId
-            );
+            throw new WeeklyExpenseForbiddenException("A settlement can only be submitted by its completion workflow.");
         }
         List<WeeklyExpensePersistence.CashflowSettlementStatusRecord> records = new ArrayList<>(
             persistence.findCashflowSettlementStatuses(actor.tenantId(), projectId, request.yearMonth())
@@ -275,14 +273,16 @@ public class WeeklyExpenseCommandService {
         }
         CashflowProjectionActualSummaryCalculator.FinanceWeek boundary =
             CashflowProjectionActualSummaryCalculator.currentFinanceWeek(Clock.systemUTC());
+        String selectedYearMonth = request.yearMonth() == null ? boundary.yearMonth() : request.yearMonth();
+        String throughMonth = selectedYearMonth.compareTo(boundary.yearMonth()) > 0 ? selectedYearMonth : boundary.yearMonth();
         List<CashflowProjectionActualSummaryBatchResponse.Item> items = new ArrayList<>();
         List<CashflowProjectionActualSummaryBatchResponse.ErrorItem> errors = new ArrayList<>();
         for (String projectId : projectIds) {
             try {
                 WeeklyExpensePersistence.CashflowLedgerSource source = persistence.findCashflowLedgerSource(
-                    actor.tenantId(), projectId, CashflowProjectionActualSummaryCalculator.FROM_MONTH, boundary.yearMonth()
+                    actor.tenantId(), projectId, CashflowProjectionActualSummaryCalculator.FROM_MONTH, throughMonth
                 );
-                items.add(toProjectionActualSummary(projectId, source, boundary));
+                items.add(toProjectionActualSummary(projectId, source, boundary, selectedYearMonth));
             } catch (WeeklyExpenseForbiddenException denied) {
                 throw denied;
             } catch (RuntimeException unavailable) {
@@ -300,26 +300,29 @@ public class WeeklyExpenseCommandService {
         WeeklyExpensePersistence.CashflowLedgerSource source
     ) {
         authorizationService.requireProjectAllowed(CASHFLOW_READ_COMMAND, actor, projectId);
-        return toProjectionActualSummary(
-            projectId,
-            source,
-            CashflowProjectionActualSummaryCalculator.currentFinanceWeek(Clock.systemUTC())
-        );
+        CashflowProjectionActualSummaryCalculator.FinanceWeek boundary =
+            CashflowProjectionActualSummaryCalculator.currentFinanceWeek(Clock.systemUTC());
+        return toProjectionActualSummary(projectId, source, boundary, boundary.yearMonth());
     }
 
     private CashflowProjectionActualSummaryBatchResponse.Item toProjectionActualSummary(
         String projectId,
         WeeklyExpensePersistence.CashflowLedgerSource source,
-        CashflowProjectionActualSummaryCalculator.FinanceWeek boundary
+        CashflowProjectionActualSummaryCalculator.FinanceWeek boundary,
+        String selectedYearMonth
     ) {
         CashflowProjectionActualSummaryCalculator.Summary summary =
-            CashflowProjectionActualSummaryCalculator.calculate(projectId, source.projection(), source.actual(), boundary);
+            CashflowProjectionActualSummaryCalculator.calculate(projectId, source.projection(), source.actual(), boundary, selectedYearMonth);
         return new CashflowProjectionActualSummaryBatchResponse.Item(
             summary.projectId(), summary.fromMonth(),
             new CashflowProjectionActualSummaryBatchResponse.ComparisonAsOfWeek(
                 summary.comparisonAsOfWeek().yearMonth(), summary.comparisonAsOfWeek().weekNo()
             ),
-            summary.settlementDifferenceAmount(), summary.settlementMatches()
+            summary.projectionAmount(), summary.actualAmount(), summary.projectionActualDifferenceAmount(),
+            summary.settlementDifferenceAmount(), summary.settlementMatches(),
+            summary.periods().stream().map(period -> new CashflowProjectionActualSummaryBatchResponse.PeriodSummary(
+                period.period(), period.projectionAmount(), period.actualAmount(), period.projectionActualDifferenceAmount()
+            )).toList()
         );
     }
 

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -1556,6 +1556,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             projectWeeks.put(weekSnapshot.getId(), week);
         }
         if (lockedCompletion != null) {
+            submitWeeklySettlementIfWaiting(actor, projectId, request.yearMonth(), request.weekNo());
             return toWeeklyCompletionRecord(
                 projectId, request.yearMonth(), request.weekNo(), lockedCompletion, true
             );
@@ -1650,7 +1651,19 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         }
         set(ref, completion);
         set(versionRef, version);
+        submitWeeklySettlementIfWaiting(actor, projectId, request.yearMonth(), request.weekNo());
         return toWeeklyCompletionRecord(projectId, request.yearMonth(), request.weekNo(), completion, false);
+    }
+
+    private void submitWeeklySettlementIfWaiting(
+        TrustedActorContext actor, String projectId, String yearMonth, int weekNo
+    ) {
+        String period = "WEEK_" + weekNo;
+        CashflowSettlementStatusRecord status = findCashflowSettlementStatuses(actor.tenantId(), projectId, yearMonth)
+            .stream().filter(item -> period.equals(item.period())).findFirst().orElseThrow();
+        if ("WAITING_FOR_UPDATE".equals(status.status())) {
+            transitionCashflowSettlementStatus(actor, projectId, yearMonth, period, "SUBMIT");
+        }
     }
 
     private List<CashflowWeekScope> consecutiveFinanceWeeks(String yearMonth, int weekNo, int count) {

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowProjectionActualSummaryCalculatorTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowProjectionActualSummaryCalculatorTest.java
@@ -30,8 +30,16 @@ class CashflowProjectionActualSummaryCalculatorTest {
         assertThat(summary.fromMonth()).isEqualTo("2023-01");
         assertThat(summary.comparisonAsOfWeek())
             .isEqualTo(new CashflowProjectionActualSummaryCalculator.FinanceWeek("2026-08", 4));
+        assertThat(summary.projectionAmount()).isEqualByComparingTo("12371453");
+        assertThat(summary.actualAmount()).isEqualByComparingTo("6000000");
+        assertThat(summary.projectionActualDifferenceAmount()).isEqualByComparingTo("6371453");
         assertThat(summary.settlementDifferenceAmount()).isEqualByComparingTo("18371453");
         assertThat(summary.settlementMatches()).isFalse();
+        assertThat(summary.periods()).extracting(CashflowProjectionActualSummaryCalculator.PeriodSummary::period)
+            .containsExactly("MONTH", "WEEK_1", "WEEK_2", "WEEK_3", "WEEK_4", "WEEK_5");
+        assertThat(summary.periods().getFirst().projectionAmount()).isEqualByComparingTo("100371453");
+        assertThat(summary.periods().getFirst().actualAmount()).isEqualByComparingTo("6000000");
+        assertThat(summary.periods().getLast().projectionAmount()).isEqualByComparingTo("88000000");
     }
 
     @Test

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowProjectionActualSummaryServiceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowProjectionActualSummaryServiceTest.java
@@ -62,6 +62,31 @@ class CashflowProjectionActualSummaryServiceTest {
     }
 
     @Test
+    void returnsTheRequestedMonthAndWeekAmountsEvenWhenTheMonthIsAfterTheCurrentBoundary() {
+        WeeklyExpensePersistence persistence = mock(WeeklyExpensePersistence.class);
+        WeeklyExpenseAuthorizationService authorization = mock(WeeklyExpenseAuthorizationService.class);
+        WeeklyExpenseCommandService service = service(persistence, authorization);
+        WeeklyExpenseProjectionEntity projection = new WeeklyExpenseProjectionEntity(
+            "tenant-a", "project-a", "2026-11", 2, "SALES_IN"
+        );
+        projection.setAmount(BigDecimal.valueOf(300));
+        when(persistence.findCashflowLedgerSource("tenant-a", "project-a", "2023-01", "2026-11"))
+            .thenReturn(new WeeklyExpensePersistence.CashflowLedgerSource(List.of(projection), List.of(), List.of(2026)));
+
+        CashflowProjectionActualSummaryBatchResponse.Item item = service.readCashflowProjectionActualSummaries(
+            ACTOR, new CashflowProjectionActualSummaryBatchRequest(List.of("project-a"), "2026-11")
+        ).items().getFirst();
+
+        assertThat(item.periods()).filteredOn(period -> period.period().equals("MONTH"))
+            .extracting(CashflowProjectionActualSummaryBatchResponse.PeriodSummary::projectionAmount)
+            .containsExactly(BigDecimal.valueOf(300));
+        assertThat(item.periods()).filteredOn(period -> period.period().equals("WEEK_2"))
+            .extracting(CashflowProjectionActualSummaryBatchResponse.PeriodSummary::projectionAmount)
+            .containsExactly(BigDecimal.valueOf(300));
+        verify(persistence).findCashflowLedgerSource("tenant-a", "project-a", "2023-01", "2026-11");
+    }
+
+    @Test
     void isolatesOneRepositoryFailureAcrossTenAuthorizedProjectsWithoutLeakingItsSecret() throws Exception {
         WeeklyExpensePersistence persistence = mock(WeeklyExpensePersistence.class);
         WeeklyExpenseAuthorizationService authorization = mock(WeeklyExpenseAuthorizationService.class);

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -2010,6 +2010,12 @@ class FirestoreCashflowLeaseGuardTest {
         );
 
         assertThat(replay).isEqualTo(first);
+        Map<?, ?> periods = (Map<?, ?>) fixture.documents.get(
+            "orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-07"
+        ).get("periods");
+        Map<?, ?> weeklyStatus = (Map<?, ?>) periods.get("WEEK_3");
+        assertThat(weeklyStatus.get("status")).isEqualTo("PENDING_APPROVAL");
+        assertThat(weeklyStatus.get("revision")).isEqualTo(1L);
         assertThat(fixture.documents.keySet().stream()
             .filter(path -> path.contains("/cashflow_weekly_update_completion_versions/")))
             .hasSize(1);
@@ -2507,11 +2513,22 @@ class FirestoreCashflowLeaseGuardTest {
         CashflowWeeklyUpdateCompletionResponse first = fixture.persistence.runCommandTransaction(() ->
             service.completeCashflowWeeklyUpdate(ACTOR, "project-a", request)
         );
+        Map<String, Object> settlement = fixture.documents.get(
+            "orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-07"
+        );
+        Map<String, Object> periods = new LinkedHashMap<>((Map<String, Object>) settlement.get("periods"));
+        Map<String, Object> approved = new LinkedHashMap<>((Map<String, Object>) periods.get("WEEK_3"));
+        approved.put("status", "COMPLETED");
+        approved.put("revision", 2L);
+        periods.put("WEEK_3", approved);
+        settlement.put("periods", periods);
         CashflowWeeklyUpdateCompletionResponse replay = fixture.persistence.runCommandTransaction(() ->
             service.completeCashflowWeeklyUpdate(ACTOR, "project-a", request)
         );
 
         assertThat(replay).isEqualTo(first);
+        assertThat(((Map<?, ?>) ((Map<?, ?>) settlement.get("periods")).get("WEEK_3")).get("status"))
+            .isEqualTo("COMPLETED");
         assertThat(fixture.documents.keySet().stream()
             .filter(path -> path.contains("/cashflow_weekly_update_completion_versions/")))
             .hasSize(1);
@@ -2533,6 +2550,10 @@ class FirestoreCashflowLeaseGuardTest {
         assertThat(completed.status()).isEqualTo("LOCKED");
         assertThat(completed.updateResult()).isEqualTo("NO_CHANGES");
         assertThat(completed.complianceStatus()).isEqualTo("ON_TIME");
+        Map<?, ?> periods = (Map<?, ?>) fixture.documents.get(
+            "orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-12"
+        ).get("periods");
+        assertThat(((Map<?, ?>) periods.get("WEEK_4")).get("status")).isEqualTo("PENDING_APPROVAL");
     }
 
     @Test

--- a/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
+++ b/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
@@ -20,12 +20,14 @@ describe('CashflowWeeklyPage settlement status surface', () => {
     expect(source).toContain('sticky left-0');
     expect(source).toContain('fetchCashflowSettlementStatusesBatchViaBff');
     expect(source).toContain('transitionCashflowSettlementStatusViaBff');
-    expect(source).toContain('주정산 전');
+    expect(source).toContain('주정산 이전');
+    expect(source).toContain('결산 전');
     expect(source).toContain('조직장 승인 필요');
-    expect(source).toContain('정산 완료');
+    expect(source).toContain('승인 완료');
     expect(source).toContain("user?.uid === project.executiveApproverId");
     expect(source).toContain("setStatuses((current) => ({ ...current, [projectId]: result }))");
     expect(source).not.toContain('window.location.reload');
+    expect(source).not.toContain("onAction('SUBMIT')");
   });
 
   it('filters both visible rows and compliance requests by normalized department', () => {

--- a/src/app/components/cashflow/CashflowWeeklyPage.tsx
+++ b/src/app/components/cashflow/CashflowWeeklyPage.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../lib/platform-bff-client';
 import { getMonthMondayWeeks } from '../../platform/cashflow-weeks';
 import { getProjectRegistrationCicOptions, normalizeProjectDepartment } from '../../platform/project-cic';
+import { useCashflowProjectionActualSummaries } from './useCashflowProjectionActualSummaries';
 
 export function filterCashflowProjectsByDepartment<T extends { department?: unknown }>(projects: T[], department: string): T[] {
   return projects.filter((project) => department === 'ALL' || normalizeProjectDepartment(project.department) === department);
@@ -31,32 +32,59 @@ function statusItem(result: CashflowSettlementStatusesResult | undefined, period
 
 function SettlementStatusButton({
   item,
+  period,
   loading,
   canApprove,
   onAction,
 }: {
   item?: CashflowSettlementStatusItem;
+  period: CashflowSettlementPeriod;
   loading: boolean;
   canApprove: boolean;
   onAction: (action: 'SUBMIT' | 'APPROVE') => void;
 }) {
   const status = item?.status || 'WAITING_FOR_UPDATE';
   if (status === 'COMPLETED') {
-    return <span className="inline-flex min-h-8 items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 font-semibold text-emerald-700"><span className="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden="true" />정산 완료</span>;
+    return <span className="inline-flex min-h-8 items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 font-semibold text-emerald-700"><span className="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden="true" />승인 완료</span>;
   }
-  const action = status === 'PENDING_APPROVAL' ? 'APPROVE' : 'SUBMIT';
+  if (status === 'WAITING_FOR_UPDATE') {
+    return <span className="inline-flex min-h-8 items-center gap-1.5 rounded-full border border-red-200 bg-red-50 px-2.5 font-semibold text-red-700"><span className="h-1.5 w-1.5 rounded-full bg-red-500" aria-hidden="true" />{period === 'MONTH' ? '결산 전' : '주정산 이전'}</span>;
+  }
   return (
     <Button
       type="button"
       size="sm"
       variant="outline"
-      className={`min-h-8 gap-1.5 whitespace-normal rounded-full px-2.5 text-[11px] font-semibold ${status === 'PENDING_APPROVAL' ? 'border-amber-200 bg-amber-50 text-amber-800 hover:bg-amber-100' : 'border-slate-200 bg-slate-50 text-slate-600 hover:bg-slate-100'}`}
-      disabled={loading || (action === 'APPROVE' && !canApprove)}
-      onClick={() => onAction(action)}
+      className="min-h-8 gap-1.5 whitespace-normal rounded-full border-amber-200 bg-amber-50 px-2.5 text-[11px] font-semibold text-amber-800 hover:bg-amber-100"
+      disabled={loading || !canApprove}
+      onClick={() => onAction('APPROVE')}
     >
-      <span className={`h-1.5 w-1.5 rounded-full ${status === 'PENDING_APPROVAL' ? 'bg-amber-500' : 'bg-slate-400'}`} aria-hidden="true" />
-      {loading ? '처리 중…' : status === 'PENDING_APPROVAL' ? '조직장 승인 필요' : '주정산 전'}
+      <span className="h-1.5 w-1.5 rounded-full bg-amber-500" aria-hidden="true" />
+      {loading ? '처리 중…' : '조직장 승인 필요'}
     </Button>
+  );
+}
+
+function PeriodAmounts({
+  summary,
+  period,
+  loading,
+  error,
+}: {
+  summary: ReturnType<typeof useCashflowProjectionActualSummaries>['summaries'][string] | undefined;
+  period: CashflowSettlementPeriod;
+  loading?: boolean;
+  error?: boolean;
+}) {
+  if (error) return <div className="mt-1 text-[9px] text-red-600">금액 조회 오류</div>;
+  if (loading) return <div className="mt-1 text-[9px] text-slate-400">금액 확인 중…</div>;
+  const amounts = summary?.periods.find((item) => item.period === period);
+  if (!amounts) return null;
+  return (
+    <div className="mt-1 space-y-0.5 text-[9px] leading-tight text-slate-500 tabular-nums">
+      <div>P {amounts.projectionAmount.toLocaleString('ko-KR')}원 · A {amounts.actualAmount.toLocaleString('ko-KR')}원</div>
+      <div className="font-semibold text-slate-700">P-A {amounts.projectionActualDifferenceAmount.toLocaleString('ko-KR')}원</div>
+    </div>
   );
 }
 
@@ -77,6 +105,29 @@ export function CashflowWeeklyPage() {
     ...projects.map((project) => normalizeProjectDepartment(project.department)).filter(Boolean),
   ])).sort((left, right) => left.localeCompare(right, 'ko')), [projects]);
   const filteredProjects = useMemo(() => filterCashflowProjectsByDepartment(projects, deptFilter), [deptFilter, projects]);
+  const projectIds = useMemo(() => filteredProjects.map((project) => project.id), [filteredProjects]);
+  const projectionActual = useCashflowProjectionActualSummaries({ tenantId: orgId, actor: user, projectIds, yearMonth });
+  const dashboard = useMemo(() => {
+    const counts = { waiting: 0, pending: 0, completed: 0 };
+    for (const project of filteredProjects) {
+      for (const period of ['MONTH', 'WEEK_1', 'WEEK_2', 'WEEK_3', 'WEEK_4', 'WEEK_5'] as CashflowSettlementPeriod[]) {
+        const status = statusItem(statuses[project.id], period)?.status || 'WAITING_FOR_UPDATE';
+        if (status === 'PENDING_APPROVAL') counts.pending += 1;
+        else if (status === 'COMPLETED') counts.completed += 1;
+        else counts.waiting += 1;
+      }
+    }
+    const summaries = filteredProjects.flatMap((project) => {
+      const summary = projectionActual.summaries[project.id]?.periods.find((period) => period.period === 'MONTH');
+      return summary ? [summary] : [];
+    });
+    return {
+      ...counts,
+      projection: summaries.reduce((sum, item) => sum + item.projectionAmount, 0),
+      actual: summaries.reduce((sum, item) => sum + item.actualAmount, 0),
+      difference: summaries.reduce((sum, item) => sum + item.projectionActualDifferenceAmount, 0),
+    };
+  }, [filteredProjects, projectionActual.summaries, statuses]);
 
   useEffect(() => {
     if (!user?.idToken || filteredProjects.length === 0) {
@@ -86,26 +137,27 @@ export function CashflowWeeklyPage() {
       return;
     }
     let active = true;
-    setStatusesLoading(true);
     const projectIds = filteredProjects.map((project) => project.id);
     const batches = Array.from(
       { length: Math.ceil(projectIds.length / 100) },
       (_, index) => projectIds.slice(index * 100, (index + 1) * 100),
     );
-    void Promise.all(batches.map(async (batchProjectIds) => fetchCashflowSettlementStatusesBatchViaBff({
-      tenantId: orgId, actor: user, projectIds: batchProjectIds, yearMonth,
-    }).catch(() => ({
-      items: [],
-      errors: batchProjectIds.map((projectId) => ({ projectId, code: 'STATUS_UNAVAILABLE' as const })),
-    })))).then((results) => {
+    const load = async (showLoading: boolean) => {
+      if (showLoading) setStatusesLoading(true);
+      const results = await Promise.all(batches.map(async (batchProjectIds) => fetchCashflowSettlementStatusesBatchViaBff({
+        tenantId: orgId, actor: user, projectIds: batchProjectIds, yearMonth,
+      }).catch(() => ({
+        items: [],
+        errors: batchProjectIds.map((projectId) => ({ projectId, code: 'STATUS_UNAVAILABLE' as const })),
+      }))));
       if (!active) return;
-      const next = Object.fromEntries(results.flatMap((result) => result.items).map((item) => [item.projectId, item]));
-      const errors = Object.fromEntries(results.flatMap((result) => result.errors).map((error) => [error.projectId, '결산 상태를 불러오지 못했습니다.']));
-      setStatuses(next);
-      setStatusErrors(errors);
+      setStatuses(Object.fromEntries(results.flatMap((result) => result.items).map((item) => [item.projectId, item])));
+      setStatusErrors(Object.fromEntries(results.flatMap((result) => result.errors).map((error) => [error.projectId, '결산 상태를 불러오지 못했습니다.'])));
       setStatusesLoading(false);
-    });
-    return () => { active = false; };
+    };
+    void load(true);
+    const interval = window.setInterval(() => void load(false), 15_000);
+    return () => { active = false; window.clearInterval(interval); };
   }, [filteredProjects, orgId, user, yearMonth]);
 
   async function transition(projectId: string, period: CashflowSettlementPeriod, action: 'SUBMIT' | 'APPROVE') {
@@ -148,6 +200,22 @@ export function CashflowWeeklyPage() {
           </div>
         )}
       />
+
+      <div className="grid gap-2 sm:grid-cols-3 xl:grid-cols-6">
+        {[
+          ['정산 이전', dashboard.waiting, 'border-red-200 bg-red-50 text-red-700'],
+          ['승인 필요', dashboard.pending, 'border-amber-200 bg-amber-50 text-amber-800'],
+          ['승인 완료', dashboard.completed, 'border-emerald-200 bg-emerald-50 text-emerald-700'],
+          ['Projection', `${dashboard.projection.toLocaleString('ko-KR')}원`, 'border-slate-200 bg-white text-slate-700'],
+          ['Actual', `${dashboard.actual.toLocaleString('ko-KR')}원`, 'border-slate-200 bg-white text-slate-700'],
+          ['P - A', `${dashboard.difference.toLocaleString('ko-KR')}원`, 'border-slate-200 bg-white text-slate-700'],
+        ].map(([label, value, className]) => (
+          <div key={label} className={`rounded-lg border px-3 py-2 ${className}`}>
+            <div className="text-[10px] font-semibold">{label}</div>
+            <div className="mt-0.5 text-[15px] font-bold tabular-nums">{value}</div>
+          </div>
+        ))}
+      </div>
 
       <div className="flex items-end gap-3 rounded-lg border bg-white px-4 py-3">
         <div className="w-[180px]">
@@ -196,11 +264,13 @@ export function CashflowWeeklyPage() {
                         {statusErrors[project.id] ? <span className="text-red-700">조회 오류</span> : statusesLoading && !projectStatuses ? <span className="text-muted-foreground">확인 중…</span> : (
                           <SettlementStatusButton
                             item={statusItem(projectStatuses, 'MONTH')}
+                            period="MONTH"
                             loading={actionKey === `${project.id}:MONTH`}
                             canApprove={canApprove}
                             onAction={(action) => void transition(project.id, 'MONTH', action)}
                           />
                         )}
+                        <PeriodAmounts summary={projectionActual.summaries[project.id]} period="MONTH" loading={projectionActual.loading[project.id]} error={projectionActual.errors[project.id]} />
                       </td>
                       <td className="px-3 py-3 text-center">
                         <Button size="sm" variant="outline" className="h-8 gap-1.5 text-[11px]" onClick={() => openProject(project.id)}>
@@ -214,11 +284,13 @@ export function CashflowWeeklyPage() {
                             {statusErrors[project.id] ? <span className="text-red-700">조회 오류</span> : statusesLoading && !projectStatuses ? <span className="text-muted-foreground">확인 중…</span> : (
                               <SettlementStatusButton
                                 item={statusItem(projectStatuses, period)}
+                                period={period}
                                 loading={actionKey === `${project.id}:${period}`}
                                 canApprove={canApprove}
                                 onAction={(action) => void transition(project.id, period, action)}
                               />
                             )}
+                            <PeriodAmounts summary={projectionActual.summaries[project.id]} period={period} loading={projectionActual.loading[project.id]} error={projectionActual.errors[project.id]} />
                           </td>
                         );
                       })}
@@ -226,7 +298,7 @@ export function CashflowWeeklyPage() {
                   );
                 })}
                 {filteredProjects.length === 0 ? (
-                  <tr><td className="px-4 py-8 text-center text-[12px] text-muted-foreground" colSpan={9}>프로젝트가 없습니다.</td></tr>
+                  <tr><td className="px-4 py-8 text-center text-[12px] text-muted-foreground" colSpan={4 + monthWeeks.length}>프로젝트가 없습니다.</td></tr>
                 ) : null}
               </tbody>
             </table>

--- a/src/app/components/cashflow/useCashflowProjectionActualSummaries.test.ts
+++ b/src/app/components/cashflow/useCashflowProjectionActualSummaries.test.ts
@@ -5,8 +5,12 @@ const summary = (projectId: string, amount = 18_371_453) => ({
   projectId,
   fromMonth: '2023-01',
   comparisonAsOfWeek: { yearMonth: '2026-08', weekNo: 4 },
+  projectionAmount: amount,
+  actualAmount: 0,
+  projectionActualDifferenceAmount: amount,
   settlementDifferenceAmount: amount,
   settlementMatches: amount === 0,
+  periods: [],
 });
 
 describe('mergeCashflowProjectionActualSummaryBatch', () => {

--- a/src/app/components/cashflow/useCashflowProjectionActualSummaries.ts
+++ b/src/app/components/cashflow/useCashflowProjectionActualSummaries.ts
@@ -35,6 +35,7 @@ export function useCashflowProjectionActualSummaries(params: {
   tenantId: string;
   actor?: ActorLike | null;
   projectIds: string[];
+  yearMonth?: string;
 }) {
   const { actor, tenantId } = params;
   const projectIdsKey = JSON.stringify(params.projectIds);
@@ -50,7 +51,7 @@ export function useCashflowProjectionActualSummaries(params: {
       errors: { ...current.errors, ...Object.fromEntries(ids.map((id) => [id, false])) },
     }));
     try {
-      const response = await fetchCashflowProjectionActualSummariesViaBff({ tenantId, actor, projectIds: ids });
+      const response = await fetchCashflowProjectionActualSummariesViaBff({ tenantId, actor, projectIds: ids, yearMonth: params.yearMonth });
       if (!active()) return;
       setState((current) => mergeCashflowProjectionActualSummaryBatch(current, ids, response));
     } catch {
@@ -61,7 +62,7 @@ export function useCashflowProjectionActualSummaries(params: {
     } finally {
       if (active()) setLoading((current) => ({ ...current, ...Object.fromEntries(ids.map((id) => [id, false])) }));
     }
-  }, [actor, tenantId]);
+  }, [actor, params.yearMonth, tenantId]);
 
   useEffect(() => {
     let active = true;

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -91,13 +91,16 @@ describe('platform-bff-client', () => {
     expect(result).toEqual(data);
   });
 
-  it('posts project IDs to the canonical JVM projection-actual summary adapter unchanged', async () => {
+  it('posts project IDs and the selected month to the canonical JVM projection-actual summary adapter unchanged', async () => {
     const data = {
       version: '1',
       items: Array.from({ length: 9 }, (_, index) => ({
         projectId: `p00${index + 1}`, fromMonth: '2023-01',
         comparisonAsOfWeek: { yearMonth: '2026-08', weekNo: 4 },
+        projectionAmount: 30_000_000 + index, actualAmount: 20_000_000 + index,
+        projectionActualDifferenceAmount: 10_000_000,
         settlementDifferenceAmount: 18_371_453 + index, settlementMatches: false,
+        periods: [{ period: 'MONTH' as const, projectionAmount: 30_000_000 + index, actualAmount: 20_000_000 + index, projectionActualDifferenceAmount: 10_000_000 }],
       })),
       errors: [{ projectId: 'p010', code: 'SUMMARY_UNAVAILABLE' as const }],
     };
@@ -106,12 +109,12 @@ describe('platform-bff-client', () => {
     });
 
     const result = await fetchCashflowProjectionActualSummariesViaBff({
-      tenantId: 'mysc', actor: { uid: 'u001', role: 'pm' }, projectIds: Array.from({ length: 10 }, (_, index) => `p0${String(index + 1).padStart(2, '0')}`), client,
+      tenantId: 'mysc', actor: { uid: 'u001', role: 'pm' }, projectIds: Array.from({ length: 10 }, (_, index) => `p0${String(index + 1).padStart(2, '0')}`), yearMonth: '2026-11', client,
     });
 
     expect(result).toBe(data);
     expect(client.post).toHaveBeenCalledWith('/api/v1/cashflow/projection-actual-summary/batch', expect.objectContaining({
-      body: { projectIds: Array.from({ length: 10 }, (_, index) => `p0${String(index + 1).padStart(2, '0')}`) }, retries: 0, timeoutMs: 12000,
+      body: { projectIds: Array.from({ length: 10 }, (_, index) => `p0${String(index + 1).padStart(2, '0')}`), yearMonth: '2026-11' }, retries: 0, timeoutMs: 12000,
     }));
     expect(result.items).toHaveLength(9);
     expect(result.errors).toEqual([{ projectId: 'p010', code: 'SUMMARY_UNAVAILABLE' }]);

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -1363,8 +1363,17 @@ export interface CashflowProjectionActualSummary {
   projectId: string;
   fromMonth: string;
   comparisonAsOfWeek: { yearMonth: string; weekNo: number };
+  projectionAmount: number;
+  actualAmount: number;
+  projectionActualDifferenceAmount: number;
   settlementDifferenceAmount: number;
   settlementMatches: boolean;
+  periods: Array<{
+    period: CashflowSettlementPeriod;
+    projectionAmount: number;
+    actualAmount: number;
+    projectionActualDifferenceAmount: number;
+  }>;
 }
 
 export interface CashflowProjectionActualSummaryBatch {
@@ -2920,7 +2929,7 @@ export async function fetchCashflowSettlementStatusesBatchViaBff(params: {
     {
       tenantId: params.tenantId,
       actor: toRequestActor(params.actor),
-      body: { projectIds: params.projectIds, yearMonth: params.yearMonth },
+      body: { projectIds: params.projectIds, ...(params.yearMonth ? { yearMonth: params.yearMonth } : {}) },
       retries: 0,
       timeoutMs: 12000,
     },
@@ -2954,6 +2963,7 @@ export async function fetchCashflowProjectionActualSummariesViaBff(params: {
   tenantId: string;
   actor: ActorLike;
   projectIds: string[];
+  yearMonth?: string;
   client?: PlatformApiClientLike;
 }): Promise<CashflowProjectionActualSummaryBatch> {
   const response = await resolveClient(params.client).post<CashflowProjectionActualSummaryBatch>(
@@ -2961,7 +2971,7 @@ export async function fetchCashflowProjectionActualSummariesViaBff(params: {
     {
       tenantId: params.tenantId,
       actor: toRequestActor(params.actor),
-      body: { projectIds: params.projectIds },
+      body: { projectIds: params.projectIds, yearMonth: params.yearMonth },
       retries: 0,
       timeoutMs: 12000,
     },
@@ -2975,6 +2985,14 @@ export async function fetchCashflowProjectionActualSummariesViaBff(params: {
     || result.items.length > params.projectIds.length
     || itemIds.some((projectId) => !requestedIds.has(projectId))
     || new Set(itemIds).size !== itemIds.length
+    || result.items.some((item) => !Number.isFinite(item?.projectionAmount)
+      || !Number.isFinite(item?.actualAmount)
+      || !Number.isFinite(item?.projectionActualDifferenceAmount)
+      || !Array.isArray(item?.periods)
+      || item.periods.some((period) => !['MONTH', 'WEEK_1', 'WEEK_2', 'WEEK_3', 'WEEK_4', 'WEEK_5'].includes(period?.period)
+        || !Number.isFinite(period?.projectionAmount)
+        || !Number.isFinite(period?.actualAmount)
+        || !Number.isFinite(period?.projectionActualDifferenceAmount)))
     || !Array.isArray(result?.errors)
     || result.errors.length > params.projectIds.length
     || result.errors.some((error) => error?.code !== 'SUMMARY_UNAVAILABLE' || !requestedIds.has(error?.projectId))


### PR DESCRIPTION
## What\n- portal weekly/month completion atomically moves settlement status to organization approval pending\n- designated approver completes the settlement; waiting states are read-only in admin\n- selected month and weekly Projection / Actual / P-A are shown with department dashboard\n- admin status polling updates without browser refresh\n\n## Verification\n- frontend/BFF targeted tests: 238 tests (one parallel socket flake passed on isolated retry)\n- JVM targeted tests: pass\n- Vite production build: pass\n- independent QA: pass\n\n## Ops\n- frontend, BFF, and JVM weekly API must deploy together