### PR TITLE
fix(portal): make project URLs authoritative

### DIFF
--- a/src/app/components/portal/PortalLayout.shell.test.ts
+++ b/src/app/components/portal/PortalLayout.shell.test.ts
@@ -119,6 +119,8 @@ describe('PortalLayout shell actions', () => {
 
   it('checks the dirty guard before changing project state or the canonical URL', () => {
     expect(portalLayoutSource).toContain('runPortalProjectSwitch');
+    expect(portalLayoutSource).toContain('resolvePortalRouteProjectId(location.pathname)');
+    expect(portalLayoutSource).toContain('setSessionActiveProject(routeProjectId)');
     expect(portalLayoutSource).toContain('isNavigationBlocked: (attempt) => Boolean(navigationHandlerRef.current?.(attempt))');
     expect(portalLayoutSource).not.toContain('setSessionActiveProject(projectId).then');
   });

--- a/src/app/components/portal/PortalLayout.tsx
+++ b/src/app/components/portal/PortalLayout.tsx
@@ -70,7 +70,11 @@ import { normalizeProjectFundInputMode } from '../../data/types';
 import { rememberRecentPortalProject } from '../../platform/portal-recent-projects';
 import { buildPortalShellCommandItems, buildPortalShellNotificationItems } from '../../platform/portal-shell-actions';
 import { shouldShowShellRoute, useShellLabEnabled } from '../../platform/shell-lab-visibility';
-import { resolvePortalProjectCandidates, runPortalProjectSwitch } from '../../platform/portal-project-selection';
+import {
+  resolvePortalProjectCandidates,
+  resolvePortalRouteProjectId,
+  runPortalProjectSwitch,
+} from '../../platform/portal-project-selection';
 
 // ═══════════════════════════════════════════════════════════════
 // PortalLayout — 사용자(PM) 전용 레이아웃
@@ -242,12 +246,27 @@ function PortalContent() {
     }));
   }, [candidateProjects.searchProjects]);
 
