### PR TITLE
fix(approval): surface projects that carry no review decision

### DIFF
--- a/src/app/components/approval/AdminApprovalPage.tsx
+++ b/src/app/components/approval/AdminApprovalPage.tsx
@@ -10,7 +10,7 @@ export function AdminApprovalPage() {
   const { projects } = useAppStore();
   const pendingProjectReviews = useMemo(
     () => projects.filter((project) => (
-      (project.executiveReviewStatus || (project.registrationSource === 'pm_portal' ? 'PENDING' : 'APPROVED')) === 'PENDING'
+      (project.executiveReviewStatus || 'PENDING') === 'PENDING'
     )),
     [projects],
   );

--- a/src/app/platform/project-migration-console.test.ts
+++ b/src/app/platform/project-migration-console.test.ts
@@ -7,6 +7,7 @@ import {
   deriveMigrationAuditStatus,
   filterMigrationAuditConsoleRecords,
   findMigrationAuditRecord,
+  getMigrationAuditStatusLabel,
   isMigrationAuditPmRegistration,
   isSameMigrationAuditCic,
   normalizeCicLabel,
@@ -133,7 +134,17 @@ describe('project-migration-console', () => {
     expect(records.map((record) => record.id)).toEqual(['p-1', 'p-2', 'p-3']);
     expect(records[0].status).toBe('APPROVED');
     expect(records[1].status).toBe('REVISION_REJECTED');
-    expect(records[2].status).toBe('APPROVED');
+    // p-3 carries no recorded decision. It is awaiting review, not approved.
+    expect(records[2].status).toBe('PENDING');
+  });
+
+  it('surfaces a migrated project that carries no recorded review decision', () => {
+    const records = buildMigrationAuditConsoleRecords(
+      [makeProject({ id: 'p-migrated', registrationSource: 'manual', name: '이관된 사업', cic: 'CIC-A' })],
+      [],
+    );
+    expect(records[0].status).toBe('PENDING');
+    expect(getMigrationAuditStatusLabel(records[0].status)).toBe('검토 대기');
   });
 
   it('treats linked pending project request as pending even when registrationSource is missing', () => {
@@ -294,8 +305,9 @@ describe('project-migration-console', () => {
     );
 
     const summary = summarizeMigrationAuditConsole(records);
-    expect(summary.pending).toBe(1);
-    expect(summary.approved).toBe(2);
+    // A project with no recorded decision now counts as awaiting review.
+    expect(summary.pending).toBe(2);
+    expect(summary.approved).toBe(1);
     expect(summary.rejected).toBe(1);
     expect(summary.discarded).toBe(1);
     expect(summary.total).toBe(5);

--- a/src/app/platform/project-migration-console.ts
+++ b/src/app/platform/project-migration-console.ts
@@ -86,7 +86,9 @@ export function deriveMigrationAuditStatus(
   if (project.executiveReviewStatus) return project.executiveReviewStatus;
   if (request?.status === 'REJECTED') return 'REVISION_REJECTED';
   if (request?.status === 'APPROVED') return 'APPROVED';
-  return project.registrationSource === 'pm_portal' ? 'PENDING' : 'APPROVED';
+  // Nobody recorded a decision on this project. Treating that as approved hid 16 migrated
+  // projects from the queue, so an unreviewed project is shown as awaiting review instead.
+  return 'PENDING';
 }
 
 export function getMigrationAuditStatusLabel(status: MigrationAuditConsoleStatus): string {


### PR DESCRIPTION
## 문제
`executiveReviewStatus`가 없는 프로젝트를 **포털 등록이 아니면 승인 완료로 간주**하고 있었습니다.

라이브 프로젝트 69건 중 **16건이 이 값 자체가 없습니다.** 마이그레이션에서 채워지지 않은 것으로, 아무도 승인한 적이 없는데 승인 완료로 집계되어 승인 대기열에 나타나지 않았습니다.

## 수정
결재 기록이 없으면 **검토 대기**로 표시합니다. 추측하지 않습니다.

- 승인 대기열 목록에 노출
- 승인 화면의 대기 건수에도 반영

## 영향
승인 대기열에 16건이 추가로 나타납니다. 실제로 검토가 필요한 건인지 판단해서 승인·반려하거나, 마이그레이션 값을 채우면 목록에서 빠집니다.

## Verification
- `npm test` — 2,680 passed / 0 failed
- `npm run typecheck` — no new type errors
- 기존 가정을 단언하던 테스트 2건 갱신, 회귀 방지 테스트 1건 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)