### PR TITLE
fix(members): stop the auth paths from writing a member's display name

### DIFF
--- a/server/bff/auth-governance.mjs
+++ b/server/bff/auth-governance.mjs
@@ -209,7 +209,9 @@ export function buildDeepSyncPlan({
   const canonicalPatch = {
     ...base,
     uid: canonicalUid,
-    name: displayName,
+    // The member ledger owns the display name. A role change must not rewrite it with the
+    // Google account name, so it is only seeded when the ledger has nothing yet.
+    ...(readOptionalText(base.name) ? {} : { name: displayName }),
     email,
     role: normalizedRole,
     tenantId,
@@ -229,7 +231,7 @@ export function buildDeepSyncPlan({
         ...member.data,
         uid: member.uid || member.docId,
         canonicalUid,
-        name: displayName,
+        ...(readOptionalText(member.data?.name) ? {} : { name: displayName }),
         email,
         role: normalizedRole,
         tenantId,

--- a/src/app/data/auth-store.first-login.test.ts
+++ b/src/app/data/auth-store.first-login.test.ts
@@ -10,8 +10,11 @@ describe('first-login member bootstrap', () => {
     // Google account names arrive in whatever form each person set them, so a sign-in
     // must not overwrite the ledger's 이름(별명) value. A first login still falls back to
     // the account name because the ledger has nothing yet.
-    expect(authStoreSource).toContain("name: existing?.name || firebaseUser.displayName || '사용자',");
+    // A sign-in writes no name at all; the field is only seeded when the ledger has none.
+    expect(authStoreSource).toContain("...(existing?.name ? {} : { name: firebaseUser.displayName || '사용자' }),");
+    expect(authStoreSource).not.toContain("name: existing?.name || firebaseUser.displayName");
     expect(authStoreSource).not.toContain("name: firebaseUser.displayName || existing?.name");
+    // First-login creation still needs a value, since the ledger has nothing yet.
     expect(authStoreSource).toContain("name: firebaseUser.displayName || '사용자',");
   });
 

--- a/src/app/data/auth-store.tsx
+++ b/src/app/data/auth-store.tsx
@@ -358,12 +358,13 @@ async function upsertMemberFromFirebase(
     access.normalizedProjectId || existing?.projectId,
   ) || '';
 
-  const merged = omitUndefinedFields<MemberDoc>({
+  // A sign-in patches an existing document, so `name` may legitimately be absent here.
+  const merged = omitUndefinedFields<Partial<MemberDoc> & { uid: string }>({
     uid: firebaseUser.uid,
-    // The member ledger owns the display name. Google account names arrive in whatever
-    // form each person set them ('Jeongtae KIM (Able)'), and letting a sign-in overwrite
-    // the ledger undid the roster's 이름(별명) normalisation every time someone logged in.
-    name: existing?.name || firebaseUser.displayName || '사용자',
+    // Signing in does not write the display name at all. The ledger owns it, and Google
+    // account names arrive in whatever form each person set them ('Jeongtae KIM (Able)').
+    // The field is only seeded when the ledger has nothing yet.
+    ...(existing?.name ? {} : { name: firebaseUser.displayName || '사용자' }),
     email: normalizedEmail,
     role: resolveEffectiveAuthRole({
       memberRole: existing?.role,
@@ -387,7 +388,9 @@ async function upsertMemberFromFirebase(
   if (department) merged.department = department;
 
   await setDoc(memberRef, merged, { merge: true });
-  return merged;
+  // Only the patch is written. The caller still needs a whole record, so the ledger's
+  // existing name is filled back in here rather than being written to Firestore.
+  return { ...merged, name: merged.name ?? existing?.name ?? '' } as MemberDoc;
 }
 
 const _g = globalThis as any;


### PR DESCRIPTION
## 3단계: 쓰기 경로 정리

`name`에 쓰는 경로가 넷이었고, 그중 둘이 아직 Google 계정 이름을 밀어넣고 있었습니다.

| 경로 | 이전 | 이후 |
|---|---|---|
| 최초 로그인 (`buildSafeFirstLoginMember`) | 계정 이름으로 생성 | **유지** — 원장에 아무것도 없는 경우 |
| 매 로그인 (`upsertMemberFromFirebase`) | `existing?.name \|\| displayName` | **아예 안 씀** (없을 때만 seed) |
| 역할 변경 (`auth-governance.mjs`) | `name: displayName` | **아예 안 씀** (없을 때만 seed) |
| 명부 임포트 | `이름(별명)` | 유지 — 유일한 주인 |

`#450`으로 화면은 이미 `nameKo`·`nickname`을 보고 있어 눈에 띄지는 않았지만, 원장 값 자체가 계속 각자의 Google 계정 이름으로 되돌아가고 있었습니다. 이제 **명부만이 이름을 씁니다.**

## 구현 메모
로그인은 기존 문서를 부분 갱신하므로 쓰기를 `Partial<MemberDoc>`으로 타입했습니다. 호출부는 완전한 레코드를 필요로 해서, **원장의 기존 이름을 반환값에만 채워 넣고 Firestore에는 쓰지 않습니다.**

## Verification
- `npm test` — 실패 1건은 알려진 `jvm-weekly-api` 병렬 부하 flaky (단독 실행 181건 통과)
- `npm run typecheck` — no new type errors
- 회귀 테스트 갱신: 로그인이 이름을 쓰지 않는지, 최초 생성만 값을 넣는지 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)