### PR TITLE
perf(cashflow): Firestore 읽기를 요청 월로 제한 (SPEC-12 개정 A)

### DIFF
--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/CashflowQueryScope.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/CashflowQueryScope.java
@@ -1,0 +1,50 @@
+package dev.merryai.innerplatform.weekly.storage;
+
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+final class CashflowQueryScope {
+    static final int FIRESTORE_WHERE_IN_LIMIT = 30;
+
+    private CashflowQueryScope() {}
+
+    static List<String> requireYearMonths(Collection<String> values) {
+        if (values == null) throw new IllegalArgumentException("yearMonths must not be null.");
+        LinkedHashSet<String> months = new LinkedHashSet<>();
+        for (String value : values) {
+            if (value == null) throw new IllegalArgumentException("yearMonth must use YYYY-MM.");
+            try {
+                if (!YearMonth.parse(value).toString().equals(value)) throw new DateTimeParseException("", value, 0);
+            } catch (DateTimeParseException error) {
+                throw new IllegalArgumentException("yearMonth must use YYYY-MM: " + value, error);
+            }
+            months.add(value);
+        }
+        return List.copyOf(months);
+    }
+
+    static List<List<String>> chunks(Collection<String> values) {
+        List<String> months = requireYearMonths(values);
+        List<List<String>> chunks = new ArrayList<>();
+        for (int start = 0; start < months.size(); start += FIRESTORE_WHERE_IN_LIMIT) {
+            chunks.add(months.subList(start, Math.min(start + FIRESTORE_WHERE_IN_LIMIT, months.size())));
+        }
+        return List.copyOf(chunks);
+    }
+
+    static List<String> between(String fromMonth, String throughMonth) {
+        YearMonth current = YearMonth.parse(requireYearMonths(List.of(fromMonth)).getFirst());
+        YearMonth end = YearMonth.parse(requireYearMonths(List.of(throughMonth)).getFirst());
+        if (current.isAfter(end)) return List.of();
+        List<String> months = new ArrayList<>();
+        while (!current.isAfter(end)) {
+            months.add(current.toString());
+            current = current.plusMonths(1);
+        }
+        return List.copyOf(months);
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -87,6 +87,10 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     private static final Set<String> CASHFLOW_CROSS_PROJECT_ROLES = Set.of("admin", "finance", "tenant_admin");
     private static final String CASHFLOW_MONTH_CLOSE_CONTRACT_VERSION = "cashflow-month-close-v1";
     private static final String CASHFLOW_CUMULATIVE_CLOSE_CONTRACT_VERSION = "cashflow-cumulative-close-v2";
+    static final List<String> CASHFLOW_MONTH_CLOSE_READ_FIELDS = List.of(
+        "contractVersion", "yearMonth", "revision", "reopenCount", "status",
+        "postDeadlineAmendmentWarningCount"
+    );
     private static final YearMonth CASHFLOW_CUMULATIVE_BASELINE = YearMonth.of(2023, 1);
     private static final List<String> CASHFLOW_CUMULATIVE_LINES = List.of(
         "MYSC_PREPAY_IN", "MYSC_PREPAY_LABOR_IN", "MYSC_PREPAY_INPUT_VAT_IN", "SALES_IN",
@@ -3485,11 +3489,14 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
 
     private List<Map<String, Object>> readProjectMonthCloses(String tenantId, String projectId) {
         QuerySnapshot snapshot = query(db.collection("orgs/" + tenantId + "/monthly_closes")
-            .whereEqualTo("projectId", projectId));
+            .whereEqualTo("projectId", projectId)
+            .select(CASHFLOW_MONTH_CLOSE_READ_FIELDS.toArray(String[]::new)));
         List<Map<String, Object>> closes = new ArrayList<>();
         for (DocumentSnapshot document : snapshot.getDocuments()) {
-            Map<String, Object> close = data(document);
+            Map<String, Object> close = new LinkedHashMap<>(data(document));
             String yearMonth = text(close.get("yearMonth"), "");
+            close.put("tenantId", tenantId);
+            close.put("projectId", projectId);
             requireYearMonth(yearMonth);
             canonicalMonthStatus(close, tenantId, projectId, yearMonth);
             closes.add(close);
@@ -3499,15 +3506,18 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
 
     private List<Map<String, Object>> readProjectMonthClosesForRead(String tenantId, String projectId) {
         QuerySnapshot snapshot = query(db.collection("orgs/" + tenantId + "/monthly_closes")
-            .whereEqualTo("projectId", projectId));
+            .whereEqualTo("projectId", projectId)
+            .select(CASHFLOW_MONTH_CLOSE_READ_FIELDS.toArray(String[]::new)));
         List<Map<String, Object>> closes = new ArrayList<>();
         for (DocumentSnapshot document : snapshot.getDocuments()) {
-            Map<String, Object> close = data(document);
+            Map<String, Object> close = new LinkedHashMap<>(data(document));
             String yearMonth = text(close.get("yearMonth"), "");
             if (yearMonth.isBlank()) {
                 String prefix = projectId + "-";
                 yearMonth = document.getId().startsWith(prefix) ? document.getId().substring(prefix.length()) : "";
             }
+            close.put("tenantId", tenantId);
+            close.put("projectId", projectId);
             requireYearMonth(yearMonth);
             closes.add(readableMonthClose(close, tenantId, projectId, yearMonth));
         }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -1566,6 +1566,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             }
         }
 
+        // SPEC-12 approved full scan: completeCashflowWeeklyUpdate requires the global targetRevision.
         QuerySnapshot projectWeekSnapshot = query(cashflowWeeks(actor.tenantId()).whereEqualTo("projectId", projectId));
         Map<String, Map<String, Object>> projectWeeks = new LinkedHashMap<>();
         for (DocumentSnapshot weekSnapshot : projectWeekSnapshot.getDocuments()) {
@@ -2058,6 +2059,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         Set<String> writeDocumentIds = new java.util.LinkedHashSet<>(requestedWeekDocumentIds == null
             ? List.of()
             : requestedWeekDocumentIds);
+        // SPEC-12 approved full scan: countCashflowActualReplacementWrites budgets existing actual documents globally.
         QuerySnapshot existing = query(cashflowWeeks(tenantId).whereEqualTo("projectId", projectId));
         for (DocumentSnapshot doc : existing.getDocuments()) {
             if (data(doc).containsKey("weeklyExpenseActualBySheet")) {
@@ -2242,6 +2244,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             targetMonthDocs.put(snap.getId(), document);
         }
 
+        // SPEC-12 approved full scan: replaceCashflowSheetMonthsInternal hashes the complete project ledger.
         QuerySnapshot existingSnapshot = query(cashflowWeeks(tenantId).whereEqualTo("projectId", projectId));
         Map<String, Map<String, Object>> allProjectWeeks = new LinkedHashMap<>();
         for (DocumentSnapshot doc : existingSnapshot.getDocuments()) {
@@ -2544,6 +2547,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
 
     @Override
     public CashflowLedgerSource findCashflowLedgerSource(String tenantId, String projectId) {
+        // SPEC-12 approved full scan: findCashflowLedgerSource serves the all-month dashboard and targetRevision.
         QuerySnapshot snapshot = query(cashflowWeeks(tenantId).whereEqualTo("projectId", projectId));
         return cashflowLedgerSource(tenantId, projectId, snapshot, null, null);
     }
@@ -2555,16 +2559,13 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         String fromMonth,
         String throughMonth
     ) {
-        int maximumCanonicalWeeks = (2099 - 2023 + 1) * 12 * CashflowSheetLabApplyRequest.FINANCE_WEEK_COUNT;
-        QuerySnapshot snapshot = query(cashflowWeeks(tenantId)
-            .whereEqualTo("projectId", projectId)
-            .whereGreaterThanOrEqualTo("yearMonth", fromMonth)
-            .whereLessThanOrEqualTo("yearMonth", throughMonth)
-            .limit(maximumCanonicalWeeks + 1));
-        if (snapshot.size() > maximumCanonicalWeeks) {
-            throw new WeeklyExpenseConflictException("Canonical cashflow ledger exceeds the bounded read limit.");
-        }
-        return cashflowLedgerSource(tenantId, projectId, snapshot, fromMonth, throughMonth);
+        return cashflowLedgerSource(
+            tenantId,
+            projectId,
+            queryCashflowWeeks(tenantId, projectId, CashflowQueryScope.between(fromMonth, throughMonth)),
+            fromMonth,
+            throughMonth
+        );
     }
 
     private CashflowLedgerSource cashflowLedgerSource(
@@ -2574,11 +2575,21 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         String fromMonth,
         String throughMonth
     ) {
+        return cashflowLedgerSource(tenantId, projectId, snapshot.getDocuments(), fromMonth, throughMonth);
+    }
+
+    private CashflowLedgerSource cashflowLedgerSource(
+        String tenantId,
+        String projectId,
+        List<? extends DocumentSnapshot> snapshots,
+        String fromMonth,
+        String throughMonth
+    ) {
         List<WeeklyExpenseProjectionEntity> projection = new ArrayList<>();
         List<WeeklyExpenseActualEntity> actual = new ArrayList<>();
         Set<Integer> weeklyYears = new java.util.TreeSet<>();
         List<Map<String, Object>> documents = new ArrayList<>();
-        for (DocumentSnapshot doc : snapshot.getDocuments()) {
+        for (DocumentSnapshot doc : snapshots) {
             Map<String, Object> document = data(doc);
             documents.add(document);
             String yearMonth = text(document.get("yearMonth"), "");
@@ -4000,6 +4011,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         }
 
         Map<String, Map<String, Object>> docs = new LinkedHashMap<>();
+        // SPEC-12 approved full scan: replaceExpenseRows reconciles actuals across the whole source sheet.
         QuerySnapshot existing = query(cashflowWeeks(tenant(sheet)).whereEqualTo("projectId", sheet.getProjectId()));
         for (DocumentSnapshot doc : existing.getDocuments()) {
             docs.put(doc.getId(), data(doc));
@@ -4082,6 +4094,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         }
 
         Map<String, Map<String, Object>> docs = new LinkedHashMap<>();
+        // SPEC-12 approved full scan: replaceActualLines reconciles every prior actual for the source sheet.
         QuerySnapshot existing = query(cashflowWeeks(tenantId).whereEqualTo("projectId", projectId));
         for (DocumentSnapshot doc : existing.getDocuments()) {
             docs.put(doc.getId(), data(doc));
@@ -4499,6 +4512,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
 
     @Override
     public List<WeeklyExpenseWeeklyStatusEntity> findWeeklyStatuses(String tenantId, String projectId) {
+        // SPEC-12 approved full scan: findWeeklyStatuses returns the complete status history.
         QuerySnapshot snap = query(cashflowWeeks(tenantId).whereEqualTo("projectId", projectId));
         List<WeeklyExpenseWeeklyStatusEntity> statuses = new ArrayList<>();
         for (DocumentSnapshot doc : snap.getDocuments()) {
@@ -4584,6 +4598,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     }
 
     private List<WeeklyExpenseProjectionEntity> readProjectionLines(String tenantId, String projectId) {
+        // SPEC-12 approved full scan: readProjectionLines backs the all-month persistence contract.
         QuerySnapshot snap = query(cashflowWeeks(tenantId).whereEqualTo("projectId", projectId));
         List<WeeklyExpenseProjectionEntity> lines = new ArrayList<>();
         for (DocumentSnapshot doc : snap.getDocuments()) {
@@ -4600,6 +4615,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     }
 
     private List<WeeklyExpenseActualEntity> readActualLines(String tenantId, String projectId, boolean auditOrder) {
+        // SPEC-12 approved full scan: readActualLines backs all-month reads and audit ordering.
         QuerySnapshot snap = query(cashflowWeeks(tenantId).whereEqualTo("projectId", projectId));
         List<WeeklyExpenseActualEntity> lines = new ArrayList<>();
         for (DocumentSnapshot doc : snap.getDocuments()) {
@@ -4664,6 +4680,23 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
 
     private CollectionReference cashflowWeeks(String tenantId) {
         return db.collection("orgs/" + tenantId + "/cashflow_weeks");
+    }
+
+    private List<DocumentSnapshot> queryCashflowWeeks(
+        String tenantId,
+        String projectId,
+        Collection<String> yearMonths
+    ) {
+        if (projectId == null || projectId.isBlank()) return List.of();
+        List<DocumentSnapshot> documents = new ArrayList<>();
+        for (List<String> chunk : CashflowQueryScope.chunks(yearMonths)) {
+            Query scoped = cashflowWeeks(tenantId).whereEqualTo("projectId", projectId);
+            scoped = chunk.size() == 1
+                ? scoped.whereEqualTo("yearMonth", chunk.getFirst())
+                : scoped.whereIn("yearMonth", chunk);
+            documents.addAll(query(scoped).getDocuments());
+        }
+        return List.copyOf(documents);
     }
 
     private DocumentReference cashflowWeekRef(String tenantId, String docId) {

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/CashflowQueryScopeTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/CashflowQueryScopeTest.java
@@ -1,0 +1,49 @@
+package dev.merryai.innerplatform.weekly.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CashflowQueryScopeTest {
+    @Test
+    void chunksAtFirestoreBoundaryWithoutDuplicates() {
+        assertThat(CashflowQueryScope.FIRESTORE_WHERE_IN_LIMIT).isEqualTo(30);
+        assertThat(CashflowQueryScope.chunks(months(29))).hasSize(1);
+        assertThat(CashflowQueryScope.chunks(months(30))).hasSize(1);
+        assertThat(CashflowQueryScope.chunks(months(31))).extracting(List::size).containsExactly(30, 1);
+        assertThat(CashflowQueryScope.chunks(months(108))).hasSize(4);
+        assertThat(CashflowQueryScope.chunks(List.of())).isEmpty();
+        assertThat(CashflowQueryScope.chunks(java.util.Collections.nCopies(30, "2026-01")))
+            .containsExactly(List.of("2026-01"));
+    }
+
+    @Test
+    void validatesInputWithoutFallback() {
+        for (String invalid : List.of("", "2026-13", "26-8", "2026-08-01", "x".repeat(100_000))) {
+            assertThatThrownBy(() -> CashflowQueryScope.requireYearMonths(List.of(invalid)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("YYYY-MM");
+        }
+        assertThatThrownBy(() -> CashflowQueryScope.requireYearMonths(null))
+            .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> CashflowQueryScope.requireYearMonths(java.util.Collections.singletonList(null)))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void buildsInclusiveMonthRangeAndReturnsEmptyForReverseRange() {
+        assertThat(CashflowQueryScope.between("2025-12", "2026-01"))
+            .containsExactly("2025-12", "2026-01");
+        assertThat(CashflowQueryScope.between("2026-02", "2026-01")).isEmpty();
+    }
+
+    private static List<String> months(int count) {
+        List<String> values = new ArrayList<>();
+        java.time.YearMonth month = java.time.YearMonth.of(2024, 1);
+        for (int index = 0; index < count; index++) values.add(month.plusMonths(index).toString());
+        return values;
+    }
+}

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -52,9 +52,12 @@ import org.mockito.InOrder;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -64,12 +67,15 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.inOrder;
@@ -1867,6 +1873,55 @@ class FirestoreCashflowLeaseGuardTest {
             assertThat(line.getYearMonth()).isEqualTo("2026-07");
             assertThat(line.getAmount()).isEqualByComparingTo("10");
         });
+    }
+
+    @Test
+    void oneMonthLedgerReadDropsFromFiveHundredFortyDocumentsToFive() {
+        Fixture fixture = fixture(activeMember(), activeLease());
+        YearMonth start = YearMonth.of(2024, 1);
+        for (int monthOffset = 0; monthOffset < 108; monthOffset++) {
+            String yearMonth = start.plusMonths(monthOffset).toString();
+            for (int weekNo = 1; weekNo <= 5; weekNo++) {
+                fixture.documents.put(
+                    "orgs/tenant-a/cashflow_weeks/project-a-" + yearMonth + "-w" + weekNo,
+                    Map.of("projectId", "project-a", "yearMonth", yearMonth, "weekNo", weekNo)
+                );
+            }
+        }
+        assertThat(fixture.documents.keySet().stream().filter(path -> path.contains("/cashflow_weeks/")).count())
+            .as("unscoped baseline")
+            .isEqualTo(540);
+
+        fixture.persistence.findCashflowLedgerSource("tenant-a", "project-a", "2026-07", "2026-07");
+
+        assertThat(fixture.queryReadSizes.getLast()).isEqualTo(5).isLessThanOrEqualTo(10);
+
+        fixture.persistence.findCashflowLedgerSource("tenant-a", "project-a", "2026-07", "2026-09");
+
+        assertThat(fixture.queryReadSizes.getLast()).isEqualTo(15);
+    }
+
+    @Test
+    void unfilteredCashflowWeekScansStayPinnedToApprovedExceptions() throws Exception {
+        String source = Files.readString(Path.of(
+            "src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java"
+        ));
+        Set<String> approved = Set.of(
+            "completeCashflowWeeklyUpdate", "countCashflowActualReplacementWrites",
+            "replaceCashflowSheetMonthsInternal", "findCashflowLedgerSource", "replaceExpenseRows",
+            "replaceActualLines", "findWeeklyStatuses", "readProjectionLines", "readActualLines"
+        );
+
+        assertThat(approved).allSatisfy(method ->
+            assertThat(source).contains("SPEC-12 approved full scan: " + method)
+        );
+        assertThat(source.split(Pattern.quote("SPEC-12 approved full scan:"), -1).length - 1).isEqualTo(approved.size());
+        assertThat(source.split(Pattern.quote("cashflowWeeks(tenantId).whereEqualTo(\"projectId\", projectId)"), -1).length - 1)
+            .isEqualTo(8);
+        assertThat(source.split(Pattern.quote("cashflowWeeks(actor.tenantId()).whereEqualTo(\"projectId\", projectId)"), -1).length - 1)
+            .isEqualTo(1);
+        assertThat(source.split(Pattern.quote("cashflowWeeks(tenant(sheet)).whereEqualTo(\"projectId\", sheet.getProjectId())"), -1).length - 1)
+            .isEqualTo(1);
     }
 
     @Test
@@ -4676,6 +4731,7 @@ class FirestoreCashflowLeaseGuardTest {
         Map<String, Map<String, Object>> docs = new HashMap<>();
         List<PendingWrite> pendingWrites = new ArrayList<>();
         List<Integer> getAllSizes = new ArrayList<>();
+        List<Integer> queryReadSizes = new ArrayList<>();
         docs.put("orgs/tenant-a/members/pm-1", member);
         docs.put(leasePath("project-a"), lease);
         for (String yearMonth : List.of("2026-06", "2026-07")) {
@@ -4722,6 +4778,7 @@ class FirestoreCashflowLeaseGuardTest {
             refs,
             queryScopes,
             docs,
+            queryReadSizes,
             invocation.getArgument(0)
         ));
         when(transaction.get(any(DocumentReference.class))).thenAnswer(invocation -> {
@@ -4757,11 +4814,12 @@ class FirestoreCashflowLeaseGuardTest {
             QueryScope scope = queryScopes.get(invocation.getArgument(0));
             List<QueryDocumentSnapshot> snapshots = docs.entrySet().stream()
                 .filter(entry -> scope != null && entry.getKey().startsWith(scope.collectionPath + "/"))
-                .filter(entry -> scope != null && java.util.Objects.equals(entry.getValue().get(scope.field), scope.value))
+                .filter(entry -> scope != null && scope.matches(entry.getValue()))
                 .map(entry -> queryDocumentSnapshot(refs, entry.getKey(), scope.project(entry.getValue())))
                 .toList();
             QuerySnapshot querySnapshot = mock(QuerySnapshot.class);
             when(querySnapshot.getDocuments()).thenReturn(snapshots);
+            queryReadSizes.add(snapshots.size());
             return ApiFutures.immediateFuture(querySnapshot);
         });
         when(transaction.set(any(DocumentReference.class), any(), any())).thenAnswer(invocation -> {
@@ -4816,7 +4874,7 @@ class FirestoreCashflowLeaseGuardTest {
             "stage-data-project",
             Clock.fixed(effectiveNow, ZoneOffset.UTC)
         );
-        return new Fixture(persistence, db, transaction, refs, collections, docs, pendingWrites, getAllSizes);
+        return new Fixture(persistence, db, transaction, refs, collections, docs, pendingWrites, getAllSizes, queryReadSizes);
     }
 
     private static DocumentReference ref(Map<String, DocumentReference> refs, String path) {
@@ -4833,6 +4891,7 @@ class FirestoreCashflowLeaseGuardTest {
         Map<String, DocumentReference> refs,
         Map<Query, QueryScope> queryScopes,
         Map<String, Map<String, Object>> docs,
+        List<Integer> queryReadSizes,
         String path
     ) {
         return collections.computeIfAbsent(path, key -> {
@@ -4843,6 +4902,14 @@ class FirestoreCashflowLeaseGuardTest {
                 Query query = mock(Query.class);
                 QueryScope scope = new QueryScope(key, invocation.getArgument(0), invocation.getArgument(1));
                 queryScopes.put(query, scope);
+                when(query.whereEqualTo(anyString(), any())).thenAnswer(filter -> {
+                    scope.equals.put(filter.getArgument(0), filter.getArgument(1));
+                    return query;
+                });
+                when(query.whereIn(anyString(), anyList())).thenAnswer(filter -> {
+                    scope.in.put(filter.getArgument(0), List.copyOf(filter.getArgument(1)));
+                    return query;
+                });
                 when(query.select(any(String[].class))).thenAnswer(selection -> {
                     scope.selected = java.util.Arrays.stream(selection.getArguments())
                         .map(String.class::cast)
@@ -4855,11 +4922,12 @@ class FirestoreCashflowLeaseGuardTest {
                 org.mockito.Mockito.doAnswer(ignored -> {
                     List<QueryDocumentSnapshot> snapshots = docs.entrySet().stream()
                         .filter(entry -> entry.getKey().startsWith(scope.collectionPath + "/"))
-                        .filter(entry -> java.util.Objects.equals(entry.getValue().get(scope.field), scope.value))
+                        .filter(entry -> scope.matches(entry.getValue()))
                         .map(entry -> queryDocumentSnapshot(refs, entry.getKey(), scope.project(entry.getValue())))
                         .toList();
                     QuerySnapshot querySnapshot = mock(QuerySnapshot.class);
                     when(querySnapshot.getDocuments()).thenReturn(snapshots);
+                    queryReadSizes.add(snapshots.size());
                     return ApiFutures.immediateFuture(querySnapshot);
                 }).when(query).get();
                 return query;
@@ -5203,7 +5271,8 @@ class FirestoreCashflowLeaseGuardTest {
         Map<String, CollectionReference> collections,
         Map<String, Map<String, Object>> documents,
         List<PendingWrite> pendingWrites,
-        List<Integer> getAllSizes
+        List<Integer> getAllSizes,
+        List<Integer> queryReadSizes
     ) {
     }
 
@@ -5212,14 +5281,18 @@ class FirestoreCashflowLeaseGuardTest {
 
     private static final class QueryScope {
         private final String collectionPath;
-        private final String field;
-        private final Object value;
+        private final Map<String, Object> equals = new LinkedHashMap<>();
+        private final Map<String, List<?>> in = new LinkedHashMap<>();
         private List<String> selected;
 
         private QueryScope(String collectionPath, String field, Object value) {
             this.collectionPath = collectionPath;
-            this.field = field;
-            this.value = value;
+            equals.put(field, value);
+        }
+
+        private boolean matches(Map<String, Object> document) {
+            return equals.entrySet().stream().allMatch(filter -> Objects.equals(document.get(filter.getKey()), filter.getValue()))
+                && in.entrySet().stream().allMatch(filter -> filter.getValue().contains(document.get(filter.getKey())));
         }
 
         private Map<String, Object> project(Map<String, Object> document) {

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -3744,6 +3744,24 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
+    void monthCloseQueriesSelectOnlyTheSixFieldsUsedAcrossAllMonths() {
+        assertThat(FirestoreInheritedWeeklyExpensePersistence.CASHFLOW_MONTH_CLOSE_READ_FIELDS)
+            .containsExactly(
+                "contractVersion", "yearMonth", "revision", "reopenCount", "status",
+                "postDeadlineAmendmentWarningCount"
+            );
+
+        Fixture fixture = fixture(activeMember(), activeLease());
+        fixture.documents.put(monthClosePath("project-a", "2026-06"), Map.of(
+            "projectId", "project-a", "status", "OPEN", "reopenCount", 2L,
+            "postDeadlineAmendmentWarningCount", 3L, "snapshot", Map.of("large", "payload")
+        ));
+
+        assertThat(fixture.persistence.findCashflowMonthClose("tenant-a", "project-a", "2026-06")
+            .projectWarningCount()).isEqualTo(5L);
+    }
+
+    @Test
     void monthCloseWritesStillRejectAnotherLegacyMonth() {
         Fixture fixture = fixture(activeMember(), activeLease());
         fixture.documents.put(monthClosePath("project-a", "2026-05"), new LinkedHashMap<>(Map.of(
@@ -4738,9 +4756,9 @@ class FirestoreCashflowLeaseGuardTest {
         when(transaction.get(any(Query.class))).thenAnswer(invocation -> {
             QueryScope scope = queryScopes.get(invocation.getArgument(0));
             List<QueryDocumentSnapshot> snapshots = docs.entrySet().stream()
-                .filter(entry -> scope != null && entry.getKey().startsWith(scope.collectionPath() + "/"))
-                .filter(entry -> scope == null || java.util.Objects.equals(entry.getValue().get(scope.field()), scope.value()))
-                .map(entry -> queryDocumentSnapshot(refs, entry.getKey(), entry.getValue()))
+                .filter(entry -> scope != null && entry.getKey().startsWith(scope.collectionPath + "/"))
+                .filter(entry -> scope != null && java.util.Objects.equals(entry.getValue().get(scope.field), scope.value))
+                .map(entry -> queryDocumentSnapshot(refs, entry.getKey(), scope.project(entry.getValue())))
                 .toList();
             QuerySnapshot querySnapshot = mock(QuerySnapshot.class);
             when(querySnapshot.getDocuments()).thenReturn(snapshots);
@@ -4825,14 +4843,20 @@ class FirestoreCashflowLeaseGuardTest {
                 Query query = mock(Query.class);
                 QueryScope scope = new QueryScope(key, invocation.getArgument(0), invocation.getArgument(1));
                 queryScopes.put(query, scope);
+                when(query.select(any(String[].class))).thenAnswer(selection -> {
+                    scope.selected = java.util.Arrays.stream(selection.getArguments())
+                        .map(String.class::cast)
+                        .toList();
+                    return query;
+                });
                 when(query.whereGreaterThanOrEqualTo(anyString(), any())).thenReturn(query);
                 when(query.whereLessThanOrEqualTo(anyString(), any())).thenReturn(query);
                 when(query.limit(org.mockito.ArgumentMatchers.anyInt())).thenReturn(query);
                 org.mockito.Mockito.doAnswer(ignored -> {
                     List<QueryDocumentSnapshot> snapshots = docs.entrySet().stream()
-                        .filter(entry -> entry.getKey().startsWith(scope.collectionPath() + "/"))
-                        .filter(entry -> java.util.Objects.equals(entry.getValue().get(scope.field()), scope.value()))
-                        .map(entry -> queryDocumentSnapshot(refs, entry.getKey(), entry.getValue()))
+                        .filter(entry -> entry.getKey().startsWith(scope.collectionPath + "/"))
+                        .filter(entry -> java.util.Objects.equals(entry.getValue().get(scope.field), scope.value))
+                        .map(entry -> queryDocumentSnapshot(refs, entry.getKey(), scope.project(entry.getValue())))
                         .toList();
                     QuerySnapshot querySnapshot = mock(QuerySnapshot.class);
                     when(querySnapshot.getDocuments()).thenReturn(snapshots);
@@ -5186,6 +5210,25 @@ class FirestoreCashflowLeaseGuardTest {
     private record PendingWrite(DocumentReference ref, Map<String, Object> data, boolean merge) {
     }
 
-    private record QueryScope(String collectionPath, String field, Object value) {
+    private static final class QueryScope {
+        private final String collectionPath;
+        private final String field;
+        private final Object value;
+        private List<String> selected;
+
+        private QueryScope(String collectionPath, String field, Object value) {
+            this.collectionPath = collectionPath;
+            this.field = field;
+            this.value = value;
+        }
+
+        private Map<String, Object> project(Map<String, Object> document) {
+            if (selected == null) return document;
+            Map<String, Object> projection = new LinkedHashMap<>();
+            selected.forEach(name -> {
+                if (document.containsKey(name)) projection.put(name, document.get(name));
+            });
+            return projection;
+        }
     }
 }


### PR DESCRIPTION
## 문제 — Firestore를 SQL처럼 쓴다

`whereEqualTo("projectId", projectId)`만 걸고 `yearMonth` 필터도 `limit`도 `select`도 없다. SQL이면 DB가 인덱스로 걸러주지만 Firestore에서는 **문서를 전부 읽어 메모리에 올린다.**

`.limit(` 사용 횟수: 약 4,700줄 파일에서 **2회.**

복합 인덱스는 `firestore.indexes.json`에 **이미 선언되어 있으나 쿼리가 `yearMonth`를 쓰지 않아 사용되지 않는다.** 인덱스 배포 불필요.

## 변경 (3커밋 = 3 Freeze Unit)

| 커밋 | Unit | 내용 |
|---|---|---|
| `6412e1c1` | 12-A | `CashflowQueryScope` 순수 도메인 클래스 + 단위 테스트 (호출부 0이어도 단독 존재) |
| `b1b13f9a` | 12-B | `monthly_closes` 필드 선택(`select`) — 6필드만 |
| `91355265` | 12-C | `cashflow_weeks` 필터를 읽기 전용 메서드에 적용 |

## 정량 — 테스트가 숫자로 강제

```
최악 조건 픽스처: 계약 9년 = 540 문서
단일 월 조회 → 5 문서 (예산 10)
3개월 조회   → 15 문서
```

`assertThat(fixture.queryReadSizes.getLast()).isEqualTo(5).isLessThanOrEqualTo(10)`

## ⚠️ 목표 미달을 명시한다

**SPEC-12의 헤드라인이었던 월 결산 대시보드 경로는 개선되지 않았다.**

`WeeklyExpenseController.java:478`의 `dashboard-source`는 여전히 무범위 `findCashflowLedgerSource`를 쓰며 승인된 전체 스캔 예외로 남았다. 개선이 적용된 곳은 `readCashflowProjectionActualSummaries`라는 **다른 엔드포인트**다.

원인은 원 스펙의 모순이다 — "단일 월 540→5"와 "대시보드가 모든 달을 그리는 것은 정당하다"를 동시에 요구했다. 구현자는 §4-2 호출부 전수 확인 절차대로 예외로 판정했고, 그 판단은 절차상 정확하다.

**SPEC-19가 이 모순을 조사 중이다.** 대시보드가 540건을 실제로 무엇에 쓰는지, 집계 문서로 대체 가능한지, `targetRevision` 제약이 걸리는지를 확인한다.

## 승인된 전체 스캔 예외 9곳

각 지점에 사유 주석(`// SPEC-12 approved full scan: ...`)을 남기고, **예외 목록 자체를 테스트로 고정**했다:

```java
assertThat(source.split("SPEC-12 approved full scan:", -1).length - 1).isEqualTo(approved.size());
assertThat(source.split("cashflowWeeks(tenantId).whereEqualTo(\"projectId\", projectId)", -1).length - 1).isEqualTo(8);
```

**새 무필터 스캔이 몰래 늘어나면 테스트가 실패한다.**

## 쓰기 경로는 제외 (개정 A)

`replaceCashflowSheetMonthsInternal`의 범위 축소는 하지 않았다. `computeCashflowTargetRevision`이 프로젝트 전체 집합의 해시라, 범위를 좁히면 revision 의미가 바뀌어 **정상 apply가 conflict로 오판**되고 기존 트랜잭션 테스트 2건이 깨진다.

구현자가 SPEC-02 §3 절차로 이의를 제기했고, 검증 결과 **원 스펙이 틀렸음**이 확인되어 개정 A로 범위를 축소했다. 월별 revision 계약 재설계는 SPEC-16 설계안으로 분리했다.

## 검증

- `mvn test` 전체 EXIT 0 (기존 MockMvc·Firestore 트랜잭션 테스트 회귀 0)
- `git diff --check` clean
- 홉 감소·응답 통합 **하지 않음** (커밋 `7247ce2`가 그 접근으로 실패한 전례)
- 배포 p95·응답 크기는 **측정 전이므로 주장하지 않는다**

🤖 Generated with [Claude Code](https://claude.com/claude-code)