### PR TITLE
fix(portal): keep a version conflict a failure, and make withdraw reachable

### DIFF
--- a/src/app/components/portal/PortalProjectEdit.rebase.shell.test.ts
+++ b/src/app/components/portal/PortalProjectEdit.rebase.shell.test.ts
@@ -26,6 +26,10 @@ describe('project info draft rebase contract', () => {
     expect(editSource).toContain("body?.error === 'canonical_version_conflict'");
     expect(editSource).toContain('function isCanonicalVersionConflict');
     expect(editSource).toContain('if (isCanonicalVersionConflict(error)) {');
+    // A conflict means the submit did not go through, so it must stay a failure for the
+    // caller; swallowing it made the wizard clear the autosave and the unsaved guard.
+    expect(editSource).toContain('        throw error;');
+    expect(editSource).not.toContain('내가 입력하지 않은 항목이라 최근 값을 그대로 가져옵니다.\n          return;');
     expect(editSource).toContain('<ProjectInfoRebaseDialog');
     expect(editSource).toContain('const applyRebase = async');
   });

--- a/src/app/components/portal/PortalProjectEdit.tsx
+++ b/src/app/components/portal/PortalProjectEdit.tsx
@@ -290,9 +290,10 @@ function ProjectInfoEditor({
   const canManagementPlanningResubmit = managementPlanningReview.status === 'REVISION_REJECTED';
   const canResubmit = canExecutiveResubmit || canManagementPlanningResubmit;
   const executiveBanner = useMemo(() => resolveExecutiveBanner(project), [project]);
-  // Only a request still awaiting a decision can be pulled back, and only by its owner.
+  // A submit clears the local draft record, so its status is never 'SUBMITTED' here.
+  // Show the action whenever the project is awaiting a decision; the server rejects it
+  // with request_not_withdrawable if there is nothing pending to pull back.
   const canWithdrawRequest = project.executiveReviewStatus === 'PENDING'
-    && record?.status === 'SUBMITTED'
     && lease.canEdit
     && !submitted;
   const reviewFeedback = useMemo(() => buildPortalProjectReviewFeedback(project, requestDoc), [project, requestDoc]);
@@ -476,13 +477,14 @@ function ProjectInfoEditor({
             autoMerged: preview.autoMerged,
             pendingActionId: actionId,
           });
-          return;
         } catch (rebaseError) {
           toast.error(rebaseError instanceof Error
             ? rebaseError.message
             : '프로젝트 변경 내역을 불러오지 못했습니다.');
-          return;
         }
+        // The submit did not go through. Rethrow so the caller keeps treating this as a
+        // failure and leaves the local autosave and the unsaved-changes guard in place.
+        throw error;
       }
       toast.error(error instanceof Error ? error.message : '저장에 실패했습니다. 다시 시도해주세요.');
       throw error;


### PR DESCRIPTION
## 1. 충돌이 성공으로 처리되던 문제 (데이터 손실 위험)

`canonical_version_conflict`를 잡아 rebase 다이얼로그를 띄운 뒤 **정상 리턴**했습니다. 호출부 입장에서는 promise가 resolve된 것이므로 저장 성공으로 간주되어:

- 로컬 임시저장 스냅샷을 삭제
- 미저장 이탈 경고를 해제

이 상태에서 화면을 벗어나면 **입력한 내용이 사라집니다.**

제출은 실제로 이뤄지지 않았으므로, 다이얼로그를 띄운 뒤 **원래 에러를 다시 던집니다.** 새로운 예외 타입이나 별도 분기를 만들지 않고 기존 실패 경로가 그대로 동작하게 했습니다.

## 2. 회수 버튼이 렌더되지 않던 문제

조건이 `record?.status === 'SUBMITTED'` 였는데, 제출 성공 시 같은 함수가 `setRecord(null)`을 수행하므로 **해당 상태에 도달하는 경로가 없습니다.** #436에서 추가한 withdraw 엔드포인트는 UI에서 호출 자체가 불가능했습니다.

프로젝트가 결재 대기 중이면 버튼을 노출하고, 회수할 요청이 없으면 서버가 `request_not_withdrawable`로 거부합니다.

## Verification
- `npx vitest run src/app/components/portal/` — 98 passed
- `npm run typecheck` — no new type errors
- 회귀 방지 단언 추가 (충돌 시 rethrow 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)