### PR TITLE
feat(members): compose a member's display name from roster-owned fields

### DIFF
--- a/scripts/import-member-roster.ts
+++ b/scripts/import-member-roster.ts
@@ -31,12 +31,15 @@ const IMPORT_HEADERS = {
 const FORBIDDEN_HEADERS = ['성별', '생년월일(양력)', '생년월일(음력)', '생년월일'] as const;
 
 type FieldKey = keyof typeof IMPORT_HEADERS;
+/** Fields written to Firestore: the roster columns plus the derived Korean-name field. */
+type MemberFieldKey = FieldKey | 'nameKo';
 
 /** firebase-admin은 CJS라 런타임 값은 default에 담겨 온다. */
 type FirebaseAdmin = typeof import('firebase-admin');
 type FirestoreDb = import('firebase-admin').firestore.Firestore;
 
-const FIELD_LABELS: Record<FieldKey, string> = {
+const FIELD_LABELS: Record<MemberFieldKey, string> = {
+  nameKo: '이름(한글)',
   name: '이름',
   nickname: '별명',
   email: '이메일',
@@ -67,7 +70,7 @@ interface PlanEntry {
   action: PlanAction;
   row: RosterRow;
   docId: string | null;
-  changedFields: FieldKey[];
+  changedFields: MemberFieldKey[];
   note: string;
 }
 
@@ -418,11 +421,11 @@ function buildPlan(rows: RosterRow[], existing: Map<string, ExistingMember[]>): 
 
     const desired = toMemberFields(row);
     if (matches.length === 0) {
-      return { action: 'CREATE', row, docId: buildMemberDocId(email), changedFields: Object.keys(desired) as FieldKey[], note: '신규 등록' };
+      return { action: 'CREATE', row, docId: buildMemberDocId(email), changedFields: Object.keys(desired) as MemberFieldKey[], note: '신규 등록' };
     }
 
     const target = matches[0];
-    const changedFields = (Object.keys(desired) as FieldKey[]).filter(
+    const changedFields = (Object.keys(desired) as MemberFieldKey[]).filter(
       (key) => String(target.data[key] ?? '') !== String(desired[key] ?? ''),
     );
     return {
@@ -436,10 +439,12 @@ function buildPlan(rows: RosterRow[], existing: Map<string, ExistingMember[]>): 
 }
 
 /** Firestore에 저장할 필드. 개인정보 항목은 여기에 포함되지 않는다. */
-function toMemberFields(row: RosterRow): Partial<Record<FieldKey, string>> {
-  const fields: Partial<Record<FieldKey, string>> = {
-    // The ledger stores the display name in one form, 이름(별명), so every screen reads the
-    // same thing. Google account names arrive in mixed forms and must not decide this.
+function toMemberFields(row: RosterRow): Partial<Record<MemberFieldKey, string>> {
+  const fields: Partial<Record<MemberFieldKey, string>> = {
+    // Screens compose the display from nameKo and nickname, which only this import writes.
+    // `name` stays in step for anything still reading the combined string, but sign-in
+    // paths overwrite it, so it must not be the field screens depend on.
+    nameKo: row.name,
     name: row.nickname ? `${row.name}(${row.nickname})` : row.name,
     email: normalizeEmail(row.email),
   };
@@ -483,7 +488,7 @@ function reportPlan(plan: PlanEntry[]): void {
 
   const changed = plan.filter((entry) => entry.action === 'UPDATE');
   if (changed.length > 0) {
-    const fieldCounts = new Map<FieldKey, number>();
+    const fieldCounts = new Map<MemberFieldKey, number>();
     for (const entry of changed) {
       for (const key of entry.changedFields) fieldCounts.set(key, (fieldCounts.get(key) || 0) + 1);
     }

--- a/src/app/data/project-team-member-options.structured-name.test.ts
+++ b/src/app/data/project-team-member-options.structured-name.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import type { OrgMember } from './types';
+import {
+  buildOrgMemberPickerOptions,
+  buildProjectTeamMemberOptions,
+} from './project-team-member-options';
+
+function member(overrides: Partial<OrgMember>): OrgMember {
+  return {
+    uid: 'u1',
+    name: '',
+    email: 'someone@mysc.co.kr',
+    role: 'pm',
+    status: 'ACTIVE',
+    ...overrides,
+  };
+}
+
+// Sign-in and role changes still write the combined `name` string with whatever the Google
+// account is called. Screens read nameKo and nickname instead, so those writes stop
+// deciding what anyone sees.
+describe('display name comes from the roster fields', () => {
+  it('ignores a Google account name once the roster fields are present', () => {
+    const [option] = buildOrgMemberPickerOptions([
+      member({ name: 'Jeongtae KIM (Able)', nameKo: '김정태', nickname: '에이블' }),
+    ]);
+    expect(option.label).toBe('김정태 (에이블)');
+    expect(option.name).toBe('김정태');
+    expect(option.nickname).toBe('에이블');
+  });
+
+  it('still searches by the Korean name after a sign-in overwrote the combined string', () => {
+    const [option] = buildOrgMemberPickerOptions([
+      member({ name: 'Minjong(파커) Seo', nameKo: '서민종', nickname: '파커' }),
+    ]);
+    expect(option.searchText).toContain('서민종');
+    expect(option.searchText).toContain('파커');
+  });
+
+  it('falls back to parsing the combined string when the roster fields are missing', () => {
+    const [option] = buildOrgMemberPickerOptions([
+      member({ name: '하송희(솔)' }),
+    ]);
+    expect(option.label).toBe('하송희 (솔)');
+  });
+
+  it('applies the same rule to the team member picker', () => {
+    const options = buildProjectTeamMemberOptions([
+      member({ uid: 'u1', name: 'Inhyo Ko (베리)', nameKo: '고인효', nickname: '베리' }),
+    ]);
+    expect(options[0].label).toBe('고인효 (베리)');
+    expect(options[0].value).toBe('고인효');
+  });
+
+  it('keeps one entry per person when both documents disagree on the combined string', () => {
+    const options = buildProjectTeamMemberOptions([
+      member({ uid: 'u1', name: 'Jeongtae KIM (Able)', nameKo: '김정태', nickname: '에이블' }),
+      member({ uid: 'u2', name: '김정태(에이블)', nameKo: '김정태', nickname: '에이블' }),
+    ]);
+    expect(options).toHaveLength(1);
+    expect(options[0].label).toBe('김정태 (에이블)');
+  });
+});

--- a/src/app/data/project-team-member-options.ts
+++ b/src/app/data/project-team-member-options.ts
@@ -54,16 +54,17 @@ export function buildProjectTeamMemberOptions(members: OrgMember[]): ProjectTeam
     const status = String(member.status || '').trim().toUpperCase();
     if (status === 'INACTIVE' || status === 'DELETED') return;
     const parsed = splitMemberDisplayName(member.name || '');
-    if (!String(member.uid || '').trim() || !parsed.name) return;
-    const canonical = findProjectTeamMemberOption(parsed.name);
-    const nickname = parsed.nickname || canonical?.nickname || '';
-    const key = parsed.name.toLowerCase();
+    const displayName = String(member.nameKo || '').trim() || parsed.name;
+    if (!String(member.uid || '').trim() || !displayName) return;
+    const canonical = findProjectTeamMemberOption(displayName);
+    const nickname = String(member.nickname || '').trim() || parsed.nickname || canonical?.nickname || '';
+    const key = displayName.toLowerCase();
     if (options.has(key)) return;
     options.set(key, {
-      value: parsed.name,
-      name: parsed.name,
+      value: displayName,
+      name: displayName,
       nickname,
-      label: nickname ? `${parsed.name} (${nickname})` : parsed.name,
+      label: nickname ? `${displayName} (${nickname})` : displayName,
     });
   });
 
@@ -95,9 +96,14 @@ export function buildOrgMemberPickerOptions(members: OrgMember[]): OrgMemberPick
     const status = String(member.status || '').trim().toUpperCase();
     if (status === 'INACTIVE' || status === 'DELETED') return;
     const email = String(member.email || '').trim();
+    // nameKo and nickname belong to the roster. The combined `name` string is still written
+    // by sign-in paths, so it is only parsed when the structured fields are absent.
     const parsed = splitMemberDisplayName(member.name || '');
-    const name = parsed.name || email || uid;
-    const nickname = parsed.nickname || findProjectTeamMemberOption(name)?.nickname || '';
+    const name = String(member.nameKo || '').trim() || parsed.name || email || uid;
+    const nickname = String(member.nickname || '').trim()
+      || parsed.nickname
+      || findProjectTeamMemberOption(name)?.nickname
+      || '';
     byUid.set(uid, {
       uid,
       name,

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -580,7 +580,15 @@ export interface CrossVerifyGroup {
 
 export interface OrgMember {
   uid: string;
+  /**
+   * Legacy combined display string, historically '이름(별명)'. Several sign-in paths still
+   * write this field, so screens should prefer nameKo and nickname when they are present.
+   */
   name: string;
+  /** Owned by the employee roster import. */
+  nameKo?: string;
+  /** Owned by the employee roster import. */
+  nickname?: string;
   email: string;
   role: UserRole;
   status?: string;

--- a/src/app/lib/firestore-service.ts
+++ b/src/app/lib/firestore-service.ts
@@ -225,6 +225,8 @@ export function buildMemberDirectoryList(docs: MemberDirectoryDocInput[]): OrgMe
     return {
       uid: String(merged.uid || '').trim(),
       name: String(merged.name || ''),
+      nameKo: typeof merged.nameKo === 'string' && merged.nameKo.trim() ? merged.nameKo.trim() : undefined,
+      nickname: typeof merged.nickname === 'string' && merged.nickname.trim() ? merged.nickname.trim() : undefined,
       email: String(merged.email || ''),
       role: (merged.role || 'pm') as OrgMember['role'],
       status: typeof merged.status === 'string' ? merged.status.trim().toUpperCase() : undefined,


### PR DESCRIPTION
## 왜 순서 조정으로는 안 되는가

`name` 한 칸에 쓰는 경로가 **네 개**입니다.

| 경로 | 쓰는 값 |
|---|---|
| 최초 로그인 | Google 계정 표시이름 |
| 매 로그인 | Google 계정 표시이름 (#448에서 순서 조정) |
| 역할 변경 (`auth-governance.mjs:209`) | Google 계정 표시이름 |
| 명부 임포트 | `이름(별명)` |

Google 계정 이름은 각자 설정한 형태라 원장에 `Jeongtae KIM (Able)`, `Minjong(파커) Seo` 같은 값이 들어오고, 화면은 그 문자열을 **정규식으로 다시 쪼개** 이름·별명을 얻고 있었습니다. 파서가 두 개(`splitMemberDisplayName`, `parseMemberDisplayName)`나 존재합니다.

쓰기 순서만 바꾸면 다음 writer가 생길 때 같은 문제가 반복됩니다.

## 무엇을 바꿨나

명부가 소유하는 **구조화된 두 필드**를 도입하고, 화면은 그것으로 표시를 조립합니다.

```
nameKo   = '김정태'      ← 명부만 씀
nickname = '에이블'      ← 명부만 씀
name     = '김정태(에이블)'  ← 호환용. 로그인·역할변경이 덮어써도 표시에 영향 없음
```

`name`이 덮어써져도 **화면이 보는 값이 아니므로** 경쟁 자체가 사라집니다.

## 호환
구조화 필드가 없는 문서는 기존처럼 `name`을 파싱해 폴백합니다. `member.name`을 읽는 **64곳은 건드리지 않았습니다** — 원장 목록과 선택지 조립이 모두 공용 헬퍼 2개를 지나가기 때문입니다.

## 남은 단계 (이 PR 범위 밖)
폴백이 더 이상 쓰이지 않는 것이 확인되면, auth 경로에서 `name` 쓰기를 제거합니다.

## Verification
- `npm test` — 실패 1건은 알려진 `cashflow-sheet-lab` 병렬 부하 flaky (단독 통과)
- `npm run typecheck` 통과
- 라이브 백필 완료: 구성원 문서 92건 중 **80건이 `nameKo` 보유**
- 회귀 테스트 5건 추가 (Google 계정 이름이 덮어써도 표시가 안 바뀌는지 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)