### PR TITLE
fix(deploy): re-enable production workers left off after maintenance

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -41,8 +41,8 @@ jobs:
       BFF_DEPLOY_ENV: live
       BFF_AUTH_MODE: firebase_required
       BFF_EDIT_LEASES_ENABLED: 'true'
-      BFF_WORKERS_ENABLED: 'false'
-      BFF_SCHEDULER_OWNER: disabled
+      BFF_WORKERS_ENABLED: 'true'
+      BFF_SCHEDULER_OWNER: vercel
       BFF_MAINTENANCE_READ_ONLY: 'false'
       BFF_ALLOWED_ORIGINS: https://myscube.myscguard.app
       JVM_WEEKLY_AUTH_MODE: strict
@@ -202,6 +202,9 @@ jobs:
             throw new Error(`production maintenance guard still active: ${mutation.response.status} ${JSON.stringify(mutation.body)}`);
           }
 
+          // Workers run from Vercel cron. An unauthenticated call must be rejected as
+          // unauthorized, which also proves CRON_SECRET reached the deployment: a missing
+          // secret would answer 503 worker_secret_missing instead.
           for (const path of [
             '/api/internal/workers/outbox/run',
             '/api/internal/workers/work-queue/run',
@@ -209,7 +212,7 @@ jobs:
             '/api/internal/workers/client-errors/run',
           ]) {
             const worker = await request(path);
-            if (worker.response.status !== 503 || worker.body.error !== 'worker_scheduler_disabled') {
+            if (worker.response.status !== 401 || worker.body.error !== 'unauthorized_worker') {
               throw new Error(`worker guard missing at ${path}: ${worker.response.status} ${JSON.stringify(worker.body)}`);
             }
           }

--- a/server/production-deploy-workflow.test.ts
+++ b/server/production-deploy-workflow.test.ts
@@ -76,8 +76,8 @@ describe('production deployment workflow safety', () => {
     expect(workflowText).toContain('LIVE_FIREBASE_PROJECT_ID: inner-platform-live-20260316');
     expect(workflowText).toContain('BFF_DEPLOY_ENV: live');
     expect(workflowText).toContain("BFF_EDIT_LEASES_ENABLED: 'true'");
-    expect(workflowText).toContain("BFF_WORKERS_ENABLED: 'false'");
-    expect(workflowText).toContain('BFF_SCHEDULER_OWNER: disabled');
+    expect(workflowText).toContain("BFF_WORKERS_ENABLED: 'true'");
+    expect(workflowText).toContain('BFF_SCHEDULER_OWNER: vercel');
     expect(workflowText).toContain("BFF_MAINTENANCE_READ_ONLY: 'false'");
     expect(workflowText).toContain('--env FIREBASE_PROJECT_ID="${LIVE_FIREBASE_PROJECT_ID}"');
     expect(workflowText).toContain('--env BFF_FIREBASE_AUTH_PROJECT_ID="${LIVE_FIREBASE_PROJECT_ID}"');
@@ -99,7 +99,7 @@ describe('production deployment workflow safety', () => {
     expect(workflowText).toContain("'x-vercel-protection-bypass': process.env.VERCEL_AUTOMATION_BYPASS_SECRET");
     expect(workflowText).toContain('deploy --prod --yes --skip-domain');
     expect(workflowText).toContain('/api/v1/__maintenance_probe__');
-    expect(workflowText).toContain('worker_scheduler_disabled');
+    expect(workflowText).toContain('unauthorized_worker');
     expect(workflowText).toContain('mutation.response.status !== 400');
     expect(workflowText).toContain("mutation.body.error === 'maintenance_read_only'");
     expect(workflowText.indexOf('Verify production surface before alias')).toBeLessThan(


### PR DESCRIPTION
## 원인: 점검 모드 해제가 절반만 반영됨

`486732f1`(7/31)은 라이브를 **점검 모드**로 넣은 배포였습니다. 세 값이 함께 설정됐습니다.

```
BFF_MAINTENANCE_READ_ONLY: 'true'
BFF_WORKERS_ENABLED: 'false'
BFF_SCHEDULER_OWNER: disabled
```

이후 점검은 해제됐지만(`BFF_MAINTENANCE_READ_ONLY`는 `'false'`로 복구됨) **워커 관련 두 값은 되돌아가지 않았습니다.**

## 영향

스케줄러가 꺼져 있어 **2026-07-29 이후 아웃박스가 한 건도 처리되지 않았습니다.**

```
project.info.submitted  PENDING  attempts=0  2026-08-05T04:44:52
project.info.submitted  PENDING  attempts=0  2026-08-04T08:48:23
project.info.submitted  PENDING  attempts=0  2026-08-04T08:45:21
```

이 큐가 하는 일이 **제출된 수정안의 첨부를 PM 개인 폴더에서 공유 폴더로 옮기는 것**입니다. 승인 큐는 첨부가 아직 개인 폴더에 있는 요청을 걸러내므로(`projectRequestAttachmentsArePublished`), 정상 제출된 변경 요청이 승인자에게 도달하지 못했습니다.

## 왜 `vercel` 소유인가

- `vercel.json`이 이미 세 워커 엔드포인트를 매일 실행하도록 예약하고 있습니다 (02:15 / 02:30 / 02:45 UTC)
- `CRON_SECRET`이 Production 환경에 설정되어 있습니다 (171일 전 등록)

## 배포 전 검증 문구 변경

기존에는 워커가 `503 worker_scheduler_disabled`를 반환하는지 확인했습니다. 이제 **인증 없는 호출이 `401 unauthorized_worker`로 거부되는지** 확인합니다. 이 단언은 크론 시크릿이 배포에 전달됐다는 것까지 함께 증명합니다 — 시크릿이 없으면 `503 worker_secret_missing`이 나옵니다.

## 안전성

`CRON_SECRET`이 32자 미만이면 런타임 안전성 검사가 부팅을 막습니다. 그 경우 **헬스체크 단계에서 배포가 실패하고 alias는 현재 배포에 그대로 남으므로**, 라이브 장애로 이어지지 않습니다.

## Verification
- `npx vitest run server/production-deploy-workflow.test.ts` — 10 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)