### PR TITLE
fix(cashflow): 시트 반영 복구 무한 루프 해제

### DIFF
--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -2996,13 +2996,33 @@ async function applyStagedCashflowSheetLab({
     ? stageRun.openingBalanceCells
     : [];
 
-  const mirror = await readCashflowSheetMirror(db, tenantId, projectId);
-  assertFreshCashflowSheetMirror(mirror);
-  if (
-    readOptionalText(mirror?.configRevision) !== readOptionalText(stageRun.configRevision)
-    || readOptionalText(mirror?.sourceRevision) !== readOptionalText(stageRun.sourceRevision)
-  ) {
-    throw createHttpError(409, '검토 후 시트 고정본이 변경되었습니다. 다시 검토해 주세요.', 'cashflow_sheet_mirror_revision_conflict');
+  let mirror;
+  try {
+    mirror = await readCashflowSheetMirror(db, tenantId, projectId);
+    assertFreshCashflowSheetMirror(mirror);
+    if (
+      readOptionalText(mirror?.configRevision) !== readOptionalText(stageRun.configRevision)
+      || readOptionalText(mirror?.sourceRevision) !== readOptionalText(stageRun.sourceRevision)
+    ) {
+      throw createHttpError(409, '검토 후 시트 고정본이 변경되었습니다. 다시 검토해 주세요.', 'cashflow_sheet_mirror_revision_conflict');
+    }
+  } catch (error) {
+    const code = readOptionalText(error?.code);
+    if (
+      resuming
+      && Object.keys(stageRun.applyOperations || {}).length === 0
+      && ['cashflow_sheet_config_changed', 'cashflow_sheet_mirror_stale', 'cashflow_sheet_mirror_revision_conflict'].includes(code)
+    ) {
+      await restoreCashflowSheetApplyReady({
+        db,
+        runRef: db.doc(`orgs/${tenantId}/${CASHFLOW_SHEET_STAGE_RUNS_COLLECTION_ID}/${stagedRunId}`),
+        publicationRef: db.doc(`orgs/${tenantId}/cashflow_sheet_publications/${projectId}`),
+        idempotencyKey: stageRun.appliedIdempotencyKey,
+        applyRequestHash: stageRun.applyRequestHash,
+        error,
+      });
+    }
+    throw error;
   }
   if (!resuming) {
     const currentTargetSnapshot = await readCashflowWeeksSnapshot(db, tenantId, projectId);

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -2727,6 +2727,59 @@ describe('cashflow sheet lab route', () => {
     expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_change_candidates/')).toHaveLength(0);
   });
 
+  it('releases a resume lock when its fixed mirror changed before any JVM operation', async () => {
+    const { app, db, stage } = await stageJanuaryApply({
+      applyCashflowSheetLab: vi.fn(async (input) => javaApplyResponse(input, 'sha256:test')),
+    }, 'resume-stale');
+    const run = db.__getDocument(`orgs/tenant-a/cashflow_sheet_stage_runs/${stage.body.runId}`);
+    const applyRequestHash = createHash('sha256').update(JSON.stringify({
+      stagedRunId: stage.body.runId,
+      applyRiskCandidates: false,
+    })).digest('hex');
+    Object.assign(run, {
+      status: 'APPLYING',
+      appliedIdempotencyKey: 'interrupted-apply',
+      applyRequestHash,
+      applyOperations: {},
+    });
+    await db.doc('orgs/tenant-a/cashflow_sheet_publications/project-a').set({
+      status: 'APPLYING',
+      stagedRunId: stage.body.runId,
+    });
+    db.__getDocument('orgs/tenant-a/cashflow_sheet_mirrors/project-a').sourceRevision = `sha256:${'9'.repeat(64)}`;
+
+    const resume = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
+      .send({ stageRunId: stage.body.runId, idempotencyKey: 'resume-stale-retry' });
+    expect(resume.status).toBe(409);
+    expect(resume.body.code).toBe('cashflow_sheet_mirror_revision_conflict');
+
+    expect(db.__getDocument(`orgs/tenant-a/cashflow_sheet_stage_runs/${stage.body.runId}`))
+      .toMatchObject({ status: 'READY', applyFailure: { code: 'cashflow_sheet_mirror_revision_conflict' } });
+    expect(db.__getDocument('orgs/tenant-a/cashflow_sheet_publications/project-a')).toMatchObject({ status: 'READY' });
+    await request(app)
+      .get('/api/v1/projects/project-a/cashflow-sheet-lab/apply-status')
+      .expect(200)
+      .expect((response) => expect(response.body.status).toBe('IDLE'));
+
+    const uncertainRun = db.__getDocument(`orgs/tenant-a/cashflow_sheet_stage_runs/${stage.body.runId}`);
+    Object.assign(uncertainRun, {
+      status: 'APPLYING',
+      appliedIdempotencyKey: 'uncertain-apply',
+      applyRequestHash,
+      applyOperations: { month: { status: 'UNCERTAIN' } },
+    });
+    await db.doc('orgs/tenant-a/cashflow_sheet_publications/project-a').set({
+      status: 'APPLYING',
+      stagedRunId: stage.body.runId,
+    });
+    await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
+      .send({ stageRunId: stage.body.runId, idempotencyKey: 'uncertain-retry' })
+      .expect(409);
+    expect(db.__getDocument(`orgs/tenant-a/cashflow_sheet_stage_runs/${stage.body.runId}`).status).toBe('APPLYING');
+  });
+
   it('replays stage idempotently without duplicating candidates', async () => {
     const db = createDb({
       project: {

--- a/src/app/components/portal/PortalBankStatementPage.tsx
+++ b/src/app/components/portal/PortalBankStatementPage.tsx
@@ -277,6 +277,7 @@ export function PortalBankStatementPage() {
     portalUser,
     myProject,
     bankStatementRows,
+    bankStatementProjectId,
     expenseSheets,
     expenseSheetRows,
     budgetCodeBook,
@@ -286,8 +287,8 @@ export function PortalBankStatementPage() {
     refreshBankStatementRows,
   } = usePortalStore();
   const { orgId } = useFirebase();
-  const [columns, setColumns] = useState<string[]>(bankStatementRows?.columns || []);
-  const [rows, setRows] = useState<BankStatementRow[]>(bankStatementRows?.rows || []);
+  const [columns, setColumns] = useState<string[]>([]);
+  const [rows, setRows] = useState<BankStatementRow[]>([]);
   const [dirty, setDirty] = useState(false);
   const [saving, setSaving] = useState(false);
   const [dragActive, setDragActive] = useState(false);
@@ -306,11 +307,14 @@ export function PortalBankStatementPage() {
   const wizardDraftsRef = useRef<Record<string, WizardDraft>>({});
   const wizardGridDraggingRef = useRef(false);
   const loadedProjectIdRef = useRef('');
+  const currentProjectIdRef = useRef('');
   const loadedPrivateDraftKeyRef = useRef('');
   const privateDraftLoadRef = useRef<{ key: string; promise: Promise<void> } | null>(null);
 
   const projectName = myProject?.name || '내 사업';
   const projectId = activeProjectId || myProject?.id || '';
+  currentProjectIdRef.current = projectId;
+  const scopedBankStatementRows = bankStatementProjectId === projectId ? bankStatementRows : null;
   const bffActor = useMemo(() => ({
     uid: authUser?.uid || portalUser?.id || 'portal-user',
     email: authUser?.email || portalUser?.email || '',
@@ -345,6 +349,7 @@ export function PortalBankStatementPage() {
     if (privateDraftLoadRef.current?.key === key) return privateDraftLoadRef.current.promise;
     const promise = (async () => {
       const opened = await cashflowPrivateDraftClient.open(ownership, { baseSnapshot: {}, payload: {} });
+      if (currentProjectIdRef.current !== projectId) return;
       const bankStatement = opened.draft.payload.bankStatement;
       if (bankStatement && typeof bankStatement === 'object' && !Array.isArray(bankStatement)) {
         const snapshot = bankStatement as { columns?: unknown; rows?: unknown };
@@ -488,13 +493,13 @@ export function PortalBankStatementPage() {
   }, [projectId]);
 
   useEffect(() => {
-    if (dirty || !bankStatementRows) return;
-    const nextColumns = bankStatementRows.columns || [];
-    const nextRows = bankStatementRows.rows || [];
+    if (dirty || !scopedBankStatementRows) return;
+    const nextColumns = scopedBankStatementRows.columns || [];
+    const nextRows = scopedBankStatementRows.rows || [];
     setColumns(nextColumns);
     setRows(nextRows);
     setSelectedRowIds(new Set());
-  }, [bankStatementRows, dirty]);
+  }, [dirty, scopedBankStatementRows]);
 
   useEffect(() => {
     wizardDraftsRef.current = wizardDrafts;

--- a/src/app/data/portal-store.cashflow-boundary.shell.test.ts
+++ b/src/app/data/portal-store.cashflow-boundary.shell.test.ts
@@ -15,6 +15,10 @@ const bankApply = source.slice(
   source.indexOf('const applyBankStatementRowsToExpenseSheet ='),
   source.indexOf('const refreshBankStatementRows ='),
 );
+const bankRefresh = source.slice(
+  source.indexOf('const refreshBankStatementRows ='),
+  source.indexOf('const upsertExpenseIntakeItems ='),
+);
 const weeklyStatus = source.slice(
   source.indexOf('const upsertWeeklySubmissionStatus ='),
   source.indexOf('const createProjectRequest ='),
@@ -41,6 +45,13 @@ describe('portal store cashflow mutation boundary', () => {
     expect(bankApply).toContain('applyBankStatementItemsViaBff');
     expect(bankApply).toContain('finalize: true');
     expect(bankApply).not.toContain('setDoc(');
+  });
+
+  it('drops bank statement results that finish after the project changes', () => {
+    expect(source).toContain("setBankStatementRows(null);\n    setBankStatementProjectId('');\n  }, [currentProjectId]);");
+    expect(source).toContain('bankStatementProjectId');
+    expect(source).toContain('setBankStatementProjectId(projectId);');
+    expect(bankRefresh).toContain('if (currentProjectIdRef.current !== projectId) return;');
   });
 
   it('sends weekly status intent to the BFF without a direct Firestore mutation', () => {

--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -504,6 +504,7 @@ interface PortalState {
   activeExpenseSheetId: string;
   expenseSheetRows: ImportRow[] | null;
   bankStatementRows: BankStatementSheet | null;
+  bankStatementProjectId: string;
   budgetPlanRows: BudgetPlanRow[] | null;
   budgetCodeBook: BudgetCodeEntry[];
   budgetTreeV2: BudgetTreeV2 | null;
@@ -721,6 +722,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
   const [activeExpenseSheetId, setActiveExpenseSheetIdState] = useState('default');
   const [expenseSheetRows, setExpenseSheetRows] = useState<ImportRow[] | null>(null);
   const [bankStatementRows, setBankStatementRows] = useState<BankStatementSheet | null>(null);
+  const [bankStatementProjectId, setBankStatementProjectId] = useState('');
   const [budgetPlanRows, setBudgetPlanRows] = useState<BudgetPlanRow[] | null>(null);
   const [budgetCodeBook, setBudgetCodeBook] = useState<BudgetCodeEntry[]>(
     normalizeBudgetCodeBook(BUDGET_CODE_BOOK as unknown as BudgetCodeEntry[]),
@@ -806,6 +808,8 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     return projects.find((project) => project.id === activeProjectId) || null;
   }, [activeProjectId, projects]);
   const currentProjectId = activeProjectId;
+  const currentProjectIdRef = useRef(currentProjectId);
+  currentProjectIdRef.current = currentProjectId;
   const { allowRealtimeListeners: livePortalMode } = useFirestoreAccessPolicy(portalUser?.role || authUser?.role);
   const hasHydratedPortalSession = Boolean(
     isAuthenticated && authUser?.uid && portalUser?.id === authUser.uid,
@@ -1117,6 +1121,11 @@ export function PortalProvider({ children }: { children: ReactNode }) {
       projectCatalogUnsubsRef.current = [];
     };
   }, [authLoading, isMemberLoading, isAuthenticated, authUser?.uid, hasHydratedPortalSession, firestoreEnabled, db, orgId, isDevHarnessUser, assignedProjectIdsKey, livePortalMode]);
+
+  useEffect(() => {
+    setBankStatementRows(null);
+    setBankStatementProjectId('');
+  }, [currentProjectId]);
 
   useEffect(() => {
     projectScopeUnsubsRef.current.forEach((unsub) => unsub());
@@ -1618,6 +1627,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
           status: row?.status === 'applied' ? 'applied' as const : 'staged' as const,
         }));
         setBankStatementRows({ columns, rows });
+        setBankStatementProjectId(currentProjectId);
       });
     };
     const handleBankStatementError = (err: unknown) => {
@@ -1637,6 +1647,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
         },
       });
       ifActive(() => setBankStatementRows(null));
+      ifActive(() => setBankStatementProjectId(''));
     };
     const handleBudgetPlanResult = (snap: { exists(): boolean; data(): unknown }) => {
       ifActive(() => {
@@ -2704,6 +2715,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     const sanitizedSheet: BankStatementSheet = { columns: sanitizedColumns, rows: sanitizedRows as BankStatementRow[] };
     if (isDevHarnessUser) {
       setBankStatementRows(sanitizedSheet);
+      setBankStatementProjectId(currentProjectId);
       return;
     }
     if (!currentProjectId || !authUser || !isPlatformApiEnabled()) {
@@ -2733,6 +2745,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
         payload: { ...opened.draft.payload, bankStatement: sanitizedSheet },
       });
       setBankStatementRows(sanitizedSheet);
+      setBankStatementProjectId(currentProjectId);
       return;
     }
     const idempotencyKey = `bank-import:${currentProjectId}:${Date.now()}`;
@@ -2766,6 +2779,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
         tempId: importedIdBySourceKey.get(row.tempId) || row.tempId,
       })),
     });
+    setBankStatementProjectId(currentProjectId);
   }, [authUser, currentProjectId, isDevHarnessUser, orgId]);
 
   const applyBankStatementRowsToExpenseSheet = useCallback(async (sheet: BankStatementSheet & { selectedRowIds?: string[] }, options?: BankStatementApplyOptions) => {
@@ -2819,6 +2833,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     if (isDevHarnessUser) {
       await saveExpenseSheetRows(mergedExpenseRows, options);
       setBankStatementRows(nextBankSheet);
+      setBankStatementProjectId(currentProjectId);
       expenseIntakeItemsRef.current = reconciledIntakeItems;
       setExpenseIntakeItems(reconciledIntakeItems);
       return { appliedCount: importRows.length };
@@ -2917,14 +2932,18 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     expenseIntakeItemsRef.current = reconciledIntakeItems;
     setExpenseIntakeItems(reconciledIntakeItems);
     setBankStatementRows(nextBankSheet);
+    setBankStatementProjectId(currentProjectId);
     return { appliedCount: applied.appliedLineCount };
   }, [authUser, bankStatementRows, currentProjectId, isDevHarnessUser, orgId, portalUser?.name, saveExpenseSheetRows]);
 
   const refreshBankStatementRows = useCallback(async () => {
     if (isDevHarnessUser || !db || !currentProjectId) return;
-    const snap = await getDoc(doc(db, `${getOrgDocumentPath(orgId, 'projects', currentProjectId)}/bank_statements/default`));
+    const projectId = currentProjectId;
+    const snap = await getDoc(doc(db, `${getOrgDocumentPath(orgId, 'projects', projectId)}/bank_statements/default`));
+    if (currentProjectIdRef.current !== projectId) return;
     if (!snap.exists()) {
       setBankStatementRows(null);
+      setBankStatementProjectId('');
       return;
     }
     const data = snap.data() as { columns?: string[]; rows?: BankStatementRow[] };
@@ -2932,6 +2951,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
       columns: Array.isArray(data.columns) ? data.columns : [],
       rows: Array.isArray(data.rows) ? data.rows : [],
     }));
+    setBankStatementProjectId(projectId);
   }, [currentProjectId, db, isDevHarnessUser, orgId]);
 
   const upsertExpenseIntakeItems = useCallback(async (items: BankImportIntakeItem[]) => {
@@ -3758,6 +3778,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     activeExpenseSheetId,
     expenseSheetRows,
     bankStatementRows,
+    bankStatementProjectId,
     budgetPlanRows,
     budgetCodeBook,
     budgetTreeV2,

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
@@ -46,11 +46,10 @@ describe('CashflowSheetLabPage shell', () => {
   it('drives every request from one project resolved by route and session together', () => {
     expect(pageSource).toContain('resolvePortalProjectContextSync');
     expect(pageSource).toContain('sessionProjectId: portalProjectId');
-    expect(pageSource).toContain('previousSessionProjectId: syncedSessionProjectIdRef.current');
     expect(pageSource).toContain('const projectId = projectContextSync.projectId;');
     expect(pageSource).toContain("projectContextAction === 'canonicalize-path'");
-    expect(pageSource).toContain("projectContextAction !== 'adopt-route'");
-    expect(pageSource).toContain('setSessionActiveProject(projectId)');
+    expect(pageSource).not.toContain('adopt-route');
+    expect(pageSource).not.toContain('setSessionActiveProject(projectId)');
     // route projectId만 신뢰하던 로컬 상태는 상단 프로젝트 전환을 따라가지 못했다.
     expect(pageSource).not.toContain('projectIdInput');
     expect(pageSource).not.toContain('setProjectIdInput');
@@ -185,7 +184,8 @@ describe('CashflowSheetLabPage shell', () => {
     expect(pageSource).not.toContain('시트 고정본 ·');
     expect(pageSource).not.toContain('검토 범위');
     expect(pageSource).toContain('시트 값으로 덮어쓰기');
-    expect(pageSource).toContain('!open && !applyResumeRequired');
+    expect(pageSource).toContain('if (!open) closeClosedMonthDialog()');
+    expect(pageSource).not.toContain('반영 상태 확인 및 이어서 완료');
     expect(pageSource).toContain('!applyResumeRequired && (');
     expect(pageSource).not.toContain('변경 내용 검토');
     expect(pageSource).not.toContain('전체 MYSCube에 저장할까요?');

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { AlertCircle, BookOpen, CheckCircle2, ChevronLeft, ChevronRight, Copy, HelpCircle, Loader2, RefreshCw, Save, UserPlus } from 'lucide-react';
-import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router';
+import { Link, useLocation, useNavigate, useParams } from 'react-router';
 import { useAuth } from '../../data/auth-store';
 import { usePortalStore } from '../../data/portal-store';
 import { CASHFLOW_SHEET_LINE_LABELS, type CashflowSheetLineId } from '../../data/types';
@@ -32,7 +32,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '../../components/ui/dialog';
-import { readRecentPortalProjectIds, rememberRecentPortalProject } from '../../platform/portal-recent-projects';
+import { rememberRecentPortalProject } from '../../platform/portal-recent-projects';
 import { recordDevtoolsLog } from '../../platform/devtools-transaction-log';
 import { resolvePortalProjectContextSync, resolvePortalProjectResourcePath } from '../../platform/portal-project-selection';
 import { CashflowSheetSyncOverlay, type CashflowSheetSyncOperation } from '../../components/cashflow/CashflowSheetSyncOverlay';
@@ -220,28 +220,15 @@ function HelpMemo({ children }: { children: ReactNode }) {
   );
 }
 
-export function CashflowSheetLabPage({
-  projectIdOverride,
-}: {
-  projectIdOverride?: string;
-} = {}) {
+export function CashflowSheetLabPage() {
   const { user: authUser, loginWithGoogle } = useAuth();
-  const { activeProjectId, myProject, setSessionActiveProject } = usePortalStore();
+  const { activeProjectId, myProject } = usePortalStore();
   const { orgId } = useFirebase();
   const { projectId: routeProjectIdParam } = useParams<{ projectId: string }>();
   const routeProjectId = routeProjectIdParam?.trim() || '';
   const location = useLocation();
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
   const portalProjectId = activeProjectId || myProject?.id || '';
-  const fallbackProjectId = useMemo(() => (
-    projectIdOverride?.trim()
-    || searchParams.get('projectId')?.trim()
-    || authUser?.projectId
-    || authUser?.projectIds?.[0]
-    || readRecentPortalProjectIds()[0]
-    || ''
-  ), [authUser?.projectId, authUser?.projectIds, projectIdOverride, searchParams]);
   const projectYears = useMemo(() => {
     const startYear = /^\d{4}-/.test(myProject?.contractStart || '') ? Number(myProject?.contractStart.slice(0, 4)) : Number.NaN;
     const endYear = /^\d{4}-/.test(myProject?.contractEnd || '') ? Number(myProject?.contractEnd.slice(0, 4)) : Number.NaN;
@@ -302,13 +289,10 @@ export function CashflowSheetLabPage({
   const configLoadGenerationRef = useRef(0);
   const refreshButtonRef = useRef<HTMLButtonElement>(null);
   const stageButtonRef = useRef<HTMLButtonElement>(null);
-  const syncedSessionProjectIdRef = useRef('');
   const currentPath = `${location.pathname}${location.search}${location.hash}`;
   const projectContextSync = resolvePortalProjectContextSync({
     routeProjectId,
     sessionProjectId: portalProjectId,
-    previousSessionProjectId: syncedSessionProjectIdRef.current,
-    fallbackProjectId,
     currentPath,
   });
   const projectId = projectContextSync.projectId;
@@ -453,25 +437,12 @@ export function CashflowSheetLabPage({
 
   // URL route projectId와 상단 선택 프로젝트를 항상 한 프로젝트로 맞춘다.
   useEffect(() => {
-    syncedSessionProjectIdRef.current = portalProjectId;
     if (projectContextAction === 'canonicalize-path') {
       if (projectContextPath && projectContextPath !== currentPath) {
         navigate(projectContextPath, { replace: true });
       }
-      return;
     }
-    if (projectContextAction !== 'adopt-route') return;
-    let cancelled = false;
-    void (async () => {
-      const adopted = await setSessionActiveProject(projectId);
-      if (cancelled || adopted) return;
-      const sessionPath = resolvePortalProjectResourcePath(currentPath, portalProjectId);
-      if (sessionPath !== currentPath) navigate(sessionPath, { replace: true });
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [currentPath, navigate, portalProjectId, projectContextAction, projectContextPath, projectId, setSessionActiveProject]);
+  }, [currentPath, navigate, projectContextAction, projectContextPath]);
 
   useEffect(() => {
     if (!projectId) return;
@@ -509,7 +480,7 @@ export function CashflowSheetLabPage({
         setClosedMonthFormulaAccepted(result.applyInput?.acceptFormulaMismatches === true);
         setClosedMonthPendingApprovalAccepted(result.applyInput?.acceptPendingApprovalDifferences === true);
         setApplyResumeRequired(true);
-        setErrorMessage('이전에 완료 응답을 받지 못한 시트 반영이 있습니다. 같은 검토본으로 이어서 완료해 주세요.');
+        setErrorMessage('이전 시트 반영이 아직 완료 상태로 확인되지 않았습니다. 반영 상태를 확인해 주세요.');
       } catch {
         // 복구 상태 조회 실패는 시트 설정 화면 진입 자체를 막지 않는다.
       }
@@ -956,6 +927,11 @@ export function CashflowSheetLabPage({
         setClosedMonthFormulaAccepted(acceptFormulaMismatches);
         setClosedMonthPendingApprovalAccepted(acceptPendingApprovalDifferences);
       } else if (activeStep === 'apply' && staged && isCashflowSheetApplyResultUncertain(error)) {
+        if (applyResumeRequired) {
+          closeClosedMonthDialog();
+          setErrorMessage('서버가 반영 결과를 확인하고 있습니다. 잠시 후 시트 값을 다시 불러와 확인해 주세요.');
+          return;
+        }
         setClosedMonthStage(staged);
         setClosedMonthChangeReason(stagedOverride ? monthCloseChangeReason.trim() : '');
         setClosedMonthFormulaAccepted(acceptFormulaMismatches);
@@ -963,6 +939,9 @@ export function CashflowSheetLabPage({
         setApplyResumeRequired(true);
         setErrorMessage(`${formatError(error)} 같은 검토본으로 이어서 완료할 수 있습니다.`);
       } else {
+        if (activeStep === 'apply' && ['cashflow_sheet_config_changed', 'cashflow_sheet_mirror_stale', 'cashflow_sheet_mirror_revision_conflict'].includes(getErrorCode(error))) {
+          closeClosedMonthDialog();
+        }
         setErrorMessage(formatError(error));
       }
     } finally {
@@ -1259,15 +1238,15 @@ export function CashflowSheetLabPage({
       <Dialog
         open={Boolean(closedMonthStage)}
         onOpenChange={(open) => {
-          if (!open && !applyResumeRequired) closeClosedMonthDialog();
+          if (!open) closeClosedMonthDialog();
         }}
       >
         <DialogContent className="max-h-[calc(100dvh-2rem)] max-w-[760px] gap-4 overflow-y-auto rounded-xl p-5">
           <DialogHeader className="space-y-1 text-left">
-            <DialogTitle className="text-[17px]">{applyResumeRequired ? '시트 반영 결과 다시 확인' : '결산 후 값이 달라요'}</DialogTitle>
+            <DialogTitle className="text-[17px]">{applyResumeRequired ? '시트 반영 상태 확인 필요' : '결산 후 값이 달라요'}</DialogTitle>
             <DialogDescription className="text-[12px] leading-relaxed text-slate-600">
               {applyResumeRequired
-                ? '시트 값을 MYSCube 현금흐름 관리시트에 반영하는 중 연결이 끊겼습니다. 시트 값을 새로 불러오거나 중복 저장하지 않고, 기존 검토본의 반영 결과를 다시 확인한 뒤 남은 저장만 이어갑니다.'
+                ? '이전 반영이 완료됐는지 서버에서 확인합니다. 완료된 값은 다시 저장하지 않으며, 확인이 오래 걸리면 창을 닫고 잠시 후 다시 시도해 주세요.'
                 : '월 결산 이후 변경입니다. 사유를 남기면 변경 이력과 경고 횟수에 함께 기록됩니다. 그래도 반영할까요?'}
             </DialogDescription>
           </DialogHeader>
@@ -1326,7 +1305,7 @@ export function CashflowSheetLabPage({
                 closedMonthPendingApprovalAccepted,
               )}
             >
-              {applyResumeRequired ? '반영 상태 확인 및 이어서 완료' : '사유와 함께 반영'}
+              {applyResumeRequired ? '반영 상태 확인' : '사유와 함께 반영'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/app/platform/portal-project-selection.test.ts
+++ b/src/app/platform/portal-project-selection.test.ts
@@ -156,11 +156,7 @@ describe('portal project selection helpers', () => {
       previousSessionProjectId: '',
       fallbackProjectId: 'p-recent',
       currentPath: '/portal/cashflow/sheets-lab?step=2',
-    })).toEqual({
-      projectId: 'p-recent',
-      action: 'canonicalize-path',
-      path: '/portal/cashflow/p-recent/sheets-lab?step=2',
-    });
+    })).toEqual({ projectId: '', action: 'idle', path: '' });
 
     expect(resolvePortalProjectContextSync({
       routeProjectId: '',
@@ -171,14 +167,14 @@ describe('portal project selection helpers', () => {
     })).toEqual({ projectId: '', action: 'idle', path: '' });
   });
 
-  it('keeps the route project while the session project is still resolving or already matches', () => {
+  it('waits for the session project instead of using a sticky route project', () => {
     expect(resolvePortalProjectContextSync({
       routeProjectId: 'p-assigned',
       sessionProjectId: '',
       previousSessionProjectId: '',
       fallbackProjectId: 'p-recent',
       currentPath: '/portal/cashflow/p-assigned/sheets-lab',
-    })).toEqual({ projectId: 'p-assigned', action: 'idle', path: '' });
+    })).toEqual({ projectId: '', action: 'idle', path: '' });
 
     expect(resolvePortalProjectContextSync({
       routeProjectId: 'p-assigned',
@@ -189,14 +185,18 @@ describe('portal project selection helpers', () => {
     })).toEqual({ projectId: 'p-assigned', action: 'idle', path: '' });
   });
 
-  it('adopts a deep-linked route project into the session instead of silently redirecting', () => {
+  it('keeps the session project authoritative over a deep-linked route project', () => {
     expect(resolvePortalProjectContextSync({
       routeProjectId: 'p-assigned',
       sessionProjectId: 'p-managed',
       previousSessionProjectId: '',
       fallbackProjectId: '',
       currentPath: '/portal/cashflow/p-assigned/sheets-lab',
-    })).toEqual({ projectId: 'p-assigned', action: 'adopt-route', path: '' });
+    })).toEqual({
+      projectId: 'p-managed',
+      action: 'canonicalize-path',
+      path: '/portal/cashflow/p-managed/sheets-lab',
+    });
   });
 
   it('realigns the route when the top project selector switches the session project', () => {

--- a/src/app/platform/portal-project-selection.ts
+++ b/src/app/platform/portal-project-selection.ts
@@ -152,7 +152,7 @@ export function resolvePortalProjectResourcePath(requestedPath: string, projectI
   return normalizedPath;
 }
 
-export type PortalProjectContextAction = 'idle' | 'adopt-route' | 'canonicalize-path';
+export type PortalProjectContextAction = 'idle' | 'canonicalize-path';
 
 export interface PortalProjectContextSync {
   projectId: string;
@@ -162,8 +162,7 @@ export interface PortalProjectContextSync {
 
 /**
  * 프로젝트 단위 화면에서 URL route projectId와 세션 선택 프로젝트가 어긋났을 때
- * 어느 쪽을 기준으로 맞출지 결정한다. 상단 선택기를 바꾼 경우에는 URL을,
- * 딥링크·뒤로가기로 들어온 경우에는 세션 선택을 다시 맞춘다.
+ * 상단 선택 프로젝트를 기준으로 URL을 맞춘다.
  */
 export function resolvePortalProjectContextSync(input: {
   routeProjectId?: string | null;
@@ -174,32 +173,13 @@ export function resolvePortalProjectContextSync(input: {
 }): PortalProjectContextSync {
   const routeProjectId = normalizedId(input.routeProjectId);
   const sessionProjectId = normalizedId(input.sessionProjectId);
-  const previousSessionProjectId = normalizedId(input.previousSessionProjectId);
-  const fallbackProjectId = normalizedId(input.fallbackProjectId);
-
-  if (!routeProjectId) {
-    const targetProjectId = sessionProjectId || fallbackProjectId;
-    if (!targetProjectId) return { projectId: '', action: 'idle', path: '' };
-    return {
-      projectId: targetProjectId,
-      action: 'canonicalize-path',
-      path: resolvePortalProjectResourcePath(input.currentPath, targetProjectId),
-    };
-  }
-
-  if (!sessionProjectId || routeProjectId === sessionProjectId) {
-    return { projectId: routeProjectId, action: 'idle', path: '' };
-  }
-
-  if (previousSessionProjectId && previousSessionProjectId !== sessionProjectId) {
-    return {
-      projectId: sessionProjectId,
-      action: 'canonicalize-path',
-      path: resolvePortalProjectResourcePath(input.currentPath, sessionProjectId),
-    };
-  }
-
-  return { projectId: routeProjectId, action: 'adopt-route', path: '' };
+  if (!sessionProjectId) return { projectId: '', action: 'idle', path: '' };
+  if (routeProjectId === sessionProjectId) return { projectId: sessionProjectId, action: 'idle', path: '' };
+  return {
+    projectId: sessionProjectId,
+    action: 'canonicalize-path',
+    path: resolvePortalProjectResourcePath(input.currentPath, sessionProjectId),
+  };
 }
 
 export async function runPortalProjectSwitch(input: {


### PR DESCRIPTION
## 변경\n- JVM 반영 기록이 없는 stale APPLYING 상태만 READY로 안전하게 복구\n- JVM 반영이 불확실하거나 일부 진행된 상태는 기존 잠금 유지\n- 복구 팝업 반복 노출 제거 및 원인 추측 없는 안내 문구 적용\n- 복구 창을 사용자가 닫을 수 있도록 변경\n\n## 검증\n- cashflow-sheet-lab BFF 108/108\n- 화면/클라이언트 28/28\n- production build PASS