### PR TITLE
fix(cashflow): compare Sheet, JVM, and stored values

### DIFF
--- a/.gstack/sprint-contract-2026-08-06-cashflow-sheet-jvm-diff.md
+++ b/.gstack/sprint-contract-2026-08-06-cashflow-sheet-jvm-diff.md
@@ -1,97 +1,95 @@
-# Sprint Contract: Google Sheet–JVM 변동 감지 및 목요일 자동 동기화
+# Sprint Contract: Cashflow 3-Way Drift Detection
+
+**SPP:** Specification–Policy–Proof
 **날짜:** 2026-08-06
-**예상 소요:** 4~6시간 + CI/배포 검증
 **상태:** APPROVED
+**대체 대상:** Google Sheet–JVM 변동 감지 및 목요일 자동 동기화 계약
 
-## Objective
-연결된 Google Sheet의 canonical 현금흐름 셀과 JVM `cashflow_weeks`를 동일한 기준으로 비교한다. 미반영 변경은 프로젝트 화면에 건수로 표시하고, 매주 목요일 18:00 Asia/Seoul에 연결된 프로젝트를 자동 동기화한다. 반영 성공은 JVM post-write read가 고정 snapshot과 일치할 때만 확정한다.
+## S — Specification
 
-## 불변조건
-- `SYNCED`는 Sheet snapshot과 JVM canonical cells가 동일할 때만 반환한다.
-- `EMPTY`, `ZERO`, `VALUE`는 서로 다른 상태다.
-- 확인 요청은 JVM을 변경하지 않는다.
-- 자동/수동 apply 모두 `snapshot -> apply -> JVM read-back` 순서를 지킨다.
-- 한 프로젝트의 실패는 다른 프로젝트 동기화를 중단하지 않는다.
-- 결산 잠금, 승인 확인, stale revision 충돌을 자동으로 우회하지 않는다.
+Google Sheet(S), JVM(J), Firestore(F)의 canonical 현금흐름 값을 독립적으로 비교한다. 값이 다르다는 이유만으로 특정 저장소를 오류로 단정하거나 자동 반영하지 않는다.
 
-## 상태 계약
-- `CHECKING`: 외부 시트 또는 JVM 비교 진행 중
-- `SYNCED`: canonical diff 0건
-- `CHANGED`: canonical diff 1건 이상
-- `UNAVAILABLE`: Sheet/JVM 조회 또는 비교 실패. 0건으로 대체하지 않는다.
+비교 키는 `sourceYear + yearMonth + weekNo + mode + cashflowLine`이며 `Projection`, `Actual`, `EMPTY`, `ZERO`, `VALUE`, 실제 금액을 비교한다. 서식, 메모, 합계·잔액 행, effective value가 같은 수식 변경, 연결 범위 밖 셀은 제외한다.
 
-## 변경 건수
-키는 `sourceYear + yearMonth + weekNo + mode + cashflowLine`이다. `cellState` 또는 `amount`가 다르면 1건이다. 서식, 메모, 동일 effective value의 수식 변경, 합계/잔액 행, 연결 범위 밖 셀은 제외한다.
+### 상태 분류
 
-## 목요일 자동 동기화
-- Vercel cron: `0 9 * * 4` (목요일 18:00 Asia/Seoul)
-- 대상: 시트 연결 설정이 있는 프로젝트
-- 프로젝트별: snapshot 보존 -> diff -> 변경이 있을 때만 기존 apply -> JVM read-back
-- no-op 프로젝트는 쓰지 않는다.
-- idempotency key는 해당 KST 실행 회차와 projectId로 고정한다.
-- 중복 실행은 같은 결과를 재사용하며 동시 실행으로 두 번 적용하지 않는다.
-- 잠긴 범위 또는 확인이 필요한 변경은 실패/보류로 기록하고 강제 반영하지 않는다.
+| 관찰 결과 | classification |
+|---|---|
+| S=J=F | `ALL_SYNCED` |
+| S=J≠F | `FIRESTORE_DIFFERS` |
+| S=F≠J | `JVM_DIFFERS` |
+| J=F≠S | `SHEET_DIFFERS` |
+| S≠J≠F | `THREE_WAY_DIFFERENT` |
+| 일부 조회 실패 | `PARTIAL` |
 
-## 서버 응답 계약
-```json
-{
-  "status": "CHANGED",
-  "pendingChangeCount": 31,
-  "projectionChangeCount": 18,
-  "actualChangeCount": 13,
-  "sourceRevision": "sha256:...",
-  "targetRevision": "sha256:...",
-  "checkedAt": "2026-08-06T02:30:00.000Z"
-}
-```
+분류는 원인을 추측하지 않고 관찰된 차이만 설명한다. API는 `sheetToJvm`, `sheetToFirestore`, `jvmToFirestore` 각각의 availability와 전체/Projection/Actual 변경 건수를 반환한다. 한 저장소를 읽지 못하면 그 저장소가 포함된 비교만 `UNAVAILABLE`로 표시한다.
 
-## Unit test 성공 기준
-- 동일 cell 집합은 0건이다.
-- `EMPTY <-> ZERO`, `ZERO <-> VALUE`, `EMPTY <-> VALUE`, 금액 변경은 각각 1건이다.
-- 수식만 바뀌고 effective value가 같으면 0건이다.
-- Projection/Actual 건수의 합은 총 건수와 같다.
-- 중복 canonical key와 알 수 없는 line은 성공으로 숨기지 않는다.
-- Sheet API/JVM 실패는 `UNAVAILABLE`이다.
-- legacy 12개 line의 누락 4개를 0으로 만들지 않는다.
-- Projection을 Actual로 fallback하지 않는다.
-- apply 후 셀 1개라도 다르면 성공하지 않는다.
-- stale source revision, 부분 저장, read-back 실패는 실패한다.
-- 같은 idempotency key는 중복 쓰기 없이 replay된다.
-- cron은 목요일 18:00 KST에만 실행 대상을 만든다.
-- 연결 없는 프로젝트, no-op 프로젝트는 apply하지 않는다.
-- 프로젝트 A 실패 후 프로젝트 B는 계속 처리한다.
-- cron 인증 실패는 401/403이며 어떤 프로젝트도 변경하지 않는다.
-- 프론트는 `CHANGED/N`을 `이전 대비 변동 사항 N건 · 새로 반영이 필요합니다`로 표시한다.
-- 작은 `시트 이동` 버튼은 기존 시트 설정 화면으로 이동한다.
-- 상태 확인만으로 apply가 호출되지 않는다.
+### UI
 
-## 통합 성공 기준
-- QA fixture `Sheet Projection 249,199,960 / JVM 218,236,560`은 `CHANGED`이고 차액을 숨기지 않는다.
-- 정상 apply 후 JVM Projection은 249,199,960이고 diff는 0건이다.
-- 31건 중 30건만 저장되면 apply는 실패한다.
-- 자동 동기화 run은 프로젝트별 결과와 revision을 감사 기록에 남긴다.
+- `시트 이동`은 프로젝트에 등록된 Google Sheet URL을 새 탭으로 연다.
+- `시트 ↔ JVM`, `시트 ↔ 저장값`, `JVM ↔ 저장값`별 변경 건수를 표시한다.
+- 조회 실패를 `0건`으로 표시하지 않는다.
+- 사용자 화면을 강제로 새로고침하지 않는다.
 
