### PR TITLE
fix(portal): report draft failures with enough context to diagnose them

### DIFF
--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -1565,8 +1565,18 @@ export function createBffApp(options = {}) {
     res.locals.errorCode = errorCode;
 
     if (statusCode >= 500) {
+      // One greppable line carrying the route and requestId, so a failure reported from
+      // the browser can be matched to this log without scanning the whole stream.
       // eslint-disable-next-line no-console
-      console.error('[bff] unhandled error', error);
+      console.error('[bff] unhandled error', JSON.stringify({
+        method: req.method,
+        path: req.originalUrl || req.url,
+        requestId: req.requestId || req.context?.requestId || null,
+        tenantId: req.context?.tenantId || null,
+        name: error?.name || null,
+        message: error?.message || String(error),
+        code: error?.code || null,
+      }), error?.stack || error);
     }
 
     res.status(statusCode).json({

--- a/server/bff/project-info-draft-merge.test.mjs
+++ b/server/bff/project-info-draft-merge.test.mjs
@@ -70,6 +70,33 @@ describe('mergeProjectInfoDraftFields', () => {
     expect(result.merged.paymentPlan).toEqual({ contract: 500, interim: 0, final: 0 });
   });
 
+  it('treats missing, null and empty text as the same "not entered" value', () => {
+    const result = mergeProjectInfoDraftFields({
+      base: { finalPaymentNote: '', settlementSystemOther: null },
+      mine: { finalPaymentNote: null, settlementSystemOther: '' },
+      theirs: { finalPaymentNote: undefined, settlementSystemOther: undefined },
+    });
+    expect(result.conflicts).toEqual([]);
+    expect(result.autoMerged).toEqual([]);
+  });
+
+  it('ignores optional keys one side simply omits inside a map', () => {
+    const attachment = {
+      path: 'orgs/mysc/drafts/att-1.pdf',
+      name: '사업자등록증.pdf',
+      size: 2215244,
+      contentType: 'application/pdf',
+    };
+    const result = mergeProjectInfoDraftFields({
+      base: { contractDocument: attachment },
+      mine: { contractDocument: { ...attachment, downloadURL: '' } },
+      theirs: { contractDocument: { ...attachment, visibility: 'PRIVATE', documentKind: 'contract' } },
+    });
+    // The owner never touched the file, so storage bookkeeping is adopted silently.
+    expect(result.conflicts).toEqual([]);
+    expect(result.autoMerged.map((entry) => entry.field)).toEqual(['contractDocument']);
+  });
+
   it('does not invent a conflict when Firestore returns the same map in another key order', () => {
     const result = mergeProjectInfoDraftFields({
       base: { paymentPlan: { contract: 0, interim: 0, final: 0 } },

--- a/server/bff/project-info-draft-withdraw.test.mjs
+++ b/server/bff/project-info-draft-withdraw.test.mjs
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { restoreExecutiveReviewAfterWithdraw } from './routes/project-info-drafts.mjs';
+
+describe('restoreExecutiveReviewAfterWithdraw', () => {
+  it('puts back the approval that the change request had interrupted', () => {
+    const restored = restoreExecutiveReviewAfterWithdraw({
+      executiveReviewStatus: 'PENDING',
+      executiveReviewHistory: [
+        { status: 'PENDING', previousStatus: null, reviewedAt: '2026-03-18T00:00:00.000Z' },
+        {
+          status: 'APPROVED',
+          previousStatus: 'PENDING',
+          reviewedAt: '2026-04-01T00:00:00.000Z',
+          reviewedById: 'head-1',
+          reviewedByName: '조직장',
+          reviewComment: '승인합니다',
+        },
+        { status: 'PENDING', previousStatus: 'APPROVED', reviewedAt: '2026-08-04T00:00:00.000Z' },
+      ],
+    });
+    expect(restored.executiveReviewStatus).toBe('APPROVED');
+    expect(restored.executiveReviewedById).toBe('head-1');
+    expect(restored.executiveReviewedByName).toBe('조직장');
+    expect(restored.executiveReviewComment).toBe('승인합니다');
+    expect(restored.executiveReviewedAt).toBe('2026-04-01T00:00:00.000Z');
+  });
+
+  it('restores the most recent decision when a project was approved then rejected', () => {
+    const restored = restoreExecutiveReviewAfterWithdraw({
+      executiveReviewHistory: [
+        { status: 'APPROVED', reviewedById: 'head-1' },
+        { status: 'REVISION_REJECTED', reviewedById: 'head-2', reviewComment: '보완 필요' },
+        { status: 'PENDING', previousStatus: 'REVISION_REJECTED' },
+      ],
+    });
+    expect(restored.executiveReviewStatus).toBe('REVISION_REJECTED');
+    expect(restored.executiveReviewedById).toBe('head-2');
+    expect(restored.executiveReviewComment).toBe('보완 필요');
+  });
+
+  it('leaves a never-decided project pending with no fabricated reviewer', () => {
+    const restored = restoreExecutiveReviewAfterWithdraw({
+      executiveReviewStatus: 'PENDING',
+      executiveReviewHistory: [
+        { status: 'PENDING', previousStatus: null, reviewedById: 'pm-1', reviewComment: 'PM 신규 등록' },
+      ],
+    });
+    expect(restored.executiveReviewStatus).toBe('PENDING');
+    expect(restored.executiveReviewedById).toBeNull();
+    expect(restored.executiveReviewedByName).toBeNull();
+    expect(restored.executiveReviewComment).toBeNull();
+    expect(restored.executiveReviewedAt).toBeNull();
+  });
+
+  it('treats a missing or empty history as never decided', () => {
+    expect(restoreExecutiveReviewAfterWithdraw({}).executiveReviewStatus).toBe('PENDING');
+    expect(restoreExecutiveReviewAfterWithdraw({ executiveReviewHistory: [] }).executiveReviewStatus).toBe('PENDING');
+    expect(restoreExecutiveReviewAfterWithdraw(null).executiveReviewStatus).toBe('PENDING');
+  });
+
+  it('ignores history rows that carry no usable status', () => {
+    const restored = restoreExecutiveReviewAfterWithdraw({
+      executiveReviewHistory: [
+        { status: 'APPROVED', reviewedById: 'head-1' },
+        { status: '' },
+        { previousStatus: 'APPROVED' },
+      ],
+    });
+    expect(restored.executiveReviewStatus).toBe('APPROVED');
+    expect(restored.executiveReviewedById).toBe('head-1');
+  });
+});

--- a/server/bff/routes/project-info-drafts.mjs
+++ b/server/bff/routes/project-info-drafts.mjs
@@ -6,6 +6,7 @@ import {
   createHttpError,
   encryptAuditEmail,
   readOptionalText,
+  stripUndefinedDeep,
 } from '../bff-utils.mjs';
 import {
   assertEditLeaseActorAccessInTransaction,
@@ -275,11 +276,15 @@ function stableValue(value) {
   if (Array.isArray(value)) return value.map(stableValue);
   if (value && typeof value === 'object') {
     return Object.keys(value).sort().reduce((sorted, key) => {
+      // An optional field the other side simply omits is not a change the owner made.
+      if (value[key] === undefined || value[key] === null || value[key] === '') return sorted;
       sorted[key] = stableValue(value[key]);
       return sorted;
     }, {});
   }
-  return value ?? null;
+  // "not set", "cleared" and "empty text" mean the same thing to the person editing.
+  if (value === undefined || value === null || value === '') return null;
+  return value;
 }
 
 function sameFieldValue(left, right) {
@@ -324,6 +329,36 @@ export function mergeProjectInfoDraftFields({ base, mine, theirs }) {
     });
   });
   return { merged, autoMerged, conflicts };
+}
+
+// Submitting a change request moves the project to PENDING and clears the recorded
+// decision. Withdrawing puts back the last real decision so the project does not sit
+// in "awaiting approval" with no request behind it.
+export function restoreExecutiveReviewAfterWithdraw(project) {
+  const history = Array.isArray(project?.executiveReviewHistory) ? project.executiveReviewHistory : [];
+  const lastDecision = history
+    .slice()
+    .reverse()
+    .find((entry) => {
+      const status = readOptionalText(entry?.status);
+      return status && status !== 'PENDING';
+    });
+  if (!lastDecision) {
+    return {
+      executiveReviewStatus: 'PENDING',
+      executiveReviewedAt: null,
+      executiveReviewedById: null,
+      executiveReviewedByName: null,
+      executiveReviewComment: null,
+    };
+  }
+  return {
+    executiveReviewStatus: readOptionalText(lastDecision.status),
+    executiveReviewedAt: readOptionalText(lastDecision.reviewedAt) || null,
+    executiveReviewedById: readOptionalText(lastDecision.reviewedById) || null,
+    executiveReviewedByName: readOptionalText(lastDecision.reviewedByName) || null,
+    executiveReviewComment: readOptionalText(lastDecision.reviewComment) || null,
+  };
 }
 
 function assertRevision(draft, expected) {
@@ -654,6 +689,111 @@ export function createProjectInfoDraftService({
       });
     },
 
+    async withdraw(input) {
+      const current = context(input);
+      const method = 'POST';
+      const path = `/api/v1/project-info-drafts/${current.projectId}/withdraw`;
+      const fingerprint = buildRequestFingerprint({
+        method, path,
+        body: {
+          actorId: current.actorId, sessionId: current.sessionId,
+          leaseId: current.leaseId, fence: current.fence,
+        },
+      });
+      return db.runTransaction(async (tx) => {
+        const nowDate = clockDate(now);
+        const timestamp = nowDate.toISOString();
+        const { actorRole, projectRef, project, draftRef, draft } = await ownedDraft(tx, current);
+        const requestRef = refs(current).request;
+        const requestSnap = await tx.get(requestRef);
+        const lock = await checkIdempotency(tx, current, fingerprint, nowDate);
+        if (lock.mode === 'replay') return { status: lock.status, body: lock.body, replayed: true };
+        const lockError = idempotencyError(lock);
+        if (lockError) throw lockError;
+        await assertLease(tx, current, nowDate);
+        const request = requestSnap.exists ? (requestSnap.data() || {}) : null;
+        if (!request || readOptionalText(request.requestKind) !== 'CHANGE') {
+          throw createHttpError(409, 'No change request to withdraw', 'request_not_withdrawable');
+        }
+        // A decided request is history; only one still awaiting a decision can be pulled back.
+        if (readOptionalText(request.status) !== 'PENDING') {
+          throw createHttpError(
+            409,
+            `Change request is already ${readOptionalText(request.status) || 'resolved'}`,
+            'request_not_withdrawable',
+          );
+        }
+        if (readOptionalText(request.requestedBy) !== current.actorId) {
+          throw createHttpError(403, 'Only the requester can withdraw this change request', 'request_owner_mismatch');
+        }
+        const actualVersion = Number.isInteger(project.version) && project.version > 0 ? project.version : 1;
+        const nextVersion = actualVersion + 1;
+        const restoredReview = restoreExecutiveReviewAfterWithdraw(project);
+        const nextProject = stripUndefinedDeep({
+          ...project,
+          ...restoredReview,
+          executiveReviewHistory: [
+            ...(Array.isArray(project.executiveReviewHistory) ? project.executiveReviewHistory : []),
+            {
+              status: restoredReview.executiveReviewStatus,
+              previousStatus: 'PENDING',
+              reviewedAt: timestamp,
+              reviewedById: current.actorId,
+              reviewedByName: current.actorDisplayName || null,
+              reviewComment: '요청자가 수정 요청을 회수했습니다.',
+            },
+          ],
+          version: nextVersion,
+          updatedBy: current.actorId,
+          updatedAt: timestamp,
+        });
+        const withdrawnRequest = stripUndefinedDeep({
+          ...request,
+          status: 'WITHDRAWN',
+          withdrawnAt: timestamp,
+          withdrawnBy: current.actorId,
+          withdrawnByName: current.actorDisplayName || null,
+          updatedAt: timestamp,
+        });
+        // Hand the submitted payload back to the owner, rebased onto the restored project
+        // so the very next submit does not trip the canonical version gate again.
+        const restoredDraft = stripUndefinedDeep({
+          ...draft,
+          status: 'ACTIVE',
+          payload: request.payload && typeof request.payload === 'object' ? request.payload : draft.payload,
+          baseSnapshot: buildProjectInfoDraftSeed({ ...nextProject, id: current.projectId }, {}),
+          baseCanonicalVersion: nextVersion,
+          draftRevision: (Number.isInteger(draft.draftRevision) ? draft.draftRevision : 0) + 1,
+          attachmentRefs: resumableDraftAttachments(current.tenantId, current.draftDocumentId, request),
+          submittedAt: null,
+          submittedProjectRequestId: null,
+          submittedProjectVersion: null,
+          submittedOutboxId: null,
+          updatedAt: timestamp,
+        });
+        assertDraftSize(restoredDraft);
+        await auditChainService.appendManyInTransaction(tx, [
+          auditEntry(current, actorRole, 'PROJECT_INFO_DRAFT_WITHDRAW', restoredDraft.draftRevision, timestamp, {
+            fence: current.fence,
+            projectRequestId: readOptionalText(request.id) || null,
+            restoredExecutiveReviewStatus: restoredReview.executiveReviewStatus,
+            canonicalVersion: nextVersion,
+          }),
+        ]);
+        tx.set(projectRef, nextProject);
+        tx.set(requestRef, withdrawnRequest);
+        tx.set(draftRef, restoredDraft);
+        const body = {
+          withdrawn: true,
+          draft: draftContract(restoredDraft),
+          canonicalVersion: nextVersion,
+          executiveReviewStatus: restoredReview.executiveReviewStatus,
+        };
+        completeIdempotency(tx, current, lock, { method, path, status: 200, body }, nowDate);
+        return { status: 200, body, replayed: false };
+      });
+    },
+
     async rebase(input) {
       const current = context(input);
       const expectedDraftRevision = Number(input?.expectedDraftRevision);
@@ -717,14 +857,16 @@ export function createProjectInfoDraftService({
         conflicts.forEach((conflict) => {
           merged[conflict.field] = resolutions[conflict.field] === 'THEIRS' ? conflict.theirs : conflict.mine;
         });
-        const nextDraft = {
+        // `merged` and `theirs` are computed rather than literal, so an absent optional
+        // field can arrive here as undefined, which Firestore rejects on write.
+        const nextDraft = stripUndefinedDeep({
           ...draft,
           payload: merged,
           baseSnapshot: theirs,
           baseCanonicalVersion: actualVersion,
           draftRevision: expectedDraftRevision + 1,
           updatedAt: timestamp,
-        };
+        });
         assertDraftSize(nextDraft);
         await auditChainService.appendManyInTransaction(tx, [
           auditEntry(current, actorRole, 'PROJECT_INFO_DRAFT_REBASE', nextDraft.draftRevision, timestamp, {
@@ -1380,6 +1522,14 @@ export function mountProjectInfoDraftRoutes(app, {
       projectId: routeProjectId(req),
       documentKind: requiredText(req.params?.documentKind, 'documentKind'),
       ...parsed,
+    }));
+  }));
+
+  app.post('/api/v1/project-info-drafts/:projectId/withdraw', asyncHandler(async (req, res) => {
+    assertActorRoleAllowed(req, PROJECT_REQUEST_ROUTE_ROLES, 'withdraw a project change request');
+    parseWithSchema(projectInfoDraftOpenSchema, req.body);
+    sendOutcome(res, await projectInfoDraftService.withdraw({
+      ...await routeContext(req, piiProtector), ...routeOwnership(req), projectId: routeProjectId(req),
     }));
   }));
 

--- a/src/app/components/portal/PortalProjectEdit.rebase.shell.test.ts
+++ b/src/app/components/portal/PortalProjectEdit.rebase.shell.test.ts
@@ -39,8 +39,19 @@ describe('project info draft rebase contract', () => {
   it('blocks confirmation until the owner has chosen a value for every conflict', () => {
     expect(dialogSource).toContain('disabled={busy || unresolvedCount > 0}');
     expect(dialogSource).toContain('내가 입력한 값');
-    expect(dialogSource).toContain('최신 프로젝트 값');
+    expect(dialogSource).toContain('임시저장된 최근 값');
     expect(dialogSource).toContain('자동으로 반영되는 항목');
+  });
+
+  it('shows form wording and recognizable values instead of stored field names', () => {
+    expect(dialogSource).toContain("teamMembersDetailed: '참여인력'");
+    expect(dialogSource).toContain("customerBusinessRegistrationDocument: '고객사 사업자등록증'");
+    expect(dialogSource).toContain("finalPaymentNote: '잔금 관련 메모'");
+    expect(dialogSource).toContain("settlementSystemOther: '기타 정산 시스템 이름'");
+    // Attachments read as a file, amount maps as 선금/중도금/잔금 — never raw JSON.
+    expect(dialogSource).toContain("{ contract: '선금', interim: '중도금', final: '잔금' }");
+    expect(dialogSource).not.toContain('JSON.stringify(value)');
+    expect(dialogSource).toContain('입력하지 않음');
   });
 
   it('exposes rebase on the draft client with resolutions optional for preview', () => {

--- a/src/app/components/portal/PortalProjectEdit.tsx
+++ b/src/app/components/portal/PortalProjectEdit.tsx
@@ -262,6 +262,8 @@ function ProjectInfoEditor({
   } | null>(null);
   const [rebaseBusy, setRebaseBusy] = useState(false);
   const rebasedVersionRef = useRef(0);
+  const [withdrawOpen, setWithdrawOpen] = useState(false);
+  const [withdrawBusy, setWithdrawBusy] = useState(false);
   const [resubmitComment, setResubmitComment] = useState('');
   const revisionRef = useRef(0);
   const recordLoadedRef = useRef(false);
@@ -287,6 +289,11 @@ function ProjectInfoEditor({
   const canManagementPlanningResubmit = managementPlanningReview.status === 'REVISION_REJECTED';
   const canResubmit = canExecutiveResubmit || canManagementPlanningResubmit;
   const executiveBanner = useMemo(() => resolveExecutiveBanner(project), [project]);
+  // Only a request still awaiting a decision can be pulled back, and only by its owner.
+  const canWithdrawRequest = project.executiveReviewStatus === 'PENDING'
+    && record?.status === 'SUBMITTED'
+    && lease.canEdit
+    && !submitted;
   const reviewFeedback = useMemo(() => buildPortalProjectReviewFeedback(project, requestDoc), [project, requestDoc]);
   const initialDraft = useMemo(
     () => (record ? editorDraftFromPrivate(record) : canonicalDraft),
@@ -483,6 +490,23 @@ function ProjectInfoEditor({
     }
   };
 
+  const withdrawRequest = async () => {
+    setWithdrawBusy(true);
+    try {
+      const result = await enqueueMutation(() => withOwnership((ownership) => draftClient.withdraw(ownership)));
+      revisionRef.current = result.draft.draftRevision;
+      rebasedVersionRef.current = result.canonicalVersion;
+      setRecord(result.draft);
+      recordLoadedRef.current = true;
+      setWithdrawOpen(false);
+      toast.success('수정 요청을 회수했습니다. 이어서 수정할 수 있습니다.');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : '수정 요청을 회수하지 못했습니다.');
+    } finally {
+      setWithdrawBusy(false);
+    }
+  };
+
   const applyRebase = async (resolutions: Record<string, ProjectInfoRebaseResolution>) => {
     if (!rebaseState) return;
     const actionId = rebaseState.pendingActionId;
@@ -565,6 +589,21 @@ function ProjectInfoEditor({
             <h2 className="mt-1 text-base font-semibold">{executiveBanner.title}</h2>
             <p className="mt-2 whitespace-pre-wrap text-sm leading-6">{executiveBanner.description}</p>
             {canExecutiveResubmit ? resubmitCommentField : null}
+            {canWithdrawRequest ? (
+              <div className="mt-3">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => setWithdrawOpen(true)}
+                  disabled={withdrawBusy || !!busyActionId}
+                >
+                  수정 요청 회수
+                </Button>
+                <p className="mt-1.5 text-[11px] leading-5 opacity-80">
+                  승인 대기열에서 요청을 빼고 이어서 수정합니다. 조직장이 이미 처리했다면 회수할 수 없습니다.
+                </p>
+              </div>
+            ) : null}
           </div>
           {busyActionId ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
         </div>
@@ -652,6 +691,26 @@ function ProjectInfoEditor({
         onReacquire={() => { void startEditing(); }}
         onTakeover={() => { void lease.takeover(); }}
       />
+      <AlertDialog open={withdrawOpen} onOpenChange={(open) => { if (!withdrawBusy) setWithdrawOpen(open); }}>
+        <AlertDialogContent className="max-w-md border border-slate-200 bg-white">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-lg text-slate-950">수정 요청을 회수할까요?</AlertDialogTitle>
+            <AlertDialogDescription className="text-sm leading-6 text-slate-600">
+              요청이 승인 대기열에서 빠지고, 프로젝트 검토 상태는 요청 이전으로 되돌아갑니다.
+              입력한 내용은 그대로 남아 이어서 수정할 수 있습니다. 다시 제출하려면 최종 저장을 눌러주세요.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={withdrawBusy}>닫기</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={withdrawBusy}
+              onClick={(event) => { event.preventDefault(); void withdrawRequest(); }}
+            >
+              {withdrawBusy ? '회수 중...' : '회수하고 이어서 수정'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
       <ProjectInfoRebaseDialog
         open={rebaseState !== null}
         conflicts={rebaseState?.conflicts || []}

--- a/src/app/components/portal/ProjectInfoRebaseDialog.tsx
+++ b/src/app/components/portal/ProjectInfoRebaseDialog.tsx
@@ -53,19 +53,97 @@ const FIELD_LABELS: Record<string, string> = {
   participantCondition: '참여 조건',
   businessManagementGoogleFolderLink: '사업관리 구글폴더링크',
   groupwareName: '그룹웨어명',
+  contractDocument: '계약서',
+  customerBusinessRegistrationDocument: '고객사 사업자등록증',
+  quoteDocument: '산출내역서(견적서)',
+  quoteSubmissionDeferred: '산출내역서 이후 제출',
+  proposalDocument: '제안서',
+  proposalWordOriginalDocument: '제안서(워드)',
+  proposalPptOriginalDocument: '제안서 원본(PPT)',
+  presentationPptOriginalDocument: '발표자료 원본(PPT)',
+  rfpRequestEvidenceDocument: 'RFP',
+  performanceCertificateDocument: '수행확인서',
+  taxInvoiceDocument: '세금계산서',
+  finalSettlementReportDocument: '최종 정산보고서',
+  teamMembers: '참여인력 요약',
+  settlementSystemOther: '기타 정산 시스템 이름',
+  finalPaymentNote: '잔금 관련 메모',
+  finalPaymentExpectedWeek: '잔금 예상 주차',
+  registrationConfirmations: '등록 확인 항목',
+  registrationOptionalDocumentNotes: '선택 제출서류 메모',
+  registrationRequirementsVersion: '등록 요건 버전',
+  checkout: '완료 처리 항목',
+  contractAnalysis: '계약서 자동 분석 결과',
+  financialInputFlags: '재무 입력 여부',
+  settlementSheetPolicy: '정산 시트 정책',
+  laborTransferPlan: '인건비 이체 계획',
+  fundInputMode: '자금 입력 방식',
+  registeredByName: '등록자',
+  managerId: 'PM 계정',
+  executiveApproverId: '최종 결재자 계정',
 };
 
 function fieldLabel(field: string) {
   return FIELD_LABELS[field] || field;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function text(value: unknown) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+// The dialog shows what the person sees on the form, never the stored shape.
 function displayValue(value: unknown): string {
-  if (value === null || value === undefined || value === '') return '비어 있음';
+  if (value === null || value === undefined || value === '') return '입력하지 않음';
   if (typeof value === 'boolean') return value ? '예' : '아니오';
   if (typeof value === 'number') return value.toLocaleString('ko-KR');
   if (typeof value === 'string') return value;
-  if (Array.isArray(value)) return `${value.length}개 항목`;
-  return JSON.stringify(value);
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return '없음';
+    const people = value
+      .map((entry) => {
+        if (!isRecord(entry)) return '';
+        const name = text(entry.memberName) || text(entry.name);
+        if (!name) return '';
+        const nickname = text(entry.memberNickname);
+        const role = text(entry.role);
+        return `${name}${nickname ? `(${nickname})` : ''}${role ? ` · ${role}` : ''}`;
+      })
+      .filter(Boolean);
+    if (people.length === value.length) return people.join(', ');
+    const years = value
+      .map((entry) => (isRecord(entry) && entry.year ? String(entry.year) : ''))
+      .filter(Boolean);
+    if (years.length === value.length) return `${years.join(', ')}년`;
+    return `${value.length}개 항목`;
+  }
+
+  if (isRecord(value)) {
+    // Attachments: the file is what the person recognizes, not its storage path.
+    const fileName = text(value.name);
+    if (fileName && (value.size !== undefined || value.contentType !== undefined)) {
+      const size = typeof value.size === 'number' ? ` · ${(value.size / 1024 / 1024).toFixed(1)}MB` : '';
+      return `${fileName}${size}`;
+    }
+    // Amount or month maps such as 선금/중도금/잔금.
+    const MONEY_LABELS: Record<string, string> = { contract: '선금', interim: '중도금', final: '잔금' };
+    const parts = Object.entries(value)
+      .filter(([key]) => key in MONEY_LABELS)
+      .map(([key, entry]) => {
+        const shown = entry === null || entry === undefined || entry === ''
+          ? '미정'
+          : typeof entry === 'number' ? `${entry.toLocaleString('ko-KR')}원` : String(entry);
+        return `${MONEY_LABELS[key]} ${shown}`;
+      });
+    if (parts.length > 0) return parts.join(' · ');
+    const filled = Object.values(value).filter((entry) => entry !== null && entry !== undefined && entry !== '').length;
+    return filled === 0 ? '입력하지 않음' : `${filled}개 항목 입력됨`;
+  }
+  return String(value);
 }
 
 export function ProjectInfoRebaseDialog({
@@ -101,7 +179,7 @@ export function ProjectInfoRebaseDialog({
           <DialogTitle>수정하는 동안 프로젝트가 변경되었습니다</DialogTitle>
           <DialogDescription>
             {conflicts.length > 0
-              ? '아래 항목은 내가 수정한 값과 최신 프로젝트 값이 서로 다릅니다. 어느 값을 남길지 선택해 주세요.'
+              ? '아래 항목은 내가 입력한 값과 임시저장된 최근 값이 서로 다릅니다. 어느 값을 남길지 선택해 주세요.'
               : '변경된 내용은 모두 자동으로 반영할 수 있습니다. 확인 후 계속 진행해 주세요.'}
           </DialogDescription>
         </DialogHeader>
@@ -110,7 +188,7 @@ export function ProjectInfoRebaseDialog({
           <div className="rounded-lg border border-slate-200 bg-white px-4 py-3 text-[12px] text-slate-700">
             <p className="font-medium">자동으로 반영되는 항목 {autoMerged.length}건</p>
             <p className="mt-1 text-[11px] text-slate-500">
-              내가 수정하지 않은 항목이라 최신 값을 그대로 가져옵니다.
+              내가 입력하지 않은 항목이라 최근 값을 그대로 가져옵니다.
             </p>
             <ul className="mt-2 grid gap-1">
               {autoMerged.map((entry) => (
@@ -127,9 +205,11 @@ export function ProjectInfoRebaseDialog({
             {conflicts.map((conflict) => (
               <div key={conflict.field} className="rounded-lg border border-slate-200 px-4 py-3">
                 <p className="text-[12px] font-medium text-slate-900">{fieldLabel(conflict.field)}</p>
-                <p className="mt-0.5 text-[11px] text-slate-500">
-                  수정 시작 시점: {displayValue(conflict.base)}
-                </p>
+                {conflict.base === null || conflict.base === undefined ? null : (
+                  <p className="mt-0.5 text-[11px] text-slate-500">
+                    수정 시작 시점: {displayValue(conflict.base)}
+                  </p>
+                )}
                 <RadioGroup
                   className="mt-2 grid gap-2"
                   value={resolutions[conflict.field] || ''}
@@ -144,7 +224,7 @@ export function ProjectInfoRebaseDialog({
                   </label>
                   <label className="flex items-start gap-2 text-[12px] text-slate-700">
                     <RadioGroupItem value="THEIRS" className="mt-0.5" />
-                    <span>최신 프로젝트 값 · <strong>{displayValue(conflict.theirs)}</strong></span>
+                    <span>임시저장된 최근 값 · <strong>{displayValue(conflict.theirs)}</strong></span>
                   </label>
                 </RadioGroup>
               </div>

--- a/src/app/lib/project-info-draft-client.ts
+++ b/src/app/lib/project-info-draft-client.ts
@@ -295,6 +295,21 @@ export function createProjectInfoDraftClient(options: {
       return parseDraftBody(response.data, projectId);
     },
 
+    // Pulls a still-pending change request back and reactivates the draft that made it.
+    async withdraw(ownership: { leaseId: string; fence: number }) {
+      const response = await client.post<unknown>(`${path}/withdraw`, {
+        ...request,
+        headers: ownershipHeaders(sessionId, ownership),
+        body: {},
+      });
+      const body = object(response.data, 'project information withdraw');
+      return {
+        draft: parseDraft(body.draft, projectId),
+        canonicalVersion: Number(body.canonicalVersion) || 0,
+        executiveReviewStatus: String(body.executiveReviewStatus ?? ''),
+      };
+    },
+
     // Without `resolutions` this previews the merge and writes nothing.
     async rebase(
       ownership: { leaseId: string; fence: number },

--- a/src/app/platform/api-client.ts
+++ b/src/app/platform/api-client.ts
@@ -418,6 +418,15 @@ export class PlatformApiClient {
               },
             });
           }
+          // The browser console is where operators copy failures from, so print the
+          // fields needed to find the matching server log instead of a bare message.
+          // eslint-disable-next-line no-console
+          console.error(`[bff] ${method} ${path} → ${response.status}`, {
+            code: responseCode || '(none)',
+            message: responseMessage || '(none)',
+            requestId: requestId || clientRequestId || '(none)',
+            tenantId: options.tenantId,
+          });
           throw new PlatformApiError(
             // 서버가 문구를 보냈다면 resolveApiErrorMessage 가 body.message 를 먼저 쓴다.
             // 이 문구는 응답 본문이 비어 있을 때(게이트웨이 오류 등)만 사용자에게 보인다.


### PR DESCRIPTION
## Why
라이브에서 rebase 적용이 500으로 실패하는데, 브라우저 콘솔에도 응답 본문에도 원인이 없습니다. 다섯 가지 가설을 라이브 데이터와 코드로 검증했으나 모두 아니었습니다.

| 가설 | 검증 결과 |
|---|---|
| seed에 `undefined` | 라이브 프로젝트로 실행 → 0개 |
| resumable 요청 분기가 `undefined` 생성 | 재현 → 0개 |
| 감사 액션 허용 목록 | 허용 목록 자체가 없음 |
| read-after-write 위반 | `checkIdempotency`·`assertLease` 모두 읽기 전용 |
| Firestore 배열 중첩 제약 | 미리보기도 동일 구조를 쓰는데 200 |

그래서 **여섯 번째 가설을 세우는 대신 실제 실패를 포착**하도록 계측합니다.

## Logging
- BFF 500 핸들러가 `method`·`path`·`requestId`·`tenantId`·에러 name/message/code를 **한 줄 JSON**으로 남기고 스택을 이어 출력
- API 클라이언트가 throw 전에 status·code·message·requestId를 브라우저 콘솔에 출력 → DevTools에서 바로 복사해 서버 로그와 대조 가능

## Hardening
rebase의 draft 쓰기를 `stripUndefinedDeep`으로 감쌌습니다. `submit`이 쓰는 객체는 전부 리터럴이지만 rebase는 **계산된 값**을 저장하므로, 없는 선택 필드가 `undefined`로 Firestore에 도달할 수 있습니다. **이것이 500의 원인이라고 확인된 것은 아니며 하드닝으로 표기합니다.**

## Merge 정확도
라이브에서 확인된 가짜 충돌을 제거합니다.
- 양쪽 모두 비어 있는데 충돌로 잡힘 → `null`·`undefined`·`''`를 동일 값으로 취급
- 첨부가 `downloadURL:""` vs `visibility:"PRIVATE"` 차이만으로 충돌 → 한쪽만 가진 빈 키 무시

## 다이얼로그 문구
- 저장 키가 아니라 **폼에서 쓰는 용어**로 표시 (라벨 55개)
- 첨부는 파일명·용량, 금액 맵은 선금/중도금/잔금, 인력은 이름·역할로 표시. 원시 JSON 노출 경로는 테스트로 차단
- "최신 프로젝트 값" → **"임시저장된 최근 값"**
- `baseSnapshot`이 없어 기준값을 **모르는** 경우 "수정 시작 시점" 줄을 숨김 (기존에는 "비어 있음"으로 단정해 오해를 유발)

## 회수 기능
`POST /api/v1/project-info-drafts/:projectId/withdraw` — 아직 결재 전인 변경 요청을 회수합니다.

| 문서 | 처리 |
|---|---|
| `project_requests/change-{id}` | `status → WITHDRAWN` |
| `projects/{id}` | 검토 상태를 제출 이전으로 복원 + `version` +1 |
| `privateEditDrafts/...` | `ACTIVE` 복원, payload·첨부 유지, `baseCanonicalVersion` 갱신 |

제출이 `version`을 +1 하므로 회수 시 `baseCanonicalVersion`을 갱신하지 않으면 동일한 409를 재생산합니다. 회수와 승인은 같은 프로젝트 문서를 쓰므로 트랜잭션이 직렬화되어 먼저 커밋한 쪽이 이깁니다.

## Verification
- `npm test` — 2,674 passed / 0 failed (회수 복원 규칙 5건, 머지 12건)
- `npm run build` 통과

## Ops notes
Firestore rules/indexes, Vercel env 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)