### PR TITLE
fix(cashflow): 월 결산 재오픈 자기승인 차단

### DIFF
--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -1196,7 +1196,7 @@ public class WeeklyExpenseController {
     public ResponseEntity<Map<String, String>> forbidden(WeeklyExpenseForbiddenException error) {
         return ResponseEntity.status(403).body(Map.of(
             "ok", "false",
-            "code", "weekly_expense_forbidden",
+            "code", error.code(),
             "message", error.getMessage()
         ));
     }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseForbiddenException.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseForbiddenException.java
@@ -1,7 +1,18 @@
 package dev.merryai.innerplatform.weekly.api;
 
 public class WeeklyExpenseForbiddenException extends RuntimeException {
+    private final String code;
+
     public WeeklyExpenseForbiddenException(String message) {
+        this("weekly_expense_forbidden", message);
+    }
+
+    public WeeklyExpenseForbiddenException(String code, String message) {
         super(message);
+        this.code = code;
+    }
+
+    public String code() {
+        return code;
     }
 }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowMonthReopenApprovalPolicy.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowMonthReopenApprovalPolicy.java
@@ -1,0 +1,17 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+public final class CashflowMonthReopenApprovalPolicy {
+    private CashflowMonthReopenApprovalPolicy() {
+    }
+
+    public static Decision decide(String requestedByUid, String decidedByUid) {
+        if (requestedByUid == null || requestedByUid.isBlank()) return Decision.LEGACY_REQUESTER_MISSING;
+        return requestedByUid.equals(decidedByUid) ? Decision.SELF_APPROVAL_FORBIDDEN : Decision.ALLOWED;
+    }
+
+    public enum Decision {
+        ALLOWED,
+        LEGACY_REQUESTER_MISSING,
+        SELF_APPROVAL_FORBIDDEN
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -28,12 +28,14 @@ import dev.merryai.innerplatform.weekly.api.RequestCashflowMonthReopenRequest;
 import dev.merryai.innerplatform.weekly.api.ReopenCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.TrustedActorContext;
 import dev.merryai.innerplatform.weekly.api.WeeklyExpenseConflictException;
+import dev.merryai.innerplatform.weekly.api.WeeklyExpenseForbiddenException;
 import dev.merryai.innerplatform.weekly.api.CashflowSettledWeekChangeConfirmation;
 import dev.merryai.innerplatform.weekly.api.CashflowSettledWeekChangeConfirmationExpiredException;
 import dev.merryai.innerplatform.weekly.api.CashflowSettledWeekChangeConfirmationRequiredException;
 import dev.merryai.innerplatform.weekly.api.WeeklyExpenseEditLeaseException;
 import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseActualEntity;
 import dev.merryai.innerplatform.weekly.domain.CashflowApplyLease;
+import dev.merryai.innerplatform.weekly.domain.CashflowMonthReopenApprovalPolicy;
 import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseAuditEventEntity;
 import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseAuditExportEntity;
 import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseBankImportBatchEntity;
@@ -82,6 +84,7 @@ import javax.crypto.spec.SecretKeySpec;
 @Repository
 @ConditionalOnProperty(name = "weekly.storage-backend", havingValue = "firestore")
 public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpensePersistence {
+    private static final System.Logger LOGGER = System.getLogger(FirestoreInheritedWeeklyExpensePersistence.class.getName());
     private static final ObjectMapper JSON = new ObjectMapper();
     private static final Set<String> CASHFLOW_WRITE_ROLES = Set.of("admin", "finance", "pm", "viewer", "tenant_admin");
     private static final Set<String> CASHFLOW_CROSS_PROJECT_ROLES = Set.of("admin", "finance", "tenant_admin");
@@ -1921,6 +1924,23 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             throw new WeeklyExpenseConflictException("Cashflow month is not awaiting a reopen decision.");
         }
         requireExpectedMonthRevision(current, request.expectedRevision());
+        CashflowMonthReopenApprovalPolicy.Decision approvalDecision = CashflowMonthReopenApprovalPolicy.decide(
+            text(nestedMap(current.get("reopenRequest")).get("requestedByUid"), ""),
+            actor.id()
+        );
+        if (approvalDecision == CashflowMonthReopenApprovalPolicy.Decision.SELF_APPROVAL_FORBIDDEN) {
+            throw new WeeklyExpenseForbiddenException(
+                "cashflow_month_close_self_approval_forbidden",
+                "Cashflow month reopen requester cannot decide their own request."
+            );
+        }
+        if (approvalDecision == CashflowMonthReopenApprovalPolicy.Decision.LEGACY_REQUESTER_MISSING) {
+            LOGGER.log(
+                System.Logger.Level.WARNING,
+                "cashflow_month_reopen_legacy_requester_missing tenantId={0} projectId={1} yearMonth={2}",
+                actor.tenantId(), projectId, request.yearMonth()
+            );
+        }
         List<Map<String, Object>> projectCloses = readProjectMonthCloses(actor.tenantId(), projectId);
         boolean approved = "APPROVE".equals(request.decision());
         long reopenCount = addMonthCounters(

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
@@ -59,6 +59,9 @@ class WeeklyExpenseControllerTest {
     private MockMvc mockMvc;
 
     @Autowired
+    private WeeklyExpenseController controller;
+
+    @Autowired
     private ObjectMapper objectMapper;
 
     @Autowired
@@ -2058,6 +2061,20 @@ class WeeklyExpenseControllerTest {
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.code").value("weekly_expense_forbidden"));
         }
+    }
+
+    @Test
+    void cashflowMonthReopenSelfApprovalErrorKeepsItsPublicCode() {
+        var response = controller.forbidden(new WeeklyExpenseForbiddenException(
+            "cashflow_month_close_self_approval_forbidden",
+            "Cashflow month reopen requester cannot decide their own request."
+        ));
+
+        assertThat(response.getStatusCode().value()).isEqualTo(403);
+        assertThat(response.getBody()).containsEntry(
+            "code",
+            "cashflow_month_close_self_approval_forbidden"
+        );
     }
 
     @Test

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowMonthReopenApprovalPolicyTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowMonthReopenApprovalPolicyTest.java
@@ -1,0 +1,43 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+import org.junit.jupiter.api.Test;
+
+import static dev.merryai.innerplatform.weekly.domain.CashflowMonthReopenApprovalPolicy.Decision.ALLOWED;
+import static dev.merryai.innerplatform.weekly.domain.CashflowMonthReopenApprovalPolicy.Decision.LEGACY_REQUESTER_MISSING;
+import static dev.merryai.innerplatform.weekly.domain.CashflowMonthReopenApprovalPolicy.Decision.SELF_APPROVAL_FORBIDDEN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CashflowMonthReopenApprovalPolicyTest {
+    @Test
+    void forbidsOnlyTheExactRequesterFromDeciding() {
+        assertThat(CashflowMonthReopenApprovalPolicy.decide("user-a", "user-a"))
+            .isEqualTo(SELF_APPROVAL_FORBIDDEN);
+        assertThat(CashflowMonthReopenApprovalPolicy.decide("user-a", "user-b"))
+            .isEqualTo(ALLOWED);
+        assertThat(CashflowMonthReopenApprovalPolicy.decide("Admin", "admin"))
+            .isEqualTo(ALLOWED);
+        assertThat(CashflowMonthReopenApprovalPolicy.decide("user-a ", "user-a"))
+            .isEqualTo(ALLOWED);
+    }
+
+    @Test
+    void identifiesMissingLegacyRequesterValues() {
+        assertThat(CashflowMonthReopenApprovalPolicy.decide(null, "admin"))
+            .isEqualTo(LEGACY_REQUESTER_MISSING);
+        assertThat(CashflowMonthReopenApprovalPolicy.decide("", "admin"))
+            .isEqualTo(LEGACY_REQUESTER_MISSING);
+        assertThat(CashflowMonthReopenApprovalPolicy.decide("   ", "admin"))
+            .isEqualTo(LEGACY_REQUESTER_MISSING);
+    }
+
+    @Test
+    void comparesUntrustedUidTextWithoutParsingOrLengthLimits() {
+        assertThat(CashflowMonthReopenApprovalPolicy.decide("__proto__", "__proto__"))
+            .isEqualTo(SELF_APPROVAL_FORBIDDEN);
+        String longUid = "x".repeat(100_000);
+        for (int index = 0; index < 1_000; index++) {
+            assertThat(CashflowMonthReopenApprovalPolicy.decide(longUid, longUid))
+                .isEqualTo(SELF_APPROVAL_FORBIDDEN);
+        }
+    }
+}

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -94,6 +94,12 @@ class FirestoreCashflowLeaseGuardTest {
         "pm@example.com",
         "viewer"
     );
+    private static final TrustedActorContext FINANCE_ACTOR = new TrustedActorContext(
+        "tenant-a",
+        "finance-1",
+        "finance@example.com",
+        "finance"
+    );
     private static final CashflowEditSession SESSION = new CashflowEditSession(
         "stage-data-project",
         "session-a",
@@ -3652,6 +3658,11 @@ class FirestoreCashflowLeaseGuardTest {
             "role", "finance",
             "projectIds", List.of()
         )));
+        fixture.documents.put("orgs/tenant-a/members/finance-1", member(Map.of(
+            "uid", "finance-1",
+            "role", "finance",
+            "projectIds", List.of()
+        )));
         DecideCashflowMonthReopenRequest decision = new DecideCashflowMonthReopenRequest(
             "reopen-decision-1",
             "2026-06",
@@ -3659,14 +3670,29 @@ class FirestoreCashflowLeaseGuardTest {
             "APPROVE",
             "증빙 확인 완료"
         );
-        CashflowMonthCloseResponse approved = fixture.persistence.runCommandTransaction(() -> service.decideCashflowMonthReopen(
+        assertThatThrownBy(() -> fixture.persistence.runCommandTransaction(() -> service.decideCashflowMonthReopen(
             ACTOR,
+            "project-a",
+            "stage-data-project",
+            decision
+        )))
+            .isInstanceOf(WeeklyExpenseForbiddenException.class)
+            .satisfies(error -> assertThat(((WeeklyExpenseForbiddenException) error).code())
+                .isEqualTo("cashflow_month_close_self_approval_forbidden"));
+        assertThat(fixture.documents.get(monthClosePath("project-a", "2026-06")))
+            .containsEntry("status", "REOPEN_REQUESTED")
+            .containsEntry("revision", 2L);
+        assertThat(fixture.documents.get(
+            "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-06-w3"
+        )).containsEntry("status", "LOCKED");
+        CashflowMonthCloseResponse approved = fixture.persistence.runCommandTransaction(() -> service.decideCashflowMonthReopen(
+            FINANCE_ACTOR,
             "project-a",
             "stage-data-project",
             decision
         ));
         CashflowMonthCloseResponse replay = fixture.persistence.runCommandTransaction(() -> service.decideCashflowMonthReopen(
-            ACTOR,
+            FINANCE_ACTOR,
             "project-a",
             "stage-data-project",
             decision
@@ -3704,6 +3730,29 @@ class FirestoreCashflowLeaseGuardTest {
                 )
             ))
         ))).doesNotThrowAnyException();
+    }
+
+    @Test
+    void legacyReopenRequestWithoutRequesterCanStillBeDecided() {
+        Fixture fixture = fixture(activeMember(), activeLease());
+        fixture.documents.put(monthClosePath("project-a", "2026-06"), closedMonth("2026-06", 1, 0));
+        fixture.persistence.runCommandTransaction(() -> fixture.persistence.requestCashflowMonthReopen(
+            ACTOR,
+            "project-a",
+            new RequestCashflowMonthReopenRequest("legacy-request", "2026-06", 1, "레거시 정정")
+        ));
+        Map<String, Object> close = fixture.documents.get(monthClosePath("project-a", "2026-06"));
+        ((Map<String, Object>) close.get("reopenRequest")).remove("requestedByUid");
+
+        WeeklyExpensePersistence.CashflowMonthCloseRecord decided = fixture.persistence.runCommandTransaction(() ->
+            fixture.persistence.decideCashflowMonthReopen(
+                ACTOR,
+                "project-a",
+                new DecideCashflowMonthReopenRequest("legacy-decision", "2026-06", 2, "APPROVE", "승인")
+            )
+        );
+
+        assertThat(decided.status()).isEqualTo("OPEN");
     }
 
     @Test
@@ -4202,7 +4251,7 @@ class FirestoreCashflowLeaseGuardTest {
             )
         ));
         fixture.persistence.runCommandTransaction(() -> fixture.persistence.decideCashflowMonthReopen(
-            ACTOR, "project-a", new DecideCashflowMonthReopenRequest(
+            FINANCE_ACTOR, "project-a", new DecideCashflowMonthReopenRequest(
                 "legacy-reopen-decision", "2026-08", 2, "APPROVE", "정정 승인"
             )
         ));
@@ -4269,7 +4318,7 @@ class FirestoreCashflowLeaseGuardTest {
             ACTOR, "project-a", new RequestCashflowMonthReopenRequest("reopen-latest", "2026-08", 1, "정정")
         ));
         fixture.persistence.runCommandTransaction(() -> fixture.persistence.decideCashflowMonthReopen(
-            ACTOR, "project-a", new DecideCashflowMonthReopenRequest("reopen-decision", "2026-08", 2, "APPROVE", "승인")
+            FINANCE_ACTOR, "project-a", new DecideCashflowMonthReopenRequest("reopen-decision", "2026-08", 2, "APPROVE", "승인")
         ));
 
         assertThat(fixture.documents.get("orgs/tenant-a/cashflow_cumulative_close_heads/project-a"))
