### PR TITLE
fix(cashflow): 중단된 시트 반영 락을 임대 만료로 해제

### DIFF
--- a/server/bff/cashflow-apply-lease.mjs
+++ b/server/bff/cashflow-apply-lease.mjs
@@ -1,0 +1,53 @@
+import { readOptionalText } from './bff-utils.mjs';
+
+// 시트 반영 락(cashflow_sheet_publications.status=APPLYING)은 반영을 시작한 요청이
+// 직접 해제한다. 그 요청이 중단되면 해제 코드가 실행되지 못해 프로젝트가 영구히 잠긴다.
+// applyStartedAt 기준 임대 만료를 두어 고착을 시간으로 끊는다.
+// 기본값 10분은 BFF 함수의 최대 수명(vercel.json maxDuration 300초)보다 길다. 즉 만료
+// 시점에는 락을 잡은 함수가 이미 강제 종료된 뒤이므로 해제해도 동시 실행이 아니다.
+// CASHFLOW_APPLY_LEASE_MS=0 은 임대를 끄고 기존 동작을 되살린다.
+export const DEFAULT_CASHFLOW_APPLY_LEASE_MS = 10 * 60 * 1000;
+
+export function cashflowApplyLeaseMs(env = process.env) {
+  const raw = readOptionalText(env?.CASHFLOW_APPLY_LEASE_MS);
+  if (!raw) return DEFAULT_CASHFLOW_APPLY_LEASE_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_CASHFLOW_APPLY_LEASE_MS;
+  return Math.floor(parsed);
+}
+
+function parseTimestampMs(value) {
+  const text = readOptionalText(value);
+  if (!text) return null;
+  const parsed = Date.parse(text);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function readCashflowApplyLeaseState(publication, { nowMs, leaseMs } = {}) {
+  const status = readOptionalText(publication?.status).toUpperCase();
+  const applying = status === 'APPLYING';
+  const startedAtMs = parseTimestampMs(publication?.applyStartedAt);
+  const effectiveLeaseMs = Number.isFinite(leaseMs) && leaseMs >= 0
+    ? leaseMs
+    : DEFAULT_CASHFLOW_APPLY_LEASE_MS;
+  const leaseEnabled = effectiveLeaseMs > 0;
+  // applyStartedAt 은 APPLYING 전이와 같은 트랜잭션에서 기록된다. 값이 없으면 이 경로가
+  // 쓰지 않은 문서이므로 시간으로 판단하지 않고 관리자 해제에 맡긴다.
+  const expired = applying
+    && leaseEnabled
+    && startedAtMs !== null
+    && Number.isFinite(nowMs)
+    && nowMs - startedAtMs >= effectiveLeaseMs;
+  return {
+    status,
+    applying,
+    stagedRunId: readOptionalText(publication?.stagedRunId),
+    applyStartedAt: readOptionalText(publication?.applyStartedAt),
+    expiresAt: applying && leaseEnabled && startedAtMs !== null
+      ? new Date(startedAtMs + effectiveLeaseMs).toISOString()
+      : '',
+    missingStartedAt: applying && startedAtMs === null,
+    expired,
+    blocked: applying && !expired,
+  };
+}

--- a/server/bff/cashflow-apply-lease.test.mjs
+++ b/server/bff/cashflow-apply-lease.test.mjs
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_CASHFLOW_APPLY_LEASE_MS,
+  cashflowApplyLeaseMs,
+  readCashflowApplyLeaseState,
+} from './cashflow-apply-lease.mjs';
+
+const LEASE_MS = DEFAULT_CASHFLOW_APPLY_LEASE_MS;
+const STARTED_AT = '2026-08-06T13:00:00.000Z';
+const STARTED_AT_MS = Date.parse(STARTED_AT);
+
+function applyingPublication(overrides = {}) {
+  return {
+    status: 'APPLYING',
+    stagedRunId: 'run-1',
+    applyStartedAt: STARTED_AT,
+    ...overrides,
+  };
+}
+
+describe('cashflowApplyLeaseMs', () => {
+  it('falls back to the default when the override is unset or invalid', () => {
+    expect(cashflowApplyLeaseMs({})).toBe(LEASE_MS);
+    expect(cashflowApplyLeaseMs({ CASHFLOW_APPLY_LEASE_MS: '' })).toBe(LEASE_MS);
+    expect(cashflowApplyLeaseMs({ CASHFLOW_APPLY_LEASE_MS: 'abc' })).toBe(LEASE_MS);
+    expect(cashflowApplyLeaseMs({ CASHFLOW_APPLY_LEASE_MS: '-1' })).toBe(LEASE_MS);
+  });
+
+  it('reads an explicit override including the disabling zero', () => {
+    expect(cashflowApplyLeaseMs({ CASHFLOW_APPLY_LEASE_MS: '60000' })).toBe(60_000);
+    expect(cashflowApplyLeaseMs({ CASHFLOW_APPLY_LEASE_MS: '0' })).toBe(0);
+  });
+});
+
+describe('readCashflowApplyLeaseState', () => {
+  it('does not block when no apply is running', () => {
+    const state = readCashflowApplyLeaseState({ status: 'READY' }, { nowMs: STARTED_AT_MS, leaseMs: LEASE_MS });
+    expect(state).toMatchObject({ applying: false, blocked: false, expired: false });
+  });
+
+  it('blocks while the lease is still held', () => {
+    const state = readCashflowApplyLeaseState(applyingPublication(), {
+      nowMs: STARTED_AT_MS + LEASE_MS - 1,
+      leaseMs: LEASE_MS,
+    });
+    expect(state.blocked).toBe(true);
+    expect(state.expired).toBe(false);
+    expect(state.expiresAt).toBe(new Date(STARTED_AT_MS + LEASE_MS).toISOString());
+  });
+
+  it('stops blocking once the lease expires', () => {
+    const state = readCashflowApplyLeaseState(applyingPublication(), {
+      nowMs: STARTED_AT_MS + LEASE_MS,
+      leaseMs: LEASE_MS,
+    });
+    expect(state.expired).toBe(true);
+    expect(state.blocked).toBe(false);
+    expect(state.stagedRunId).toBe('run-1');
+  });
+
+  it('keeps blocking indefinitely when the lease is disabled', () => {
+    const state = readCashflowApplyLeaseState(applyingPublication(), {
+      nowMs: STARTED_AT_MS + LEASE_MS * 1000,
+      leaseMs: 0,
+    });
+    expect(state.expired).toBe(false);
+    expect(state.blocked).toBe(true);
+    expect(state.expiresAt).toBe('');
+  });
+
+  it('does not expire a publication that never recorded a start time', () => {
+    const state = readCashflowApplyLeaseState(applyingPublication({ applyStartedAt: '' }), {
+      nowMs: STARTED_AT_MS + LEASE_MS * 10,
+      leaseMs: LEASE_MS,
+    });
+    expect(state.missingStartedAt).toBe(true);
+    expect(state.expired).toBe(false);
+    expect(state.blocked).toBe(true);
+  });
+
+  it('ignores an unparsable start time instead of expiring on it', () => {
+    const state = readCashflowApplyLeaseState(applyingPublication({ applyStartedAt: 'not-a-date' }), {
+      nowMs: STARTED_AT_MS + LEASE_MS * 10,
+      leaseMs: LEASE_MS,
+    });
+    expect(state.missingStartedAt).toBe(true);
+    expect(state.blocked).toBe(true);
+  });
+});

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -22,6 +22,7 @@ import {
 import { assertCashflowMutationRuntime, createJavaWeeklyClient } from '../java-weekly-client.mjs';
 import { createCashflowPerformanceTrace } from '../cashflow-performance.mjs';
 import { stableStringify } from '../utils.mjs';
+import { cashflowApplyLeaseMs, readCashflowApplyLeaseState } from '../cashflow-apply-lease.mjs';
 import { getMonthFinanceWeeks } from '../../../src/app/platform/cashflow-week-core.mjs';
 import {
   cashflowSheetLabApplySchema,
@@ -311,6 +312,18 @@ function assertCashflowSheetLabAccess(req, workspaceEmailDomain = 'mysc.co.kr') 
   throw createHttpError(
     403,
     `Workspace email is required to preview cashflow sheets lab: ${actorRole || 'unknown'}`,
+    'forbidden',
+  );
+}
+
+// 강제 해제는 진행 중일 수 있는 반영을 끊는 조작이므로 워크스페이스 사용자 전체가 아니라
+// 관리 역할에게만 연다.
+function assertCashflowSheetApplyLockAdmin(req) {
+  const actorRole = normalizeRole(req.context?.actorRole);
+  if (['admin', 'finance_admin'].includes(actorRole)) return;
+  throw createHttpError(
+    403,
+    '시트 반영 대기 상태 해제는 관리자만 할 수 있습니다.',
     'forbidden',
   );
 }
@@ -2320,7 +2333,8 @@ async function reserveCashflowSheetApply({
   return { ...result, runRef, publicationRef };
 }
 
-async function readCashflowSheetApplyStatus({ db, tenantId, projectId }) {
+async function readCashflowSheetApplyStatus({ db, tenantId, projectId, nowMs = Date.now() }) {
+  await releaseExpiredCashflowSheetApplyLease({ db, tenantId, projectId, nowMs });
   const publicationRef = db.doc(`orgs/${tenantId}/cashflow_sheet_publications/${projectId}`);
   const publicationSnap = await publicationRef.get();
   const publication = publicationSnap.exists ? (publicationSnap.data() || {}) : {};
@@ -2390,6 +2404,70 @@ async function readCashflowSheetApplyStatus({ db, tenantId, projectId }) {
       replaceAllActualSources: stageRunDocument.replaceAllActualSources === true,
     },
   };
+}
+
+// 락을 놓을 때 무엇이 반영됐는지는 여기서 판정하지 않는다. 반영 여부의 진실은 JVM
+// 멱등키와 revision 가드가 쥐고 있고, 다음 반영 요청이 그 가드를 정상적으로 통과하거나
+// 거절된다. force=true 는 임대가 아직 남아 있어도 관리자 판단으로 해제한다.
+async function releaseCashflowSheetApplyLock({
+  db,
+  tenantId,
+  projectId,
+  nowMs = Date.now(),
+  leaseMs = cashflowApplyLeaseMs(),
+  force = false,
+  reason = '',
+  actor = null,
+}) {
+  const publicationRef = db.doc(`orgs/${tenantId}/cashflow_sheet_publications/${projectId}`);
+  return db.runTransaction(async (transaction) => {
+    const publicationSnap = await transaction.get(publicationRef);
+    const publication = publicationSnap.exists ? (publicationSnap.data() || {}) : {};
+    const lease = readCashflowApplyLeaseState(publication, { nowMs, leaseMs });
+    if (!lease.applying) return { released: false, reasonCode: 'not_applying', lease };
+    if (!force && !lease.expired) return { released: false, reasonCode: 'lease_held', lease };
+    const releasedAt = new Date(nowMs).toISOString();
+    const failure = stripUndefinedDeep({
+      code: force ? 'cashflow_sheet_apply_lock_force_released' : 'cashflow_sheet_apply_lease_expired',
+      message: force
+        ? '관리자가 시트 반영 대기 상태를 해제했습니다.'
+        : '시트 반영이 끝나지 않아 대기 상태를 해제했습니다.',
+      reason: readOptionalText(reason) || undefined,
+      releasedById: readOptionalText(actor?.actorId) || undefined,
+      releasedByEmail: readOptionalText(actor?.actorEmail) || undefined,
+      previousApplyStartedAt: lease.applyStartedAt || undefined,
+      previousStagedRunId: lease.stagedRunId || undefined,
+    });
+    const stagedRunId = lease.stagedRunId;
+    if (stagedRunId) {
+      const runRef = db.doc(`orgs/${tenantId}/${CASHFLOW_SHEET_STAGE_RUNS_COLLECTION_ID}/${stagedRunId}`);
+      const runSnap = await transaction.get(runRef);
+      const stageRun = runSnap.exists ? (runSnap.data() || {}) : {};
+      if (
+        runSnap.exists
+        && readOptionalText(stageRun.projectId) === readOptionalText(projectId)
+        && readOptionalText(stageRun.status) === 'APPLYING'
+      ) {
+        transaction.set(runRef, stripUndefinedDeep({
+          status: 'READY',
+          appliedIdempotencyKey: null,
+          applyRequestHash: null,
+          applyFailedAt: releasedAt,
+          applyFailure: failure,
+        }), { merge: true });
+      }
+    }
+    transaction.set(publicationRef, stripUndefinedDeep({
+      status: 'READY',
+      applyFailedAt: releasedAt,
+      applyFailure: failure,
+    }), { merge: true });
+    return { released: true, reasonCode: failure.code, lease, releasedAt, stagedRunId };
+  });
+}
+
+function releaseExpiredCashflowSheetApplyLease(options) {
+  return releaseCashflowSheetApplyLock({ ...options, force: false });
 }
 
 async function restoreCashflowSheetApplyReady({
@@ -3077,6 +3155,15 @@ async function applyStagedCashflowSheetLab({
     }
   }
 
+  // 중단된 이전 반영이 남긴 락은 새 검토본으로 재시도해도 stagedRunId가 달라 계속 막힌다.
+  // 예약 전에 만료된 락을 먼저 놓아 그 고착을 끊는다.
+  await releaseExpiredCashflowSheetApplyLease({
+    db,
+    tenantId,
+    projectId,
+    nowMs: Date.parse(now),
+  });
+
   const reservation = await reserveCashflowSheetApply({
     db,
     tenantId,
@@ -3456,7 +3543,6 @@ async function applyStagedCashflowSheetLab({
       if (rejected) throw rejected.reason;
     }
   } catch (error) {
-    const statusCode = Number(error?.statusCode || error?.status);
     if (readOptionalText(error?.code) === 'cashflow_sheet_operation_uncertain' && error.operationKey) {
       await persistOperation(error.operationKey, {
         status: 'UNCERTAIN',
@@ -3475,7 +3561,12 @@ async function applyStagedCashflowSheetLab({
         closedMonthDifferences: summarizeCandidateMonthDifferences(selectedCandidates, requiredMonths),
       };
     }
-    if (completedOperationCount === 0 && statusCode >= 400 && statusCode < 500) {
+    // 반영된 작업이 하나도 없고 결과가 불확정도 아니면 락을 즉시 놓는다. 5xx·전송 실패는
+    // 이전에 해제 대상이 아니어서, 서버 오류 한 번이 프로젝트를 영구히 잠그는 원인이었다.
+    // 불확정(uncertain)은 JVM 반영 여부를 모르는 상태이므로 임대 만료에 맡긴다.
+    const uncertainOutcome = readOptionalText(error?.code) === 'cashflow_sheet_operation_uncertain'
+      || error?.mutationOutcome === 'uncertain';
+    if (completedOperationCount === 0 && !uncertainOutcome) {
       await restoreCashflowSheetApplyReady({
         db,
         runRef: reservation.runRef,
@@ -4070,6 +4161,36 @@ export function mountCashflowSheetLabRoutes(app, {
     const { projectId } = req.params;
     await readProjectDocument(db, tenantId, projectId);
     res.status(200).json(await readCashflowSheetApplyStatus({ db, tenantId, projectId }));
+  }));
+
+  app.post('/api/v1/projects/:projectId/cashflow-sheet-lab/apply-lock/release', asyncHandler(async (req, res) => {
+    assertCashflowSheetApplyLockAdmin(req);
+    const { tenantId } = req.context;
+    const { projectId } = req.params;
+    const reason = readOptionalText(req.body?.reason);
+    if (!reason) {
+      throw createHttpError(
+        422,
+        '해제 사유를 입력해 주세요.',
+        'cashflow_sheet_apply_lock_release_reason_required',
+      );
+    }
+    await readProjectDocument(db, tenantId, projectId);
+    const result = await releaseCashflowSheetApplyLock({
+      db,
+      tenantId,
+      projectId,
+      force: true,
+      reason,
+      actor: req.context,
+    });
+    res.status(200).json({
+      projectId,
+      released: result.released,
+      status: result.released ? 'READY' : result.lease.status || 'IDLE',
+      stagedRunId: result.stagedRunId || '',
+      releasedAt: result.releasedAt || '',
+    });
   }));
 
   app.get('/api/v1/projects/:projectId/cashflow-sheet-lab/years', asyncHandler(async (req, res) => {

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -4930,3 +4930,226 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
   });
 });
+
+describe('cashflow sheet apply lock lease', () => {
+  const PUBLICATION_PATH = 'orgs/tenant-a/cashflow_sheet_publications/project-a';
+  const STAGE_RUN_PATH = 'orgs/tenant-a/cashflow_sheet_stage_runs/run-v1';
+
+  function minutesAgo(minutes) {
+    return new Date(Date.now() - minutes * 60 * 1000).toISOString();
+  }
+
+  function applyingDb(applyStartedAt) {
+    return createDb({
+      initialDocuments: {
+        [PUBLICATION_PATH]: {
+          projectId: 'project-a',
+          status: 'APPLYING',
+          stagedRunId: 'run-v1',
+          sourceRevision: 'sha256:source',
+          targetRevisionAtFetch: 'sha256:target',
+          applyStartedAt,
+        },
+        [STAGE_RUN_PATH]: {
+          runId: 'run-v1',
+          projectId: 'project-a',
+          status: 'APPLYING',
+          applyStartedAt,
+          appliedIdempotencyKey: 'idem-v1',
+          applyRequestHash: 'sha256:req',
+        },
+      },
+    });
+  }
+
+  it('keeps reporting an apply in progress while the lease is held', async () => {
+    const db = applyingDb(minutesAgo(1));
+
+    const response = await request(createApp({ db }))
+      .get('/api/v1/projects/project-a/cashflow-sheet-lab/apply-status')
+      .expect(200);
+
+    expect(response.body.status).toBe('APPLYING');
+    expect(db.__getDocument(PUBLICATION_PATH).status).toBe('APPLYING');
+  });
+
+  it('releases an abandoned apply lock once the lease expires', async () => {
+    const db = applyingDb(minutesAgo(11));
+
+    const response = await request(createApp({ db }))
+      .get('/api/v1/projects/project-a/cashflow-sheet-lab/apply-status')
+      .expect(200);
+
+    expect(response.body.status).toBe('IDLE');
+    const publication = db.__getDocument(PUBLICATION_PATH);
+    expect(publication.status).toBe('READY');
+    expect(publication.applyFailure.code).toBe('cashflow_sheet_apply_lease_expired');
+    const stageRun = db.__getDocument(STAGE_RUN_PATH);
+    expect(stageRun.status).toBe('READY');
+    expect(stageRun.appliedIdempotencyKey).toBeNull();
+  });
+
+  // 2026-08-06 사고: 반영이 중단된 뒤 시트 값을 다시 불러오면 stagedRunId가 달라져
+  // 재반영도 409로 막혔다. 임대가 만료되면 그 고착이 풀려야 한다.
+  it('clears a stale lock that pins an older staged run so a new run can apply', async () => {
+    const db = applyingDb(minutesAgo(11));
+
+    await request(createApp({ db }))
+      .get('/api/v1/projects/project-a/cashflow-sheet-lab/apply-status')
+      .expect(200);
+
+    const publication = db.__getDocument(PUBLICATION_PATH);
+    // reserve 트랜잭션의 차단 조건(APPLYING && stagedRunId 불일치)이 더는 성립하지 않는다.
+    expect(publication.status).not.toBe('APPLYING');
+  });
+
+  it('does not release a held lease for a non-admin actor', async () => {
+    const db = applyingDb(minutesAgo(1));
+
+    await request(createApp({ db }))
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply-lock/release')
+      .send({ reason: '반영이 멈춰 있음' })
+      .expect(403);
+
+    expect(db.__getDocument(PUBLICATION_PATH).status).toBe('APPLYING');
+  });
+
+  it('requires a reason before an admin releases the lock', async () => {
+    const db = applyingDb(minutesAgo(1));
+
+    await request(createApp({ db, context: { actorRole: 'admin' } }))
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply-lock/release')
+      .send({})
+      .expect(422)
+      .expect((response) => {
+        expect(response.body.code).toBe('cashflow_sheet_apply_lock_release_reason_required');
+      });
+
+    expect(db.__getDocument(PUBLICATION_PATH).status).toBe('APPLYING');
+  });
+
+  it('lets an admin release a lease that has not expired yet', async () => {
+    const db = applyingDb(minutesAgo(1));
+
+    const response = await request(createApp({ db, context: { actorRole: 'admin' } }))
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply-lock/release')
+      .send({ reason: '반영 프로세스가 중단됨' })
+      .expect(200);
+
+    expect(response.body).toMatchObject({ released: true, status: 'READY', stagedRunId: 'run-v1' });
+    const publication = db.__getDocument(PUBLICATION_PATH);
+    expect(publication.status).toBe('READY');
+    expect(publication.applyFailure).toMatchObject({
+      code: 'cashflow_sheet_apply_lock_force_released',
+      reason: '반영 프로세스가 중단됨',
+      releasedById: 'actor-a',
+    });
+    expect(db.__getDocument(STAGE_RUN_PATH).status).toBe('READY');
+  });
+
+  it('treats a repeated admin release as a no-op instead of failing', async () => {
+    const db = createDb({
+      initialDocuments: {
+        [PUBLICATION_PATH]: { projectId: 'project-a', status: 'READY' },
+      },
+    });
+
+    const response = await request(createApp({ db, context: { actorRole: 'admin' } }))
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply-lock/release')
+      .send({ reason: '이미 해제됨' })
+      .expect(200);
+
+    expect(response.body.released).toBe(false);
+    expect(db.__getDocument(PUBLICATION_PATH).status).toBe('READY');
+  });
+});
+
+describe('cashflow sheet apply lock release on failure', () => {
+  function labDb() {
+    return createDb({
+      project: {
+        id: 'project-a',
+        cashflowSheetLab: {
+          value: 'saved-spreadsheet-a',
+          sheetName: 'cashflow(사용내역 연동)',
+          startWeek: '26-1-1',
+          endWeek: '26-1-5',
+        },
+      },
+    });
+  }
+
+  function previewStub() {
+    return vi.fn(async () => ({
+      spreadsheetId: 'spreadsheet-a',
+      selectedSheetName: 'cashflow(사용내역 연동)',
+      availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
+      matrix: buildMatrixWithWeekLabels(JANUARY_FINANCE_WEEKS),
+    }));
+  }
+
+  async function stageOne(app, keySuffix) {
+    const mirror = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: `refresh-${keySuffix}` })
+      .expect(200);
+    return request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+      .send({
+        expectedMirrorRevision: mirror.body.sourceRevision,
+        yearMonth: '2026-01',
+        idempotencyKey: `stage-${keySuffix}`,
+      })
+      .expect(200);
+  }
+
+  // 예약 전에 실패하면 락 자체가 잡히지 않는다. 락 고착은 예약 이후에만 생긴다.
+  it('never takes an apply lock when validation fails before the reservation', async () => {
+    const db = labDb();
+    const javaWeeklyClient = {
+      validateCashflowSheetFormulas: vi.fn(async () => {
+        throw new TypeError('unexpected internal failure');
+      }),
+      applyCashflowSheetLab: vi.fn(),
+    };
+    const app = createApp({ db, googleSheetsService: { previewSpreadsheet: previewStub() }, routeOptions: { javaWeeklyClient } });
+    const stage = await stageOne(app, 'internal-error');
+
+    await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
+      .send({ stageRunId: stage.body.runId, idempotencyKey: 'apply-internal-error' })
+      .expect((response) => {
+        expect(response.status).toBeGreaterThanOrEqual(500);
+      });
+
+    expect(javaWeeklyClient.applyCashflowSheetLab).not.toHaveBeenCalled();
+    expect(db.__getDocument('orgs/tenant-a/cashflow_sheet_publications/project-a')).toBeUndefined();
+    expect(db.__getDocument(`orgs/tenant-a/cashflow_sheet_stage_runs/${stage.body.runId}`).status).toBe('READY');
+  });
+
+  // 반영 여부를 모르는 상태에서 락을 놓으면 이중 반영 위험이 있다. 임대 만료에 맡긴다.
+  it('keeps the apply lock when the mutation outcome is uncertain', async () => {
+    const db = labDb();
+    const javaWeeklyClient = {
+      applyCashflowSheetLab: vi.fn(async () => {
+        throw Object.assign(new Error('transport failure'), {
+          statusCode: 503,
+          code: 'jvm_weekly_api_unavailable',
+          transportFailure: true,
+          mutationOutcome: 'uncertain',
+        });
+      }),
+    };
+    const app = createApp({ db, googleSheetsService: { previewSpreadsheet: previewStub() }, routeOptions: { javaWeeklyClient } });
+    const stage = await stageOne(app, 'uncertain');
+
+    await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
+      .send({ stageRunId: stage.body.runId, idempotencyKey: 'apply-uncertain' })
+      .expect((response) => {
+        expect(response.status).toBeGreaterThanOrEqual(400);
+      });
+
+    expect(db.__getDocument('orgs/tenant-a/cashflow_sheet_publications/project-a').status).toBe('APPLYING');
+  });
+});

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -18,6 +18,7 @@ import {
 } from '../cashflow-comparison.mjs';
 import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES } from '../cashflow-policy.mjs';
 import { stableStringify } from '../utils.mjs';
+import { cashflowApplyLeaseMs, readCashflowApplyLeaseState } from '../cashflow-apply-lease.mjs';
 import { getMonthFinanceWeeks } from '../../../src/app/platform/cashflow-week-core.mjs';
 import { createHash } from 'node:crypto';
 
@@ -1456,7 +1457,7 @@ function buildCumulativeCloseScope(yearMonth, evidence = null) {
   };
 }
 
-async function readCashflowSheetPublicationState({ db, tenantId, projectId }) {
+async function readCashflowSheetPublicationState({ db, tenantId, projectId, nowMs = Date.now() }) {
   if (!db?.doc) {
     return { blocked: false, fingerprint: '{}' };
   }
@@ -1472,19 +1473,26 @@ async function readCashflowSheetPublicationState({ db, tenantId, projectId }) {
     applyFailedAt: readOptionalText(data.applyFailedAt),
     appliedAt: readOptionalText(data.appliedAt),
   };
+  const lease = readCashflowApplyLeaseState(publication, {
+    nowMs,
+    leaseMs: cashflowApplyLeaseMs(),
+  });
   return {
-    blocked: publication.status === 'APPLYING',
+    blocked: lease.blocked,
+    leaseExpiresAt: lease.expiresAt,
     fingerprint: stableStringify(publication),
   };
 }
 
 function assertCashflowSheetPublicationReady(state) {
   if (!state.blocked) return;
-  throw createHttpError(
+  const error = createHttpError(
     409,
     '시트 값을 MYSCube 시트에 반영 중입니다. 반영이 끝난 뒤 다시 확인해 주세요.',
     'cashflow_sheet_apply_in_progress',
   );
+  if (state.leaseExpiresAt) error.details = { leaseExpiresAt: state.leaseExpiresAt };
+  throw error;
 }
 
 // 월 결산 기한은 대상월 다음 달 10일이다. 판정 주체는 JVM이며(WeeklyExpensePersistence.closeDeadline),
@@ -2519,6 +2527,7 @@ export function mountJvmWeeklyApiRoutes(app, {
             db,
             tenantId: req.context.tenantId,
             projectId: rawProjectId,
+            nowMs: currentNow.getTime(),
           }),
           { attempt: traceAttempt },
         );
@@ -2607,6 +2616,7 @@ export function mountJvmWeeklyApiRoutes(app, {
             db,
             tenantId: req.context.tenantId,
             projectId: rawProjectId,
+            nowMs: currentNow.getTime(),
           }),
           { attempt: traceAttempt },
         );
@@ -2875,6 +2885,7 @@ export function mountJvmWeeklyApiRoutes(app, {
         db,
         tenantId: req.context.tenantId,
         projectId: rawProjectId,
+        nowMs: currentNow.getTime(),
       });
       assertCashflowSheetPublicationReady(publicationBefore);
       const comparisonBoundary = {
@@ -2922,6 +2933,7 @@ export function mountJvmWeeklyApiRoutes(app, {
         db,
         tenantId: req.context.tenantId,
         projectId: rawProjectId,
+        nowMs: currentNow.getTime(),
       });
       assertCashflowSheetPublicationReady(publicationAfter);
       if (publicationBefore.fingerprint !== publicationAfter.fingerprint) {

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -892,6 +892,7 @@ describe('JVM weekly API BFF proxy', () => {
     const { app } = createApp(fetchImpl, createIdempotencyService(), {}, {
       env: runtimeEnv,
       db: source.db,
+      now: () => new Date('2026-07-24T08:01:00.000Z'),
     });
 
     await request(app)
@@ -902,6 +903,33 @@ describe('JVM weekly API BFF proxy', () => {
       });
 
     expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('stops blocking the month dashboard once an abandoned sheet apply lease expires', async () => {
+    const source = fullMonthCloseSource();
+    source.documents.set('orgs/tenant-a/cashflow_sheet_publications/project-a', {
+      projectId: 'project-a',
+      status: 'APPLYING',
+      stagedRunId: 'run-abandoned',
+      sourceRevision: source.sourceRevision,
+      targetRevisionAtFetch: source.targetRevision,
+      applyStartedAt: '2026-07-24T08:00:00.000Z',
+    });
+    const fetchImpl = vi.fn();
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, {
+      env: runtimeEnv,
+      db: source.db,
+      now: () => new Date('2026-07-24T09:00:00.000Z'),
+    });
+
+    await request(app)
+      .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
+      .expect((response) => {
+        expect(response.body.code).not.toBe('cashflow_sheet_apply_in_progress');
+      });
+
+    // 만료된 락이 더 이상 JVM 조회를 가로막지 않는다.
+    expect(fetchImpl).toHaveBeenCalled();
   });
 
   it('combines explicit sheet refresh and JVM month-close audit records for the activity timeline', async () => {


### PR DESCRIPTION
## 문제

시트 반영 락(`cashflow_sheet_publications.status=APPLYING`)은 반영을 시작한 요청이 직접 해제한다. 그 요청이 중단되면 해제 코드가 실행되지 못해 **프로젝트가 영구히 잠긴다.**

2026-08-06 22:09 실제 발생:
- 월 결산 조회 → `409 cashflow_sheet_apply_in_progress`
- 시트 값을 다시 불러와 재반영 → `stagedRunId`가 달라져 또 `409`
- 코드에도 화면에도 푸는 경로가 없어 Firestore를 직접 고쳐야 복구 가능

`#466`(같은 stagedRunId resume + mirror 오류)과 `#469`(uncertain mutation)는 인접한 다른 실패 모드를 다뤘고, **프로세스 중단·새 stagedRunId 케이스는 어느 쪽도 잡지 못한다.** `#469` 머지 13분 뒤에 사고가 났다.

`origin/main` 기준 재확인:
- `jvm-weekly-api.mjs` — `blocked: publication.status === 'APPLYING'` (시간 제한 없음)
- `cashflow-sheet-lab.mjs` — 해제 조건이 `4xx && completedOperationCount === 0`
- `leaseExpiresAt` / TTL 개념 부재

## 변경

`applyStartedAt` 기준 **임대(lease) 만료**를 도입해 고착을 시간으로 끊는다.

기본 10분은 BFF 함수의 최대 수명(`vercel.json` `maxDuration: 300`)보다 길다. 즉 만료 시점에는 락을 잡은 함수가 **이미 강제 종료된 뒤**이므로 해제해도 동시 실행이 아니다.

- `server/bff/cashflow-apply-lease.mjs` — 임대 판정을 순수 함수로 분리, BFF 판정 2곳이 공유
- 만료된 락은 `apply-status` 조회와 반영 예약 직전에 해제
- **무엇이 반영됐는지는 판정하지 않는다.** 그 진실은 JVM 멱등키와 revision 가드가 쥐고 있고, 다음 요청이 그 가드를 통과하거나 거절된다
- 관리자 강제 해제 `POST /api/v1/projects/:projectId/cashflow-sheet-lab/apply-lock/release` (admin·finance_admin, 사유 필수, 해제 근거 기록, 멱등)
- 반영된 작업이 없고 결과가 불확정도 아니면 즉시 해제. 불확정은 이중 반영을 피하려 임대 만료에 맡긴다

## 효과

**락 고착이 "영구"에서 "최대 10분"으로 바뀐다.** 원인이 프로세스 사망이든 중단이든 불확정이든 자동 해제된다. 사람이 DB를 만져야 풀리던 장애가 사라진다.

## 하지 않은 것

- 응답 속도 개선 없음 (별건: `month-close` 쿼리의 `yearMonth` 필터 누락 — `docs/architecture/2026-07-27-jvm-bff-channel-audit.md` 5번)
- JVM `FirestoreInheritedWeeklyExpensePersistence.java:3596`의 동일 판정은 그대로 (배포 주기가 다름, 후속)
- 반영 여부 판정 없음 (의도된 설계)
- 해제 조건 확대(5xx)는 방어적 개선에 가깝다. 예약 이후 실패는 대부분 `cashflow_sheet_operation_uncertain`으로 수렴하고, 그 경우 락 유지가 맞다. **이번 사고를 실제로 해결하는 것은 임대 만료다.**

## 검증

- `npx vitest run` — **2,745 passed** / 241 skipped, exit 0
- `npm run build` — 성공
- `git diff --check` — clean

신규 테스트 11종. 사고 재현(`clears a stale lock that pins an older staged run`)과 **유지돼야 할 동작**(임대 중 계속 차단 / 불확정 시 락 유지 / 예약 전 실패는 락을 잡지 않음)을 같은 스위트에서 함께 검증한다.

## 롤백 / ops

`CASHFLOW_APPLY_LEASE_MS=0` → 임대 비활성, 기존 동작 복원. Firestore rules·인덱스 변경 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)