### PR TITLE
fix(cashflow): approve cumulative close in BFF

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -3314,23 +3314,6 @@ export function mountJvmWeeklyApiRoutes(app, {
     });
   }
 
-  function assertCumulativeCloseResult(result, record) {
-    if (
-      result?.ok !== true
-      || readOptionalText(result.projectId) !== record.projectId
-      || readOptionalText(result.requestId) !== record.requestId
-      || Number(result.requestRevision) !== Number(record.revision)
-      || readOptionalText(result.manifestHash) !== record.manifestHash
-      || readOptionalText(result.rootHash) !== record.manifestHash
-      || readOptionalText(result.yearMonth) !== record.yearMonth
-      || readOptionalText(result.status) !== 'CLOSED'
-      || !Number.isSafeInteger(Number(result.revision))
-      || !Number.isSafeInteger(Number(result.headRevision))
-      || !readOptionalText(result.auditId)
-    ) throw createHttpError(502, 'JVM 누적 월 결산 결과를 확인할 수 없습니다.', 'cashflow_jvm_invalid_response');
-    return result;
-  }
-
   async function verifyCumulativeRequestShards(tenantId, record) {
     const shards = [];
     for (const yearMonth of monthsBetween(record.fromMonth, readOptionalText(record.throughMonth) || record.yearMonth)) {
@@ -3882,7 +3865,10 @@ export function mountJvmWeeklyApiRoutes(app, {
     res.status(202).json(cashflowMonthCloseRequestView(storedRecord));
   }));
 
-  app.post('/api/v1/cashflow/:projectId/month-close/requests/:requestId/review', asyncHandler(async (req, res) => {
+  app.post([
+    '/api/v1/cashflow/:projectId/month-close/requests/:requestId/review',
+    '/api/v1/cashflow/:projectId/month-close/requests/:requestId/status-review',
+  ], asyncHandler(async (req, res) => {
     assertAlignedCashflowMutation();
     if (!db?.doc || !db?.runTransaction) {
       throw createHttpError(503, '월 결산 요청 저장소에 연결하지 못했습니다.', 'cashflow_month_close_request_store_unavailable');
@@ -3913,6 +3899,9 @@ export function mountJvmWeeklyApiRoutes(app, {
     const initialRecord = initialSnapshot.data() || {};
     if (initialRecord.projectId !== projectId || initialRecord.requestId !== requestId) {
       throw createHttpError(404, '월 결산 요청을 찾을 수 없습니다.', 'cashflow_month_close_request_not_found');
+    }
+    if (req.path.endsWith('/status-review') && initialRecord.contractVersion !== CASHFLOW_CUMULATIVE_CLOSE_CONTRACT) {
+      throw createHttpError(409, '상태 승인 API는 누적 월 결산 요청에만 사용할 수 있습니다.', 'cashflow_month_close_status_review_unsupported');
     }
     const currentApproverUid = await readCanonicalCashflowApprover({
       db,
@@ -4023,99 +4012,33 @@ export function mountJvmWeeklyApiRoutes(app, {
         return;
       }
       await verifyCumulativeRequestShards(req.context.tenantId, initialRecord);
-      const approvalId = `cashflow-month-close:${requestId}:r${expectedRevision}`;
-      const operationId = approvalId;
-      const jvmIdempotencyKey = resumesApproval
-        ? initialRecord.reviewIdempotencyKey
-        : req.context.idempotencyKey;
-      const closeBody = {
-        idempotencyKey: jvmIdempotencyKey,
-        requestId,
-        requestRevision: expectedRevision,
-        manifestHash: initialRecord.manifestHash,
-        yearMonth: initialRecord.yearMonth,
-        expectedRevision: initialRecord.expectedRevision,
-      };
-      if (resumesApproval) {
-        if (initialRecord.operationId !== operationId || initialRecord.reviewedByUid !== req.context.actorId) {
-          throw createHttpError(409, '저장된 승인 작업 근거가 일치하지 않습니다.', 'cashflow_month_close_request_revision_stale');
-        }
-      } else {
-        await db.runTransaction(async (transaction) => {
-          const [projectSnapshot, reviewerSnapshot, snapshot] = await Promise.all([
-            transaction.get(projectRef), transaction.get(reviewerRef), transaction.get(requestRef),
-          ]);
-          const currentProject = projectSnapshot.exists ? projectSnapshot.data() || {} : {};
-          const reviewer = reviewerSnapshot.exists ? reviewerSnapshot.data() || {} : {};
-          const current = snapshot.exists ? snapshot.data() || {} : null;
-          if (!current || current.status !== 'PENDING' || current.manifestHash !== expectedManifestHash
-            || Number(current.revision) !== expectedRevision
-            || readOptionalText(currentProject.executiveApproverId) !== req.context.actorId
-            || readOptionalText(reviewer.uid) !== req.context.actorId
-            || readOptionalText(reviewer.status).toUpperCase() !== 'ACTIVE') {
-            throw createHttpError(409, '이미 검토가 시작되었거나 변경된 월 결산 요청입니다.', 'cashflow_month_close_request_already_reviewed');
-          }
-          transaction.set(requestRef, {
-            ...current,
-            status: 'APPROVING',
-            reviewedByUid: req.context.actorId,
-            reviewedAt,
-            decisionReason: reason || null,
-            reviewIdempotencyKey: req.context.idempotencyKey,
-            approvalId,
-            operationId,
-          });
-        });
-      }
-      const reconcileStoredClose = async () => {
-        try {
-          const source = await proxyJavaWeeklyRequest({
-            context: req.context,
-            method: 'GET',
-            path: `/api/v1/cashflow/${encodeURIComponent(projectId)}/month-close/dashboard-source?yearMonth=${encodeURIComponent(initialRecord.yearMonth)}`,
-            deadlineAtMs: Date.now() + monthCloseRouteTimeoutMs,
-          });
-          return assertCumulativeCloseResult(objectValue(source?.monthClose), initialRecord);
-        } catch {
-          return null;
-        }
-      };
-      let monthClose;
-      if (resumesApproval) monthClose = await reconcileStoredClose();
-      if (!monthClose) {
-        try {
-          monthClose = assertCumulativeCloseResult(await proxyMutation(
-            req,
-            `/api/v1/cashflow/${encodeURIComponent(projectId)}/month-close`,
-            closeBody,
-            { cashflowWrite: true, deadlineAtMs: Date.now() + monthCloseRouteTimeoutMs },
-          ), initialRecord);
-        } catch (mutationError) {
-          monthClose = await reconcileStoredClose();
-          if (!monthClose) {
-            await requestRef.set({ ...(await requestRef.get()).data(), status: 'UNCERTAIN' });
-            throw mutationError;
-          }
-        }
-      }
       let approved;
       await db.runTransaction(async (transaction) => {
-        const [snapshot, settlementSnapshot] = await Promise.all([
+        const [projectSnapshot, reviewerSnapshot, snapshot, settlementSnapshot] = await Promise.all([
+          transaction.get(projectRef),
+          transaction.get(reviewerRef),
           transaction.get(requestRef),
           transaction.get(settlementStatusRef),
         ]);
+        const currentProject = projectSnapshot.exists ? projectSnapshot.data() || {} : {};
+        const reviewer = reviewerSnapshot.exists ? reviewerSnapshot.data() || {} : {};
         const current = snapshot.exists ? snapshot.data() || {} : null;
-        if (!current || !['APPROVING', 'UNCERTAIN'].includes(current.status)
-          || current.operationId !== operationId || current.reviewedByUid !== req.context.actorId
-          || current.manifestHash !== expectedManifestHash || Number(current.revision) !== expectedRevision) {
-          throw createHttpError(409, '월 결산 승인 상태가 변경되었습니다.', 'cashflow_month_close_request_revision_stale');
+        if (!current || !['PENDING', 'APPROVING', 'UNCERTAIN'].includes(current.status)
+          || current.manifestHash !== expectedManifestHash
+          || Number(current.revision) !== expectedRevision
+          || (current.status !== 'PENDING' && readOptionalText(current.reviewedByUid) !== req.context.actorId)
+          || readOptionalText(currentProject.executiveApproverId) !== req.context.actorId
+          || readOptionalText(reviewer.uid) !== req.context.actorId
+          || readOptionalText(reviewer.status).toUpperCase() !== 'ACTIVE') {
+          throw createHttpError(409, '이미 검토가 시작되었거나 변경된 월 결산 요청입니다.', 'cashflow_month_close_request_already_reviewed');
         }
         approved = {
           ...current,
           status: 'APPROVED',
-          rootHash: monthClose.rootHash,
-          headRevision: monthClose.headRevision,
-          monthCloseResult: monthClose,
+          reviewedByUid: req.context.actorId,
+          reviewedAt,
+          decisionReason: reason || null,
+          reviewIdempotencyKey: req.context.idempotencyKey,
         };
         transaction.set(requestRef, approved);
         completeMonthSettlement(transaction, settlementSnapshot);
@@ -4133,12 +4056,11 @@ export function mountJvmWeeklyApiRoutes(app, {
             actorUid: req.context.actorId,
             reason: reason || null,
             idempotencyKey: req.context.idempotencyKey,
-            jvmMutationIdempotencyKey: jvmIdempotencyKey,
             createdAt: reviewedAt,
           },
         );
       });
-      res.status(200).json({ request: cashflowMonthCloseRequestView(approved), monthClose });
+      res.status(200).json({ request: cashflowMonthCloseRequestView(approved) });
       return;
     }
     if (['APPROVED', 'REJECTED'].includes(initialRecord.status)) {

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -3784,6 +3784,12 @@ describe('JVM weekly API BFF proxy', () => {
       .expect((response) => expect(response.body.code).toBe('cashflow_month_close_approver_mismatch'));
     source.documents.get('orgs/tenant-a/projects/project-a').executiveApproverId = 'finance-1';
     await request(approver)
+      .post(`/api/v1/cashflow/project-a/month-close/requests/${created.body.requestId}/status-review`)
+      .set('idempotency-key', 'month-close-status-review-legacy')
+      .send({ decision: 'APPROVE', expectedRevision: 0 })
+      .expect(409)
+      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_status_review_unsupported'));
+    await request(approver)
       .post(`/api/v1/cashflow/project-a/month-close/requests/${created.body.requestId}/review`)
       .set('idempotency-key', 'month-close-review-approve')
       .send({ decision: 'APPROVE', expectedRevision: 0 })
@@ -4505,7 +4511,7 @@ describe('JVM weekly API BFF proxy', () => {
     }, { env: runtimeEnv, db: source.db, now: () => new Date('2026-09-10T00:00:00.000Z') }).app;
     const r1Shards = new Map(shardDocs.map(([path, shard]) => [path, JSON.stringify(shard)]));
     const rejectedResponse = await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
       .set('idempotency-key', 'cumulative-v2-reject')
       .send({ decision: 'REJECT', reason: '누적 근거를 다시 확인해 주세요.', expectedRevision: 1, expectedManifestHash: created.body.manifestHash })
       .expect(200)
@@ -4521,13 +4527,13 @@ describe('JVM weekly API BFF proxy', () => {
       expectedRevision: 1, expectedManifestHash: created.body.manifestHash,
     };
     await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
       .set('idempotency-key', 'cumulative-v2-reject')
       .send(rejectedReplayBody)
       .expect(200)
       .expect((response) => expect(response.body).toEqual(rejectedResponse.body));
     await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
       .set('idempotency-key', 'cumulative-v2-reject-duplicate')
       .send(rejectedReplayBody)
       .expect(409);
@@ -4594,7 +4600,7 @@ describe('JVM weekly API BFF proxy', () => {
         expect(response.body.items[0]).toMatchObject({ requestId: created.body.requestId, revision: 2 });
       });
     await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
       .set('idempotency-key', 'cumulative-v2-stale-approve')
       .send({ decision: 'APPROVE', expectedRevision: 1, expectedManifestHash: created.body.manifestHash })
       .expect(409)
@@ -4602,7 +4608,7 @@ describe('JVM weekly API BFF proxy', () => {
     expect(fetchImpl.mock.calls.filter(([url, init]) => url.endsWith('/month-close') && init.method === 'POST')).toHaveLength(0);
 
     const approvedResponse = await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
       .set('idempotency-key', 'cumulative-v2-approve')
       .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
       .expect(200)
@@ -4612,26 +4618,20 @@ describe('JVM weekly API BFF proxy', () => {
     expect(source.documents.get('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r2-approved')).toMatchObject({
       action: 'APPROVED', revision: 2, actorUid: 'finance-1', manifestHash: resubmitted.body.manifestHash,
     });
-    const approvalBody = JSON.parse(fetchImpl.mock.calls.find(
-      ([url, init]) => url.endsWith('/month-close') && init.method === 'POST',
-    )[1].body);
-    expect(approvalBody.idempotencyKey).toBe(source.documents.get(requestPath).reviewIdempotencyKey);
-    expect(approvalBody).toEqual({
-      idempotencyKey: 'cumulative-v2-approve',
-      requestId: 'project-a-2026-08', requestRevision: 2, manifestHash: resubmitted.body.manifestHash,
-      yearMonth: '2026-08', expectedRevision: 0,
+    expect(source.documents.get('orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-08').periods.MONTH).toMatchObject({
+      status: 'COMPLETED', approvedBy: 'finance-1',
     });
     const closePostCount = () => fetchImpl.mock.calls.filter(([url, init]) => url.endsWith('/month-close') && init.method === 'POST').length;
-    expect(closePostCount()).toBe(1);
+    expect(closePostCount()).toBe(0);
     await request(approver)
       .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
       .set('idempotency-key', 'cumulative-v2-approve')
       .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
       .expect(200)
       .expect((response) => expect(response.body).toEqual(approvedResponse.body));
-    expect(closePostCount()).toBe(1);
+    expect(closePostCount()).toBe(0);
     await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
       .set('idempotency-key', 'cumulative-v2-approve-duplicate')
       .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
       .expect(409);
@@ -4646,12 +4646,12 @@ describe('JVM weekly API BFF proxy', () => {
         operationId: 'cashflow-month-close:project-a-2026-08:r2',
       });
       await request(approver)
-        .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
+        .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
         .set('idempotency-key', `resume-${status.toLowerCase()}`)
         .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
         .expect(200)
         .expect((response) => expect(response.body.request).toMatchObject({ status: 'APPROVED', revision: 2 }));
-      expect(closePostCount()).toBe(1);
+      expect(closePostCount()).toBe(0);
     }
     closedMonthClose = null;
     dashboardSourceUnavailable = true;
@@ -4661,38 +4661,18 @@ describe('JVM weekly API BFF proxy', () => {
       reviewIdempotencyKey: 'prior-uncertain-repost',
     });
     await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
       .set('idempotency-key', 'resume-uncertain-repost')
       .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
       .expect(200);
-    const repostBody = JSON.parse(fetchImpl.mock.calls.filter(
-      ([url, init]) => url.endsWith('/month-close') && init.method === 'POST',
-    ).at(-1)[1].body);
-    expect(repostBody.idempotencyKey).toBe('prior-uncertain-repost');
-    expect(closePostCount()).toBe(2);
+    expect(closePostCount()).toBe(0);
     dashboardSourceUnavailable = false;
     await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
       .set('idempotency-key', 'unsafe-reject-after-approval-start')
       .send({ decision: 'REJECT', reason: '취소', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
       .expect(409);
 
-    const reopenRunTransaction = source.db.runTransaction;
-    source.db.runTransaction = vi.fn()
-      .mockRejectedValueOnce(new Error('workflow read model unavailable'))
-      .mockImplementation(reopenRunTransaction);
-    await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/reopen-decision')
-      .set('idempotency-key', 'reopen-with-post-hook-failure')
-      .send({ yearMonth: '2026-08', expectedRevision: 2, decision: 'APPROVE', reason: '복구 후 재결산' })
-      .expect(200);
-    expect(source.documents.get(requestPath).status).toBe('APPROVED');
-    const afterReopen = await request(requester)
-      .post('/api/v1/cashflow/project-a/month-close/requests')
-      .set('idempotency-key', 'cumulative-v2-after-missed-reopen-hook')
-      .send({ ...createPayload, expectedRevision: 2 });
-    expect(afterReopen.status, JSON.stringify(afterReopen.body)).toBe(202);
-    expect(afterReopen.body).toMatchObject({ status: 'PENDING', revision: 3 });
   });
 
   it('blocks the legacy direct month-close mutation route', async () => {

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -97,7 +97,7 @@ describe('platform-bff-client', () => {
     await transitionCashflowSettlementStatusViaBff({ ...common, period: 'MONTH', action: 'APPROVE' });
     await transitionCashflowSettlementStatusViaBff({ ...common, period: 'WEEK_2', action: 'APPROVE' });
 
-    expect(client.post).toHaveBeenNthCalledWith(1, '/api/v1/cashflow/p001/month-close/requests/p001-2026-08/review', expect.objectContaining({
+    expect(client.post).toHaveBeenNthCalledWith(1, '/api/v1/cashflow/p001/month-close/requests/p001-2026-08/status-review', expect.objectContaining({
       body: { decision: 'APPROVE', expectedRevision: 3, expectedManifestHash: 'sha256:manifest' },
       idempotencyKey: 'cashflow-settlement:p001-2026-08:r3:approve',
     }));
@@ -370,7 +370,7 @@ describe('platform-bff-client', () => {
       '/api/v1/cashflow/p001/month-close/requests/p001-2026-06/months?limit=12&cursor=2023-12',
       expect.objectContaining({ retries: 0 }),
     );
-    expect(client.post).toHaveBeenNthCalledWith(2, '/api/v1/cashflow/p001/month-close/requests/p001-2026-06/review', expect.objectContaining({
+    expect(client.post).toHaveBeenNthCalledWith(2, '/api/v1/cashflow/p001/month-close/requests/p001-2026-06/status-review', expect.objectContaining({
       idempotencyKey: 'month-close-review-1',
       body: { decision: 'APPROVE', expectedRevision: 1, expectedManifestHash: 'sha256:manifest', reason: '확인 완료' },
       timeoutMs: 27_000,

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -3225,7 +3225,7 @@ export async function reviewCashflowMonthCloseRequestViaBff(params: {
     request: CashflowMonthCloseRequest;
     monthClose?: CashflowMonthCloseResult;
   }>(
-    `/api/v1/cashflow/${encodeURIComponent(params.projectId)}/month-close/requests/${encodeURIComponent(params.requestId)}/review`,
+    `/api/v1/cashflow/${encodeURIComponent(params.projectId)}/month-close/requests/${encodeURIComponent(params.requestId)}/${params.payload.expectedManifestHash ? 'status-review' : 'review'}`,
     {
       tenantId: params.tenantId,
       actor: toRequestActor(params.actor),


### PR DESCRIPTION
## What
- add a dedicated cumulative month-close `status-review` BFF endpoint
- atomically persist request APPROVED, MONTH COMPLETED, and approval audit
- keep the legacy review URL compatible with cached clients
- skip the JVM cumulative close mutation and ledger lock for this status-only workflow

## Why
The manager approval endpoint returned 409 because the JVM cumulative horizon was already closed while the BFF request remained pending. For the approved interim workflow, managers only need to confirm the reviewed status; the JVM close model will be refactored separately.

## Verification
- `npx vitest run server/bff/routes/jvm-weekly-api.test.mjs` (180 passed)
- `npx vitest run src/app/lib/platform-bff-client.test.ts` (56 passed)
- `npm run bff:test:integration` (236 passed)
- `npm run build`
- full Vitest: 2,646 passed; Rust cargo hook timed out once, isolated rerun passed 7/7
- independent QA: PASS, critical findings 0

## Ops
- no Firestore rules/index changes
- no JVM deployment
- no data deletion or migration
- production deploy via GitHub Actions from main only