### PR TITLE
fix(cashflow): 오류를 설명 가능한 가이드로 표시

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -33,6 +33,8 @@ import { useAuth } from '../../data/auth-store';
 import { useFirebase } from '../../lib/firebase-context';
 import { getAuthInstance } from '../../lib/firebase';
 import { resolveApiErrorMessage } from '../../platform/api-error-message';
+import { PlatformApiError } from '../../platform/api-client';
+import { resolveApiErrorPresentation, type ApiErrorPresentation } from '../../platform/api-error-messages';
 import { recordDevtoolsLog, toDevtoolsError } from '../../platform/devtools-transaction-log';
 import {
   fetchCashflowActivityViaBff,
@@ -388,6 +390,10 @@ export function CashflowProjectSheet({
   const [monthCloseRequest, setMonthCloseRequest] = useState<CashflowMonthCloseRequest | null>(null);
   const [monthCloseLoading, setMonthCloseLoading] = useState(false);
   const [monthCloseError, setMonthCloseError] = useState<string | null>(null);
+  const [monthCloseErrorPresentation, setMonthCloseErrorPresentation] = useState<(ApiErrorPresentation & {
+    code: string;
+    requestId: string;
+  }) | null>(null);
   const [monthCloseBusy, setMonthCloseBusy] = useState(false);
   const [selectedExecutiveApproverId, setSelectedExecutiveApproverId] = useState(project?.executiveApproverId || '');
   const [savedExecutiveApproverId, setSavedExecutiveApproverId] = useState(project?.executiveApproverId || '');
@@ -682,12 +688,19 @@ export function CashflowProjectSheet({
     const isCurrentRequest = () => requestGeneration === monthCloseRequestGenerationRef.current;
     if (!projectId || !orgId || !user?.uid) {
       setMonthCloseResult(null);
-      setMonthCloseError('로그인 세션이 만료되었습니다.');
+      setMonthCloseError('로그인 세션이 만료됐어요. 다시 로그인해 주세요.');
+      setMonthCloseErrorPresentation({
+        guide: '로그인 세션이 만료됐어요. 다시 로그인해 주세요.',
+        resolution: 'contact',
+        code: '',
+        requestId: '',
+      });
       return;
     }
     setMonthCloseResult((current) => current?.yearMonth === yearMonth ? current : null);
     setMonthCloseLoading(true);
     setMonthCloseError(null);
+    setMonthCloseErrorPresentation(null);
     const startedAt = Date.now();
     logCashflowSettlement({
       phase: 'start',
@@ -739,7 +752,19 @@ export function CashflowProjectSheet({
       }
     } catch (error) {
       if (!isCurrentRequest()) return;
-      setMonthCloseError(resolveApiErrorMessage(error, '월 결산 상태를 불러오지 못했습니다.'));
+      if (error instanceof PlatformApiError) {
+        const presentation = resolveApiErrorPresentation(error.code, error.status);
+        setMonthCloseError(presentation.guide);
+        setMonthCloseErrorPresentation({
+          ...presentation,
+          code: error.code.slice(0, 64),
+          requestId: String(error.requestId || '').slice(0, 64),
+        });
+      } else {
+        const presentation = resolveApiErrorPresentation('', 500);
+        setMonthCloseError(presentation.guide);
+        setMonthCloseErrorPresentation({ ...presentation, code: '', requestId: '' });
+      }
       logCashflowSettlement({
         phase: 'error',
         operation: 'cashflow.month_close.status.load',
@@ -2405,8 +2430,20 @@ export function CashflowProjectSheet({
     }
     if (monthCloseError || !monthCloseResult?.dashboard?.canonical?.range) {
       return (
-        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-6 text-center text-[12px] text-red-700">
-          {monthCloseError || '서버 확정 시트와 기간 합계를 불러오지 못했습니다.'}
+        <div role="alert" className="rounded-md border border-red-200 bg-red-50 px-3 py-6 text-center text-[12px] text-red-700">
+          <div>{monthCloseError || '서버 확정 시트와 기간 합계를 불러오지 못했습니다. 화면을 다시 확인해 주세요.'}</div>
+          {monthCloseErrorPresentation ? (
+            <>
+              <div className="mt-1 text-[12px] text-red-700">
+                {monthCloseErrorPresentation.resolution === 'retry' ? '상태: 다시 시도 가능' : monthCloseErrorPresentation.resolution === 'wait' ? '상태: 기다린 뒤 확인' : '상태: 담당자 확인 필요'}
+              </div>
+              {monthCloseErrorPresentation.code || monthCloseErrorPresentation.requestId ? (
+                <div className="mt-1 text-[12px] text-red-600">
+                  {[monthCloseErrorPresentation.code, monthCloseErrorPresentation.requestId].filter(Boolean).join(' · ')}
+                </div>
+              ) : null}
+            </>
+          ) : null}
         </div>
       );
     }
@@ -2552,7 +2589,7 @@ export function CashflowProjectSheet({
             summary={dashboard?.projectionActualSummary}
             loading={monthCloseLoading}
             error={Boolean(monthCloseError)}
-            onRetry={() => void loadCashflowMonthClose()}
+            onRetry={monthCloseErrorPresentation?.resolution === 'contact' ? undefined : () => void loadCashflowMonthClose()}
           />
         </div>
       );

--- a/src/app/data/cashflow-weeks-store.tsx
+++ b/src/app/data/cashflow-weeks-store.tsx
@@ -35,6 +35,7 @@ import type { CashflowMutationLease } from '../lib/cashflow-edit-lease';
 import { addMonthsToYearMonth, getSeoulTodayIso } from '../platform/business-days';
 import { getMonthMondayWeeks } from '../platform/cashflow-weeks';
 import { recordDevtoolsLog, summarizeAmountMap, toDevtoolsError } from '../platform/devtools-transaction-log';
+import { resolveApiErrorPresentation } from '../platform/api-error-messages';
 
 interface CashflowWeekState {
   yearMonth: string; // selected month ("YYYY-MM")
@@ -235,7 +236,7 @@ export function CashflowWeekProvider({ children }: { children: ReactNode }) {
         setWeeks([]);
         setWeeklySettlementCompletedKeys([]);
         setIsLoading(false);
-        setLoadError('현금흐름 데이터를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.');
+        setLoadError(resolveApiErrorPresentation('', 500).guide);
       });
 
     return () => {

--- a/src/app/platform/__snapshots__/api-error-messages.test.ts.snap
+++ b/src/app/platform/__snapshots__/api-error-messages.test.ts.snap
@@ -1,0 +1,54 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`resolveApiErrorPresentation > keeps the approved guides reviewable as a snapshot 1`] = `
+{
+  "cashflow_month_close_approver_required": {
+    "guide": "월 결산을 맡을 조직장이 지정되지 않았어요. 프로젝트에서 조직장을 지정해 주세요.",
+    "resolution": "contact",
+  },
+  "cashflow_month_close_request_conflict": {
+    "guide": "이미 같은 월의 결산 요청이 있어요. 기존 요청의 진행 상태를 확인해 주세요.",
+    "resolution": "contact",
+  },
+  "cashflow_month_close_route_timeout": {
+    "guide": "월 결산 처리 시간이 초과됐어요. 잠시 후 진행 상태를 확인하고 다시 시도해 주세요.",
+    "resolution": "retry",
+  },
+  "cashflow_month_close_self_approval_forbidden": {
+    "guide": "요청한 사람은 자신의 월 결산을 승인할 수 없어요. 다른 조직장에게 승인을 요청해 주세요.",
+    "resolution": "contact",
+  },
+  "cashflow_sheet_apply_in_progress": {
+    "guide": "시트 값을 반영하는 중이에요. 잠시 뒤 자동으로 풀리면 다시 확인해 주세요.",
+    "resolution": "wait",
+  },
+  "cashflow_sheet_mirror_revision_conflict": {
+    "guide": "검토한 뒤 시트 고정본이 변경됐어요. 최신 시트 내용을 다시 검토해 주세요.",
+    "resolution": "contact",
+  },
+  "cashflow_sheet_operation_uncertain": {
+    "guide": "반영 결과를 확인하는 중이에요. 같은 요청으로 다시 시도해 주세요.",
+    "resolution": "retry",
+  },
+  "forbidden": {
+    "guide": "이 작업을 수행할 권한이 없어요. 프로젝트 담당자에게 권한을 확인해 주세요.",
+    "resolution": "contact",
+  },
+  "internal_error": {
+    "guide": "요청을 처리하는 중 문제가 생겼어요. 잠시 후 다시 시도해 주세요.",
+    "resolution": "retry",
+  },
+  "jvm_weekly_api_identity_token_unavailable": {
+    "guide": "서버 인증 설정을 확인할 수 없어요. 시스템 담당자에게 문의해 주세요.",
+    "resolution": "contact",
+  },
+  "jvm_weekly_api_internal_error": {
+    "guide": "서버에서 요청을 마치지 못했어요. 잠시 후 다시 시도해 주세요.",
+    "resolution": "retry",
+  },
+  "jvm_weekly_api_token_unconfigured": {
+    "guide": "서버 연결 설정을 확인할 수 없어요. 시스템 담당자에게 문의해 주세요.",
+    "resolution": "contact",
+  },
+}
+`;

--- a/src/app/platform/api-client.test.ts
+++ b/src/app/platform/api-client.test.ts
@@ -84,7 +84,7 @@ describe('PlatformApiClient', () => {
 
   it('throws PlatformApiError on non-2xx responses', async () => {
     const fetchImpl = vi.fn(async () => {
-      return new Response(JSON.stringify({ error: 'nope' }), {
+      return new Response(JSON.stringify({ code: 'forbidden', message: 'Access denied' }), {
         status: 403,
         headers: {
           'content-type': 'application/json',
@@ -105,8 +105,50 @@ describe('PlatformApiClient', () => {
         name: 'PlatformApiError',
         status: 403,
         requestId: 'req-denied',
+        code: 'forbidden',
+        serverMessage: 'Access denied',
+        message: '요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+        body: { code: 'forbidden', message: 'Access denied' },
       }),
     );
+  });
+
+  it('keeps empty gateway responses safe and preserves the default message', async () => {
+    const client = new PlatformApiClient({
+      fetchImpl: vi.fn(async () => new Response('<html>bad gateway</html>', {
+        status: 502,
+        headers: { 'content-type': 'text/html' },
+      })),
+    });
+
+    await expect(client.get('/api/v1/secure', {
+      tenantId: 'mysc',
+      actor: { id: 'u001' },
+    })).rejects.toMatchObject({
+      code: '',
+      serverMessage: '',
+      message: '요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요.',
+    });
+  });
+
+  it('does not preserve non-string server messages', async () => {
+    const client = new PlatformApiClient({
+      fetchImpl: vi.fn(async () => new Response(JSON.stringify({ code: 500, message: { nested: true } }), {
+        status: 400,
+        headers: { 'content-type': 'application/json' },
+      })),
+    });
+
+    await expect(client.get('/api/v1/secure', {
+      tenantId: 'mysc',
+      actor: { id: 'u001' },
+    })).rejects.toMatchObject({ code: '', serverMessage: '' });
+  });
+
+  it('preserves long server codes so the UI can limit them to 64 characters', () => {
+    const error = new PlatformApiError('failed', 400, 'request-id', { code: 'x'.repeat(100_000) });
+    expect(error.code).toHaveLength(100_000);
+    expect(error.code.slice(0, 64)).toHaveLength(64);
   });
 
   it('retries transient failures and eventually succeeds', async () => {

--- a/src/app/platform/api-client.ts
+++ b/src/app/platform/api-client.ts
@@ -120,6 +120,8 @@ export class PlatformApiError extends Error {
   status: number;
   requestId?: string;
   body?: unknown;
+  code: string;
+  serverMessage: string;
 
   constructor(message: string, status: number, requestId?: string, body?: unknown) {
     super(message);
@@ -127,6 +129,9 @@ export class PlatformApiError extends Error {
     this.status = status;
     this.requestId = requestId;
     this.body = body;
+    const responseCode = body && typeof body === 'object' ? (body as { code?: unknown }).code : undefined;
+    this.code = typeof responseCode === 'string' ? responseCode : '';
+    this.serverMessage = readErrorMessage(body) || '';
   }
 }
 

--- a/src/app/platform/api-error-messages.test.ts
+++ b/src/app/platform/api-error-messages.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveApiErrorPresentation } from './api-error-messages';
+
+const cases = [
+  ['cashflow_sheet_apply_in_progress', 'wait'],
+  ['cashflow_sheet_operation_uncertain', 'retry'],
+  ['cashflow_month_close_request_conflict', 'contact'],
+  ['cashflow_month_close_approver_required', 'contact'],
+  ['cashflow_month_close_self_approval_forbidden', 'contact'],
+  ['cashflow_sheet_mirror_revision_conflict', 'contact'],
+  ['jvm_weekly_api_identity_token_unavailable', 'contact'],
+  ['jvm_weekly_api_token_unconfigured', 'contact'],
+  ['jvm_weekly_api_internal_error', 'retry'],
+  ['cashflow_month_close_route_timeout', 'retry'],
+  ['internal_error', 'retry'],
+  ['forbidden', 'contact'],
+] as const;
+
+describe('resolveApiErrorPresentation', () => {
+  it.each(cases)('maps %s to %s guidance', (code, resolution) => {
+    const result = resolveApiErrorPresentation(code, 500);
+    expect(result.resolution).toBe(resolution);
+    expect(result.guide).not.toBe('');
+    expect(result.guide).not.toContain(code);
+    expect(result.guide).not.toMatch(/[a-z_]{8,}/);
+  });
+
+  it('keeps the approved guides reviewable as a snapshot', () => {
+    expect(Object.fromEntries(cases.map(([code]) => [code, resolveApiErrorPresentation(code, 500)])))
+      .toMatchSnapshot();
+  });
+
+  it('falls back by status without throwing for hostile inputs', () => {
+    expect(resolveApiErrorPresentation('unknown_code', 503).resolution).toBe('retry');
+    expect(resolveApiErrorPresentation('unknown_code', 422).resolution).toBe('contact');
+    expect(resolveApiErrorPresentation('', 500)).toMatchObject({ resolution: 'retry' });
+
+    for (const code of [null, undefined, 500, {}, []]) {
+      expect(() => resolveApiErrorPresentation(code as never, 500)).not.toThrow();
+    }
+    for (const status of [Number.NaN, -1, 999, undefined]) {
+      expect(() => resolveApiErrorPresentation('', status as never)).not.toThrow();
+    }
+    for (const code of ['__proto__', 'constructor', 'toString', '<script>alert(1)</script>', 'x'.repeat(100_000)]) {
+      expect(resolveApiErrorPresentation(code, 422)).toMatchObject({ resolution: 'contact' });
+    }
+  });
+
+  it('returns fresh values and stays deterministic across 1,000 calls', () => {
+    const first = resolveApiErrorPresentation('internal_error', 500);
+    first.guide = 'mutated';
+    const expected = resolveApiErrorPresentation('internal_error', 500);
+    for (let index = 0; index < 1_000; index += 1) {
+      expect(resolveApiErrorPresentation('internal_error', 500)).toEqual(expected);
+    }
+  });
+
+  it('never tells contact cases to retry', () => {
+    for (const [code, resolution] of cases) {
+      const { guide } = resolveApiErrorPresentation(code, 500);
+      if (resolution === 'contact') expect(guide).not.toMatch(/다시\s*시도|재시도/);
+    }
+  });
+});

--- a/src/app/platform/api-error-messages.ts
+++ b/src/app/platform/api-error-messages.ts
@@ -1,0 +1,64 @@
+export interface ApiErrorPresentation {
+  guide: string;
+  resolution: 'retry' | 'wait' | 'contact';
+}
+
+const presentations = new Map<string, ApiErrorPresentation>([
+  ['cashflow_sheet_apply_in_progress', {
+    guide: '시트 값을 반영하는 중이에요. 잠시 뒤 자동으로 풀리면 다시 확인해 주세요.',
+    resolution: 'wait',
+  }],
+  ['cashflow_sheet_operation_uncertain', {
+    guide: '반영 결과를 확인하는 중이에요. 같은 요청으로 다시 시도해 주세요.',
+    resolution: 'retry',
+  }],
+  ['cashflow_month_close_request_conflict', {
+    guide: '이미 같은 월의 결산 요청이 있어요. 기존 요청의 진행 상태를 확인해 주세요.',
+    resolution: 'contact',
+  }],
+  ['cashflow_month_close_approver_required', {
+    guide: '월 결산을 맡을 조직장이 지정되지 않았어요. 프로젝트에서 조직장을 지정해 주세요.',
+    resolution: 'contact',
+  }],
+  ['cashflow_month_close_self_approval_forbidden', {
+    guide: '요청한 사람은 자신의 월 결산을 승인할 수 없어요. 다른 조직장에게 승인을 요청해 주세요.',
+    resolution: 'contact',
+  }],
+  ['cashflow_sheet_mirror_revision_conflict', {
+    guide: '검토한 뒤 시트 고정본이 변경됐어요. 최신 시트 내용을 다시 검토해 주세요.',
+    resolution: 'contact',
+  }],
+  ['jvm_weekly_api_identity_token_unavailable', {
+    guide: '서버 인증 설정을 확인할 수 없어요. 시스템 담당자에게 문의해 주세요.',
+    resolution: 'contact',
+  }],
+  ['jvm_weekly_api_token_unconfigured', {
+    guide: '서버 연결 설정을 확인할 수 없어요. 시스템 담당자에게 문의해 주세요.',
+    resolution: 'contact',
+  }],
+  ['jvm_weekly_api_internal_error', {
+    guide: '서버에서 요청을 마치지 못했어요. 잠시 후 다시 시도해 주세요.',
+    resolution: 'retry',
+  }],
+  ['cashflow_month_close_route_timeout', {
+    guide: '월 결산 처리 시간이 초과됐어요. 잠시 후 진행 상태를 확인하고 다시 시도해 주세요.',
+    resolution: 'retry',
+  }],
+  ['internal_error', {
+    guide: '요청을 처리하는 중 문제가 생겼어요. 잠시 후 다시 시도해 주세요.',
+    resolution: 'retry',
+  }],
+  ['forbidden', {
+    guide: '이 작업을 수행할 권한이 없어요. 프로젝트 담당자에게 권한을 확인해 주세요.',
+    resolution: 'contact',
+  }],
+]);
+
+export function resolveApiErrorPresentation(code: string, statusCode: number): ApiErrorPresentation {
+  const mapped = typeof code === 'string' ? presentations.get(code) : undefined;
+  if (mapped) return { ...mapped };
+
+  return Number.isFinite(statusCode) && statusCode >= 500
+    ? { guide: '요청을 처리하는 중 문제가 생겼어요. 잠시 후 다시 시도해 주세요.', resolution: 'retry' }
+    : { guide: '요청을 처리할 수 없어요. 입력 내용과 권한을 확인해 주세요.', resolution: 'contact' };
+}


### PR DESCRIPTION
## 문제

모든 5xx가 화면에 `Internal server error` 하나로 표시된다. 서버는 이미 `code`를 응답에 싣고 있으나(`bff-utils.mjs:27-36`) 프론트가 쓰지 않는다(`api-client.ts`).

결과: **영구 장애와 일시 장애를 구분할 수 없다.**

| 실제 원인 | 성질 | 사용자가 보는 것 |
|---|---|---|
| 환경변수 미설정 | 영구 | Internal server error |
| 토큰 발급 실패 | 영구/일시 | Internal server error |
| 네트워크 타임아웃 | 일시 | Internal server error |

사용자는 풀리지 않을 오류에 새로고침을 반복하고, 지원 담당자는 서버 로그를 뒤져야 한다.

## 변경 — 3층 구조

| 층 | 내용 | 예 |
|---|---|---|
| 1. 가이드 | 무엇이 일어났고 **다음에 무엇을 하면 되는지** | "시트 값을 반영하는 중이에요. 잠시 뒤 자동으로 풀리면 다시 확인해 주세요." |
| 2. 상태 | `retry` / `wait` / `contact` | 기다림 |
| 3. 식별자 | `code` + `requestId` (보조 표시) | `cashflow_sheet_apply_in_progress · req-…` |

- `api-error-messages.ts` — 기존 12개 코드 매핑. **순수 함수, import 0개, `Map`**(프로토타입 오염 차단), 반환값 복사로 테이블 오염 차단
- `PlatformApiError`가 `code`/`serverMessage` 보존. 기존 `message`·`body`·`requestId` 계약 유지
- `contact` 상태에서는 재시도 버튼을 노출하지 않는다 (헛된 재시도 유도 제거)

## 정량

| 축 | 현재 | 변경 후 |
|---|---|---|
| 화면에서 원인 식별 | 0% | 100% (매핑 12/12) |
| `contact` 코드의 재시도 유도 | 항상 | **0건** |
| 응답시간·트래픽·참조 횟수 | — | **변화 0** (서버 무변경) |

`resolution` 분포: retry 4 / wait 1 / contact 7

## 검증

- `npm test` — 신규 19건 포함 통과. `npm run build`, `git diff --check` 통과
- 적대적 입력: `null`/`undefined`/숫자/객체/배열, `__proto__`·`constructor`·`toString`, XSS 문자열, 10만 자 code, 비정상 status(`NaN`/-1/999), 1,000회 결정성
- **사보타주 검증**: `contact` 코드에 "다시 시도" 문구를 심고 가이드에 내부 식별자를 노출시킨 뒤 테스트를 돌려 **3건이 정확히 실패**함을 확인. 테스트가 실제 게이트로 동작한다

> 전체 스위트에서 관측되는 `socket hang up`(BFF supertest)은 여러 파일 동시 실행 시의 소켓 경합이며 이 변경과 무관하다. 해당 파일 단독 실행 3/3 통과로 확인했다.

## 하지 않은 것

- `bff-utils.mjs`의 5xx 메시지 가림 정책 **미변경** — 노출하는 것은 `code`이지 `message`가 아니다
- 새 오류 코드 신설 없음. 서버·JVM 무변경
- **알려진 한계**: `resolution: 'contact'` 7건 중 3건(`approver_required`, `mirror_revision_conflict`, `request_conflict`)은 실제로는 사용자 본인 행동이라 상태명과 안내가 어긋난다. 4번째 상태 추가 여부는 후속 얼라인에서 다룬다

🤖 Generated with [Claude Code](https://claude.com/claude-code)