### PR TITLE
docs(agents): record the ERP minimum-scope policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,14 @@ npm run build
 ## High-Priority Operating Policies
 These policies override lower-priority workflow suggestions when they apply.
 
+### ERP Minimum-Scope Implementation
+- Treat this repository as a production ERP: implement only the behavior explicitly requested by the user.
+- Reuse the existing data path, helper, type, and UI pattern before adding code. Do not add speculative features, configuration, abstractions, or unrelated refactors.
+- Keep the changed files and diff as small as practical, and ensure every changed line is traceable to the request.
+- Minimum scope must not remove trust-boundary validation, authorization, audit/history integrity, idempotency, data-loss protection, accessibility basics, or required error handling.
+- Fix shared root causes once when multiple requested callers use the same flow; do not patch only a visible symptom or duplicate the fix across screens.
+- Verify the affected persisted data path and its user-visible readback. A successful build or cosmetic UI change alone is not completion.
+
 ### QA Stage Gates
 - For implementation work that can affect users, data, integrations, permissions, deployment, or cross-screen behavior, run the work with an independent QA lens based on `/Users/boram/gstack/.agents/skills/gstack-qa/SKILL.md`.
 - Where subagents are available, assign a separate QA subagent to define stage pass criteria and challenge the implementation. If subagents are unavailable, perform a separate QA pass in the main thread using the same criteria.


### PR DESCRIPTION
세션 중 저장소 소유자가 작성했으나 커밋되지 않은 채 남아 있던 정책을 기록합니다.

이 저장소의 작업 규칙을 정의합니다.
- 요청된 동작만 구현하고, 기존 데이터 경로·헬퍼·타입·UI 패턴을 먼저 재사용
- 변경된 모든 줄이 요청에서 추적 가능해야 함
- **최소 범위가 신뢰 경계 검증·인가·감사 이력 무결성·멱등성·데이터 손실 방지·접근성·에러 처리를 제거하는 근거가 될 수 없음**
- 여러 호출자가 같은 흐름을 쓰면 공통 원인을 한 번만 고치고, 증상만 덧대거나 화면마다 중복 수정하지 않음
- 빌드 성공이나 겉모습 변경만으로 완료로 보지 않고, 저장 경로와 사용자에게 보이는 결과까지 확인

문서 변경으로 런타임 영향은 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)