### PR TITLE
feat(rbac): give every member access to every project

### DIFF
--- a/server/bff/edit-lease.mjs
+++ b/server/bff/edit-lease.mjs
@@ -6,7 +6,8 @@ import { buildRequestFingerprint, sha256 } from './utils.mjs';
 export const EDIT_LEASE_TTL_MS = 1_800_000;
 
 const RESOURCE_TYPES = new Set(['project-registration', 'project-info', 'cashflow']);
-const CROSS_PROJECT_ROLES = new Set(['admin', 'finance']);
+// Every member works across all projects; see CROSS_PROJECT_ROLES in src/app/platform/rbac.ts.
+const CROSS_PROJECT_ROLES = new Set(['admin', 'finance', 'pm', 'viewer']);
 const FIRESTORE_DOCUMENT_ID_MAX_BYTES = 1_500;
 
 function editLeaseError(statusCode, message, code, publicDetails, auditContext) {

--- a/server/bff/edit-lease.test.mjs
+++ b/server/bff/edit-lease.test.mjs
@@ -355,13 +355,18 @@ describe('edit lease service', () => {
     });
     await expect(service.getStatus(base)).resolves.toMatchObject({ state: 'AVAILABLE' });
 
+    // Assignment no longer gates access: every member works across all projects.
     db.__set(memberPath, {
       uid: 'actor-a', role: 'pm', status: 'ACTIVE', projectIds: ['project-b'],
     });
-    await expectHttpError(service.getStatus(base), 403, 'forbidden');
-
-    db.__set('orgs/tenant-a/projects/project-a', { id: 'project-a', managerId: 'actor-a' });
     await expect(service.getStatus(base)).resolves.toMatchObject({ state: 'AVAILABLE' });
+
+    db.__set(memberPath, { uid: 'actor-a', role: 'viewer', status: 'ACTIVE', projectIds: [] });
+    await expect(service.getStatus(base)).resolves.toMatchObject({ state: 'AVAILABLE' });
+
+    // An inactive member is still refused.
+    db.__set(memberPath, { uid: 'actor-a', role: 'pm', status: 'INACTIVE', projectIds: [] });
+    await expectHttpError(service.getStatus(base), 403, 'forbidden');
 
     db.__set(memberPath, { uid: 'actor-a', role: 'finance', status: 'ACTIVE' });
     await expect(service.getStatus(base)).resolves.toMatchObject({ state: 'AVAILABLE' });

--- a/server/bff/routes/members.mjs
+++ b/server/bff/routes/members.mjs
@@ -79,7 +79,8 @@ export function buildMemberPermissionOverview(entry, projects) {
   const actorId = String(entry.authUid || entry.canonicalMember?.uid || member.uid || '').trim();
   const role = normalizeRole(entry.effectiveRole);
   const isActive = !entry.authDisabled && String(member.status || '').trim().toUpperCase() === 'ACTIVE';
-  const crossProject = role === 'admin' || role === 'finance';
+  // Every member works across all projects; see CROSS_PROJECT_ROLES in src/app/platform/rbac.ts.
+  const crossProject = true;
   const organizationHeadProjects = projects.filter((project) => actorId && project.executiveApproverId === actorId);
   const accessibleProjects = projects.filter((project) => (
     crossProject

--- a/server/bff/routes/project-info-drafts.mjs
+++ b/server/bff/routes/project-info-drafts.mjs
@@ -38,7 +38,8 @@ import {
 } from '../project-document-validation.mjs';
 
 const RESOURCE_TYPE = 'project-info';
-const CROSS_PROJECT_ROLES = new Set(['admin', 'finance']);
+// Every member works across all projects; see CROSS_PROJECT_ROLES in src/app/platform/rbac.ts.
+const CROSS_PROJECT_ROLES = new Set(['admin', 'finance', 'pm', 'viewer']);
 const DOCUMENT_KINDS = PROJECT_INFO_DOCUMENT_KINDS;
 const DOCUMENT_FIELD_BY_KIND = {
   contract: 'contractDocument',

--- a/src/app/platform/firestore-rules-policy.test.ts
+++ b/src/app/platform/firestore-rules-policy.test.ts
@@ -129,25 +129,16 @@ describe('firestore rules policy alignment', () => {
     }
   });
 
-  it('pm needs project assignment for access', () => {
-    expect(canAccessProject({
-      actorRole: 'pm', permission: 'project:read', targetProjectId: 'p1', assignedProjectIds: ['p1'],
-    })).toBe(true);
-    expect(canAccessProject({
-      actorRole: 'pm', permission: 'project:read', targetProjectId: 'p2', assignedProjectIds: ['p1'],
-    })).toBe(false);
-  });
-
-  it('viewer needs assignment and can read/write assigned projects', () => {
-    expect(canAccessProject({
-      actorRole: 'viewer', permission: 'project:read', targetProjectId: 'p1', assignedProjectIds: ['p1'],
-    })).toBe(true);
-    expect(canAccessProject({
-      actorRole: 'viewer', permission: 'project:write', targetProjectId: 'p1', assignedProjectIds: ['p1'],
-    })).toBe(true);
-    expect(canAccessProject({
-      actorRole: 'viewer', permission: 'project:write', targetProjectId: 'p2', assignedProjectIds: ['p1'],
-    })).toBe(false);
+  it('lets pm and viewer reach a project they were never assigned to', () => {
+    // Access is no longer gated by assignment; every member works across all projects.
+    for (const actorRole of ['pm', 'viewer'] as const) {
+      expect(canAccessProject({
+        actorRole, permission: 'project:read', targetProjectId: 'p2', assignedProjectIds: ['p1'],
+      })).toBe(true);
+      expect(canAccessProject({
+        actorRole, permission: 'project:write', targetProjectId: 'p2', assignedProjectIds: [],
+      })).toBe(true);
+    }
   });
 
   // ── canAccessTenant: cross-tenant ──

--- a/src/app/platform/rbac.test.ts
+++ b/src/app/platform/rbac.test.ts
@@ -61,20 +61,15 @@ describe('rbac helpers', () => {
     expect(canAccessTenant({ actorRole: 'admin', actorTenantId: 't1', targetTenantId: 't2' })).toBe(true);
   });
 
-  it('checks project-scoped access based on role and assignment', () => {
-    // Admin can access any project without assignment
-    expect(canAccessProject({ actorRole: 'admin', permission: 'project:read', targetProjectId: 'p1' })).toBe(true);
-    expect(canAccessProject({ actorRole: 'finance', permission: 'project:write', targetProjectId: 'p1' })).toBe(true);
-
-    // PM needs assignment
-    expect(canAccessProject({ actorRole: 'pm', permission: 'project:write', targetProjectId: 'p1', assignedProjectIds: ['p1', 'p2'] })).toBe(true);
-    expect(canAccessProject({ actorRole: 'pm', permission: 'project:write', targetProjectId: 'p3', assignedProjectIds: ['p1', 'p2'] })).toBe(false);
-
-    // Viewer can write with assignment
-    expect(canAccessProject({ actorRole: 'viewer', permission: 'project:write', targetProjectId: 'p1', assignedProjectIds: ['p1'] })).toBe(true);
-
-    // Viewer can read with assignment
-    expect(canAccessProject({ actorRole: 'viewer', permission: 'project:read', targetProjectId: 'p1', assignedProjectIds: ['p1'] })).toBe(true);
-    expect(canAccessProject({ actorRole: 'viewer', permission: 'project:read', targetProjectId: 'p2', assignedProjectIds: ['p1'] })).toBe(false);
+  it('gives every role access to every project, assigned or not', () => {
+    // The organisation works across all projects, so assignment no longer gates access.
+    for (const actorRole of ['admin', 'finance', 'pm', 'viewer'] as const) {
+      expect(canAccessProject({ actorRole, permission: 'project:read', targetProjectId: 'p1' })).toBe(true);
+      expect(canAccessProject({ actorRole, permission: 'project:write', targetProjectId: 'p1' })).toBe(true);
+      expect(canAccessProject({
+        actorRole, permission: 'project:write', targetProjectId: 'p3', assignedProjectIds: ['p1', 'p2'],
+      })).toBe(true);
+    }
   });
+
 });

--- a/src/app/platform/rbac.ts
+++ b/src/app/platform/rbac.ts
@@ -142,7 +142,15 @@ export function hasPermission(
 
 export type ProjectScopedPermission = 'project:read' | 'project:write' | 'project:evidence_drive:write';
 
-const CROSS_PROJECT_ROLES: PlatformRole[] = ['admin', 'finance'];
+/**
+ * Roles that reach every project without being assigned to it one by one.
+ *
+ * The organisation decided every member works across all projects, so this is the full
+ * role list. Narrowing access again means shortening this list — and the matching sets in
+ * server/bff/edit-lease.mjs, server/bff/routes/project-info-drafts.mjs and
+ * server/bff/routes/members.mjs, which cannot import from the app bundle.
+ */
+const CROSS_PROJECT_ROLES: PlatformRole[] = ['admin', 'finance', 'pm', 'viewer'];
 
 export function canAccessProject(options: {
   actorRole: PlatformRole;


### PR DESCRIPTION
## 무엇이 바뀌나
전 구성원이 **모든 프로젝트를 보고 수정**할 수 있습니다. 프로젝트별 배정(`projectIds`)이 더 이상 접근을 가르지 않습니다.

## 권한은 새로 준 게 없습니다
`policies/rbac-policy.json` 기준으로 **네 역할 모두 이미** 세 가지 프로젝트 권한을 갖고 있었습니다.

| 역할 | project:read | project:write | evidence_drive:write |
|---|---|---|---|
| admin / finance / pm / viewer | ✅ | ✅ | ✅ |

막고 있던 것은 **범위(배정)**뿐이었고, admin·finance에만 열려 있던 전체 접근을 pm·viewer까지 확장했습니다.

## 왜 데이터가 아니라 규칙인가
92명의 `projectIds`에 69개 프로젝트를 밀어넣는 방식은 **새 프로젝트가 생길 때마다 다시 돌려야** 합니다. 규칙으로 두면 이후 만들어지는 프로젝트도 자동 포함됩니다.

## 되돌리는 방법
`src/app/platform/rbac.ts`의 `CROSS_PROJECT_ROLES` 목록을 줄이면 됩니다. 같은 규칙이 앱 번들을 import할 수 없는 BFF 3곳에 복제되어 있어 함께 주석으로 연결해 두었습니다.

```
src/app/platform/rbac.ts              ← 기준
server/bff/edit-lease.mjs
server/bff/routes/project-info-drafts.mjs
server/bff/routes/members.mjs
```

## 바뀌지 않은 것
- 테넌트 격리
- 역할별 권한 자체
- 비활성 구성원 차단 (`status: INACTIVE`는 여전히 거부)

## Verification
- `npm test` — 2,685 passed / 0 failed
- `npm run typecheck` — no new type errors
- 옛 정책을 단언하던 테스트 4건을 새 정책으로 재작성 (배정 없는 pm·viewer가 접근 가능한지, 비활성은 여전히 거부되는지 검증)

Firestore 규칙은 프로젝트별 배정을 강제하지 않아 규칙 변경이 필요 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)