### PR TITLE
fix(cashflow): align sheet apply with JVM canonical reads

### DIFF
--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -1014,6 +1014,60 @@ export function assertJavaCashflowMatchesFirestore(javaSnapshot, firestoreSnapsh
   }
 }
 
+export function assertJavaCashflowReadbackMatchesAppliedMonths(
+  javaSnapshot,
+  stagedMonths,
+  { projectId, resultingTargetRevision } = {},
+) {
+  if (
+    readOptionalText(javaSnapshot?.projectId) !== readOptionalText(projectId)
+    || !/^sha256:[a-f0-9]{64}$/.test(readOptionalText(resultingTargetRevision))
+    || readOptionalText(javaSnapshot?.targetRevision) !== readOptionalText(resultingTargetRevision)
+  ) {
+    throw createHttpError(502, 'JVM canonical revision does not match the applied revision.', 'cashflow_jvm_readback_revision_mismatch');
+  }
+  const expected = new Map();
+  for (const month of stagedMonths || []) {
+    for (const cell of month?.cells || []) {
+      const normalized = {
+        sourceYear: Number(readOptionalText(month?.yearMonth).slice(0, 4)),
+        yearMonth: readOptionalText(month?.yearMonth),
+        weekNo: Number(cell?.weekNo),
+        mode: readOptionalText(cell?.mode),
+        cashflowLine: readOptionalText(cell?.cashflowLine),
+        state: readOptionalText(cell?.cellState),
+        ...(['VALUE', 'ZERO'].includes(readOptionalText(cell?.cellState)) ? { amount: Number(cell?.amount) } : {}),
+      };
+      const key = canonicalCellKey(normalized);
+      if (
+        !Number.isSafeInteger(normalized.sourceYear)
+        || !/^20\d{2}-(0[1-9]|1[0-2])$/.test(normalized.yearMonth)
+        || !Number.isSafeInteger(normalized.weekNo) || normalized.weekNo < 1 || normalized.weekNo > 5
+        || !CASHFLOW_MODES.includes(normalized.mode)
+        || !CASHFLOW_LINE_ORDER.has(normalized.cashflowLine)
+        || !['EMPTY', 'ZERO', 'VALUE'].includes(normalized.state)
+        || (normalized.state !== 'EMPTY' && !Number.isSafeInteger(normalized.amount))
+        || expected.has(key)
+      ) {
+        throw createHttpError(502, 'Staged cashflow readback contract is invalid.', 'cashflow_jvm_readback_contract_invalid');
+      }
+      expected.set(key, normalized);
+    }
+  }
+  const expectedCellCount = (stagedMonths || []).length * CASHFLOW_MODES.length * 5 * CASHFLOW_ALL_LINES.length;
+  if (expected.size !== expectedCellCount) {
+    throw createHttpError(502, 'Staged cashflow readback contract is incomplete.', 'cashflow_jvm_readback_contract_invalid');
+  }
+  const actual = canonicalCellsFromSnapshot(
+    { weeks: canonicalSheetSourceWeeksFromJavaSnapshot(javaSnapshot) },
+    expected.keys(),
+  );
+  if (compareCanonicalCells(expected, actual, expected.keys()).changeCount !== 0) {
+    throw createHttpError(502, 'JVM canonical readback does not match the staged sheet.', 'cashflow_jvm_readback_mismatch');
+  }
+  return expected.size;
+}
+
 function canonicalCellKey(cell) {
   return `${cell.sourceYear}:${cell.yearMonth}:${cell.weekNo}:${cell.mode}:${cell.cashflowLine}`;
 }
