### PR TITLE
fix(cashflow): align close status and management scope

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -124,6 +124,28 @@ function cashflowMonthCloseRequestPath(tenantId, requestId) {
   return `orgs/${tenantId}/cashflow_month_close_requests/${requestId}`;
 }
 
+async function alignMonthSettlementStatus(db, tenantId, result) {
+  const projects = Array.isArray(result?.items) && result.items.some((item) => item?.projectId)
+    ? result.items
+    : [result];
+  if (!db?.doc) return result;
+  await Promise.all(projects.map(async (project) => {
+    const projectId = readOptionalText(project?.projectId);
+    const yearMonth = readOptionalText(project?.yearMonth);
+    if (!projectId || !yearMonth || !Array.isArray(project.items)) return;
+    const snapshot = await db.doc(cashflowMonthCloseRequestPath(tenantId, `${projectId}-${yearMonth}`)).get();
+    if (!snapshot.exists) return;
+    const requestStatus = readOptionalText(snapshot.data()?.status);
+    const status = requestStatus === 'APPROVED'
+      ? 'COMPLETED'
+      : ['PENDING', 'APPROVING', 'UNCERTAIN'].includes(requestStatus)
+        ? 'PENDING_APPROVAL'
+        : 'WAITING_FOR_UPDATE';
+    project.items = project.items.map((item) => item.period === 'MONTH' ? { ...item, status } : item);
+  }));
+  return result;
+}
+
 function cashflowMonthCloseRequestMonthPath(tenantId, requestId, revision, yearMonth) {
   return `orgs/${tenantId}/cashflow_month_close_request_months/${requestId}-r${revision}-${yearMonth}`;
 }
@@ -707,12 +729,11 @@ function managementCheck(id, status, title, detail, findings = []) {
   return findings.length > 0 ? { id, status, title, detail, findings } : { id, status, title, detail };
 }
 
-function laborTransferCheck(weeks, cellStates, yearMonth, asOfKey) {
+function laborTransferCheck(weeks, cellStates, yearMonth) {
   const yearMonths = [...new Set([yearMonth, ...weeks.map((week) => readOptionalText(week.yearMonth))])].sort();
   const warnings = [];
   const reviews = [];
   for (const yearMonth of yearMonths) {
-    if (cashflowRangeSortKey({ yearMonth, weekNo: 3 }) > asOfKey) continue;
     const projection = cellStates.get(`${yearMonth}:projection:3:MYSC_LABOR_OUT`);
     if (!projection || projection.cellState === 'EMPTY') {
       warnings.push(`${yearMonth} 3주차 인건비 미입력`);
@@ -823,7 +844,7 @@ export function buildCashflowManagementChecks({ cashflow, cells, yearMonth, depo
     yearMonth: /^20\d{2}-(0[1-9]|1[0-2])$/.test(readOptionalText(row?.yearMonth)) ? row.yearMonth : yearMonth,
   }));
   return [
-    laborTransferCheck(weeks, cellStates, yearMonth, asOfKey),
+    laborTransferCheck(weeks, cellStates, yearMonth),
     profitVatAfterDepositCheck(weeks),
     negativeProjectionCheck(weeks, projectionOpeningBalance),
     futurePrepayCheck(weeks, asOfKey),
@@ -2640,7 +2661,7 @@ export function mountJvmWeeklyApiRoutes(app, {
       method: 'GET',
       path: `/api/v1/cashflow/${encodeURIComponent(projectId)}/settlement-statuses?yearMonth=${encodeURIComponent(yearMonth)}`,
     });
-    res.status(200).json(result);
+    res.status(200).json(await alignMonthSettlementStatus(db, req.context.tenantId, result));
   }));
 
   app.post('/api/v1/cashflow/settlement-statuses/batch', asyncHandler(async (req, res) => {
@@ -2667,7 +2688,7 @@ export function mountJvmWeeklyApiRoutes(app, {
       body: { projectIds, yearMonth },
       mutation: false,
     });
-    res.status(200).json(result);
+    res.status(200).json(await alignMonthSettlementStatus(db, req.context.tenantId, result));
   }));
 
   app.post('/api/v1/cashflow/:projectId/settlement-statuses/transition', asyncHandler(async (req, res) => {

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -456,6 +456,36 @@ describe('JVM weekly API BFF proxy', () => {
     );
   });
 
+  it('uses the canonical month-close request as the MONTH status source of truth', async () => {
+    const source = fullMonthCloseSource();
+    source.documents.set('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-08', {
+      requestId: 'project-a-2026-08', projectId: 'project-a', yearMonth: '2026-08', status: 'PENDING',
+    });
+    const settlement = {
+      projectId: 'project-a', yearMonth: '2026-08',
+      items: [{ period: 'MONTH', status: 'COMPLETED' }, { period: 'WEEK_1', status: 'COMPLETED' }],
+    };
+    const fetchImpl = vi.fn(async (_url, init) => new Response(JSON.stringify(
+      init.method === 'POST' ? { items: [structuredClone(settlement)], errors: [] } : structuredClone(settlement),
+    ), { status: 200, headers: { 'content-type': 'application/json' } }));
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { env: runtimeEnv, db: source.db });
+
+    await request(app)
+      .get('/api/v1/cashflow/project-a/settlement-statuses?yearMonth=2026-08')
+      .expect(200)
+      .expect((response) => {
+        expect(response.body.items).toEqual([
+          { period: 'MONTH', status: 'PENDING_APPROVAL' },
+          { period: 'WEEK_1', status: 'COMPLETED' },
+        ]);
+      });
+    await request(app)
+      .post('/api/v1/cashflow/settlement-statuses/batch')
+      .send({ projectIds: ['project-a'], yearMonth: '2026-08' })
+      .expect(200)
+      .expect((response) => expect(response.body.items[0].items[0]).toEqual({ period: 'MONTH', status: 'PENDING_APPROVAL' }));
+  });
+
   it('blocks an administrator from submitting an uncompleted settlement', async () => {
     const fetchImpl = vi.fn();
     const { app } = createApp(fetchImpl, createIdempotencyService(), { actorRole: 'admin' }, { env: runtimeEnv });
@@ -1244,7 +1274,7 @@ describe('JVM weekly API BFF proxy', () => {
           comparisonAsOfWeek: { yearMonth: '2026-06', weekNo: 2 },
         });
         expect(response.body.dashboard.comparison.weeks.map((week) => week.weekNo)).toEqual([1, 2]);
-        expect(response.body.dashboard.managementChecks.find((check) => check.id === 'labor-transfer')).toMatchObject({ status: 'OK' });
+        expect(response.body.dashboard.managementChecks.find((check) => check.id === 'labor-transfer')).toMatchObject({ status: 'WARNING' });
         expect(response.body.dashboard.deadlineSummary.current).toBeNull();
       });
   });
