### PR TITLE
docs(cashflow): add project switching hotfix note

### DIFF
--- a/docs/wiki/patch-notes/log.md
+++ b/docs/wiki/patch-notes/log.md
@@ -1,5 +1,11 @@
 # Patch Notes Log
 
+## [2026-08-06] hotfix | portal-cashflow | 프로젝트 전환 시 시트 반영 상태 고정 복구
+- pages: [portal-cashflow](./pages/portal-cashflow.md)
+- prs: [#463](https://github.com/merryAI-dev/MYSCube/pull/463), [#464](https://github.com/merryAI-dev/MYSCube/pull/464)
+- commits: `a3809da`, `404a532`
+- summary: 프로젝트 선택을 바꾼 뒤에도 이전 사업의 시트 반영 복구 모달이 남는 문제를 고쳤다. 시트 연동 화면은 URL·세션 선택·BFF 요청을 같은 프로젝트 ID로 정렬하고, 전환 시 이전 프로젝트의 반영 복구와 임시 시트 상태를 비운다. 조직장 선택은 현재 요청자만 제외해 다른 사용자가 지정할 때 활성 프로젝트 담당자도 선택할 수 있다.
+
 ## [2026-08-03] patch-note | portal-budget | 예산 총계 가독성 정리
 - pages: [portal-budget](./pages/portal-budget.md)
 - summary: 포털 예산 화면의 중복 전체 소진율·집행·잔액 표시를 제거하고 예산·집행·잔액 총계의 글자 크기를 한 단계 키웠다.

--- a/docs/wiki/patch-notes/pages/portal-cashflow.md
+++ b/docs/wiki/patch-notes/pages/portal-cashflow.md
@@ -3,7 +3,7 @@
 - route: `/portal/cashflow`
 - primary users: PM, projection 입력 담당자
 - status: active
-- last updated: 2026-07-24
+- last updated: 2026-08-06
 
 ## Purpose
 
@@ -29,6 +29,8 @@
 ## Recent Changes
 
 - [2026-07-24] 이전 형식의 월 결산 기록에 주차 합계 블록이 없어도 현금흐름 화면 전체가 중단되지 않고, 저장된 행 값으로 합계를 표시하도록 복구했다.
+- [2026-08-06] 상단 프로젝트 선택을 바꾼 뒤에도 이전 프로젝트의 시트 반영 상태가 남아 보이던 문제를 수정했다. 시트 연동 화면은 URL·선택 프로젝트·BFF 요청을 같은 프로젝트 ID로 맞추고, 전환 시 이전 프로젝트의 반영 복구 모달과 임시 시트 상태를 비운다.
+- [2026-08-06] 조직장 선택 목록은 현재 요청자만 제외한다. 다른 사용자가 지정하는 경우에는 프로젝트 등록자 또는 담당자도 활성 구성원이면 조직장으로 선택할 수 있다.
 - [2026-07-24] 공식 시트의 계산 결과를 그대로 고정하는 one-way 연동으로 정리했다. `미입력`, `0`, 금액과 전년도 행별 이월값을 보존하고, 결산된 월의 값이 달라지면 서버가 사유와 경고 누적을 요구한다. 시트 반영과 월 결산이 겹칠 때는 한쪽이 미완료 데이터를 읽지 않도록 차단하며, 중단된 반영은 서버 상태를 기준으로 복구한다.
 - [2026-04-14] migration 설명 카드와 긴 형식 안내를 제거하고 compact import action만 남겼다.
 - [2026-04-15] PM용 cashflow 주차 구독은 Firestore에서 project 기준으로만 listen하고, 연도 범위는 클라이언트에서 필터링하도록 바꿔 PM 포털 전체가 cashflow index drift에 덜 민감하게 만들었다.
@@ -45,12 +47,14 @@
 - `src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx`
 - `server/bff/routes/cashflow-sheet-lab.mjs`
 - `src/app/routes.tsx`
+- `src/app/platform/portal-project-selection.ts`
 
 ## Related Tests
 
 - `src/app/components/portal/PortalMinimalSweep.layout.test.ts`
 - `src/app/components/cashflow/CashflowProjectSheet.shell.test.ts`
 - `src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts`
+- `src/app/platform/portal-project-selection.test.ts`
 - `server/bff/routes/cashflow-sheet-lab.test.mjs`
 
 ## Next Watch Points


### PR DESCRIPTION
## Summary
- 8월 6일 캐시플로 프로젝트 전환 Sticky hotfix와 조직장 선택 기준을 패치노트에 기록합니다.

## Verification
- patch-note wiki directory contract 확인