@@ -3408,6 +3462,27 @@ async function applyStagedCashflowSheetLab({
   }
 
   const appliedMonthSnapshots = stagedMonths.filter((month) => month.apply);
+  let canonicalReadbackVerifiedCellCount = 0;
+  if (appliedMonthSnapshots.length > 0) {
+    let canonicalReadback;
+    try {
+      canonicalReadback = await javaWeeklyClient.getCashflowSnapshot({ context, projectId });
+      canonicalReadbackVerifiedCellCount = assertJavaCashflowReadbackMatchesAppliedMonths(
+        canonicalReadback,
+        appliedMonthSnapshots,
+        { projectId, resultingTargetRevision: targetRevision },
+      );
+    } catch (error) {
+      throw Object.assign(createHttpError(
+        503,
+        'JVM 저장 후 canonical 값을 확인하지 못했습니다. 같은 요청으로 다시 확인해 주세요.',
+        'cashflow_sheet_canonical_readback_uncertain',
+      ), {
+        cause: error,
+        details: { readbackCode: readOptionalText(error?.code) || 'cashflow_jvm_readback_failed' },
+      });
+    }
+  }
   const appliedCells = [
     ...appliedMonthSnapshots.flatMap((month) => month.cells),
     ...stagedYears.flatMap((year) => year.cells),
@@ -3439,6 +3514,7 @@ async function applyStagedCashflowSheetLab({
       role: readOptionalText(context?.actorRole) || 'workspace_user',
     },
     verifiedLineCount,
+    canonicalReadbackVerifiedCellCount,
     formulaValidation: verifiedFormulaValidation,
     firebaseResult: {
       ok: true,
@@ -3458,6 +3534,7 @@ async function applyStagedCashflowSheetLab({
         auditId: readOptionalText(result.auditId) || undefined,
       })),
       verifiedLineCount,
+      canonicalReadbackVerifiedCellCount,
     },
   };
   const runCompletionPatch = {

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -6,6 +6,7 @@ import request from 'supertest';
 import { describe, expect, it, vi } from 'vitest';
 import {
   assertJavaCashflowMatchesFirestore,
+  assertJavaCashflowReadbackMatchesAppliedMonths,
   classifyCashflowComparisons,
   mountCashflowSheetLabRoutes,
 } from './cashflow-sheet-lab.mjs';
@@ -235,6 +236,22 @@ function javaBatchApplyResponse(request, resultingTargetRevision) {
     settledWeekChanges: [],
     durationMs: 12,
     auditId: 'audit-batch',
+  };
+}
+
+function completeStagedMonth(yearMonth = '2026-01') {
+  return {
+    yearMonth,
+    apply: true,
+    cells: ['projection', 'actual'].flatMap((mode) => Array.from({ length: 5 }, (_unused, weekIndex) => (
+      CASHFLOW_LINE_IDS.map((cashflowLine) => ({
+        yearMonth,
+        mode,
+        weekNo: weekIndex + 1,
+        cashflowLine,
+        cellState: 'EMPTY',
+      }))
+    )).flat()),
   };
 }
 
@@ -541,6 +558,63 @@ function createApp({ context = {}, db = createDb(), googleSheetsService, routeOp
       weeklyCheckCount: 0,
     }));
   }
