### PR TITLE
fix(projects): show whether the payment plan adds up to the contract amount

### DIFF
--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -1879,6 +1879,9 @@ export function ProjectEditorWizard({
             placeholder="0"
             className={cn('mt-1 h-9 text-sm', usesRegistrationV2 && hasMultiYearContract && 'bg-muted/40')}
           />
+          <p className="mt-1 text-[10px] text-muted-foreground">
+            {hasSalesVatAmountInput ? `${fmtKRW(draft.salesVatAmount)}원` : '미입력'}
+          </p>
         </div>
         <div>
           <Label className="text-xs">총수익</Label>
@@ -1890,6 +1893,9 @@ export function ProjectEditorWizard({
             placeholder="0"
             className={cn('mt-1 h-9 text-sm', usesRegistrationV2 && hasMultiYearContract && 'bg-muted/40')}
           />
+          <p className="mt-1 text-[10px] text-muted-foreground">
+            {hasTotalRevenueAmountInput ? `${fmtKRW(draft.totalRevenueAmount)}원` : '미입력'}
+          </p>
         </div>
         <div>
           <Label className="text-xs">총실비(원가)</Label>
@@ -1901,6 +1907,9 @@ export function ProjectEditorWizard({
             placeholder="0"
             className={cn('mt-1 h-9 text-sm', usesRegistrationV2 && hasMultiYearContract && 'bg-muted/40')}
           />
+          <p className="mt-1 text-[10px] text-muted-foreground">
+            {hasTotalActualCostInput ? `${fmtKRW(draft.totalActualCost)}원` : '미입력'}
+          </p>
         </div>
         <div>
           <Label className="text-xs">총지원금</Label>
@@ -1912,6 +1921,9 @@ export function ProjectEditorWizard({
             placeholder="0"
             className={cn('mt-1 h-9 text-sm', usesRegistrationV2 && hasMultiYearContract && 'bg-muted/40')}
           />
+          <p className="mt-1 text-[10px] text-muted-foreground">
+            {hasSupportAmountInput ? `${fmtKRW(draft.supportAmount)}원` : '미입력'}
+          </p>
         </div>
         <div>
           <Label className="text-xs">총수익률</Label>
@@ -2345,6 +2357,9 @@ export function ProjectEditorWizard({
       && paymentPlan.contract + paymentPlan.interim + paymentPlan.final > 0
       && yearAdvanceInterimRatio !== null
       && yearAdvanceInterimRatio < 0.7;
+    const planTotal = paymentPlan.contract + paymentPlan.interim + paymentPlan.final;
+    const planBase = financialYear?.contractAmount || draft.contractAmount;
+    const planGap = planBase - planTotal;
     return (
     <div className="space-y-4">
       <div className="grid gap-4 lg:grid-cols-3">
@@ -2367,6 +2382,26 @@ export function ProjectEditorWizard({
           <Label className="mt-3 block text-xs">예상 입금 시점{paymentPlan.final > 0 ? ' *' : ''}</Label><Input type="month" aria-label={`${financialYear ? `${financialYear.year}년 ` : ''}잔금 예상 입금 시점`} aria-required={paymentPlan.final > 0} value={paymentExpectedMonths.final} onChange={(event) => updatePaymentExpectedMonth('final', event.target.value)} className="mt-1 h-9 text-sm" />
         </div>
       </div>
+      {planBase > 0 ? (
+        <div className="rounded-lg border border-slate-200 bg-white px-4 py-3 text-[12px]">
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-slate-600">{financialYear ? `${financialYear.year}년 ` : ''}입금 계획 합계</span>
+            <span className="font-semibold tabular-nums text-slate-900">{fmtKRW(planTotal)}원</span>
+          </div>
+          <div className="mt-1 flex items-center justify-between gap-3">
+            <span className="text-slate-600">계약금액</span>
+            <span className="tabular-nums text-slate-700">{fmtKRW(planBase)}원</span>
+          </div>
+          {/* The three amounts had to be added up by eye to see whether they matched the contract. */}
+          <div className={`mt-2 border-t border-slate-200 pt-2 ${planGap === 0 ? 'text-slate-600' : 'text-red-700'}`}>
+            {planGap === 0
+              ? '계약금액과 일치합니다.'
+              : planGap > 0
+                ? `계약금액보다 ${fmtKRW(planGap)}원 적습니다.`
+                : `계약금액보다 ${fmtKRW(Math.abs(planGap))}원 많습니다.`}
+          </div>
+        </div>
+      ) : null}
       {requiresYearAdvanceInterimReason ? (
         <div>
           <Label className="text-xs">{financialYear.year}년 선금·중도금 합계 70% 미만 사유 *</Label>
@@ -2379,8 +2414,9 @@ export function ProjectEditorWizard({
         </div>
       ) : null}
       {!financialYear && advanceInterimRatio !== null && paymentPlanTotal > 0 ? (
-        <div className={`rounded-lg border px-3 py-2 text-[12px] ${requiresAdvanceInterimReason ? 'border-amber-300 bg-amber-50 text-amber-900' : 'border-slate-200 bg-slate-50 text-slate-700'}`}>
+        <div className={`rounded-lg border border-slate-200 bg-white px-3 py-2 text-[12px] ${requiresAdvanceInterimReason ? 'text-red-700' : 'text-slate-700'}`}>
           선금+중도금 비율 {(advanceInterimRatio * 100).toFixed(1)}%
+          {requiresAdvanceInterimReason ? ' · 70% 미만이라 사유가 필요합니다.' : ''}
         </div>
       ) : null}
       {!financialYear && requiresAdvanceInterimReason ? (


### PR DESCRIPTION
계약/재무 단계에서 **코드로 확인된 문제 3건**만 고쳤습니다.

## 1. 입금 계획 합계가 없음
선금·중도금·잔금이 각각 따로 있고 합계가 없어, 계약금액과 맞는지 **사람이 암산**해야 했습니다.

```
입금 계획 합계        0원
계약금액       12,000,000원
─────────────────────────
계약금액보다 12,000,000원 적습니다.
```

일치하면 회색, 어긋나면 빨간 글씨로 **어느 방향으로 얼마나** 차이나는지 표시합니다. 연도별 재무의 각 연도에도 같은 줄이 들어갑니다.

## 2. `0`과 "안 넣음"이 구분되지 않음
총매출부가세·총수익·총실비·총지원금 네 항목이 값이 0이든 미입력이든 똑같이 `0`으로 보였습니다. 같은 화면의 `당해연도 예산`이 이미 쓰던 `미입력` 보조문구를 네 항목에도 붙였습니다.

## 3. 주황 틴트 패널 (DESIGN.md 위반)
선금+중도금 비율 안내가 `bg-amber-50`을 쓰고 있었습니다. DESIGN.md 53행은 **경고를 중립 배경 위 색 글씨로** 규정합니다. 흰 배경 + 빨간 글씨로 바꾸고, 비율만 말하던 문구에 *왜 문제인지*(70% 미만이면 사유 필요)를 덧붙였습니다.

## 하지 않은 것
- **계약금액 자동계산** — 계약금액은 계약서에 적힌 사실이고 총수익률·입금비율의 기준점이라, 파생값으로 만들면 입력 도중 기준이 계속 움직입니다. 대신 위 정합성 검사로 어긋남을 드러냅니다
- **관계없는 필드 숨김** — 어떤 필드가 언제 필요한지는 업무 판단이라 제외했습니다
- **서류 7종 표 전환** — 별도 작업

## Verification
- `npm run typecheck` — no new type errors
- `npm test` — `cashflow-sheet-lab` 실패는 알려진 병렬 부하 flaky (단독 실행 87건 통과). 이 변경은 프로젝트 편집기 한 파일만 건드립니다

🤖 Generated with [Claude Code](https://claude.com/claude-code)