### PR TITLE
fix(cashflow): fetch linked sheet values once

### DIFF
--- a/server/bff/google-sheets.mjs
+++ b/server/bff/google-sheets.mjs
@@ -280,7 +280,7 @@ export function createGoogleSheetsService(options = {}) {
     };
   }
 
-  async function previewSpreadsheet({ value, sheetName, accessToken, rangeA1 }) {
+  async function previewSpreadsheet({ value, sheetName, accessToken, rangeA1, selectSheet }) {
     const spreadsheetId = extractSpreadsheetId(value);
     if (!spreadsheetId) {
       throw new GoogleSheetsServiceError(
@@ -301,6 +301,8 @@ export function createGoogleSheetsService(options = {}) {
           { statusCode: 404, code: 'sheet_tab_not_found' },
         );
       }
+    } else if (typeof selectSheet === 'function') {
+      selectedSheet = selectSheet(meta.availableSheets) || null;
     } else if (gid != null) {
       selectedSheet = meta.availableSheets.find((sheet) => sheet.sheetId === gid) || null;
     }

--- a/server/bff/google-sheets.test.ts
+++ b/server/bff/google-sheets.test.ts
@@ -60,6 +60,35 @@ describe('google-sheets helpers', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
+  it('selects a preferred sheet before fetching values', async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        properties: { title: '캐시플로 시트' },
+        sheets: [
+          { properties: { sheetId: 0, title: '요약', index: 0 } },
+          { properties: { sheetId: 1, title: 'cashflow(사용내역 연동)', index: 1 } },
+        ],
+      }), { status: 200, headers: { 'content-type': 'application/json' } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ values: [['연동값']] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }));
+    const service = createGoogleSheetsService({
+      fetchImpl,
+      authHeadersFactory: async () => ({ authorization: 'Bearer test-token' }),
+    });
+
+    const preview = await service.previewSpreadsheet({
+      value: 'https://docs.google.com/spreadsheets/d/1abcDEFghiJKlmnOPQ_rst-123/edit#gid=0',
+      selectSheet: (sheets) => sheets.find((sheet) => sheet.title.includes('사용내역 연동')),
+    });
+
+    expect(preview.selectedSheetName).toBe('cashflow(사용내역 연동)');
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl.mock.calls[1]?.[0]).toContain(encodeURIComponent("'cashflow(사용내역 연동)'"));
+  });
+
   it('prefers caller google access token over service account auth', async () => {
     const fetchImpl = vi
       .fn()

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -3978,24 +3978,15 @@ function createSheetPreviewLoader({ googleSheetsService, cacheTtlMs = DEFAULT_SH
       return { ...value, cacheStatus: 'in_flight_join' };
     }
 
-    async function requestPreview(sheetName) {
-      return googleSheetsService.previewSpreadsheet({
-        value: params.value,
-        sheetName,
-        rangeA1: CASHFLOW_SHEET_LAB_READ_RANGE,
-      });
-    }
-
     const request = (async () => {
       const authMode = 'service_account';
-      const first = await requestPreview(params.sheetName);
-      if (params.sheetName || isCashflowUsageLinkedSheetName(first.selectedSheetName)) {
-        return { ...first, authMode };
-      }
-      const linkedSheet = findCashflowUsageLinkedSheet(first.availableSheets);
-      if (!linkedSheet) return { ...first, authMode };
-      const linkedPreview = await requestPreview(linkedSheet.title);
-      return { ...linkedPreview, authMode };
+      const preview = await googleSheetsService.previewSpreadsheet({
+        value: params.value,
+        sheetName: params.sheetName,
+        rangeA1: CASHFLOW_SHEET_LAB_READ_RANGE,
+        ...(!params.sheetName ? { selectSheet: findCashflowUsageLinkedSheet } : {}),
+      });
+      return { ...preview, authMode };
     })();
     inFlight.set(key, request);
     try {

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -1196,6 +1196,45 @@ describe('cashflow sheet lab route', () => {
     expect(performanceEvents.every((event) => event.requestId === 'req-1')).toBe(true);
   });
 
+  it('selects the linked tab before the single sheet values fetch', async () => {
+    const performanceEvents = [];
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        cashflowSheetLab: { value: 'spreadsheet-a' },
+      },
+    });
+    const availableSheets = [
+      { sheetId: 1, title: '요약', index: 0 },
+      { sheetId: 2, title: 'cashflow(사용내역 연동)', index: 1 },
+    ];
+    const previewSpreadsheet = vi.fn(async ({ selectSheet }) => ({
+      spreadsheetId: 'spreadsheet-a',
+      spreadsheetTitle: 'Cashflow workbook',
+      selectedSheetName: selectSheet(availableSheets).title,
+      availableSheets,
+      matrix: buildMatrix(),
+    }));
+    const app = createApp({
+      db,
+      googleSheetsService: { previewSpreadsheet },
+      routeOptions: { performanceLogger: (event) => performanceEvents.push(event) },
+    });
+
+    const refreshed = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'mirror-single-fetch-001' })
+      .expect(200);
+
+    expect(refreshed.body).toMatchObject({
+      status: 'FRESH',
+      selectedSheetName: 'cashflow(사용내역 연동)',
+    });
+    expect(previewSpreadsheet).toHaveBeenCalledTimes(1);
+    expect(performanceEvents.filter((event) => event.phase === 'sheet_parse_validate')).toHaveLength(1);
+    expect(performanceEvents.filter((event) => event.phase === 'mirror_publish')).toHaveLength(1);
+  });
+
   it('stores weekly values and annual totals without requiring a missing future year', async () => {
     const db = createDb({
       project: {


### PR DESCRIPTION
## Hotfix\n- Google Sheets metadata 1회 + values 1회 조회\n- parse/publish 중복 실행 제거\n- 기존 관련 테스트 93개 통과\n\n라이브 연동 지연/오류 대응용 최소 변경입니다.