### PR TITLE
fix(approval): show when a request actually arrived

### DIFF
--- a/src/app/components/projects/migration-audit/MigrationAuditRecordList.tsx
+++ b/src/app/components/projects/migration-audit/MigrationAuditRecordList.tsx
@@ -18,8 +18,20 @@ function statusClass(status: MigrationAuditConsoleRecord['status']) {
   return 'border-amber-300 text-amber-800';
 }
 
-function formatDate(value: string) {
-  return value ? value.slice(0, 10).replace(/-/g, '.') : '-';
+// Several requests can arrive on the same day, so the reviewer needs the time too.
+function formatReceivedAt(value: string) {
+  if (!value) return '-';
+  const at = new Date(value);
+  if (Number.isNaN(at.getTime())) return value.slice(0, 10).replace(/-/g, '.');
+  return new Intl.DateTimeFormat('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(at).replace(/\.\s*$/, '');
 }
 
 export function MigrationAuditRecordList({ records, onOpen, reviewStage = 'executive' }: MigrationAuditRecordListProps) {
@@ -42,7 +54,7 @@ export function MigrationAuditRecordList({ records, onOpen, reviewStage = 'execu
                 <th className="px-4 py-3">담당조직(CIC)</th>
                 <th className="px-4 py-3">프로젝트명</th>
                 <th className="px-4 py-3">등록자</th>
-                <th className="px-4 py-3">접수일</th>
+                <th className="px-4 py-3">접수일시</th>
                 {isManagementPlanning ? <th className="px-4 py-3">프로젝트 코드</th> : null}
                 <th className="px-4 py-3 text-right">문서</th>
               </tr>
@@ -57,7 +69,7 @@ export function MigrationAuditRecordList({ records, onOpen, reviewStage = 'execu
                     <p className="mt-1 truncate text-[11px] text-slate-500">{record.clientOrg || '계약 대상 미지정'}</p>
                   </td>
                   <td className="px-4 py-3 text-[12px] text-slate-700">{record.managerName || '-'}</td>
-                  <td className="px-4 py-3 text-[12px] text-slate-600">{formatDate(record.requestedAt)}</td>
+                  <td className="px-4 py-3 text-[12px] text-slate-600">{formatReceivedAt(record.requestedAt)}</td>
                   {isManagementPlanning ? <td className="px-4 py-3 text-[12px] font-medium text-slate-700">{getManagementPlanningReview(record.project).projectCode || '부여 대기'}</td> : null}
                   <td className="px-4 py-3 text-right">
                     <Button type="button" variant="outline" size="sm" className="h-8 rounded-none border-slate-400 text-[11px]" onClick={() => onOpen(record)}>

--- a/src/app/platform/project-migration-console.ts
+++ b/src/app/platform/project-migration-console.ts
@@ -165,7 +165,11 @@ export function buildMigrationAuditConsoleRecords(
         title: normalizeText(project.officialContractName || project.name) || '이름 없음',
         clientOrg: normalizeText(project.clientOrg),
         managerName: normalizeText(project.registeredByName || project.managerName),
-        requestedAt: normalizeText(request?.requestedAt || project.createdAt),
+        // The date a reviewer needs is when the request arrived. Falling back to the
+        // project's creation date showed a months-old date for a request filed today.
+        requestedAt: normalizeText(
+          request?.updatedAt || request?.requestedAt || project.registeredAt || project.createdAt,
+        ),
       };
     })
     .sort((left, right) => String(right.requestedAt).localeCompare(String(left.requestedAt)));


### PR DESCRIPTION
## 문제
승인 대기열이 요청을 찾지 못하면 **프로젝트 생성일**로 폴백해서, 오늘 접수된 수정 요청이 `2026.03.18`로 표시됐습니다. 검토자가 새로 들어온 건과 오래된 건을 구분할 수 없었습니다.

## 수정
요청 자체의 시각을 우선 사용하고, **같은 날 여러 건이 들어올 수 있어 시간까지** 표시합니다 (KST 기준).

```
접수일  2026.03.18        →   접수일시  2026. 08. 05. 13:44
```

## Verification
- `npm run typecheck` — no new type errors

## 범위
첨부 이관 관련 변경은 이 PR에서 **분리**했습니다. 재제출 경쟁 상황에서 기존 아웃박스 동작과 충돌하는 것이 통합 테스트로 확인되어 별도로 다룹니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)