### PR TITLE
fix(cashflow): unify period approval hook

### DIFF
--- a/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
+++ b/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
@@ -25,7 +25,7 @@ describe('CashflowWeeklyPage settlement status surface', () => {
     expect(source).toContain('sticky left-0');
     expect(source).toContain('fetchCashflowSettlementStatusesBatchViaBff');
     expect(source).toContain('transitionCashflowSettlementStatusViaBff');
-    expect(source).toContain("onAction={() => navigate('/approvals')}");
+    expect(source).toContain("onAction={(action) => void transition(project.id, 'MONTH', action)}");
     expect(source).toContain('주정산 이전');
     expect(source).toContain('결산 전');
     expect(source).toContain('조직장 승인 필요');

--- a/src/app/components/cashflow/CashflowWeeklyPage.tsx
+++ b/src/app/components/cashflow/CashflowWeeklyPage.tsx
@@ -228,7 +228,7 @@ export function CashflowWeeklyPage() {
                             period="MONTH"
                             loading={actionKey === `${project.id}:MONTH`}
                             canApprove={canApprove}
-                            onAction={() => navigate('/approvals')}
+                            onAction={(action) => void transition(project.id, 'MONTH', action)}
                           />
                         )}
                         <PeriodAmounts summary={projectionActual.summaries[project.id]} period="MONTH" loading={projectionActual.loading[project.id]} error={projectionActual.errors[project.id]} />

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -43,6 +43,7 @@ import {
   fetchCashflowWeeklyComplianceViaBff,
   fetchCashflowProjectionActualSummariesViaBff,
   fetchCashflowSettlementStatusesBatchViaBff,
+  transitionCashflowSettlementStatusViaBff,
   fetchCashflowActivityViaBff,
   fetchCashflowAppliedCellChangesViaBff,
   type CashflowCumulativeCloseScope,
@@ -76,6 +77,35 @@ function asMockClient<T extends {
 }
 
 describe('platform-bff-client', () => {
+  it('uses the canonical month-close review hook for MONTH and the status transition hook for WEEK', async () => {
+    const status = { projectId: 'p001', yearMonth: '2026-08', items: [] };
+    const monthRequest = {
+      requestId: 'p001-2026-08', projectId: 'p001', yearMonth: '2026-08', status: 'PENDING',
+      revision: 3, manifestHash: 'sha256:manifest', reviewWarnings: [],
+    };
+    const client = asMockClient({
+      get: vi.fn()
+        .mockResolvedValueOnce({ data: { request: monthRequest } })
+        .mockResolvedValueOnce({ data: status }),
+      post: vi.fn()
+        .mockResolvedValueOnce({ data: { request: { ...monthRequest, status: 'APPROVED' } } })
+        .mockResolvedValueOnce({ data: status }),
+      request: vi.fn(),
+    });
+    const common = { tenantId: 'mysc', actor: { uid: 'head-1', role: 'admin' }, projectId: 'p001', yearMonth: '2026-08', client };
+
+    await transitionCashflowSettlementStatusViaBff({ ...common, period: 'MONTH', action: 'APPROVE' });
+    await transitionCashflowSettlementStatusViaBff({ ...common, period: 'WEEK_2', action: 'APPROVE' });
+
+    expect(client.post).toHaveBeenNthCalledWith(1, '/api/v1/cashflow/p001/month-close/requests/p001-2026-08/review', expect.objectContaining({
+      body: { decision: 'APPROVE', expectedRevision: 3, expectedManifestHash: 'sha256:manifest' },
+      idempotencyKey: 'cashflow-settlement:p001-2026-08:r3:approve',
+    }));
+    expect(client.post).toHaveBeenNthCalledWith(2, '/api/v1/cashflow/p001/settlement-statuses/transition', expect.objectContaining({
+      body: { yearMonth: '2026-08', period: 'WEEK_2', action: 'APPROVE' },
+    }));
+  });
+
   it('posts all settlement project IDs in one bounded batch request', async () => {
     const data = { items: [], errors: [{ projectId: 'p002', code: 'STATUS_UNAVAILABLE' }] };
     const client = asMockClient({ post: vi.fn(async () => ({ data })), get: vi.fn(), request: vi.fn() });

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -2948,6 +2948,26 @@ export async function transitionCashflowSettlementStatusViaBff(params: {
   action: 'SUBMIT' | 'APPROVE';
   client?: PlatformApiClientLike;
 }): Promise<CashflowSettlementStatusesResult> {
+  if (params.period === 'MONTH' && params.action === 'APPROVE') {
+    const request = await fetchCurrentCashflowMonthCloseRequestViaBff(params);
+    if (!request || !['PENDING', 'APPROVING', 'UNCERTAIN'].includes(request.status)) {
+      throw new Error('승인할 월 결산 요청을 찾을 수 없습니다.');
+    }
+    if ((request.reviewWarnings ?? []).length > 0) {
+      throw new Error('확인이 필요한 월 결산 항목이 있어 결재 페이지에서 검토해 주세요.');
+    }
+    await reviewCashflowMonthCloseRequestViaBff({
+      ...params,
+      requestId: request.requestId,
+      payload: {
+        decision: 'APPROVE',
+        expectedRevision: request.revision,
+        expectedManifestHash: request.manifestHash,
+      },
+      idempotencyKey: `cashflow-settlement:${request.requestId}:r${request.revision}:approve`,
+    });
+    return fetchCashflowSettlementStatusesViaBff(params);
+  }
   const response = await resolveClient(params.client).post<CashflowSettlementStatusesResult>(
     `/api/v1/cashflow/${encodeURIComponent(params.projectId)}/settlement-statuses/transition`,
     {


### PR DESCRIPTION
## What
- route both monthly and weekly approvals through the shared settlement transition client hook
- keep monthly approval on the canonical request/snapshot/audit path
- refresh persisted period statuses after approval

## Verification
- npm test -- --run src/app/lib/platform-bff-client.test.ts src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
- npm run build

## QA
- MONTH: current request -> canonical review -> persisted status reread
- WEEK_n: persisted status transition
- warnings remain blocked for detailed review