### PR TITLE
feat(cashflow): detect and sync sheet changes

### DIFF
--- a/.gstack/sprint-contract-2026-08-06-cashflow-sheet-jvm-diff.md
+++ b/.gstack/sprint-contract-2026-08-06-cashflow-sheet-jvm-diff.md
@@ -1,0 +1,97 @@
+# Sprint Contract: Google Sheet–JVM 변동 감지 및 목요일 자동 동기화
+**날짜:** 2026-08-06
+**예상 소요:** 4~6시간 + CI/배포 검증
+**상태:** APPROVED
+
+## Objective
+연결된 Google Sheet의 canonical 현금흐름 셀과 JVM `cashflow_weeks`를 동일한 기준으로 비교한다. 미반영 변경은 프로젝트 화면에 건수로 표시하고, 매주 목요일 09:30 Asia/Seoul에 연결된 프로젝트를 자동 동기화한다. 반영 성공은 JVM post-write read가 고정 snapshot과 일치할 때만 확정한다.
+
+## 불변조건
+- `SYNCED`는 Sheet snapshot과 JVM canonical cells가 동일할 때만 반환한다.
+- `EMPTY`, `ZERO`, `VALUE`는 서로 다른 상태다.
+- 확인 요청은 JVM을 변경하지 않는다.
+- 자동/수동 apply 모두 `snapshot -> apply -> JVM read-back` 순서를 지킨다.
+- 한 프로젝트의 실패는 다른 프로젝트 동기화를 중단하지 않는다.
+- 결산 잠금, 승인 확인, stale revision 충돌을 자동으로 우회하지 않는다.
+
+## 상태 계약
+- `CHECKING`: 외부 시트 또는 JVM 비교 진행 중
+- `SYNCED`: canonical diff 0건
+- `CHANGED`: canonical diff 1건 이상
+- `UNAVAILABLE`: Sheet/JVM 조회 또는 비교 실패. 0건으로 대체하지 않는다.
+
+## 변경 건수
+키는 `sourceYear + yearMonth + weekNo + mode + cashflowLine`이다. `cellState` 또는 `amount`가 다르면 1건이다. 서식, 메모, 동일 effective value의 수식 변경, 합계/잔액 행, 연결 범위 밖 셀은 제외한다.
+
+## 목요일 자동 동기화
+- Vercel cron: `30 0 * * 4` (목요일 09:30 Asia/Seoul)
+- 대상: 시트 연결 설정이 있는 프로젝트
+- 프로젝트별: snapshot 보존 -> diff -> 변경이 있을 때만 기존 apply -> JVM read-back
+- no-op 프로젝트는 쓰지 않는다.
+- idempotency key는 해당 KST 실행 회차와 projectId로 고정한다.
+- 중복 실행은 같은 결과를 재사용하며 동시 실행으로 두 번 적용하지 않는다.
+- 잠긴 범위 또는 확인이 필요한 변경은 실패/보류로 기록하고 강제 반영하지 않는다.
+
+## 서버 응답 계약
+```json
+{
+  "status": "CHANGED",
+  "pendingChangeCount": 31,
+  "projectionChangeCount": 18,
+  "actualChangeCount": 13,
+  "sourceRevision": "sha256:...",
+  "targetRevision": "sha256:...",
+  "checkedAt": "2026-08-06T02:30:00.000Z"
+}
+```
+
+## Unit test 성공 기준
+- 동일 cell 집합은 0건이다.
+- `EMPTY <-> ZERO`, `ZERO <-> VALUE`, `EMPTY <-> VALUE`, 금액 변경은 각각 1건이다.
+- 수식만 바뀌고 effective value가 같으면 0건이다.
+- Projection/Actual 건수의 합은 총 건수와 같다.
+- 중복 canonical key와 알 수 없는 line은 성공으로 숨기지 않는다.
+- Sheet API/JVM 실패는 `UNAVAILABLE`이다.
+- legacy 12개 line의 누락 4개를 0으로 만들지 않는다.
+- Projection을 Actual로 fallback하지 않는다.
+- apply 후 셀 1개라도 다르면 성공하지 않는다.
+- stale source revision, 부분 저장, read-back 실패는 실패한다.
+- 같은 idempotency key는 중복 쓰기 없이 replay된다.
+- cron은 목요일 09:30 KST에만 실행 대상을 만든다.
+- 연결 없는 프로젝트, no-op 프로젝트는 apply하지 않는다.
+- 프로젝트 A 실패 후 프로젝트 B는 계속 처리한다.
+- cron 인증 실패는 401/403이며 어떤 프로젝트도 변경하지 않는다.
+- 프론트는 `CHANGED/N`을 `이전 대비 변동 사항 N건 · 새로 반영이 필요합니다`로 표시한다.
+- 작은 `시트 이동` 버튼은 기존 시트 설정 화면으로 이동한다.
+- 상태 확인만으로 apply가 호출되지 않는다.
+
+## 통합 성공 기준
+- QA fixture `Sheet Projection 249,199,960 / JVM 218,236,560`은 `CHANGED`이고 차액을 숨기지 않는다.
+- 정상 apply 후 JVM Projection은 249,199,960이고 diff는 0건이다.
+- 31건 중 30건만 저장되면 apply는 실패한다.
+- 자동 동기화 run은 프로젝트별 결과와 revision을 감사 기록에 남긴다.
+
+## 실패 기준
+- 마지막 refresh 성공만으로 `SYNCED/FRESH`를 표시한다.
+- 프론트가 자체 diff를 계산한다.
+- API/JVM 실패를 0건으로 표시한다.
+- apply 후 read-back 없이 성공 처리한다.
+- 자동 동기화가 잠금/승인 정책을 우회한다.
+- 사용자 화면을 강제 refresh한다.
+- 테스트를 skip하거나 실제 크기보다 축소된 예제로만 검증한다.
+
+## 범위 밖
+- 실시간 polling
+- Google Sheet 편집
+- 계산 공식 변경
+- 결산 상태 모델 재설계
+- AXR–CMK QA 연결 교체
+
+## 검증 명령
+```bash
+npx vitest run src/app/components/cashflow/CashflowProjectSheet.shell.test.ts src/app/lib/sheets-cashflow-readonly-client.test.ts
+node --test server/bff/cashflow-sheet-snapshot.test.mjs server/bff/routes/cashflow-sheet-lab.test.mjs server/bff/worker-endpoints.test.ts server/bff/scheduler-config.test.ts
+npm test
+npm run bff:test:integration
+npm run build
+```

