### PR TITLE
fix(cashflow): validate weekly projection window from JVM state

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -2767,6 +2767,9 @@ export function mountJvmWeeklyApiRoutes(app, {
     const requestedYearMonth = readOptionalText(requested.yearMonth);
     const requestedWeekNo = Number(requested.weekNo);
     const updateResult = readOptionalText(requested.updateResult).toUpperCase();
+    const ignoreProjectionValidation = requested.ignoreProjectionValidation === true;
+    const projectionValidationEvidenceHash = readOptionalText(requested.projectionValidationEvidenceHash);
+    const projectionValidationIssueCount = Number(requested.projectionValidationIssueCount || 0);
     const hasExplicitScope = Object.prototype.hasOwnProperty.call(requested, 'yearMonth')
       || Object.prototype.hasOwnProperty.call(requested, 'weekNo');
     if (!['CHANGED', 'NO_CHANGES'].includes(updateResult) || (hasExplicitScope && (
@@ -2774,6 +2777,11 @@ export function mountJvmWeeklyApiRoutes(app, {
       || !Number.isSafeInteger(requestedWeekNo)
       || requestedWeekNo < 1
       || requestedWeekNo > 5
+    )) || (ignoreProjectionValidation && (
+      !/^sha256:[a-f0-9]{64}$/.test(projectionValidationEvidenceHash)
+      || !Number.isSafeInteger(projectionValidationIssueCount)
+      || projectionValidationIssueCount < 1
+      || projectionValidationIssueCount > 256
     ))) {
       throw createHttpError(
         400,
@@ -2795,6 +2803,9 @@ export function mountJvmWeeklyApiRoutes(app, {
         weekNo: hasExplicitScope ? requestedWeekNo : boundary.asOfWeek.weekNo,
         completedAt: currentNow.toISOString(),
         updateResult,
+        ignoreProjectionValidation,
+        projectionValidationEvidenceHash: ignoreProjectionValidation ? projectionValidationEvidenceHash : '',
+        projectionValidationIssueCount: ignoreProjectionValidation ? projectionValidationIssueCount : 0,
       },
       { cashflowWrite: true },
     );

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -1685,6 +1685,11 @@ describe('JVM weekly API BFF proxy', () => {
     const fetchImpl = vi.fn(async (_url, init) => {
       const body = JSON.parse(init.body);
       expect(body.updateResult).toBe('NO_CHANGES');
+      expect(body).toMatchObject({
+        ignoreProjectionValidation: false,
+        projectionValidationEvidenceHash: '',
+        projectionValidationIssueCount: 0,
+      });
       return {
         ok: false,
         status: 409,
@@ -1705,7 +1710,11 @@ describe('JVM weekly API BFF proxy', () => {
     await request(app)
       .post('/api/v1/cashflow/project-a/weekly-update-complete')
       .set('idempotency-key', 'weekly-no-changes')
-      .send({ yearMonth: '2026-06', weekNo: 2, updateResult: 'NO_CHANGES' })
+      .send({
+        yearMonth: '2026-06', weekNo: 2, updateResult: 'NO_CHANGES',
+        projectionValidationEvidenceHash: `sha256:${'f'.repeat(64)}`,
+        projectionValidationIssueCount: 42,
+      })
       .expect(409)
       .expect((response) => expect(response.body).toMatchObject({
         code: 'cashflow_projection_window_incomplete',
@@ -1714,6 +1723,35 @@ describe('JVM weekly API BFF proxy', () => {
           missingCells: [{ yearMonth: '2026-05', weekNo: 1, lineId: 'SALES_IN' }],
         },
       }));
+  });
+
+  it('forwards an explicit projection validation override and its evidence to JVM', async () => {
+    const evidenceHash = `sha256:${'a'.repeat(64)}`;
+    const fetchImpl = vi.fn(async (_url, init) => {
+      expect(JSON.parse(init.body)).toMatchObject({
+        updateResult: 'CHANGED',
+        ignoreProjectionValidation: true,
+        projectionValidationEvidenceHash: evidenceHash,
+        projectionValidationIssueCount: 32,
+      });
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ projectId: 'project-a', yearMonth: '2026-06', weekNo: 2, status: 'LOCKED' }),
+      };
+    });
+    const { app } = createApp(fetchImpl, createIdempotencyService(), { actorRole: 'viewer' }, {
+      env: runtimeEnv, db: fullMonthCloseSource().db,
+    });
+    await request(app)
+      .post('/api/v1/cashflow/project-a/weekly-update-complete')
+      .send({
+        yearMonth: '2026-06', weekNo: 2, updateResult: 'CHANGED',
+        ignoreProjectionValidation: true,
+        projectionValidationEvidenceHash: evidenceHash,
+        projectionValidationIssueCount: 32,
+      })
+      .expect(200);
   });
 
   it('adapts the canonical JVM weekly compliance cursor page and validates its query', async () => {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CompleteCashflowWeeklyUpdateRequest.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CompleteCashflowWeeklyUpdateRequest.java
@@ -11,9 +11,18 @@ public record CompleteCashflowWeeklyUpdateRequest(
     @NotBlank @Pattern(regexp = "20\\d{2}-(0[1-9]|1[0-2])") String yearMonth,
     @Min(1) @Max(CashflowSheetLabApplyRequest.FINANCE_WEEK_COUNT) int weekNo,
     @NotBlank @Size(max = 64) String completedAt,
-    @NotBlank @Pattern(regexp = "CHANGED|NO_CHANGES") String updateResult
+    @NotBlank @Pattern(regexp = "CHANGED|NO_CHANGES") String updateResult,
+    boolean ignoreProjectionValidation,
+    @Size(max = 80) String projectionValidationEvidenceHash,
+    @Min(0) @Max(256) int projectionValidationIssueCount
 ) {
     public CompleteCashflowWeeklyUpdateRequest(String idempotencyKey, String yearMonth, int weekNo, String completedAt) {
-        this(idempotencyKey, yearMonth, weekNo, completedAt, "CHANGED");
+        this(idempotencyKey, yearMonth, weekNo, completedAt, "CHANGED", false, "", 0);
+    }
+
+    public CompleteCashflowWeeklyUpdateRequest(
+        String idempotencyKey, String yearMonth, int weekNo, String completedAt, String updateResult
+    ) {
+        this(idempotencyKey, yearMonth, weekNo, completedAt, updateResult, false, "", 0);
     }
 }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -1061,11 +1061,17 @@ public class WeeklyExpenseCommandService {
             actor,
             projectId
         );
-        String requestHash = hashJson(Map.of(
+        Map<String, Object> requestHashInput = new LinkedHashMap<>(Map.of(
             "yearMonth", request.yearMonth(),
             "weekNo", request.weekNo(),
             "updateResult", request.updateResult()
         ));
+        if (request.ignoreProjectionValidation()) {
+            requestHashInput.put("ignoreProjectionValidation", true);
+            requestHashInput.put("projectionValidationEvidenceHash", normalizeText(request.projectionValidationEvidenceHash()));
+            requestHashInput.put("projectionValidationIssueCount", request.projectionValidationIssueCount());
+        }
+        String requestHash = hashJson(requestHashInput);
         Optional<CashflowWeeklyUpdateCompletionResponse> replay = readIdempotentResponse(
             writer.tenantId(),
             projectId,
@@ -1081,7 +1087,14 @@ public class WeeklyExpenseCommandService {
             projectId,
             request
         );
-        if (!saved.alreadyCompleted()) {
+        if (!saved.alreadyCompleted() || request.ignoreProjectionValidation()) {
+            String auditEventId = saved.alreadyCompleted()
+                ? "weekly-override-" + hashJson(Map.of(
+                    "tenantId", writer.tenantId(),
+                    "projectId", projectId,
+                    "idempotencyKey", request.idempotencyKey()
+                )).replace("sha256:", "")
+                : saved.auditId();
             WeeklyExpenseAuditEventEntity event = new WeeklyExpenseAuditEventEntity(
                 writer.tenantId(),
                 projectId,
@@ -1098,15 +1111,18 @@ public class WeeklyExpenseCommandService {
                     Map.entry("deadline", saved.deadline()),
                     Map.entry("status", saved.complianceStatus()),
                     Map.entry("operationId", saved.operationId()),
-                    Map.entry("auditId", saved.auditId()),
+                    Map.entry("auditId", auditEventId),
                     Map.entry("updateResult", saved.updateResult()),
+                    Map.entry("projectionValidationOverride", saved.projectionValidationOverride()),
+                    Map.entry("projectionValidationIssueCount", saved.projectionValidationIssueCount()),
+                    Map.entry("projectionValidationEvidenceHash", saved.projectionValidationEvidenceHash()),
                     Map.entry("snapshotHash", saved.snapshotHash()),
                     Map.entry("sourceRevision", saved.sourceRevision()),
                     Map.entry("targetRevision", saved.targetRevision()),
                     Map.entry("revision", saved.revision())
                 ))
             );
-            event.restorePersistenceState(saved.auditId(), event.getCreatedAt());
+            event.restorePersistenceState(auditEventId, event.getCreatedAt());
             persistence.saveAuditEvent(event);
         }
         CashflowWeeklyUpdateCompletionResponse response = weeklyCompletionResponse(

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -1559,6 +1559,61 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             WeekDocParts parts = parseCashflowWeekId(projectId, weekSnapshot.getId());
             projectWeeks.put(weekSnapshot.getId(), week);
         }
+        List<Map<String, Object>> missingCells = new ArrayList<>();
+        List<CashflowWeekScope> projectionValidationWindow = consecutiveFinanceWeeks(
+            request.yearMonth(), request.weekNo(), 16
+        );
+        for (CashflowWeekScope scope : projectionValidationWindow) {
+            Map<String, Object> candidate = projectWeeks.getOrDefault(
+                cashflowWeekId(projectId, scope.yearMonth(), scope.weekNo()),
+                Map.of()
+            );
+            Map<String, Object> projection = nestedMap(candidate.get("projection"));
+            for (String lineId : CASHFLOW_CUMULATIVE_LINES) {
+                if (projection.containsKey(lineId) && projection.get(lineId) != null) continue;
+                missingCells.add(Map.of(
+                    "yearMonth", scope.yearMonth(),
+                    "weekNo", scope.weekNo(),
+                    "lineId", lineId
+                ));
+            }
+        }
+        Map<String, Object> projectionValidationEvidence = Map.ofEntries(
+            Map.entry("tenantId", actor.tenantId()),
+            Map.entry("projectId", projectId),
+            Map.entry("yearMonth", request.yearMonth()),
+            Map.entry("weekNo", request.weekNo()),
+            Map.entry("windowStart", projectionValidationWindow.getFirst().yearMonth() + "-w" + projectionValidationWindow.getFirst().weekNo()),
+            Map.entry("windowEnd", projectionValidationWindow.getLast().yearMonth() + "-w" + projectionValidationWindow.getLast().weekNo()),
+            Map.entry("requiredWeekCount", 16),
+            Map.entry("requiredCellCount", 256),
+            Map.entry("missingCells", List.copyOf(missingCells))
+        );
+        String projectionValidationEvidenceHash = hashCanonicalJson(projectionValidationEvidence);
+        if (!missingCells.isEmpty() && !request.ignoreProjectionValidation()) {
+            Map<String, Object> details = new LinkedHashMap<>(projectionValidationEvidence);
+            details.put("evidenceHash", projectionValidationEvidenceHash);
+            throw new WeeklyExpenseEditLeaseException(
+                409,
+                "cashflow_projection_window_incomplete",
+                "대상 주차와 그 이후 15개 재무주차의 Projection 값을 모두 입력해 주세요.",
+                Map.copyOf(details)
+            );
+        }
+        if (request.ignoreProjectionValidation() && (
+            !projectionValidationEvidenceHash.equals(text(request.projectionValidationEvidenceHash(), ""))
+            || request.projectionValidationIssueCount() != missingCells.size()
+        )) {
+            Map<String, Object> details = new LinkedHashMap<>(projectionValidationEvidence);
+            details.put("evidenceHash", projectionValidationEvidenceHash);
+            throw new WeeklyExpenseEditLeaseException(
+                409,
+                "cashflow_projection_window_changed",
+                "Projection 검증 결과가 변경되었습니다. 최신 결과를 다시 확인해 주세요.",
+                Map.copyOf(details)
+            );
+        }
+        boolean projectionValidationOverride = request.ignoreProjectionValidation() && !missingCells.isEmpty();
         if (lockedCompletion != null) {
             submitWeeklySettlementIfWaiting(actor, projectId, request.yearMonth(), settlementStatus);
             return toWeeklyCompletionRecord(
@@ -1620,6 +1675,9 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         completion.put("completedByEmail", actor.email());
         completion.put("completedByName", actor.name());
         completion.put("updateResult", request.updateResult());
+        completion.put("projectionValidationOverride", projectionValidationOverride);
+        completion.put("projectionValidationIssueCount", missingCells.size());
+        completion.put("projectionValidationEvidenceHash", projectionValidationEvidenceHash);
         Instant deadline = financeWeekDeadline(request.yearMonth(), request.weekNo());
         completion.put("deadline", deadline.toString());
         completion.put("complianceStatus", weeklyComplianceStatus(request.yearMonth(), request.weekNo(), completedAt, deadline));
@@ -3781,7 +3839,10 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             text(document.get("complianceStatus"), ""),
             text(document.get("operationId"), ""),
             text(document.get("auditId"), ""),
-            text(document.get("updateResult"), "")
+            text(document.get("updateResult"), ""),
+            bool(document.get("projectionValidationOverride")),
+            intValue(document.get("projectionValidationIssueCount"), 0),
+            text(document.get("projectionValidationEvidenceHash"), "")
         );
     }
 

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
@@ -300,7 +300,10 @@ public interface WeeklyExpensePersistence {
         String complianceStatus,
         String operationId,
         String auditId,
-        String updateResult
+        String updateResult,
+        boolean projectionValidationOverride,
+        int projectionValidationIssueCount,
+        String projectionValidationEvidenceHash
     ) {
         public CashflowWeeklyUpdateCompletionRecord(
             String projectId, String yearMonth, int weekNo, String completedAt, String completedBy,
@@ -309,7 +312,7 @@ public interface WeeklyExpensePersistence {
         ) {
             this(projectId, yearMonth, weekNo, completedAt, completedBy, alreadyCompleted, status, revision,
                 reopenCount, snapshotHash, sourceRevision, targetRevision, reopenedAt, reopenedBy, reopenReason,
-                "", "", "", "", "");
+                "", "", "", "", "", false, 0, "");
         }
     }
 

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -192,6 +192,7 @@ class FirestoreCashflowLeaseGuardTest {
     @Test
     void readsWeeklySettlementStatusBeforeTheFirstTransactionalWrite() {
         Fixture fixture = fixture(activeMember(), Map.of());
+        putCompleteProjectionWindow(fixture, "2026-08", 2);
 
         fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
             .completeCashflowWeeklyUpdate(
@@ -215,6 +216,8 @@ class FirestoreCashflowLeaseGuardTest {
     void writesCanonicalJanuaryAndAugustWeeklySettlementKeys() {
         Fixture january = fixture(activeMember(), Map.of());
         Fixture august = fixture(activeMember(), Map.of());
+        putCompleteProjectionWindow(january, "2026-01", 1);
+        putCompleteProjectionWindow(august, "2026-08", 2);
 
         january.persistence.runCommandTransaction(() -> commandService(january.persistence)
             .completeCashflowWeeklyUpdate(
@@ -271,6 +274,7 @@ class FirestoreCashflowLeaseGuardTest {
     @Test
     void allowsManagerApprovalAfterWeeklyCompletion() {
         Fixture fixture = fixture(activeMember(), Map.of());
+        putCompleteProjectionWindow(fixture, "2026-08", 2);
         fixture.documents.put("orgs/tenant-a/projects/project-a", Map.of(
             "id", "project-a",
             "tenantId", "tenant-a",
@@ -2652,22 +2656,111 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
-    void weeklyCompletionTracksStatusWithoutRequiringProjectionValues() {
+    void weeklyCompletionValidatesCanonicalSixteenWeekWindowAndAllowsAuditedOverride() {
         Fixture fixture = fixture(activeMember(), Map.of());
-        CompleteCashflowWeeklyUpdateRequest request = new CompleteCashflowWeeklyUpdateRequest(
+        putCompleteProjectionWindow(fixture, "2026-12", 4);
+        String missingPath = "orgs/tenant-a/cashflow_weeks/project-a-2027-01-w2";
+        Map<String, Object> missingWeek = new LinkedHashMap<>(fixture.documents.get(missingPath));
+        Map<String, Object> projection = new LinkedHashMap<>((Map<String, Object>) missingWeek.get("projection"));
+        projection.remove("SALES_IN");
+        missingWeek.put("projection", projection);
+        fixture.documents.put(missingPath, missingWeek);
+        CompleteCashflowWeeklyUpdateRequest initial = new CompleteCashflowWeeklyUpdateRequest(
             "window-cross-year", "2026-12", 4, "2026-12-24T14:59:00Z", "NO_CHANGES"
         );
 
+        Throwable failure = catchThrowable(() -> fixture.persistence.runCommandTransaction(() -> commandService(
+            fixture.persistence
+        ).completeCashflowWeeklyUpdate(ACTOR, "project-a", initial)));
+        assertThat(failure).isInstanceOf(WeeklyExpenseEditLeaseException.class);
+        WeeklyExpenseEditLeaseException incomplete = (WeeklyExpenseEditLeaseException) failure;
+        assertThat(incomplete.code()).isEqualTo("cashflow_projection_window_incomplete");
+        assertThat(incomplete.details())
+            .containsEntry("tenantId", "tenant-a")
+            .containsEntry("projectId", "project-a")
+            .containsEntry("yearMonth", "2026-12")
+            .containsEntry("weekNo", 4)
+            .containsEntry("windowStart", "2026-12-w4")
+            .containsEntry("windowEnd", "2027-03-w4")
+            .containsEntry("requiredWeekCount", 16)
+            .containsEntry("requiredCellCount", 256);
+        assertThat((List<Map<String, Object>>) incomplete.details().get("missingCells"))
+            .containsExactly(Map.of("yearMonth", "2027-01", "weekNo", 2, "lineId", "SALES_IN"));
+        assertThat(fixture.documents.keySet()).noneMatch(path -> path.contains("/cashflow_weekly_update_completions/")
+            || path.contains("/cashflow_weekly_update_completion_versions/")
+            || path.contains("/weekly_api_audit_events/"));
+        verify(fixture.transaction, never()).set(any(DocumentReference.class), any(), any());
+
+        String evidenceHash = String.valueOf(incomplete.details().get("evidenceHash"));
+        Throwable staleOverride = catchThrowable(() -> fixture.persistence.runCommandTransaction(() -> commandService(
+            fixture.persistence
+        ).completeCashflowWeeklyUpdate(ACTOR, "project-a", new CompleteCashflowWeeklyUpdateRequest(
+            "window-cross-year-stale", "2026-12", 4, "2026-12-24T14:59:00Z", "NO_CHANGES",
+            true, "sha256:" + "f".repeat(64), 1
+        ))));
+        assertThat(staleOverride).isInstanceOf(WeeklyExpenseEditLeaseException.class);
+        assertThat(((WeeklyExpenseEditLeaseException) staleOverride).code())
+            .isEqualTo("cashflow_projection_window_changed");
+        assertThat(fixture.documents.keySet()).noneMatch(path -> path.contains("/cashflow_weekly_update_completions/")
+            || path.contains("/cashflow_weekly_update_completion_versions/")
+            || path.contains("/weekly_api_audit_events/"));
+
+        projection.put("SALES_IN", 0L);
+        missingWeek.put("projection", projection);
+        fixture.documents.put(missingPath, missingWeek);
+        Throwable resolvedOverride = catchThrowable(() -> fixture.persistence.runCommandTransaction(() -> commandService(
+            fixture.persistence
+        ).completeCashflowWeeklyUpdate(ACTOR, "project-a", new CompleteCashflowWeeklyUpdateRequest(
+            "window-cross-year-resolved", "2026-12", 4, "2026-12-24T14:59:00Z", "NO_CHANGES",
+            true, evidenceHash, 1
+        ))));
+        assertThat(resolvedOverride).isInstanceOf(WeeklyExpenseEditLeaseException.class);
+        assertThat(((WeeklyExpenseEditLeaseException) resolvedOverride).code())
+            .isEqualTo("cashflow_projection_window_changed");
+
+        projection.remove("SALES_IN");
+        missingWeek.put("projection", projection);
+        fixture.documents.put(missingPath, missingWeek);
+
+        CompleteCashflowWeeklyUpdateRequest override = new CompleteCashflowWeeklyUpdateRequest(
+            "window-cross-year-override", "2026-12", 4, "2026-12-24T14:59:00Z", "NO_CHANGES",
+            true, evidenceHash, 1
+        );
         CashflowWeeklyUpdateCompletionResponse completed = fixture.persistence.runCommandTransaction(() -> commandService(
             fixture.persistence
-        ).completeCashflowWeeklyUpdate(ACTOR, "project-a", request));
+        ).completeCashflowWeeklyUpdate(ACTOR, "project-a", override));
         assertThat(completed.status()).isEqualTo("LOCKED");
         assertThat(completed.updateResult()).isEqualTo("NO_CHANGES");
         assertThat(completed.complianceStatus()).isEqualTo("ON_TIME");
+        assertThat(fixture.documents.get(
+            "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-12-w4"
+        ))
+            .containsEntry("projectionValidationOverride", true)
+            .containsEntry("projectionValidationIssueCount", 1)
+            .containsEntry("projectionValidationEvidenceHash", evidenceHash);
+        assertThat(fixture.documents.entrySet().stream()
+            .filter(entry -> entry.getKey().contains("/weekly_api_audit_events/"))
+            .map(entry -> String.valueOf(entry.getValue().get("metadataJson"))))
+            .singleElement()
+            .satisfies(metadata -> assertThat(metadata)
+                .contains("\"projectionValidationOverride\":true")
+                .contains("\"projectionValidationIssueCount\":1")
+                .contains(evidenceHash));
         Map<?, ?> periods = (Map<?, ?>) fixture.documents.get(
             "orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-12"
         ).get("periods");
         assertThat(((Map<?, ?>) periods.get("WEEK_4")).get("status")).isEqualTo("PENDING_APPROVAL");
+
+        CashflowWeeklyUpdateCompletionResponse replay = fixture.persistence.runCommandTransaction(() -> commandService(
+            fixture.persistence
+        ).completeCashflowWeeklyUpdate(ACTOR, "project-a", override));
+        assertThat(replay).isEqualTo(completed);
+        assertThat(fixture.documents.keySet().stream()
+            .filter(path -> path.contains("/cashflow_weekly_update_completion_versions/")))
+            .hasSize(1);
+        assertThat(fixture.documents.keySet().stream()
+            .filter(path -> path.contains("/weekly_api_audit_events/")))
+            .hasSize(1);
     }
 
     @Test

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -381,15 +381,14 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain("updateResult: weeklyUpdateResult");
     expect(source).toContain("['CHANGED', '변경사항 반영 완료'");
     expect(source).toContain("['NO_CHANGES', '변경사항 없음'");
-    expect(source).toContain('이번 주차의 처리 결과만 선택해 정산 상태를 업데이트합니다.');
+    expect(source).toContain('대상 주차와 그 이후 15개 재무주차(총 16주·256칸)의 JVM 저장 Projection 값을 확인합니다.');
     expect(source).toContain(".sort((left, right) => left.localeCompare(right))");
-    expect(source).toContain('>}반영');
-    expect(source).not.toContain('무시하고 반영');
+    expect(source).toContain("weeklyProjectionWarning ? '무시하고 반영' : '반영'");
     expect(source).not.toContain('선택한 결과로 완료');
-    expect(source).not.toContain('그 이후 15개 재무주차(총 16주·256칸)');
+    expect(source).toContain('서버가 확인한 미입력 항목');
     expect(source).not.toContain('ZERO(0원)는 작성값이며 EMPTY(미입력)는 완료할 수 없습니다.');
     expect(source).not.toContain('Cashflow weekly lock no longer matches');
-    expect(source).not.toContain('weeklyProjectionMissingCells(error)');
+    expect(source).toContain('weeklyProjectionValidation(error)');
     expect(source).toContain('fetchCashflowWeeklyComplianceViaBff');
     expect(source).toContain("week.status === 'ON_TIME'");
     expect(source).toContain("week.status === 'COMPLETED_LATE'");
@@ -557,9 +556,9 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain("const totalActual = projectLineTotalFor('actual', lineId)");
   });
 
-  it('does not expose the retired Projection completeness gate', () => {
-    expect(source).not.toContain('서버가 확인한 EMPTY 항목');
-    expect(source).not.toContain('Projection 미입력 주차와 항목');
+  it('shows the restored JVM Projection completeness warning', () => {
+    expect(source).toContain('서버가 확인한 미입력 항목');
+    expect(source).toContain('Projection 미입력 주차와 항목');
   });
 
   it('renders annual carry-forward and future totals around the selected year weekly ledger', () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -128,6 +128,25 @@ function formatSheetAppliedAt(value?: string | null): string {
   }).format(date);
 }
 
+type WeeklyProjectionMissingCell = { yearMonth: string; weekNo: number; lineId: string };
+type WeeklyProjectionValidation = { missingCells: WeeklyProjectionMissingCell[]; evidenceHash: string };
+
+function weeklyProjectionValidation(error: unknown): WeeklyProjectionValidation | null {
+  const details = (error as { body?: { details?: { missingCells?: unknown; evidenceHash?: unknown } } })?.body?.details;
+  const missingCells = Array.isArray(details?.missingCells)
+    ? details.missingCells.filter((cell): cell is WeeklyProjectionMissingCell => Boolean(
+      cell && typeof cell === 'object'
+      && /^20\d{2}-(0[1-9]|1[0-2])$/.test(String((cell as WeeklyProjectionMissingCell).yearMonth))
+      && Number.isInteger(Number((cell as WeeklyProjectionMissingCell).weekNo))
+      && typeof (cell as WeeklyProjectionMissingCell).lineId === 'string',
+    ))
+    : [];
+  const evidenceHash = typeof details?.evidenceHash === 'string' ? details.evidenceHash : '';
+  return missingCells.length > 0 && /^sha256:[a-f0-9]{64}$/.test(evidenceHash)
+    ? { missingCells, evidenceHash }
+    : null;
+}
+
 function decodeActivityActor(value?: string): string {
   const text = String(value || '').trim();
   if (!text) return '';
@@ -372,6 +391,7 @@ export function CashflowProjectSheet({
   const [weeklyCompletionOpen, setWeeklyCompletionOpen] = useState(false);
   const [weeklyUpdateResult, setWeeklyUpdateResult] = useState<'CHANGED' | 'NO_CHANGES' | ''>('');
   const [weeklyCompletionError, setWeeklyCompletionError] = useState('');
+  const [weeklyProjectionWarning, setWeeklyProjectionWarning] = useState<WeeklyProjectionValidation | null>(null);
   const [weeklyHistoryOpen, setWeeklyHistoryOpen] = useState(false);
   const [weeklyComplianceHistory, setWeeklyComplianceHistory] = useState<CashflowWeeklyComplianceItem[]>([]);
   const [weeklyComplianceHistoryLoading, setWeeklyComplianceHistoryLoading] = useState(false);
@@ -731,6 +751,9 @@ export function CashflowProjectSheet({
         yearMonth: currentDeadline?.yearMonth,
         weekNo: currentDeadline?.weekNo,
         updateResult: weeklyUpdateResult,
+        ignoreProjectionValidation: Boolean(weeklyProjectionWarning),
+        projectionValidationEvidenceHash: weeklyProjectionWarning?.evidenceHash,
+        projectionValidationIssueCount: weeklyProjectionWarning?.missingCells.length,
       });
       let result;
       try {
@@ -744,6 +767,7 @@ export function CashflowProjectSheet({
       await loadCashflowMonthClose();
       setWeeklyCompletionOpen(false);
       setWeeklyCompletionError('');
+      setWeeklyProjectionWarning(null);
       setWeeklyUpdateResult('');
       logCashflowSettlement({
         phase: 'success',
@@ -769,11 +793,12 @@ export function CashflowProjectSheet({
       });
       const message = resolveApiErrorMessage(error, '주간 정산 완료 상태를 저장하지 못했습니다.');
       setWeeklyCompletionError(message);
+      setWeeklyProjectionWarning(weeklyProjectionValidation(error));
       toast.error(message);
     } finally {
       setWeeklyCompletionBusy(false);
     }
-  }, [canCompleteWeekly, loadCashflowMonthClose, monthCloseResult?.dashboard?.deadlineSummary?.current, orgId, projectId, resolveBffActor, weeklyUpdateResult, yearMonth]);
+  }, [canCompleteWeekly, loadCashflowMonthClose, monthCloseResult?.dashboard?.deadlineSummary?.current, orgId, projectId, resolveBffActor, weeklyProjectionWarning, weeklyUpdateResult, yearMonth]);
 
   const loadWeeklyComplianceHistory = useCallback(async (): Promise<void> => {
     setWeeklyComplianceHistoryLoading(true);
@@ -2658,6 +2683,7 @@ export function CashflowProjectSheet({
                       disabled={weeklyCompletionBusy || monthCloseLoading || Boolean(monthCloseResult?.dashboard?.deadlineSummary?.current?.completedAt)}
                       onClick={() => {
                         setWeeklyCompletionError('');
+                        setWeeklyProjectionWarning(null);
                         setWeeklyUpdateResult('');
                         setWeeklyCompletionOpen(true);
                       }}
@@ -3084,13 +3110,26 @@ export function CashflowProjectSheet({
 
       {renderUnifiedMonthlyBoard()}
 
-      <AlertDialog open={weeklyCompletionOpen} onOpenChange={(open) => { if (!weeklyCompletionBusy) setWeeklyCompletionOpen(open); }}>
+      <AlertDialog open={weeklyCompletionOpen} onOpenChange={(open) => {
+        if (!weeklyCompletionBusy) {
+          setWeeklyCompletionOpen(open);
+          if (!open) setWeeklyProjectionWarning(null);
+        }
+      }}>
         <AlertDialogContent className="w-[calc(100vw-2rem)] max-w-[620px]">
           <AlertDialogHeader>
             <AlertDialogTitle>주간 정산 완료</AlertDialogTitle>
-            <AlertDialogDescription>이번 주차의 처리 결과만 선택해 정산 상태를 업데이트합니다.</AlertDialogDescription>
+            <AlertDialogDescription>대상 주차와 그 이후 15개 재무주차(총 16주·256칸)의 JVM 저장 Projection 값을 확인합니다.</AlertDialogDescription>
           </AlertDialogHeader>
           {weeklyCompletionError ? <div role="alert" className="rounded-md border border-red-200 bg-red-50 p-3 text-[12px] leading-5 text-red-800">{weeklyCompletionError}</div> : null}
+          {weeklyProjectionWarning ? (
+            <details open className="max-h-[260px] overflow-auto rounded-md border border-red-300 bg-red-50 p-3 text-[12px]">
+              <summary className="cursor-pointer font-bold text-red-950">서버가 확인한 미입력 항목 {weeklyProjectionWarning.missingCells.length.toLocaleString()}건</summary>
+              <ul className="mt-2 space-y-1" aria-label="Projection 미입력 주차와 항목">
+                {weeklyProjectionWarning.missingCells.map((cell) => <li key={`${cell.yearMonth}:${cell.weekNo}:${cell.lineId}`}>{cell.yearMonth} {cell.weekNo}주차 · {CASHFLOW_SHEET_LINE_LABELS[cell.lineId as CashflowSheetLineId] || cell.lineId}이 미작성입니다.</li>)}
+              </ul>
+            </details>
+          ) : null}
           <fieldset className="space-y-2">
             <legend className="mb-2 text-[13px] font-bold text-slate-900">이번 주차 처리 결과를 하나 선택해 주세요.</legend>
             {([
@@ -3106,7 +3145,7 @@ export function CashflowProjectSheet({
           <AlertDialogFooter>
             <AlertDialogCancel disabled={weeklyCompletionBusy}>취소</AlertDialogCancel>
             <Button type="button" disabled={weeklyCompletionBusy || !weeklyUpdateResult} onClick={() => void handleCompleteWeeklyUpdate()}>
-              {weeklyCompletionBusy ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <ClipboardCheck className="mr-1.5 h-3.5 w-3.5" />}반영
+              {weeklyCompletionBusy ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <ClipboardCheck className="mr-1.5 h-3.5 w-3.5" />}{weeklyProjectionWarning ? '무시하고 반영' : '반영'}
             </Button>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -532,6 +532,25 @@ describe('platform-bff-client', () => {
     );
   });
 
+  it('sends an explicit projection validation override with its JVM evidence', async () => {
+    const client = asMockClient({ post: vi.fn(async () => ({ data: { ok: true } })), get: vi.fn(), request: vi.fn() });
+    await completeCashflowWeeklyUpdateViaBff({
+      tenantId: 'mysc', actor: { uid: 'pm-1', role: 'pm' }, projectId: 'p001',
+      yearMonth: '2026-08', weekNo: 2, updateResult: 'CHANGED',
+      ignoreProjectionValidation: true,
+      projectionValidationEvidenceHash: `sha256:${'a'.repeat(64)}`,
+      projectionValidationIssueCount: 32,
+      client,
+    });
+    expect(client.post).toHaveBeenCalledWith('/api/v1/cashflow/p001/weekly-update-complete', expect.objectContaining({
+      body: expect.objectContaining({
+        ignoreProjectionValidation: true,
+        projectionValidationEvidenceHash: `sha256:${'a'.repeat(64)}`,
+        projectionValidationIssueCount: 32,
+      }),
+    }));
+  });
+
   it('reads canonical weekly compliance with bounded cursor paging', async () => {
     const client = asMockClient({ post: vi.fn(), get: vi.fn(async () => ({ data: { items: [], nextCursor: '', onTimeCount: 0, missedCount: 0 } })), request: vi.fn() });
     await fetchCashflowWeeklyComplianceViaBff({ tenantId: 'mysc', actor: { uid: 'admin-1', role: 'admin' }, projectId: 'p001', limit: 50, cursor: 'opaque/cursor', client });

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -2845,6 +2845,9 @@ export async function completeCashflowWeeklyUpdateViaBff(params: {
   yearMonth?: string;
   weekNo?: number;
   updateResult: 'CHANGED' | 'NO_CHANGES';
+  ignoreProjectionValidation?: boolean;
+  projectionValidationEvidenceHash?: string;
+  projectionValidationIssueCount?: number;
   client?: PlatformApiClientLike;
 }): Promise<CashflowWeeklyUpdateCompletionResult> {
   const hasExplicitScope = params.yearMonth !== undefined || params.weekNo !== undefined;
@@ -2856,6 +2859,11 @@ export async function completeCashflowWeeklyUpdateViaBff(params: {
       body: {
         ...(hasExplicitScope ? { yearMonth: params.yearMonth, weekNo: params.weekNo } : {}),
         updateResult: params.updateResult,
+        ...(params.ignoreProjectionValidation ? {
+          ignoreProjectionValidation: true,
+          projectionValidationEvidenceHash: params.projectionValidationEvidenceHash,
+          projectionValidationIssueCount: params.projectionValidationIssueCount,
+        } : {}),
       },
       retries: 0,
       timeoutMs: 12000,


### PR DESCRIPTION
## 변경 사항
- Google Sheet 재조회 없이 JVM canonical cashflow_weeks 기준으로 대상 주차 +15주 Projection 256칸 검증
- 미입력 경고 후 명시적 `무시하고 반영` 지원
- evidence를 tenant/project/대상 window에 결속하고 stale override 차단
- completion과 audit에 서버 확정 증빙 기록

## 검증
- JVM 전체 테스트 PASS
- 관련 프런트/BFF 296 tests PASS
- production build PASS
- independent diff QA PASS (참고용; 이후 정책상 별도 QA 제외)