### PR TITLE
fix(cashflow): recover uncertain sheet applies

### DIFF
--- a/server/bff/java-weekly-client.mjs
+++ b/server/bff/java-weekly-client.mjs
@@ -374,6 +374,7 @@ export function createJavaWeeklyClient({
     } catch (error) {
       if (!error?.transportFailure) throw error;
       if (callerDeadlineReached()) throw callerDeadlineError(1, error.mutationOutcome);
+      if (mutation && error.mutationOutcome === 'uncertain') throw error;
       if (!retryAllowed) throw error;
       trace.emit('retry_scheduled', {
         attempt: 2,

--- a/server/bff/java-weekly-client.test.mjs
+++ b/server/bff/java-weekly-client.test.mjs
@@ -447,7 +447,7 @@ describe('Java weekly cashflow client', () => {
     expect(fetchImpl).toHaveBeenCalledOnce();
   });
 
-  it('retries a transient JVM transport failure with the same request body', async () => {
+  it('does not retry a sent mutation after a transient JVM transport failure', async () => {
     const fetchImpl = vi.fn()
       .mockRejectedValueOnce(new TypeError('fetch failed'))
       .mockResolvedValueOnce({
@@ -457,18 +457,17 @@ describe('Java weekly cashflow client', () => {
       });
     const client = createJavaWeeklyClient({ env: liveEnv(), fetchImpl });
 
-    await client.applyCashflowSheetLab({
+    await expect(client.applyCashflowSheetLab({
       context,
       projectId: 'project-a',
       idempotencyKey: 'apply-retry-1',
       ...monthlyContract,
-    });
+    })).rejects.toMatchObject({ mutationOutcome: 'uncertain', attempt: 1 });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
-    expect(fetchImpl.mock.calls[1][1].body).toBe(fetchImpl.mock.calls[0][1].body);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
-  it('separates auth, TTFB, body read, and retry timing without logging request data', async () => {
+  it('records an uncertain mutation attempt without logging request data', async () => {
     const events = [];
     const fetchImpl = vi.fn()
       .mockRejectedValueOnce(new TypeError('fetch failed'))
@@ -483,24 +482,24 @@ describe('Java weekly cashflow client', () => {
       performanceLogger: (event) => events.push(event),
     });
 
-    await client.applyCashflowSheetLab({
+    await expect(client.applyCashflowSheetLab({
       context: { ...context, requestId: 'req-performance-1' },
       projectId: 'project-a',
       idempotencyKey: 'apply-performance-1',
       ...monthlyContract,
-    });
+    })).rejects.toMatchObject({ mutationOutcome: 'uncertain', attempt: 1 });
     await new Promise((resolve) => setImmediate(resolve));
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(events.every((event) => event.requestId === 'req-performance-1')).toBe(true);
-    expect(events.filter((event) => event.phase === 'attempt_start').map((event) => event.attempt)).toEqual([1, 2]);
+    expect(events.filter((event) => event.phase === 'attempt_start').map((event) => event.attempt)).toEqual([1]);
     expect(events).toEqual(expect.arrayContaining([
       expect.objectContaining({ phase: 'auth_headers', attempt: 1, outcome: 'ok' }),
       expect.objectContaining({ phase: 'upstream_ttfb', attempt: 1, outcome: 'error' }),
-      expect.objectContaining({ phase: 'retry_scheduled', attempt: 2, retryable: true }),
-      expect.objectContaining({ phase: 'upstream_ttfb', attempt: 2, outcome: 'ok' }),
-      expect.objectContaining({ phase: 'body_read', attempt: 2, outcome: 'ok', statusCode: 200 }),
-      expect.objectContaining({ phase: 'attempt_complete', attempt: 2, outcome: 'ok', statusCode: 200 }),
+      expect.objectContaining({ phase: 'attempt_complete', attempt: 1, outcome: 'error' }),
+    ]));
+    expect(events).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ phase: 'retry_scheduled' }),
     ]));
     const serialized = JSON.stringify(events);
     expect(serialized).not.toContain('project-a');
@@ -509,7 +508,7 @@ describe('Java weekly cashflow client', () => {
     expect(serialized).not.toContain('service-token');
   });
 
-  it('starts the retry before a slow performance logger runs', async () => {
+  it('reports a failed mutation asynchronously without retrying it', async () => {
     let loggerRan = false;
     const fetchImpl = vi.fn()
       .mockRejectedValueOnce(new TypeError('fetch failed'))
@@ -533,9 +532,9 @@ describe('Java weekly cashflow client', () => {
       projectId: 'project-a',
       idempotencyKey: 'apply-slow-logger',
       ...monthlyContract,
-    })).resolves.toMatchObject({ ok: true });
+    })).rejects.toMatchObject({ mutationOutcome: 'uncertain', attempt: 1 });
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(loggerRan).toBe(false);
     await new Promise((resolve) => setImmediate(resolve));
     expect(loggerRan).toBe(true);
@@ -588,12 +587,12 @@ describe('Java weekly cashflow client', () => {
     })).rejects.toMatchObject({
       statusCode: 503,
       code: 'jvm_weekly_api_unreachable',
-      attempt: 2,
+      attempt: 1,
       retryable: true,
       mutationOutcome: 'uncertain',
       elapsedMs: expect.any(Number),
     });
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
   it('aborts a hanging JVM request before the frontend timeout and returns the stable unreachable code', async () => {
@@ -614,11 +613,11 @@ describe('Java weekly cashflow client', () => {
     })).rejects.toMatchObject({
       statusCode: 503,
       code: 'jvm_weekly_api_unreachable',
-      attempt: 2,
+      attempt: 1,
       retryable: true,
       mutationOutcome: 'uncertain',
     });
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
     expect(fetchImpl.mock.calls.every(([, init]) => init.signal instanceof AbortSignal)).toBe(true);
   });
 
@@ -677,7 +676,30 @@ describe('Java weekly cashflow client', () => {
     expect(fetchImpl.mock.calls.every(([url]) => String(url).includes('metadata.google.internal'))).toBe(true);
   });
 
-  it('caps the configured timeout so two attempts stay within the 24-second total budget', async () => {
+  it('does not resend an annual mutation after a transport failure', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new TypeError('fetch failed');
+    });
+    const client = createJavaWeeklyClient({ env: liveEnv(), fetchImpl });
+
+    await expect(client.applyCashflowSheetAnnualTotal({
+      context,
+      projectId: 'project-a',
+      idempotencyKey: 'annual-unreachable-1',
+      sourceRevision: 'source-a',
+      year: 2026,
+      expectedRevision: 0,
+      cells: [],
+    })).rejects.toMatchObject({
+      statusCode: 503,
+      code: 'jvm_weekly_api_unreachable',
+      attempt: 1,
+      mutationOutcome: 'uncertain',
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('caps an in-flight mutation at one configured attempt', async () => {
     vi.useFakeTimers();
     try {
       const fetchImpl = vi.fn(async (_url, init) => new Promise((_resolve, reject) => {
@@ -697,9 +719,9 @@ describe('Java weekly cashflow client', () => {
       const assertion = expect(requestPromise)
         .rejects.toMatchObject({ statusCode: 503, code: 'jvm_weekly_api_unreachable' });
 
-      await vi.advanceTimersByTimeAsync(24_001);
+      await vi.advanceTimersByTimeAsync(12_001);
       await assertion;
-      expect(fetchImpl).toHaveBeenCalledTimes(2);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
     } finally {
       vi.useRealTimers();
     }

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -2647,6 +2647,13 @@ async function executeCashflowSheetOperation({
       }
       const checkpoint = await reconcile(mutationError);
       if (checkpoint) return checkpoint;
+      if (mutationError?.mutationOutcome === 'uncertain') {
+        throw cashflowSheetOperationUncertainError(operationKey, {
+          outcome: 'NOT_FOUND_AFTER_UNCERTAIN_MUTATION',
+          mutationErrorCode: readOptionalText(mutationError?.code) || null,
+          expected,
+        });
+      }
       if (attempt === 1) {
         throw cashflowSheetOperationUncertainError(operationKey, {
           outcome: 'NOT_FOUND_AFTER_RETRY',

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -4249,6 +4249,60 @@ describe('cashflow sheet lab route', () => {
       .toMatchObject({ status: 'APPLIED' });
   });
 
+  it('does not resend a mutation that may still be running when operation status is not found yet', async () => {
+    let sourceRevision;
+    let expectedTargetRevision;
+    let statusReads = 0;
+    const resultingTargetRevision = `sha256:${'2'.repeat(64)}`;
+    const javaWeeklyClient = {
+      applyCashflowSheetLab: vi.fn(async () => {
+        throw Object.assign(new Error('JVM response deadline exceeded'), {
+          statusCode: 503,
+          code: 'jvm_weekly_api_unreachable',
+          mutationOutcome: 'uncertain',
+        });
+      }),
+      getCashflowSheetOperationStatus: vi.fn(async (input) => {
+        if (statusReads++ === 0) return javaOperationNotFound(input);
+        return javaOperationApplied(input, {
+          sourceRevision,
+          expectedTargetRevision,
+          resultingTargetRevision,
+          appliedMonths: ['2026-01'],
+        });
+      }),
+    };
+    const staged = await stageJanuaryApply(javaWeeklyClient, 'in-flight-not-found');
+    sourceRevision = staged.mirror.body.sourceRevision;
+    expectedTargetRevision = staged.mirror.body.targetRevisionAtFetch;
+    const payload = {
+      stageRunId: staged.stage.body.runId,
+      idempotencyKey: 'apply-in-flight-not-found',
+    };
+
+    await request(staged.app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
+      .send(payload)
+      .expect(503)
+      .expect((response) => expect(response.body.code).toBe('cashflow_sheet_operation_uncertain'));
+
+    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(1);
+    expect(javaWeeklyClient.getCashflowSheetOperationStatus).toHaveBeenCalledTimes(1);
+    expect(staged.db.__getDocument(`orgs/tenant-a/cashflow_sheet_stage_runs/${staged.stage.body.runId}`))
+      .toMatchObject({ status: 'APPLYING' });
+
+    await request(staged.app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
+      .send(payload)
+      .expect(200)
+      .expect((response) => expect(response.body.resultingTargetRevision).toBe(resultingTargetRevision));
+
+    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(1);
+    expect(javaWeeklyClient.getCashflowSheetOperationStatus).toHaveBeenCalledTimes(2);
+    expect(staged.db.__getDocument(`orgs/tenant-a/cashflow_sheet_stage_runs/${staged.stage.body.runId}`))
+      .toMatchObject({ status: 'APPLIED' });
+  });
+
   it('replays the applied response when two requests finish the same staged run together', async () => {
     let releaseBoth;
     let callCount = 0;

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
@@ -941,6 +941,7 @@ class WeeklyExpenseControllerTest {
             .andExpect(status().isServiceUnavailable())
             .andExpect(jsonPath("$.code").value("cashflow_month_amendment_backend_unavailable"));
 
+        verify(weeklyExpensePersistence, times(2)).runCommandTransaction(any());
         assertThat(projectionRepository.findByTenantIdAndProjectId("tenant-sheet-lab", "project-sheet-lab")).isEmpty();
         assertThat(actualRepository.findByTenantIdAndProjectId("tenant-sheet-lab", "project-sheet-lab")).isEmpty();
     }

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
@@ -69,6 +69,7 @@ describe('CashflowSheetLabPage shell', () => {
     expect(recoveryReset).toContain('setPendingApprovalStage(null);');
     expect(recoveryReset).toContain('setFormulaMismatchPrompt(null);');
     expect(recoveryReset).toContain('setApplyResumeRequired(false);');
+    expect(recoveryReset).toContain("setApplyStatusState('checking');");
 
     const draftReset = pageSource.slice(
       pageSource.indexOf('이전 시트 draft를 남기지 않는다'),
@@ -122,6 +123,14 @@ describe('CashflowSheetLabPage shell', () => {
     expect(pageSource).toContain('void handleLoadShareAccount();');
     expect(pageSource).toContain('canRefresh');
     expect(pageSource).toContain('canOverwrite');
+    expect(pageSource).toContain("applyStatusState === 'ready'");
+    expect(pageSource).toContain("applyStatusState === 'error'");
+    expect(pageSource).toContain('applyResumeRequired && !stagedOverride');
+    expect(pageSource).toContain('!stagedOverride && !spreadsheetId');
+    expect(pageSource).toContain('반영 상태 다시 확인');
+    expect(pageSource).toContain("getErrorCode(error) === 'cashflow_sheet_apply_in_progress'");
+    expect(pageSource).toContain("setApplyStatusState('checking');");
+    expect(pageSource).toContain('setApplyStatusRetry((current) => current + 1);');
     expect(pageSource).toContain('reflectResult');
     expect(pageSource).toContain('buildSourceKey');
     expect(pageSource).toContain('reviewedSourceKey === sourceKey');

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
@@ -264,6 +264,8 @@ export function CashflowSheetLabPage() {
     && closedMonthStage?.closedMonthDifferenceCount === closedMonthChangeRows.length
     && closedMonthWarning.every((month) => !month.truncatedChangeCount);
   const [applyResumeRequired, setApplyResumeRequired] = useState(false);
+  const [applyStatusState, setApplyStatusState] = useState<'checking' | 'ready' | 'error'>('checking');
+  const [applyStatusRetry, setApplyStatusRetry] = useState(0);
   const [closedMonthChangeReason, setClosedMonthChangeReason] = useState('');
   const [closedMonthFormulaAccepted, setClosedMonthFormulaAccepted] = useState(false);
   const [closedMonthPendingApprovalAccepted, setClosedMonthPendingApprovalAccepted] = useState(false);
@@ -459,11 +461,13 @@ export function CashflowSheetLabPage() {
     setPendingApprovalStage(null);
     setFormulaMismatchPrompt(null);
     setApplyResumeRequired(false);
+    setApplyStatusState('checking');
   }, [projectId]);
 
   useEffect(() => {
     let cancelled = false;
     if (!projectId || !actor.idToken) return () => { cancelled = true; };
+    setApplyStatusState('checking');
     const loadApplyStatus = async (): Promise<void> => {
       try {
         const result = await runWithBffAuthRetry('apply.status', (requestActor) => (
@@ -473,7 +477,14 @@ export function CashflowSheetLabPage() {
             projectId,
           })
         ));
-        if (cancelled || result?.status !== 'APPLYING' || !result.stagedRun) return;
+        if (cancelled) return;
+        if (!result) {
+          setApplyStatusState('error');
+          setErrorMessage('기존 시트 반영 상태를 확인하지 못했습니다. 다시 확인해 주세요.');
+          return;
+        }
+        setApplyStatusState('ready');
+        if (result?.status !== 'APPLYING' || !result.stagedRun) return;
         setClosedMonthStage(result.stagedRun);
         setClosedMonthWarning(result.stagedRun.closedMonthDifferences || []);
         setClosedMonthChangeReason(result.applyInput?.closedMonthChangeReason || '');
@@ -481,15 +492,17 @@ export function CashflowSheetLabPage() {
         setClosedMonthPendingApprovalAccepted(result.applyInput?.acceptPendingApprovalDifferences === true);
         setApplyResumeRequired(true);
         setErrorMessage('이전 시트 반영이 아직 완료 상태로 확인되지 않았습니다. 반영 상태를 확인해 주세요.');
-      } catch {
-        // 복구 상태 조회 실패는 시트 설정 화면 진입 자체를 막지 않는다.
+      } catch (error) {
+        if (cancelled) return;
+        setApplyStatusState('error');
+        setErrorMessage(`기존 시트 반영 상태를 확인하지 못했습니다. ${formatError(error)}`);
       }
     };
     void loadApplyStatus();
     return () => {
       cancelled = true;
     };
-  }, [actor.idToken, orgId, projectId]);
+  }, [actor.idToken, applyStatusRetry, orgId, projectId]);
 
   useEffect(() => {
     if (projectYears.includes(sourceYear)) return;
@@ -722,7 +735,9 @@ export function CashflowSheetLabPage() {
     if (
       !projectId
       || loading
-      || !spreadsheetId
+      || applyStatusState !== 'ready'
+      || (applyResumeRequired && !stagedOverride)
+      || (!stagedOverride && !spreadsheetId)
       || (!stagedOverride && (mirror?.status !== 'FRESH' || !mirror.sourceRevision || reviewedSourceKey !== sourceKey))
     ) return;
     const startedAt = Date.now();
@@ -903,6 +918,13 @@ export function CashflowSheetLabPage() {
         totalDurationMs: Date.now() - startedAt,
         ...errorDiagnostics(error),
       }, 'warn');
+      if (activeStep === 'apply' && getErrorCode(error) === 'cashflow_sheet_apply_in_progress') {
+        closeClosedMonthDialog();
+        setApplyStatusState('checking');
+        setApplyStatusRetry((current) => current + 1);
+        setErrorMessage('진행 중인 시트 반영 작업을 확인하고 있습니다.');
+        return;
+      }
       if (activeStep === 'apply' && getErrorCode(error) === 'cashflow_formula_mismatch_confirmation_required' && staged) {
         const issues = cashflowFormulaMismatchesFromError(error);
         if (issues.length > 0) {
@@ -953,7 +975,15 @@ export function CashflowSheetLabPage() {
   const canRefresh = Boolean(projectId && spreadsheetId && isCurrentSheetConfigSaved && !loading);
   const canSaveConfig = Boolean(projectId && spreadsheetId && !loading);
   const hasCurrentFreshMirror = Boolean(mirror?.status === 'FRESH' && mirror.sourceRevision && reviewedSourceKey === sourceKey);
-  const canOverwrite = Boolean(projectId && spreadsheetId && hasCurrentFreshMirror && !reflectResult && !loading);
+  const canOverwrite = Boolean(
+    projectId
+    && spreadsheetId
+    && hasCurrentFreshMirror
+    && !reflectResult
+    && !loading
+    && applyStatusState === 'ready'
+    && !applyResumeRequired
+  );
   const hasSavedConfig = Boolean(savedConfig?.value);
   const currentStep = reflectResult || hasCurrentFreshMirror ? 3 : isCurrentSheetConfigSaved ? 2 : 1;
   const stepNumberClass = (step: number) =>
@@ -1145,11 +1175,18 @@ export function CashflowSheetLabPage() {
                     ref={stageButtonRef}
                     type="button"
                     className="h-10 gap-1.5 rounded-none px-4 text-[13px]"
-                    disabled={!canOverwrite}
-                    onClick={() => void handleOverwriteSheetValues()}
+                    disabled={applyStatusState === 'error' ? loading : !canOverwrite}
+                    onClick={() => {
+                      if (applyStatusState === 'error') {
+                        setErrorMessage('');
+                        setApplyStatusRetry((current) => current + 1);
+                        return;
+                      }
+                      void handleOverwriteSheetValues();
+                    }}
                   >
                     {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-                    시트 값으로 덮어쓰기
+                    {applyStatusState === 'error' ? '반영 상태 다시 확인' : '시트 값으로 덮어쓰기'}
                   </Button>
                 </div>
               )}


### PR DESCRIPTION
## What\n- stop retrying JVM mutations after a request may already have reached the server\n- reconcile uncertain sheet applies through the authoritative JVM operation status\n- recover the publication-owned staged run in the sheet lab UI and fail closed while status is unknown\n\n## Why\nA timed-out BFF→JVM request could still be executing while the BFF immediately sent the same mutation again. The publication remained APPLYING and later attempts using a new staged run received cashflow_sheet_apply_in_progress.\n\n## Verification\n- Java weekly client and sheet apply recovery tests: 58 passed\n- Cashflow sheet page shell tests: 11 passed\n- JVM controller transaction regression: passed\n- npm run build: passed (2,921 modules)\n- independent QA: PASS\n\n## Ops\nProduction deploy must run through the GitHub Actions Production Deploy workflow on main.