+  const routeProjectId = useMemo(
+    () => resolvePortalRouteProjectId(location.pathname),
+    [location.pathname],
+  );
+
   const currentProject = useMemo(() => {
+    if (routeProjectId) {
+      const routeProject = candidateProjects.searchProjects.find((project) => project.id === routeProjectId);
+      if (routeProject) return routeProject;
+    }
     if (activeProjectId) {
       return candidateProjects.searchProjects.find((project) => project.id === activeProjectId) || myProject;
     }
     return myProject || candidateProjects.priorityProjects[0] || candidateProjects.searchProjects[0] || null;
-  }, [activeProjectId, candidateProjects.priorityProjects, candidateProjects.searchProjects, myProject]);
+  }, [activeProjectId, candidateProjects.priorityProjects, candidateProjects.searchProjects, myProject, routeProjectId]);
+
+  useEffect(() => {
+    if (!routeProjectId || routeProjectId === activeProjectId) return;
+    if (!candidateProjects.searchProjects.some((project) => project.id === routeProjectId)) return;
+    void setSessionActiveProject(routeProjectId);
+  }, [activeProjectId, candidateProjects.searchProjects, routeProjectId, setSessionActiveProject]);
 
   const selectedProjectOptionValue = useMemo(() => {
     if (!currentProject?.id) return '';

--- a/src/app/platform/portal-project-selection.test.ts
+++ b/src/app/platform/portal-project-selection.test.ts
@@ -6,6 +6,7 @@ import {
   resolvePortalProjectContextSync,
   resolvePortalProjectResourceId,
   resolvePortalProjectResourcePath,
+  resolvePortalRouteProjectId,
   resolvePortalProjectSelectPath,
   resolvePortalProjectSwitchPath,
   runPortalProjectSwitch,
@@ -137,6 +138,13 @@ describe('portal project selection helpers', () => {
     );
   });
 
+  it('reads the project context from every project-scoped portal URL', () => {
+    expect(resolvePortalRouteProjectId('/portal/cashflow/p-axr')).toBe('p-axr');
+    expect(resolvePortalRouteProjectId('/portal/cashflow/p%2Fkimje/sheets-lab')).toBe('p/kimje');
+    expect(resolvePortalRouteProjectId('/portal/edit-project/p-sangscam')).toBe('p-sangscam');
+    expect(resolvePortalRouteProjectId('/portal/budget')).toBe('');
+  });
+
   it('canonicalizes a bare project resource path to the session project', () => {
     expect(resolvePortalProjectContextSync({
       routeProjectId: '',
@@ -167,14 +175,14 @@ describe('portal project selection helpers', () => {
     })).toEqual({ projectId: '', action: 'idle', path: '' });
   });
 
-  it('waits for the session project instead of using a sticky route project', () => {
+  it('uses the route project before the session has caught up', () => {
     expect(resolvePortalProjectContextSync({
       routeProjectId: 'p-assigned',
       sessionProjectId: '',
       previousSessionProjectId: '',
       fallbackProjectId: 'p-recent',
       currentPath: '/portal/cashflow/p-assigned/sheets-lab',
-    })).toEqual({ projectId: '', action: 'idle', path: '' });
+    })).toEqual({ projectId: 'p-assigned', action: 'idle', path: '' });
 
     expect(resolvePortalProjectContextSync({
       routeProjectId: 'p-assigned',
@@ -185,7 +193,7 @@ describe('portal project selection helpers', () => {
     })).toEqual({ projectId: 'p-assigned', action: 'idle', path: '' });
   });
 
-  it('keeps the session project authoritative over a deep-linked route project', () => {
+  it('keeps a deep-linked route project authoritative over the previous session', () => {
     expect(resolvePortalProjectContextSync({
       routeProjectId: 'p-assigned',
       sessionProjectId: 'p-managed',
@@ -193,13 +201,13 @@ describe('portal project selection helpers', () => {
       fallbackProjectId: '',
       currentPath: '/portal/cashflow/p-assigned/sheets-lab',
     })).toEqual({
-      projectId: 'p-managed',
-      action: 'canonicalize-path',
-      path: '/portal/cashflow/p-managed/sheets-lab',
+      projectId: 'p-assigned',
+      action: 'idle',
+      path: '',
     });
   });
 
-  it('realigns the route when the top project selector switches the session project', () => {
+  it('does not rewrite an explicit project URL from stale session state', () => {
     expect(resolvePortalProjectContextSync({
       routeProjectId: 'p-assigned',
       sessionProjectId: 'p-managed',
@@ -207,9 +215,9 @@ describe('portal project selection helpers', () => {
       fallbackProjectId: 'p-assigned',
       currentPath: '/portal/cashflow/p-assigned/sheets-lab#review',
     })).toEqual({
-      projectId: 'p-managed',
-      action: 'canonicalize-path',
-      path: '/portal/cashflow/p-managed/sheets-lab#review',
+      projectId: 'p-assigned',
+      action: 'idle',
+      path: '',
     });
   });
 

--- a/src/app/platform/portal-project-selection.ts
+++ b/src/app/platform/portal-project-selection.ts
@@ -125,6 +125,17 @@ export function resolvePortalProjectResourceId(
   return [routeProjectId, ...fallbackProjectIds].map(normalizedId).find(Boolean) || '';
 }
 
+export function resolvePortalRouteProjectId(pathname?: string | null): string {
+  const normalizedPath = typeof pathname === 'string' ? pathname.trim() : '';
+  const match = normalizedPath.match(/^\/portal\/(?:cashflow\/([^/]+)(?:\/sheets-lab)?|edit-project\/([^/]+))\/?$/);
+  if (!match) return '';
+  try {
+    return decodeURIComponent(match[1] || match[2] || '').trim();
+  } catch {
+    return '';
+  }
+}
+
 export function resolvePortalProjectResourcePath(requestedPath: string, projectId: string): string {
   const normalizedProjectId = normalizedId(projectId);
   const normalizedPath = typeof requestedPath === 'string' ? requestedPath.trim() : '';
@@ -161,8 +172,8 @@ export interface PortalProjectContextSync {
 }
 
 /**
- * 프로젝트 단위 화면에서 URL route projectId와 세션 선택 프로젝트가 어긋났을 때
- * 상단 선택 프로젝트를 기준으로 URL을 맞춘다.
+ * 프로젝트 단위 URL은 새로고침과 직접 진입에서도 같은 프로젝트를 열어야 한다.
+ * URL에 프로젝트가 없을 때만 세션 선택값으로 canonical path를 만든다.
  */
 export function resolvePortalProjectContextSync(input: {
   routeProjectId?: string | null;
@@ -173,8 +184,8 @@ export function resolvePortalProjectContextSync(input: {
 }): PortalProjectContextSync {
   const routeProjectId = normalizedId(input.routeProjectId);
   const sessionProjectId = normalizedId(input.sessionProjectId);
+  if (routeProjectId) return { projectId: routeProjectId, action: 'idle', path: '' };
   if (!sessionProjectId) return { projectId: '', action: 'idle', path: '' };
-  if (routeProjectId === sessionProjectId) return { projectId: sessionProjectId, action: 'idle', path: '' };
   return {
     projectId: sessionProjectId,
     action: 'canonicalize-path',


### PR DESCRIPTION
## What
- 프로젝트 범위 Portal URL의 projectId를 화면 기준으로 사용
- 공통 PortalLayout 세션을 URL 프로젝트로 동기화
- cashflow/sheets-lab/edit-project 새로고침 경계 테스트 추가

## Verification
- 40 targeted tests passed
- npm run build passed