### PR TITLE
refactor(cashflow): 프론트 라인 카탈로그를 policy에서 파생 (13-B)

### DIFF
--- a/src/app/platform/cashflow-sheet.test.ts
+++ b/src/app/platform/cashflow-sheet.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Transaction } from '../data/types';
+import cashflowPolicyData from '../../../policies/cashflow-policy.json';
 import type { MonthMondayWeek } from './cashflow-weeks';
 import {
   aggregateTransactionsToActual,
@@ -52,6 +53,15 @@ function makeWeek(weekNo: number, start: string, end: string): MonthMondayWeek {
 }
 
 describe('cashflow line catalog', () => {
+  it('derives the line catalog from the policy', () => {
+    expect(CASHFLOW_IN_LINES).toEqual(
+      cashflowPolicyData.lineEntries.filter((entry) => entry.direction === 'IN').map((entry) => entry.lineId),
+    );
+    expect(CASHFLOW_OUT_LINES).toEqual(
+      cashflowPolicyData.lineEntries.filter((entry) => entry.direction === 'OUT').map((entry) => entry.lineId),
+    );
+  });
+
   it('keeps the approved IN and OUT line order', () => {
     expect(CASHFLOW_IN_LINES).toEqual([
       'MYSC_PREPAY_IN',

--- a/src/app/platform/cashflow-sheet.ts
+++ b/src/app/platform/cashflow-sheet.ts
@@ -1,27 +1,10 @@
 import type { CashflowCategory, CashflowSheetLineId, CashflowWeekSheet, Direction, Transaction } from '../data/types';
 import type { MonthMondayWeek } from './cashflow-weeks';
+import { CASHFLOW_IN_LINE_IDS, CASHFLOW_OUT_LINE_IDS } from './policies/cashflow-policy';
 
-export const CASHFLOW_IN_LINES: CashflowSheetLineId[] = [
-  'MYSC_PREPAY_IN',
-  'MYSC_PREPAY_LABOR_IN',
-  'MYSC_PREPAY_INPUT_VAT_IN',
-  'SALES_IN',
-  'SALES_VAT_IN',
-  'TEAM_SUPPORT_IN',
-  'BANK_INTEREST_IN',
-];
+export const CASHFLOW_IN_LINES: CashflowSheetLineId[] = CASHFLOW_IN_LINE_IDS;
 
-export const CASHFLOW_OUT_LINES: CashflowSheetLineId[] = [
-  'MYSC_PREPAY_DIRECT_OUT',
-  'MYSC_PREPAY_LABOR_OUT',
-  'DIRECT_COST_OUT',
-  'INPUT_VAT_OUT',
-  'MYSC_LABOR_OUT',
-  'MYSC_PROFIT_OUT',
-  'SALES_VAT_OUT',
-  'TEAM_SUPPORT_OUT',
-  'BANK_INTEREST_OUT',
-];
+export const CASHFLOW_OUT_LINES: CashflowSheetLineId[] = CASHFLOW_OUT_LINE_IDS;
 
 export const CASHFLOW_ALL_LINES: CashflowSheetLineId[] = [...CASHFLOW_IN_LINES, ...CASHFLOW_OUT_LINES];
 


### PR DESCRIPTION
## 문제

캐시플로 라인 16종이 **3벌** 존재했다 — policy JSON, 프론트 하드코딩 배열, JVM 하드코딩. 라인 하나를 추가하려면 세 곳을 고쳐야 하고, 하나를 빠뜨리면 조용히 갈라진다.

이 PR은 그중 **프론트 하드코딩**을 제거한다.

## 변경

`src/app/platform/cashflow-sheet.ts`

```diff
-export const CASHFLOW_IN_LINES: CashflowSheetLineId[] = [
-  'MYSC_PREPAY_IN', 'MYSC_PREPAY_LABOR_IN', ... (7개)
-];
-export const CASHFLOW_OUT_LINES: CashflowSheetLineId[] = [ ... (9개) ];
+import { CASHFLOW_IN_LINE_IDS, CASHFLOW_OUT_LINE_IDS } from './policies/cashflow-policy';
```

| 축 | 이전 | 이후 |
|---|---|---|
| 라인 정의처 (프론트) | 하드코딩 16개 | **policy 파생** |
| 라인 1종 추가 시 수정 파일 | 3 | **2** (JVM은 13-E에서) |

## 검증

- **계약 테스트 추가**: policy JSON을 직접 읽어 `CASHFLOW_IN_LINES`/`OUT_LINES`와 대조
- **SSOT 사보타주 검증**: policy에 IN 라인 1개를 추가하자 파생값이 **7개로 정확히 따라갔고**, 기존 "승인된 라인 순서 유지" 안전장치가 이를 감지해 실패 → SSOT가 실제로 작동함을 확인
- 39/39 통과, `npm run build` EXIT 0, `git diff --check` clean

## 13-D는 blocker로 남긴다

`server/bff → src/app` 역참조 0건화(13-D)는 **보류**한다. 남은 역참조가 `jvm-weekly-api.mjs`와 `cashflow-sheet-lab.mjs`에 있는데, 전자를 다른 작업(SPEC-01, 머지됨)이 동시 수정 중이었다. 예외 승인이 아니라 **순서 조정**이 맞다고 판단했다.

역참조는 13-A 머지로 8건 → 5건으로 이미 감소했다.

## 범위 밖

13-C(리터럴 160), 13-E(JVM 카탈로그), 13-F(기한 판정), 13-G(타임존 — SPEC-21 조사 결과 **불필요**로 판명)

🤖 Generated with [Claude Code](https://claude.com/claude-code)