@@ -4298,7 +4347,7 @@ class FirestoreCashflowLeaseGuardTest {
             ACTOR, "project-a", new RequestCashflowMonthReopenRequest("reopen-request", "2026-08", 1, "정정")
         ));
         fixture.persistence.runCommandTransaction(() -> fixture.persistence.decideCashflowMonthReopen(
-            ACTOR, "project-a", new DecideCashflowMonthReopenRequest("reopen-decision", "2026-08", 2, "APPROVE", "승인")
+            FINANCE_ACTOR, "project-a", new DecideCashflowMonthReopenRequest("reopen-decision", "2026-08", 2, "APPROVE", "승인")
         ));
 
         assertThat(fixture.documents.get("orgs/tenant-a/cashflow_cumulative_close_heads/project-a"))


### PR DESCRIPTION
## 문제 — 확정 후 불변성을 해제하는 유일한 경로에 게이트가 없다

월 결산 재오픈은 **요청 → 결정** 2단계이고, 결정은 CLOSED 월을 다시 OPEN으로 되돌린다. 즉 확정 후 불변성을 해제하는 유일한 경로다.

그런데 요청자와 결정자가 같은지 검사하지 않았다.

| 지점 | 상태 |
|---|---|
| 요청자 UID 저장 (`Persistence.java:1857`) | ✅ |
| 결정자 UID 저장 (`:1963`) | ✅ |
| **두 값 비교** | **전수 검색 0건** |
| BFF 권한 검사 (`jvm-weekly-api.mjs:4282`) | 역할(`admin`/`finance`)**만** 확인 |

