### PR TITLE
fix(projects): explain why final save is blocked

### DIFF
--- a/src/app/components/projects/ProjectEditorWizard.shell.test.ts
+++ b/src/app/components/projects/ProjectEditorWizard.shell.test.ts
@@ -442,7 +442,7 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain('readOnly?: boolean');
     expect(source).toContain('<fieldset disabled={readOnly} className="contents">');
     expect(source).toContain('disabled={readOnly || autosaveState');
-    expect(source).toContain("disabled={readOnly || autosaveState === 'saving' || uploadInProgress || hasPendingRetryFile || !!busyActionId");
+    expect(source).toContain('disabled={readOnly || !!busyActionId || action.disabled}');
     expect(source).toContain('shouldResetProjectEditorDraft({');
     expect(source).toContain('autosave?.onSave, draftKey, hasPendingRetryFile, hasRequiredRegistrationDocuments, mode, readOnly, uploadInProgress');
   });
@@ -474,7 +474,23 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain("toast.error('첨부파일 처리를 완료한 뒤 임시저장해 주세요.')");
     expect(source).toContain("toast.error('첨부파일 처리를 완료한 뒤 최종 저장해 주세요.')");
     expect(source).toContain("disabled={readOnly || autosaveState === 'saving' || uploadInProgress || hasPendingRetryFile || (mode === 'portal-register' && !hasRequiredRegistrationDocuments)}");
