### PR TITLE
fix(cashflow): 시트 반영 중에도 월 결산 조회를 유지 (작업중단 0)

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -1479,6 +1479,7 @@ async function readCashflowSheetPublicationState({ db, tenantId, projectId, nowM
   });
   return {
     blocked: lease.blocked,
+    applyStartedAt: publication.applyStartedAt || null,
     leaseExpiresAt: lease.expiresAt,
     fingerprint: stableStringify(publication),
   };
@@ -2531,7 +2532,6 @@ export function mountJvmWeeklyApiRoutes(app, {
           }),
           { attempt: traceAttempt },
         );
-        assertCashflowSheetPublicationReady(publicationBefore);
         const source = await trace.measure(
           'jvm_dashboard',
           () => proxyJavaWeeklyRequest({
@@ -2620,16 +2620,17 @@ export function mountJvmWeeklyApiRoutes(app, {
           }),
           { attempt: traceAttempt },
         );
-        assertCashflowSheetPublicationReady(publicationAfter);
+        const pendingApply = publicationAfter.blocked ? {
+          startedAt: publicationAfter.applyStartedAt,
+          expiresAt: publicationAfter.leaseExpiresAt,
+        } : null;
         if (publicationBefore.fingerprint === publicationAfter.fingerprint) {
-          return { ...cumulativeClose, dashboard };
+          return { ...cumulativeClose, dashboard, pendingApply, publicationChangedDuringRead: false };
+        }
+        if (attempt === 1) {
+          return { ...cumulativeClose, dashboard, pendingApply, publicationChangedDuringRead: true };
         }
       }
-      throw createHttpError(
-        409,
-        '시트 반영 상태가 조회 중 변경되었습니다. 잠시 후 다시 확인해 주세요.',
-        'cashflow_sheet_publication_changed',
-      );
     }, monthCloseRouteTimeoutMs);
     res.status(200).json(body);
   }));

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -878,7 +878,7 @@ describe('JVM weekly API BFF proxy', () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
-  it('does not publish a month dashboard while a sheet apply is in progress', async () => {
+  it('publishes a month dashboard with pending apply metadata while a sheet apply is in progress', async () => {
     const source = fullMonthCloseSource();
     source.documents.set('orgs/tenant-a/cashflow_sheet_publications/project-a', {
       projectId: 'project-a',
@@ -888,7 +888,14 @@ describe('JVM weekly API BFF proxy', () => {
       targetRevisionAtFetch: source.targetRevision,
       applyStartedAt: '2026-07-24T08:00:00.000Z',
     });
-    const fetchImpl = vi.fn();
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(monthDashboardSource({
+        ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0,
+        reopenCount: 0, projectWarningCount: 0, snapshot: {},
+      })),
+    }));
     const { app } = createApp(fetchImpl, createIdempotencyService(), {}, {
       env: runtimeEnv,
       db: source.db,
@@ -897,12 +904,51 @@ describe('JVM weekly API BFF proxy', () => {
 
     await request(app)
       .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
-      .expect(409)
+      .expect(200)
       .expect((response) => {
-        expect(response.body.code).toBe('cashflow_sheet_apply_in_progress');
+        expect(response.body.pendingApply).toEqual({
+          startedAt: '2026-07-24T08:00:00.000Z',
+          expiresAt: '2026-07-24T08:10:00.000Z',
+        });
+        expect(response.body.publicationChangedDuringRead).toBe(false);
       });
 
-    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the latest month dashboard with metadata when publication changes twice', async () => {
+    const source = fullMonthCloseSource();
+    let publicationReadCount = 0;
+    const baseDoc = source.db.doc;
+    source.db.doc = (path) => {
+      if (path !== 'orgs/tenant-a/cashflow_sheet_publications/project-a') return baseDoc(path);
+      return {
+        get: async () => ({
+          exists: true,
+          data: () => ({ status: 'APPLIED', stagedRunId: `run-${publicationReadCount += 1}` }),
+        }),
+      };
+    };
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(monthDashboardSource({
+        ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0,
+        reopenCount: 0, projectWarningCount: 0, snapshot: {},
+      })),
+    }));
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { env: runtimeEnv, db: source.db });
+
+    await request(app)
+      .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
+      .expect(200)
+      .expect((response) => {
+        expect(response.body.publicationChangedDuringRead).toBe(true);
+        expect(response.body.pendingApply).toBeNull();
+      });
+
+    expect(publicationReadCount).toBe(4);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
   it('stops blocking the month dashboard once an abandoned sheet apply lease expires', async () => {
@@ -915,7 +961,14 @@ describe('JVM weekly API BFF proxy', () => {
       targetRevisionAtFetch: source.targetRevision,
       applyStartedAt: '2026-07-24T08:00:00.000Z',
     });
-    const fetchImpl = vi.fn();
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(monthDashboardSource({
+        ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0,
+        reopenCount: 0, projectWarningCount: 0, snapshot: {},
+      })),
+    }));
     const { app } = createApp(fetchImpl, createIdempotencyService(), {}, {
       env: runtimeEnv,
       db: source.db,
@@ -924,8 +977,9 @@ describe('JVM weekly API BFF proxy', () => {
 
     await request(app)
       .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
+      .expect(200)
       .expect((response) => {
-        expect(response.body.code).not.toBe('cashflow_sheet_apply_in_progress');
+        expect(response.body.pendingApply).toBeNull();
       });
 
     // 만료된 락이 더 이상 JVM 조회를 가로막지 않는다.


### PR DESCRIPTION
## 문제 — 쓰기 상태가 읽기를 막는다

시트 반영(쓰기)이 진행 중이면 월 결산 **조회**가 409로 전면 차단됐다. 2026-08-06 사고의 구조적 원인이다.

PR #470(BFF 임대)·#474(JVM 임대)가 **시간으로** 끊었으나 **결합 자체는 남아 있었다.** 요청받지 않은 관심사(쓰기) 때문에 요청한 작업(읽기)이 중단되는 구조다.

추가로 `publication` fingerprint가 조회 중 바뀌면 전체를 재실행한 뒤 **409로 응답 자체를 없앴다.**

## 변경 — 응답을 없애지 않고 데이터로 전달

| 이전 | 이후 |
|---|---|
| 반영 중 → `409 cashflow_sheet_apply_in_progress` | **200** + `pendingApply { startedAt, expiresAt }` |
| fingerprint 2회 변경 → `409 cashflow_sheet_publication_changed` | **200** + `publicationChangedDuringRead: true` |

```diff
-        assertCashflowSheetPublicationReady(publicationBefore);
-        assertCashflowSheetPublicationReady(publicationAfter);
+        const pendingApply = publicationAfter.blocked ? {
+          startedAt: publicationAfter.applyStartedAt,
+          expiresAt: publicationAfter.leaseExpiresAt,
+        } : null;
```

**진행 중이라는 사실은 반드시 응답에 실린다.** 조용한 성공이 아니라 부분 정보 + 사유 전달이다.

| 체감 지표 | 이전 | 이후 |
|---|---|---|
| 반영 중 대시보드 조회 성공률 | **0%** | **100%** |
| 읽기가 쓰기 상태로 중단되는 BFF 지점 | 2 | **0** |

## 쓰기 보호는 그대로

`assertCashflowSheetPublicationReady`는 **월 결산 요청 생성(쓰기 경로)** 에 남아 있다(`:2891`, `:2939`). 읽기만 풀고 쓰기는 계속 차단한다. PR #470의 임대 만료 동작도 변경 없다.

## 검증

**회귀 방지 쌍** — 실제 HTTP 회귀 테스트 2종 추가:
- 반영 진행 중 대시보드가 `pendingApply` 메타와 함께 발행되는가 (신규 동작)
- publication이 두 번 바뀌어도 최신 결과 + `publicationChangedDuringRead`를 반환하는가

변경 파일 183 테스트 통과, build·diff-check 통과, 격리 revert 후 182 테스트/build 통과.

> 전체 스위트의 간헐 실패는 이 변경과 무관하다. 매 실행마다 **다른 테스트**가 실패하고(`forwards an explicit projection validation override`, `requires explicit reviewed close input` 등 전부 기존 테스트), 4회 중 1회는 전체 통과했다. 기존 병렬 경합 플레이키다.

## 범위 밖 (그대로 유지)

- JVM `requireCashflowSheetPublicationReady` — 배포 주기가 달라 PR #474에서 별도 처리
- 쓰기 경로 락 판정 · `cashflow-sheet-lab.mjs` · 502 계열 필드 검증 6종

🤖 Generated with [Claude Code](https://claude.com/claude-code)