### PR TITLE
fix(bff): pass a key schema to z.record for rebase resolutions

### DIFF
--- a/server/bff/schemas.mjs
+++ b/server/bff/schemas.mjs
@@ -53,7 +53,7 @@ export const projectInfoDraftAttachmentSchema = projectRegistrationDraftAttachme
 export const projectInfoDraftRebaseSchema = z.object({
   expectedDraftRevision: z.number().int().nonnegative(),
   // Absent means "preview only": report the merge outcome without writing.
-  resolutions: z.record(z.enum(['MINE', 'THEIRS'])).optional(),
+  resolutions: z.record(z.string().min(1), z.enum(['MINE', 'THEIRS'])).optional(),
 }).strict();
 
 export const projectInfoDraftSubmitSchema = z.object({

--- a/server/bff/schemas.rebase.test.mjs
+++ b/server/bff/schemas.rebase.test.mjs
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { projectInfoDraftRebaseSchema } from './schemas.mjs';
+
+// A single-argument z.record() parses fine while the optional field is absent and only
+// throws once a value is present, so the preview call succeeded and every apply call
+// returned 500. Both shapes are asserted here.
+describe('projectInfoDraftRebaseSchema', () => {
+  it('accepts a preview request that omits resolutions', () => {
+    expect(projectInfoDraftRebaseSchema.parse({ expectedDraftRevision: 8 }))
+      .toEqual({ expectedDraftRevision: 8 });
+  });
+
+  it('accepts an apply request carrying resolutions', () => {
+    const parsed = projectInfoDraftRebaseSchema.parse({
+      expectedDraftRevision: 8,
+      resolutions: { teamMembersDetailed: 'MINE', paymentExpectedMonths: 'THEIRS' },
+    });
+    expect(parsed.resolutions).toEqual({
+      teamMembersDetailed: 'MINE',
+      paymentExpectedMonths: 'THEIRS',
+    });
+  });
+
+  it('rejects a resolution value outside MINE and THEIRS', () => {
+    expect(() => projectInfoDraftRebaseSchema.parse({
+      expectedDraftRevision: 8,
+      resolutions: { teamMembersDetailed: 'BOTH' },
+    })).toThrow();
+  });
+
+  it('rejects an empty field name', () => {
+    expect(() => projectInfoDraftRebaseSchema.parse({
+      expectedDraftRevision: 8,
+      resolutions: { '': 'MINE' },
+    })).toThrow();
+  });
+
+  it('rejects unknown top-level keys', () => {
+    expect(() => projectInfoDraftRebaseSchema.parse({
+      expectedDraftRevision: 8,
+      unexpected: true,
+    })).toThrow();
+  });
+});


### PR DESCRIPTION
## 근본 원인

라이브 런타임 로그에서 실제 스택을 확보했습니다 (`requestId: req_1785903496367_ae0cbebe0b7e401d`).

```
TypeError: Cannot read properties of undefined (reading '_zod')
POST /api/v1/project-info-drafts/p1773817948751/rebase → 500
```

`projectInfoDraftRebaseSchema`가 `resolutions`를 `z.record(z.enum(['MINE','THEIRS']))`로 선언했습니다. **zod 4는 `z.record(keySchema, valueSchema)` 두 인자를 요구**하므로 값 스키마가 `undefined`가 되고, 파싱 시 그 `._zod`를 읽다가 예외가 발생합니다.

## 미리보기는 되고 적용만 실패한 이유

zod 4.3.6으로 재현한 결과:

| 요청 | 결과 |
|---|---|
| `{ expectedDraftRevision }` — 미리보기 | **통과** → 200, 다이얼로그 정상 표시 |
| `{ expectedDraftRevision, resolutions }` — 적용 | **TypeError** → 500 |

선택 필드가 없으면 값 스키마를 건드리지 않아 통과합니다. 보고된 증상과 정확히 일치합니다.

저장소의 다른 `z.record(...)` 3곳은 모두 두 인자를 올바르게 전달하고 있었습니다.

## 테스트가 못 잡은 이유
기존 테스트는 `resolutions` 없는 형태만 파싱했습니다. `schemas.rebase.test.mjs`에서 **두 형태 모두**와 잘못된 값·빈 필드명·미지의 키까지 검증합니다.

## Verification
- `npx vitest run server/bff/schemas.rebase.test.mjs` — 5 passed
- `npm test` — 2,679 passed / 0 failed
- `npm run typecheck` — no new type errors

## Ops notes
Firestore rules/indexes, Vercel env 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)