@@ -1841,6 +1871,7 @@ describe('JVM weekly API BFF proxy', () => {
     expect(checks[1].detail).toContain('2026-06 5주차에 매출입금이 있으나 [MYSC 수익·매출부가세] 계획이 Projection에 없습니다.');
     expect(checks[0].detail).toContain('실제 0원 · 실제 미이관');
     expect(checks[0].findings).toContain('2026-06 3주차 · 예정 10원 · 실제 0원 · 실제 미이관');
+    expect(checks[0].findings).toContain('2026-08 3주차 인건비 미입력');
     expect(checks[2].findings).toHaveLength(5);
     expect(checks[2].findings[0]).toContain('2026-06 1주차');
     expect(checks[2].findings.at(-1)).toContain('2026-06 5주차');

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -506,15 +506,13 @@ describe('CashflowProjectSheet monthly close shell', () => {
 
   it('keeps exact applied history in General Activity and searchable', () => {
     expect(source).not.toContain('AppliedCellHistory');
-    expect(source).toContain('일반 활동 기록');
-    expect(source).toContain('aria-label="일반 활동 기록 검색"');
+    expect(source).toContain('실제 반영 기록');
+    expect(source).toContain('aria-label="실제 반영 기록 검색"');
     expect(source).toContain("event.beforeState === 'EMPTY'");
     expect(source).toContain("event.beforeState === 'ZERO'");
     expect(source).toContain("event.afterState === 'EMPTY'");
-    expect(source).toContain('event.operationId');
-    expect(source).toContain('event.auditId');
-    expect(source).toContain('source {event.sourceDetail || event.source ||');
-    expect(source).toContain('operation {event.operation || event.type}');
+    expect(source).not.toContain('source {event.sourceDetail || event.source ||');
+    expect(source).not.toContain('operation {event.operation || event.type}');
     expect(source).toContain('aria-label="마감 후 변경 후보 전체 목록"');
   });
 
@@ -529,7 +527,7 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('setCashflowEvents((current) => mergeCashflowEvents(current, response.events))');
     expect(source).toContain('cashflowEventErrors.map');
     expect(source).toContain('onClick={() => void loadCashflowEventSource(failure.source)}');
-    expect(source).toContain('일반 활동 기록을 불러오는 중입니다.');
+    expect(source).toContain('실제 반영 기록을 불러오는 중입니다.');
     expect(source).toContain('아직 표시할 변경 기록이 없습니다.');
     expect(source).toContain('role="alert"');
     expect(source).not.toContain("setCashflowEventsError(resolveApiErrorMessage(error, '변경 이력을 불러오지 못했습니다.'))");

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -2955,7 +2955,7 @@ export function CashflowProjectSheet({
         <CardContent className="p-4">
           <div className="flex items-start justify-between gap-2 pb-3">
             <div>
-              <div className="text-[15px] font-bold tracking-[-0.01em] text-slate-950">일반 활동 기록</div>
+              <div className="text-[15px] font-bold tracking-[-0.01em] text-slate-950">실제 반영 기록</div>
               <div className="mt-0.5 text-[12px] leading-4 text-slate-600">{latestCashflowEventSummary(latestEvent)}</div>
             </div>
             <div className="flex shrink-0 flex-wrap justify-end gap-1">
@@ -2970,7 +2970,7 @@ export function CashflowProjectSheet({
             </div>
           </div>
           <div className="mb-2 grid gap-2 sm:grid-cols-3">
-            <Input aria-label="일반 활동 기록 검색" value={cashflowEventQuery} onChange={(event) => setCashflowEventQuery(event.target.value)} placeholder="항목·담당자·source 검색" />
+            <Input aria-label="실제 반영 기록 검색" value={cashflowEventQuery} onChange={(event) => setCashflowEventQuery(event.target.value)} placeholder="항목·담당자 검색" />
             <select aria-label="실제 반영 mode 필터" className="h-9 rounded-md border border-slate-300 bg-white px-2 text-[12px]" value={cashflowEventMode} onChange={(event) => setCashflowEventMode(event.target.value)}><option value="ALL">전체 mode</option><option value="projection">Projection</option><option value="actual">Actual</option></select>
             <select aria-label="실제 반영 월 필터" className="h-9 rounded-md border border-slate-300 bg-white px-2 text-[12px]" value={cashflowEventMonth} onChange={(event) => setCashflowEventMonth(event.target.value)}><option value="ALL">전체 월</option>{[...new Set(cashflowEvents.map((event) => event.yearMonth).filter(Boolean))].map((month) => <option key={month} value={month}>{month}</option>)}</select>
           </div>
@@ -2982,7 +2982,7 @@ export function CashflowProjectSheet({
           ))}
           <div className="max-h-[230px] space-y-0 overflow-auto rounded-md border border-slate-200 bg-slate-50 px-2 py-2 pr-1">
             {cashflowEventLoadingSources.length > 0 && filteredEvents.length === 0 ? (
-              <div role="status" className="px-2 py-8 text-center text-[12px] leading-4 text-slate-500">일반 활동 기록을 불러오는 중입니다.</div>
+              <div role="status" className="px-2 py-8 text-center text-[12px] leading-4 text-slate-500">실제 반영 기록을 불러오는 중입니다.</div>
             ) : filteredEvents.length === 0 ? (
               <div className="px-2 py-8 text-center text-[12px] leading-4 text-slate-500">
                 아직 표시할 변경 기록이 없습니다.
@@ -3017,7 +3017,6 @@ export function CashflowProjectSheet({
                     <div className="shrink-0 text-[12px] tabular-nums text-slate-400">{formatSheetAppliedAt(event.createdAt)}</div>
                   </div>
                   <div className="mt-1 text-[12px] leading-4 text-slate-500">{cashflowEventDetail(event)}</div>
-                  <div className="mt-1 break-all text-[12px] leading-4 text-slate-400">source {event.sourceDetail || event.source || '-'} · operation {event.operation || event.type} · operation ID {event.operationId || '-'} · run {event.runId || '-'} · audit {event.auditId || '-'} · 사유 {event.reason || '미기록'}</div>
                   {canRevert && (
                     <Button
                       type="button"


### PR DESCRIPTION
## What
- use the canonical monthly close request as the MONTH status source of truth
- include past and future project months in labor-transfer management checks
- restore the actual-application history label and hide developer metadata

## Verification
- 237 targeted tests passed
- production build passed
- open-code-review: no functional blocker