--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -29,6 +29,7 @@ import {
 import {
   runPayrollWorker,
 } from './payroll-worker.mjs';
+import { runCashflowSheetSyncWorker } from './cashflow-sheet-sync-worker.mjs';
 import {
   resolveAffectedViews,
   resolveRelationRules,
@@ -125,6 +126,16 @@ import {
 } from './routes/cashflow-edit-drafts.mjs';
 import { createHttpError, resolveErrorResponse } from './bff-utils.mjs';
 
+function formatSeoulDate(value) {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(new Date(value));
+  const byType = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  return `${byType.year}-${byType.month}-${byType.day}`;
+}
 
 function parseLimit(raw, fallback = 50, max = 200) {
   const n = Number.parseInt(String(raw ?? ''), 10);
@@ -715,6 +726,7 @@ export function createBffApp(options = {}) {
   const driveService = options.driveService || createGoogleDriveService();
   const googleSheetsService = options.googleSheetsService || createGoogleSheetsService();
   const googleSheetMigrationAiService = options.googleSheetMigrationAiService || createGoogleSheetMigrationAiService();
+  let cashflowSheetSyncProject = null;
   const projectRequestContractAiService = options.projectRequestContractAiService || createProjectRequestContractAiService();
   const projectRequestContractStorageService = options.projectRequestContractStorageService || createProjectRequestContractStorageService({ projectId });
   const projectRegistrationDraftStorageService = options.projectRegistrationDraftStorageService
@@ -1012,6 +1024,37 @@ export function createBffApp(options = {}) {
   });
   app.get('/api/internal/workers/payroll/run', runPayrollWorkerRoute);
   app.post('/api/internal/workers/payroll/run', runPayrollWorkerRoute);
+
+  const executeCashflowSheetSyncWorker = options.cashflowSheetSyncWorker
+    || ((workerOptions) => runCashflowSheetSyncWorker(db, workerOptions));
+  const runCashflowSheetSyncWorkerRoute = asyncHandler(async (req, res) => {
+    assertInternalWorkerAuthorized(req);
+    const tenantId = readOptionalText(req.body?.tenantId ?? req.query?.tenantId) || 'mysc';
+    const runId = `cashflow-sheet-sync:${formatSeoulDate(now())}`;
+    const result = await executeCashflowSheetSyncWorker({
+      tenantId,
+      concurrency: 4,
+      runId,
+      syncProject: ({ tenantId: projectTenantId, projectId: cashflowProjectId, runId: projectRunId }) => {
+        if (typeof cashflowSheetSyncProject !== 'function') {
+          throw createHttpError(503, 'Cashflow sheet sync is not configured.', 'cashflow_sheet_sync_unconfigured');
+        }
+        return cashflowSheetSyncProject({
+          tenantId: projectTenantId,
+          projectId: cashflowProjectId,
+          runId: projectRunId,
+          apply: true,
+        });
+      },
+    });
+    res.status(200).json({
+      worker: 'cashflow_sheet_sync',
+      projectId,
+      ...result,
+    });
+  });
+  app.get('/api/internal/workers/cashflow-sheet-sync/run', runCashflowSheetSyncWorkerRoute);
+  app.post('/api/internal/workers/cashflow-sheet-sync/run', runCashflowSheetSyncWorkerRoute);
 
   const runClientErrorSlackWorkerRoute = asyncHandler(async (req, res) => {
     assertInternalWorkerAuthorized(req);
@@ -1504,12 +1547,13 @@ export function createBffApp(options = {}) {
     now,
     legacyCashflowWritesEnabled: options.legacyCashflowWritesEnabled,
   });
-  mountCashflowSheetLabRoutes(app, {
+  const cashflowSheetLabRoutes = mountCashflowSheetLabRoutes(app, {
     db,
     googleSheetsService,
-    editLeasesEnabled,
-    editLeaseService,
+    env,
+    javaWeeklyClient: options.javaWeeklyClient,
   });
+  cashflowSheetSyncProject = cashflowSheetLabRoutes?.syncProject || null;
   mountCashflowLaborRiskRoutes(app, {
     db,
     now,

--- a/server/bff/cashflow-sheet-sync-worker.mjs
+++ b/server/bff/cashflow-sheet-sync-worker.mjs
@@ -1,0 +1,96 @@
+import { createHttpError, readOptionalText } from './bff-utils.mjs';
+
+function hasCashflowSheetConnection(project = {}) {
+  if (readOptionalText(project?.cashflowSheetLab?.value)) return true;
+  return Object.values(project?.cashflowSheetLabSources || {})
+    .some((source) => readOptionalText(source?.value));
+}
+
+function failureSummary(projectId, error) {
+  return {
+    projectId,
+    code: readOptionalText(error?.code) || readOptionalText(error?.name) || 'cashflow_sheet_sync_failed',
+    message: readOptionalText(error?.message) || 'Cashflow sheet sync failed.',
+  };
+}
+
+export function assertCashflowSheetSyncComplete(discoveredProjects, processedProjects) {
+  if (discoveredProjects === processedProjects) return;
+  throw createHttpError(
+    500,
+    `Cashflow sheet sync was partial (${processedProjects}/${discoveredProjects}).`,
+    'cashflow_sheet_sync_partial_forbidden',
+  );
+}
+
+async function mapWithConcurrency(items, concurrency, mapper) {
+  const results = new Array(items.length);
+  let nextIndex = 0;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      try {
+        results[index] = { status: 'fulfilled', value: await mapper(items[index]) };
+      } catch (reason) {
+        results[index] = { status: 'rejected', reason };
+      }
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+export async function runCashflowSheetSyncWorker(db, {
+  tenantId = 'mysc',
+  concurrency = 4,
+  syncProject,
+  runId,
+} = {}) {
+  const resolvedTenantId = readOptionalText(tenantId) || 'mysc';
+  if (typeof syncProject !== 'function') {
+    throw createHttpError(503, 'Cashflow sheet sync is not configured.', 'cashflow_sheet_sync_unconfigured');
+  }
+  const normalizedConcurrency = Math.max(1, Math.min(8, Math.trunc(Number(concurrency) || 4)));
+  const snapshot = await db.collection(`orgs/${resolvedTenantId}/projects`).get();
+  const projects = snapshot.docs
+    .map((doc) => ({ id: doc.id, ...(doc.data() || {}) }))
+    .filter(hasCashflowSheetConnection)
+    .sort((left, right) => left.id.localeCompare(right.id));
+  const resolvedRunId = readOptionalText(runId) || `cashflow-sheet-sync:${new Date().toISOString()}`;
+  const settled = await mapWithConcurrency(projects, normalizedConcurrency, (project) => syncProject({
+    tenantId: resolvedTenantId,
+    projectId: project.id,
+    runId: resolvedRunId,
+  }));
+  assertCashflowSheetSyncComplete(projects.length, settled.length);
+
+  const failures = [];
+  let changedCount = 0;
+  let appliedCount = 0;
+  let noChangeProjects = 0;
+  settled.forEach((result, index) => {
+    if (result.status === 'rejected') {
+      failures.push(failureSummary(projects[index].id, result.reason));
+      return;
+    }
+    changedCount += Math.max(0, Number(result.value?.changedCount) || 0);
+    appliedCount += Math.max(0, Number(result.value?.appliedCount) || 0);
+    if (['SYNCED', 'NO_CHANGES'].includes(readOptionalText(result.value?.status))) noChangeProjects += 1;
+  });
+
+  return {
+    ok: failures.length === 0,
+    tenantId: resolvedTenantId,
+    runId: resolvedRunId,
+    concurrency: normalizedConcurrency,
+    discoveredProjects: projects.length,
+    processedProjects: settled.length,
+    succeededProjects: settled.length - failures.length,
+    failedProjects: failures.length,
+    changedCount,
+    appliedCount,
+    noChangeProjects,
+    failures,
+  };
+}

--- a/server/bff/cashflow-sheet-sync-worker.test.mjs
+++ b/server/bff/cashflow-sheet-sync-worker.test.mjs
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  assertCashflowSheetSyncComplete,
+  runCashflowSheetSyncWorker,
+} from './cashflow-sheet-sync-worker.mjs';
+
+function projectDoc(id, data) {
+  return { id, data: () => ({ id, ...data }) };
+}
+
+function createDb(projects) {
+  return {
+    collection: vi.fn((path) => {
+      expect(path).toBe('orgs/mysc/projects');
+      return {
+        get: vi.fn(async () => ({ docs: projects })),
+      };
+    }),
+  };
+}
+
+describe('cashflow sheet sync worker', () => {
+  it('processes every connected project with bounded concurrency and isolates failures', async () => {
+    const db = createDb([
+      projectDoc('project-a', { cashflowSheetLab: { value: 'sheet-a' } }),
+      projectDoc('project-b', { cashflowSheetLabSources: { 2026: { value: 'sheet-b' } } }),
+      projectDoc('project-c', { cashflowSheetLab: { value: 'sheet-c' } }),
+      projectDoc('project-without-sheet', {}),
+    ]);
+    let active = 0;
+    let maxActive = 0;
+    const syncProject = vi.fn(async ({ projectId }) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
+      if (projectId === 'project-b') throw Object.assign(new Error('sheet denied'), { code: 'sheet_denied' });
+      return projectId === 'project-a'
+        ? { changedCount: 0, appliedCount: 0, status: 'NO_CHANGES' }
+        : { changedCount: 3, appliedCount: 1, status: 'APPLIED' };
+    });
+
+    const result = await runCashflowSheetSyncWorker(db, {
+      tenantId: 'mysc',
+      concurrency: 2,
+      syncProject,
+      runId: 'cashflow-sheet-sync:2026-08-06',
+    });
+
+    expect(maxActive).toBeLessThanOrEqual(2);
+    expect(syncProject).toHaveBeenCalledTimes(3);
+    expect(result).toMatchObject({
+      ok: false,
+      discoveredProjects: 3,
+      processedProjects: 3,
+      succeededProjects: 2,
+      failedProjects: 1,
+      changedCount: 3,
+      appliedCount: 1,
+      noChangeProjects: 1,
+      failures: [{ projectId: 'project-b', code: 'sheet_denied' }],
+    });
+    expect(result.discoveredProjects).toBe(result.processedProjects);
+  });
+
+  it('rejects a partial worker result instead of reporting success', async () => {
+    expect(() => assertCashflowSheetSyncComplete(2, 1))
+      .toThrow(expect.objectContaining({ code: 'cashflow_sheet_sync_partial_forbidden' }));
+  });
+});

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -923,6 +923,84 @@ async function readCashflowWeeksSnapshot(db, tenantId, projectId) {
   };
 }
 
+function canonicalCellEntriesFromWeeks(weeks = []) {
+  const entries = [];
+  for (const week of weeks) {
+    const yearMonth = readOptionalText(week?.yearMonth);
+    const weekNo = Number(week?.weekNo);
+    for (const mode of ['projection', 'actual']) {
+      const amounts = week?.[mode] && typeof week[mode] === 'object' ? week[mode] : {};
+      for (const [cashflowLine, rawAmount] of Object.entries(amounts)) {
+        const amount = Number(rawAmount);
+        if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(yearMonth)
+          || !Number.isSafeInteger(weekNo) || weekNo < 1 || weekNo > 5
+          || !CASHFLOW_LINE_ORDER.has(readOptionalText(cashflowLine)) || !Number.isSafeInteger(amount)) {
+          throw createHttpError(502, 'Canonical cashflow snapshot is invalid.', 'cashflow_canonical_snapshot_invalid');
+        }
+        entries.push({ yearMonth, weekNo, mode, cashflowLine, state: amount === 0 ? 'ZERO' : 'VALUE', amount });
+      }
+    }
+  }
+  return entries.sort((left, right) => (
+    left.yearMonth.localeCompare(right.yearMonth)
+    || left.weekNo - right.weekNo
+    || left.mode.localeCompare(right.mode)
+    || left.cashflowLine.localeCompare(right.cashflowLine)
+  ));
+}
+
+function canonicalWeeksFromJavaSnapshot(snapshot = {}) {
+  if (Array.isArray(snapshot?.readModel?.months)) {
+    return snapshot.readModel.months.flatMap((month) => ['projection', 'actual'].flatMap((mode) => (
+      Array.isArray(month?.[mode]?.weeks) ? month[mode].weeks : []
+    ).map((week) => ({
+      yearMonth: month.yearMonth,
+      weekNo: week.weekNo,
+      [mode]: week.amounts || {},
+    }))));
+  }
+  if (!Array.isArray(snapshot?.projection) || !Array.isArray(snapshot?.actual)) {
+    throw createHttpError(502, 'JVM cashflow snapshot is invalid.', 'jvm_cashflow_snapshot_invalid');
+  }
+  const byWeek = new Map();
+  const addLine = (mode, line) => {
+    const yearMonth = readOptionalText(line?.yearMonth);
+    const weekNo = Number(line?.weekNo);
+    const cashflowLine = readOptionalText(line?.cashflowLine);
+    const amount = Number(line?.amount);
+    if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(yearMonth)
+      || !Number.isSafeInteger(weekNo) || weekNo < 1 || weekNo > 5
+      || !CASHFLOW_LINE_ORDER.has(cashflowLine) || !Number.isSafeInteger(amount)) {
+      throw createHttpError(502, 'JVM cashflow snapshot is invalid.', 'jvm_cashflow_snapshot_invalid');
+    }
+    const key = `${yearMonth}:${weekNo}`;
+    const week = byWeek.get(key) || { yearMonth, weekNo, projection: {}, actual: {} };
+    if (mode === 'actual') {
+      week.actual[cashflowLine] = (week.actual[cashflowLine] || 0) + amount;
+    } else if (Object.hasOwn(week.projection, cashflowLine)) {
+      throw createHttpError(502, 'JVM projection snapshot contains duplicate cells.', 'jvm_cashflow_snapshot_invalid');
+    } else {
+      week.projection[cashflowLine] = amount;
+    }
+    byWeek.set(key, week);
+  };
+  snapshot.projection.forEach((line) => addLine('projection', line));
+  snapshot.actual.forEach((line) => addLine('actual', line));
+  return [...byWeek.values()];
+}
+
+export function assertJavaCashflowMatchesFirestore(javaSnapshot, firestoreSnapshot) {
+  const javaCells = canonicalCellEntriesFromWeeks(canonicalWeeksFromJavaSnapshot(javaSnapshot));
+  const firestoreCells = canonicalCellEntriesFromWeeks(firestoreSnapshot?.weeks || []);
+  if (stableHash(javaCells) !== stableHash(firestoreCells)) {
+    throw createHttpError(
+      503,
+      'JVM and Firestore cashflow snapshots do not match.',
+      'jvm_cashflow_canonical_mismatch',
+    );
+  }
+}
+
 async function readCashflowSheetMirror(db, tenantId, projectId) {
   if (!db) {
     throw createHttpError(503, '불러온 시트 값을 읽을 수 없습니다. 담당자에게 문의해 주세요.', 'firestore_unconfigured');
@@ -3782,8 +3860,7 @@ export function mountCashflowSheetLabRoutes(app, {
     }));
   }));
 
-  app.post('/api/v1/projects/:projectId/cashflow-sheet-lab/mirror/refresh', asyncHandler(async (req, res) => {
-    assertCashflowSheetLabAccess(req, workspaceEmailDomain);
+  const executeCashflowSheetMirrorRefresh = async (req) => {
     const trace = createCashflowPerformanceTrace({
       requestId: req.context?.requestId || req.requestId,
       operation: 'cashflow.sheet_mirror.refresh',
@@ -3840,8 +3917,7 @@ export function mountCashflowSheetLabRoutes(app, {
       }),
     );
     if (refreshRun.replay) {
-      res.status(200).json(refreshRun.replay);
-      return;
+      return refreshRun.replay;
     }
     if (readOptionalText(previousMirror?.lastRefreshIdempotencyKey) === parsed.idempotencyKey) {
       const completedMirror = await completeCashflowSheetRefreshRun({
@@ -3854,8 +3930,7 @@ export function mountCashflowSheetLabRoutes(app, {
         response: previousMirror,
         completedAt: attemptedAt,
       });
-      res.status(200).json(completedMirror);
-      return;
+      return completedMirror;
     }
 
     logCashflowSheetLab('mirror.refresh.start', req, {
@@ -3945,7 +4020,7 @@ export function mountCashflowSheetLabRoutes(app, {
         targetRevisionAtFetch: completedMirror.targetRevisionAtFetch,
         ...completedMirror.summary,
       });
-      res.status(200).json(completedMirror);
+      return completedMirror;
     } catch (error) {
       const normalized = normalizeRouteError(error);
       const diagnostics = Array.isArray(normalized?.diagnostics) ? normalized.diagnostics : [];
@@ -3995,7 +4070,200 @@ export function mountCashflowSheetLabRoutes(app, {
         mirrorStatus: completedMirror.status,
         ...routeErrorDetails(normalized),
       }, 'warn');
-      res.status(200).json(completedMirror);
+      return completedMirror;
+    }
+  };
+
+  app.post('/api/v1/projects/:projectId/cashflow-sheet-lab/mirror/refresh', asyncHandler(async (req, res) => {
+    assertCashflowSheetLabAccess(req, workspaceEmailDomain);
+    res.status(200).json(await executeCashflowSheetMirrorRefresh(req));
+  }));
+
+  const syncCashflowSheetProject = async ({
+    tenantId,
+    projectId,
+    runId,
+    context,
+    apply = false,
+  } = {}) => {
+    if (!authoritativeJavaClient) {
+      throw createHttpError(503, 'JVM cashflow API is not configured.', 'jvm_weekly_api_unconfigured');
+    }
+    const project = await readProjectDocument(db, tenantId, projectId);
+    const configs = readCashflowSheetLabConfigs(project);
+    if (configs.length === 0) {
+      throw createHttpError(400, 'Cashflow sheet URL is not configured.', 'cashflow_sheet_config_required');
+    }
+    const actorContext = context || {
+      tenantId,
+      actorId: 'cashflow-sheet-sync',
+      actorRole: 'admin',
+      actorEmail: 'cashflow-sheet-sync@mysc.co.kr',
+      requestId: runId,
+    };
+    const requestLike = (sourceYear, operation) => ({
+      context: actorContext,
+      requestId: actorContext.requestId,
+      params: { projectId },
+      body: {
+        sourceYear,
+        idempotencyKey: `${runId}:${projectId}:${operation}:${sourceYear}`,
+      },
+    });
+    let pendingChangeCount = 0;
+    let projectionChangeCount = 0;
+    let actualChangeCount = 0;
+    let appliedCount = 0;
+    let blocked = false;
+    let sourceRevision = '';
+    let targetRevision = '';
+
+    for (const config of configs) {
+      const sourceYear = config.sourceYear;
+      const mirror = await executeCashflowSheetMirrorRefresh(requestLike(sourceYear, 'refresh'));
+      if (readOptionalText(mirror?.status) !== 'FRESH') {
+        const refreshError = mirror?.lastRefreshError || {};
+        throw createHttpError(
+          Number(refreshError.statusCode) || 503,
+          readOptionalText(refreshError.message) || 'Cashflow sheet refresh failed.',
+          readOptionalText(refreshError.code) || 'cashflow_sheet_refresh_failed',
+        );
+      }
+      const beforeReadback = await authoritativeJavaClient.getCashflowSnapshot({
+        context: actorContext,
+        projectId,
+      });
+      if (readOptionalText(beforeReadback?.projectId) !== projectId) {
+        throw createHttpError(502, 'JVM cashflow readback project mismatch.', 'jvm_cashflow_readback_mismatch');
+      }
+      assertJavaCashflowMatchesFirestore(
+        beforeReadback,
+        await readCashflowWeeksSnapshot(db, tenantId, projectId),
+      );
+      const stage = await stagePinnedCashflowSheetLab({
+        db,
+        tenantId,
+        projectId,
+        parsed: {
+          expectedMirrorRevision: mirror.sourceRevision,
+          idempotencyKey: `${runId}:${projectId}:stage:${sourceYear}`,
+        },
+        context: actorContext,
+      });
+      pendingChangeCount += Math.max(0, Number(stage.stagedLineCount) || 0);
+      projectionChangeCount += Math.max(0, Number(stage.projectionLineCount) || 0);
+      actualChangeCount += Math.max(0, Number(stage.actualLineCount) || 0);
+      sourceRevision = readOptionalText(stage.sourceRevision);
+      targetRevision = readOptionalText(stage.targetRevisionAtFetch);
+
+      if (!apply || stage.status === 'NO_CHANGES') continue;
+      if (stage.status !== 'READY') {
+        blocked = true;
+        continue;
+      }
+      if (!javaWeeklyClient) assertCashflowMutationRuntime({}, env);
+      await applyStagedCashflowSheetLab({
+        db,
+        tenantId,
+        projectId,
+        parsed: {
+          stageRunId: stage.runId,
+          idempotencyKey: `${runId}:${projectId}:apply:${sourceYear}`,
+        },
+        context: actorContext,
+        javaWeeklyClient: authoritativeJavaClient,
+        editSession: null,
+        resolveEditSession: null,
+        idempotencyKey: `${runId}:${projectId}:apply:${sourceYear}`,
+      });
+      const afterReadback = await authoritativeJavaClient.getCashflowSnapshot({
+        context: actorContext,
+        projectId,
+      });
+      if (readOptionalText(afterReadback?.projectId) !== projectId) {
+        throw createHttpError(502, 'JVM cashflow readback project mismatch.', 'jvm_cashflow_readback_mismatch');
+      }
+      assertJavaCashflowMatchesFirestore(
+        afterReadback,
+        await readCashflowWeeksSnapshot(db, tenantId, projectId),
+      );
+      const verificationMirror = await executeCashflowSheetMirrorRefresh(
+        requestLike(sourceYear, 'verify-refresh'),
+      );
+      if (readOptionalText(verificationMirror?.status) !== 'FRESH') {
+        throw createHttpError(503, 'Post-apply sheet refresh failed.', 'cashflow_sheet_post_apply_refresh_failed');
+      }
+      const verificationStage = await stagePinnedCashflowSheetLab({
+        db,
+        tenantId,
+        projectId,
+        parsed: {
+          expectedMirrorRevision: verificationMirror.sourceRevision,
+          idempotencyKey: `${runId}:${projectId}:verify-stage:${sourceYear}`,
+        },
+        context: actorContext,
+      });
+      if (verificationStage.status !== 'NO_CHANGES') {
+        throw createHttpError(
+          503,
+          'Post-apply JVM readback does not match the pinned sheet.',
+          'cashflow_sheet_post_apply_mismatch',
+        );
+      }
+      sourceRevision = readOptionalText(verificationStage.sourceRevision);
+      targetRevision = readOptionalText(verificationStage.targetRevisionAtFetch);
+      appliedCount += 1;
+    }
+
+    return {
+      status: pendingChangeCount === 0 ? 'SYNCED' : blocked ? 'BLOCKED' : apply ? 'APPLIED' : 'CHANGED',
+      changedCount: pendingChangeCount,
+      pendingChangeCount,
+      projectionChangeCount,
+      actualChangeCount,
+      appliedCount,
+      sourceRevision,
+      targetRevision,
+      checkedAt: new Date().toISOString(),
+    };
+  };
+
+  app.post('/api/v1/projects/:projectId/cashflow-sheet-lab/changes/check', asyncHandler(async (req, res) => {
+    assertCashflowSheetLabAccess(req, workspaceEmailDomain);
+    const { tenantId } = req.context;
+    const { projectId } = req.params;
+    const checkedAt = new Date().toISOString();
+    try {
+      const result = await syncCashflowSheetProject({
+        tenantId,
+        projectId,
+        runId: `cashflow-sheet-check:${req.context.requestId}`,
+        context: req.context,
+        apply: false,
+      });
+      res.status(200).json({
+        status: result.pendingChangeCount > 0 ? 'CHANGED' : 'SYNCED',
+        pendingChangeCount: result.pendingChangeCount,
+        projectionChangeCount: result.projectionChangeCount,
+        actualChangeCount: result.actualChangeCount,
+        sourceRevision: result.sourceRevision,
+        targetRevision: result.targetRevision,
+        checkedAt: result.checkedAt,
+      });
+    } catch (error) {
+      logCashflowSheetLab('changes.check.unavailable', req, {
+        projectId,
+        ...routeErrorDetails(normalizeRouteError(error)),
+      }, 'warn');
+      res.status(200).json({
+        status: 'UNAVAILABLE',
+        pendingChangeCount: 0,
+        projectionChangeCount: 0,
+        actualChangeCount: 0,
+        sourceRevision: '',
+        targetRevision: '',
+        checkedAt,
+      });
     }
   }));
 
@@ -4163,4 +4431,6 @@ export function mountCashflowSheetLabRoutes(app, {
       throw normalizeRouteError(error);
     }
   }));
+
+  return { syncProject: syncCashflowSheetProject };
 }

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -4,7 +4,10 @@ import { createHash } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 import request from 'supertest';
 import { describe, expect, it, vi } from 'vitest';
-import { mountCashflowSheetLabRoutes } from './cashflow-sheet-lab.mjs';
+import {
+  assertJavaCashflowMatchesFirestore,
+  mountCashflowSheetLabRoutes,
+} from './cashflow-sheet-lab.mjs';
 import { GoogleSheetsServiceError } from '../google-sheets.mjs';
 import { stableStringify } from '../utils.mjs';
 
@@ -615,6 +618,37 @@ function createDisabledApp() {
 }
 
 describe('cashflow sheet lab route', () => {
+  it('fails closed when the JVM canonical snapshot differs from Firestore before or after apply', () => {
+    const firestoreSnapshot = {
+      weeks: [{
+        yearMonth: '2026-08',
+        weekNo: 2,
+        projection: { SALES_IN: 100 },
+        actual: { DIRECT_COST_OUT: 30 },
+      }],
+    };
+    const matchingJvmSnapshot = {
+      projectId: 'project-a',
+      projection: [{ yearMonth: '2026-08', weekNo: 2, cashflowLine: 'SALES_IN', amount: 100 }],
+      actual: [
+        { sheetKey: 'bank', yearMonth: '2026-08', weekNo: 2, cashflowLine: 'DIRECT_COST_OUT', amount: 10 },
+        { sheetKey: 'cashflow-sheet-lab', yearMonth: '2026-08', weekNo: 2, cashflowLine: 'DIRECT_COST_OUT', amount: 20 },
+      ],
+    };
+    expect(() => assertJavaCashflowMatchesFirestore(matchingJvmSnapshot, firestoreSnapshot)).not.toThrow();
+    expect(() => assertJavaCashflowMatchesFirestore({
+      ...matchingJvmSnapshot,
+      projection: [{ yearMonth: '2026-08', weekNo: 2, cashflowLine: 'SALES_IN', amount: 101 }],
+    }, firestoreSnapshot)).toThrow(expect.objectContaining({ code: 'jvm_cashflow_canonical_mismatch' }));
+    expect(() => assertJavaCashflowMatchesFirestore({
+      projectId: 'project-a',
+      projection: [{ yearMonth: '2026-08', weekNo: 2, cashflowLine: 'UNKNOWN_LINE', amount: 1 }],
+      actual: [],
+    }, {
+      weeks: [{ yearMonth: '2026-08', weekNo: 2, projection: { UNKNOWN_LINE: 1 }, actual: {} }],
+    })).toThrow(expect.objectContaining({ code: 'jvm_cashflow_snapshot_invalid' }));
+  });
+
   it('returns 404 when the deployment surface disables sheet lab', async () => {
     await request(createDisabledApp())
       .get('/api/v1/projects/project-a/cashflow-sheet-lab/config')
@@ -622,6 +656,165 @@ describe('cashflow sheet lab route', () => {
       .expect((response) => {
         expect(response.body.code).toBe('cashflow_sheet_lab_not_available');
       });
+  });
+
+  it('returns the Google Sheet versus JVM canonical change summary without applying', async () => {
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        contractStart: '2026-01-01',
+        contractEnd: '2026-12-31',
+        cashflowSheetLab: {
+          sourceYear: 2026,
+          value: 'https://docs.google.com/spreadsheets/d/spreadsheet-a/edit',
+          sheetName: 'cashflow(사용내역 연동)',
+        },
+      },
+    });
+    const javaWeeklyClient = {
+      applyCashflowSheetBatch: vi.fn(),
+      applyCashflowSheetLab: vi.fn(),
+      applyCashflowSheetAnnualTotal: vi.fn(),
+      getCashflowSheetOperationStatus: vi.fn(),
+      getCashflowSnapshot: vi.fn(async () => ({
+        projectId: 'project-a',
+        projection: [],
+        actual: [],
+      })),
+    };
+    const app = createApp({
+      db,
+      routeOptions: { javaWeeklyClient },
+    });
+
+    const response = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/changes/check')
+      .send({})
+      .expect(200);
+
+    expect(response.body).toEqual({
+      status: 'CHANGED',
+      pendingChangeCount: 1920,
+      projectionChangeCount: 960,
+      actualChangeCount: 960,
+      sourceRevision: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      targetRevision: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      checkedAt: expect.stringMatching(/^2026-|^20\d{2}-/),
+    });
+    expect(javaWeeklyClient.applyCashflowSheetBatch).not.toHaveBeenCalled();
+    expect(javaWeeklyClient.applyCashflowSheetLab).not.toHaveBeenCalled();
+    expect(javaWeeklyClient.applyCashflowSheetAnnualTotal).not.toHaveBeenCalled();
+    expect(javaWeeklyClient.getCashflowSheetOperationStatus).not.toHaveBeenCalled();
+    expect(javaWeeklyClient.getCashflowSnapshot).toHaveBeenCalledOnce();
+    expect(javaWeeklyClient.getCashflowSnapshot).toHaveBeenCalledWith(expect.objectContaining({
+      projectId: 'project-a',
+    }));
+  });
+
+  it('returns UNAVAILABLE instead of diffing against stale Firestore data when JVM canonical differs', async () => {
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        contractStart: '2026-01-01',
+        contractEnd: '2026-12-31',
+        cashflowSheetLab: {
+          sourceYear: 2026,
+          value: 'https://docs.google.com/spreadsheets/d/spreadsheet-a/edit',
+          sheetName: 'cashflow(사용내역 연동)',
+        },
+      },
+      weeks: [{
+        id: 'project-a-2026-01-w1',
+        projectId: 'project-a',
+        yearMonth: '2026-01',
+        weekNo: 1,
+        projection: { SALES_IN: 1 },
+        actual: {},
+      }],
+    });
+    const javaWeeklyClient = {
+      applyCashflowSheetBatch: vi.fn(),
+      applyCashflowSheetLab: vi.fn(),
+      applyCashflowSheetAnnualTotal: vi.fn(),
+      getCashflowSheetOperationStatus: vi.fn(),
+      getCashflowSnapshot: vi.fn(async () => ({ projectId: 'project-a', projection: [], actual: [] })),
+    };
+
+    const response = await request(createApp({ db, routeOptions: { javaWeeklyClient } }))
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/changes/check')
+      .send({})
+      .expect(200);
+
+    expect(response.body).toEqual({
+      status: 'UNAVAILABLE',
+      pendingChangeCount: 0,
+      projectionChangeCount: 0,
+      actualChangeCount: 0,
+      sourceRevision: '',
+      targetRevision: '',
+      checkedAt: expect.stringMatching(/^20\d{2}-/),
+    });
+    expect(javaWeeklyClient.applyCashflowSheetBatch).not.toHaveBeenCalled();
+    expect(javaWeeklyClient.applyCashflowSheetLab).not.toHaveBeenCalled();
+    expect(javaWeeklyClient.applyCashflowSheetAnnualTotal).not.toHaveBeenCalled();
+  });
+
+  it('returns SYNCED with zero pending changes when the fresh sheet already matches JVM canonical', async () => {
+    const yearMonths = Array.from({ length: 12 }, (_unused, index) => `2026-${String(index + 1).padStart(2, '0')}`);
+    const weeks = matchingCanonicalWeeks(1920, yearMonths);
+    const javaWeeklyClient = {
+      applyCashflowSheetBatch: vi.fn(),
+      applyCashflowSheetLab: vi.fn(),
+      applyCashflowSheetAnnualTotal: vi.fn(),
+      getCashflowSheetOperationStatus: vi.fn(),
+      getCashflowSnapshot: vi.fn(async () => ({
+        projectId: 'project-a',
+        projection: weeks.flatMap((week) => Object.entries(week.projection || {}).map(([cashflowLine, amount]) => ({
+          yearMonth: week.yearMonth,
+          weekNo: week.weekNo,
+          cashflowLine,
+          amount,
+        }))),
+        actual: weeks.flatMap((week) => Object.entries(week.actual || {}).map(([cashflowLine, amount]) => ({
+          sheetKey: 'cashflow-sheet-lab',
+          yearMonth: week.yearMonth,
+          weekNo: week.weekNo,
+          cashflowLine,
+          amount,
+        }))),
+      })),
+    };
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        contractStart: '2026-01-01',
+        contractEnd: '2026-12-31',
+        cashflowSheetLab: {
+          sourceYear: 2026,
+          value: 'https://docs.google.com/spreadsheets/d/spreadsheet-a/edit',
+          sheetName: 'cashflow(사용내역 연동)',
+        },
+      },
+      weeks,
+    });
+
+    const response = await request(createApp({ db, routeOptions: { javaWeeklyClient } }))
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/changes/check')
+      .send({})
+      .expect(200);
+
+    expect(response.body).toEqual({
+      status: 'SYNCED',
+      pendingChangeCount: 0,
+      projectionChangeCount: 0,
+      actualChangeCount: 0,
+      sourceRevision: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      targetRevision: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      checkedAt: expect.stringMatching(/^20\d{2}-/),
+    });
+    expect(javaWeeklyClient.applyCashflowSheetBatch).not.toHaveBeenCalled();
+    expect(javaWeeklyClient.applyCashflowSheetLab).not.toHaveBeenCalled();
+    expect(javaWeeklyClient.applyCashflowSheetAnnualTotal).not.toHaveBeenCalled();
   });
 
   it('reads Google Sheets only on explicit mirror refresh and pins the result', async () => {

--- a/server/bff/scheduler-config.test.ts
+++ b/server/bff/scheduler-config.test.ts
@@ -5,15 +5,19 @@ import { describe, expect, it } from 'vitest';
 const repoRoot = resolve(__dirname, '../..');
 const vercelConfig = JSON.parse(readFileSync(resolve(repoRoot, 'vercel.json'), 'utf8'));
 
-const VERCEL_OWNED_WORKERS = new Set([
-  '/api/internal/workers/work-queue/run',
-  '/api/internal/workers/outbox/run',
-  '/api/internal/workers/payroll/run',
+const VERCEL_OWNED_WORKERS = new Map([
+  ['/api/internal/workers/work-queue/run', '15 2 * * *'],
+  ['/api/internal/workers/outbox/run', '30 2 * * *'],
+  ['/api/internal/workers/payroll/run', '45 2 * * *'],
+  ['/api/internal/workers/cashflow-sheet-sync/run', '30 0 * * 4'],
 ]);
 
 describe('scheduler ownership config', () => {
   it('keeps every Vercel cron on the documented Vercel-owned worker set', () => {
-    const cronPaths = new Set((vercelConfig.crons || []).map((cron: { path: string }) => cron.path));
+    const cronPaths = new Map((vercelConfig.crons || []).map((cron: { path: string; schedule: string }) => [
+      cron.path,
+      cron.schedule,
+    ]));
 
     expect(cronPaths).toEqual(VERCEL_OWNED_WORKERS);
   });
@@ -24,8 +28,12 @@ describe('scheduler ownership config', () => {
       rewrite.destination,
     ]));
 
-    for (const workerPath of VERCEL_OWNED_WORKERS) {
+    for (const workerPath of VERCEL_OWNED_WORKERS.keys()) {
       expect(rewrites.get(workerPath)).toBe(`/api/bff?__path=${workerPath}`);
     }
+  });
+
+  it('allows the cashflow sheet sync enough runtime to finish every connected project', () => {
+    expect(vercelConfig.functions?.['api/bff.js']?.maxDuration).toBeGreaterThanOrEqual(300);
   });
 });

--- a/server/bff/worker-endpoints.test.ts
+++ b/server/bff/worker-endpoints.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import request from 'supertest';
 import { createBffApp } from './app.mjs';
 
@@ -11,6 +11,7 @@ const INTERNAL_WORKER_PATHS = [
   '/api/internal/workers/work-queue/run',
   '/api/internal/workers/payroll/run',
   '/api/internal/workers/client-errors/run',
+  '/api/internal/workers/cashflow-sheet-sync/run',
 ];
 
 function createTestApp(options: Parameters<typeof createBffApp>[0] = {}) {
@@ -140,6 +141,71 @@ describe('internal worker endpoints (cron)', () => {
 
     expect(res.status).toBe(401);
     expect(res.body?.error).toBe('unauthorized_worker');
+  });
+
+  it('runs the cashflow sheet sync only with the Vercel cron bearer token', async () => {
+    const cashflowSheetSyncWorker = vi.fn(async () => ({
+      ok: true,
+      tenantId: 'mysc',
+      discoveredProjects: 2,
+      processedProjects: 2,
+      succeededProjects: 2,
+      failedProjects: 0,
+    }));
+    const app = createTestApp({
+      projectId: LIVE_PROJECT_ID,
+      allowedOrigins: [LIVE_ORIGIN],
+      cashflowSheetSyncWorker,
+      env: {
+        BFF_DEPLOY_ENV: 'live',
+        BFF_SCHEDULER_OWNER: 'vercel',
+        CRON_SECRET: LONG_CRON_SECRET,
+      },
+    });
+
+    const res = await request(app)
+      .get('/api/internal/workers/cashflow-sheet-sync/run')
+      .set('Authorization', `Bearer ${LONG_CRON_SECRET}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      ok: true,
+      worker: 'cashflow_sheet_sync',
+      discoveredProjects: 2,
+      processedProjects: 2,
+    });
+    expect(cashflowSheetSyncWorker).toHaveBeenCalledOnce();
+  });
+
+  it('reuses the same KST schedule run ID when Vercel retries the Thursday cron', async () => {
+    const cashflowSheetSyncWorker = vi.fn(async ({ runId }) => ({
+      ok: true,
+      runId,
+      discoveredProjects: 0,
+      processedProjects: 0,
+    }));
+    const app = createTestApp({
+      projectId: LIVE_PROJECT_ID,
+      allowedOrigins: [LIVE_ORIGIN],
+      cashflowSheetSyncWorker,
+      now: () => '2026-08-06T00:30:00.000Z',
+      env: {
+        BFF_DEPLOY_ENV: 'live',
+        BFF_SCHEDULER_OWNER: 'vercel',
+        CRON_SECRET: LONG_CRON_SECRET,
+      },
+    });
+
+    for (let retry = 0; retry < 2; retry += 1) {
+      await request(app)
+        .get('/api/internal/workers/cashflow-sheet-sync/run')
+        .set('Authorization', `Bearer ${LONG_CRON_SECRET}`)
+        .expect(200);
+    }
+
+    expect(cashflowSheetSyncWorker).toHaveBeenCalledTimes(2);
+    expect(cashflowSheetSyncWorker.mock.calls[0][0].runId).toBe('cashflow-sheet-sync:2026-08-06');
+    expect(cashflowSheetSyncWorker.mock.calls[1][0].runId).toBe('cashflow-sheet-sync:2026-08-06');
   });
 
   it('rejects unsafe runtime configuration before creating the Firestore client', () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -295,6 +295,23 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain('setInterval');
   });
 
+  it('checks linked sheet changes on entry without applying them', () => {
+    expect(source).toContain('checkCashflowSheetChangesViaBff');
+    expect(source).toContain("setCashflowSheetChangeCheck({ status: 'CHECKING', pendingChangeCount: null })");
+    expect(source).toContain("result.status === 'CHANGED' ? result.pendingChangeCount : null");
+    expect(source).toContain('이전 대비 변동 사항 ${(cashflowSheetChangeCheck.pendingChangeCount || 0).toLocaleString()}건 · 새로 반영이 필요합니다');
+    expect(source).toContain('시트와 동기화됨');
+    expect(source).toContain('시트 변경 확인 불가');
+    expect(source).toContain('시트 이동');
+
+    const checkFlow = source.slice(
+      source.indexOf('const checkSheetChanges = async'),
+      source.indexOf('void checkSheetChanges();'),
+    );
+    expect(checkFlow).not.toContain('applyCashflowSheetLabViaBff');
+    expect(checkFlow).not.toContain('refreshCashflowSheetLabMirrorViaBff');
+  });
+
   it('keeps the sheet refresh loading state open until the successful response is processed', () => {
     expect(source).toContain('CashflowSheetSyncOverlay');
     expect(source).toContain('{sheetRefreshLoading ? <CashflowSheetSyncOverlay operation="refresh" /> : null}');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -60,6 +60,7 @@ import type { CashflowOpsTone } from './cashflow-ops-summary';
 import {
   applyCashflowSheetLabViaBff,
   cashflowFormulaMismatchesFromError,
+  checkCashflowSheetChangesViaBff,
   getCashflowSheetLabApplyStatusViaBff,
   getCashflowSheetLabMirrorViaBff,
   getCashflowSheetLabShareAccountViaBff,
@@ -67,6 +68,7 @@ import {
   refreshCashflowSheetLabMirrorViaBff,
   stageCashflowSheetLabViaBff,
   type CashflowSheetLabMirrorResult,
+  type CashflowSheetChangeCheckResult,
   type CashflowSheetLabShareAccountResult,
   type CashflowSheetLabStageResult,
   type CashflowFormulaMismatch,
@@ -378,6 +380,10 @@ export function CashflowProjectSheet({
     lastActualLineCount?: number;
   } | null>(null);
   const [cashflowSheetConfigLoaded, setCashflowSheetConfigLoaded] = useState(false);
+  const [cashflowSheetChangeCheck, setCashflowSheetChangeCheck] = useState<{
+    status: CashflowSheetChangeCheckResult['status'];
+    pendingChangeCount: number | null;
+  } | null>(null);
   const [cashflowSystemAccountEmail, setCashflowSystemAccountEmail] = useState('');
   const [cashflowSystemAccountError, setCashflowSystemAccountError] = useState(false);
   const [cashflowSheetMirror, setCashflowSheetMirror] = useState<CashflowSheetLabMirrorResult | null>(null);
@@ -564,6 +570,60 @@ export function CashflowProjectSheet({
       cancelled = true;
     };
   }, [orgId, projectId, resolveBffActor, selectedYear, user?.uid]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setCashflowSheetChangeCheck(null);
+    if (!cashflowSheetConfigLoaded || !cashflowSheetConfig?.value || !projectId || !orgId || !user?.uid) {
+      return () => { cancelled = true; };
+    }
+
+    setCashflowSheetChangeCheck({ status: 'CHECKING', pendingChangeCount: null });
+    const checkSheetChanges = async (): Promise<void> => {
+      try {
+        let actor = await resolveBffActor();
+        if (!actor?.idToken) throw new Error('Cashflow sheet change check requires authentication.');
+        let result: CashflowSheetChangeCheckResult;
+        try {
+          result = await checkCashflowSheetChangesViaBff({
+            tenantId: orgId,
+            actor,
+            projectId,
+            sourceYear: cashflowSheetConfig.sourceYear || selectedYear,
+          });
+        } catch (error) {
+          if (!isBffAuthRejection(error)) throw error;
+          actor = await resolveBffActor({ forceRefresh: true });
+          if (!actor?.idToken) throw error;
+          result = await checkCashflowSheetChangesViaBff({
+            tenantId: orgId,
+            actor,
+            projectId,
+            sourceYear: cashflowSheetConfig.sourceYear || selectedYear,
+          });
+        }
+        if (!cancelled) {
+          setCashflowSheetChangeCheck({
+            status: result.status,
+            pendingChangeCount: result.status === 'CHANGED' ? result.pendingChangeCount : null,
+          });
+        }
+      } catch {
+        if (!cancelled) setCashflowSheetChangeCheck({ status: 'UNAVAILABLE', pendingChangeCount: null });
+      }
+    };
+    void checkSheetChanges();
+    return () => { cancelled = true; };
+  }, [
+    cashflowSheetConfig?.sourceYear,
+    cashflowSheetConfig?.value,
+    cashflowSheetConfigLoaded,
+    orgId,
+    projectId,
+    resolveBffActor,
+    selectedYear,
+    user?.uid,
+  ]);
 
   useEffect(() => {
     if (!cashflowSheetConfigLoaded || cashflowSheetConfig || !projectId || typeof window === 'undefined') return;
@@ -1789,6 +1849,22 @@ export function CashflowProjectSheet({
   const sheetIdentityLabel = cashflowSheetConfig
     ? cashflowSheetConfig.spreadsheetTitle || cashflowSheetConfig.spreadsheetId || 'Google Sheet'
     : '시트 연결 필요';
+  const sheetChangeBadgeLabel = cashflowSheetChangeCheck?.status === 'CHECKING'
+    ? '시트 변경 확인 중'
+    : cashflowSheetChangeCheck?.status === 'SYNCED'
+      ? '시트와 동기화됨'
+      : cashflowSheetChangeCheck?.status === 'CHANGED'
+        ? `이전 대비 변동 사항 ${(cashflowSheetChangeCheck.pendingChangeCount || 0).toLocaleString()}건 · 새로 반영이 필요합니다`
+        : cashflowSheetChangeCheck?.status === 'UNAVAILABLE'
+          ? '시트 변경 확인 불가'
+          : '';
+  const sheetChangeBadgeClass = cashflowSheetChangeCheck?.status === 'SYNCED'
+    ? 'border-emerald-200 bg-emerald-50 text-emerald-800'
+    : cashflowSheetChangeCheck?.status === 'CHANGED'
+      ? 'border-yellow-300 bg-yellow-50 text-yellow-900'
+      : cashflowSheetChangeCheck?.status === 'UNAVAILABLE'
+        ? 'border-red-200 bg-red-50 text-red-800'
+        : 'border-slate-200 bg-slate-50 text-slate-600';
   const sheetMirrorStatus = cashflowSheetMirror?.status || 'EMPTY';
   const sheetMirrorCapturedAt = formatSheetAppliedAt(cashflowSheetMirror?.capturedAt)
     || cashflowSheetMirror?.capturedAt
@@ -2609,7 +2685,7 @@ export function CashflowProjectSheet({
       <Card className="overflow-hidden rounded-lg border border-border bg-card shadow-sm">
         <CardContent className="space-y-3 p-4">
           <div className="flex items-center justify-between gap-3">
-            <div className="flex min-w-0 items-center gap-2">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
               <ClipboardList className="h-4 w-4 shrink-0 text-primary" />
               <div className="truncate text-[16px] font-bold tracking-[-0.01em] text-card-foreground">{dashboardTitle}</div>
               <Button
@@ -2623,6 +2699,27 @@ export function CashflowProjectSheet({
               >
                 {cashflowSheetConfig ? '시트 설정' : '시트 연결'}
               </Button>
+              {cashflowSheetConfig && sheetChangeBadgeLabel ? (
+                <Badge
+                  role="status"
+                  className={`h-7 rounded-md border px-2.5 text-[12px] font-semibold shadow-none ${sheetChangeBadgeClass}`}
+                >
+                  {cashflowSheetChangeCheck?.status === 'CHECKING' ? <Loader2 className="mr-1 h-3 w-3 animate-spin" /> : null}
+                  {sheetChangeBadgeLabel}
+                </Badge>
+              ) : null}
+              {cashflowSheetConfig ? (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 shrink-0 px-2 text-[12px] font-semibold text-[#17324D]"
+                  onClick={() => navigate(`/portal/cashflow/${encodeURIComponent(projectId)}/sheets-lab`)}
+                >
+                  <FileSpreadsheet className="mr-1 h-3 w-3" />
+                  시트 이동
+                </Button>
+              ) : null}
               {cashflowSheetConfig ? (
                 <Button
                   type="button"

--- a/src/app/lib/sheets-cashflow-readonly-client.test.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.test.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import {
   applyCashflowSheetLabViaBff,
+  checkCashflowSheetChangesViaBff,
   extractSpreadsheetIdFromSheetInput,
   getCashflowSheetLabMirrorViaBff,
   getCashflowSheetLabShareAccountViaBff,
@@ -229,6 +230,43 @@ describe('sheets cashflow readonly client', () => {
       expect.objectContaining({ tenantId: 'mysc' }),
     );
     expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('checks sheet changes without applying or refreshing canonical values', async () => {
+    const client = asMockClient({
+      post: vi.fn(async () => ({
+        data: {
+          status: 'CHANGED',
+          pendingChangeCount: 31,
+          projectionChangeCount: 18,
+          actualChangeCount: 13,
+          sourceRevision: 'sha256:source-001',
+          targetRevision: 'sha256:target-001',
+          checkedAt: '2026-08-06T02:30:00.000Z',
+        },
+      })),
+    });
+
+    const result = await checkCashflowSheetChangesViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'user-1', role: 'workspace_user', email: 'user@mysc.co.kr' },
+      projectId: 'p001',
+      sourceYear: 2026,
+      client,
+    });
+
+    expect(result).toMatchObject({ status: 'CHANGED', pendingChangeCount: 31 });
+    expect(client.post).toHaveBeenCalledTimes(1);
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/v1/projects/p001/cashflow-sheet-lab/changes/check',
+      expect.objectContaining({
+        tenantId: 'mysc',
+        body: { sourceYear: 2026 },
+        retries: 0,
+      }),
+    );
+    expect(client.post.mock.calls[0]?.[0]).not.toContain('/apply');
+    expect(client.post.mock.calls[0]?.[0]).not.toContain('/mirror/refresh');
   });
 
   it('reads the server-owned annual view for the selected year', async () => {

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -636,6 +636,16 @@ export interface CashflowSheetLabShareAccountResult {
   };
 }
 
+export interface CashflowSheetChangeCheckResult {
+  status: 'CHECKING' | 'SYNCED' | 'CHANGED' | 'UNAVAILABLE';
+  pendingChangeCount: number;
+  projectionChangeCount: number;
+  actualChangeCount: number;
+  sourceRevision: string;
+  targetRevision: string;
+  checkedAt: string;
+}
+
 export const extractSpreadsheetIdFromSheetInput = extractSpreadsheetId;
 
 let sameOriginBffClient: PlatformApiClient | undefined;
@@ -896,6 +906,27 @@ export async function getCashflowSheetLabShareAccountViaBff(params: {
       tenantId: params.tenantId,
       actor: toRequestActor(params.actor),
       timeoutMs: 15000,
+      retries: 0,
+    },
+  );
+  return response.data;
+}
+
+export async function checkCashflowSheetChangesViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectId: string;
+  sourceYear: number;
+  client?: PlatformApiClientLike;
+}): Promise<CashflowSheetChangeCheckResult> {
+  const apiClient = params.client || createSameOriginBffClient();
+  const response = await apiClient.post<CashflowSheetChangeCheckResult>(
+    `/api/v1/projects/${encodeURIComponent(params.projectId)}/cashflow-sheet-lab/changes/check`,
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      body: { sourceYear: params.sourceYear },
+      timeoutMs: 30000,
       retries: 0,
     },
   );

--- a/vercel.json
+++ b/vercel.json
@@ -10,7 +10,7 @@
   },
   "functions": {
     "api/bff.js": {
-      "maxDuration": 60
+      "maxDuration": 300
     }
   },
   "crons": [
@@ -25,6 +25,10 @@
     {
       "path": "/api/internal/workers/payroll/run",
       "schedule": "45 2 * * *"
+    },
+    {
+      "path": "/api/internal/workers/cashflow-sheet-sync/run",
+      "schedule": "30 0 * * 4"
     }
   ],
   "redirects": [
@@ -124,6 +128,10 @@
     {
       "source": "/api/internal/workers/payroll/run",
       "destination": "/api/bff?__path=/api/internal/workers/payroll/run"
+    },
+    {
+      "source": "/api/internal/workers/cashflow-sheet-sync/run",
+      "destination": "/api/bff?__path=/api/internal/workers/cashflow-sheet-sync/run"
     },
     {
       "source": "/api/internal/workers/client-errors/run",


### PR DESCRIPTION
## What\n- compare fresh Google Sheet snapshots with JVM canonical cashflow and show pending change status/count\n- add a small sheet navigation action without forcing page refresh\n- sync connected project sheets every Thursday at 09:30 KST through the existing guarded apply path\n- fail closed on JVM/Firestore drift, unknown lines, stale revisions, locks, and post-apply mismatch\n\n## Why\nThe UI could show stale JVM values after the source Sheet changed, with no indication that a new explicit apply was needed.\n\n## Verification\n- focused frontend/server tests: 191 passed\n- npm test: passed on final run (independent QA observed one transient socket hang-up; isolated retry passed)\n- npm run bff:test:integration: passed\n- npm run build: passed\n- git diff --check: passed\n\n## Ops\n- adds Vercel cron: 30 0 * * 4 (Thursday 09:30 Asia/Seoul)\n- raises api/bff.js maxDuration to 300s for 34 currently connected projects\n- production deploy remains GitHub Actions on main only