+  if (routeOptions.javaWeeklyClient && !routeOptions.javaWeeklyClient.getCashflowSnapshot) {
+    const snapshot = { projectId: 'project-a', targetRevision: '', projection: [], actual: [] };
+    const appliedRequests = [];
+    const remember = (result) => {
+      snapshot.projectId = result.projectId;
+      snapshot.targetRevision = result.resultingTargetRevision;
+      const monthResults = Array.isArray(result.months) ? result.months : [result];
+      for (const month of monthResults) {
+        snapshot.projection = snapshot.projection
+          .filter((line) => line.yearMonth !== month.yearMonth)
+          .concat(month.projection || []);
+        snapshot.actual = snapshot.actual
+          .filter((line) => line.yearMonth !== month.yearMonth || line.sheetKey !== 'cashflow-sheet-lab')
+          .concat(month.actual || []);
+      }
+      return result;
+    };
+    for (const method of ['applyCashflowSheetLab', 'applyCashflowSheetBatch']) {
+      if (!routeOptions.javaWeeklyClient[method]) continue;
+      const apply = routeOptions.javaWeeklyClient[method];
+      if (vi.isMockFunction(apply)) {
+        const implementation = apply.getMockImplementation();
+        apply.mockImplementation(async (...args) => {
+          appliedRequests.push(args[0]);
+          return remember(await implementation(...args));
+        });
+      } else {
+        routeOptions.javaWeeklyClient[method] = async (...args) => {
+          appliedRequests.push(args[0]);
+          return remember(await apply(...args));
+        };
+      }
+    }
+    if (routeOptions.javaWeeklyClient.getCashflowSheetOperationStatus) {
+      const readStatus = routeOptions.javaWeeklyClient.getCashflowSheetOperationStatus;
+      const implementation = vi.isMockFunction(readStatus) ? readStatus.getMockImplementation() : readStatus;
+      const wrapped = async (...args) => {
+        const result = await implementation(...args);
+        if (result?.status === 'APPLIED') snapshot.targetRevision = result.resultingTargetRevision;
+        return result;
+      };
+      if (vi.isMockFunction(readStatus)) readStatus.mockImplementation(wrapped);
+      else routeOptions.javaWeeklyClient.getCashflowSheetOperationStatus = wrapped;
+    }
+    routeOptions.javaWeeklyClient.getCashflowSnapshot = vi.fn(async () => {
+      if (snapshot.projection.length === 0 && snapshot.actual.length === 0 && appliedRequests.length > 0) {
+        const request = appliedRequests.at(-1);
+        const months = Array.isArray(request.months) ? request.months : [request];
+        for (const month of months.filter((candidate) => candidate.apply !== false)) {
+          const response = javaApplyResponse({ ...request, ...month }, snapshot.targetRevision);
+          snapshot.projection.push(...response.projection);
+          snapshot.actual.push(...response.actual);
+        }
+      }
+      return { ...snapshot };
+    });
+  }
   mountCashflowSheetLabRoutes(app, {
     db,
     googleSheetsService: googleSheetsService || {
@@ -619,6 +693,64 @@ function createDisabledApp() {
 }
 
 describe('cashflow sheet lab route', () => {
+  it('accepts a complete JVM canonical readback while preserving EMPTY, ZERO, and VALUE', () => {
+    const revision = `sha256:${'a'.repeat(64)}`;
+    const month = completeStagedMonth();
+    month.cells.find((cell) => cell.mode === 'projection' && cell.weekNo === 1).cellState = 'ZERO';
+    month.cells.find((cell) => cell.mode === 'projection' && cell.weekNo === 1).amount = 0;
+    month.cells.find((cell) => cell.mode === 'actual' && cell.weekNo === 2).cellState = 'VALUE';
+    month.cells.find((cell) => cell.mode === 'actual' && cell.weekNo === 2).amount = 1234;
+    const projectionCell = month.cells.find((cell) => cell.cellState === 'ZERO');
+    const actualCell = month.cells.find((cell) => cell.cellState === 'VALUE');
+
+    expect(assertJavaCashflowReadbackMatchesAppliedMonths({
+      projectId: 'project-a',
+      targetRevision: revision,
+      projection: [{
+        yearMonth: projectionCell.yearMonth,
+        weekNo: projectionCell.weekNo,
+        cashflowLine: projectionCell.cashflowLine,
+        amount: 0,
+      }],
+      actual: [{
+        sheetKey: 'cashflow-sheet-lab',
+        yearMonth: actualCell.yearMonth,
+        weekNo: actualCell.weekNo,
+        cashflowLine: actualCell.cashflowLine,
+        amount: 1234,
+      }],
+    }, [month], { projectId: 'project-a', resultingTargetRevision: revision })).toBe(160);
+  });
+
+  it.each([
+    ['revision', (snapshot) => { snapshot.targetRevision = `sha256:${'b'.repeat(64)}`; }, 'cashflow_jvm_readback_revision_mismatch'],
+    ['missing ZERO', (snapshot) => { snapshot.projection = []; }, 'cashflow_jvm_readback_mismatch'],
+    ['wrong VALUE', (snapshot) => { snapshot.actual[0].amount += 1; }, 'cashflow_jvm_readback_mismatch'],
+    ['unknown line', (snapshot) => { snapshot.actual[0].cashflowLine = 'UNKNOWN'; }, 'jvm_cashflow_snapshot_invalid'],
+    ['duplicate projection', (snapshot) => { snapshot.projection.push({ ...snapshot.projection[0] }); }, 'jvm_cashflow_snapshot_invalid'],
+  ])('rejects a JVM canonical readback with %s mismatch', (_label, mutate, expectedCode) => {
+    const revision = `sha256:${'a'.repeat(64)}`;
+    const month = completeStagedMonth();
+    const projectionCell = month.cells[0];
+    projectionCell.cellState = 'ZERO';
+    projectionCell.amount = 0;
+    const actualCell = month.cells.find((cell) => cell.mode === 'actual');
+    actualCell.cellState = 'VALUE';
+    actualCell.amount = 1234;
+    const snapshot = {
+      projectId: 'project-a',
+      targetRevision: revision,
+      projection: [{ yearMonth: '2026-01', weekNo: 1, cashflowLine: projectionCell.cashflowLine, amount: 0 }],
+      actual: [{ sheetKey: 'cashflow-sheet-lab', yearMonth: '2026-01', weekNo: 1, cashflowLine: actualCell.cashflowLine, amount: 1234 }],
+    };
+    mutate(snapshot);
+    expect(() => assertJavaCashflowReadbackMatchesAppliedMonths(
+      snapshot,
+      [month],
+      { projectId: 'project-a', resultingTargetRevision: revision },
+    )).toThrow(expect.objectContaining({ code: expectedCode }));
+  });
+
   it.each([
     [0, 0, 0, 'ALL_SYNCED'],
     [0, 1, 1, 'FIRESTORE_DIFFERS'],

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSnapshotResponse.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSnapshotResponse.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 public record CashflowSnapshotResponse(
     String projectId,
+    String targetRevision,
     List<ProjectionLine> projection,
     List<ActualLine> actual,
     ReadModel readModel

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -327,6 +327,7 @@ public class WeeklyExpenseController {
             .toList();
         return new CashflowSnapshotResponse(
             projectId,
+            source.targetRevision(),
             projection,
             actual,
             buildCashflowReadModel(projection, actual)

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
@@ -409,6 +409,7 @@ class WeeklyExpenseControllerTest {
 
         mockMvc.perform(asActor(get("/api/v1/cashflow/project-a"), "tenant-a", "viewer-a", "viewer"))
             .andExpect(status().isOk())
+            .andExpect(jsonPath("$.targetRevision").isString())
             .andExpect(jsonPath("$.actual[0].sheetKey").value("default"))
             .andExpect(jsonPath("$.actual[0].amount").value(1200000))
             .andExpect(jsonPath("$.readModel.months[0].yearMonth").value("2026-06"))

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -115,7 +115,7 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain('fetchCashflowSnapshotViaBff');
     expect(source).not.toContain('loadCashflowComparison');
     expect(source).not.toContain('cashflowSnapshot');
-    expect(source).toContain('monthCloseResult.dashboard.comparison');
+    expect(source).toContain('month?.comparison?.weeks');
     expect(source).toContain('projectionSummary?.projectionSalesAndVatTotal');
     expect(source).toContain('dashboard?.projectionActualSummary');
     expect(source).toContain('CashflowCanonicalSummary');
@@ -148,15 +148,14 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toMatch(/\}, \[orgId, projectId, resolveBffActor, selectedYear, user\?\.uid, yearMonth\]\);/);
   });
 
-  it('renders the pinned sheet formula results instead of recomputing summary cells in the browser', () => {
-    expect(source).toContain('cashflowSheetMirror.sheetFacts?.weeklyCalculationChecks');
-    expect(source).toContain('monthCloseResult?.dashboard?.sheetCalculationChecks');
-    expect(source).toContain('closedMonthStatus?.sheetCalculationChecks');
-    expect(source).toContain('const check = monthIsClosed');
-    expect(source).toContain('check?.reported?.depositTotal');
-    expect(source).toContain('check?.reported?.withdrawalTotal');
-    expect(source).toContain('check?.reported?.balance');
-    expect(source).toContain('getPinnedDerivedAmount(mode, week.yearMonth, week.weekNo, kind)');
+  it('renders JVM canonical formula results instead of the pinned Sheet formulas', () => {
+    expect(source).toContain('function getCanonicalDerivedAmount');
+    expect(source).toContain("monthCloseResult?.dashboard?.canonical?.months");
+    expect(source).toContain('check?.totalIn');
+    expect(source).toContain('check?.totalOut');
+    expect(source).toContain('check?.net');
+    expect(source).toContain('getCanonicalDerivedAmount(mode, week.yearMonth, week.weekNo, kind)');
+    expect(source).not.toContain('function getPinnedDerivedAmount');
   });
 
   it('drops the inbox card but keeps the issue count badge', () => {
@@ -596,7 +595,7 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('const previousAnnualYears = annualYears.filter((year) => year < selectedYear)');
     expect(source).toContain('const followingAnnualYears = annualYears.filter((year) => year > selectedYear)');
     expect(source).toContain('const renderAnnualSummaryCell');
-    expect(source).toContain('cashflowSheetMirror?.sheetFacts?.annualCashflowTotals');
+    expect(source).not.toContain('cashflowSheetMirror?.sheetFacts?.annualCashflowTotals');
     expect(source).toContain('annualYears.some((year) => !annualTotalFor(year, mode))');
     expect(source).toContain('Total');
     expect(source).toContain('const visibleWeeks = annualWeeks');
@@ -620,7 +619,7 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('visibleComparisonAnnualYears');
     expect(source).toContain('comparisonWeeks.reduce');
     expect(source).not.toContain('const cashflowTotalPeriodLabel = `${previousAnnualYears[0] || selectedYear}년 ~ ${followingAnnualYears.at(-1) || selectedYear}년`');
-    expect(source).toContain('const mirroredAnnualTotals = useMemo');
+    expect(source).not.toContain('const mirroredAnnualTotals = useMemo');
     expect(source).toContain('const annualTotalFor = (year: number');
     expect(source).not.toContain("const totalProjection = projectLineTotalFor('projection', lineId)");
     expect(source).not.toContain("const totalActual = projectLineTotalFor('actual', lineId)");
@@ -630,8 +629,8 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('followingComparisonAnnualYears.includes(cell.year)');
     expect(source).toContain('row.totalCell.difference');
     expect(source).toContain('difference: hasValue ? projection - actual : null');
-    expect(source).toContain("pinned.state === 'VALUE' || pinned.state === 'ZERO'");
-    expect(source).toContain("cell?.cellState === 'VALUE' || cell?.cellState === 'ZERO'");
+    expect(source).not.toContain("pinned.state === 'VALUE' || pinned.state === 'ZERO'");
+    expect(source).toContain('monthCloseResult?.dashboard?.canonical?.months?.find');
     expect(source).toContain('const columnCount = visibleComparisonAnnualYears.length + visibleComparisonWeeks.length + 1');
   });
 

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1718,9 +1718,6 @@ export function CashflowProjectSheet({
       || `w${weekNo}`;
   }
 
-  const mirroredAnnualTotals = useMemo(() => new Map((cashflowSheetMirror?.sheetFacts?.annualCashflowTotals || [])
-    .filter((row) => Number.isSafeInteger(row.year))
-    .map((row) => [row.year, row])), [cashflowSheetMirror?.sheetFacts?.annualCashflowTotals]);
   const annualYears = useMemo(() => {
     return CASHFLOW_STANDARD_ANNUAL_YEARS.filter((year) => year !== selectedYear);
   }, [selectedYear]);
@@ -1743,10 +1740,6 @@ export function CashflowProjectSheet({
     mode,
   );
   const annualTotalFor = (year: number, mode: 'projection' | 'actual') => {
-    const pinned = monthCloseResult?.status === 'OPEN'
-      ? mirroredAnnualTotals.get(year)?.[mode] || null
-      : null;
-    if (pinned) return pinned;
     const canonical = canonicalAnnualTotalFor(year, mode);
     if (canonical) return canonical;
     const jvmSource = monthCloseResult?.dashboard?.openingBalances?.selectedYear === selectedYear
@@ -1763,15 +1756,9 @@ export function CashflowProjectSheet({
         net: totalIn - totalOut,
       };
     }
-    return mirroredAnnualTotals.get(year)?.[mode] || null;
+    return null;
   };
-  const sheetGrandTotalFor = (mode: 'projection' | 'actual') => cashflowSheetMirror?.sheetFacts?.cashflowGrandTotalsBySourceYear
-    ?.find((total) => total.sourceYear === selectedYear)?.[mode] || null;
   const projectLineTotalFor = (mode: 'projection' | 'actual', lineId: CashflowSheetLineId) => {
-    const sheetGrandTotal = sheetGrandTotalFor(mode);
-    if (Object.prototype.hasOwnProperty.call(sheetGrandTotal?.lineAmounts || {}, lineId)) {
-      return Number(sheetGrandTotal?.lineAmounts[lineId] || 0);
-    }
     const rangeTotals = monthCloseResult?.dashboard?.canonical?.range?.[mode] as {
       rowTotals?: Record<CashflowSheetLineId, number>;
       lineAmounts?: Record<CashflowSheetLineId, number>;
@@ -1840,7 +1827,7 @@ export function CashflowProjectSheet({
       rows,
       changedRows: rows.filter((row) => row.changed),
     };
-  }, [cashflowSheetMirror, mirroredAnnualTotals, monthCloseResult, selectedYear, visibleComparisonAnnualYears, visibleComparisonWeeks, yearMonth]);
+  }, [monthCloseResult, selectedYear, visibleComparisonAnnualYears, visibleComparisonWeeks, yearMonth]);
 
   const cashflowTotalPeriodLabel = comparisonScope.periodLabel;
   const sheetRangeLabel = cashflowSheetConfig
@@ -1916,44 +1903,6 @@ export function CashflowProjectSheet({
     weekNo: number;
     lineId: CashflowSheetLineId;
   }): { amount: number; hasValue: boolean; mismatch: boolean } {
-    const monthIsClosed = (
-      monthCloseResult?.yearMonth === params.targetYearMonth
-      && ['CLOSED', 'REOPEN_REQUESTED'].includes(monthCloseResult.status)
-    ) || monthCloseResult?.dashboard?.monthCloseStatuses?.some((month) => (
-      month.yearMonth === params.targetYearMonth && ['CLOSED', 'REOPEN_REQUESTED'].includes(month.status)
-    ));
-    const pinned = !monthIsClosed && cashflowSheetMirror?.status === 'FRESH'
-      ? cashflowSheetMirror.cells?.find((candidate) => (
-        candidate.mode === params.mode
-        && candidate.yearMonth === params.targetYearMonth
-        && candidate.weekNo === params.weekNo
-        && candidate.lineId === params.lineId
-      ))
-      : null;
-    if (pinned) {
-      const hasValue = pinned.state === 'VALUE' || pinned.state === 'ZERO';
-      return {
-        amount: hasValue ? Number(pinned.amount || 0) : 0,
-        hasValue,
-        mismatch: false,
-      };
-    }
-    if (params.targetYearMonth === yearMonth && monthCloseResult?.dashboard) {
-      const cell = monthCloseResult.dashboard.cells?.find((candidate) => (
-        candidate.mode === params.mode
-        && candidate.weekNo === params.weekNo
-        && candidate.cashflowLine === params.lineId
-      ));
-      const comparisonLine = monthCloseResult.dashboard.comparison?.weeks
-        ?.find((candidate) => candidate.weekNo === params.weekNo)
-        ?.lines?.find((candidate) => candidate.lineId === params.lineId);
-      const hasValue = cell?.cellState === 'VALUE' || cell?.cellState === 'ZERO';
-      return {
-        amount: hasValue ? Number(cell?.amount || 0) : 0,
-        hasValue,
-        mismatch: comparisonLine?.mismatch === true,
-      };
-    }
     const month = monthCloseResult?.dashboard?.canonical?.months?.find((candidate) => candidate.yearMonth === params.targetYearMonth);
     const week = month?.[params.mode]?.weeks?.find((candidate) => candidate.weekNo === params.weekNo);
     const comparisonLine = month?.comparison?.weeks
@@ -1976,37 +1925,20 @@ export function CashflowProjectSheet({
     return getServerReadCell(params).amount;
   }
 
-  function getPinnedDerivedAmount(
+  function getCanonicalDerivedAmount(
     mode: 'projection' | 'actual',
     targetYearMonth: string,
     weekNo: number,
     kind: 'totalIn' | 'totalOut' | 'net',
   ): number | null {
-    const selectedMonthIsClosed = (
-      monthCloseResult?.yearMonth === targetYearMonth
-      && ['CLOSED', 'REOPEN_REQUESTED'].includes(monthCloseResult.status)
-    );
-    const closedMonthStatus = monthCloseResult?.dashboard?.monthCloseStatuses?.find((month) => (
-      month.yearMonth === targetYearMonth && ['CLOSED', 'REOPEN_REQUESTED'].includes(month.status)
-    ));
-    const monthIsClosed = selectedMonthIsClosed || Boolean(closedMonthStatus);
-    const frozenChecks = selectedMonthIsClosed
-      ? monthCloseResult?.dashboard?.sheetCalculationChecks
-      : closedMonthStatus?.sheetCalculationChecks;
-    const check = monthIsClosed
-      ? frozenChecks?.find((candidate) => (
-        candidate.mode === mode && candidate.yearMonth === targetYearMonth && candidate.weekNo === weekNo
-      ))
-      : cashflowSheetMirror?.status === 'FRESH'
-        ? cashflowSheetMirror.sheetFacts?.weeklyCalculationChecks?.find((candidate) => (
-          candidate.mode === mode && candidate.yearMonth === targetYearMonth && candidate.weekNo === weekNo
-        ))
-        : null;
+    const check = monthCloseResult?.dashboard?.canonical?.months
+      ?.find((month) => month.yearMonth === targetYearMonth)?.[mode]?.weeks
+      ?.find((week) => week.weekNo === weekNo);
     const value = kind === 'totalIn'
-      ? check?.reported?.depositTotal
+      ? check?.totalIn
       : kind === 'totalOut'
-        ? check?.reported?.withdrawalTotal
-        : check?.reported?.balance;
+        ? check?.totalOut
+        : check?.net;
     return typeof value === 'number' && Number.isSafeInteger(value) ? value : null;
   }
 
@@ -2197,14 +2129,6 @@ export function CashflowProjectSheet({
       actual: readServerSummary('actual'),
     };
     const projectTotalsFor = (mode: 'projection' | 'actual') => {
-      const sheetGrandTotal = sheetGrandTotalFor(mode);
-      if (sheetGrandTotal) {
-        return {
-          totalIn: Number(sheetGrandTotal.totalIn || 0),
-          totalOut: Number(sheetGrandTotal.totalOut || 0),
-          net: Number(sheetGrandTotal.net || 0),
-        };
-      }
       if (annualYears.some((year) => !annualTotalFor(year, mode))) {
         return { totalIn: null, totalOut: null, net: null };
       }
@@ -2301,7 +2225,7 @@ export function CashflowProjectSheet({
           {previousAnnualYears.map((year) => renderAnnualSummaryCell(mode, kind, year, emphasis, rowTone))}
           {visibleWeeks.map((week, index) => renderSummaryCell({
             keyName: `${mode}-${kind}-${week.yearMonth}-${week.weekNo}`,
-            value: getPinnedDerivedAmount(mode, week.yearMonth, week.weekNo, kind) ?? (derived[mode].weekTotals[index]?.[kind] || 0),
+            value: getCanonicalDerivedAmount(mode, week.yearMonth, week.weekNo, kind) ?? (derived[mode].weekTotals[index]?.[kind] || 0),
             mode,
             isThisWeek: todayYearMonth === week.yearMonth && todayIso >= week.weekStart && todayIso <= week.weekEnd,
             monthCloseStatus: monthCloseStatusByMonth.get(week.yearMonth),


### PR DESCRIPTION
## What
- Verify each applied Sheet month by reading back the JVM canonical snapshot with the resulting revision and all 160 cell states.
- Render project cashflow values from JVM canonical data only, then refresh that data after apply.
- Keep the admin Projection/Actual summary on the existing JVM batch endpoint.

## Why
Prevents a successful Sheet apply from leaving a Firestore mirror or stale UI value presented as the canonical cashflow value.

## Verification
- `npx vitest run server/bff/routes/cashflow-sheet-lab.test.mjs` (107 passed)
- `npx vitest run src/app/components/cashflow/CashflowProjectSheet.shell.test.ts` (59 passed)
- focused admin/BFF tests (190 passed)
- `mvn -q -Dtest=WeeklyExpenseControllerTest test` (59 passed)
- `npm run build`

## QA
Independent QA: PASS_WITH_GAPS, no merge blocker. Emulator not used.