### PR TITLE
fix(portal): let project edits recover from a canonical version conflict

### DIFF
--- a/server/bff/project-info-draft-merge.test.mjs
+++ b/server/bff/project-info-draft-merge.test.mjs
@@ -70,6 +70,25 @@ describe('mergeProjectInfoDraftFields', () => {
     expect(result.merged.paymentPlan).toEqual({ contract: 500, interim: 0, final: 0 });
   });
 
+  it('does not invent a conflict when Firestore returns the same map in another key order', () => {
+    const result = mergeProjectInfoDraftFields({
+      base: { paymentPlan: { contract: 0, interim: 0, final: 0 } },
+      mine: { paymentPlan: { final: 0, contract: 0, interim: 0 } },
+      theirs: { paymentPlan: { interim: 0, final: 0, contract: 0 } },
+    });
+    expect(result.conflicts).toEqual([]);
+    expect(result.autoMerged).toEqual([]);
+  });
+
+  it('ignores key order inside arrays of objects too', () => {
+    const result = mergeProjectInfoDraftFields({
+      base: { teamMembersDetailed: [{ memberName: '변민욱', role: '운영매니저' }] },
+      mine: { teamMembersDetailed: [{ role: '운영매니저', memberName: '변민욱' }] },
+      theirs: { teamMembersDetailed: [{ memberName: '변민욱', role: '운영매니저' }] },
+    });
+    expect(result.conflicts).toEqual([]);
+  });
+
   it('treats every difference as a conflict for drafts opened before rebase support', () => {
     const result = mergeProjectInfoDraftFields({
       base: null,

--- a/server/bff/project-info-draft-merge.test.mjs
+++ b/server/bff/project-info-draft-merge.test.mjs
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { mergeProjectInfoDraftFields } from './routes/project-info-drafts.mjs';
+
+const base = { name: '가나AC', contractAmount: 1000, status: 'CONTRACT_PENDING', note: '' };
+
+describe('mergeProjectInfoDraftFields', () => {
+  it('keeps the owner edit when only the owner changed the field', () => {
+    const result = mergeProjectInfoDraftFields({
+      base,
+      mine: { ...base, contractAmount: 2000 },
+      theirs: base,
+    });
+    expect(result.conflicts).toEqual([]);
+    expect(result.autoMerged).toEqual([]);
+    expect(result.merged.contractAmount).toBe(2000);
+  });
+
+  it('adopts the canonical value when only the other side changed the field', () => {
+    const result = mergeProjectInfoDraftFields({
+      base,
+      mine: { ...base, contractAmount: 2000 },
+      theirs: { ...base, status: 'IN_PROGRESS' },
+    });
+    expect(result.conflicts).toEqual([]);
+    expect(result.autoMerged).toEqual([{ field: 'status', value: 'IN_PROGRESS' }]);
+    expect(result.merged.status).toBe('IN_PROGRESS');
+    expect(result.merged.contractAmount).toBe(2000);
+  });
+
+  it('reports a conflict only when both sides moved the same field differently', () => {
+    const result = mergeProjectInfoDraftFields({
+      base,
+      mine: { ...base, contractAmount: 2000 },
+      theirs: { ...base, contractAmount: 3000 },
+    });
+    expect(result.conflicts).toEqual([
+      { field: 'contractAmount', base: 1000, mine: 2000, theirs: 3000 },
+    ]);
+    expect(result.merged.contractAmount).toBe(2000);
+  });
+
+  it('does not report a conflict when both sides made the same change', () => {
+    const result = mergeProjectInfoDraftFields({
+      base,
+      mine: { ...base, contractAmount: 3000 },
+      theirs: { ...base, contractAmount: 3000 },
+    });
+    expect(result.conflicts).toEqual([]);
+    expect(result.autoMerged).toEqual([]);
+  });
+
+  it('adopts canonical fields the draft never had', () => {
+    const result = mergeProjectInfoDraftFields({
+      base,
+      mine: base,
+      theirs: { ...base, groupwareName: '그룹웨어' },
+    });
+    expect(result.conflicts).toEqual([]);
+    expect(result.merged.groupwareName).toBe('그룹웨어');
+  });
+
+  it('compares nested values structurally instead of by reference', () => {
+    const nestedBase = { paymentPlan: { contract: 0, interim: 0, final: 0 } };
+    const result = mergeProjectInfoDraftFields({
+      base: nestedBase,
+      mine: { paymentPlan: { contract: 0, interim: 0, final: 0 } },
+      theirs: { paymentPlan: { contract: 500, interim: 0, final: 0 } },
+    });
+    expect(result.conflicts).toEqual([]);
+    expect(result.merged.paymentPlan).toEqual({ contract: 500, interim: 0, final: 0 });
+  });
+
+  it('treats every difference as a conflict for drafts opened before rebase support', () => {
+    const result = mergeProjectInfoDraftFields({
+      base: null,
+      mine: { ...base, contractAmount: 2000 },
+      theirs: { ...base, status: 'IN_PROGRESS' },
+    });
+    expect(result.autoMerged).toEqual([]);
+    expect(result.conflicts.map((conflict) => conflict.field).sort()).toEqual(['contractAmount', 'status']);
+    expect(result.conflicts.every((conflict) => conflict.base === null)).toBe(true);
+  });
+
+  it('never drops an owner field while resolving', () => {
+    const result = mergeProjectInfoDraftFields({
+      base,
+      mine: { ...base, note: '내 메모' },
+      theirs: { ...base, note: '남의 메모' },
+    });
+    expect(Object.keys(result.merged).sort()).toEqual(Object.keys(base).sort());
+    expect(result.merged.note).toBe('내 메모');
+  });
+});

--- a/server/bff/routes/project-info-drafts.mjs
+++ b/server/bff/routes/project-info-drafts.mjs
@@ -268,8 +268,22 @@ function assertActive(draft) {
   }
 }
 
+// Firestore returns map keys in its own order, so a draft read back from storage
+// and a freshly computed snapshot can hold identical values in a different key
+// order. Compare by value, not by serialization order.
+function stableValue(value) {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (value && typeof value === 'object') {
+    return Object.keys(value).sort().reduce((sorted, key) => {
+      sorted[key] = stableValue(value[key]);
+      return sorted;
+    }, {});
+  }
+  return value ?? null;
+}
+
 function sameFieldValue(left, right) {
-  return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+  return JSON.stringify(stableValue(left)) === JSON.stringify(stableValue(right));
 }
 
 // Three-way merge between the canonical values the draft started from (base),

--- a/server/bff/routes/project-info-drafts.mjs
+++ b/server/bff/routes/project-info-drafts.mjs
@@ -19,6 +19,7 @@ import {
   projectInfoDraftAttachmentSchema,
   projectInfoDraftOpenSchema,
   projectInfoDraftPatchSchema,
+  projectInfoDraftRebaseSchema,
   projectInfoDraftSubmitSchema,
 } from '../schemas.mjs';
 import { buildRequestFingerprint, sha256 } from '../utils.mjs';
@@ -265,6 +266,50 @@ function assertActive(draft) {
   if (draft.status !== 'ACTIVE') {
     throw createHttpError(409, 'Project information draft is not active', 'draft_not_active');
   }
+}
+
+function sameFieldValue(left, right) {
+  return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+}
+
+// Three-way merge between the canonical values the draft started from (base),
+// the owner's edits (mine), and the canonical values now (theirs). Only fields
+// that both sides moved in different directions are reported as conflicts;
+// everything else resolves without asking the owner.
+export function mergeProjectInfoDraftFields({ base, mine, theirs }) {
+  const asFields = (value) => (value && typeof value === 'object' && !Array.isArray(value) ? value : {});
+  const baseFields = asFields(base);
+  const mineFields = asFields(mine);
+  const theirsFields = asFields(theirs);
+  // Drafts opened before rebase support have no base, so nothing can be
+  // auto-merged and every difference must be confirmed by the owner.
+  const hasBase = base !== null && base !== undefined;
+  const merged = { ...mineFields };
+  const autoMerged = [];
+  const conflicts = [];
+  Array.from(new Set([
+    ...Object.keys(baseFields),
+    ...Object.keys(mineFields),
+    ...Object.keys(theirsFields),
+  ])).sort().forEach((field) => {
+    const baseValue = baseFields[field];
+    const mineValue = mineFields[field];
+    const theirsValue = theirsFields[field];
+    if (sameFieldValue(mineValue, theirsValue)) return;
+    if (hasBase && sameFieldValue(mineValue, baseValue)) {
+      merged[field] = theirsValue;
+      autoMerged.push({ field, value: theirsValue ?? null });
+      return;
+    }
+    if (hasBase && sameFieldValue(theirsValue, baseValue)) return;
+    conflicts.push({
+      field,
+      base: hasBase ? (baseValue ?? null) : null,
+      mine: mineValue ?? null,
+      theirs: theirsValue ?? null,
+    });
+  });
+  return { merged, autoMerged, conflicts };
 }
 
 function assertRevision(draft, expected) {
@@ -558,6 +603,7 @@ export function createProjectInfoDraftService({
         await assertLease(tx, current, nowDate);
         const existing = draftSnap.exists ? (draftSnap.data() || {}) : null;
         const previousRequest = requestSnap.exists ? (requestSnap.data() || {}) : {};
+        const seed = buildProjectInfoDraftSeed(project, previousRequest);
         const draft = existing?.status === 'ACTIVE' && readOptionalText(existing.ownerUid) === current.actorId
           ? existing
           : {
@@ -567,7 +613,10 @@ export function createProjectInfoDraftService({
               resourceId: current.projectId,
               draftRevision: 0,
               baseCanonicalVersion: Number.isInteger(project.version) && project.version > 0 ? project.version : 1,
-              payload: buildProjectInfoDraftSeed(project, previousRequest),
+              // Frozen copy of the canonical values this draft started from, so a
+              // later rebase can tell "the user changed it" from "someone else did".
+              baseSnapshot: seed,
+              payload: seed,
               attachmentRefs: resumableDraftAttachments(
                 current.tenantId,
                 current.draftDocumentId,
@@ -586,6 +635,102 @@ export function createProjectInfoDraftService({
           ]);
           tx.set(draftRef, draft);
         }
+        completeIdempotency(tx, current, lock, { method, path, status: 200, body }, nowDate);
+        return { status: 200, body, replayed: false };
+      });
+    },
+
+    async rebase(input) {
+      const current = context(input);
+      const expectedDraftRevision = Number(input?.expectedDraftRevision);
+      if (!Number.isInteger(expectedDraftRevision) || expectedDraftRevision < 0) {
+        throw createHttpError(400, 'Draft rebase version is invalid', 'draft_request_invalid');
+      }
+      const resolutions = input?.resolutions && typeof input.resolutions === 'object'
+        ? input.resolutions
+        : null;
+      const method = 'POST';
+      const path = `/api/v1/project-info-drafts/${current.projectId}/rebase`;
+      const fingerprint = buildRequestFingerprint({
+        method, path,
+        body: {
+          actorId: current.actorId, sessionId: current.sessionId, leaseId: current.leaseId,
+          fence: current.fence, expectedDraftRevision, resolutions,
+        },
+      });
+      return db.runTransaction(async (tx) => {
+        const nowDate = clockDate(now);
+        const timestamp = nowDate.toISOString();
+        const { actorRole, project, draftRef, draft } = await ownedDraft(tx, current);
+        const requestSnap = await tx.get(refs(current).request);
+        const previousRequest = requestSnap.exists ? (requestSnap.data() || {}) : {};
+        const lock = await checkIdempotency(tx, current, fingerprint, nowDate);
+        if (lock.mode === 'replay') return { status: lock.status, body: lock.body, replayed: true };
+        const lockError = idempotencyError(lock);
+        if (lockError) throw lockError;
+        assertActive(draft);
+        assertRevision(draft, expectedDraftRevision);
+        await assertLease(tx, current, nowDate);
+        const actualVersion = Number.isInteger(project.version) && project.version > 0 ? project.version : 1;
+        const theirs = buildProjectInfoDraftSeed(project, previousRequest);
+        const { merged, autoMerged, conflicts } = mergeProjectInfoDraftFields({
+          base: draft.baseSnapshot ?? null,
+          mine: draft.payload,
+          theirs,
+        });
+        // Without resolutions this is a preview: report the merge outcome and write nothing.
+        if (!resolutions) {
+          const body = {
+            rebased: false,
+            baseCanonicalVersion: Number.isInteger(draft.baseCanonicalVersion) ? draft.baseCanonicalVersion : 1,
+            canonicalVersion: actualVersion,
+            autoMerged,
+            conflicts,
+          };
+          completeIdempotency(tx, current, lock, { method, path, status: 200, body }, nowDate);
+          return { status: 200, body, replayed: false };
+        }
+        const unresolved = conflicts.filter((conflict) => (
+          resolutions[conflict.field] !== 'MINE' && resolutions[conflict.field] !== 'THEIRS'
+        ));
+        if (unresolved.length > 0) {
+          throw createHttpError(
+            422,
+            `Unresolved rebase conflicts: ${unresolved.map((conflict) => conflict.field).join(', ')}`,
+            'draft_rebase_unresolved',
+          );
+        }
+        conflicts.forEach((conflict) => {
+          merged[conflict.field] = resolutions[conflict.field] === 'THEIRS' ? conflict.theirs : conflict.mine;
+        });
+        const nextDraft = {
+          ...draft,
+          payload: merged,
+          baseSnapshot: theirs,
+          baseCanonicalVersion: actualVersion,
+          draftRevision: expectedDraftRevision + 1,
+          updatedAt: timestamp,
+        };
+        assertDraftSize(nextDraft);
+        await auditChainService.appendManyInTransaction(tx, [
+          auditEntry(current, actorRole, 'PROJECT_INFO_DRAFT_REBASE', nextDraft.draftRevision, timestamp, {
+            fence: current.fence,
+            baseCanonicalVersion: actualVersion,
+            autoMergedFields: autoMerged.map((entry) => entry.field),
+            resolvedFields: conflicts.map((conflict) => ({
+              field: conflict.field,
+              resolution: resolutions[conflict.field],
+            })),
+          }),
+        ]);
+        tx.set(draftRef, nextDraft);
+        const body = {
+          rebased: true,
+          draft: draftContract(nextDraft),
+          canonicalVersion: actualVersion,
+          autoMerged,
+          conflicts,
+        };
         completeIdempotency(tx, current, lock, { method, path, status: 200, body }, nowDate);
         return { status: 200, body, replayed: false };
       });
@@ -1221,6 +1366,14 @@ export function mountProjectInfoDraftRoutes(app, {
       projectId: routeProjectId(req),
       documentKind: requiredText(req.params?.documentKind, 'documentKind'),
       ...parsed,
+    }));
+  }));
+
+  app.post('/api/v1/project-info-drafts/:projectId/rebase', asyncHandler(async (req, res) => {
+    assertActorRoleAllowed(req, PROJECT_REQUEST_ROUTE_ROLES, 'rebase a project information draft');
+    const parsed = parseWithSchema(projectInfoDraftRebaseSchema, req.body);
+    sendOutcome(res, await projectInfoDraftService.rebase({
+      ...await routeContext(req, piiProtector), ...routeOwnership(req), projectId: routeProjectId(req), ...parsed,
     }));
   }));
 

--- a/server/bff/schemas.mjs
+++ b/server/bff/schemas.mjs
@@ -50,6 +50,12 @@ export const projectInfoDraftAttachmentSchema = projectRegistrationDraftAttachme
   documentKind: z.enum(PROJECT_INFO_DOCUMENT_KINDS),
 });
 
+export const projectInfoDraftRebaseSchema = z.object({
+  expectedDraftRevision: z.number().int().nonnegative(),
+  // Absent means "preview only": report the merge outcome without writing.
+  resolutions: z.record(z.enum(['MINE', 'THEIRS'])).optional(),
+}).strict();
+
 export const projectInfoDraftSubmitSchema = z.object({
   expectedDraftRevision: z.number().int().nonnegative(),
   expectedVersion: z.number().int().positive(),

--- a/src/app/components/portal/PortalProjectEdit.rebase.shell.test.ts
+++ b/src/app/components/portal/PortalProjectEdit.rebase.shell.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const editSource = readFileSync(resolve(import.meta.dirname, 'PortalProjectEdit.tsx'), 'utf8');
+const dialogSource = readFileSync(resolve(import.meta.dirname, 'ProjectInfoRebaseDialog.tsx'), 'utf8');
+const clientSource = readFileSync(resolve(import.meta.dirname, '../../lib/project-info-draft-client.ts'), 'utf8');
+const routeSource = readFileSync(resolve(import.meta.dirname, '../../../../server/bff/routes/project-info-drafts.mjs'), 'utf8');
+
+describe('project info draft rebase contract', () => {
+  it('freezes the canonical values a draft started from so a rebase can tell the sides apart', () => {
+    expect(routeSource).toContain('baseSnapshot: seed');
+    expect(routeSource).toContain('export function mergeProjectInfoDraftFields');
+    expect(routeSource).toContain("app.post('/api/v1/project-info-drafts/:projectId/rebase'");
+  });
+
+  it('rebases only after every conflict is resolved, and never writes during a preview', () => {
+    expect(routeSource).toContain("'draft_rebase_unresolved'");
+    expect(routeSource).toContain('if (!resolutions) {');
+    expect(routeSource).toContain('rebased: false');
+    expect(routeSource).toContain('baseCanonicalVersion: actualVersion');
+    expect(routeSource).toContain('PROJECT_INFO_DRAFT_REBASE');
+  });
+
+  it('routes a canonical version conflict into the rebase dialog instead of a dead-end error', () => {
+    expect(editSource).toContain("body?.error === 'canonical_version_conflict'");
+    expect(editSource).toContain('function isCanonicalVersionConflict');
+    expect(editSource).toContain('if (isCanonicalVersionConflict(error)) {');
+    expect(editSource).toContain('<ProjectInfoRebaseDialog');
+    expect(editSource).toContain('const applyRebase = async');
+  });
+
+  it('submits against the version the rebase aligned to, not the stale store copy', () => {
+    expect(editSource).toContain('expectedVersion: rebasedVersionRef.current || storedVersion');
+    expect(editSource).toContain('rebasedVersionRef.current = result.canonicalVersion;');
+    expect(editSource).toContain('rebasedVersionRef.current = 0;');
+  });
+
+  it('blocks confirmation until the owner has chosen a value for every conflict', () => {
+    expect(dialogSource).toContain('disabled={busy || unresolvedCount > 0}');
+    expect(dialogSource).toContain('내가 입력한 값');
+    expect(dialogSource).toContain('최신 프로젝트 값');
+    expect(dialogSource).toContain('자동으로 반영되는 항목');
+  });
+
+  it('exposes rebase on the draft client with resolutions optional for preview', () => {
+    expect(clientSource).toContain('async rebase(');
+    expect(clientSource).toContain('...(input.resolutions ? { resolutions: input.resolutions } : {})');
+    expect(clientSource).toContain('export interface ProjectInfoRebaseResult');
+  });
+});

--- a/src/app/components/portal/PortalProjectEdit.tsx
+++ b/src/app/components/portal/PortalProjectEdit.tsx
@@ -27,7 +27,18 @@ import {
   type ProjectInfoDocumentKind,
   type ProjectInfoDraft,
   type ProjectInfoFileLike,
+  type ProjectInfoRebaseConflict,
+  type ProjectInfoRebaseResolution,
 } from '../../lib/project-info-draft-client';
+import { ProjectInfoRebaseDialog } from './ProjectInfoRebaseDialog';
+import { PlatformApiError } from '../../platform/api-client';
+
+// The draft froze the project version it started from; the project has moved since.
+function isCanonicalVersionConflict(error: unknown) {
+  if (!(error instanceof PlatformApiError) || error.status !== 409) return false;
+  const body = error.body as { error?: string } | null | undefined;
+  return body?.error === 'canonical_version_conflict';
+}
 import {
   analyzeProjectRequestContractViaBff,
   fetchLatestProjectRequestViaBff,
@@ -244,6 +255,13 @@ function ProjectInfoEditor({
   const [submitted, setSubmitted] = useState(false);
   const [busyActionId, setBusyActionId] = useState<string | null>(null);
   const [saveSuccessDialogOpen, setSaveSuccessDialogOpen] = useState(false);
+  const [rebaseState, setRebaseState] = useState<{
+    conflicts: ProjectInfoRebaseConflict[];
+    autoMerged: Array<{ field: string; value: unknown }>;
+    pendingActionId: string;
+  } | null>(null);
+  const [rebaseBusy, setRebaseBusy] = useState(false);
+  const rebasedVersionRef = useRef(0);
   const [resubmitComment, setResubmitComment] = useState('');
   const revisionRef = useRef(0);
   const recordLoadedRef = useRef(false);
@@ -410,6 +428,26 @@ function ProjectInfoEditor({
     })
   )), [draftClient, enqueueMutation, record, withOwnership]);
 
+  const submitDraft = async (actionId: string) => {
+    const shouldResubmit = canResubmit || actionId === 'resubmit';
+    const storedVersion = Number.isInteger(project.version) && Number(project.version) > 0 ? Number(project.version) : 1;
+    await enqueueMutation(() => withOwnership((ownership) => draftClient.submit(ownership, {
+      expectedDraftRevision: revisionRef.current,
+      // A rebase reports the canonical version it aligned to; the store copy can still be stale.
+      expectedVersion: rebasedVersionRef.current || storedVersion,
+      resubmit: shouldResubmit,
+      ...(shouldResubmit && resubmitComment.trim() ? { reviewComment: resubmitComment.trim() } : {}),
+    })));
+    await lease.checkStatus();
+    if (shouldResubmit) setResubmitComment('');
+    rebasedVersionRef.current = 0;
+    setSubmitted(true);
+    recordLoadedRef.current = false;
+    setRecord(null);
+    setSaveSuccessDialogOpen(true);
+    void lease.release();
+  };
+
   const handleSubmit = async (_draft: ProjectEditorDraft, actionId: string) => {
     if (busyActionId) return;
     if (!record) {
@@ -418,25 +456,58 @@ function ProjectInfoEditor({
     }
     setBusyActionId(actionId);
     try {
-      const shouldResubmit = canResubmit || actionId === 'resubmit';
-      await enqueueMutation(() => withOwnership((ownership) => draftClient.submit(ownership, {
-        expectedDraftRevision: revisionRef.current,
-        expectedVersion: Number.isInteger(project.version) && Number(project.version) > 0 ? Number(project.version) : 1,
-        resubmit: shouldResubmit,
-        ...(shouldResubmit && resubmitComment.trim() ? { reviewComment: resubmitComment.trim() } : {}),
-      })));
-      await lease.checkStatus();
-      if (shouldResubmit) setResubmitComment('');
-      setSubmitted(true);
-      recordLoadedRef.current = false;
-      setRecord(null);
-      setSaveSuccessDialogOpen(true);
-      void lease.release();
+      await submitDraft(actionId);
     } catch (error) {
+      if (isCanonicalVersionConflict(error)) {
+        try {
+          const preview = await enqueueMutation(() => withOwnership((ownership) => draftClient.rebase(ownership, {
+            expectedDraftRevision: revisionRef.current,
+          })));
+          setRebaseState({
+            conflicts: preview.conflicts,
+            autoMerged: preview.autoMerged,
+            pendingActionId: actionId,
+          });
+          return;
+        } catch (rebaseError) {
+          toast.error(rebaseError instanceof Error
+            ? rebaseError.message
+            : '프로젝트 변경 내역을 불러오지 못했습니다.');
+          return;
+        }
+      }
       toast.error(error instanceof Error ? error.message : '저장에 실패했습니다. 다시 시도해주세요.');
       throw error;
     } finally {
       setBusyActionId(null);
+    }
+  };
+
+  const applyRebase = async (resolutions: Record<string, ProjectInfoRebaseResolution>) => {
+    if (!rebaseState) return;
+    const actionId = rebaseState.pendingActionId;
+    setRebaseBusy(true);
+    try {
+      const result = await enqueueMutation(() => withOwnership((ownership) => draftClient.rebase(ownership, {
+        expectedDraftRevision: revisionRef.current,
+        resolutions,
+      })));
+      if (result.draft) {
+        revisionRef.current = result.draft.draftRevision;
+        setRecord(result.draft);
+      }
+      rebasedVersionRef.current = result.canonicalVersion;
+      setRebaseState(null);
+      setBusyActionId(actionId);
+      try {
+        await submitDraft(actionId);
+      } finally {
+        setBusyActionId(null);
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : '변경 내용을 반영하지 못했습니다. 다시 시도해주세요.');
+    } finally {
+      setRebaseBusy(false);
     }
   };
 
@@ -580,6 +651,14 @@ function ProjectInfoEditor({
         onContinueReadOnly={lease.continueReadOnly}
         onReacquire={() => { void startEditing(); }}
         onTakeover={() => { void lease.takeover(); }}
+      />
+      <ProjectInfoRebaseDialog
+        open={rebaseState !== null}
+        conflicts={rebaseState?.conflicts || []}
+        autoMerged={rebaseState?.autoMerged || []}
+        busy={rebaseBusy}
+        onConfirm={(resolutions) => { void applyRebase(resolutions); }}
+        onCancel={() => setRebaseState(null)}
       />
       <AlertDialog open={saveSuccessDialogOpen}
         onOpenChange={(open) => {

--- a/src/app/components/portal/ProjectInfoRebaseDialog.tsx
+++ b/src/app/components/portal/ProjectInfoRebaseDialog.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Button } from '../ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '../ui/dialog';
+import { RadioGroup, RadioGroupItem } from '../ui/radio-group';
+import type {
+  ProjectInfoRebaseConflict,
+  ProjectInfoRebaseResolution,
+} from '../../lib/project-info-draft-client';
+
+const FIELD_LABELS: Record<string, string> = {
+  name: '프로젝트명',
+  officialContractName: '공식 계약명',
+  clientOrg: '계약 대상',
+  department: '담당조직(CIC)',
+  type: '프로젝트 유형',
+  status: '프로젝트 진행 상태',
+  phase: '프로젝트 구분',
+  description: '프로젝트 주요 내용',
+  projectPurpose: '프로젝트 목적',
+  contractType: '계약서 유형',
+  contractStart: '계약 시작일',
+  contractEnd: '계약 종료일',
+  currency: '통화',
+  contractAmount: '계약금액',
+  salesVatAmount: '총매출부가세',
+  totalRevenueAmount: '총수익',
+  totalActualCost: '총실비(원가)',
+  supportAmount: '총지원금',
+  financialYears: '연도별 재무',
+  settlementType: '사업유형',
+  basis: '정산 기준',
+  accountType: '통장 유형',
+  interestRefundPolicy: '이자 반납 여부',
+  settlementSystem: '정산 시스템',
+  laborSettlementBasis: '인건비 정산 기준',
+  paymentPlan: '입금 계획',
+  paymentExpectedMonths: '입금 예상월',
+  advanceInterimBelow70Reason: '선금·중도금 70% 미만 사유',
+  paymentPlanDesc: '입금 계획 메모',
+  settlementGuide: '정산 안내',
+  note: '특이사항',
+  managerName: 'PM',
+  executiveApproverName: '최종 결재자 (사업총괄)',
+  teamName: '팀',
+  teamMembersDetailed: '참여인력',
+  participantCondition: '참여 조건',
+  businessManagementGoogleFolderLink: '사업관리 구글폴더링크',
+  groupwareName: '그룹웨어명',
+};
+
+function fieldLabel(field: string) {
+  return FIELD_LABELS[field] || field;
+}
+
+function displayValue(value: unknown): string {
+  if (value === null || value === undefined || value === '') return '비어 있음';
+  if (typeof value === 'boolean') return value ? '예' : '아니오';
+  if (typeof value === 'number') return value.toLocaleString('ko-KR');
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return `${value.length}개 항목`;
+  return JSON.stringify(value);
+}
+
+export function ProjectInfoRebaseDialog({
+  open,
+  conflicts,
+  autoMerged,
+  busy,
+  onConfirm,
+  onCancel,
+}: {
+  open: boolean;
+  conflicts: ProjectInfoRebaseConflict[];
+  autoMerged: Array<{ field: string; value: unknown }>;
+  busy: boolean;
+  onConfirm: (resolutions: Record<string, ProjectInfoRebaseResolution>) => void;
+  onCancel: () => void;
+}) {
+  const [resolutions, setResolutions] = useState<Record<string, ProjectInfoRebaseResolution>>({});
+
+  useEffect(() => {
+    if (open) setResolutions({});
+  }, [open, conflicts]);
+
+  const unresolvedCount = useMemo(
+    () => conflicts.filter((conflict) => !resolutions[conflict.field]).length,
+    [conflicts, resolutions],
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => { if (!next && !busy) onCancel(); }}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>수정하는 동안 프로젝트가 변경되었습니다</DialogTitle>
+          <DialogDescription>
+            {conflicts.length > 0
+              ? '아래 항목은 내가 수정한 값과 최신 프로젝트 값이 서로 다릅니다. 어느 값을 남길지 선택해 주세요.'
+              : '변경된 내용은 모두 자동으로 반영할 수 있습니다. 확인 후 계속 진행해 주세요.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        {autoMerged.length > 0 ? (
+          <div className="rounded-lg border border-slate-200 bg-white px-4 py-3 text-[12px] text-slate-700">
+            <p className="font-medium">자동으로 반영되는 항목 {autoMerged.length}건</p>
+            <p className="mt-1 text-[11px] text-slate-500">
+              내가 수정하지 않은 항목이라 최신 값을 그대로 가져옵니다.
+            </p>
+            <ul className="mt-2 grid gap-1">
+              {autoMerged.map((entry) => (
+                <li key={entry.field}>
+                  {fieldLabel(entry.field)} · {displayValue(entry.value)}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {conflicts.length > 0 ? (
+          <div className="max-h-[46vh] space-y-3 overflow-y-auto">
+            {conflicts.map((conflict) => (
+              <div key={conflict.field} className="rounded-lg border border-slate-200 px-4 py-3">
+                <p className="text-[12px] font-medium text-slate-900">{fieldLabel(conflict.field)}</p>
+                <p className="mt-0.5 text-[11px] text-slate-500">
+                  수정 시작 시점: {displayValue(conflict.base)}
+                </p>
+                <RadioGroup
+                  className="mt-2 grid gap-2"
+                  value={resolutions[conflict.field] || ''}
+                  onValueChange={(value) => setResolutions((previous) => ({
+                    ...previous,
+                    [conflict.field]: value as ProjectInfoRebaseResolution,
+                  }))}
+                >
+                  <label className="flex items-start gap-2 text-[12px] text-slate-700">
+                    <RadioGroupItem value="MINE" className="mt-0.5" />
+                    <span>내가 입력한 값 · <strong>{displayValue(conflict.mine)}</strong></span>
+                  </label>
+                  <label className="flex items-start gap-2 text-[12px] text-slate-700">
+                    <RadioGroupItem value="THEIRS" className="mt-0.5" />
+                    <span>최신 프로젝트 값 · <strong>{displayValue(conflict.theirs)}</strong></span>
+                  </label>
+                </RadioGroup>
+              </div>
+            ))}
+          </div>
+        ) : null}
+
+        <DialogFooter className="gap-2">
+          <Button type="button" variant="outline" onClick={onCancel} disabled={busy}>
+            취소
+          </Button>
+          <Button
+            type="button"
+            onClick={() => onConfirm(resolutions)}
+            disabled={busy || unresolvedCount > 0}
+          >
+            {busy
+              ? '반영 중...'
+              : unresolvedCount > 0
+                ? `${unresolvedCount}건 선택 필요`
+                : '선택한 내용으로 계속'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/lib/project-info-draft-client.ts
+++ b/src/app/lib/project-info-draft-client.ts
@@ -127,6 +127,50 @@ function parseDraftBody(value: unknown, projectId: string) {
   return { draft: parseDraft(object(value, 'project information draft').draft, projectId) };
 }
 
+export type ProjectInfoRebaseResolution = 'MINE' | 'THEIRS';
+
+export interface ProjectInfoRebaseConflict {
+  field: string;
+  base: unknown;
+  mine: unknown;
+  theirs: unknown;
+}
+
+export interface ProjectInfoRebaseResult {
+  rebased: boolean;
+  canonicalVersion: number;
+  baseCanonicalVersion?: number;
+  autoMerged: Array<{ field: string; value: unknown }>;
+  conflicts: ProjectInfoRebaseConflict[];
+  draft?: ProjectInfoDraft;
+}
+
+function parseRebaseBody(value: unknown, projectId: string): ProjectInfoRebaseResult {
+  const body = object(value, 'project information rebase');
+  const list = (input: unknown) => (Array.isArray(input) ? input : []);
+  return {
+    rebased: body.rebased === true,
+    canonicalVersion: Number(body.canonicalVersion) || 0,
+    ...(body.baseCanonicalVersion === undefined
+      ? {}
+      : { baseCanonicalVersion: Number(body.baseCanonicalVersion) || 0 }),
+    autoMerged: list(body.autoMerged).map((entry) => {
+      const row = object(entry, 'project information rebase merge');
+      return { field: String(row.field ?? ''), value: row.value ?? null };
+    }),
+    conflicts: list(body.conflicts).map((entry) => {
+      const row = object(entry, 'project information rebase conflict');
+      return {
+        field: String(row.field ?? ''),
+        base: row.base ?? null,
+        mine: row.mine ?? null,
+        theirs: row.theirs ?? null,
+      };
+    }),
+    ...(body.draft === undefined ? {} : { draft: parseDraft(body.draft, projectId) }),
+  };
+}
+
 function parseAttachment(value: unknown): ProjectInfoAttachment {
   const attachment = object(value, 'project information attachment');
   if (
@@ -249,6 +293,25 @@ export function createProjectInfoDraftClient(options: {
         },
       );
       return parseDraftBody(response.data, projectId);
+    },
+
+    // Without `resolutions` this previews the merge and writes nothing.
+    async rebase(
+      ownership: { leaseId: string; fence: number },
+      input: {
+        expectedDraftRevision: number;
+        resolutions?: Record<string, ProjectInfoRebaseResolution>;
+      },
+    ): Promise<ProjectInfoRebaseResult> {
+      const response = await client.post<unknown>(`${path}/rebase`, {
+        ...request,
+        headers: ownershipHeaders(sessionId, ownership),
+        body: {
+          expectedDraftRevision: revision(input.expectedDraftRevision),
+          ...(input.resolutions ? { resolutions: input.resolutions } : {}),
+        },
+      });
+      return parseRebaseBody(response.data, projectId);
     },
 
     async submit(


### PR DESCRIPTION
## Why
`baseCanonicalVersion`은 draft를 **처음 만들 때만** 설정되고, 이미 ACTIVE인 draft를 다시 열면 갱신 없이 그대로 반환됐습니다. 그 사이 프로젝트가 한 번이라도 수정되면 제출이 영구히 409로 실패합니다.

라이브에서 확인된 상태 (`p1773817948751` · AXR프로젝트경비경):

| | |
|---|---|
| `draft.baseCanonicalVersion` | 16 |
| `project.version` | 18 |
| 결과 | `canonical_version_conflict` — 재시도해도 동일 |

사용자 입력은 draft에 남고, 변경 요청은 생성되지 않으며, 승인 대기열에도 도달하지 않습니다. 화면상으로는 "저장이 안 되는" 것으로 보입니다.

## What
- draft 생성 시 출발 시점의 정본 값을 `baseSnapshot`으로 저장
- `rebase` 액션 추가 — base / 내 수정 / 현재 정본을 3-way 머지
- 충돌 항목만 다이얼로그로 물어보고, 선택 후 자동 재제출

## 머지 규칙
| 상황 | 처리 |
|---|---|
| 나만 바꾼 항목 | 내 값 유지 (질문 없음) |
| 상대만 바꾼 항목 | 최신 값 자동 반영 (질문 없음) |
| 양쪽이 다르게 바꾼 항목 | **사용자에게 선택 요청** |
| `baseSnapshot` 없는 기존 draft | 자동 병합 없이 모든 차이를 확인받음 |

## 데이터 보호
버전 게이트 자체는 **변경하지 않았습니다.** 이는 낙관적 동시성 제어이자 lost update 방지 장치입니다.
- `resolutions` 없는 요청은 미리보기 — 아무것도 쓰지 않음
- 미해결 충돌이 하나라도 있으면 422로 거부 (`draft_rebase_unresolved`)
- 감사 로그에 자동 병합 필드와 사용자 선택을 `PROJECT_INFO_DRAFT_REBASE`로 기록

rebase 후 재제출 시 `expectedVersion`을 스토어의 낡은 `project.version`이 아니라 rebase가 반환한 `canonicalVersion`으로 보냅니다. 그렇지 않으면 두 번째 409가 발생합니다.

## Verification
- `npm test` — 2,664 passed / 0 failed (머지 단위 8건, 계약 6건 신규)
- `npm run build` 통과

## Ops notes
Firestore rules/indexes, Vercel env 변경 없음. 신규 엔드포인트 `POST /api/v1/project-info-drafts/:projectId/rebase` (기존 draft 라우트와 동일한 lease·idempotency·audit 규약).

🤖 Generated with [Claude Code](https://claude.com/claude-code)