-    expect(source).toContain("disabled={readOnly || autosaveState === 'saving' || uploadInProgress || hasPendingRetryFile || !!busyActionId || action.disabled || !canSubmit}");
+    expect(source).toContain("toast.error('첨부파일 처리를 완료한 뒤 최종 저장해 주세요.')");
+  });
+
+  it('keeps the final save button pressable and explains every reason it cannot submit yet', () => {
+    expect(source).toContain('disabled={readOnly || !!busyActionId || action.disabled}');
+    expect(source).toContain('const submitBlocked = !canSubmit || Boolean(submitBlockedStatusReason);');
+    expect(source).toContain('if (submitBlocked) {');
+    expect(source).toContain('setSubmitBlockedNotice(true);');
+    expect(source).toContain("'첨부파일을 처리하고 있습니다. 처리가 끝난 뒤 최종 저장해 주세요.'");
+    expect(source).toContain("'업로드하지 못한 첨부파일이 있습니다. 해당 파일을 다시 첨부해 주세요.'");
+    expect(source).toContain("'임시저장을 진행하고 있습니다. 잠시 후 다시 시도해 주세요.'");
+    expect(source).toContain('아직 최종 저장할 수 없습니다');
+    expect(source).toContain('최종 저장 전 확인이 필요합니다');
+    expect(source).toContain('setStepIndex(Math.max(0, STEPS.findIndex((step) => step.id === issue.step)))');
+    expect(source).toContain('단계로 이동');
+    expect(source).toContain('{stepIndex === STEPS.length - 1 && !readOnly ? (');
+    expect(source).toContain('if (!submitBlocked) setSubmitBlockedNotice(false);');
   });
 
   it('removes private registration attachments through the owner-authorized draft API before clearing local state', () => {

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -656,6 +656,7 @@ export function ProjectEditorWizard({
   const [autosaveState, setAutosaveState] = useState<AutosaveState>('idle');
   const [exitDialogOpen, setExitDialogOpen] = useState(false);
   const [exitIntent, setExitIntent] = useState<'cancel' | 'route' | null>(null);
+  const [submitBlockedNotice, setSubmitBlockedNotice] = useState(false);
   const [exitBusy, setExitBusy] = useState(false);
   const [lastAutosavedAt, setLastAutosavedAt] = useState('');
   const [preloadWarningVisible, setPreloadWarningVisible] = useState(false);
@@ -1387,6 +1388,52 @@ export function ProjectEditorWizard({
   }, [departmentOptionSet, draft, hasContractAmountInput, hasMultiYearContract, onProjectDocumentFileUpload, requiresAdvanceInterimReason, requiresSettlementConfirmations, selectedExecutiveApprover, showProjectCheckout, usesRegistrationV2]);
 
   const canSubmit = submitIssues.length === 0;
+
+  const submitBlockedStatusReason = uploadInProgress
+    ? '첨부파일을 처리하고 있습니다. 처리가 끝난 뒤 최종 저장해 주세요.'
+    : hasPendingRetryFile
+      ? '업로드하지 못한 첨부파일이 있습니다. 해당 파일을 다시 첨부해 주세요.'
+      : autosaveState === 'saving'
+        ? '임시저장을 진행하고 있습니다. 잠시 후 다시 시도해 주세요.'
+        : null;
+  const submitBlocked = !canSubmit || Boolean(submitBlockedStatusReason);
+
+  useEffect(() => {
+    if (!submitBlocked) setSubmitBlockedNotice(false);
+  }, [submitBlocked]);
+
+  const renderSubmitBlockers = () => {
+    if (!submitBlocked) return null;
+    return (
+      <div
+        aria-live="polite"
+        className={cn(
+          'rounded-lg border bg-white px-4 py-3 text-[12px] text-red-700',
+          submitBlockedNotice ? 'border-red-400' : 'border-slate-200',
+        )}
+      >
+        <p className="font-medium">
+          {submitBlockedNotice ? '아직 최종 저장할 수 없습니다' : '최종 저장 전 확인이 필요합니다'}
+        </p>
+        {submitBlockedStatusReason ? <p className="mt-1.5">{submitBlockedStatusReason}</p> : null}
+        {submitIssues.length > 0 ? (
+          <ul className="mt-1.5 grid gap-1">
+            {submitIssues.map((issue, index) => (
+              <li key={`${issue.step}-${issue.label}-${index}`}>
+                <button
+                  type="button"
+                  onClick={() => setStepIndex(Math.max(0, STEPS.findIndex((step) => step.id === issue.step)))}
+                  className="text-left underline underline-offset-2 hover:text-red-900"
+                >
+                  {issue.label} · {STEPS.find((step) => step.id === issue.step)?.label} 단계로 이동
+                </button>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+      </div>
+    );
+  };
 
   const renderBasicStep = () => (
     <div className="space-y-4">
@@ -2868,6 +2915,9 @@ export function ProjectEditorWizard({
       </div>
 
       <div className="z-20 rounded-2xl border border-slate-200 bg-white/95 px-4 py-3 shadow-lg backdrop-blur">
+        {stepIndex === STEPS.length - 1 && !readOnly ? (
+          <div className="mb-3 empty:mb-0">{renderSubmitBlockers()}</div>
+        ) : null}
         <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex items-center gap-2 text-[12px] text-muted-foreground">
             <CalendarRange className="h-4 w-4" />
@@ -2925,8 +2975,14 @@ export function ProjectEditorWizard({
                     key={action.id}
                     type="button"
                     variant={action.variant || 'default'}
-                    disabled={readOnly || autosaveState === 'saving' || uploadInProgress || hasPendingRetryFile || !!busyActionId || action.disabled || !canSubmit}
-                    onClick={() => void handleActionSubmit(action.id)}
+                    disabled={readOnly || !!busyActionId || action.disabled}
+                    onClick={() => {
+                      if (submitBlocked) {
+                        setSubmitBlockedNotice(true);
+                        return;
+                      }
+                      void handleActionSubmit(action.id);
+                    }}
                     className="gap-2"
                   >
                     <Icon className={`h-4 w-4 ${busyActionId === action.id ? 'animate-spin' : ''}`} />


### PR DESCRIPTION
## What
- 최종 저장 버튼을 누를 수 있게 유지하고, 버튼 바로 위에 잠금 사유를 표시
- 미충족 항목마다 해당 위저드 단계로 이동하는 링크 제공
- 기존에 **아무 설명 없이** 버튼을 죽이던 상태(첨부 업로드 중 · 업로드 재시도 대기 · 임시저장 진행 중)에도 사유 문구 추가

## Why
검토 및 저장(4/4) 화면에서 유일한 안내가 긴 페이지 **맨 위**에 있고 `최종 저장` 버튼은 **맨 아래**에 있어서, 스크롤해 내려오면 반투명한 버튼만 보이고 이유는 화면 밖이었습니다. 사용자에게는 고장난 화면으로 읽혔습니다. 업로드/재시도 대기 상태는 아예 화면상 사유가 없었습니다.

## 동작 변화
| 상황 | 이전 | 이후 |
|---|---|---|
| 입력 미충족 | 버튼 비활성 · 이유는 페이지 상단에만 | 버튼 클릭 가능 · 누르면 버튼 위에 사유 + 단계 이동 링크 |
| 업로드 중 / 재시도 대기 / 임시저장 중 | 버튼 비활성 · **설명 없음** | 각 상황별 안내 문구 표시 |
| 저장 진행 중 · 읽기전용 | 비활성 | **비활성 유지** (중복 제출 방지) |

제출 가능 조건 자체는 바뀌지 않았습니다. 기존 `disabled` 조건을 `onClick` 가드로 옮긴 것이라 통과 집합이 동일하고, `handleActionSubmit`의 첨부 처리 중 차단(projects 경로 무관, ProjectEditorWizard.tsx:938)도 그대로 유지됩니다.

## Design
DESIGN.md 53행("빨강 틴트 패널 금지, 경고는 중립 배경 위 빨간 글씨")에 따라 기존 배너와 동일한 `bg-white` + `text-red-700`을 사용했습니다. `aria-live="polite"` 적용.

## Verification
- `npx vitest run src/app/components/projects/ProjectEditorWizard.shell.test.ts` — 40 passed (신규 케이스 1건 추가)
- `npm run build` 통과

## Ops notes
Firestore rules/indexes, Vercel env 변경 없음. 프론트엔드 전용 변경입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)