### PR TITLE
fix(projects): tidy the project wizard review step

### DIFF
--- a/src/app/components/projects/ProjectEditorWizard.shell.test.ts
+++ b/src/app/components/projects/ProjectEditorWizard.shell.test.ts
@@ -409,7 +409,7 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain('total.contract + (row.paymentPlan?.contract || 0)');
     expect(source).toContain('년 선금·중도금 합계 70% 미만 사유 *');
     expect(source).toContain("updateFinancialYear(financialYearIndex!, 'advanceInterimBelow70Reason'");
-    expect(source).toContain("updateFinancialYear(financialYearIndex!, 'isSettled'");
+    expect(source).not.toContain('년 계약/재무 정산 완료');
     expect(source).toContain('(기존값 · 선택 불가)');
     expect(source).toContain('disabled>{member.role}');
     expect(source).not.toContain('최종 입금 주차 ${row.finalPaymentExpectedWeek || \'-\'}');
@@ -491,6 +491,11 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain('단계로 이동');
     expect(source).toContain('{stepIndex === STEPS.length - 1 && !readOnly ? (');
     expect(source).toContain('if (!submitBlocked) setSubmitBlockedNotice(false);');
+  });
+
+  it('shows the blocking reason only beside the final save button, not at the top of the review step', () => {
+    expect(source).not.toContain('입력이 필요합니다.');
+    expect(source.match(/renderSubmitBlockers\(\)/g)).toHaveLength(1);
   });
 
   it('removes private registration attachments through the owner-authorized draft API before clearing local state', () => {

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -2367,15 +2367,6 @@ export function ProjectEditorWizard({
           <Label className="mt-3 block text-xs">예상 입금 시점{paymentPlan.final > 0 ? ' *' : ''}</Label><Input type="month" aria-label={`${financialYear ? `${financialYear.year}년 ` : ''}잔금 예상 입금 시점`} aria-required={paymentPlan.final > 0} value={paymentExpectedMonths.final} onChange={(event) => updatePaymentExpectedMonth('final', event.target.value)} className="mt-1 h-9 text-sm" />
         </div>
       </div>
-      {financialYear ? (
-        <div>
-          <label className="flex items-center gap-2 text-[12px] text-slate-700">
-            <Checkbox checked={financialYear.isSettled === true} onCheckedChange={(checked) => updateFinancialYear(financialYearIndex!, 'isSettled', checked === true)} />
-            {financialYear.year}년 계약/재무 정산 완료
-          </label>
-          <p className="ml-6 mt-1 text-[11px] text-muted-foreground">해당 연도의 계약금 수납과 정산 업무가 모두 끝났음을 표시합니다. 현금흐름 월결산과는 별개입니다.</p>
-        </div>
-      ) : null}
       {requiresYearAdvanceInterimReason ? (
         <div>
           <Label className="text-xs">{financialYear.year}년 선금·중도금 합계 70% 미만 사유 *</Label>
@@ -2521,11 +2512,6 @@ export function ProjectEditorWizard({
 
   const renderReviewStep = () => (
     <div className="space-y-4">
-      {submitIssues.length > 0 ? (
-        <div className="rounded-lg border border-slate-200 bg-white px-4 py-3 text-[12px] text-red-700">
-          제출 전 {submitIssues.map((issue) => issue.label).join(', ')} 입력이 필요합니다.
-        </div>
-      ) : null}
       <div className="grid gap-4 lg:grid-cols-2 lg:items-start">
         <Card className="shadow-none lg:col-start-1 lg:row-start-1 lg:self-start">
           <CardHeader className="pb-2"><CardTitle className="text-sm">기본 정보</CardTitle></CardHeader>


### PR DESCRIPTION
## What
1. **최종 저장 잠금 사유를 버튼 옆에만 표시** — 검토 및 저장 단계 상단의 중복 배너 제거
2. **연도별 "계약/재무 정산 완료" 블록 삭제** — 체크박스와 반복되는 설명 문구 모두 제거

## Why
**1번** — #431에서 버튼 옆 안내를 추가했지만 기존 상단 배너를 남겨둬서, 같은 내용이 긴 검토 페이지의 위아래 두 곳에 표시됐습니다. 상단 배너는 자기가 설명하는 버튼에서 한 화면 이상 떨어져 있어 오히려 혼란스러웠습니다.

**2번** — `{연도}년 계약/재무 정산 완료` 체크박스가 계약 연도마다 반복되면서, 동일한 2줄짜리 설명("해당 연도의 계약금 수납과 정산 업무가 모두 끝났음을 표시합니다. 현금흐름 월결산과는 별개입니다.")이 연도 수만큼 중복 출력됐습니다. 다년도 계약에서 선금/중도금/잔금 입력 필드 사이를 크게 벌려놓았습니다.

## 영향 범위 (확인 완료)
`financialYears[].isSettled`의 **UI 입력 지점이 사라집니다.** 이후 이 값은 Excel 마이그레이션 경로(`DataMigrationTab`)를 제외하면 `false`로 유지되며, 검토 요약·마이그레이션 감사 패널에는 "정산 미완료"로 표시됩니다. 제품 담당자에게 영향을 안내하고 확인받은 뒤 진행했습니다.

프로젝트 상세 화면의 `project.isSettled`(사업정산 여부)는 **별개 필드**로 영향받지 않습니다.

## Verification
- `npm test` — 2,667 passed / 0 failed (329 files)
- `npm run build` 통과
- 삭제된 UI를 단언하던 shell 테스트 1건 갱신, 재발 방지 단언 2건 추가

## Ops notes
Firestore rules/indexes, Vercel env 변경 없음. 프론트엔드 전용입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)