### PR TITLE
fix(cashflow): sync sheet lab with selected project

### DIFF
--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
@@ -43,6 +43,47 @@ describe('CashflowSheetLabPage shell', () => {
     expect(pageSource).toContain('../../data/portal-store');
   });
 
+  it('drives every request from one project resolved by route and session together', () => {
+    expect(pageSource).toContain('resolvePortalProjectContextSync');
+    expect(pageSource).toContain('sessionProjectId: portalProjectId');
+    expect(pageSource).toContain('previousSessionProjectId: syncedSessionProjectIdRef.current');
+    expect(pageSource).toContain('const projectId = projectContextSync.projectId;');
+    expect(pageSource).toContain("projectContextAction === 'canonicalize-path'");
+    expect(pageSource).toContain("projectContextAction !== 'adopt-route'");
+    expect(pageSource).toContain('setSessionActiveProject(projectId)');
+    // route projectId만 신뢰하던 로컬 상태는 상단 프로젝트 전환을 따라가지 못했다.
+    expect(pageSource).not.toContain('projectIdInput');
+    expect(pageSource).not.toContain('setProjectIdInput');
+    expect(pageSource).not.toContain('initialProjectId');
+  });
+
+  it('never carries a previous project apply recovery or sheet draft into the next project', () => {
+    const recoveryReset = pageSource.slice(
+      pageSource.indexOf('이전 프로젝트의 반영 복구 상태를'),
+      pageSource.indexOf('}, [projectId]);', pageSource.indexOf('이전 프로젝트의 반영 복구 상태를')),
+    );
+    expect(recoveryReset).toContain('setClosedMonthStage(null);');
+    expect(recoveryReset).toContain('setClosedMonthWarning([]);');
+    expect(recoveryReset).toContain("setClosedMonthChangeReason('');");
+    expect(recoveryReset).toContain('setClosedMonthFormulaAccepted(false);');
+    expect(recoveryReset).toContain('setClosedMonthPendingApprovalAccepted(false);');
+    expect(recoveryReset).toContain('setPendingApprovalStage(null);');
+    expect(recoveryReset).toContain('setFormulaMismatchPrompt(null);');
+    expect(recoveryReset).toContain('setApplyResumeRequired(false);');
+
+    const draftReset = pageSource.slice(
+      pageSource.indexOf('이전 시트 draft를 남기지 않는다'),
+      pageSource.indexOf('}, [projectId, sourceYear]);'),
+    );
+    expect(draftReset).toContain('setSavedConfig(null);');
+    expect(draftReset).toContain("setSheetLink('');");
+    expect(draftReset).toContain('setMirror(null);');
+    expect(draftReset).toContain("setReviewedSourceKey('');");
+    expect(draftReset).toContain('setReflectResult(null);');
+    // 시트 draft 정리는 BFF 토큰 유무와 무관하게 프로젝트 전환마다 실행돼야 한다.
+    expect(draftReset).not.toContain('actor.idToken');
+  });
+
   it('uses the lab BFF client without exposing legacy cashflow write actions', () => {
     expect(pageSource).not.toContain('getCashflowSheetLabMirrorViaBff');
     expect(pageSource).toContain('refreshCashflowSheetLabMirrorViaBff');

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
@@ -34,7 +34,7 @@ import {
 } from '../../components/ui/dialog';
 import { readRecentPortalProjectIds, rememberRecentPortalProject } from '../../platform/portal-recent-projects';
 import { recordDevtoolsLog } from '../../platform/devtools-transaction-log';
-import { resolvePortalProjectResourcePath } from '../../platform/portal-project-selection';
+import { resolvePortalProjectContextSync, resolvePortalProjectResourcePath } from '../../platform/portal-project-selection';
 import { CashflowSheetSyncOverlay, type CashflowSheetSyncOperation } from '../../components/cashflow/CashflowSheetSyncOverlay';
 import { CashflowFormulaMismatchDialog } from '../../components/cashflow/CashflowFormulaMismatchDialog';
 
@@ -226,7 +226,7 @@ export function CashflowSheetLabPage({
   projectIdOverride?: string;
 } = {}) {
   const { user: authUser, loginWithGoogle } = useAuth();
-  const { activeProjectId, myProject } = usePortalStore();
+  const { activeProjectId, myProject, setSessionActiveProject } = usePortalStore();
   const { orgId } = useFirebase();
   const { projectId: routeProjectIdParam } = useParams<{ projectId: string }>();
   const routeProjectId = routeProjectIdParam?.trim() || '';
@@ -234,17 +234,14 @@ export function CashflowSheetLabPage({
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const portalProjectId = activeProjectId || myProject?.id || '';
-  const initialProjectId = useMemo(() => (
-    routeProjectId
-    || projectIdOverride?.trim()
+  const fallbackProjectId = useMemo(() => (
+    projectIdOverride?.trim()
     || searchParams.get('projectId')?.trim()
-    || portalProjectId
     || authUser?.projectId
     || authUser?.projectIds?.[0]
     || readRecentPortalProjectIds()[0]
     || ''
-  ), [authUser?.projectId, authUser?.projectIds, portalProjectId, projectIdOverride, routeProjectId, searchParams]);
-  const [projectIdInput, setProjectIdInput] = useState(initialProjectId);
+  ), [authUser?.projectId, authUser?.projectIds, projectIdOverride, searchParams]);
   const projectYears = useMemo(() => {
     const startYear = /^\d{4}-/.test(myProject?.contractStart || '') ? Number(myProject?.contractStart.slice(0, 4)) : Number.NaN;
     const endYear = /^\d{4}-/.test(myProject?.contractEnd || '') ? Number(myProject?.contractEnd.slice(0, 4)) : Number.NaN;
@@ -305,9 +302,19 @@ export function CashflowSheetLabPage({
   const configLoadGenerationRef = useRef(0);
   const refreshButtonRef = useRef<HTMLButtonElement>(null);
   const stageButtonRef = useRef<HTMLButtonElement>(null);
-  const projectId = projectIdInput.trim();
-  const tutorialStorageKey = projectId ? `cashflow-sheet-tutorial:${projectId}` : '';
+  const syncedSessionProjectIdRef = useRef('');
   const currentPath = `${location.pathname}${location.search}${location.hash}`;
+  const projectContextSync = resolvePortalProjectContextSync({
+    routeProjectId,
+    sessionProjectId: portalProjectId,
+    previousSessionProjectId: syncedSessionProjectIdRef.current,
+    fallbackProjectId,
+    currentPath,
+  });
+  const projectId = projectContextSync.projectId;
+  const projectContextAction = projectContextSync.action;
+  const projectContextPath = projectContextSync.path;
+  const tutorialStorageKey = projectId ? `cashflow-sheet-tutorial:${projectId}` : '';
   const spreadsheetId = useMemo(() => extractSpreadsheetIdFromSheetInput(sheetLink), [sheetLink]);
   const hasSheetDraft = Boolean(sheetLink.trim() || sheetName.trim());
   const sourceKey = useMemo(() => buildSourceKey({
@@ -444,31 +451,43 @@ export function CashflowSheetLabPage({
     }
   }
 
+  // URL route projectId와 상단 선택 프로젝트를 항상 한 프로젝트로 맞춘다.
   useEffect(() => {
-    if (projectIdInput || !initialProjectId) return;
-    setProjectIdInput(initialProjectId);
-  }, [initialProjectId, projectIdInput]);
-
-  useEffect(() => {
-    if (!routeProjectId || routeProjectId === projectIdInput) return;
-    setProjectIdInput(routeProjectId);
-  }, [projectIdInput, routeProjectId]);
-
-  useEffect(() => {
-    if (routeProjectId) return;
-    const nextProjectId = projectIdOverride?.trim();
-    if (!nextProjectId || nextProjectId === projectIdInput) return;
-    setProjectIdInput(nextProjectId);
-  }, [projectIdInput, projectIdOverride, routeProjectId]);
-
-  useEffect(() => {
-    if (projectIdInput || !portalProjectId) return;
-    setProjectIdInput(portalProjectId);
-  }, [portalProjectId, projectIdInput]);
+    syncedSessionProjectIdRef.current = portalProjectId;
+    if (projectContextAction === 'canonicalize-path') {
+      if (projectContextPath && projectContextPath !== currentPath) {
+        navigate(projectContextPath, { replace: true });
+      }
+      return;
+    }
+    if (projectContextAction !== 'adopt-route') return;
+    let cancelled = false;
+    void (async () => {
+      const adopted = await setSessionActiveProject(projectId);
+      if (cancelled || adopted) return;
+      const sessionPath = resolvePortalProjectResourcePath(currentPath, portalProjectId);
+      if (sessionPath !== currentPath) navigate(sessionPath, { replace: true });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [currentPath, navigate, portalProjectId, projectContextAction, projectContextPath, projectId, setSessionActiveProject]);
 
   useEffect(() => {
     if (!projectId) return;
     rememberRecentPortalProject(projectId);
+  }, [projectId]);
+
+  // 프로젝트가 바뀌면 이전 프로젝트의 반영 복구 상태를 새 프로젝트로 이어받지 않는다.
+  useEffect(() => {
+    setClosedMonthStage(null);
+    setClosedMonthWarning([]);
+    setClosedMonthChangeReason('');
+    setClosedMonthFormulaAccepted(false);
+    setClosedMonthPendingApprovalAccepted(false);
+    setPendingApprovalStage(null);
+    setFormulaMismatchPrompt(null);
+    setApplyResumeRequired(false);
   }, [projectId]);
 
   useEffect(() => {
@@ -505,11 +524,6 @@ export function CashflowSheetLabPage({
     if (projectYears.includes(sourceYear)) return;
     setSourceYear(projectYears[0] || 2026);
   }, [projectYears, sourceYear]);
-
-  useEffect(() => {
-    if (routeProjectId || !projectId) return;
-    navigate(resolvePortalProjectResourcePath(currentPath, projectId), { replace: true });
-  }, [currentPath, navigate, projectId, routeProjectId]);
 
   useEffect(() => {
     if (!tutorialStorageKey) return;
@@ -598,8 +612,8 @@ export function CashflowSheetLabPage({
     }
   }
 
+  // 프로젝트나 연동 연도가 바뀌면 이전 시트 draft를 남기지 않는다.
   useEffect(() => {
-    if (!projectId || !actor.idToken) return;
     configLoadGenerationRef.current += 1;
     setSavedConfig(null);
     setSavedConfigs([]);
@@ -610,6 +624,10 @@ export function CashflowSheetLabPage({
     setReflectResult(null);
     setStatusMessage('');
     setErrorMessage('');
+  }, [projectId, sourceYear]);
+
+  useEffect(() => {
+    if (!projectId || !actor.idToken) return;
     void handleLoadShareAccount({ forceHydrate: true });
   }, [actor.idToken, projectId, sourceYear]);
 

--- a/src/app/platform/portal-project-selection.test.ts
+++ b/src/app/platform/portal-project-selection.test.ts
@@ -3,6 +3,7 @@ import type { Project } from '../data/types';
 import {
   resolveActivePortalProjectId,
   resolvePortalProjectCandidates,
+  resolvePortalProjectContextSync,
   resolvePortalProjectResourceId,
   resolvePortalProjectResourcePath,
   resolvePortalProjectSelectPath,
@@ -134,6 +135,101 @@ describe('portal project selection helpers', () => {
     expect(resolvePortalProjectResourcePath('/portal/budget?month=2026-07', 'new-project')).toBe(
       '/portal/budget?month=2026-07',
     );
+  });
+
+  it('canonicalizes a bare project resource path to the session project', () => {
+    expect(resolvePortalProjectContextSync({
+      routeProjectId: '',
+      sessionProjectId: 'p-managed',
+      previousSessionProjectId: '',
+      fallbackProjectId: 'p-recent',
+      currentPath: '/portal/cashflow/sheets-lab',
+    })).toEqual({
+      projectId: 'p-managed',
+      action: 'canonicalize-path',
+      path: '/portal/cashflow/p-managed/sheets-lab',
+    });
+
+    expect(resolvePortalProjectContextSync({
+      routeProjectId: '',
+      sessionProjectId: '',
+      previousSessionProjectId: '',
+      fallbackProjectId: 'p-recent',
+      currentPath: '/portal/cashflow/sheets-lab?step=2',
+    })).toEqual({
+      projectId: 'p-recent',
+      action: 'canonicalize-path',
+      path: '/portal/cashflow/p-recent/sheets-lab?step=2',
+    });
+
+    expect(resolvePortalProjectContextSync({
+      routeProjectId: '',
+      sessionProjectId: '',
+      previousSessionProjectId: '',
+      fallbackProjectId: '',
+      currentPath: '/portal/cashflow/sheets-lab',
+    })).toEqual({ projectId: '', action: 'idle', path: '' });
+  });
+
+  it('keeps the route project while the session project is still resolving or already matches', () => {
+    expect(resolvePortalProjectContextSync({
+      routeProjectId: 'p-assigned',
+      sessionProjectId: '',
+      previousSessionProjectId: '',
+      fallbackProjectId: 'p-recent',
+      currentPath: '/portal/cashflow/p-assigned/sheets-lab',
+    })).toEqual({ projectId: 'p-assigned', action: 'idle', path: '' });
+
+    expect(resolvePortalProjectContextSync({
+      routeProjectId: 'p-assigned',
+      sessionProjectId: 'p-assigned',
+      previousSessionProjectId: 'p-assigned',
+      fallbackProjectId: '',
+      currentPath: '/portal/cashflow/p-assigned/sheets-lab',
+    })).toEqual({ projectId: 'p-assigned', action: 'idle', path: '' });
+  });
+
+  it('adopts a deep-linked route project into the session instead of silently redirecting', () => {
+    expect(resolvePortalProjectContextSync({
+      routeProjectId: 'p-assigned',
+      sessionProjectId: 'p-managed',
+      previousSessionProjectId: '',
+      fallbackProjectId: '',
+      currentPath: '/portal/cashflow/p-assigned/sheets-lab',
+    })).toEqual({ projectId: 'p-assigned', action: 'adopt-route', path: '' });
+  });
+
+  it('realigns the route when the top project selector switches the session project', () => {
+    expect(resolvePortalProjectContextSync({
+      routeProjectId: 'p-assigned',
+      sessionProjectId: 'p-managed',
+      previousSessionProjectId: 'p-assigned',
+      fallbackProjectId: 'p-assigned',
+      currentPath: '/portal/cashflow/p-assigned/sheets-lab#review',
+    })).toEqual({
+      projectId: 'p-managed',
+      action: 'canonicalize-path',
+      path: '/portal/cashflow/p-managed/sheets-lab#review',
+    });
+  });
+
+  it('settles on one project after a session switch is applied to the route', () => {
+    const switched = resolvePortalProjectContextSync({
+      routeProjectId: 'p-assigned',
+      sessionProjectId: 'p-managed',
+      previousSessionProjectId: 'p-assigned',
+      fallbackProjectId: '',
+      currentPath: '/portal/cashflow/p-assigned/sheets-lab',
+    });
+    const settled = resolvePortalProjectContextSync({
+      routeProjectId: 'p-managed',
+      sessionProjectId: 'p-managed',
+      previousSessionProjectId: 'p-managed',
+      fallbackProjectId: '',
+      currentPath: switched.path,
+    });
+
+    expect(settled).toEqual({ projectId: 'p-managed', action: 'idle', path: '' });
   });
 
   it('runs the dirty guard before state mutation and navigation', async () => {

--- a/src/app/platform/portal-project-selection.ts
+++ b/src/app/platform/portal-project-selection.ts
@@ -152,6 +152,56 @@ export function resolvePortalProjectResourcePath(requestedPath: string, projectI
   return normalizedPath;
 }
 
+export type PortalProjectContextAction = 'idle' | 'adopt-route' | 'canonicalize-path';
+
+export interface PortalProjectContextSync {
+  projectId: string;
+  action: PortalProjectContextAction;
+  path: string;
+}
+
+/**
+ * 프로젝트 단위 화면에서 URL route projectId와 세션 선택 프로젝트가 어긋났을 때
+ * 어느 쪽을 기준으로 맞출지 결정한다. 상단 선택기를 바꾼 경우에는 URL을,
+ * 딥링크·뒤로가기로 들어온 경우에는 세션 선택을 다시 맞춘다.
+ */
+export function resolvePortalProjectContextSync(input: {
+  routeProjectId?: string | null;
+  sessionProjectId?: string | null;
+  previousSessionProjectId?: string | null;
+  fallbackProjectId?: string | null;
+  currentPath: string;
+}): PortalProjectContextSync {
+  const routeProjectId = normalizedId(input.routeProjectId);
+  const sessionProjectId = normalizedId(input.sessionProjectId);
+  const previousSessionProjectId = normalizedId(input.previousSessionProjectId);
+  const fallbackProjectId = normalizedId(input.fallbackProjectId);
+
+  if (!routeProjectId) {
+    const targetProjectId = sessionProjectId || fallbackProjectId;
+    if (!targetProjectId) return { projectId: '', action: 'idle', path: '' };
+    return {
+      projectId: targetProjectId,
+      action: 'canonicalize-path',
+      path: resolvePortalProjectResourcePath(input.currentPath, targetProjectId),
+    };
+  }
+
+  if (!sessionProjectId || routeProjectId === sessionProjectId) {
+    return { projectId: routeProjectId, action: 'idle', path: '' };
+  }
+
+  if (previousSessionProjectId && previousSessionProjectId !== sessionProjectId) {
+    return {
+      projectId: sessionProjectId,
+      action: 'canonicalize-path',
+      path: resolvePortalProjectResourcePath(input.currentPath, sessionProjectId),
+    };
+  }
+
+  return { projectId: routeProjectId, action: 'adopt-route', path: '' };
+}
+
 export async function runPortalProjectSwitch(input: {
   projectId: string;
   currentPath: string;

--- a/src/app/routes.portal-canonical.shell.test.ts
+++ b/src/app/routes.portal-canonical.shell.test.ts
@@ -31,7 +31,9 @@ describe('portal canonical edit resource routes', () => {
     expect(cashflowSource).toContain('<Navigate to={resolvePortalProjectResourcePath(currentPath, projectId)} replace />');
     expect(sheetLabSource).toContain('useParams');
     expect(sheetLabSource).toContain('routeProjectId');
-    expect(sheetLabSource).toContain("navigate(resolvePortalProjectResourcePath(currentPath, projectId), { replace: true })");
+    // 시트 연동 화면은 route projectId와 상단 선택 프로젝트를 한 프로젝트로 맞춘 뒤 URL을 정규화한다.
+    expect(sheetLabSource).toContain('resolvePortalProjectContextSync');
+    expect(sheetLabSource).toContain('navigate(projectContextPath, { replace: true })');
   });
 
   it('remounts the finance screen when the project resource changes', () => {


### PR DESCRIPTION
## What
- 프로젝트 전환 시 URL·세션·시트 연동 요청이 동일한 프로젝트를 사용하도록 정규화합니다.
- 이전 프로젝트의 시트 반영 복구 모달과 draft 상태를 즉시 초기화합니다.

## Verification
- focused tests 34/34
- full unit suite 2719 passed / 10 skipped
- typecheck baseline passed
- production build passed