### PR TITLE
fix(cashflow): persist weekly submission status in transaction

### DIFF
--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -1534,6 +1534,10 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             "orgs/" + actor.tenantId() + "/cashflow_weekly_compliance_heads/" + projectId
         );
         DocumentSnapshot complianceHeadSnapshot = get(complianceHeadRef);
+        String settlementPeriod = "WEEK_" + request.weekNo();
+        CashflowSettlementStatusRecord settlementStatus = findCashflowSettlementStatuses(
+            actor.tenantId(), projectId, request.yearMonth()
+        ).stream().filter(item -> settlementPeriod.equals(item.period())).findFirst().orElseThrow();
         Map<String, Object> lockedCompletion = null;
         if (snapshot.exists()) {
             Map<String, Object> existing = data(snapshot);
@@ -1556,7 +1560,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             projectWeeks.put(weekSnapshot.getId(), week);
         }
         if (lockedCompletion != null) {
-            submitWeeklySettlementIfWaiting(actor, projectId, request.yearMonth(), request.weekNo());
+            submitWeeklySettlementIfWaiting(actor, projectId, request.yearMonth(), settlementStatus);
             return toWeeklyCompletionRecord(
                 projectId, request.yearMonth(), request.weekNo(), lockedCompletion, true
             );
@@ -1651,18 +1655,18 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         }
         set(ref, completion);
         set(versionRef, version);
