### PR TITLE
feat(cashflow): 조직장 승인 마감 계산을 도메인으로 (SPEC-18-B)

### DIFF
--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/ApproverDeadlineCalculator.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/ApproverDeadlineCalculator.java
@@ -1,0 +1,28 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.util.Objects;
+
+public final class ApproverDeadlineCalculator {
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+    private ApproverDeadlineCalculator() {
+    }
+
+    public static Instant weekly(Instant practitionerDeadline, Duration approvalDelay) {
+        return Objects.requireNonNull(practitionerDeadline, "practitionerDeadline")
+            .plus(Objects.requireNonNull(approvalDelay, "approvalDelay"));
+    }
+
+    public static Instant monthly(String yearMonth, long approvalDelayDays) {
+        return YearMonth.parse(Objects.requireNonNull(yearMonth, "yearMonth"))
+            .plusMonths(1)
+            .atDay(11)
+            .atStartOfDay(SEOUL)
+            .plusDays(approvalDelayDays)
+            .toInstant();
+    }
+}

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/ApproverDeadlineCalculatorTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/ApproverDeadlineCalculatorTest.java
@@ -1,0 +1,51 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class ApproverDeadlineCalculatorTest {
+    @Test
+    void addsThirteenHoursToTheExistingWeeklyPractitionerDeadline() {
+        Instant practitionerDeadline = Instant.parse("2026-04-30T15:00:00Z");
+
+        assertThat(ApproverDeadlineCalculator.weekly(practitionerDeadline, Duration.ofHours(13)))
+            .isEqualTo("2026-05-01T04:00:00Z");
+    }
+
+    @Test
+    void calculatesMonthlyDeadlineAcrossYearAndLeapYearBoundariesInKst() {
+        assertThat(ApproverDeadlineCalculator.monthly("2026-12", 3))
+            .isEqualTo("2027-01-13T15:00:00Z");
+        assertThat(ApproverDeadlineCalculator.monthly("2024-02", 3))
+            .isEqualTo("2024-03-13T15:00:00Z");
+        assertThat(ApproverDeadlineCalculator.monthly("2024-02", 3).atZone(ZoneId.of("Asia/Seoul")))
+            .hasToString("2024-03-14T00:00+09:00[Asia/Seoul]");
+    }
+
+    @Test
+    void isDeterministicFromInputsAlone() {
+        Instant expected = Instant.parse("2026-09-13T15:00:00Z");
+
+        for (int iteration = 0; iteration < 1_000; iteration++) {
+            assertThat(ApproverDeadlineCalculator.monthly("2026-08", 3)).isEqualTo(expected);
+        }
+    }
+
+    @Test
+    void rejectsInvalidYearMonthsWithoutFallback() {
+        assertThatNullPointerException()
+            .isThrownBy(() -> ApproverDeadlineCalculator.monthly(null, 3));
+        assertThatExceptionOfType(DateTimeParseException.class)
+            .isThrownBy(() -> ApproverDeadlineCalculator.monthly("", 3));
+        assertThatExceptionOfType(DateTimeParseException.class)
+            .isThrownBy(() -> ApproverDeadlineCalculator.monthly("2026-13", 3));
+    }
+}


### PR DESCRIPTION
## 무엇을

조직장 최종 승인 마감을 계산하는 도메인 순수 함수 `ApproverDeadlineCalculator` 를 추가합니다.

| 주기 | 실무자 마감 | 승인 마감 |
|---|---|---|
| 주간 | 목요일 자정 (금 0시 KST) | **금요일 13시** (+13h) |
| 월간 | 익월 11일 0시 | **익월 14일 0시** (+3d) |

## 왜 이 형태인가

**주간은 요일 계산을 새로 만들지 않았습니다.** 기존 `financeWeekDeadline` 결과를 입력으로 받아 델타만 더합니다. 마감 규칙이 두 곳에 생기면 그게 바로 이번 리팩터링이 없애려는 이중 계약입니다.

**미준수 누적은 건드리지 않았습니다.** 누적 판정은 실무자 마감 기준이라는 불변식이 있어 `weeklyComplianceStatus` 와 persistence 를 수정하지 않았습니다.

## 계층

Firestore 핸들도 Spring 컨텍스트도 받지 않습니다. DB 와 mock 없이 실행되는 계약 테스트를 붙였습니다.

## Freeze 단위

호출부가 0이어도 단독으로 존재하며 단독 revert 가능합니다 (F-1, F-2). 이 PR 은 계산 규칙만 확정하고 배선은 하지 않습니다.

## 검증

\`mvn -Dtest=ApproverDeadlineCalculatorTest test\` → EXIT=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)