### PR TITLE
fix(members): let the ledger own a member's display name

### DIFF
--- a/src/app/data/auth-store.first-login.test.ts
+++ b/src/app/data/auth-store.first-login.test.ts
@@ -6,6 +6,15 @@ import { buildSafeFirstLoginMember } from './auth-store';
 const authStoreSource = readFileSync(resolve(import.meta.dirname, 'auth-store.tsx'), 'utf8');
 
 describe('first-login member bootstrap', () => {
+  it('lets the member ledger keep its display name when someone signs in again', () => {
+    // Google account names arrive in whatever form each person set them, so a sign-in
+    // must not overwrite the ledger's 이름(별명) value. A first login still falls back to
+    // the account name because the ledger has nothing yet.
+    expect(authStoreSource).toContain("name: existing?.name || firebaseUser.displayName || '사용자',");
+    expect(authStoreSource).not.toContain("name: firebaseUser.displayName || existing?.name");
+    expect(authStoreSource).toContain("name: firebaseUser.displayName || '사용자',");
+  });
+
   it('creates only an unassigned PM profile that cannot self-elevate', () => {
     const member = buildSafeFirstLoginMember({
       uid: 'new-user',

--- a/src/app/data/auth-store.tsx
+++ b/src/app/data/auth-store.tsx
@@ -360,7 +360,10 @@ async function upsertMemberFromFirebase(
 
   const merged = omitUndefinedFields<MemberDoc>({
     uid: firebaseUser.uid,
-    name: firebaseUser.displayName || existing?.name || '사용자',
+    // The member ledger owns the display name. Google account names arrive in whatever
+    // form each person set them ('Jeongtae KIM (Able)'), and letting a sign-in overwrite
+    // the ledger undid the roster's 이름(별명) normalisation every time someone logged in.
+    name: existing?.name || firebaseUser.displayName || '사용자',
     email: normalizedEmail,
     role: resolveEffectiveAuthRole({
       memberRole: existing?.role,


### PR DESCRIPTION
## 문제
로그인할 때마다 Google 계정 표시이름으로 구성원 문서의 `name`을 덮어쓰고 있었습니다.

```
name: firebaseUser.displayName || existing?.name || '사용자'
```

Google 계정 이름은 각자 설정한 형태 그대로라, 원장에 이런 값들이 들어와 있었습니다.

```
Jeongtae KIM (Able)     ← 김정태
Inhyo Ko (베리)          ← 고인효
Minjong(파커) Seo        ← 서민종
```

이 상태에서는 명부로 `이름(별명)` 정규화를 해도 **그 사람이 다음에 로그인하는 순간 되돌아갑니다.**

## 수정
```
name: existing?.name || firebaseUser.displayName || '사용자'
```

**원장이 이름의 주인**입니다. 계정 이름은 원장에 값이 없을 때만 쓰이며, 이는 최초 로그인 경우에 해당합니다. 최초 로그인 생성 경로(`buildSafeFirstLoginMember`)는 그대로입니다.

## Verification
- `npm test` — 실패 2건은 알려진 병렬 부하 flaky(`business-card-routes`, `standalone-workers`)이며 단독 실행 시 모두 통과
- `npm run typecheck` — no new type errors
- 회귀 방지 테스트 추가 (덮어쓰기 순서가 되돌아가면 실패)

## 관련
라이브 members의 이름은 명부 기준 `이름(별명)`으로 이미 정규화했습니다(61건). 이 PR이 배포되어야 그 값이 유지됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)