### PR TITLE
fix(frontend): apply cashflow and project QA updates

### DIFF
--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -509,7 +509,7 @@ function buildConfigResponse(projectId, config, systemAccountEmail = '', project
   };
 }
 
-function resolvePreviewSource(parsed, savedConfig, preserveLegacySavedRange = false) {
+function resolvePreviewSource(parsed, savedConfig) {
   const value = readOptionalText(parsed.value);
   if (value) {
     return {
@@ -526,8 +526,8 @@ function resolvePreviewSource(parsed, savedConfig, preserveLegacySavedRange = fa
       sourceYear: Number(savedConfig.sourceYear),
       value: savedConfig.value,
       sheetName: readOptionalText(parsed.sheetName) || savedConfig.sheetName || undefined,
-      startWeek: preserveLegacySavedRange ? savedConfig.startWeek : '',
-      endWeek: preserveLegacySavedRange ? savedConfig.endWeek : '',
+      startWeek: '',
+      endWeek: '',
       source: 'saved_config',
     };
   }
@@ -3716,7 +3716,6 @@ export function mountCashflowSheetLabRoutes(app, {
   sheetPreviewCacheTtlMs = DEFAULT_SHEET_PREVIEW_CACHE_TTL_MS,
   performanceLogger,
   performanceNow,
-  preserveLegacySavedRange = false,
 } = {}) {
   if (enabled === false) {
     app.use('/api/v1/projects/:projectId/cashflow-sheet-lab', (_req, res) => {
@@ -3806,7 +3805,6 @@ export function mountCashflowSheetLabRoutes(app, {
     const source = resolvePreviewSource(
       { ...parsed, sourceYear },
       readCashflowSheetLabConfig(project, sourceYear),
-      preserveLegacySavedRange,
     );
     const weekRange = normalizeWeekRange(source);
     const configRevision = computeCashflowSheetConfigRevision({ ...source, ...weekRange });

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -509,15 +509,15 @@ function buildConfigResponse(projectId, config, systemAccountEmail = '', project
   };
 }
 
-function resolvePreviewSource(parsed, savedConfig) {
+function resolvePreviewSource(parsed, savedConfig, preserveLegacySavedRange = false) {
   const value = readOptionalText(parsed.value);
   if (value) {
     return {
       sourceYear: Number(parsed.sourceYear || savedConfig?.sourceYear),
       value,
       sheetName: readOptionalText(parsed.sheetName) || undefined,
-      startWeek: readOptionalText(parsed.startWeek),
-      endWeek: readOptionalText(parsed.endWeek),
+      startWeek: '',
+      endWeek: '',
       source: 'request',
     };
   }
@@ -526,8 +526,8 @@ function resolvePreviewSource(parsed, savedConfig) {
       sourceYear: Number(savedConfig.sourceYear),
       value: savedConfig.value,
       sheetName: readOptionalText(parsed.sheetName) || savedConfig.sheetName || undefined,
-      startWeek: readOptionalText(parsed.startWeek) || savedConfig.startWeek,
-      endWeek: readOptionalText(parsed.endWeek) || savedConfig.endWeek,
+      startWeek: preserveLegacySavedRange ? savedConfig.startWeek : '',
+      endWeek: preserveLegacySavedRange ? savedConfig.endWeek : '',
       source: 'saved_config',
     };
   }
@@ -566,14 +566,11 @@ function normalizeWeekRange({ startWeek, endWeek }) {
 }
 
 function computeCashflowSheetConfigRevision(config = {}) {
-  const weekRange = normalizeWeekRange(config);
   const rawValue = readOptionalText(config?.value);
   return `sha256:${stableHash({
     sourceYear: Number(config?.sourceYear) || null,
     spreadsheetId: extractSpreadsheetId(rawValue) || rawValue,
     sheetName: readOptionalText(config?.sheetName),
-    startWeek: weekRange.startWeek,
-    endWeek: weekRange.endWeek,
   })}`;
 }
 
@@ -804,8 +801,8 @@ async function saveCashflowSheetLabConfig({ db, tenantId, projectId, project, pa
     sheetName: readOptionalText(parsed.sheetName),
     spreadsheetId,
     spreadsheetTitle: shouldKeepVerifiedMetadata ? readOptionalText(existingConfig?.spreadsheetTitle) : '',
-    startWeek: readOptionalText(parsed.startWeek),
-    endWeek: readOptionalText(parsed.endWeek),
+    startWeek: '',
+    endWeek: '',
     weekBasis: CASHFLOW_WEEK_BASIS,
     totalBasis: CASHFLOW_WEEK_BASIS,
     updatedAt: now,
@@ -3719,6 +3716,7 @@ export function mountCashflowSheetLabRoutes(app, {
   sheetPreviewCacheTtlMs = DEFAULT_SHEET_PREVIEW_CACHE_TTL_MS,
   performanceLogger,
   performanceNow,
+  preserveLegacySavedRange = false,
 } = {}) {
   if (enabled === false) {
     app.use('/api/v1/projects/:projectId/cashflow-sheet-lab', (_req, res) => {
@@ -3808,6 +3806,7 @@ export function mountCashflowSheetLabRoutes(app, {
     const source = resolvePreviewSource(
       { ...parsed, sourceYear },
       readCashflowSheetLabConfig(project, sourceYear),
+      preserveLegacySavedRange,
     );
     const weekRange = normalizeWeekRange(source);
     const configRevision = computeCashflowSheetConfigRevision({ ...source, ...weekRange });
@@ -4008,14 +4007,13 @@ export function mountCashflowSheetLabRoutes(app, {
     const { tenantId } = req.context;
     const { projectId } = req.params;
     const parsed = parseWithSchema(cashflowSheetLabConfigSchema, req.body, 'Invalid cashflow sheet lab config payload');
-    normalizeWeekRange(parsed);
     logCashflowSheetLab('config.save.start', req, {
       projectId,
       authMode: 'bff_config_only',
       sheetName: parsed.sheetName || null,
       valueProvided: Boolean(parsed.value),
-      startWeek: parsed.startWeek || null,
-      endWeek: parsed.endWeek || null,
+      startWeek: null,
+      endWeek: null,
     });
 
     const project = await readProjectDocument(db, tenantId, projectId);

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -554,7 +554,6 @@ function createApp({ context = {}, db = createDb(), googleSheetsService, routeOp
         matrix: buildMatrix(),
       })),
     },
-    preserveLegacySavedRange: true,
     ...routeOptions,
   });
   app.use((error, _req, res, _next) => {
@@ -1781,7 +1780,7 @@ describe('cashflow sheet lab route', () => {
           matrix: buildMatrixWithWeekLabels(JANUARY_FINANCE_WEEKS),
         })),
       },
-      routeOptions: { editLeasesEnabled: true, javaWeeklyClient, preserveLegacySavedRange: false },
+      routeOptions: { editLeasesEnabled: true, javaWeeklyClient },
     });
     const mirror = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -554,6 +554,7 @@ function createApp({ context = {}, db = createDb(), googleSheetsService, routeOp
         matrix: buildMatrix(),
       })),
     },
+    preserveLegacySavedRange: true,
     ...routeOptions,
   });
   app.use((error, _req, res, _next) => {
@@ -1754,7 +1755,7 @@ describe('cashflow sheet lab route', () => {
     expect(javaWeeklyClient.applyCashflowSheetLab).not.toHaveBeenCalled();
   });
 
-  it('pins and applies an explicit owner-draft source even when the shared project config is older', async () => {
+  it('pins the whole selected tab when refreshing a legacy saved range config', async () => {
     const db = createDb({
       project: {
         id: 'project-a',
@@ -1780,15 +1781,11 @@ describe('cashflow sheet lab route', () => {
           matrix: buildMatrixWithWeekLabels(JANUARY_FINANCE_WEEKS),
         })),
       },
-      routeOptions: { editLeasesEnabled: true, javaWeeklyClient },
+      routeOptions: { editLeasesEnabled: true, javaWeeklyClient, preserveLegacySavedRange: false },
     });
     const mirror = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
       .send({
-        value: 'spreadsheet-b',
-        sheetName: 'cashflow(사용내역 연동)',
-        startWeek: '26-1-1',
-        endWeek: '26-1-5',
         idempotencyKey: 'refresh-owner-draft-b',
       })
       .expect(200);
@@ -1797,17 +1794,10 @@ describe('cashflow sheet lab route', () => {
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
       .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-owner-draft-b' })
       .expect(200);
-    await request(app)
-      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
-      .set({
-        'x-edit-session-id': 'session-a',
-        'x-edit-lease-id': 'lease-a',
-        'x-edit-fence': '7',
-      })
-      .send({ stageRunId: stage.body.runId, idempotencyKey: 'apply-owner-draft-b' })
-      .expect(200);
-
-    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(1);
+    expect(stage.body.stagedLineCount).toBeGreaterThan(0);
+    expect(mirror.body.cells).toHaveLength(1920);
+    expect(mirror.body.activeWeekRange).toMatchObject({ startWeek: '', endWeek: '' });
+    expect(javaWeeklyClient.applyCashflowSheetLab).not.toHaveBeenCalled();
   });
 
   it('does not reserve an old staged apply when config changes during the final preflight', async () => {

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -596,7 +596,7 @@ async function stageJanuaryApply(javaWeeklyClient, suffix) {
     .expect(200);
   const stage = await request(app)
     .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
-    .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: `stage-${suffix}` })
+    .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-01', idempotencyKey: `stage-${suffix}` })
     .expect(200);
   return { app, db, mirror, stage };
 }
@@ -667,7 +667,7 @@ describe('cashflow sheet lab route', () => {
       status: 'FRESH',
       sourceRevision: expect.stringMatching(/^sha256:/),
       targetRevisionAtFetch: expect.stringMatching(/^sha256:/),
-      summary: { cellCount: 32, valueCount: 32, emptyCount: 0, invalidCount: 0 },
+      summary: { cellCount: 1920, valueCount: 1920, emptyCount: 0, invalidCount: 0 },
     });
     expect(previewSpreadsheet).toHaveBeenCalledTimes(1);
 
@@ -675,7 +675,7 @@ describe('cashflow sheet lab route', () => {
       .get('/api/v1/projects/project-a/cashflow-sheet-lab/mirror')
       .expect(200);
     expect(pinned.body.sourceRevision).toBe(refreshed.body.sourceRevision);
-    expect(pinned.body.cells).toHaveLength(32);
+    expect(pinned.body.cells).toHaveLength(1920);
     expect(previewSpreadsheet).toHaveBeenCalledTimes(1);
     expect(db.__getDocument().cashflowSheetLab.activeWeeks).toBeUndefined();
     await new Promise((resolve) => setImmediate(resolve));
@@ -736,7 +736,7 @@ describe('cashflow sheet lab route', () => {
     expect(mirror[0].data).toMatchObject({ projectId: 'project-a', status: 'FRESH', snapshotSchemaVersion: 2 });
     expect(mirror[0].data.snapshotId).toMatch(/^cfsnap_[a-f0-9]{32}$/);
     expect(snapshots).toHaveLength(1);
-    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_snapshot_months/')).toHaveLength(1);
+    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_snapshot_months/')).toHaveLength(12);
     const yearSnapshots = db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_snapshot_years/');
     expect(yearSnapshots).toHaveLength(9);
     const reordered = yearSnapshots.find(({ data }) => data.year === 2025);
@@ -782,6 +782,7 @@ describe('cashflow sheet lab route', () => {
     const annualCallsReady = new Promise((resolve) => { releaseAnnualCalls = resolve; });
     const javaWeeklyClient = {
       applyCashflowSheetLab: vi.fn(async (input) => javaApplyResponse(input, `sha256:${'1'.repeat(64)}`)),
+      applyCashflowSheetBatch: vi.fn(async (input) => javaBatchApplyResponse(input, `sha256:${'1'.repeat(64)}`)),
       applyCashflowSheetAnnualTotal: vi.fn(async (input) => {
         annualCallsStarted += 1;
         if (annualCallsStarted === 3) releaseAnnualCalls();
@@ -824,7 +825,7 @@ describe('cashflow sheet lab route', () => {
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
       .send({ idempotencyKey: 'annual-refresh-001' })
       .expect(200);
-    expect(mirror.body.cells).toHaveLength(160);
+    expect(mirror.body.cells).toHaveLength(1920);
     expect(mirror.body.annualCells).toHaveLength(288);
     expect(mirror.body.totalCells).toHaveLength(38);
 
@@ -832,22 +833,31 @@ describe('cashflow sheet lab route', () => {
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
       .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'annual-stage-001' })
       .expect(200);
-    expect(stage.body).toMatchObject({ stagedMonths: ['2026-01'], stagedYears: [2024, 2025, 2028], annualLineCount: 96 });
+    expect(stage.body).toMatchObject({
+      stagedMonths: Array.from({ length: 12 }, (_unused, index) => `2026-${String(index + 1).padStart(2, '0')}`),
+      stagedYears: [2024, 2025, 2028],
+      annualLineCount: 96,
+    });
     expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_stage_years/')).toHaveLength(3);
 
     const applied = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
       .send({ stageRunId: stage.body.runId, idempotencyKey: 'annual-apply-001' })
       .expect(200);
-    expect(applied.body).toMatchObject({ appliedMonths: ['2026-01'], appliedYears: [2024, 2025, 2028], appliedLineCount: 256 });
-    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(1);
-    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledWith(expect.objectContaining({
+    expect(applied.body).toMatchObject({
+      appliedMonths: Array.from({ length: 12 }, (_unused, index) => `2026-${String(index + 1).padStart(2, '0')}`),
+      appliedYears: [2024, 2025, 2028],
+      appliedLineCount: 2016,
+    });
+    expect(javaWeeklyClient.applyCashflowSheetLab).not.toHaveBeenCalled();
+    expect(javaWeeklyClient.applyCashflowSheetBatch).toHaveBeenCalledTimes(1);
+    expect(javaWeeklyClient.applyCashflowSheetBatch).toHaveBeenCalledWith(expect.objectContaining({
       openingBalanceCells: expect.arrayContaining([
         expect.objectContaining({ year: 2025, mode: 'projection', cashflowLine: 'MYSC_PREPAY_IN', cellState: 'ZERO', amount: 0 }),
         expect.objectContaining({ year: 2025, mode: 'actual', cashflowLine: 'BANK_INTEREST_OUT', cellState: 'VALUE', amount: 50 }),
       ]),
     }));
-    expect(javaWeeklyClient.applyCashflowSheetLab.mock.calls[0][0].openingBalanceCells).toHaveLength(64);
+    expect(javaWeeklyClient.applyCashflowSheetBatch.mock.calls[0][0].openingBalanceCells).toHaveLength(64);
     expect(javaWeeklyClient.applyCashflowSheetAnnualTotal).toHaveBeenCalledWith(expect.objectContaining({
       projectId: 'project-a',
       year: 2025,
@@ -902,6 +912,7 @@ describe('cashflow sheet lab route', () => {
     });
     const javaWeeklyClient = {
       applyCashflowSheetLab: vi.fn(async (input) => javaApplyResponse(input, `sha256:${'1'.repeat(64)}`)),
+      applyCashflowSheetBatch: vi.fn(async (input) => javaBatchApplyResponse(input, `sha256:${'1'.repeat(64)}`)),
       applyCashflowSheetAnnualTotal: vi.fn(async (input) => ({
         ...javaAnnualApplyResponse(input),
         commandName: 'weeklyExpense.cashflowSheetAnnual.apply',
@@ -977,6 +988,7 @@ describe('cashflow sheet lab route', () => {
         return javaAnnualApplyResponse(input);
       }),
       applyCashflowSheetLab: vi.fn(async (input) => javaApplyResponse(input, `sha256:${'1'.repeat(64)}`)),
+      applyCashflowSheetBatch: vi.fn(async (input) => javaBatchApplyResponse(input, `sha256:${'1'.repeat(64)}`)),
     };
     const app = createApp({
       db,
@@ -1033,7 +1045,8 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
     expect(replay.body.appliedYears).toEqual([2024, 2025, 2028]);
     expect(javaWeeklyClient.applyCashflowSheetAnnualTotal).toHaveBeenCalledTimes(4);
-    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(1);
+    expect(javaWeeklyClient.applyCashflowSheetLab).not.toHaveBeenCalled();
+    expect(javaWeeklyClient.applyCashflowSheetBatch).toHaveBeenCalledTimes(1);
     expect(db.__getDocument('orgs/tenant-a/cashflow_sheet_publications/project-a')).toMatchObject({
       status: 'APPLIED',
       stagedRunId: stage.body.runId,
@@ -2138,6 +2151,7 @@ describe('cashflow sheet lab route', () => {
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
       .send({
         expectedMirrorRevision: mirror.body.sourceRevision,
+        yearMonth: '2026-01',
         idempotencyKey: 'stage-001',
       })
       .expect(200);
@@ -2234,6 +2248,7 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
     const payload = {
       expectedMirrorRevision: mirror.body.sourceRevision,
+      yearMonth: '2026-01',
       idempotencyKey: 'stage-replay-001',
     };
 
@@ -2283,6 +2298,7 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
     const payload = {
       expectedMirrorRevision: mirror.body.sourceRevision,
+      yearMonth: '2026-01',
       idempotencyKey: 'stage-overlap-001',
     };
     let tick = 0;
@@ -2337,7 +2353,7 @@ describe('cashflow sheet lab route', () => {
 
     const stage = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
-      .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-invalid-month' })
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-01', idempotencyKey: 'stage-invalid-month' })
       .expect(200);
     expect(stage.body).toMatchObject({
       status: 'BLOCKED',
@@ -2385,7 +2401,7 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
     const stage = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
-      .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-empty-cell' })
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-01', idempotencyKey: 'stage-empty-cell' })
       .expect(200);
     const removal = stage.body.candidates.find((candidate) => (
       candidate.mode === 'projection' && candidate.lineId === 'MYSC_PREPAY_IN'
@@ -2441,7 +2457,7 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
     const stage = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
-      .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-source-specific-actual' })
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-01', idempotencyKey: 'stage-source-specific-actual' })
       .expect(200);
 
     expect(stage.body.candidates).toContainEqual(expect.objectContaining({
@@ -2494,7 +2510,7 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
     const stage = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
-      .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-legacy-actual' })
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-01', idempotencyKey: 'stage-legacy-actual' })
       .expect(200);
 
     expect(stage.body.candidates).toContainEqual(expect.objectContaining({
@@ -2543,7 +2559,7 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
     const stage = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
-      .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-pending-close' })
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-01', idempotencyKey: 'stage-pending-close' })
       .expect(200);
 
     expect(stage.body.pendingApprovalDifferenceCount).toBe(160);
@@ -2632,7 +2648,7 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
     const stage = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
-      .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-pending-race' })
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-01', idempotencyKey: 'stage-pending-race' })
       .expect(200);
     db.__getDocument('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-01').status = 'APPROVING';
 
@@ -2678,7 +2694,7 @@ describe('cashflow sheet lab route', () => {
     const mirror = await request(app).post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
       .send({ idempotencyKey: 'refresh-pending-100' }).expect(200);
     const stage = await request(app).post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
-      .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-pending-100' }).expect(200);
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-01', idempotencyKey: 'stage-pending-100' }).expect(200);
     expect(stage.body.pendingApprovalDifferenceCount).toBe(100);
     const applyPayload = {
       stageRunId: stage.body.runId,
@@ -2793,7 +2809,7 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
     const stage = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
-      .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-closed-month' })
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-01', idempotencyKey: 'stage-closed-month' })
       .expect(200);
 
     expect(stage.body).toMatchObject({
@@ -2890,6 +2906,7 @@ describe('cashflow sheet lab route', () => {
     const canonicalBefore = db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_weeks/');
     const payload = {
       expectedMirrorRevision: mirror.body.sourceRevision,
+      yearMonth: '2026-01',
       idempotencyKey: 'stage-closed-month-same-values',
     };
     const stage = await request(app)
@@ -2976,6 +2993,7 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
     const payload = {
       expectedMirrorRevision: mirror.body.sourceRevision,
+      yearMonth: '2026-01',
       idempotencyKey: 'stage-expired-no-changes',
     };
     let now = Date.now();
@@ -3178,7 +3196,7 @@ describe('cashflow sheet lab route', () => {
     });
   });
 
-  it('stages every complete month from a multi-month mirror for one explicit apply', async () => {
+  it('stages every complete month from the selected tab for one explicit apply', async () => {
     const db = createDb({
       project: {
         id: 'project-a',
@@ -3226,28 +3244,33 @@ describe('cashflow sheet lab route', () => {
       .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-two-months' })
       .expect(200);
 
-    expect(stage.body.stagedMonths).toEqual(['2026-01', '2026-02']);
+    const fullYearMonths = Array.from(
+      { length: 12 },
+      (_unused, index) => `2026-${String(index + 1).padStart(2, '0')}`,
+    );
+    expect(stage.body.stagedMonths).toEqual(fullYearMonths);
     expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_change_candidates/').length).toBeGreaterThan(0);
     expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_stage_runs/')).toHaveLength(1);
-    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_stage_months/')).toHaveLength(2);
+    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_stage_months/')).toHaveLength(12);
     const apply = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
       .send({ stageRunId: stage.body.runId, idempotencyKey: 'apply-two-months' })
       .expect(200);
 
     expect(apply.body).toMatchObject({
-      appliedMonths: ['2026-01', '2026-02'],
-      appliedLineCount: 320,
-      verifiedLineCount: 320,
+      appliedMonths: fullYearMonths,
+      appliedLineCount: 1920,
+      verifiedLineCount: 1920,
     });
     expect(javaWeeklyClient.applyCashflowSheetBatch).toHaveBeenCalledTimes(1);
     expect(javaWeeklyClient.applyCashflowSheetBatch).toHaveBeenCalledWith(expect.objectContaining({
       targetRevision: mirror.body.targetRevisionAtFetch,
-      months: [
+      months: expect.arrayContaining([
         expect.objectContaining({ yearMonth: '2026-01', cells: expect.any(Array) }),
         expect.objectContaining({ yearMonth: '2026-02', cells: expect.any(Array) }),
-      ],
+      ]),
     }));
+    expect(javaWeeklyClient.applyCashflowSheetBatch.mock.calls[0][0].months).toHaveLength(12);
     expect(editLeaseService.release).not.toHaveBeenCalled();
   });
 
@@ -3510,7 +3533,7 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
     const stage = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
-      .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-jvm-mismatch' })
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-01', idempotencyKey: 'stage-jvm-mismatch' })
       .expect(200);
 
     await request(app)
@@ -3567,7 +3590,7 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
     const stage = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
-      .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-resume-months' })
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-01', idempotencyKey: 'stage-resume-months' })
       .expect(200);
     const headers = {
       'x-edit-session-id': 'session-a',
@@ -3935,7 +3958,7 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
     const stage = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
-      .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-formula-mismatch' })
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-01', idempotencyKey: 'stage-formula-mismatch' })
       .expect(200);
 
     const currentMirror = db.__getDocument('orgs/tenant-a/cashflow_sheet_mirrors/project-a');
@@ -4028,7 +4051,7 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
     const stage = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
-      .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-legacy-month-close' })
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-01', idempotencyKey: 'stage-legacy-month-close' })
       .expect(200);
 
     await request(app)
@@ -4076,7 +4099,7 @@ describe('cashflow sheet lab route', () => {
 
     await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
-      .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: `stage-invalid-month-close-${_field}` })
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-01', idempotencyKey: `stage-invalid-month-close-${_field}` })
       .expect(409)
       .expect((response) => expect(response.body.code).toBe('cashflow_month_close_contract_invalid'));
   });
@@ -4114,7 +4137,7 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
     const stage = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
-      .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-settled-change' })
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-01', idempotencyKey: 'stage-settled-change' })
       .expect(200);
 
     const applied = await request(app)
@@ -4126,7 +4149,7 @@ describe('cashflow sheet lab route', () => {
     expect(javaWeeklyClient.applyCashflowSheetLab.mock.calls[0][0].settledWeekChangeConfirmation).toBeUndefined();
   });
 
-  it('blocks a partial month instead of authoritatively replacing only weeks 4 and 5', async () => {
+  it('ignores a legacy saved weeks 4 and 5 range and stages the full selected tab', async () => {
     const db = createDb({
       project: {
         id: 'project-a',
@@ -4147,12 +4170,10 @@ describe('cashflow sheet lab route', () => {
         matrix: buildMatrixWithWeekLabels(['26-2-4', '26-2-5']),
       })),
     };
-    const javaWeeklyClient = { applyCashflowSheetLab: vi.fn() };
-
     const app = createApp({
       db,
       googleSheetsService,
-      routeOptions: { editLeasesEnabled: true, javaWeeklyClient },
+      routeOptions: { editLeasesEnabled: true },
     });
     const mirror = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
@@ -4163,27 +4184,17 @@ describe('cashflow sheet lab route', () => {
       .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-fixed-weeks' })
       .expect(200);
     expect(stage.body).toMatchObject({
-      status: 'BLOCKED',
-      blockedMonths: ['2026-02'],
-      stagedLineCount: 0,
+      status: 'READY',
+      blockedMonths: [],
+      stagedLineCount: 1920,
     });
-    await request(app)
-      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
-      .set({
-        'x-edit-session-id': 'session-a',
-        'x-edit-lease-id': 'lease-a',
-        'x-edit-fence': '7',
-      })
-      .send({ stageRunId: stage.body.runId, idempotencyKey: 'apply-002' })
-      .expect(409)
-      .expect((response) => {
-        expect(response.body.code).toBe('cashflow_sheet_stage_run_blocked');
-      });
-    expect(javaWeeklyClient.applyCashflowSheetLab).not.toHaveBeenCalled();
+    expect(mirror.body.activeWeekRange).toMatchObject({ startWeek: '', endWeek: '' });
+    expect(mirror.body.cells).toHaveLength(1920);
+    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_stage_months/')).toHaveLength(12);
     expect(db.__getDocument('orgs/tenant-a/cashflow_weeks/project-a-2026-02-w4')).toBeUndefined();
   });
 
-  it('blocks weeks 1 and 2 because they are not a complete five-week finance month', async () => {
+  it('ignores a legacy saved weeks 1 and 2 range and stages the full selected tab', async () => {
     const db = createDb({
       project: {
         id: 'project-a',
@@ -4216,11 +4227,13 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
 
     expect(stage.body).toMatchObject({
-      status: 'BLOCKED',
-      blockedMonths: ['2026-01'],
-      stagedLineCount: 0,
+      status: 'READY',
+      blockedMonths: [],
+      stagedLineCount: 1920,
     });
-    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_stage_months/')).toHaveLength(0);
+    expect(mirror.body.activeWeekRange).toMatchObject({ startWeek: '', endWeek: '' });
+    expect(mirror.body.cells).toHaveLength(1920);
+    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_stage_months/')).toHaveLength(12);
   });
 
   it('retires both sheet write-back routes for inbound-only finance sync', async () => {

--- a/server/bff/routes/projects.mjs
+++ b/server/bff/routes/projects.mjs
@@ -714,7 +714,7 @@ const REGISTRATION_ACCOUNT_TYPES = new Set(['DEDICATED', 'OPERATING', 'NONE', 'O
 const SETTLEMENT_SYSTEM_CODES = new Set([
   'E_NARA_DOUM', 'IRIS', 'RCMS', 'EZBARO', 'E_HIJO', 'EDUFINE',
   'HAPPYEUM', 'AGRIX', 'BOTAEM_E', 'SMTECH', 'KOCCA_PMS', 'NIPA',
-  'ACCOUNTANT', 'PRIVATE', 'NONE',
+  'ACCOUNTANT', 'PRIVATE', 'OTHER', 'NONE',
 ]);
 const LABOR_SETTLEMENT_BASES = new Set([
   'INCLUDE_ACTUAL_SALARY', 'EXCLUDE_ACTUAL_SALARY', 'FIXED_AMOUNT', 'NONE',
@@ -905,6 +905,40 @@ function normalizePaymentExpectedMonths(value) {
   };
 }
 
+function normalizeSettlementSystemOther(value) {
+  return readOptionalText(value).replace(/\s+/g, ' ');
+}
+
+function assertProjectPaymentExtensions(payload) {
+  const settlementSystem = readOptionalText(payload?.settlementSystem);
+  const settlementSystemOther = normalizeSettlementSystemOther(payload?.settlementSystemOther);
+  if (settlementSystem && !SETTLEMENT_SYSTEM_CODES.has(settlementSystem)) {
+    invalidRegistration('Project registration settlementSystem is invalid');
+  }
+  if (settlementSystem === 'OTHER' && !settlementSystemOther) {
+    invalidRegistration('Project registration settlementSystemOther is required');
+  }
+  if (settlementSystemOther.length > 100) {
+    invalidRegistration('Project registration settlementSystemOther is too long');
+  }
+  if (!Array.isArray(payload?.financialYears)) return;
+  for (const row of payload.financialYears) {
+    if (!row || typeof row !== 'object' || Array.isArray(row) || row.paymentExpectedMonths === undefined) continue;
+    if (!row.paymentExpectedMonths || typeof row.paymentExpectedMonths !== 'object' || Array.isArray(row.paymentExpectedMonths)) {
+      invalidRegistration('Project registration financialYears paymentExpectedMonths is invalid');
+    }
+    for (const field of REGISTRATION_PAYMENT_FIELDS) {
+      const rawMonth = readOptionalText(row.paymentExpectedMonths[field]);
+      if (rawMonth && !normalizeExpectedMonth(rawMonth)) {
+        invalidRegistration(`Project registration financialYears.${row.year}.paymentExpectedMonths.${field} is invalid`);
+      }
+      if (registrationAmount(row.paymentPlan?.[field]) > 0 && !normalizeExpectedMonth(rawMonth)) {
+        invalidRegistration(`Project registration financialYears.${row.year}.paymentExpectedMonths.${field} is required`);
+      }
+    }
+  }
+}
+
 function normalizeLaborTransferPlan(_value) {
   return {
     mode: 'MONTHLY_WEEK_3',
@@ -1020,6 +1054,9 @@ function normalizeRegistrationFinancialYears(value) {
           interim: registrationAmount(row.paymentPlan.interim),
           final: registrationAmount(row.paymentPlan.final),
         },
+      } : {}),
+      ...(row?.paymentExpectedMonths && typeof row.paymentExpectedMonths === 'object' && !Array.isArray(row.paymentExpectedMonths) ? {
+        paymentExpectedMonths: normalizePaymentExpectedMonths(row.paymentExpectedMonths),
       } : {}),
       ...(Object.hasOwn(row || {}, 'advanceInterimBelow70Reason') ? {
         advanceInterimBelow70Reason: readOptionalText(row.advanceInterimBelow70Reason),
@@ -1162,6 +1199,7 @@ function assertRegistrationV2Requirements(payload, attachmentRefs, validateAttac
   if (settlementDetailsEnabled && settlementSystem && !SETTLEMENT_SYSTEM_CODES.has(settlementSystem)) {
     invalidRegistration('Project registration settlementSystem is invalid');
   }
+  assertProjectPaymentExtensions(payload);
   if (settlementDetailsEnabled && laborSettlementBasis && !LABOR_SETTLEMENT_BASES.has(laborSettlementBasis)) {
     invalidRegistration('Project registration laborSettlementBasis is invalid');
   }
@@ -1443,6 +1481,9 @@ export function buildProjectRegistrationCanonicalDocuments({
     basis,
     accountType: !settlementDetailsEnabled ? 'NONE' : normalizeAccountType(readOptionalText(payload.accountType)),
     settlementSystem: !settlementDetailsEnabled ? 'NONE' : normalizeSettlementSystemCode(payload.settlementSystem),
+    settlementSystemOther: settlementDetailsEnabled && normalizeSettlementSystemCode(payload.settlementSystem) === 'OTHER'
+      ? normalizeSettlementSystemOther(payload.settlementSystemOther)
+      : undefined,
     laborSettlementBasis: !settlementDetailsEnabled
       ? 'NONE'
       : normalizeLaborSettlementBasis(payload.laborSettlementBasis),
@@ -1626,6 +1667,9 @@ function buildProjectRequestPayloadFromProject(project, existingPayload = {}) {
     basis: Number(pickValue('registrationRequirementsVersion')) === 2 || settlementDetailsEnabled ? basis : 'NONE',
     accountType: !settlementDetailsEnabled ? 'NONE' : normalizeAccountType(pickText('accountType')),
     settlementSystem: !settlementDetailsEnabled ? 'NONE' : normalizeSettlementSystemCode(pickText('settlementSystem')),
+    settlementSystemOther: settlementDetailsEnabled && normalizeSettlementSystemCode(pickText('settlementSystem')) === 'OTHER'
+      ? normalizeSettlementSystemOther(pickText('settlementSystemOther'))
+      : undefined,
     laborSettlementBasis: !settlementDetailsEnabled
       ? 'NONE'
       : normalizeLaborSettlementBasis(pickText('laborSettlementBasis')),
@@ -1756,6 +1800,9 @@ export function buildProjectPatchFromChangeRequestPayload(payload = {}, currentP
     basis: registrationVersion === 2 || settlementDetailsEnabled ? basis : 'NONE',
     accountType: !settlementDetailsEnabled ? 'NONE' : normalizeAccountType(readOptionalText(payload.accountType)),
     settlementSystem: !settlementDetailsEnabled ? 'NONE' : normalizeSettlementSystemCode(payload.settlementSystem),
+    settlementSystemOther: settlementDetailsEnabled && normalizeSettlementSystemCode(payload.settlementSystem) === 'OTHER'
+      ? normalizeSettlementSystemOther(payload.settlementSystemOther)
+      : undefined,
     laborSettlementBasis: !settlementDetailsEnabled
       ? 'NONE'
       : normalizeLaborSettlementBasis(payload.laborSettlementBasis),
@@ -2841,6 +2888,21 @@ export function mountProjectRoutes(app, {
       );
     }
 
+    assertProjectPaymentExtensions(parsed);
+    const hasSettlementSystem = Object.hasOwn(parsed, 'settlementSystem');
+    const settlementSystem = hasSettlementSystem ? normalizeSettlementSystemCode(parsed.settlementSystem) : undefined;
+    const financialYears = Array.isArray(parsed.financialYears)
+      ? parsed.financialYears.map((row) => ({
+        ...row,
+        ...(row?.paymentExpectedMonths !== undefined ? {
+          paymentExpectedMonths: normalizePaymentExpectedMonths(row.paymentExpectedMonths),
+        } : {}),
+        ...(Object.hasOwn(row || {}, 'advanceInterimBelow70Reason') ? {
+          advanceInterimBelow70Reason: readOptionalText(row.advanceInterimBelow70Reason),
+        } : {}),
+      }))
+      : parsed.financialYears;
+
     const projectPayload = normalizeProjectRevenueFields({
       ...stripServerManagedFields(stripExpectedVersion(parsed)),
       id: parsed.id.trim(),
@@ -2848,6 +2910,13 @@ export function mountProjectRoutes(app, {
       orgId: tenantId,
       currency: normalizeProjectCurrency(parsed.currency),
       teamMembersDetailed: normalizeProjectTeamMembersDetailed(parsed.teamMembersDetailed),
+      ...(hasSettlementSystem ? {
+        settlementSystem,
+        settlementSystemOther: settlementSystem === 'OTHER'
+          ? normalizeSettlementSystemOther(parsed.settlementSystemOther)
+          : undefined,
+      } : {}),
+      ...(Array.isArray(financialYears) ? { financialYears } : {}),
     }, 'totalRevenueAmount');
 
     const shouldProvisionProjectDriveRoot = !!(

--- a/server/bff/routes/projects.test.ts
+++ b/server/bff/routes/projects.test.ts
@@ -82,8 +82,8 @@ function registrationV2Payload(overrides: Record<string, unknown> = {}) {
     },
     registrationRequirementsVersion: 2,
     financialYears: [
-      { year: 2026, contractAmount: 100_000, salesVatAmount: 10_000, totalRevenueAmount: 40_000, totalActualCost: 25_000, supportAmount: 0, profitRate: 0.4, confirmed: true, paymentPlan: { contract: 50_000, interim: 20_000, final: 30_000 }, finalPaymentExpectedWeek: '26-8-1', advanceInterimBelow70Reason: '연차별 일정', isSettled: true },
-      { year: 2027, contractAmount: 200_000, salesVatAmount: 20_000, totalRevenueAmount: 80_000, totalActualCost: 50_000, supportAmount: 10_000, profitRate: 0.4, confirmed: true, paymentPlan: { contract: 100_000, interim: 40_000, final: 60_000 }, finalPaymentExpectedWeek: '27-12-4', advanceInterimBelow70Reason: '', isSettled: false },
+      { year: 2026, contractAmount: 100_000, salesVatAmount: 10_000, totalRevenueAmount: 40_000, totalActualCost: 25_000, supportAmount: 0, profitRate: 0.4, confirmed: true, paymentPlan: { contract: 50_000, interim: 20_000, final: 30_000 }, paymentExpectedMonths: { contract: '2026-02', interim: '2026-06', final: '2026-12' }, finalPaymentExpectedWeek: '26-8-1', advanceInterimBelow70Reason: '연차별 일정', isSettled: true },
+      { year: 2027, contractAmount: 200_000, salesVatAmount: 20_000, totalRevenueAmount: 80_000, totalActualCost: 50_000, supportAmount: 10_000, profitRate: 0.4, confirmed: true, paymentPlan: { contract: 100_000, interim: 40_000, final: 60_000 }, paymentExpectedMonths: { contract: '2027-02', interim: '2027-06', final: '2027-12' }, finalPaymentExpectedWeek: '27-12-4', advanceInterimBelow70Reason: '', isSettled: false },
     ],
     interestRefundPolicy: 'REFUND',
     finalPaymentExpectedWeek: '27-12-4',

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -382,7 +382,9 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain("['CHANGED', '변경사항 반영 완료'");
     expect(source).toContain("['NO_CHANGES', '변경사항 없음'");
     expect(source).toContain('이번 주차의 처리 결과만 선택해 정산 상태를 업데이트합니다.');
-    expect(source).toContain('무시하고 반영');
+    expect(source).toContain(".sort((left, right) => left.localeCompare(right))");
+    expect(source).toContain('>}반영');
+    expect(source).not.toContain('무시하고 반영');
     expect(source).not.toContain('선택한 결과로 완료');
     expect(source).not.toContain('그 이후 15개 재무주차(총 16주·256칸)');
     expect(source).not.toContain('ZERO(0원)는 작성값이며 EMPTY(미입력)는 완료할 수 없습니다.');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1271,8 +1271,6 @@ export function CashflowProjectSheet({
         sourceYear: selectedYear,
         value: cashflowSheetConfig.value,
         sheetName: cashflowSheetConfig.sheetName || undefined,
-        startWeek: cashflowSheetConfig.startWeek || undefined,
-        endWeek: cashflowSheetConfig.endWeek || undefined,
         idempotencyKey: refreshIdempotencyKey,
       })
     );
@@ -1762,7 +1760,7 @@ export function CashflowProjectSheet({
 
   const cashflowTotalPeriodLabel = comparisonScope.periodLabel;
   const sheetRangeLabel = cashflowSheetConfig
-    ? `${cashflowSheetConfig.sheetName || '시트 탭'} · ${cashflowSheetConfig.startWeek || '전체'} ~ ${cashflowSheetConfig.endWeek || '전체'}`
+    ? `${cashflowSheetConfig.sheetName || '시트 탭'} · 탭 전체`
     : '연결된 Google Sheet가 없습니다.';
   const sheetIdentityLabel = cashflowSheetConfig
     ? cashflowSheetConfig.spreadsheetTitle || cashflowSheetConfig.spreadsheetId || 'Google Sheet'
@@ -2947,7 +2945,7 @@ export function CashflowProjectSheet({
           <div className="mb-2 grid gap-2 sm:grid-cols-3">
             <Input aria-label="실제 반영 기록 검색" value={cashflowEventQuery} onChange={(event) => setCashflowEventQuery(event.target.value)} placeholder="항목·담당자 검색" />
             <select aria-label="실제 반영 mode 필터" className="h-9 rounded-md border border-slate-300 bg-white px-2 text-[12px]" value={cashflowEventMode} onChange={(event) => setCashflowEventMode(event.target.value)}><option value="ALL">전체 mode</option><option value="projection">Projection</option><option value="actual">Actual</option></select>
-            <select aria-label="실제 반영 월 필터" className="h-9 rounded-md border border-slate-300 bg-white px-2 text-[12px]" value={cashflowEventMonth} onChange={(event) => setCashflowEventMonth(event.target.value)}><option value="ALL">전체 월</option>{[...new Set(cashflowEvents.map((event) => event.yearMonth).filter(Boolean))].map((month) => <option key={month} value={month}>{month}</option>)}</select>
+            <select aria-label="실제 반영 월 필터" className="h-9 rounded-md border border-slate-300 bg-white px-2 text-[12px]" value={cashflowEventMonth} onChange={(event) => setCashflowEventMonth(event.target.value)}><option value="ALL">전체 월</option>{[...new Set(cashflowEvents.map((event) => event.yearMonth).filter(Boolean))].sort((left, right) => left.localeCompare(right)).map((month) => <option key={month} value={month}>{month}</option>)}</select>
           </div>
           {cashflowEventErrors.map((failure) => (
             <div key={failure.source} role="alert" className="mb-2 flex flex-wrap items-center justify-between gap-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-700">
@@ -3108,7 +3106,7 @@ export function CashflowProjectSheet({
           <AlertDialogFooter>
             <AlertDialogCancel disabled={weeklyCompletionBusy}>취소</AlertDialogCancel>
             <Button type="button" disabled={weeklyCompletionBusy || !weeklyUpdateResult} onClick={() => void handleCompleteWeeklyUpdate()}>
-              {weeklyCompletionBusy ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <ClipboardCheck className="mr-1.5 h-3.5 w-3.5" />}무시하고 반영
+              {weeklyCompletionBusy ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <ClipboardCheck className="mr-1.5 h-3.5 w-3.5" />}반영
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -3319,7 +3317,7 @@ export function CashflowProjectSheet({
                 ['3', '변경 이력', '결산 후 변경은 시점과 사유, 경고 횟수를 기록합니다.'],
               ] : [
                 ['1', '공유 권한 확인', '연동할 Google Sheet에 조회 권한이 있는지 확인합니다.'],
-                ['2', '시트·주차 선택', '사용할 시트 탭과 시작·종료 주차를 지정합니다.'],
+                ['2', '시트 탭 선택', '사용할 시트 탭을 지정하면 탭 전체를 불러옵니다.'],
                 ['3', '명시적으로 불러오기', '설정 후 시트 설정에서 직접 값을 가져와 저장할 값을 확인합니다.'],
               ]).map(([step, title, detail]) => (
                 <div key={step} className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2">
@@ -3334,7 +3332,7 @@ export function CashflowProjectSheet({
             <div className={`rounded-md border px-3 py-2 text-[12px] leading-5 ${cashflowSheetConfig ? 'border-slate-200 bg-slate-50 text-slate-600' : 'border-[#C7D3DF] bg-[#EAF0F5] text-[#17324D]'}`}>
               {cashflowSheetConfig
                 ? `${sheetIdentityLabel} · ${sheetRangeLabel}`
-                : '먼저 Google Sheet 공유 권한과 시트 범위를 설정해야 합니다.'}
+                : '먼저 Google Sheet 공유 권한과 시트 탭을 설정해야 합니다.'}
             </div>
           </div>
 

--- a/src/app/components/portal/PortalProjectEdit.tsx
+++ b/src/app/components/portal/PortalProjectEdit.tsx
@@ -225,6 +225,7 @@ function ProjectInfoEditor({
   members,
   project,
   requestDoc,
+  settlementSystemOptions,
   session,
 }: {
   actor: ActorLike;
@@ -234,6 +235,7 @@ function ProjectInfoEditor({
   members: ReturnType<typeof usePortalStore>['members'];
   project: Project;
   requestDoc: ProjectRequest | null;
+  settlementSystemOptions: string[];
   session: EditSession;
 }) {
   const navigate = useNavigate();
@@ -539,6 +541,7 @@ function ProjectInfoEditor({
         members={members}
         requesterId={actor.uid}
         departmentOptions={departmentOptions}
+        settlementSystemOptions={settlementSystemOptions}
         topSlot={topSlot}
         showCheckoutEntry
         readOnly={!editorCanEdit}
@@ -740,6 +743,7 @@ export function PortalProjectEdit() {
       members={members}
       project={project}
       requestDoc={requestDoc}
+      settlementSystemOptions={projects.flatMap((item) => item.settlementSystem === 'OTHER' && item.settlementSystemOther && !item.trashedAt ? [item.settlementSystemOther] : [])}
       session={bootstrap.session}
     />
   );

--- a/src/app/components/portal/PortalProjectRegister.tsx
+++ b/src/app/components/portal/PortalProjectRegister.tsx
@@ -78,7 +78,7 @@ function RegistrationEditor({
 }) {
   const navigate = useNavigate();
   const { orgId } = useFirebase();
-  const { members } = usePortalStore();
+  const { members, projects } = usePortalStore();
   const { options: departmentOptions } = useProjectDepartmentSettings();
   const [record, setRecord] = useState(initialRecord);
   const [busyActionId, setBusyActionId] = useState<string | null>(null);
@@ -284,6 +284,7 @@ function RegistrationEditor({
         members={members}
         requesterId={actor.uid}
         departmentOptions={departmentOptions}
+        settlementSystemOptions={projects.flatMap((project) => project.settlementSystem === 'OTHER' && project.settlementSystemOther && !project.trashedAt ? [project.settlementSystemOther] : [])}
         topSlot={topSlot}
         readOnly={!lease.canEdit}
         autosave={autosave}

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -45,6 +45,7 @@ import {
   type ProjectCurrency,
   type ProjectFinancialYear,
   type ProjectFinancialInputFlags,
+  type ProjectPaymentExpectedMonths,
   type ProjectPhase,
   type ProjectRequestContractAnalysis,
   type ProjectStatus,
@@ -154,6 +155,7 @@ interface ProjectEditorWizardProps {
   members?: OrgMember[];
   requesterId?: string;
   departmentOptions?: string[];
+  settlementSystemOptions?: string[];
   topSlot?: ReactNode;
   showCheckoutEntry?: boolean;
   actions: ProjectEditorAction[];
@@ -602,6 +604,7 @@ export function ProjectEditorWizard({
   members = [],
   requesterId,
   departmentOptions,
+  settlementSystemOptions = [],
   topSlot,
   showCheckoutEntry = false,
   actions,
@@ -1069,6 +1072,14 @@ export function ProjectEditorWizard({
     setDraft((prev) => createProjectEditorWizardDraft({ ...prev, [key]: value }));
   };
 
+  const updateSettlementSystem = (value: string) => {
+    setDraft((prev) => createProjectEditorWizardDraft({
+      ...prev,
+      settlementSystem: (value.startsWith('OTHER:') ? 'OTHER' : value) as SettlementSystemCode,
+      settlementSystemOther: value.startsWith('OTHER:') ? value.slice('OTHER:'.length) : '',
+    }));
+  };
+
   const updateAmount = (key: 'contractAmount' | 'salesVatAmount' | 'totalRevenueAmount' | 'totalActualCost' | 'supportAmount', rawValue: string) => {
     setDraft((prev) => createProjectEditorWizardDraft({
       ...prev,
@@ -1079,8 +1090,8 @@ export function ProjectEditorWizard({
 
   const updateFinancialYear = (
     index: number,
-    key: 'contractAmount' | 'salesVatAmount' | 'totalRevenueAmount' | 'totalActualCost' | 'supportAmount' | 'paymentPlan' | 'advanceInterimBelow70Reason' | 'isSettled' | 'confirmed',
-    value: number | string | boolean | ProjectFinancialYear['paymentPlan'],
+    key: 'contractAmount' | 'salesVatAmount' | 'totalRevenueAmount' | 'totalActualCost' | 'supportAmount' | 'paymentPlan' | 'paymentExpectedMonths' | 'advanceInterimBelow70Reason' | 'isSettled' | 'confirmed',
+    value: number | string | boolean | ProjectFinancialYear['paymentPlan'] | ProjectFinancialYear['paymentExpectedMonths'],
   ) => {
     setDraft((prev) => {
       const financialYears = prev.financialYears.map((row, rowIndex) => (
@@ -1310,12 +1321,27 @@ export function ProjectEditorWizard({
         issues.push({ step: 'financial', label: '계약기간 전체 연도별 재무 확인' });
       }
       if (draft.settlementType === 'NONE') issues.push({ step: 'financial', label: '사업유형' });
+      if (settlementDetailsEnabled && draft.settlementSystem === 'OTHER') {
+        const customSystem = draft.settlementSystemOther.trim();
+        if (!customSystem) issues.push({ step: 'financial', label: '기타 정산 시스템 이름' });
+        if (customSystem.length > 100) issues.push({ step: 'financial', label: '기타 정산 시스템 이름은 100자 이하여야 합니다.' });
+      }
       (!hasMultiYearContract ? ['contract', 'interim', 'final'] as const : []).forEach((field) => {
         if (draft.paymentPlan[field] > 0 && !draft.paymentExpectedMonths[field]) {
           const label = field === 'contract' ? '선금/계약금 입금 예상월' : field === 'interim' ? '중도금 입금 예상월' : '잔금 입금 예상월';
           issues.push({ step: 'financial', label });
         }
       });
+      if (hasMultiYearContract) {
+        draft.financialYears.forEach((row) => {
+          (['contract', 'interim', 'final'] as const).forEach((field) => {
+            if ((row.paymentPlan?.[field] || 0) > 0 && !row.paymentExpectedMonths?.[field]) {
+              const label = field === 'contract' ? '선금/계약금' : field === 'interim' ? '중도금' : '잔금';
+              issues.push({ step: 'financial', label: `${row.year}년 ${label} 예상 입금 시점` });
+            }
+          });
+        });
+      }
       const missingAnnualAdvanceInterimReason = hasMultiYearContract && draft.financialYears.some((row) => {
         const paymentPlan = row.paymentPlan || { contract: 0, interim: 0, final: 0 };
         const paymentTotal = paymentPlan.contract + paymentPlan.interim + paymentPlan.final;
@@ -1895,12 +1921,8 @@ export function ProjectEditorWizard({
             </div>
           ))}
           <div>
-            <Label className="text-xs">입금 계획 설명</Label>
+            <Label className="text-xs">기타 메모</Label>
             <Textarea value={draft.paymentPlanDesc} onChange={(event) => update('paymentPlanDesc', event.target.value)} className="mt-1 min-h-[92px] bg-white text-sm" />
-          </div>
-          <div>
-            <Label className="text-xs">계약/재무 안내</Label>
-            <Textarea value={draft.settlementGuide} onChange={(event) => update('settlementGuide', event.target.value)} className="mt-1 min-h-[92px] bg-white text-sm" />
           </div>
         </div>
       ) : null}
@@ -2016,7 +2038,10 @@ export function ProjectEditorWizard({
         <div className="grid gap-4 lg:grid-cols-2">
           <div>
             <Label className="text-xs">정산 시스템</Label>
-            <Select value={draft.settlementSystem} onValueChange={(value) => update('settlementSystem', value as SettlementSystemCode)}>
+            <Select
+              value={draft.settlementSystem === 'OTHER' && draft.settlementSystemOther.trim() ? `OTHER:${draft.settlementSystemOther.trim()}` : draft.settlementSystem}
+              onValueChange={updateSettlementSystem}
+            >
               <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue /></SelectTrigger>
               <SelectContent>
                 {[
@@ -2025,8 +2050,23 @@ export function ProjectEditorWizard({
                 ].map((key) => (
                   <SelectItem key={key} value={key}>{SETTLEMENT_SYSTEM_LABELS[key]}</SelectItem>
                 ))}
+                {[...settlementSystemOptions, draft.settlementSystemOther]
+                  .map((value) => value.replace(/\s+/g, ' ').trim())
+                  .filter((value, index, values) => value && values.findIndex((candidate) => candidate.toLocaleLowerCase('ko-KR') === value.toLocaleLowerCase('ko-KR')) === index)
+                  .map((value) => (
+                  <SelectItem key={`OTHER:${value}`} value={`OTHER:${value}`}>{value}</SelectItem>
+                ))}
               </SelectContent>
             </Select>
+            {draft.settlementSystem === 'OTHER' ? (
+              <Input
+                value={draft.settlementSystemOther}
+                onChange={(event) => update('settlementSystemOther', event.target.value)}
+                placeholder="정산 시스템 이름 직접 입력"
+                aria-label="기타 정산 시스템 이름"
+                className="mt-2 h-9 text-sm"
+              />
+            ) : null}
           </div>
           <div>
             <Label className="text-xs">인건비 정산 기준</Label>
@@ -2243,6 +2283,14 @@ export function ProjectEditorWizard({
         update('paymentPlan', { ...paymentPlan, [field]: value });
       }
     };
+    const paymentExpectedMonths = financialYear?.paymentExpectedMonths || draft.paymentExpectedMonths;
+    const updatePaymentExpectedMonth = (field: keyof ProjectPaymentExpectedMonths, value: string) => {
+      if (financialYear && financialYearIndex !== undefined) {
+        updateFinancialYear(financialYearIndex, 'paymentExpectedMonths', { ...paymentExpectedMonths, [field]: value });
+      } else {
+        update('paymentExpectedMonths', { ...paymentExpectedMonths, [field]: value });
+      }
+    };
     const yearAdvanceInterimRatio = financialYear && financialYear.contractAmount > 0
       ? (paymentPlan.contract + paymentPlan.interim) / financialYear.contractAmount
       : null;
@@ -2257,26 +2305,29 @@ export function ProjectEditorWizard({
           <Label className="text-xs">선금/계약금 (원)</Label>
           <Input value={formatProjectAmountInput(paymentPlan.contract, true)} onChange={(event) => updatePaymentPlan('contract', parseProjectAmountInput(event.target.value))} className="mt-1 h-9 text-sm" />
           <p className="mt-1 text-[10px] text-muted-foreground">{formatPaymentPlanAmount(paymentPlan.contract, financialYear?.contractAmount || draft.contractAmount)}</p>
-          {!financialYear ? <><Label className="mt-3 block text-xs">입금 예상월{paymentPlan.contract > 0 ? ' *' : ''}</Label><Input type="month" value={draft.paymentExpectedMonths.contract} onChange={(event) => update('paymentExpectedMonths', { ...draft.paymentExpectedMonths, contract: event.target.value })} className="mt-1 h-9 text-sm" /></> : null}
+          <Label className="mt-3 block text-xs">예상 입금 시점{paymentPlan.contract > 0 ? ' *' : ''}</Label><Input type="month" aria-label={`${financialYear ? `${financialYear.year}년 ` : ''}선금/계약금 예상 입금 시점`} aria-required={paymentPlan.contract > 0} value={paymentExpectedMonths.contract} onChange={(event) => updatePaymentExpectedMonth('contract', event.target.value)} className="mt-1 h-9 text-sm" />
         </div>
         <div>
           <Label className="text-xs">중도금 (원)</Label>
           <Input value={formatProjectAmountInput(paymentPlan.interim, true)} onChange={(event) => updatePaymentPlan('interim', parseProjectAmountInput(event.target.value))} className="mt-1 h-9 text-sm" />
           <p className="mt-1 text-[10px] text-muted-foreground">{formatPaymentPlanAmount(paymentPlan.interim, financialYear?.contractAmount || draft.contractAmount)}</p>
-          {!financialYear ? <><Label className="mt-3 block text-xs">입금 예상월{paymentPlan.interim > 0 ? ' *' : ''}</Label><Input type="month" value={draft.paymentExpectedMonths.interim} onChange={(event) => update('paymentExpectedMonths', { ...draft.paymentExpectedMonths, interim: event.target.value })} className="mt-1 h-9 text-sm" /></> : null}
+          <Label className="mt-3 block text-xs">예상 입금 시점{paymentPlan.interim > 0 ? ' *' : ''}</Label><Input type="month" aria-label={`${financialYear ? `${financialYear.year}년 ` : ''}중도금 예상 입금 시점`} aria-required={paymentPlan.interim > 0} value={paymentExpectedMonths.interim} onChange={(event) => updatePaymentExpectedMonth('interim', event.target.value)} className="mt-1 h-9 text-sm" />
         </div>
         <div>
           <Label className="text-xs">잔금 (원)</Label>
           <Input value={formatProjectAmountInput(paymentPlan.final, true)} onChange={(event) => updatePaymentPlan('final', parseProjectAmountInput(event.target.value))} className="mt-1 h-9 text-sm" />
           <p className="mt-1 text-[10px] text-muted-foreground">{formatPaymentPlanAmount(paymentPlan.final, financialYear?.contractAmount || draft.contractAmount)}</p>
-          {!financialYear ? <><Label className="mt-3 block text-xs">입금 예상월{paymentPlan.final > 0 ? ' *' : ''}</Label><Input type="month" value={draft.paymentExpectedMonths.final} onChange={(event) => update('paymentExpectedMonths', { ...draft.paymentExpectedMonths, final: event.target.value })} className="mt-1 h-9 text-sm" /></> : null}
+          <Label className="mt-3 block text-xs">예상 입금 시점{paymentPlan.final > 0 ? ' *' : ''}</Label><Input type="month" aria-label={`${financialYear ? `${financialYear.year}년 ` : ''}잔금 예상 입금 시점`} aria-required={paymentPlan.final > 0} value={paymentExpectedMonths.final} onChange={(event) => updatePaymentExpectedMonth('final', event.target.value)} className="mt-1 h-9 text-sm" />
         </div>
       </div>
       {financialYear ? (
-        <label className="flex items-center gap-2 text-[12px] text-slate-700">
-          <Checkbox checked={financialYear.isSettled === true} onCheckedChange={(checked) => updateFinancialYear(financialYearIndex!, 'isSettled', checked === true)} />
-          {financialYear.year}년 계약/재무 정산 완료
-        </label>
+        <div>
+          <label className="flex items-center gap-2 text-[12px] text-slate-700">
+            <Checkbox checked={financialYear.isSettled === true} onCheckedChange={(checked) => updateFinancialYear(financialYearIndex!, 'isSettled', checked === true)} />
+            {financialYear.year}년 계약/재무 정산 완료
+          </label>
+          <p className="ml-6 mt-1 text-[11px] text-muted-foreground">해당 연도의 계약금 수납과 정산 업무가 모두 끝났음을 표시합니다. 현금흐름 월결산과는 별개입니다.</p>
+        </div>
       ) : null}
       {requiresYearAdvanceInterimReason ? (
         <div>
@@ -2306,20 +2357,11 @@ export function ProjectEditorWizard({
         </div>
       ) : null}
       {!financialYear ? <div>
-        <Label className="text-xs">입금 계획 설명</Label>
+        <Label className="text-xs">기타 메모</Label>
         <Textarea
           value={draft.paymentPlanDesc}
           onChange={(event) => update('paymentPlanDesc', event.target.value)}
           placeholder="예: 검수 완료 후 세금계산서 발행, 발행일로부터 14일 이내 입금"
-          className="mt-1 min-h-[92px] text-sm"
-        />
-      </div> : null}
-      {!financialYear ? <div>
-        <Label className="text-xs">계약/재무 안내</Label>
-        <Textarea
-          value={draft.settlementGuide}
-          onChange={(event) => update('settlementGuide', event.target.value)}
-          placeholder="예: 이나라도움 수령, 공급가액 기준, 선지급 후 정산"
           className="mt-1 min-h-[92px] text-sm"
         />
       </div> : null}
@@ -2479,7 +2521,7 @@ export function ProjectEditorWizard({
               <>
                 <ReviewRow label="통장 유형" value={ACCOUNT_TYPE_LABELS[draft.accountType]} />
                 <ReviewRow label="이자 반납 여부" value={draft.interestRefundPolicy ? INTEREST_REFUND_POLICY_LABELS[draft.interestRefundPolicy] : '-'} />
-                <ReviewRow label="정산 시스템" value={SETTLEMENT_SYSTEM_LABELS[draft.settlementSystem]} />
+                <ReviewRow label="정산 시스템" value={draft.settlementSystem === 'OTHER' ? draft.settlementSystemOther : SETTLEMENT_SYSTEM_LABELS[draft.settlementSystem]} />
                 <ReviewRow label="인건비 정산 기준" value={LABOR_SETTLEMENT_BASIS_LABELS[draft.laborSettlementBasis]} />
               </>
             ) : null}
@@ -2488,7 +2530,7 @@ export function ProjectEditorWizard({
                 <ReviewRow
                   label="연도별 재무"
                   value={draft.financialYears.map((row) => (
-                    `${row.year}년 계약 ${fmtKRW(row.contractAmount)}원 · 매출VAT ${fmtKRW(row.salesVatAmount)}원 · 총수익 ${fmtKRW(row.totalRevenueAmount)}원 · 총실비 ${fmtKRW(row.totalActualCost)}원 · 지원금 ${fmtKRW(row.supportAmount)}원 · 선금 ${fmtKRW(row.paymentPlan?.contract || 0)}원 · 중도금 ${fmtKRW(row.paymentPlan?.interim || 0)}원 · 잔금 ${fmtKRW(row.paymentPlan?.final || 0)}원 · 정산 ${row.isSettled ? '완료' : '미완료'}${row.advanceInterimBelow70Reason ? ` · 70% 미만 사유 ${row.advanceInterimBelow70Reason}` : ''} · 수익률 ${(row.profitRate * 100).toFixed(2)}%${row.confirmed ? ' · 확인' : ' · 미확인'}`
+                    `${row.year}년 계약 ${fmtKRW(row.contractAmount)}원 · 매출VAT ${fmtKRW(row.salesVatAmount)}원 · 총수익 ${fmtKRW(row.totalRevenueAmount)}원 · 총실비 ${fmtKRW(row.totalActualCost)}원 · 지원금 ${fmtKRW(row.supportAmount)}원 · 선금 ${fmtKRW(row.paymentPlan?.contract || 0)}원 (${row.paymentExpectedMonths?.contract || '-'}) · 중도금 ${fmtKRW(row.paymentPlan?.interim || 0)}원 (${row.paymentExpectedMonths?.interim || '-'}) · 잔금 ${fmtKRW(row.paymentPlan?.final || 0)}원 (${row.paymentExpectedMonths?.final || '-'}) · 정산 ${row.isSettled ? '완료' : '미완료'}${row.advanceInterimBelow70Reason ? ` · 70% 미만 사유 ${row.advanceInterimBelow70Reason}` : ''} · 수익률 ${(row.profitRate * 100).toFixed(2)}%${row.confirmed ? ' · 확인' : ' · 미확인'}`
                   )).join('\n')}
                 />
                 <ReviewRow
@@ -2537,8 +2579,7 @@ export function ProjectEditorWizard({
             {!hasMultiYearContract ? <ReviewRow label="잔금 예상월" value={draft.paymentExpectedMonths.final} /> : null}
             <ReviewRow label="선금+중도금 비율" value={advanceInterimRatio === null ? '-' : `${(advanceInterimRatio * 100).toFixed(1)}%`} />
             {requiresAdvanceInterimReason ? <ReviewRow label="70% 미만 사유" value={draft.advanceInterimBelow70Reason} /> : null}
-            <ReviewRow label="입금 계획" value={draft.paymentPlanDesc} />
-            <ReviewRow label="계약/재무 안내" value={draft.settlementGuide} />
+            <ReviewRow label="기타 메모" value={draft.paymentPlanDesc} />
             {showProjectCheckout ? (
               <ReviewRow
                 label="종료사업 체크아웃"

--- a/src/app/components/projects/ProjectWizard.tsx
+++ b/src/app/components/projects/ProjectWizard.tsx
@@ -58,6 +58,8 @@ function createProjectFromDraft(
     basis: draft.basis,
     accountType: draft.accountType,
     fundInputMode: draft.fundInputMode,
+    settlementSystem: draft.settlementSystem,
+    settlementSystemOther: draft.settlementSystemOther,
     settlementSheetPolicy: draft.settlementSheetPolicy,
     paymentPlan: draft.paymentPlan,
     paymentPlanDesc: draft.paymentPlanDesc,
@@ -97,7 +99,7 @@ function createProjectFromDraft(
 
 export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: ProjectWizardProps) {
   const navigate = useNavigate();
-  const { addProject, updateProject, upsertMember, members, currentUser } = useAppStore();
+  const { addProject, updateProject, upsertMember, members, projects, currentUser } = useAppStore();
   const { orgId } = useFirebase();
   const { options: departmentOptions } = useProjectDepartmentSettings();
   const [busyActionId, setBusyActionId] = useState<string | null>(null);
@@ -217,6 +219,7 @@ export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: Projec
       members={members}
       requesterId={currentUser?.uid}
       departmentOptions={departmentOptions}
+      settlementSystemOptions={projects.flatMap((project) => project.settlementSystem === 'OTHER' && project.settlementSystemOther && !project.trashedAt ? [project.settlementSystemOther] : [])}
       actions={editProject ? [
         { id: 'save', label: '수정 저장', icon: Save },
       ] : [

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -435,6 +435,7 @@ export type SettlementSystemCode =
   | 'NIPA'           // 정보통신산업진흥원 사업관리시스템
   | 'ACCOUNTANT'     // 회계사정산 (전문 회계법인 정산)
   | 'PRIVATE'        // 민간사업
+  | 'OTHER'          // 기타 직접 입력
   | 'NONE';          // 미정/없음
 
 export type LaborSettlementBasis =
@@ -475,7 +476,8 @@ export const SETTLEMENT_SYSTEM_LABELS: Record<SettlementSystemCode, string> = {
   NIPA: 'NIPA 사업관리시스템',
   ACCOUNTANT: '회계사정산',
   PRIVATE: '민간사업',
-  NONE: '정산없음',
+  OTHER: '기타',
+  NONE: '시스템 미사용',
 };
 
 export const PROJECT_SETTLEMENT_SYSTEM_CODES: SettlementSystemCode[] = [
@@ -488,6 +490,7 @@ export const PROJECT_SETTLEMENT_SYSTEM_CODES: SettlementSystemCode[] = [
   'KOCCA_PMS',
   'NIPA',
   'IRIS',
+  'OTHER',
 ];
 
 export const SETTLEMENT_SYSTEM_SHORT: Record<SettlementSystemCode, string> = {
@@ -505,6 +508,7 @@ export const SETTLEMENT_SYSTEM_SHORT: Record<SettlementSystemCode, string> = {
   NIPA: 'NIPA',
   ACCOUNTANT: '회계사정산',
   PRIVATE: '민간',
+  OTHER: '기타',
   NONE: '정산없음',
 };
 
@@ -613,6 +617,7 @@ export interface ProjectFinancialYear {
   profitRate: number;
   confirmed: boolean;
   paymentPlan?: Project['paymentPlan'];
+  paymentExpectedMonths?: ProjectPaymentExpectedMonths;
   finalPaymentExpectedWeek?: string;
   advanceInterimBelow70Reason?: string;
   isSettled?: boolean;
@@ -692,6 +697,7 @@ export interface Project {
   accountType: AccountType;      // 전용통장/운영통장
   interestRefundPolicy?: InterestRefundPolicy;
   settlementSystem?: SettlementSystemCode;
+  settlementSystemOther?: string;
   laborSettlementBasis?: LaborSettlementBasis;
   fundInputMode?: ProjectFundInputMode;
   settlementSheetPolicy?: SettlementSheetPolicy;
@@ -917,6 +923,7 @@ export interface ProjectRequestPayload {
   accountType: AccountType;
   interestRefundPolicy?: InterestRefundPolicy;
   settlementSystem?: SettlementSystemCode;
+  settlementSystemOther?: string;
   laborSettlementBasis?: LaborSettlementBasis;
   fundInputMode?: ProjectFundInputMode;
   settlementSheetPolicy?: SettlementSheetPolicy;

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
@@ -85,7 +85,10 @@ describe('CashflowSheetLabPage shell', () => {
     expect(pageSource).toContain('reflectResult');
     expect(pageSource).toContain('buildSourceKey');
     expect(pageSource).toContain('reviewedSourceKey === sourceKey');
-    expect(pageSource).toContain('buildSourceKey({ projectId, sourceYear, value: sheetLink, sheetName: nextSheetName, startWeek, endWeek })');
+    expect(pageSource).toContain('buildSourceKey({ projectId, sourceYear, value: sheetLink, sheetName: nextSheetName })');
+    expect(pageSource).not.toContain('startWeek');
+    expect(pageSource).not.toContain('endWeek');
+    expect(pageSource).toContain('선택한 탭 전체를 불러옵니다.');
     expect(pageSource).toContain('expectedMirrorRevision,');
     expect(pageSource).toContain('const refreshIdempotencyKey =');
     expect(pageSource).toContain('const stageIdempotencyKey =');

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
@@ -35,7 +35,6 @@ import {
 import { readRecentPortalProjectIds, rememberRecentPortalProject } from '../../platform/portal-recent-projects';
 import { recordDevtoolsLog } from '../../platform/devtools-transaction-log';
 import { resolvePortalProjectResourcePath } from '../../platform/portal-project-selection';
-import { resolveFinanceWeekForDate } from '../../platform/cashflow-weeks';
 import { CashflowSheetSyncOverlay, type CashflowSheetSyncOperation } from '../../components/cashflow/CashflowSheetSyncOverlay';
 import { CashflowFormulaMismatchDialog } from '../../components/cashflow/CashflowFormulaMismatchDialog';
 
@@ -188,23 +187,17 @@ function buildSourceKey({
   sourceYear,
   value,
   sheetName,
-  startWeek,
-  endWeek,
 }: {
   projectId: string;
   sourceYear: number;
   value: string;
   sheetName: string;
-  startWeek: string;
-  endWeek: string;
 }) {
   return JSON.stringify({
     projectId: projectId.trim(),
     sourceYear,
     value: value.trim(),
     sheetName: sheetName.trim(),
-    startWeek: startWeek.trim(),
-    endWeek: endWeek.trim(),
   });
 }
 
@@ -261,23 +254,11 @@ export function CashflowSheetLabPage({
     const financialYears = (myProject?.financialYears || []).map((row) => row.year).filter(Number.isSafeInteger);
     return financialYears.length > 0 ? financialYears : [2026];
   }, [myProject?.contractEnd, myProject?.contractStart, myProject?.financialYears]);
-  const projectWeekRange = useCallback((year: number) => {
-    const firstYear = projectYears[0];
-    const lastYear = projectYears.at(-1);
-    const startDate = year === firstYear && myProject?.contractStart ? myProject.contractStart : `${year}-01-01`;
-    const endDate = year === lastYear && myProject?.contractEnd ? myProject.contractEnd : `${year}-12-31`;
-    return {
-      startWeek: resolveFinanceWeekForDate(startDate)?.label || `${String(year).slice(2)}-1-1`,
-      endWeek: resolveFinanceWeekForDate(endDate)?.label || `${String(year).slice(2)}-12-5`,
-    };
-  }, [myProject?.contractEnd, myProject?.contractStart, projectYears]);
   const [sourceYear, setSourceYear] = useState(() => (
     projectYears.includes(2026) ? 2026 : projectYears[0] || 2026
   ));
   const [sheetLink, setSheetLink] = useState('');
   const [sheetName, setSheetName] = useState('cashflow(사용내역 연동)');
-  const [startWeek, setStartWeek] = useState('');
-  const [endWeek, setEndWeek] = useState('');
   const [mirror, setMirror] = useState<CashflowSheetLabMirrorResult | null>(null);
   const [reviewedSourceKey, setReviewedSourceKey] = useState('');
   const [savedConfig, setSavedConfig] = useState<CashflowSheetLabShareAccountResult['config']>(null);
@@ -328,15 +309,13 @@ export function CashflowSheetLabPage({
   const tutorialStorageKey = projectId ? `cashflow-sheet-tutorial:${projectId}` : '';
   const currentPath = `${location.pathname}${location.search}${location.hash}`;
   const spreadsheetId = useMemo(() => extractSpreadsheetIdFromSheetInput(sheetLink), [sheetLink]);
-  const hasSheetDraft = Boolean(sheetLink.trim() || sheetName.trim() || startWeek.trim() || endWeek.trim());
+  const hasSheetDraft = Boolean(sheetLink.trim() || sheetName.trim());
   const sourceKey = useMemo(() => buildSourceKey({
     projectId,
     sourceYear,
     value: sheetLink,
     sheetName,
-    startWeek,
-    endWeek,
-  }), [endWeek, projectId, sheetLink, sheetName, sourceYear, startWeek]);
+  }), [projectId, sheetLink, sheetName, sourceYear]);
   const detectedYearModes = useMemo(() => (mirror?.sheetFacts?.annualCashflowTotals || []).map((row) => {
     const sources = new Set([row.projection.source, row.actual.source]);
     const valueCellCount = row.projection.valueCellCount + row.actual.valueCellCount;
@@ -352,8 +331,6 @@ export function CashflowSheetLabPage({
           sourceYear,
           value: savedConfig.value,
           sheetName: savedConfig.sheetName || '',
-          startWeek: savedConfig.startWeek || '',
-          endWeek: savedConfig.endWeek || '',
         })
       : ''
   ), [projectId, savedConfig, sourceYear]);
@@ -530,13 +507,6 @@ export function CashflowSheetLabPage({
   }, [projectYears, sourceYear]);
 
   useEffect(() => {
-    if (savedConfig?.sourceYear === sourceYear || startWeek || endWeek) return;
-    const range = projectWeekRange(sourceYear);
-    setStartWeek(range.startWeek);
-    setEndWeek(range.endWeek);
-  }, [endWeek, projectWeekRange, savedConfig?.sourceYear, sourceYear, startWeek]);
-
-  useEffect(() => {
     if (routeProjectId || !projectId) return;
     navigate(resolvePortalProjectResourcePath(currentPath, projectId), { replace: true });
   }, [currentPath, navigate, projectId, routeProjectId]);
@@ -573,13 +543,10 @@ export function CashflowSheetLabPage({
 
   function handleSourceYearChange(nextYear: number) {
     const nextConfig = savedConfigs.find((config) => config.sourceYear === nextYear) || null;
-    const range = projectWeekRange(nextYear);
     setSourceYear(nextYear);
     setSavedConfig(nextConfig);
     setSheetLink(nextConfig?.value || '');
     setSheetName(nextConfig?.sheetName || 'cashflow(사용내역 연동)');
-    setStartWeek(nextConfig?.startWeek || range.startWeek);
-    setEndWeek(nextConfig?.endWeek || range.endWeek);
     setReviewedSourceKey('');
     setReflectResult(null);
     setStatusMessage('');
@@ -617,8 +584,6 @@ export function CashflowSheetLabPage({
       if (scopedConfig?.value && (forceHydrate || !hasSheetDraft || scopedConfig.sourceYear !== savedConfig?.sourceYear)) {
         setSheetLink(scopedConfig.value);
         setSheetName(scopedConfig.sheetName || 'cashflow(사용내역 연동)');
-        setStartWeek(scopedConfig.startWeek || '');
-        setEndWeek(scopedConfig.endWeek || '');
       }
       if (!scopedConfig?.value) setStatusMessage('공유 계정을 확인했습니다.');
       logCashflowLab('share_account.load.ok', {
@@ -636,13 +601,10 @@ export function CashflowSheetLabPage({
   useEffect(() => {
     if (!projectId || !actor.idToken) return;
     configLoadGenerationRef.current += 1;
-    const range = projectWeekRange(sourceYear);
     setSavedConfig(null);
     setSavedConfigs([]);
     setSheetLink('');
     setSheetName('cashflow(사용내역 연동)');
-    setStartWeek(range.startWeek);
-    setEndWeek(range.endWeek);
     setMirror(null);
     setReviewedSourceKey('');
     setReflectResult(null);
@@ -674,8 +636,6 @@ export function CashflowSheetLabPage({
           sourceYear,
           value: sheetLink,
           sheetName: sheetName || undefined,
-          startWeek: startWeek || undefined,
-          endWeek: endWeek || undefined,
         })
       ));
       if (!result) return;
@@ -713,8 +673,6 @@ export function CashflowSheetLabPage({
           sourceYear,
           value: sheetLink,
           sheetName: sheetName || undefined,
-          startWeek: startWeek || undefined,
-          endWeek: endWeek || undefined,
           idempotencyKey: refreshIdempotencyKey,
         })
       ));
@@ -731,7 +689,7 @@ export function CashflowSheetLabPage({
           }
         : result);
       setReviewedSourceKey(result.status === 'FRESH' && result.sourceRevision
-        ? buildSourceKey({ projectId, sourceYear, value: sheetLink, sheetName: nextSheetName, startWeek, endWeek })
+        ? buildSourceKey({ projectId, sourceYear, value: sheetLink, sheetName: nextSheetName })
         : '');
       if (result.status === 'FRESH' && result.sourceRevision) {
         setStatusMessage('시트 최신값을 고정했습니다. 시트 값으로 덮어쓸 수 있습니다.');
@@ -1081,26 +1039,12 @@ export function CashflowSheetLabPage({
                 aria-label="Google Sheet 링크"
                 className="h-11 rounded-none text-[13px]"
               />
-              <div className="grid gap-2 sm:grid-cols-3">
+              <div>
                 <Input
                   value={sheetName}
                   onChange={(event) => setSheetName(event.target.value)}
                   placeholder="시트 탭 이름"
                   aria-label="시트 탭 이름"
-                  className="h-10 rounded-none text-[12px]"
-                />
-                <Input
-                  value={startWeek}
-                  onChange={(event) => setStartWeek(event.target.value)}
-                  placeholder="시작 주차"
-                  aria-label="시작 주차"
-                  className="h-10 rounded-none text-[12px]"
-                />
-                <Input
-                  value={endWeek}
-                  onChange={(event) => setEndWeek(event.target.value)}
-                  placeholder="종료 주차"
-                  aria-label="종료 주차"
                   className="h-10 rounded-none text-[12px]"
                 />
               </div>
@@ -1117,7 +1061,7 @@ export function CashflowSheetLabPage({
                   {isCurrentSheetConfigSaved ? '저장됨' : '시트 정보 저장'}
                 </Button>
                 <div className="text-[12px] text-slate-500">
-                  {sourceYear}년 링크와 {String(sourceYear).slice(2)}-1-1 ~ {String(sourceYear).slice(2)}-12-5 범위를 입력하세요.
+                  {sourceYear}년 링크와 탭 이름을 입력하면 선택한 탭 전체를 불러옵니다.
                 </div>
               </div>
               <div className="mt-2 space-y-2 border-l-2 border-blue-200 pl-3 text-[12px] text-slate-600" aria-label="Google Sheet 편집자 공유 안내">
@@ -1431,20 +1375,18 @@ export function CashflowSheetLabPage({
                 <DialogHeader>
                   <div className="text-[12px] font-bold text-blue-700">MISSION 2 · 연결 정보</div>
                   <DialogTitle className="text-[25px] font-black leading-tight text-slate-950">
-                    이 네 칸만 시트와 똑같이 적어주세요
+                    이 두 칸만 시트와 똑같이 적어주세요
                   </DialogTitle>
                   <DialogDescription className="text-[14px] leading-relaxed text-slate-600">
-                    Google Sheet 링크, 탭 이름, 시작 주차와 종료 주차를 입력합니다.
+                    Google Sheet 링크와 탭 이름을 입력합니다. 선택한 탭 전체를 불러옵니다.
                   </DialogDescription>
                 </DialogHeader>
                 <div className="mt-6 border-2 border-blue-200 bg-blue-50/60 p-4 shadow-[0_12px_30px_rgba(79,124,255,0.1)]">
                   <div className="mb-3 h-10 border border-blue-300 bg-white px-3 py-2 text-[12px] text-slate-400">
                     https://docs.google.com/spreadsheets/d/...
                   </div>
-                  <div className="grid gap-2 sm:grid-cols-3">
+                  <div>
                     <div className="border border-slate-200 bg-white px-3 py-2 text-[12px] font-medium text-slate-700">cashflow(사용내역 연동)</div>
-                    <div className="border border-slate-200 bg-white px-3 py-2 text-[12px] font-medium text-slate-700">{startWeek || '예: 26-1-1'}</div>
-                    <div className="border border-slate-200 bg-white px-3 py-2 text-[12px] font-medium text-slate-700">{endWeek || '예: 26-12-5'}</div>
                   </div>
                 </div>
                 <div className="mt-4 flex gap-3 border-l-4 border-amber-400 bg-amber-50 px-4 py-3 text-[12px] leading-relaxed text-amber-950">

--- a/src/app/platform/project-editor.test.ts
+++ b/src/app/platform/project-editor.test.ts
@@ -321,7 +321,7 @@ describe('project editor draft mapping', () => {
   it('exposes the exact PPT labels for settlement-none and other account options', () => {
     expect(ACCOUNT_TYPE_LABELS.OTHER).toBe('기타');
     expect(normalizeAccountType('OTHER')).toBe('OTHER');
-    expect(SETTLEMENT_SYSTEM_LABELS.NONE).toBe('정산없음');
+    expect(SETTLEMENT_SYSTEM_LABELS.NONE).toBe('시스템 미사용');
     expect(LABOR_SETTLEMENT_BASIS_LABELS).toMatchObject({
       INCLUDE_ACTUAL_SALARY: '4대보험, 퇴직금 포함 실급여',
       EXCLUDE_ACTUAL_SALARY: '4대보험, 퇴직금 제외 실급여',
@@ -332,7 +332,7 @@ describe('project editor draft mapping', () => {
 
   it('exposes the exact PPT page 30 settlement-system options while retaining legacy codes', () => {
     expect(PROJECT_SETTLEMENT_SYSTEM_CODES.map((code) => [code, SETTLEMENT_SYSTEM_LABELS[code]])).toEqual([
-      ['NONE', '정산없음'],
+      ['NONE', '시스템 미사용'],
       ['E_NARA_DOUM', 'e나라도움 (국고보조금통합관리시스템)'],
       ['BOTAEM_E', '보탬e(지방보조금관리시스템)'],
       ['RCMS', 'RCMS (실시간연구비관리시스템)'],
@@ -341,6 +341,7 @@ describe('project editor draft mapping', () => {
       ['KOCCA_PMS', 'KOCCA PMS'],
       ['NIPA', 'NIPA 사업관리시스템'],
       ['IRIS', 'IRIS(범부처통합연구지원시스템)'],
+      ['OTHER', '기타'],
     ]);
     expect(SETTLEMENT_SYSTEM_LABELS.ACCOUNTANT).toBe('회계사정산');
   });
@@ -511,6 +512,9 @@ describe('project editor draft mapping', () => {
         supportAmount: 5_000,
         profitRate: 0.91,
         confirmed: true,
+        paymentPlan: { contract: 50_000, interim: 0, final: 50_000 },
+        paymentExpectedMonths: { contract: '2026-03', interim: '', final: '2026-12' },
+        advanceInterimBelow70Reason: '  발주처 지급 조건  ',
       }],
       registrationConfirmations: {
         laborIncludesFourInsurance: true,
@@ -547,6 +551,10 @@ describe('project editor draft mapping', () => {
       presentationPptOriginal: 'https://docs.google.com/presentation/d/presentation/edit',
     });
     expect(payload.checkout?.evidenceDeletedAfterUsb).toBe(true);
+    expect(payload.financialYears?.[0]).toMatchObject({
+      paymentExpectedMonths: { contract: '2026-03', interim: '', final: '2026-12' },
+      advanceInterimBelow70Reason: '발주처 지급 조건',
+    });
     expect(payload.customerBusinessRegistrationDocument?.name).toBe('customer-registration.pdf');
     expect(payload.performanceCertificateDocument?.name).toBe('performance.pdf');
   });
@@ -626,7 +634,7 @@ describe('project editor draft mapping', () => {
       expect.arrayContaining([
         {
           key: 'paymentPlanDesc',
-          label: '입금 계획',
+          label: '기타 메모',
           before: '선금 50%, 잔금 50%',
           after: '선금 80%, 잔금 20%',
         },
@@ -842,5 +850,27 @@ describe('project editor draft mapping', () => {
 
     expect(patch.note).toBe('마고와 써니 참여율 보정 메모');
     expect(payload.note).toBe('마고와 써니 참여율 보정 메모');
+  });
+
+  it('preserves spaces while typing a custom settlement system and audits label changes', () => {
+    const customProject = {
+      ...baseProject,
+      settlementSystem: 'OTHER' as const,
+      settlementSystemOther: '기존 시스템',
+    };
+    const draft = createProjectEditorDraft({
+      ...buildProjectEditorDraftFromProject(customProject),
+      settlementSystem: 'OTHER',
+      settlementSystemOther: '새 시스템 ',
+    });
+
+    expect(draft.settlementSystemOther).toBe('새 시스템 ');
+    expect(buildProjectRequestPayloadFromDraft(draft).settlementSystemOther).toBe('새 시스템');
+    expect(buildProjectEditorReviewChanges(customProject, draft)).toEqual(expect.arrayContaining([{
+      key: 'settlementSystem',
+      label: '정산 시스템',
+      before: '기존 시스템',
+      after: '새 시스템',
+    }]));
   });
 });

--- a/src/app/platform/project-editor.ts
+++ b/src/app/platform/project-editor.ts
@@ -110,6 +110,7 @@ export interface ProjectEditorDraft {
   accountType: AccountType;
   interestRefundPolicy: InterestRefundPolicy | '';
   settlementSystem: SettlementSystemCode;
+  settlementSystemOther: string;
   laborSettlementBasis: LaborSettlementBasis;
   fundInputMode: ProjectFundInputMode;
   settlementSheetPolicy: SettlementSheetPolicy;
@@ -215,6 +216,7 @@ const DEFAULT_DRAFT: ProjectEditorDraft = {
   accountType: 'NONE',
   interestRefundPolicy: '',
   settlementSystem: 'NONE',
+  settlementSystemOther: '',
   laborSettlementBasis: 'NONE',
   fundInputMode: 'BANK_UPLOAD',
   settlementSheetPolicy: createSettlementSheetPolicy('STANDARD'),
@@ -317,8 +319,9 @@ function projectFinancialYears(
       profitRate: projectFinancialYearProfitRate(contractAmount, totalRevenueAmount),
       confirmed: source.confirmed === true,
       paymentPlan: normalizePaymentPlan(source.paymentPlan),
+      paymentExpectedMonths: normalizePaymentExpectedMonths(source.paymentExpectedMonths),
       finalPaymentExpectedWeek: normalizeFinanceWeek(source.finalPaymentExpectedWeek, year),
-      advanceInterimBelow70Reason: text(source.advanceInterimBelow70Reason),
+      advanceInterimBelow70Reason: String(source.advanceInterimBelow70Reason || ''),
       isSettled: source.isSettled === true,
     });
   }
@@ -344,6 +347,7 @@ function projectFinancialYears(
         : 0,
       confirmed: false,
       paymentPlan: { contract: 0, interim: 0, final: 0 },
+      paymentExpectedMonths: { contract: '', interim: '', final: '' },
       finalPaymentExpectedWeek: '',
       advanceInterimBelow70Reason: '',
       isSettled: false,
@@ -352,7 +356,11 @@ function projectFinancialYears(
 }
 
 function projectFinancialYearsForWrite(rows: ProjectFinancialYear[]): ProjectFinancialYear[] {
-  return rows.map(({ finalPaymentExpectedWeek: _historicalWeek, ...row }) => row);
+  return rows.map(({ finalPaymentExpectedWeek: _historicalWeek, ...row }) => ({
+    ...row,
+    paymentExpectedMonths: normalizePaymentExpectedMonths(row.paymentExpectedMonths),
+    advanceInterimBelow70Reason: text(row.advanceInterimBelow70Reason),
+  }));
 }
 
 function registrationConfirmations(value: unknown): ProjectRegistrationConfirmations {
@@ -491,7 +499,7 @@ const REVIEW_CHANGE_FIELDS: Array<{
   { key: 'settlementType', label: '정산 유형', before: (project) => SETTLEMENT_TYPE_LABELS[normalizeSettlementType(project.settlementType)] || '-', after: (draft) => SETTLEMENT_TYPE_LABELS[normalizeSettlementType(draft.settlementType)] || '-' },
   { key: 'basis', label: '정산 기준', before: (project) => BASIS_LABELS[normalizeBasis(project.basis)] || '-', after: (draft) => BASIS_LABELS[normalizeBasis(draft.basis)] || '-' },
   { key: 'accountType', label: '통장 유형', before: (project) => ACCOUNT_TYPE_LABELS[normalizeAccountType(project.accountType)] || '-', after: (draft) => ACCOUNT_TYPE_LABELS[normalizeAccountType(draft.accountType)] || '-' },
-  { key: 'settlementSystem', label: '정산 시스템', before: (project) => SETTLEMENT_SYSTEM_LABELS[normalizeSettlementSystemCode(project.settlementSystem)] || '-', after: (draft) => SETTLEMENT_SYSTEM_LABELS[normalizeSettlementSystemCode(draft.settlementSystem)] || '-' },
+  { key: 'settlementSystem', label: '정산 시스템', before: (project) => normalizeSettlementSystemCode(project.settlementSystem) === 'OTHER' ? normalizeChangeValue(project.settlementSystemOther) : SETTLEMENT_SYSTEM_LABELS[normalizeSettlementSystemCode(project.settlementSystem)] || '-', after: (draft) => normalizeSettlementSystemCode(draft.settlementSystem) === 'OTHER' ? normalizeChangeValue(draft.settlementSystemOther) : SETTLEMENT_SYSTEM_LABELS[normalizeSettlementSystemCode(draft.settlementSystem)] || '-' },
   { key: 'laborSettlementBasis', label: '인건비 정산 기준', before: (project) => LABOR_SETTLEMENT_BASIS_LABELS[normalizeLaborSettlementBasis(project.laborSettlementBasis)] || '-', after: (draft) => LABOR_SETTLEMENT_BASIS_LABELS[normalizeLaborSettlementBasis(draft.laborSettlementBasis)] || '-' },
   { key: 'fundInputMode', label: '자금 입력 방식', before: (project) => PROJECT_FUND_INPUT_MODE_LABELS[normalizeProjectFundInputMode(project.fundInputMode)] || '-', after: (draft) => PROJECT_FUND_INPUT_MODE_LABELS[normalizeProjectFundInputMode(draft.fundInputMode)] || '-' },
   { key: 'registeredByName', label: '사업 담당자', before: (project) => normalizeChangeValue(project.registeredByName || project.managerName), after: (draft) => normalizeChangeValue(draft.registeredByName || draft.managerName) },
@@ -501,7 +509,7 @@ const REVIEW_CHANGE_FIELDS: Array<{
   { key: 'paymentPlan', label: '입금 분할', before: (project) => formatPaymentPlanForChange(project.paymentPlan), after: (draft) => formatPaymentPlanForChange(draft.paymentPlan) },
   { key: 'paymentExpectedMonths', label: '입금 예상월', before: (project) => formatPaymentExpectedMonthsForChange(project.paymentExpectedMonths), after: (draft) => formatPaymentExpectedMonthsForChange(draft.paymentExpectedMonths) },
   { key: 'advanceInterimBelow70Reason', label: '선금·중도금 70% 미만 사유', before: (project) => normalizeChangeValue(project.advanceInterimBelow70Reason), after: (draft) => normalizeChangeValue(draft.advanceInterimBelow70Reason) },
-  { key: 'paymentPlanDesc', label: '입금 계획', before: (project) => normalizeChangeValue(project.paymentPlanDesc), after: (draft) => normalizeChangeValue(draft.paymentPlanDesc) },
+  { key: 'paymentPlanDesc', label: '기타 메모', before: (project) => normalizeChangeValue(project.paymentPlanDesc), after: (draft) => normalizeChangeValue(draft.paymentPlanDesc) },
   { key: 'finalPaymentNote', label: '최종 입금 메모', before: (project) => normalizeChangeValue(project.finalPaymentNote), after: (draft) => normalizeChangeValue(draft.finalPaymentNote) },
   { key: 'projectPurpose', label: '프로젝트 목적', before: (project) => normalizeChangeValue(project.projectPurpose), after: (draft) => normalizeChangeValue(draft.projectPurpose) },
   { key: 'description', label: '주요 내용', before: (project) => normalizeChangeValue(project.description), after: (draft) => normalizeChangeValue(draft.description) },
@@ -560,6 +568,9 @@ export function createProjectEditorDraft(overrides: Partial<ProjectEditorDraft> 
     settlementSystem: !settlementDetailsEnabled
       ? 'NONE'
       : normalizeSettlementSystemCode(overrides.settlementSystem ?? DEFAULT_DRAFT.settlementSystem),
+    settlementSystemOther: !settlementDetailsEnabled
+      ? ''
+      : String(overrides.settlementSystemOther || ''),
     laborSettlementBasis: !settlementDetailsEnabled
       ? 'NONE'
       : normalizeLaborSettlementBasis(overrides.laborSettlementBasis ?? DEFAULT_DRAFT.laborSettlementBasis),
@@ -690,6 +701,9 @@ export function buildProjectEditorDraftFromProject(
     settlementSystem: normalizeSettlementSystemCode(
       normalizedProject.settlementSystem || payload?.settlementSystem,
     ),
+    settlementSystemOther: text(
+      normalizedProject.settlementSystemOther || payload?.settlementSystemOther,
+    ),
     laborSettlementBasis: normalizeLaborSettlementBasis(
       normalizedProject.laborSettlementBasis || payload?.laborSettlementBasis,
     ),
@@ -781,6 +795,7 @@ export function buildProjectRequestPayloadFromDraft(draftInput: ProjectEditorDra
     accountType: normalizeAccountType(draft.accountType),
     interestRefundPolicy: normalizeInterestRefundPolicy(draft.interestRefundPolicy) || undefined,
     settlementSystem: normalizeSettlementSystemCode(draft.settlementSystem),
+    settlementSystemOther: draft.settlementSystem === 'OTHER' ? text(draft.settlementSystemOther) : '',
     laborSettlementBasis: normalizeLaborSettlementBasis(draft.laborSettlementBasis),
     fundInputMode: normalizeProjectFundInputMode(draft.fundInputMode),
     settlementSheetPolicy: normalizeSettlementSheetPolicy(draft.settlementSheetPolicy, normalizeProjectFundInputMode(draft.fundInputMode)),
@@ -890,6 +905,7 @@ export function buildProjectEditorProjectPatch(
     accountType: normalizeAccountType(draft.accountType),
     interestRefundPolicy: normalizeInterestRefundPolicy(draft.interestRefundPolicy) || undefined,
     settlementSystem: normalizeSettlementSystemCode(draft.settlementSystem),
+    settlementSystemOther: draft.settlementSystem === 'OTHER' ? text(draft.settlementSystemOther) : '',
     laborSettlementBasis: normalizeLaborSettlementBasis(draft.laborSettlementBasis),
     fundInputMode: normalizeProjectFundInputMode(draft.fundInputMode),
     settlementSheetPolicy: normalizeSettlementSheetPolicy(draft.settlementSheetPolicy, normalizeProjectFundInputMode(draft.fundInputMode)),
@@ -911,7 +927,7 @@ export function buildProjectEditorProjectPatch(
     salesVatAmount: nonNegativeAmount(draft.salesVatAmount),
     financialInputFlags: flags,
     registrationRequirementsVersion: draft.registrationRequirementsVersion,
-    financialYears: draft.financialYears,
+    financialYears: projectFinancialYearsForWrite(draft.financialYears),
     registrationOptionalDocumentNotes: draft.registrationOptionalDocumentNotes,
     registrationConfirmations: draft.registrationConfirmations,
     finalPaymentExpectedWeek: normalizeFinanceWeek(draft.finalPaymentExpectedWeek),


### PR DESCRIPTION
## What
- sort cashflow activity month filters chronologically and simplify weekly apply wording
- refresh the full selected Google Sheet tab instead of exposing week-range controls
- rename settlement non-use state and persist/select custom settlement systems
- clarify annual contract/finance confirmation, preserve input spacing, and simplify memo guidance
- add expected receipt month fields for advance, interim, and final payments

## Why
Apply the six scoped frontend QA items without changing unrelated ERP behavior.

## Verification
- Full Vitest: 809/809 suites, 2,895 tests, 0 failures (2,654 passed, 241 pending)
- Targeted affected tests: 278/278 passed
- Failure-file isolation rerun: 363/363 passed
- Production build: passed
- git diff --check: passed

## Ops
- No Firestore rules/index changes
- No environment variable changes
- Production deployment remains GitHub Actions-only after merge