-        submitWeeklySettlementIfWaiting(actor, projectId, request.yearMonth(), request.weekNo());
+        submitWeeklySettlementIfWaiting(actor, projectId, request.yearMonth(), settlementStatus);
         return toWeeklyCompletionRecord(projectId, request.yearMonth(), request.weekNo(), completion, false);
     }
 
     private void submitWeeklySettlementIfWaiting(
-        TrustedActorContext actor, String projectId, String yearMonth, int weekNo
+        TrustedActorContext actor,
+        String projectId,
+        String yearMonth,
+        CashflowSettlementStatusRecord status
     ) {
-        String period = "WEEK_" + weekNo;
-        CashflowSettlementStatusRecord status = findCashflowSettlementStatuses(actor.tenantId(), projectId, yearMonth)
-            .stream().filter(item -> period.equals(item.period())).findFirst().orElseThrow();
         if ("WAITING_FOR_UPDATE".equals(status.status())) {
-            transitionCashflowSettlementStatus(actor, projectId, yearMonth, period, "SUBMIT");
+            transitionCashflowSettlementStatus(actor, projectId, yearMonth, status.period(), "SUBMIT");
         }
     }
 

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -48,6 +48,7 @@ import dev.merryai.innerplatform.weekly.service.WeeklyExpenseAuthorizationServic
 import dev.merryai.innerplatform.weekly.service.WeeklyExpenseCommandService;
 import dev.merryai.innerplatform.weekly.service.WeeklyProjectExistenceRepository;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -71,6 +72,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -185,6 +187,118 @@ class FirestoreCashflowLeaseGuardTest {
         assertThat(result).containsOnlyKeys("project-a");
         assertThat(result.get("project-a")).hasSize(6);
         assertThat(result.get("project-a").getFirst().status()).isEqualTo("COMPLETED");
+    }
+
+    @Test
+    void readsWeeklySettlementStatusBeforeTheFirstTransactionalWrite() {
+        Fixture fixture = fixture(activeMember(), Map.of());
+
+        fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
+            .completeCashflowWeeklyUpdate(
+                ACTOR,
+                "project-a",
+                new CompleteCashflowWeeklyUpdateRequest(
+                    "read-before-write", "2026-08", 2, "2026-08-04T01:21:00Z", "NO_CHANGES"
+                )
+            ));
+
+        InOrder order = inOrder(fixture.transaction);
+        order.verify(fixture.transaction).get(fixture.refs.get(
+            "orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-08"
+        ));
+        order.verify(fixture.transaction).set(argThat(ref -> ref.getPath().equals(
+            "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-08-w2"
+        )), any(), any());
+    }
+
+    @Test
+    void writesCanonicalJanuaryAndAugustWeeklySettlementKeys() {
+        Fixture january = fixture(activeMember(), Map.of());
+        Fixture august = fixture(activeMember(), Map.of());
+
+        january.persistence.runCommandTransaction(() -> commandService(january.persistence)
+            .completeCashflowWeeklyUpdate(
+                ACTOR,
+                "project-a",
+                new CompleteCashflowWeeklyUpdateRequest(
+                    "january-week-one", "2026-01", 1, "2026-01-02T01:00:00Z", "NO_CHANGES"
+                )
+            ));
+        august.persistence.runCommandTransaction(() -> commandService(august.persistence)
+            .completeCashflowWeeklyUpdate(
+                ACTOR,
+                "project-a",
+                new CompleteCashflowWeeklyUpdateRequest(
+                    "august-week-two", "2026-08", 2, "2026-08-04T01:21:00Z", "NO_CHANGES"
+                )
+            ));
+
+        assertThat(january.documents)
+            .containsKey("orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-01-w1")
+            .containsKey("orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-01");
+        assertThat(((Map<?, ?>) ((Map<?, ?>) january.documents.get(
+            "orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-01"
+        ).get("periods")).get("WEEK_1")).get("status")).isEqualTo("PENDING_APPROVAL");
+        assertThat(august.documents)
+            .containsKey("orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-08-w2")
+            .containsKey("orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-08");
+        assertThat(((Map<?, ?>) ((Map<?, ?>) august.documents.get(
+            "orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-08"
+        ).get("periods")).get("WEEK_2")).get("status")).isEqualTo("PENDING_APPROVAL");
+    }
+
+    @Test
+    void rejectsManagerApprovalBeforeWeeklyCompletion() {
+        Fixture fixture = fixture(activeMember(), Map.of());
+        fixture.documents.put("orgs/tenant-a/projects/project-a", Map.of(
+            "id", "project-a",
+            "tenantId", "tenant-a",
+            "executiveApproverId", "manager-1"
+        ));
+        TrustedActorContext manager = new TrustedActorContext(
+            "tenant-a", "manager-1", "manager@example.com", "manager", "Manager"
+        );
+
+        assertThatThrownBy(() -> fixture.persistence.runCommandTransaction(() ->
+            fixture.persistence.transitionCashflowSettlementStatus(
+                manager, "project-a", "2026-08", "WEEK_2", "APPROVE"
+            )
+        ))
+            .isInstanceOf(WeeklyExpenseConflictException.class)
+            .hasMessageContaining("status changed");
+    }
+
+    @Test
+    void allowsManagerApprovalAfterWeeklyCompletion() {
+        Fixture fixture = fixture(activeMember(), Map.of());
+        fixture.documents.put("orgs/tenant-a/projects/project-a", Map.of(
+            "id", "project-a",
+            "tenantId", "tenant-a",
+            "executiveApproverId", "manager-1"
+        ));
+        TrustedActorContext manager = new TrustedActorContext(
+            "tenant-a", "manager-1", "manager@example.com", "manager", "Manager"
+        );
+
+        fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
+            .completeCashflowWeeklyUpdate(
+                ACTOR,
+                "project-a",
+                new CompleteCashflowWeeklyUpdateRequest(
+                    "complete-then-approve", "2026-08", 2, "2026-08-04T01:21:00Z", "NO_CHANGES"
+                )
+            ));
+        WeeklyExpensePersistence.CashflowSettlementStatusRecord approved = fixture.persistence
+            .runCommandTransaction(() -> fixture.persistence.transitionCashflowSettlementStatus(
+                manager, "project-a", "2026-08", "WEEK_2", "APPROVE"
+            ));
+
+        assertThat(approved.status()).isEqualTo("COMPLETED");
+        assertThat(approved.approvedBy()).isEqualTo("Manager");
+        Map<?, ?> week = (Map<?, ?>) ((Map<?, ?>) fixture.documents.get(
+            "orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-08"
+        ).get("periods")).get("WEEK_2");
+        assertThat(week.get("status")).isEqualTo("COMPLETED");
     }
 
     @Test


### PR DESCRIPTION
## What
- read the canonical weekly settlement status before the first Firestore transaction write
- reuse that read when the completion button submits `WEEK_N` to `PENDING_APPROVAL`
- keep legacy completion history out of the admin status path

## Why
Firestore rejects reads performed after transaction writes. The completion record could succeed while the canonical admin status transition failed, leaving `주정산 이전` visible.

## Verification
- `mvn -f server/jvm-weekly-api/pom.xml -Dtest=FirestoreCashflowLeaseGuardTest test` (115 passed)
- `mvn -f server/jvm-weekly-api/pom.xml test` (291 passed)
- `git diff --check origin/main...HEAD`

## Ops
- JVM production deployment is required after merge.
- No database reset or legacy backfill.