### PR TITLE
fix(members): stop hiding members and let the pickers be searched

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -89,6 +89,8 @@ import { CashflowSheetSyncOverlay } from './CashflowSheetSyncOverlay';
 import { CashflowFormulaMismatchDialog } from './CashflowFormulaMismatchDialog';
 import { CashflowCanonicalSummary } from './CashflowCanonicalSummary';
 import { AxrMonthCloseQaPanel } from './AxrMonthCloseQaPanel';
+import { MemberPicker } from '../ui/member-picker';
+import { buildOrgMemberPickerOptions } from '../../data/project-team-member-options';
 import { loadCashflowActivitySourcesSequentially } from './cashflow-activity-loader';
 
 const CASHFLOW_STANDARD_ANNUAL_YEARS = [2024, 2025, 2027, 2028, 2029, 2030, 2031, 2032] as const;
@@ -437,15 +439,12 @@ export function CashflowProjectSheet({
       && (lateSheetDiffWeek === 'ALL' || String(change.weekNo) === lateSheetDiffWeek)
       && (!query || `${change.yearMonth} ${change.weekNo} ${change.mode} ${label} ${change.lineId}`.toLocaleLowerCase('ko-KR').includes(query));
   });
-  const executiveApproverOptions = useMemo(() => (members || [])
+  const executiveApproverOptions = useMemo(() => buildOrgMemberPickerOptions(members || [])
     .filter((member) => (
-      Boolean(String(member.uid || '').trim())
-      && String(member.status || '').trim().toUpperCase() === 'ACTIVE'
-      && member.uid !== user?.uid
+      member.uid !== user?.uid
       && member.uid !== project?.registeredById
       && member.uid !== project?.managerId
-    ))
-    .sort((left, right) => String(left.name || left.email).localeCompare(String(right.name || right.email), 'ko-KR')),
+    )),
   [members, project?.managerId, project?.registeredById, user?.uid]);
 
   useEffect(() => {
@@ -2749,22 +2748,14 @@ export function CashflowProjectSheet({
                     <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
                       <div className="min-w-0 flex-1">
                         <label className="mb-1 block text-[12px] font-semibold text-slate-800">조직장 선택</label>
-                        <Select
+                        <MemberPicker
+                          className="h-8 border-slate-300 bg-white text-[12px]"
+                          options={executiveApproverOptions}
                           value={selectedExecutiveApproverId}
-                          onValueChange={setSelectedExecutiveApproverId}
+                          onChange={setSelectedExecutiveApproverId}
+                          placeholder="월 결산 승인 조직장을 선택하세요"
                           disabled={executiveApproverBusy || ['PENDING', 'APPROVING'].includes(monthCloseRequest?.status || '')}
-                        >
-                          <SelectTrigger className="h-8 border-slate-300 bg-white text-[12px]">
-                            <SelectValue placeholder="월 결산 승인 조직장을 선택하세요" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {executiveApproverOptions.map((member) => (
-                              <SelectItem key={member.uid} value={member.uid}>
-                                {member.name || member.email}{member.email ? ` · ${member.email}` : ''}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
+                        />
                       </div>
                       <Button
                         type="button"

--- a/src/app/components/projects/ProjectEditorWizard.shell.test.ts
+++ b/src/app/components/projects/ProjectEditorWizard.shell.test.ts
@@ -62,7 +62,11 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain('const hasUnlinkedStoredOwner');
     expect(source).toContain('구성원 원장에서 선택');
     expect(source).not.toContain('<SelectItem value="none">선택 안 함</SelectItem>');
-    expect(source).not.toContain('uid: draft.registeredById');
+    // The stored value is offered back explicitly, labelled, so it is never silently lost.
+    expect(source).toContain('withSavedOrgMemberOption(ledgerMemberOptions');
+    expect(source).toContain('· 기존 선택');
+    // Linkage is still judged against the ledger, so the unlinked warning keeps firing.
+    expect(source).toContain('ledgerMemberOptions.find((member) => member.uid === draft.registeredById)');
     expect(source).toContain("onSelect({ memberName: '', memberNickname: '' })");
     expect(source).toContain('currentTeamMemberOptionExists');
     expect(source).toContain('member.memberNickname ? `${member.memberName} (${member.memberNickname})` : member.memberName');
@@ -71,7 +75,7 @@ describe('ProjectEditorWizard dropdown contract', () => {
   it('uses a member select for project owner instead of free text manager input', () => {
     expect(source).toContain('사업 담당자');
     expect(source).toContain('registeredById');
-    expect(source).toContain('registeredByName: member.name || member.email || member.uid');
+    expect(source).toContain('registeredByName: member.label.replace(');
     expect(source).not.toContain('<Input value={draft.managerName}');
   });
 
@@ -82,20 +86,22 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain('requesterId?: string');
     expect(source).toContain('member.uid !== draft.registeredById && member.uid !== requesterId');
     expect(portalRegisterSource).toContain('requesterId={actor.uid}');
-    expect(source).toContain('requesterId, ownerOptions');
+    expect(source).toContain('requesterId, ledgerMemberOptions');
     expect(source).toContain('const isSelfExecutiveApprover = Boolean(');
     expect(source).toContain('사업 담당자와 최종 결재자는 달라야 합니다.');
   });
 
-  it('offers only active members as project owners and designated executive approvers', () => {
-    const ownerOptionsBlock = source.slice(
-      source.indexOf('const ownerOptions = useMemo'),
-      source.indexOf('const selectedOwner = useMemo'),
+  it('drops only members marked inactive, so members without a status still appear', () => {
+    // Requiring status to equal ACTIVE hid the 15 members whose document carries no status
+    // field at all, which is what QA reported as missing people.
+    const optionsSource = readFileSync(
+      resolve(import.meta.dirname, '../../data/project-team-member-options.ts'),
+      'utf8',
     );
-
-    expect(ownerOptionsBlock).toContain("String(member.status || '').trim().toUpperCase() === 'ACTIVE'");
+    expect(optionsSource).toContain("if (status === 'INACTIVE' || status === 'DELETED') return;");
+    expect(optionsSource).not.toContain("=== 'ACTIVE'");
+    expect(source).toContain('buildOrgMemberPickerOptions(members)');
     expect(source).toContain('const executiveApproverOptions = useMemo');
-    expect(source).toContain('requesterId, ownerOptions');
   });
 
   it('uses a searchable team member picker for registration and edit flows', () => {

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -106,6 +106,11 @@ import {
   PROJECT_TEAM_MEMBER_ROLES,
   RETIRED_PROJECT_TEAM_MEMBER_ROLES,
 } from '../../platform/project-team-members';
+import { MemberPicker } from '../ui/member-picker';
+import {
+  buildOrgMemberPickerOptions,
+  withSavedOrgMemberOption,
+} from '../../data/project-team-member-options';
 import { shouldResetProjectEditorDraft } from './project-editor-reset';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
@@ -998,28 +1003,35 @@ export function ProjectEditorWizard({
   const teamMemberOptionMap = useMemo(() => Object.fromEntries(
     teamMemberOptions.map((option) => [option.value, option]),
   ) as Record<string, ProjectTeamMemberOption>, [teamMemberOptions]);
+  // The ledger list decides whether a stored value is still linked, so the "not in the
+  // member ledger" warning keeps working. The picker lists carry the stored value on top
+  // of it so opening an old project never silently drops its owner or approver.
+  const ledgerMemberOptions = useMemo(() => buildOrgMemberPickerOptions(members), [members]);
   const ownerOptions = useMemo(
-    () => [...members]
-      .filter((member) => (
-        String(member.uid || '').trim()
-        && String(member.status || '').trim().toUpperCase() === 'ACTIVE'
-      ))
-      .sort((left, right) => String(left.name || left.email || left.uid).localeCompare(String(right.name || right.email || right.uid), 'ko')),
-    [members],
+    () => withSavedOrgMemberOption(ledgerMemberOptions, {
+      uid: draft.registeredById,
+      name: draft.registeredByName,
+      email: draft.registeredByEmail,
+    }),
+    [draft.registeredByEmail, draft.registeredById, draft.registeredByName, ledgerMemberOptions],
   );
   const executiveApproverOptions = useMemo(
-    () => ownerOptions.filter((member) => (
+    () => withSavedOrgMemberOption(ledgerMemberOptions, {
+      uid: draft.executiveApproverId,
+      name: draft.executiveApproverName,
+      email: draft.executiveApproverEmail,
+    }).filter((member) => (
       member.uid !== draft.registeredById && member.uid !== requesterId
     )),
-    [draft.registeredById, requesterId, ownerOptions],
+    [draft.executiveApproverEmail, draft.executiveApproverId, draft.executiveApproverName, draft.registeredById, requesterId, ledgerMemberOptions],
   );
   const selectedOwner = useMemo(
-    () => ownerOptions.find((member) => member.uid === draft.registeredById) || null,
-    [draft.registeredById, ownerOptions],
+    () => ledgerMemberOptions.find((member) => member.uid === draft.registeredById) || null,
+    [draft.registeredById, ledgerMemberOptions],
   );
   const linkedExecutiveApprover = useMemo(
-    () => ownerOptions.find((member) => member.uid === draft.executiveApproverId) || null,
-    [draft.executiveApproverId, ownerOptions],
+    () => ledgerMemberOptions.find((member) => member.uid === draft.executiveApproverId) || null,
+    [draft.executiveApproverId, ledgerMemberOptions],
   );
   const selectedExecutiveApprover = useMemo(
     () => executiveApproverOptions.find((member) => member.uid === draft.executiveApproverId) || null,
@@ -2137,30 +2149,24 @@ export function ProjectEditorWizard({
       <div className="grid gap-4 lg:grid-cols-2">
         <div>
           <Label className="text-xs">사업 담당자 *</Label>
-          <Select value={selectedOwner?.uid} onValueChange={(value) => {
-            const member = ownerOptions.find((item) => item.uid === value);
-            if (!member) return;
-            setDraft((prev) => createProjectEditorDraft({
-              ...prev,
-              registeredById: member.uid,
-              registeredByName: member.name || member.email || member.uid,
-              registeredByEmail: member.email || '',
-              managerId: member.uid,
-              managerName: member.name || member.email || member.uid,
-            }));
-          }} disabled={ownerOptions.length === 0}>
-            <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue placeholder="구성원 원장에서 선택" /></SelectTrigger>
-            <SelectContent>
-              {ownerOptions.map((member) => (
-                <SelectItem key={member.uid} value={member.uid}>
-                  {member.email ? `${member.name || member.uid} (${member.email})` : (member.name || member.uid)}
-                </SelectItem>
-              ))}
-              {ownerOptions.length === 0 ? (
-                <SelectItem value="__no_org_members__" disabled>구성원 원장을 불러오는 중입니다</SelectItem>
-              ) : null}
-            </SelectContent>
-          </Select>
+          <MemberPicker
+            className="mt-1 h-9 text-sm"
+            options={ownerOptions}
+            value={draft.registeredById}
+            placeholder="구성원 원장에서 선택"
+            onChange={(value) => {
+              const member = ownerOptions.find((item) => item.uid === value);
+              if (!member) return;
+              setDraft((prev) => createProjectEditorDraft({
+                ...prev,
+                registeredById: member.uid,
+                registeredByName: member.label.replace(' · 기존 선택', ''),
+                registeredByEmail: member.email,
+                managerId: member.uid,
+                managerName: member.label.replace(' · 기존 선택', ''),
+              }));
+            }}
+          />
           <p className="mt-1 text-[11px] text-muted-foreground">
             구성원 원장(orgs/{'{'}orgId{'}'}/members)의 UID를 저장합니다. 프로젝트 현황과 실무자 포털 노출은 이 UID 기준으로 연결됩니다.
           </p>
@@ -2172,28 +2178,22 @@ export function ProjectEditorWizard({
         </div>
         <div>
           <Label className="text-xs">최종 결재자 지정 (사업총괄) *</Label>
-          <Select value={selectedExecutiveApprover?.uid} onValueChange={(value) => {
-            const member = executiveApproverOptions.find((item) => item.uid === value);
-            if (!member) return;
-            setDraft((prev) => createProjectEditorDraft({
-              ...prev,
-              executiveApproverId: member.uid,
-              executiveApproverName: member.name || member.email || member.uid,
-              executiveApproverEmail: member.email || '',
-            }));
-          }} disabled={executiveApproverOptions.length === 0}>
-            <SelectTrigger className="mt-1 h-9 text-sm"><SelectValue placeholder="구성원 원장에서 선택" /></SelectTrigger>
-            <SelectContent>
-              {executiveApproverOptions.map((member) => (
-                <SelectItem key={member.uid} value={member.uid}>
-                  {member.email ? `${member.name || member.uid} (${member.email})` : (member.name || member.uid)}
-                </SelectItem>
-              ))}
-              {executiveApproverOptions.length === 0 ? (
-                <SelectItem value="__no_org_members__" disabled>구성원 원장을 불러오는 중입니다</SelectItem>
-              ) : null}
-            </SelectContent>
-          </Select>
+          <MemberPicker
+            className="mt-1 h-9 text-sm"
+            options={executiveApproverOptions}
+            value={draft.executiveApproverId}
+            placeholder="구성원 원장에서 선택"
+            onChange={(value) => {
+              const member = executiveApproverOptions.find((item) => item.uid === value);
+              if (!member) return;
+              setDraft((prev) => createProjectEditorDraft({
+                ...prev,
+                executiveApproverId: member.uid,
+                executiveApproverName: member.label.replace(' · 기존 선택', ''),
+                executiveApproverEmail: member.email,
+              }));
+            }}
+          />
           <p className="mt-1 text-[11px] text-muted-foreground">
             선택한 구성원이 조직장 승인 결재선의 대기 결재자로 표시됩니다.
           </p>

--- a/src/app/components/ui/member-picker.tsx
+++ b/src/app/components/ui/member-picker.tsx
@@ -1,0 +1,97 @@
+import { useMemo, useState } from 'react';
+import { Check, ChevronsUpDown } from 'lucide-react';
+import { Button } from './button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from './command';
+import { Popover, PopoverContent, PopoverTrigger } from './popover';
+import { cn } from './utils';
+import type { OrgMemberPickerOption } from '../../data/project-team-member-options';
+
+/**
+ * Person picker with a search box. The org has ~90 members, which is more than anyone
+ * wants to scroll through, and the same list is chosen from in several places.
+ */
+export function MemberPicker({
+  options,
+  value,
+  onChange,
+  placeholder = '구성원을 선택하세요',
+  emptyLabel = '구성원 원장을 불러오는 중입니다',
+  disabled = false,
+  className,
+}: {
+  options: OrgMemberPickerOption[];
+  value: string;
+  onChange: (uid: string) => void;
+  placeholder?: string;
+  emptyLabel?: string;
+  disabled?: boolean;
+  className?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const selected = useMemo(
+    () => options.find((option) => option.uid === value) || null,
+    [options, value],
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled || options.length === 0}
+          className={cn('w-full justify-between font-normal', className)}
+        >
+          <span className={cn('truncate', !selected && 'text-muted-foreground')}>
+            {options.length === 0 ? emptyLabel : selected?.label || placeholder}
+          </span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+        <Command
+          filter={(itemValue, search) => {
+            const option = options.find((entry) => entry.uid === itemValue);
+            if (!option) return 0;
+            return option.searchText.includes(search.trim().toLowerCase()) ? 1 : 0;
+          }}
+        >
+          <CommandInput placeholder="이름 · 별명 · 이메일로 검색" />
+          <CommandList>
+            <CommandEmpty>검색 결과가 없습니다.</CommandEmpty>
+            <CommandGroup>
+              {options.map((option) => (
+                <CommandItem
+                  key={option.uid}
+                  value={option.uid}
+                  onSelect={() => {
+                    onChange(option.uid);
+                    setOpen(false);
+                  }}
+                  className="gap-2"
+                >
+                  <Check className={cn('h-4 w-4', option.uid === value ? 'opacity-100' : 'opacity-0')} />
+                  <span className="flex min-w-0 flex-col">
+                    <span className="truncate">{option.label}</span>
+                    {option.email ? (
+                      <span className="truncate text-[11px] text-muted-foreground">{option.email}</span>
+                    ) : null}
+                  </span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/app/data/project-team-member-options.ts
+++ b/src/app/data/project-team-member-options.ts
@@ -39,7 +39,7 @@ export function findProjectTeamMemberOption(value: string): ProjectTeamMemberOpt
   return PROJECT_TEAM_MEMBER_SEARCH_MAP.get(normalized);
 }
 
-function splitMemberDisplayName(value: string): { name: string; nickname: string } {
+export function splitMemberDisplayName(value: string): { name: string; nickname: string } {
   const normalized = String(value || '').trim();
   const match = normalized.match(/^(.+?)\s*\(([^()]+)\)\s*$/);
   if (!match) return { name: normalized, nickname: '' };
@@ -70,4 +70,63 @@ export function buildProjectTeamMemberOptions(members: OrgMember[]): ProjectTeam
   const liveOptions = [...options.values()]
     .sort((left, right) => left.label.localeCompare(right.label, 'ko'));
   return liveOptions.length ? liveOptions : PROJECT_TEAM_MEMBER_OPTIONS;
+}
+
+export interface OrgMemberPickerOption {
+  uid: string;
+  name: string;
+  nickname: string;
+  email: string;
+  label: string;
+  searchText: string;
+}
+
+/**
+ * Options for the pickers that choose a person (PM, 최종 결재자, 월 결산 조직장).
+ *
+ * Only an explicit INACTIVE or DELETED status removes someone. Requiring status to equal
+ * ACTIVE hid the 15 members whose document carries no status field at all.
+ */
+export function buildOrgMemberPickerOptions(members: OrgMember[]): OrgMemberPickerOption[] {
+  const byUid = new Map<string, OrgMemberPickerOption>();
+  members.forEach((member) => {
+    const uid = String(member.uid || '').trim();
+    if (!uid || byUid.has(uid)) return;
+    const status = String(member.status || '').trim().toUpperCase();
+    if (status === 'INACTIVE' || status === 'DELETED') return;
+    const email = String(member.email || '').trim();
+    const parsed = splitMemberDisplayName(member.name || '');
+    const name = parsed.name || email || uid;
+    const nickname = parsed.nickname || findProjectTeamMemberOption(name)?.nickname || '';
+    byUid.set(uid, {
+      uid,
+      name,
+      nickname,
+      email,
+      label: nickname ? `${name} (${nickname})` : name,
+      searchText: [name, nickname, email].filter(Boolean).join(' ').toLowerCase(),
+    });
+  });
+  return [...byUid.values()].sort((left, right) => left.label.localeCompare(right.label, 'ko'));
+}
+
+/**
+ * Keeps a value that was saved earlier selectable even when that person no longer appears
+ * in the current list, so opening an old project cannot silently drop its PM or approver.
+ */
+export function withSavedOrgMemberOption(
+  options: OrgMemberPickerOption[],
+  saved: { uid?: string | null; name?: string | null; email?: string | null },
+): OrgMemberPickerOption[] {
+  const uid = String(saved?.uid || '').trim();
+  if (!uid || options.some((option) => option.uid === uid)) return options;
+  const parsed = splitMemberDisplayName(String(saved?.name || ''));
+  const email = String(saved?.email || '').trim();
+  const name = parsed.name || email || uid;
+  const nickname = parsed.nickname || findProjectTeamMemberOption(name)?.nickname || '';
+  const label = nickname ? `${name} (${nickname})` : name;
+  return [
+    { uid, name, nickname, email, label: `${label} · 기존 선택`, searchText: [name, nickname, email].filter(Boolean).join(' ').toLowerCase() },
+    ...options,
+  ];
 }


### PR DESCRIPTION
## 구성원 누락 (QA 제보 원인)

사람 선택 드롭다운이 **`status === 'ACTIVE'`인 구성원만** 남기고 있었습니다. 라이브 91명 중 **15명은 `status` 필드 자체가 없어** 통째로 빠졌습니다.

```
고유 이메일(사람) 91
    76  ACTIVE
    15  (status 없음)   ← 드롭다운에서 사라짐
```

이제 **명시적으로 INACTIVE·DELETED인 경우만** 제외합니다. 참여인력 선택이 이미 쓰던 규칙과 같습니다.

영향받는 곳: PM(사업 담당자), 최종 결재자, 월 결산 조직장.

## 이름(별명) 정규화
세 드롭다운이 공용 헬퍼(`buildOrgMemberPickerOptions`)로 옵션을 만들어, 어디서든 `이름 (별명)`으로 동일하게 보입니다. 구성원 문서에 별명이 없으면 임직원 명부에서 보완합니다.

## 이전 값 보존
저장된 담당자·결재자가 현재 원장에 없더라도 **`· 기존 선택` 라벨을 달아 목록 맨 위에 표시**합니다. 오래된 프로젝트를 열었을 때 값이 조용히 사라지지 않습니다.

연결 여부 판정은 **원장 목록만으로** 하므로, 기존의 "구성원 원장에 없습니다" 경고는 그대로 동작합니다. (이 분리를 하지 않으면 경고가 영영 뜨지 않게 됩니다)

## 검색
90명을 스크롤로 찾기 어려워, 드롭다운을 **이름·별명·이메일로 검색되는 콤보박스**로 교체했습니다.

## Verification
- `npm test` — 2,680 passed / 0 failed
- `npm run typecheck` / `npm run build` 통과

기존 동작을 단언하던 shell 테스트 2건을 재작성했습니다. 그중 하나는 **`status === 'ACTIVE'`를 요구하는 단언으로, 이번 결함 자체를 고정하고 있었습니다.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)