### PR TITLE
fix(cashflow): show eligible project managers as approvers

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -166,6 +166,12 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain('xl:max-h-[126px]');
   });
 
+  it('allows an active project manager to be selected as organization head by another requester', () => {
+    expect(source).toContain('.filter((member) => member.uid !== user?.uid)');
+    expect(source).not.toContain('member.uid !== project?.registeredById');
+    expect(source).not.toContain('member.uid !== project?.managerId');
+  });
+
   it('labels rate tiles by loading, over, under, and OK', () => {
     expect(source).toContain('function rateStatusLabel');
     expect(source).toContain("if (monthCloseLoading || !monthCloseResult?.dashboard) return '확인 중';");

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -443,12 +443,8 @@ export function CashflowProjectSheet({
       && (!query || `${change.yearMonth} ${change.weekNo} ${change.mode} ${label} ${change.lineId}`.toLocaleLowerCase('ko-KR').includes(query));
   });
   const executiveApproverOptions = useMemo(() => buildOrgMemberPickerOptions(members || [])
-    .filter((member) => (
-      member.uid !== user?.uid
-      && member.uid !== project?.registeredById
-      && member.uid !== project?.managerId
-    )),
-  [members, project?.managerId, project?.registeredById, user?.uid]);
+    .filter((member) => member.uid !== user?.uid),
+  [members, user?.uid]);
 
   useEffect(() => {
     const approverId = project?.executiveApproverId || '';


### PR DESCRIPTION
## What
- 조직장 선택에서 현재 요청자만 제외합니다.
- 프로젝트 담당자/등록자는 다른 요청자가 지정할 수 있습니다.

## Verification
- `npm test -- --run src/app/components/cashflow/CashflowProjectSheet.shell.test.ts` (60/60)
- `npm run build`