-## 실패 기준
-- 마지막 refresh 성공만으로 `SYNCED/FRESH`를 표시한다.
-- 프론트가 자체 diff를 계산한다.
-- API/JVM 실패를 0건으로 표시한다.
-- apply 후 read-back 없이 성공 처리한다.
-- 자동 동기화가 잠금/승인 정책을 우회한다.
-- 사용자 화면을 강제 refresh한다.
-- 테스트를 skip하거나 실제 크기보다 축소된 예제로만 검증한다.
+## P — Policy
 
-## 범위 밖
-- 실시간 polling
-- Google Sheet 편집
-- 계산 공식 변경
-- 결산 상태 모델 재설계
-- AXR–CMK QA 연결 교체
+- 변동 확인은 read-only다.
+- JVM과 Firestore가 달라도 조회를 차단하지 않는다.
+- 어떤 값이 정답인지 시스템이 자동 결정하지 않는다.
+- 목요일 18시 worker는 비교와 감사 기록만 수행하며 canonical 값을 쓰지 않는다.
+- 기존 명시적 `반영` 버튼만 쓰기 경로로 유지한다.
+- 수동 반영은 `고정 Sheet snapshot → 잠금·승인·revision 검증 → JVM 반영 → JVM read-back` 순서를 지킨다.
+- 이번 스프린트에서 Firestore 불일치를 자동 복구하지 않는다.
+- Google Sheet 자체를 읽지 못했을 때만 `시트 변경 확인 불가`를 표시한다.
 
-## 검증 명령
+## P — Proof
+
+### Unit
+
+- `S=J=F`, `S=J≠F`, `S=F≠J`, `J=F≠S`, `S≠J≠F`를 모두 검증한다.
+- `EMPTY ↔ ZERO ↔ VALUE` 전이를 각각 1건으로 계산한다.
+- JVM 또는 Firestore 한쪽 실패 시 가능한 다른 비교를 유지한다.
+- 중복 key와 알 수 없는 line을 0건으로 숨기지 않는다.
+- 확인 endpoint와 목요일 worker에서 apply/canonical write 호출이 0회다.
+
+### Integration
+
+- AXR fixture의 `Projection 249,199,960원 / 218,236,560원` 차이를 숨기지 않는다.
+- JVM과 Firestore가 달라도 Sheet 비교 API가 성공한다.
+- 반복 확인 요청이 canonical 데이터를 바꾸지 않는다.
+- 수동 반영은 JVM read-back이 일치해야만 성공한다.
+
+### Browser
+
+- 실제 등록 Sheet가 새 탭으로 열리고 Sheet Lab으로 이동하지 않는다.
+- 로딩 중 오류 문구를 표시하지 않는다.
+- 부분 실패 시 확인 가능한 비교는 계속 표시한다.
+- 자동 또는 강제 refresh가 발생하지 않는다.
+
+### Regression commands
+
 ```bash
 npx vitest run src/app/components/cashflow/CashflowProjectSheet.shell.test.ts src/app/lib/sheets-cashflow-readonly-client.test.ts
-node --test server/bff/cashflow-sheet-snapshot.test.mjs server/bff/routes/cashflow-sheet-lab.test.mjs server/bff/worker-endpoints.test.ts server/bff/scheduler-config.test.ts
+npx vitest run server/bff/cashflow-sheet-snapshot.test.mjs server/bff/routes/cashflow-sheet-lab.test.mjs server/bff/worker-endpoints.test.ts server/bff/scheduler-config.test.ts
 npm test
 npm run bff:test:integration
 npm run build
 ```
+
+## 실패 판정
+
+- JVM/Firestore 불일치가 Sheet 비교를 차단한다.
+- 조회 실패를 변동 0건으로 표시한다.
+- cron이 apply 또는 canonical write를 호출한다.
+- 프론트가 자체 금액 diff를 계산한다.
+- `시트 이동`이 Sheet Lab을 연다.
+- 실제 AXR 데이터 경로 없이 mock 테스트만 통과한다.
+
+## 범위 밖
+
+- 자동 동기화 및 자동 복구
+- 정답 저장소 자동 선정
+- 결산 상태 모델 변경
+- Google Sheet 직접 수정
+- 실시간 polling
+- 새로운 비교 프레임워크나 의존성 추가

