### PR TITLE
fix(cashflow): require approver before weekly close

### DIFF
--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -1516,6 +1516,16 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         CompleteCashflowWeeklyUpdateRequest request
     ) {
         requireValidatedCashflowWriteScope(actor.tenantId(), projectId);
+        Map<String, Object> project = data(get(db.document(
+            "orgs/" + actor.tenantId() + "/projects/" + projectId
+        )));
+        if (text(project.get("executiveApproverId"), "").isBlank()) {
+            throw new WeeklyExpenseEditLeaseException(
+                409,
+                "cashflow_weekly_approver_required",
+                "주간 정산 전에 조직장을 먼저 선택·확정해 주세요."
+            );
+        }
         requireYearMonth(request.yearMonth());
         if (request.weekNo() < 1 || request.weekNo() > CashflowSheetLabApplyRequest.FINANCE_WEEK_COUNT) {
             throw new IllegalArgumentException("Cashflow weekNo must be between 1 and 5.");

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -213,6 +213,34 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
+    void rejectsWeeklyCompletionUntilExecutiveApproverIsConfirmed() {
+        Fixture fixture = fixture(activeMember(), Map.of());
+        putCompleteProjectionWindow(fixture, "2026-08", 2);
+        fixture.documents.put("orgs/tenant-a/projects/project-a", Map.of(
+            "id", "project-a",
+            "tenantId", "tenant-a"
+        ));
+
+        Throwable failure = catchThrowable(() -> fixture.persistence.runCommandTransaction(() -> commandService(
+            fixture.persistence
+        ).completeCashflowWeeklyUpdate(
+            ACTOR,
+            "project-a",
+            new CompleteCashflowWeeklyUpdateRequest(
+                "approver-required", "2026-08", 2, "2026-08-04T01:21:00Z", "NO_CHANGES"
+            )
+        )));
+
+        assertThat(failure).isInstanceOfSatisfying(WeeklyExpenseEditLeaseException.class, error -> {
+            assertThat(error.statusCode()).isEqualTo(409);
+            assertThat(error.code()).isEqualTo("cashflow_weekly_approver_required");
+        });
+        assertThat(fixture.documents)
+            .doesNotContainKey("orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-08-w2")
+            .doesNotContainKey("orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-08");
+    }
+
+    @Test
     void writesCanonicalJanuaryAndAugustWeeklySettlementKeys() {
         Fixture january = fixture(activeMember(), Map.of());
         Fixture august = fixture(activeMember(), Map.of());
@@ -4627,7 +4655,8 @@ class FirestoreCashflowLeaseGuardTest {
         if (projectExists) {
             docs.put("orgs/tenant-a/projects/project-a", Map.of(
                 "id", "project-a",
-                "tenantId", "tenant-a"
+                "tenantId", "tenant-a",
+                "executiveApproverId", "manager-1"
             ));
         }
 

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -386,6 +386,7 @@ export function CashflowProjectSheet({
   const [monthCloseBusy, setMonthCloseBusy] = useState(false);
   const [selectedExecutiveApproverId, setSelectedExecutiveApproverId] = useState(project?.executiveApproverId || '');
   const [savedExecutiveApproverId, setSavedExecutiveApproverId] = useState(project?.executiveApproverId || '');
+  const weeklyCompletionBlockedByApprover = !savedExecutiveApproverId.trim();
   const [executiveApproverBusy, setExecutiveApproverBusy] = useState(false);
   const [weeklyCompletionBusy, setWeeklyCompletionBusy] = useState(false);
   const [weeklyCompletionOpen, setWeeklyCompletionOpen] = useState(false);
@@ -729,7 +730,7 @@ export function CashflowProjectSheet({
   }, [loadMonthCloseRequest]);
 
   const handleCompleteWeeklyUpdate = useCallback(async (): Promise<void> => {
-    if (!canCompleteWeekly || !weeklyUpdateResult) return;
+    if (!canCompleteWeekly || weeklyCompletionBlockedByApprover || !weeklyUpdateResult) return;
     setWeeklyCompletionBusy(true);
     const startedAt = Date.now();
     const currentDeadline = monthCloseResult?.dashboard?.deadlineSummary?.current;
@@ -798,7 +799,7 @@ export function CashflowProjectSheet({
     } finally {
       setWeeklyCompletionBusy(false);
     }
-  }, [canCompleteWeekly, loadCashflowMonthClose, monthCloseResult?.dashboard?.deadlineSummary?.current, orgId, projectId, resolveBffActor, weeklyProjectionWarning, weeklyUpdateResult, yearMonth]);
+  }, [canCompleteWeekly, loadCashflowMonthClose, monthCloseResult?.dashboard?.deadlineSummary?.current, orgId, projectId, resolveBffActor, weeklyCompletionBlockedByApprover, weeklyProjectionWarning, weeklyUpdateResult, yearMonth]);
 
   const loadWeeklyComplianceHistory = useCallback(async (): Promise<void> => {
     setWeeklyComplianceHistoryLoading(true);
@@ -2680,7 +2681,7 @@ export function CashflowProjectSheet({
                       size="sm"
                       variant="outline"
                       className="h-8 shrink-0 rounded-md border-slate-300 bg-white px-3 text-[12px] font-semibold text-[#17324D]"
-                      disabled={weeklyCompletionBusy || monthCloseLoading || Boolean(monthCloseResult?.dashboard?.deadlineSummary?.current?.completedAt)}
+                      disabled={weeklyCompletionBlockedByApprover || weeklyCompletionBusy || monthCloseLoading || Boolean(monthCloseResult?.dashboard?.deadlineSummary?.current?.completedAt)}
                       onClick={() => {
                         setWeeklyCompletionError('');
                         setWeeklyProjectionWarning(null);
@@ -2693,6 +2694,9 @@ export function CashflowProjectSheet({
                     </Button>
                   ) : null}
                 </div>
+                {canCompleteWeekly && weeklyCompletionBlockedByApprover ? (
+                  <div className="mt-2 text-[12px] font-medium text-red-700">조직장을 먼저 선택·확정해 주세요.</div>
+                ) : null}
                 <div className="mt-3 flex items-center gap-4 text-[12px] text-muted-foreground">
                   <span>누적 미준수 <strong className="ml-1 text-red-700">{monthCloseResult?.dashboard?.deadlineSummary?.missedCount || 0}회</strong></span>
                   <span>기한 내 완료 <strong className="ml-1 text-primary">{monthCloseResult?.dashboard?.deadlineSummary?.completedCount || 0}회</strong></span>

--- a/src/app/components/cashflow/ProjectCashflowSheetPage.tsx
+++ b/src/app/components/cashflow/ProjectCashflowSheetPage.tsx
@@ -7,7 +7,7 @@ import { useCashflowWeeks } from '../../data/cashflow-weeks-store';
 export function ProjectCashflowSheetPage() {
   const { projectId } = useParams();
   const [searchParams] = useSearchParams();
-  const { getProjectById } = useAppStore();
+  const { getProjectById, members } = useAppStore();
   const { setYearMonth } = useCashflowWeeks();
 
   const ym = searchParams.get('ym') || '';
@@ -37,6 +37,8 @@ export function ProjectCashflowSheetPage() {
       key={projectId}
       projectId={projectId}
       projectName={project.name}
+      project={project}
+      members={members}
       initialViewMode={initialViewMode}
     />
   );


### PR DESCRIPTION
## What
- 조직장 확정 전 주간 정산 완료 버튼을 비활성화합니다.
- JVM 저장 경로에서도 조직장 미지정 완료 요청을 409로 거부합니다.
- 관리자 cashflow 화면에 프로젝트와 구성원 정보를 전달합니다.

## Why
실무자가 조직장을 확정하기 전에 주간 정산을 제출하면 이후 승인 주체가 없는 상태가 생성될 수 있었습니다.

## Verification
- `mvn -q -Dtest=FirestoreCashflowLeaseGuardTest test`
- `npm test -- --run src/app/components/cashflow/CashflowProjectSheet.shell.test.ts`
- `npm run build`