**`admin` 또는 `finance` 역할자가 자신이 요청한 재오픈을 스스로 승인할 수 있었다.**

다른 승인 경로에는 게이트가 있다 — 월 결산 승인 요청자≠승인자(`:322-333`), 조직장 지정 시 자기승인 차단(`:3436`), 검토자 일치(`:3917`). **재오픈만 빠져 있었다.** 설계 의도가 아니라 누락으로 판단했다.

## 변경

| 축 | 이전 | 이후 |
|---|---|---|
| 재오픈 자기승인 차단 | **0%** | **100%** |
| 정상 재오픈 흐름 | 동작 | **변화 없음** |

- `domain/CashflowMonthReopenApprovalPolicy.java` (17줄) — 순수 판정. `ALLOWED` / `LEGACY_REQUESTER_MISSING` / `SELF_APPROVAL_FORBIDDEN`
- **JVM 트랜잭션 내부**에서 비교 (요청자가 중간에 바뀌는 경합 차단)
- 판정은 **JVM 소유**. BFF는 역할 검사만 유지 (SPEC-01 계층 규칙)
- 기존 오류 코드 **`cashflow_month_close_self_approval_forbidden` 재사용** — 새 코드 신설 없음. PR #472가 이미 이 코드를 사용자 가이드로 매핑했다