--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -726,7 +726,7 @@ export function createBffApp(options = {}) {
   const driveService = options.driveService || createGoogleDriveService();
   const googleSheetsService = options.googleSheetsService || createGoogleSheetsService();
   const googleSheetMigrationAiService = options.googleSheetMigrationAiService || createGoogleSheetMigrationAiService();
-  let cashflowSheetSyncProject = null;
+  let cashflowSheetCompareProject = null;
   const projectRequestContractAiService = options.projectRequestContractAiService || createProjectRequestContractAiService();
   const projectRequestContractStorageService = options.projectRequestContractStorageService || createProjectRequestContractStorageService({ projectId });
   const projectRegistrationDraftStorageService = options.projectRegistrationDraftStorageService
@@ -1036,14 +1036,13 @@ export function createBffApp(options = {}) {
       concurrency: 4,
       runId,
       syncProject: ({ tenantId: projectTenantId, projectId: cashflowProjectId, runId: projectRunId }) => {
-        if (typeof cashflowSheetSyncProject !== 'function') {
-          throw createHttpError(503, 'Cashflow sheet sync is not configured.', 'cashflow_sheet_sync_unconfigured');
+        if (typeof cashflowSheetCompareProject !== 'function') {
+          throw createHttpError(503, 'Cashflow sheet comparison is not configured.', 'cashflow_sheet_comparison_unconfigured');
         }
-        return cashflowSheetSyncProject({
+        return cashflowSheetCompareProject({
           tenantId: projectTenantId,
           projectId: cashflowProjectId,
           runId: projectRunId,
-          apply: true,
         });
       },
     });
@@ -1553,7 +1552,7 @@ export function createBffApp(options = {}) {
     env,
     javaWeeklyClient: options.javaWeeklyClient,
   });
-  cashflowSheetSyncProject = cashflowSheetLabRoutes?.syncProject || null;
+  cashflowSheetCompareProject = cashflowSheetLabRoutes?.compareProject || null;
   mountCashflowLaborRiskRoutes(app, {
     db,
     now,

--- a/server/bff/cashflow-sheet-sync-worker.mjs
+++ b/server/bff/cashflow-sheet-sync-worker.mjs
@@ -74,9 +74,9 @@ export async function runCashflowSheetSyncWorker(db, {
       failures.push(failureSummary(projects[index].id, result.reason));
       return;
     }
-    changedCount += Math.max(0, Number(result.value?.changedCount) || 0);
+    changedCount += Math.max(0, Number(result.value?.comparisons?.sheetToJvm?.changeCount) || 0);
     appliedCount += Math.max(0, Number(result.value?.appliedCount) || 0);
-    if (['SYNCED', 'NO_CHANGES'].includes(readOptionalText(result.value?.status))) noChangeProjects += 1;
+    if (readOptionalText(result.value?.classification) === 'ALL_SYNCED') noChangeProjects += 1;
   });
 
   return {

--- a/server/bff/cashflow-sheet-sync-worker.test.mjs
+++ b/server/bff/cashflow-sheet-sync-worker.test.mjs
@@ -36,8 +36,8 @@ describe('cashflow sheet sync worker', () => {
       active -= 1;
       if (projectId === 'project-b') throw Object.assign(new Error('sheet denied'), { code: 'sheet_denied' });
       return projectId === 'project-a'
-        ? { changedCount: 0, appliedCount: 0, status: 'NO_CHANGES' }
-        : { changedCount: 3, appliedCount: 1, status: 'APPLIED' };
+        ? { classification: 'ALL_SYNCED', comparisons: { sheetToJvm: { changeCount: 0 } } }
+        : { classification: 'SHEET_DIFFERS', comparisons: { sheetToJvm: { changeCount: 3 } } };
     });
 
     const result = await runCashflowSheetSyncWorker(db, {
@@ -56,10 +56,11 @@ describe('cashflow sheet sync worker', () => {
       succeededProjects: 2,
       failedProjects: 1,
       changedCount: 3,
-      appliedCount: 1,
+      appliedCount: 0,
       noChangeProjects: 1,
       failures: [{ projectId: 'project-b', code: 'sheet_denied' }],
     });
+    expect(syncProject.mock.calls.every(([input]) => !Object.hasOwn(input, 'apply'))).toBe(true);
     expect(result.discoveredProjects).toBe(result.processedProjects);
   });
 

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -989,6 +989,19 @@ function canonicalWeeksFromJavaSnapshot(snapshot = {}) {
   return [...byWeek.values()];
 }
 
+function canonicalSheetSourceWeeksFromJavaSnapshot(snapshot = {}) {
+  if (!Array.isArray(snapshot?.projection) || !Array.isArray(snapshot?.actual)) {
+    return canonicalWeeksFromJavaSnapshot(snapshot);
+  }
+  const hasActualProvenance = snapshot.actual.some((line) => readOptionalText(line?.sheetKey));
+  return canonicalWeeksFromJavaSnapshot({
+    ...snapshot,
+    actual: hasActualProvenance
+      ? snapshot.actual.filter((line) => readOptionalText(line?.sheetKey) === CASHFLOW_SHEET_SOURCE_KEY)
+      : snapshot.actual,
+  });
+}
+
 export function assertJavaCashflowMatchesFirestore(javaSnapshot, firestoreSnapshot) {
   const javaCells = canonicalCellEntriesFromWeeks(canonicalWeeksFromJavaSnapshot(javaSnapshot));
   const firestoreCells = canonicalCellEntriesFromWeeks(firestoreSnapshot?.weeks || []);
@@ -999,6 +1012,125 @@ export function assertJavaCashflowMatchesFirestore(javaSnapshot, firestoreSnapsh
       'jvm_cashflow_canonical_mismatch',
     );
   }
+}
+
+function canonicalCellKey(cell) {
+  return `${cell.sourceYear}:${cell.yearMonth}:${cell.weekNo}:${cell.mode}:${cell.cashflowLine}`;
+}
+
+function canonicalCellsFromMirror(mirrors = []) {
+  const cells = mirrors.flatMap((mirror) => (mirror?.cells || []).map((cell) => ({
+    sourceYear: Number(readOptionalText(cell?.yearMonth).slice(0, 4)),
+    yearMonth: readOptionalText(cell?.yearMonth),
+    weekNo: Number(cell?.weekNo),
+    mode: readOptionalText(cell?.mode),
+    cashflowLine: readOptionalText(cell?.lineId),
+    state: readOptionalText(cell?.state),
+    ...(['VALUE', 'ZERO'].includes(readOptionalText(cell?.state)) ? { amount: Number(cell?.amount) } : {}),
+  })));
+  const index = new Map();
+  for (const cell of cells) {
+    if (!Number.isSafeInteger(cell.sourceYear)
+      || !/^20\d{2}-(0[1-9]|1[0-2])$/.test(cell.yearMonth)
+      || !Number.isSafeInteger(cell.weekNo) || cell.weekNo < 1 || cell.weekNo > 5
+      || !CASHFLOW_MODES.includes(cell.mode)
+      || !CASHFLOW_LINE_ORDER.has(cell.cashflowLine)
+      || !['EMPTY', 'ZERO', 'VALUE'].includes(cell.state)
+      || (cell.state !== 'EMPTY' && !Number.isSafeInteger(cell.amount))) {
+      throw createHttpError(502, 'Sheet cashflow snapshot is invalid.', 'cashflow_sheet_snapshot_invalid');
+    }
+    const key = canonicalCellKey(cell);
+    if (index.has(key)) {
+      throw createHttpError(502, 'Sheet cashflow snapshot contains duplicate cells.', 'cashflow_sheet_snapshot_invalid');
+    }
+    index.set(key, cell);
+  }
+  return index;
+}
+
+function canonicalCellsFromSnapshot(snapshot, allowedKeys) {
+  const entries = canonicalCellEntriesFromWeeks(snapshot?.weeks || []).map((cell) => ({
+    ...cell,
+    sourceYear: Number(cell.yearMonth.slice(0, 4)),
+  }));
+  const index = new Map(entries.map((cell) => [canonicalCellKey(cell), cell]));
+  return new Map([...allowedKeys].map((key) => [key, index.get(key) || { state: 'EMPTY' }]));
+}
+
+function canonicalSheetSourceCellsFromSnapshot(snapshot, sheetCells) {
+  const amounts = buildSnapshotAmountIndex(snapshot);
+  return new Map([...sheetCells].map(([key, sheetCell]) => {
+    const mapping = {
+      mode: sheetCell.mode,
+      yearMonth: sheetCell.yearMonth,
+      weekNo: sheetCell.weekNo,
+      lineId: sheetCell.cashflowLine,
+    };
+    const hasValue = hasIndexedSnapshotAmount(amounts, mapping);
+    const amount = hasValue ? normalizeAppliedAmount(readIndexedSnapshotAmount(amounts, mapping)) : null;
+    return [key, hasValue ? { ...sheetCell, state: amount === 0 ? 'ZERO' : 'VALUE', amount } : { state: 'EMPTY' }];
+  }));
+}
+
+function canonicalAggregateCellIndex(snapshot) {
+  return new Map(canonicalCellEntriesFromWeeks(snapshot?.weeks || []).map((cell) => {
+    const normalized = { ...cell, sourceYear: Number(cell.yearMonth.slice(0, 4)) };
+    return [canonicalCellKey(normalized), normalized];
+  }));
+}
+
+function compareCanonicalCellIndexes(left, right) {
+  return compareCanonicalCells(left, right, new Set([...left.keys(), ...right.keys()]));
+}
+
+function compareCanonicalCells(left, right, keys) {
+  let projectionChangeCount = 0;
+  let actualChangeCount = 0;
+  for (const key of keys) {
+    const leftCell = left.get(key) || { state: 'EMPTY' };
+    const rightCell = right.get(key) || { state: 'EMPTY' };
+    if (leftCell.state === rightCell.state
+      && (leftCell.state === 'EMPTY' || leftCell.amount === rightCell.amount)) continue;
+    if (key.includes(':projection:')) projectionChangeCount += 1;
+    else actualChangeCount += 1;
+  }
+  return {
+    status: 'AVAILABLE',
+    changeCount: projectionChangeCount + actualChangeCount,
+    projectionChangeCount,
+    actualChangeCount,
+  };
+}
+
+function unavailableComparison(error) {
+  return {
+    status: 'UNAVAILABLE',
+    changeCount: null,
+    projectionChangeCount: null,
+    actualChangeCount: null,
+    code: readOptionalText(error?.code) || 'cashflow_comparison_unavailable',
+  };
+}
+
+function attemptComparison(compare, error) {
+  try {
+    return compare();
+  } catch (comparisonError) {
+    return unavailableComparison(comparisonError || error);
+  }
+}
+
+export function classifyCashflowComparisons(comparisons) {
+  const values = Object.values(comparisons);
+  if (values.some((value) => value.status !== 'AVAILABLE')) return 'PARTIAL';
+  const sj = comparisons.sheetToJvm.changeCount === 0;
+  const sf = comparisons.sheetToFirestore.changeCount === 0;
+  const jf = comparisons.jvmToFirestore.changeCount === 0;
+  if (sj && sf && jf) return 'ALL_SYNCED';
+  if (sj && !sf && !jf) return 'FIRESTORE_DIFFERS';
+  if (sf && !sj && !jf) return 'JVM_DIFFERS';
+  if (jf && !sj && !sf) return 'SHEET_DIFFERS';
+  return 'THREE_WAY_DIFFERENT';
 }
 
 async function readCashflowSheetMirror(db, tenantId, projectId) {
@@ -4079,6 +4211,115 @@ export function mountCashflowSheetLabRoutes(app, {
     res.status(200).json(await executeCashflowSheetMirrorRefresh(req));
   }));
 
+  const compareCashflowSheetProject = async ({ tenantId, projectId, runId, context } = {}) => {
+    const project = await readProjectDocument(db, tenantId, projectId);
+    const configs = readCashflowSheetLabConfigs(project);
+    if (configs.length === 0) {
+      throw createHttpError(400, 'Cashflow sheet URL is not configured.', 'cashflow_sheet_config_required');
+    }
+    const actorContext = context || {
+      tenantId,
+      actorId: 'cashflow-sheet-observer',
+      actorRole: 'admin',
+      actorEmail: 'cashflow-sheet-observer@mysc.co.kr',
+      requestId: runId,
+    };
+    const sheetPromise = (async () => {
+      const mirrors = [];
+      for (const config of configs) {
+        const mirror = await executeCashflowSheetMirrorRefresh({
+          context: actorContext,
+          requestId: actorContext.requestId,
+          params: { projectId },
+          body: {
+            sourceYear: config.sourceYear,
+            idempotencyKey: `${runId}:${projectId}:observe:${config.sourceYear}`,
+          },
+        });
+        if (readOptionalText(mirror?.status) !== 'FRESH') {
+          const refreshError = mirror?.lastRefreshError || {};
+          throw createHttpError(
+            Number(refreshError.statusCode) || 503,
+            readOptionalText(refreshError.message) || 'Cashflow sheet refresh failed.',
+            readOptionalText(refreshError.code) || 'cashflow_sheet_refresh_failed',
+          );
+        }
+        mirrors.push(mirror);
+      }
+      return { mirrors, cells: canonicalCellsFromMirror(mirrors) };
+    })();
+    const [sheetResult, javaResult, firestoreResult] = await Promise.allSettled([
+      sheetPromise,
+      authoritativeJavaClient
+        ? authoritativeJavaClient.getCashflowSnapshot({ context: actorContext, projectId })
+        : Promise.reject(createHttpError(503, 'JVM cashflow API is not configured.', 'jvm_weekly_api_unconfigured')),
+      readCashflowWeeksSnapshot(db, tenantId, projectId),
+    ]);
+    let sheetCells;
+    let javaAggregateCells;
+    let firestoreAggregateCells;
+    let javaSnapshot;
+    let javaSheetSourceSnapshot;
+    let firestoreSnapshot;
+    const sheetError = sheetResult.status === 'rejected' ? sheetResult.reason : null;
+    let javaError = javaResult.status === 'rejected' ? javaResult.reason : null;
+    let firestoreError = firestoreResult.status === 'rejected' ? firestoreResult.reason : null;
+    if (sheetResult.status === 'fulfilled') sheetCells = sheetResult.value.cells;
+    try {
+      if (javaError) throw javaError;
+      if (readOptionalText(javaResult.value?.projectId) !== projectId) {
+        throw createHttpError(502, 'JVM cashflow readback project mismatch.', 'jvm_cashflow_readback_mismatch');
+      }
+      javaSnapshot = { weeks: canonicalWeeksFromJavaSnapshot(javaResult.value) };
+      javaSheetSourceSnapshot = { weeks: canonicalSheetSourceWeeksFromJavaSnapshot(javaResult.value) };
+      javaAggregateCells = canonicalAggregateCellIndex(javaSnapshot);
+    } catch (error) {
+      javaError = error;
+      javaSnapshot = undefined;
+      javaSheetSourceSnapshot = undefined;
+      javaAggregateCells = undefined;
+    }
+    try {
+      if (firestoreError) throw firestoreError;
+      firestoreSnapshot = firestoreResult.value;
+      firestoreAggregateCells = canonicalAggregateCellIndex(firestoreSnapshot);
+    } catch (error) {
+      firestoreError = error;
+      firestoreSnapshot = undefined;
+      firestoreAggregateCells = undefined;
+    }
+    const comparisons = {
+      sheetToJvm: sheetCells && javaSheetSourceSnapshot
+        ? attemptComparison(
+          () => compareCanonicalCells(sheetCells, canonicalCellsFromSnapshot(javaSheetSourceSnapshot, sheetCells.keys()), sheetCells.keys()),
+          javaError,
+        )
+        : unavailableComparison(sheetError || javaError),
+      sheetToFirestore: sheetCells && firestoreSnapshot
+        ? attemptComparison(
+          () => compareCanonicalCells(sheetCells, canonicalSheetSourceCellsFromSnapshot(firestoreSnapshot, sheetCells), sheetCells.keys()),
+          firestoreError,
+        )
+        : unavailableComparison(sheetError || firestoreError),
+      jvmToFirestore: javaAggregateCells && firestoreAggregateCells
+        ? attemptComparison(() => compareCanonicalCellIndexes(javaAggregateCells, firestoreAggregateCells), javaError || firestoreError)
+        : unavailableComparison(javaError || firestoreError),
+    };
+    const classification = classifyCashflowComparisons(comparisons);
+    return {
+      status: classification === 'PARTIAL' ? 'PARTIAL' : 'COMPARED',
+      classification,
+      checkedAt: new Date().toISOString(),
+      sheet: {
+        status: sheetCells ? 'AVAILABLE' : 'UNAVAILABLE',
+        revisions: sheetResult.status === 'fulfilled'
+          ? sheetResult.value.mirrors.map((mirror) => readOptionalText(mirror.sourceRevision)).filter(Boolean)
+          : [],
+      },
+      comparisons,
+    };
+  };
+
   const syncCashflowSheetProject = async ({
     tenantId,
     projectId,
@@ -4234,22 +4475,13 @@ export function mountCashflowSheetLabRoutes(app, {
     const { projectId } = req.params;
     const checkedAt = new Date().toISOString();
     try {
-      const result = await syncCashflowSheetProject({
+      const result = await compareCashflowSheetProject({
         tenantId,
         projectId,
         runId: `cashflow-sheet-check:${req.context.requestId}`,
         context: req.context,
-        apply: false,
       });
-      res.status(200).json({
-        status: result.pendingChangeCount > 0 ? 'CHANGED' : 'SYNCED',
-        pendingChangeCount: result.pendingChangeCount,
-        projectionChangeCount: result.projectionChangeCount,
-        actualChangeCount: result.actualChangeCount,
-        sourceRevision: result.sourceRevision,
-        targetRevision: result.targetRevision,
-        checkedAt: result.checkedAt,
-      });
+      res.status(200).json(result);
     } catch (error) {
       logCashflowSheetLab('changes.check.unavailable', req, {
         projectId,
@@ -4257,11 +4489,13 @@ export function mountCashflowSheetLabRoutes(app, {
       }, 'warn');
       res.status(200).json({
         status: 'UNAVAILABLE',
-        pendingChangeCount: 0,
-        projectionChangeCount: 0,
-        actualChangeCount: 0,
-        sourceRevision: '',
-        targetRevision: '',
+        classification: 'PARTIAL',
+        sheet: { status: 'UNAVAILABLE' },
+        comparisons: {
+          sheetToJvm: unavailableComparison(error),
+          sheetToFirestore: unavailableComparison(error),
+          jvmToFirestore: unavailableComparison(error),
+        },
         checkedAt,
       });
     }
@@ -4432,5 +4666,5 @@ export function mountCashflowSheetLabRoutes(app, {
     }
   }));
 
-  return { syncProject: syncCashflowSheetProject };
+  return { compareProject: compareCashflowSheetProject, syncProject: syncCashflowSheetProject };
 }

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -6,6 +6,7 @@ import request from 'supertest';
 import { describe, expect, it, vi } from 'vitest';
 import {
   assertJavaCashflowMatchesFirestore,
+  classifyCashflowComparisons,
   mountCashflowSheetLabRoutes,
 } from './cashflow-sheet-lab.mjs';
 import { GoogleSheetsServiceError } from '../google-sheets.mjs';
@@ -618,6 +619,29 @@ function createDisabledApp() {
 }
 
 describe('cashflow sheet lab route', () => {
+  it.each([
+    [0, 0, 0, 'ALL_SYNCED'],
+    [0, 1, 1, 'FIRESTORE_DIFFERS'],
+    [1, 0, 1, 'JVM_DIFFERS'],
+    [1, 1, 0, 'SHEET_DIFFERS'],
+    [1, 2, 3, 'THREE_WAY_DIFFERENT'],
+  ])('classifies independent Sheet/JVM/Firestore comparisons (%s, %s, %s)', (sheetToJvm, sheetToFirestore, jvmToFirestore, expected) => {
+    const available = (changeCount) => ({ status: 'AVAILABLE', changeCount });
+    expect(classifyCashflowComparisons({
+      sheetToJvm: available(sheetToJvm),
+      sheetToFirestore: available(sheetToFirestore),
+      jvmToFirestore: available(jvmToFirestore),
+    })).toBe(expected);
+  });
+
+  it('keeps an unavailable pair partial instead of replacing it with zero', () => {
+    expect(classifyCashflowComparisons({
+      sheetToJvm: { status: 'UNAVAILABLE', changeCount: null },
+      sheetToFirestore: { status: 'AVAILABLE', changeCount: 4 },
+      jvmToFirestore: { status: 'UNAVAILABLE', changeCount: null },
+    })).toBe('PARTIAL');
+  });
+
   it('fails closed when the JVM canonical snapshot differs from Firestore before or after apply', () => {
     const firestoreSnapshot = {
       weeks: [{
@@ -693,12 +717,14 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
 
     expect(response.body).toEqual({
-      status: 'CHANGED',
-      pendingChangeCount: 1920,
-      projectionChangeCount: 960,
-      actualChangeCount: 960,
-      sourceRevision: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
-      targetRevision: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      status: 'COMPARED',
+      classification: 'SHEET_DIFFERS',
+      sheet: { status: 'AVAILABLE', revisions: [expect.stringMatching(/^sha256:[a-f0-9]{64}$/)] },
+      comparisons: {
+        sheetToJvm: { status: 'AVAILABLE', changeCount: 1920, projectionChangeCount: 960, actualChangeCount: 960 },
+        sheetToFirestore: { status: 'AVAILABLE', changeCount: 1920, projectionChangeCount: 960, actualChangeCount: 960 },
+        jvmToFirestore: { status: 'AVAILABLE', changeCount: 0, projectionChangeCount: 0, actualChangeCount: 0 },
+      },
       checkedAt: expect.stringMatching(/^2026-|^20\d{2}-/),
     });
     expect(javaWeeklyClient.applyCashflowSheetBatch).not.toHaveBeenCalled();
@@ -711,7 +737,7 @@ describe('cashflow sheet lab route', () => {
     }));
   });
 
-  it('returns UNAVAILABLE instead of diffing against stale Firestore data when JVM canonical differs', async () => {
+  it('reports JVM and Firestore drift without blocking the Sheet comparison', async () => {
     const db = createDb({
       project: {
         id: 'project-a',
@@ -745,18 +771,113 @@ describe('cashflow sheet lab route', () => {
       .send({})
       .expect(200);
 
-    expect(response.body).toEqual({
-      status: 'UNAVAILABLE',
-      pendingChangeCount: 0,
-      projectionChangeCount: 0,
-      actualChangeCount: 0,
-      sourceRevision: '',
-      targetRevision: '',
-      checkedAt: expect.stringMatching(/^20\d{2}-/),
+    expect(response.body).toMatchObject({
+      status: 'COMPARED',
+      classification: 'THREE_WAY_DIFFERENT',
+      sheet: { status: 'AVAILABLE' },
+      comparisons: {
+        sheetToJvm: { status: 'AVAILABLE', changeCount: 1920 },
+        sheetToFirestore: { status: 'AVAILABLE', changeCount: 1920 },
+        jvmToFirestore: { status: 'AVAILABLE', changeCount: 1 },
+      },
     });
     expect(javaWeeklyClient.applyCashflowSheetBatch).not.toHaveBeenCalled();
     expect(javaWeeklyClient.applyCashflowSheetLab).not.toHaveBeenCalled();
     expect(javaWeeklyClient.applyCashflowSheetAnnualTotal).not.toHaveBeenCalled();
+  });
+
+  it('keeps the JVM versus Firestore comparison when Google Sheet refresh fails', async () => {
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        contractStart: '2026-01-01',
+        contractEnd: '2026-12-31',
+        cashflowSheetLab: {
+          sourceYear: 2026,
+          value: 'https://docs.google.com/spreadsheets/d/spreadsheet-a/edit',
+          sheetName: 'cashflow(사용내역 연동)',
+        },
+      },
+      weeks: [{ id: 'w1', projectId: 'project-a', yearMonth: '2026-01', weekNo: 1, projection: { SALES_IN: 1 }, actual: {} }],
+    });
+    const response = await request(createApp({
+      db,
+      googleSheetsService: {
+        previewSpreadsheet: vi.fn(async () => { throw new GoogleSheetsServiceError('unavailable', { statusCode: 503 }); }),
+      },
+      routeOptions: {
+        javaWeeklyClient: {
+          getCashflowSnapshot: vi.fn(async () => ({ projectId: 'project-a', projection: [], actual: [] })),
+        },
+      },
+    }))
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/changes/check')
+      .send({})
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      status: 'PARTIAL',
+      classification: 'PARTIAL',
+      sheet: { status: 'UNAVAILABLE' },
+      comparisons: {
+        sheetToJvm: { status: 'UNAVAILABLE', changeCount: null },
+        sheetToFirestore: { status: 'UNAVAILABLE', changeCount: null },
+        jvmToFirestore: { status: 'AVAILABLE', changeCount: 1 },
+      },
+    });
+  });
+
+  it('keeps Sheet versus Firestore available when the JVM snapshot is invalid', async () => {
+    const db = createDb({
+      project: {
+        id: 'project-a', contractStart: '2026-01-01', contractEnd: '2026-12-31',
+        cashflowSheetLab: { sourceYear: 2026, value: 'https://docs.google.com/spreadsheets/d/spreadsheet-a/edit', sheetName: 'cashflow(사용내역 연동)' },
+      },
+    });
+    const response = await request(createApp({ db, routeOptions: { javaWeeklyClient: {
+      getCashflowSnapshot: vi.fn(async () => ({
+        projectId: 'project-a',
+        projection: [{ yearMonth: '2026-01', weekNo: 1, cashflowLine: 'UNKNOWN', amount: 1 }],
+        actual: [],
+      })),
+    } } }))
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/changes/check')
+      .send({})
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      status: 'PARTIAL',
+      comparisons: {
+        sheetToJvm: { status: 'UNAVAILABLE', changeCount: null },
+        sheetToFirestore: { status: 'AVAILABLE', changeCount: 1920 },
+        jvmToFirestore: { status: 'UNAVAILABLE', changeCount: null },
+      },
+    });
+  });
+
+  it('keeps Sheet versus JVM available when the Firestore snapshot is invalid', async () => {
+    const db = createDb({
+      project: {
+        id: 'project-a', contractStart: '2026-01-01', contractEnd: '2026-12-31',
+        cashflowSheetLab: { sourceYear: 2026, value: 'https://docs.google.com/spreadsheets/d/spreadsheet-a/edit', sheetName: 'cashflow(사용내역 연동)' },
+      },
+      weeks: [{ id: 'bad', projectId: 'project-a', yearMonth: '2026-01', weekNo: 1, projection: { UNKNOWN: 1 }, actual: {} }],
+    });
+    const response = await request(createApp({ db, routeOptions: { javaWeeklyClient: {
+      getCashflowSnapshot: vi.fn(async () => ({ projectId: 'project-a', projection: [], actual: [] })),
+    } } }))
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/changes/check')
+      .send({})
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      status: 'PARTIAL',
+      comparisons: {
+        sheetToJvm: { status: 'AVAILABLE', changeCount: 1920 },
+        sheetToFirestore: { status: 'UNAVAILABLE', changeCount: null },
+        jvmToFirestore: { status: 'UNAVAILABLE', changeCount: null },
+      },
+    });
   });
 
   it('returns SYNCED with zero pending changes when the fresh sheet already matches JVM canonical', async () => {
@@ -804,17 +925,75 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
 
     expect(response.body).toEqual({
-      status: 'SYNCED',
-      pendingChangeCount: 0,
-      projectionChangeCount: 0,
-      actualChangeCount: 0,
-      sourceRevision: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
-      targetRevision: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      status: 'COMPARED',
+      classification: 'ALL_SYNCED',
+      sheet: { status: 'AVAILABLE', revisions: [expect.stringMatching(/^sha256:[a-f0-9]{64}$/)] },
+      comparisons: {
+        sheetToJvm: { status: 'AVAILABLE', changeCount: 0, projectionChangeCount: 0, actualChangeCount: 0 },
+        sheetToFirestore: { status: 'AVAILABLE', changeCount: 0, projectionChangeCount: 0, actualChangeCount: 0 },
+        jvmToFirestore: { status: 'AVAILABLE', changeCount: 0, projectionChangeCount: 0, actualChangeCount: 0 },
+      },
       checkedAt: expect.stringMatching(/^20\d{2}-/),
     });
     expect(javaWeeklyClient.applyCashflowSheetBatch).not.toHaveBeenCalled();
     expect(javaWeeklyClient.applyCashflowSheetLab).not.toHaveBeenCalled();
     expect(javaWeeklyClient.applyCashflowSheetAnnualTotal).not.toHaveBeenCalled();
+  });
+
+  it('compares Sheet Actual against its source ledger while JVM and Firestore compare aggregates', async () => {
+    const yearMonths = Array.from({ length: 12 }, (_unused, index) => `2026-${String(index + 1).padStart(2, '0')}`);
+    const weeks = matchingCanonicalWeeks(1920, yearMonths);
+    const firstWeek = weeks[0];
+    const [lineId] = Object.keys(firstWeek.actual);
+    const sheetAmount = firstWeek.actual[lineId];
+    firstWeek.weeklyExpenseActualBySheet = {
+      'cashflow-sheet-lab': { ...firstWeek.actual },
+      bank: { [lineId]: 10 },
+    };
+    firstWeek.actual[lineId] = sheetAmount + 10;
+    const javaWeeklyClient = {
+      getCashflowSnapshot: vi.fn(async () => ({
+        projectId: 'project-a',
+        projection: weeks.flatMap((week) => Object.entries(week.projection || {}).map(([cashflowLine, amount]) => ({
+          yearMonth: week.yearMonth, weekNo: week.weekNo, cashflowLine, amount,
+        }))),
+        actual: weeks.flatMap((week) => Object.entries(week.actual || {}).flatMap(([cashflowLine, amount]) => (
+          week === firstWeek && cashflowLine === lineId
+            ? [
+              { sheetKey: 'cashflow-sheet-lab', yearMonth: week.yearMonth, weekNo: week.weekNo, cashflowLine, amount: sheetAmount },
+              { sheetKey: 'bank', yearMonth: week.yearMonth, weekNo: week.weekNo, cashflowLine, amount: 10 },
+            ]
+            : [{ sheetKey: 'cashflow-sheet-lab', yearMonth: week.yearMonth, weekNo: week.weekNo, cashflowLine, amount }]
+        ))),
+      })),
+    };
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        contractStart: '2026-01-01',
+        contractEnd: '2026-12-31',
+        cashflowSheetLab: {
+          sourceYear: 2026,
+          value: 'https://docs.google.com/spreadsheets/d/spreadsheet-a/edit',
+          sheetName: 'cashflow(사용내역 연동)',
+        },
+      },
+      weeks,
+    });
+
+    const response = await request(createApp({ db, routeOptions: { javaWeeklyClient } }))
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/changes/check')
+      .send({})
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      classification: 'ALL_SYNCED',
+      comparisons: {
+        sheetToJvm: { changeCount: 0 },
+        sheetToFirestore: { changeCount: 0 },
+        jvmToFirestore: { changeCount: 0 },
+      },
+    });
   });
 
   it('reads Google Sheets only on explicit mirror refresh and pins the result', async () => {

--- a/server/bff/worker-endpoints.test.ts
+++ b/server/bff/worker-endpoints.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
 import request from 'supertest';
 import { createBffApp } from './app.mjs';
 
@@ -33,6 +34,17 @@ function createTestApp(options: Parameters<typeof createBffApp>[0] = {}) {
 }
 
 describe('internal worker endpoints (cron)', () => {
+  it('wires the Thursday cashflow worker to comparison without automatic apply', () => {
+    const source = readFileSync(new URL('./app.mjs', import.meta.url), 'utf8');
+    const route = source.slice(
+      source.indexOf('const runCashflowSheetSyncWorkerRoute'),
+      source.indexOf("app.get('/api/internal/workers/cashflow-sheet-sync/run'"),
+    );
+    expect(route).toContain('cashflowSheetCompareProject');
+    expect(route).not.toContain('cashflowSheetSyncProject');
+    expect(route).not.toContain('apply: true');
+  });
+
   it('keeps the Live maintenance probe open while workers stay disabled', async () => {
     const app = createTestApp({
       projectId: LIVE_PROJECT_ID,

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -297,12 +297,16 @@ describe('CashflowProjectSheet monthly close shell', () => {
 
   it('checks linked sheet changes on entry without applying them', () => {
     expect(source).toContain('checkCashflowSheetChangesViaBff');
-    expect(source).toContain("setCashflowSheetChangeCheck({ status: 'CHECKING', pendingChangeCount: null })");
-    expect(source).toContain("result.status === 'CHANGED' ? result.pendingChangeCount : null");
-    expect(source).toContain('이전 대비 변동 사항 ${(cashflowSheetChangeCheck.pendingChangeCount || 0).toLocaleString()}건 · 새로 반영이 필요합니다');
-    expect(source).toContain('시트와 동기화됨');
+    expect(source).toContain("status: 'CHECKING'");
+    expect(source).toContain('setCashflowSheetChangeCheck(result)');
+    expect(source).toContain("['시트↔JVM', cashflowSheetChangeCheck.comparisons.sheetToJvm]");
+    expect(source).toContain("['시트↔저장값', cashflowSheetChangeCheck.comparisons.sheetToFirestore]");
+    expect(source).toContain("['JVM↔저장값', cashflowSheetChangeCheck.comparisons.jvmToFirestore]");
     expect(source).toContain('시트 변경 확인 불가');
     expect(source).toContain('시트 이동');
+    expect(source).toContain('href={configuredSheetUrl}');
+    expect(source).toContain('target="_blank"');
+    expect(source).toContain('rel="noopener noreferrer"');
 
     const checkFlow = source.slice(
       source.indexOf('const checkSheetChanges = async'),

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1863,13 +1863,14 @@ export function CashflowProjectSheet({
   const sheetIdentityLabel = cashflowSheetConfig
     ? cashflowSheetConfig.spreadsheetTitle || cashflowSheetConfig.spreadsheetId || 'Google Sheet'
     : '시트 연결 필요';
-  const availableSheetComparisons: Array<[string, CashflowSheetChangeCheckResult['comparisons']['sheetToJvm']]> = cashflowSheetChangeCheck
+  const sheetComparisonEntries: Array<[string, CashflowSheetChangeCheckResult['comparisons']['sheetToJvm']]> = cashflowSheetChangeCheck
     ? [
       ['시트↔JVM', cashflowSheetChangeCheck.comparisons.sheetToJvm],
       ['시트↔저장값', cashflowSheetChangeCheck.comparisons.sheetToFirestore],
       ['JVM↔저장값', cashflowSheetChangeCheck.comparisons.jvmToFirestore],
-    ].filter(([, comparison]) => comparison.status === 'AVAILABLE')
+    ]
     : [];
+  const availableSheetComparisons = sheetComparisonEntries.filter(([, comparison]) => comparison.status === 'AVAILABLE');
   const availableSheetComparisonLabel = availableSheetComparisons
     .map(([label, comparison]) => `${label} ${(comparison.changeCount ?? 0).toLocaleString()}건`)
     .join(' · ');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -380,10 +380,7 @@ export function CashflowProjectSheet({
     lastActualLineCount?: number;
   } | null>(null);
   const [cashflowSheetConfigLoaded, setCashflowSheetConfigLoaded] = useState(false);
-  const [cashflowSheetChangeCheck, setCashflowSheetChangeCheck] = useState<{
-    status: CashflowSheetChangeCheckResult['status'];
-    pendingChangeCount: number | null;
-  } | null>(null);
+  const [cashflowSheetChangeCheck, setCashflowSheetChangeCheck] = useState<CashflowSheetChangeCheckResult | null>(null);
   const [cashflowSystemAccountEmail, setCashflowSystemAccountEmail] = useState('');
   const [cashflowSystemAccountError, setCashflowSystemAccountError] = useState(false);
   const [cashflowSheetMirror, setCashflowSheetMirror] = useState<CashflowSheetLabMirrorResult | null>(null);
@@ -578,7 +575,17 @@ export function CashflowProjectSheet({
       return () => { cancelled = true; };
     }
 
-    setCashflowSheetChangeCheck({ status: 'CHECKING', pendingChangeCount: null });
+    setCashflowSheetChangeCheck({
+      status: 'CHECKING',
+      classification: 'PARTIAL',
+      checkedAt: '',
+      sheet: { status: 'AVAILABLE' },
+      comparisons: {
+        sheetToJvm: { status: 'UNAVAILABLE', changeCount: null, projectionChangeCount: null, actualChangeCount: null },
+        sheetToFirestore: { status: 'UNAVAILABLE', changeCount: null, projectionChangeCount: null, actualChangeCount: null },
+        jvmToFirestore: { status: 'UNAVAILABLE', changeCount: null, projectionChangeCount: null, actualChangeCount: null },
+      },
+    });
     const checkSheetChanges = async (): Promise<void> => {
       try {
         let actor = await resolveBffActor();
@@ -603,13 +610,20 @@ export function CashflowProjectSheet({
           });
         }
         if (!cancelled) {
-          setCashflowSheetChangeCheck({
-            status: result.status,
-            pendingChangeCount: result.status === 'CHANGED' ? result.pendingChangeCount : null,
-          });
+          setCashflowSheetChangeCheck(result);
         }
       } catch {
-        if (!cancelled) setCashflowSheetChangeCheck({ status: 'UNAVAILABLE', pendingChangeCount: null });
+        if (!cancelled) setCashflowSheetChangeCheck({
+          status: 'UNAVAILABLE',
+          classification: 'PARTIAL',
+          checkedAt: '',
+          sheet: { status: 'UNAVAILABLE' },
+          comparisons: {
+            sheetToJvm: { status: 'UNAVAILABLE', changeCount: null, projectionChangeCount: null, actualChangeCount: null },
+            sheetToFirestore: { status: 'UNAVAILABLE', changeCount: null, projectionChangeCount: null, actualChangeCount: null },
+            jvmToFirestore: { status: 'UNAVAILABLE', changeCount: null, projectionChangeCount: null, actualChangeCount: null },
+          },
+        });
       }
     };
     void checkSheetChanges();
@@ -1849,23 +1863,41 @@ export function CashflowProjectSheet({
   const sheetIdentityLabel = cashflowSheetConfig
     ? cashflowSheetConfig.spreadsheetTitle || cashflowSheetConfig.spreadsheetId || 'Google Sheet'
     : '시트 연결 필요';
+  const availableSheetComparisons: Array<[string, CashflowSheetChangeCheckResult['comparisons']['sheetToJvm']]> = cashflowSheetChangeCheck
+    ? [
+      ['시트↔JVM', cashflowSheetChangeCheck.comparisons.sheetToJvm],
+      ['시트↔저장값', cashflowSheetChangeCheck.comparisons.sheetToFirestore],
+      ['JVM↔저장값', cashflowSheetChangeCheck.comparisons.jvmToFirestore],
+    ].filter(([, comparison]) => comparison.status === 'AVAILABLE')
+    : [];
+  const availableSheetComparisonLabel = availableSheetComparisons
+    .map(([label, comparison]) => `${label} ${(comparison.changeCount ?? 0).toLocaleString()}건`)
+    .join(' · ');
   const sheetChangeBadgeLabel = cashflowSheetChangeCheck?.status === 'CHECKING'
     ? '시트 변경 확인 중'
-    : cashflowSheetChangeCheck?.status === 'SYNCED'
-      ? '시트와 동기화됨'
-      : cashflowSheetChangeCheck?.status === 'CHANGED'
-        ? `이전 대비 변동 사항 ${(cashflowSheetChangeCheck.pendingChangeCount || 0).toLocaleString()}건 · 새로 반영이 필요합니다`
-        : cashflowSheetChangeCheck?.status === 'UNAVAILABLE'
-          ? '시트 변경 확인 불가'
-          : '';
-  const sheetChangeBadgeClass = cashflowSheetChangeCheck?.status === 'SYNCED'
+    : cashflowSheetChangeCheck?.sheet.status === 'UNAVAILABLE'
+          ? ['시트 변경 확인 불가', availableSheetComparisonLabel].filter(Boolean).join(' · ')
+          : availableSheetComparisons.length > 0
+            ? availableSheetComparisonLabel
+            : '비교 가능한 저장값이 없습니다';
+  const sheetChangeBadgeClass = cashflowSheetChangeCheck?.classification === 'ALL_SYNCED'
     ? 'border-emerald-200 bg-emerald-50 text-emerald-800'
-    : cashflowSheetChangeCheck?.status === 'CHANGED'
+    : cashflowSheetChangeCheck?.status === 'COMPARED'
       ? 'border-yellow-300 bg-yellow-50 text-yellow-900'
-      : cashflowSheetChangeCheck?.status === 'UNAVAILABLE'
+      : cashflowSheetChangeCheck?.sheet.status === 'UNAVAILABLE'
         ? 'border-red-200 bg-red-50 text-red-800'
         : 'border-slate-200 bg-slate-50 text-slate-600';
   const sheetMirrorStatus = cashflowSheetMirror?.status || 'EMPTY';
+  const configuredSheetUrl = (() => {
+    try {
+      const url = new URL(cashflowSheetConfig?.value || '');
+      return url.protocol === 'https:' && url.hostname === 'docs.google.com' && url.pathname.startsWith('/spreadsheets/')
+        ? url.toString()
+        : '';
+    } catch {
+      return '';
+    }
+  })();
   const sheetMirrorCapturedAt = formatSheetAppliedAt(cashflowSheetMirror?.capturedAt)
     || cashflowSheetMirror?.capturedAt
     || '';
@@ -2708,17 +2740,16 @@ export function CashflowProjectSheet({
                   {sheetChangeBadgeLabel}
                 </Badge>
               ) : null}
-              {cashflowSheetConfig ? (
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="ghost"
-                  className="h-7 shrink-0 px-2 text-[12px] font-semibold text-[#17324D]"
-                  onClick={() => navigate(`/portal/cashflow/${encodeURIComponent(projectId)}/sheets-lab`)}
+              {configuredSheetUrl ? (
+                <a
+                  className="inline-flex h-7 shrink-0 items-center rounded-md px-2 text-[12px] font-semibold text-[#17324D] hover:bg-accent"
+                  href={configuredSheetUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
                 >
                   <FileSpreadsheet className="mr-1 h-3 w-3" />
                   시트 이동
-                </Button>
+                </a>
               ) : null}
               {cashflowSheetConfig ? (
                 <Button

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -637,13 +637,17 @@ export interface CashflowSheetLabShareAccountResult {
 }
 
 export interface CashflowSheetChangeCheckResult {
-  status: 'CHECKING' | 'SYNCED' | 'CHANGED' | 'UNAVAILABLE';
-  pendingChangeCount: number;
-  projectionChangeCount: number;
-  actualChangeCount: number;
-  sourceRevision: string;
-  targetRevision: string;
+  status: 'CHECKING' | 'COMPARED' | 'PARTIAL' | 'UNAVAILABLE';
+  classification: 'ALL_SYNCED' | 'FIRESTORE_DIFFERS' | 'JVM_DIFFERS' | 'SHEET_DIFFERS' | 'THREE_WAY_DIFFERENT' | 'PARTIAL';
   checkedAt: string;
+  sheet: { status: 'AVAILABLE' | 'UNAVAILABLE'; revisions?: string[] };
+  comparisons: Record<'sheetToJvm' | 'sheetToFirestore' | 'jvmToFirestore', {
+    status: 'AVAILABLE' | 'UNAVAILABLE';
+    changeCount: number | null;
+    projectionChangeCount: number | null;
+    actualChangeCount: number | null;
+    code?: string;
+  }>;
 }
 
 export const extractSpreadsheetIdFromSheetInput = extractSpreadsheetId;


### PR DESCRIPTION
## What
- compare Google Sheet, JVM snapshot, and Firestore independently
- preserve available pair comparisons when one source fails
- keep Thursday worker observation-only with no automatic apply
- open the project's configured Google Sheet directly

## Verification
- focused Vitest: 203 passed
- full unit suite: 2,702 passed, 241 skipped
- production build: passed
- independent QA: passed
- Firestore emulator is not part of the release gate per project policy