### PR TITLE
fix(runtime): retire stale service worker caches

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'myscube-shell-v2';
+const CACHE_NAME = 'myscube-shell-v3';
 const CACHEABLE_PREFIXES = ['/brand/'];
 const NEVER_CACHE_PREFIXES = ['/api/', '/api/v1/', '/business-card-imports/'];
 

--- a/src/app/platform/service-worker-cache.shell.test.ts
+++ b/src/app/platform/service-worker-cache.shell.test.ts
@@ -3,10 +3,28 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const serviceWorkerSource = readFileSync(resolve(import.meta.dirname, '../../../public/sw.js'), 'utf8');
+const mainSource = readFileSync(resolve(import.meta.dirname, '../../main.tsx'), 'utf8');
+const vercelConfig = JSON.parse(
+  readFileSync(resolve(import.meta.dirname, '../../../vercel.json'), 'utf8'),
+) as { headers?: Array<{ source?: string; headers?: Array<{ key?: string; value?: string }> }> };
 
 describe('service worker cache policy', () => {
   it('does not cache hashed Vite assets ahead of the network', () => {
     expect(serviceWorkerSource).not.toContain("'/assets/'");
     expect(serviceWorkerSource).toContain("const CACHEABLE_PREFIXES = ['/brand/'];");
+  });
+
+  it('retires legacy asset caches and bypasses HTTP cache for worker updates', () => {
+    expect(serviceWorkerSource).toContain("const CACHE_NAME = 'myscube-shell-v3';");
+    expect(mainSource).toContain("navigator.serviceWorker.register('/sw.js', { updateViaCache: 'none' })");
+  });
+
+  it('serves the worker without CDN or browser caching', () => {
+    const workerHeaders = vercelConfig.headers?.find(({ source }) => source === '/sw.js')?.headers;
+
+    expect(workerHeaders).toContainEqual({
+      key: 'Cache-Control',
+      value: 'no-store, max-age=0, must-revalidate',
+    });
   });
 });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,7 +11,7 @@ installGlobalObservabilityHandlers();
 
 if (typeof window !== 'undefined' && 'serviceWorker' in navigator && import.meta.env.PROD) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch((error) => {
+    navigator.serviceWorker.register('/sw.js', { updateViaCache: 'none' }).catch((error) => {
       console.warn('[MYSC] service worker registration failed:', error);
     });
   });

--- a/vercel.json
+++ b/vercel.json
@@ -61,6 +61,12 @@
   ],
   "headers": [
     {
+      "source": "/sw.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, max-age=0, must-revalidate" }
+      ]
+    },
+    {
       "source": "/__/auth/(.*)",
       "headers": [
         { "key": "X-Content-Type-Options", "value": "nosniff" },


### PR DESCRIPTION
## What
- bump the service worker cache version so legacy cached assets are deleted
- bypass HTTP cache when checking `/sw.js` updates
- serve `/sw.js` with `no-store` while keeping user-controlled refresh behavior

## Why
Older workers cached hashed Vite assets under the same `myscube-shell-v2` cache. Live `/sw.js` was also served with a four-hour cache TTL, allowing weekly/monthly cashflow pages to keep obsolete JavaScript after deployments.

## Verification
- focused runtime/PWA tests: 9 passed
- PWA package validation: passed
- production build: passed
- full suite: 2,651 passed; two unrelated socket-hang-up flakes passed when rerun in isolation
- `git diff --check`: passed

## Ops
After deployment, verify canonical `/sw.js` returns `Cache-Control: no-store, max-age=0, must-revalidate`, contains `myscube-shell-v3`, and current hashed JS assets return 200. No forced page refresh was added.