## 레거시 호환 (SPEC-04)

`requestedByUid`가 **없는 과거 요청 문서**는 비교를 건너뛰고 **허용**한다. 값이 없다고 거부하면 과거 요청이 영구히 막힌다.

이 폴백은 **WARNING 로그로 관측 가능**하다 (조용한 폴백 금지). 확정된 과거 문서는 수정하지 않는다.

## 검증

- **사보타주 검증**: 자기승인 차단 로직을 제거하자 테스트 2건이 정확히 실패 → 게이트가 실제로 작동함을 확인
- `mvn test` 전체 **EXIT 0** (기존 회귀 0), `git diff --check` clean
- 거부 시 `monthly_closes` 상태 미변경, 주차 잠금 해제도 미발생 (부분 상태 없음)

## Freeze Unit

- **94da9ad6** — 순수 정책 클래스 + 단위 테스트 (호출부 0이어도 단독 존재)
- **c5df0fc2** — persistence 연결 + 통합 테스트

## 발견 경위

SPEC-15(소유권 재편) 영향 분석 조사 중 발견. 조사 워커가 *"JVM 재오픈 경로가 요청자와 결정자 UID를 저장만 하고 서로 비교하지 않는다"*고 보고했고, `requestedByUid` 비교 코드 전수 검색 0건으로 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)