### PR TITLE
fix(cashflow): enforce canonical month approval

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -2707,6 +2707,9 @@ export function mountJvmWeeklyApiRoutes(app, {
     if (action === 'SUBMIT') {
       throw createHttpError(403, '실무자 포털에서 정산을 완료한 뒤에만 제출할 수 있습니다.', 'cashflow_settlement_submit_forbidden');
     }
+    if (period === 'MONTH') {
+      throw createHttpError(409, '월 결산은 저장된 결재 요청을 승인해 주세요.', 'cashflow_month_close_canonical_review_required');
+    }
     const result = await proxyMutation(
       req,
       `/api/v1/cashflow/${encodeURIComponent(projectId)}/settlement-statuses/transition`,

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -498,6 +498,18 @@ describe('JVM weekly API BFF proxy', () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it('blocks legacy MONTH approval from bypassing the canonical review request', async () => {
+    const fetchImpl = vi.fn();
+    const { app } = createApp(fetchImpl, createIdempotencyService(), { actorRole: 'admin' }, { env: runtimeEnv });
+
+    await request(app)
+      .post('/api/v1/cashflow/project-a/settlement-statuses/transition')
+      .send({ yearMonth: '2026-08', period: 'MONTH', action: 'APPROVE' })
+      .expect(409)
+      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_canonical_review_required'));
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it('reads up to 100 project settlement statuses with one JVM batch request', async () => {
     const projectIds = Array.from({ length: 100 }, (_, index) => `project-${index + 1}`);
     const canonical = {

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -106,6 +106,24 @@ describe('platform-bff-client', () => {
     }));
   });
 
+  it('does not report a direct canonical review as successful until approval is complete', async () => {
+    const monthRequest = {
+      requestId: 'p001-2026-08', projectId: 'p001', yearMonth: '2026-08', status: 'PENDING',
+      revision: 3, manifestHash: 'sha256:manifest', reviewWarnings: [],
+    };
+    const client = asMockClient({
+      get: vi.fn(),
+      post: vi.fn().mockResolvedValue({ data: { request: { ...monthRequest, status: 'APPROVING' } } }),
+      request: vi.fn(),
+    });
+
+    await expect(reviewCashflowMonthCloseRequestViaBff({
+      tenantId: 'mysc', actor: { uid: 'head-1', role: 'admin' }, projectId: 'p001', requestId: monthRequest.requestId,
+      payload: { decision: 'APPROVE', expectedRevision: 3, expectedManifestHash: 'sha256:manifest' },
+      idempotencyKey: 'month-close-review-1', client,
+    })).rejects.toThrow('월 결산 승인 상태를 확인하지 못했습니다.');
+  });
+
   it('posts all settlement project IDs in one bounded batch request', async () => {
     const data = { items: [], errors: [{ projectId: 'p002', code: 'STATUS_UNAVAILABLE' }] };
     const client = asMockClient({ post: vi.fn(async () => ({ data })), get: vi.fn(), request: vi.fn() });
@@ -273,6 +291,7 @@ describe('platform-bff-client', () => {
         projectId: 'p001',
         yearMonth: '2026-06',
         status: 'CLOSED',
+        request: { status: 'APPROVED' },
       } })),
       request: vi.fn(),
     });

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -3235,6 +3235,9 @@ export async function reviewCashflowMonthCloseRequestViaBff(params: {
       timeoutMs: 27_000,
     },
   );
+  if (params.payload.decision === 'APPROVE' && response.data.request.status !== 'APPROVED') {
+    throw new Error('월 결산 승인 상태를 확인하지 못했습니다.');
+  }
   return response.data;
 }
 


### PR DESCRIPTION
## What
- reject legacy generic MONTH approvals before they reach the JVM settlement transition
- fail closed unless canonical month-close review returns APPROVED
- preserve the existing WEEK transition path

## Why
Old browser bundles could send MONTH approval to the weekly settlement endpoint and show success while the canonical month-close request remained PENDING.

## Verification
- `npx vitest run src/app/lib/platform-bff-client.test.ts server/bff/routes/jvm-weekly-api.test.mjs` (236 passed)
- `npm run build`
- independent QA: PASS