### PR TITLE
fix(portal): import AlertDialogCancel used by the withdraw dialog

### DIFF
--- a/src/app/components/portal/PortalProjectEdit.tsx
+++ b/src/app/components/portal/PortalProjectEdit.tsx
@@ -73,6 +73,7 @@ import { Textarea } from '../ui/textarea';
 import {
   AlertDialog,
   AlertDialogAction,
+  AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
   AlertDialogFooter,


### PR DESCRIPTION
## 라이브 장애 복구

프로젝트 수정 화면이 `AlertDialogCancel is not defined`로 크래시했습니다. #436에서 회수 확인 다이얼로그를 추가하면서 `AlertDialogCancel`을 import 하지 않았습니다.

## 왜 통과했나

| 검증 | 결과 |
|---|---|
| `npm run build` | vite 빌드는 **타입체크를 하지 않음** → 통과 |
| shell 테스트 | 소스 **문자열**만 대조, 렌더링하지 않음 → 통과 |
| `npx tsc --noEmit` | `TS2304: Cannot find name 'AlertDialogCancel'` — **이걸 돌렸어야 했습니다** |

수정 후 해당 파일들에 대해 `tsc --noEmit` 클린을 확인했습니다.

## 재발 방지 제안 (별건)
이 저장소는 기존 타입 에러가 203건 있어 전역 `tsc` 게이트를 바로 켤 수 없습니다. 변경된 파일에 한해 기준선 대비 신규 타입 에러만 차단하는 방식을 제안합니다. 별도 논의가 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)