### PR TITLE
fix(cashflow): JVM 락 판정에 임대 만료 적용 (사고 원인 완결)

### DIFF
--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowApplyLease.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowApplyLease.java
@@ -1,0 +1,75 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Locale;
+
+public final class CashflowApplyLease {
+    public static final long DEFAULT_LEASE_MS = 600_000L;
+
+    private CashflowApplyLease() {}
+
+    public static long leaseMs(String raw) {
+        if (raw == null || raw.trim().isEmpty()) return DEFAULT_LEASE_MS;
+        try {
+            double parsed = Double.parseDouble(raw.trim());
+            if (!Double.isFinite(parsed) || parsed < 0) return DEFAULT_LEASE_MS;
+            return (long) Math.floor(parsed);
+        } catch (NumberFormatException ignored) {
+            return DEFAULT_LEASE_MS;
+        }
+    }
+
+    public static State read(Object statusValue, Object stagedRunIdValue, Object applyStartedAtValue, long nowMs, long leaseMs) {
+        String status = text(statusValue).toUpperCase(Locale.ROOT);
+        boolean applying = "APPLYING".equals(status);
+        String applyStartedAt = text(applyStartedAtValue);
+        Long startedAtMs = timestampMs(applyStartedAt);
+        long effectiveLeaseMs = leaseMs >= 0 ? leaseMs : DEFAULT_LEASE_MS;
+        boolean leaseEnabled = effectiveLeaseMs > 0;
+        boolean expired = applying
+            && leaseEnabled
+            && startedAtMs != null
+            && nowMs - startedAtMs >= effectiveLeaseMs;
+        return new State(
+            status,
+            applying,
+            text(stagedRunIdValue),
+            applyStartedAt,
+            applying && leaseEnabled && startedAtMs != null
+                ? Instant.ofEpochMilli(startedAtMs + effectiveLeaseMs).toString()
+                : "",
+            applying && startedAtMs == null,
+            expired,
+            applying && !expired
+        );
+    }
+
+    private static String text(Object value) {
+        return value instanceof String text ? text.trim() : "";
+    }
+
+    private static Long timestampMs(String value) {
+        if (value.isEmpty()) return null;
+        try {
+            return Instant.parse(value).toEpochMilli();
+        } catch (RuntimeException ignored) {}
+        try {
+            return LocalDate.parse(value).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
+        } catch (RuntimeException ignored) {
+            return null;
+        }
+    }
+
+    public record State(
+        String status,
+        boolean applying,
+        String stagedRunId,
+        String applyStartedAt,
+        String expiresAt,
+        boolean missingStartedAt,
+        boolean expired,
+        boolean blocked
+    ) {}
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -33,6 +33,7 @@ import dev.merryai.innerplatform.weekly.api.CashflowSettledWeekChangeConfirmatio
 import dev.merryai.innerplatform.weekly.api.CashflowSettledWeekChangeConfirmationRequiredException;
 import dev.merryai.innerplatform.weekly.api.WeeklyExpenseEditLeaseException;
 import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseActualEntity;
+import dev.merryai.innerplatform.weekly.domain.CashflowApplyLease;
 import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseAuditEventEntity;
 import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseAuditExportEntity;
 import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseBankImportBatchEntity;
@@ -117,6 +118,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     private final Firestore db;
     private final String firestoreProjectId;
     private final Clock clock;
+    private final long cashflowApplyLeaseMs;
     private final byte[] cashflowSettledWeekConfirmationKey;
     private final FirestoreWeeklyExpenseDocumentMapper sheetMapper = new FirestoreWeeklyExpenseDocumentMapper();
     private final ThreadLocal<Transaction> currentTransaction = new ThreadLocal<>();
@@ -131,29 +133,37 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     @Autowired
     public FirestoreInheritedWeeklyExpensePersistence(
         @Value("${weekly.firestore-project-id:}") String firestoreProjectId,
-        @Value("${weekly.cashflow-settled-week-confirmation-key:}") String cashflowSettledWeekConfirmationKey
+        @Value("${weekly.cashflow-settled-week-confirmation-key:}") String cashflowSettledWeekConfirmationKey,
+        @Value("${weekly.cashflow-apply-lease-ms:600000}") String cashflowApplyLeaseMs
     ) {
         this(
             createFirestore(firestoreProjectId),
             normalizeFirestoreProjectId(firestoreProjectId),
             Clock.systemUTC(),
-            cashflowSettledWeekConfirmationKey
+            cashflowSettledWeekConfirmationKey,
+            CashflowApplyLease.leaseMs(cashflowApplyLeaseMs)
         );
     }
 
     FirestoreInheritedWeeklyExpensePersistence(Firestore db, String firestoreProjectId, Clock clock) {
-        this(db, firestoreProjectId, clock, TEST_CASHFLOW_SETTLED_WEEK_CONFIRMATION_KEY);
+        this(db, firestoreProjectId, clock, TEST_CASHFLOW_SETTLED_WEEK_CONFIRMATION_KEY, CashflowApplyLease.DEFAULT_LEASE_MS);
+    }
+
+    FirestoreInheritedWeeklyExpensePersistence(Firestore db, String firestoreProjectId, Clock clock, long cashflowApplyLeaseMs) {
+        this(db, firestoreProjectId, clock, TEST_CASHFLOW_SETTLED_WEEK_CONFIRMATION_KEY, cashflowApplyLeaseMs);
     }
 
     private FirestoreInheritedWeeklyExpensePersistence(
         Firestore db,
         String firestoreProjectId,
         Clock clock,
-        String cashflowSettledWeekConfirmationKey
+        String cashflowSettledWeekConfirmationKey,
+        long cashflowApplyLeaseMs
     ) {
         this.db = db;
         this.firestoreProjectId = normalizeFirestoreProjectId(firestoreProjectId);
         this.clock = clock;
+        this.cashflowApplyLeaseMs = cashflowApplyLeaseMs;
         this.cashflowSettledWeekConfirmationKey = requireCashflowSettledWeekConfirmationKey(cashflowSettledWeekConfirmationKey);
     }
 
@@ -3796,8 +3806,8 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         if (!publicationSnapshot.exists()) {
             return;
         }
-        String status = text(data(publicationSnapshot).get("status"), "").toUpperCase(Locale.ROOT);
-        if ("APPLYING".equals(status)) {
+        Map<String, Object> publication = data(publicationSnapshot);
+        if (CashflowApplyLease.read(publication.get("status"), publication.get("stagedRunId"), publication.get("applyStartedAt"), clock.instant().toEpochMilli(), cashflowApplyLeaseMs).blocked()) {
             throw new WeeklyExpenseConflictException(
                 "Cashflow sheet values are being applied. Retry the month close after the apply finishes."
             );

--- a/server/jvm-weekly-api/src/main/resources/application.yml
+++ b/server/jvm-weekly-api/src/main/resources/application.yml
@@ -10,6 +10,7 @@ weekly:
   deploy-env: ${JVM_WEEKLY_DEPLOY_ENV:local}
   legacy-week-close-enabled: false
   cashflow-edit-leases-enabled: ${JVM_WEEKLY_EDIT_LEASES_ENABLED:false}
+  cashflow-apply-lease-ms: ${CASHFLOW_APPLY_LEASE_MS:600000}
   storage-backend: ${JVM_WEEKLY_STORAGE_BACKEND:firestore}
   internal-api-token-enabled: ${JVM_WEEKLY_INTERNAL_API_TOKEN_ENABLED:false}
   internal-api-token: ${JVM_WEEKLY_INTERNAL_API_TOKEN:}

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowApplyLeaseTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowApplyLeaseTest.java
@@ -1,0 +1,93 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CashflowApplyLeaseTest {
+    private static final long LEASE_MS = CashflowApplyLease.DEFAULT_LEASE_MS;
+    private static final String STARTED_AT = "2026-08-06T13:00:00.000Z";
+    private static final long STARTED_AT_MS = Instant.parse(STARTED_AT).toEpochMilli();
+
+    @Test
+    void fallsBackToTheDefaultWhenTheOverrideIsUnsetOrInvalid() {
+        assertThat(CashflowApplyLease.leaseMs(null)).isEqualTo(LEASE_MS);
+        assertThat(CashflowApplyLease.leaseMs("")).isEqualTo(LEASE_MS);
+        assertThat(CashflowApplyLease.leaseMs("abc")).isEqualTo(LEASE_MS);
+        assertThat(CashflowApplyLease.leaseMs("-1")).isEqualTo(LEASE_MS);
+    }
+
+    @Test
+    void readsAnExplicitOverrideIncludingTheDisablingZero() {
+        assertThat(CashflowApplyLease.leaseMs("60000")).isEqualTo(60_000L);
+        assertThat(CashflowApplyLease.leaseMs("0")).isZero();
+    }
+
+    @Test
+    void doesNotBlockWhenNoApplyIsRunning() {
+        var state = read("READY", null, STARTED_AT_MS, LEASE_MS);
+        assertThat(state.applying()).isFalse();
+        assertThat(state.blocked()).isFalse();
+        assertThat(state.expired()).isFalse();
+    }
+
+    @Test
+    void blocksWhileTheLeaseIsStillHeld() {
+        var state = read("APPLYING", STARTED_AT, STARTED_AT_MS + LEASE_MS - 1, LEASE_MS);
+        assertThat(state.blocked()).isTrue();
+        assertThat(state.expired()).isFalse();
+        assertThat(state.expiresAt()).isEqualTo("2026-08-06T13:10:00Z");
+    }
+
+    @Test
+    void stopsBlockingOnceTheLeaseExpires() {
+        var state = read("APPLYING", STARTED_AT, STARTED_AT_MS + LEASE_MS, LEASE_MS);
+        assertThat(state.expired()).isTrue();
+        assertThat(state.blocked()).isFalse();
+        assertThat(state.stagedRunId()).isEqualTo("run-1");
+    }
+
+    @Test
+    void keepsBlockingIndefinitelyWhenTheLeaseIsDisabled() {
+        var state = read("APPLYING", STARTED_AT, STARTED_AT_MS + LEASE_MS * 1000, 0);
+        assertThat(state.expired()).isFalse();
+        assertThat(state.blocked()).isTrue();
+        assertThat(state.expiresAt()).isEmpty();
+    }
+
+    @Test
+    void doesNotExpireAPublicationThatNeverRecordedAStartTime() {
+        var state = read("APPLYING", "", STARTED_AT_MS + LEASE_MS * 10, LEASE_MS);
+        assertThat(state.missingStartedAt()).isTrue();
+        assertThat(state.expired()).isFalse();
+        assertThat(state.blocked()).isTrue();
+    }
+
+    @Test
+    void ignoresAnUnparsableStartTimeInsteadOfExpiringOnIt() {
+        for (Object invalid : new Object[] {"not-a-date", 1, "x".repeat(100_000), "+1000000000-12-31T23:59:59.999999999Z"}) {
+            var state = CashflowApplyLease.read("APPLYING", "run-1", invalid, STARTED_AT_MS + LEASE_MS * 10, LEASE_MS);
+            assertThat(state.missingStartedAt()).isTrue();
+            assertThat(state.blocked()).isTrue();
+        }
+    }
+
+    @Test
+    void acceptsTheDateOnlyFormatParsedByTheBffContract() {
+        var state = read("APPLYING", "2026-08-06", STARTED_AT_MS + LEASE_MS, LEASE_MS);
+        assertThat(state.expired()).isTrue();
+    }
+
+    @Test
+    void normalizesStatusAndDoesNotExpireFutureStarts() {
+        assertThat(read("applying", STARTED_AT, STARTED_AT_MS + LEASE_MS, LEASE_MS).expired()).isTrue();
+        assertThat(read(" APPLYING ", STARTED_AT, STARTED_AT_MS + LEASE_MS, LEASE_MS).expired()).isTrue();
+        assertThat(read("APPLYING", STARTED_AT, STARTED_AT_MS - 1, LEASE_MS).blocked()).isTrue();
+    }
+
+    private static CashflowApplyLease.State read(Object status, Object startedAt, long nowMs, long leaseMs) {
+        return CashflowApplyLease.read(status, "run-1", startedAt, nowMs, leaseMs);
+    }
+}

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -1982,6 +1982,62 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
+    void monthCloseContinuesWhenTheSheetPublicationLeaseHasExpired() {
+        CloseCashflowMonthRequest request = monthCloseRequest("month-close-publication-expired", 0, 3);
+        Fixture fixture = fixture(activeMember(), activeLease());
+        String publicationPath = "orgs/tenant-a/cashflow_sheet_publications/project-a";
+        fixture.documents.put(
+            publicationPath,
+            new LinkedHashMap<>(Map.of(
+                "projectId", "project-a",
+                "status", "APPLYING",
+                "stagedRunId", "abandoned-stage-run",
+                "applyStartedAt", NOW.minusMillis(600_000).toString(),
+                "sourceRevision", SOURCE_REVISION
+            ))
+        );
+        fixture.documents.put(
+            "orgs/tenant-a/cashflow_sheet_mirrors/project-a",
+            pinnedMirror(request)
+        );
+
+        fixture.persistence.runCommandTransaction(() -> commandService(
+            fixture.persistence
+        ).closeCashflowMonth(ACTOR, "project-a", SESSION, request));
+
+        assertThat(fixture.documents).containsKey(monthClosePath("project-a", request.yearMonth()));
+        assertThat(fixture.documents.get(publicationPath))
+            .containsEntry("status", "APPLYING")
+            .containsEntry("stagedRunId", "abandoned-stage-run");
+    }
+
+    @Test
+    void monthCloseRejectsAnApplyingSheetPublicationWhileItsLeaseIsValid() {
+        CloseCashflowMonthRequest request = monthCloseRequest("month-close-publication-valid-lease", 0, 3);
+        Fixture fixture = fixture(activeMember(), activeLease());
+        fixture.documents.put(
+            "orgs/tenant-a/cashflow_sheet_publications/project-a",
+            new LinkedHashMap<>(Map.of(
+                "projectId", "project-a",
+                "status", "APPLYING",
+                "applyStartedAt", NOW.minusMillis(599_999).toString()
+            ))
+        );
+        fixture.documents.put(
+            "orgs/tenant-a/cashflow_sheet_mirrors/project-a",
+            pinnedMirror(request)
+        );
+
+        assertThatThrownBy(() -> fixture.persistence.runCommandTransaction(() -> commandService(
+            fixture.persistence
+        ).closeCashflowMonth(ACTOR, "project-a", SESSION, request)))
+            .isInstanceOf(WeeklyExpenseConflictException.class)
+            .hasMessage("Cashflow sheet values are being applied. Retry the month close after the apply finishes.");
+
+        assertThat(fixture.documents).doesNotContainKey(monthClosePath("project-a", request.yearMonth()));
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     void monthCloseTransactionRetriesAndRejectsAnAnnualOnlyPublicationReservedAfterItsFirstRead() {
         CloseCashflowMonthRequest request = monthCloseRequest("month-close-publication-race", 0, 3);


### PR DESCRIPTION
## 문제 — 2026-08-06 사고의 미해결 절반

PR #470이 **BFF**에 임대 만료를 도입했으나, **JVM 쪽 같은 판정은 그대로**였다.

`FirestoreInheritedWeeklyExpensePersistence.java:3792`
```java
if ("APPLYING".equals(status)) {
    throw new WeeklyExpenseConflictException("Cashflow sheet values are being applied...");
}
```
`applyStartedAt` / lease 참조: **파일 전체 0건**

**결과:** BFF 임대가 만료돼 조회를 열어줘도 JVM이 월 결산을 **무기한 거부**한다. 락 문서를 고아로 만드는 어떤 장애에서도 월 결산이 영구 차단된다.

## 변경

BFF `cashflow-apply-lease.mjs`를 **원본 계약**으로 삼아 동일 시맨틱을 JVM 도메인 순수 클래스로 미러링.

| 축 | 이전 | 이후 |
|---|---|---|
| JVM 월 결산 차단 (락 고아 시) | **무기한** | **최대 10분** |
| BFF·JVM 판정 | 불일치 | **동일 규칙** |
| 임대 유효 중 차단 | 동작 | **변화 없음** |

- `domain/CashflowApplyLease.java` — I/O·프레임워크 import **0건**. `nowMs`/`leaseMs`/필드값을 인자로 받는 순수 판정
- persistence에는 **호출 한 줄만** 추가 (SPEC-05 트랜잭션 경계 준수)
- env **`CASHFLOW_APPLY_LEASE_MS` 공유** (`application.yml:13`, 기본 600000) — 운영자가 한 값만 관리
- **JVM은 `cashflow_sheet_publications`에 쓰지 않는다** (writer는 BFF). 만료 임대를 차단하지 않는 것까지만

## 검증

- **사보타주 검증**: 경계 조건 `>=`를 `>`로 바꾸자 테스트 2건이 정확히 실패 → 경계값이 실제로 고정됨을 확인
- BFF 테스트 8케이스를 **같은 픽스처 값으로 미러링** — 두 구현이 갈리면 테스트가 먼저 알림
- `mvn test` 전체 **EXIT 0** (기존 회귀 0)
- `git diff --check` clean

> BFF 테스트 간헐 실패는 이 변경과 무관하다. **`server/bff` diff가 0건**이며, 실패 테스트가 매 실행마다 달라지는 기존 병렬 경합 플레이키다(격리 3회 중 1회 전체 통과, 매번 다른 테스트).

## Freeze Unit

- **20-A** `5e093f86` — 순수 클래스 + 미러 테스트 (호출부 0이어도 단독 존재)
- **20-B** `ac2afc44` — persistence 연결 + 통합 테스트

각각 단독 배포·단독 revert 가능.

## 롤백

`CASHFLOW_APPLY_LEASE_MS=0` → 임대 비활성, 기존 무기한 차단 동작 복원 (BFF와 동일 스위치).

🤖 Generated with [Claude Code](https://claude.com/claude-code)