### PR TITLE
fix(cashflow): 감사 이벤트 단언을 테넌트 범위로 (배포 차단 해소)

### DIFF
--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
@@ -402,7 +402,7 @@ class WeeklyExpenseControllerTest {
 
         assertThat(sheetRepository.findByTenantIdAndProjectIdAndSheetKey("tenant-a", "project-a", "default")).isPresent();
         assertThat(actualRepository.findByTenantIdAndProjectId("tenant-a", "project-a")).hasSize(1);
-        assertThat(auditEventRepository.findAll()).hasSize(1);
+        assertThat(auditEventRepository.findByTenantIdAndProjectIdOrderByCreatedAtAsc("tenant-a", "project-a")).hasSize(1);
         assertThat(idempotencyRepository.findByTenantIdAndProjectIdAndCommandNameAndIdempotencyKey(
             "tenant-a",
             "project-a",


### PR DESCRIPTION
## 증상

main CI 의 JVM 테스트가 **5회 중 3회 실패**했고 (`3d186063`, `ed47b70a`, 그리고 오늘 JVM 배포 빌드), 그 사이 3회는 통과했습니다. 이 때문에 라이브 JVM 배포가 막혀 있습니다.

```
WeeklyExpenseControllerTest.saveDraftPersistsRowsActualsAuditAndIdempotentResponse
Expected size: 1 but was: 5
```

## 원인

`:405` 한 줄만 테넌트 필터 없는 `findAll()` 을 씁니다.

```java
assertThat(auditEventRepository.findAll()).hasSize(1);
```

같은 클래스의 다른 테스트들이 남긴 감사 이벤트를 전부 셉니다. JUnit 5 의 기본 메서드 순서는 리플렉션 순서에 의존해 실행마다 달라질 수 있어서, 이 테스트가 먼저 돌면 1, 나중에 돌면 5나 39가 됩니다.

**기능 결함이 아니라 테스트 격리 결함입니다.** 최근 머지된 변경들과 무관하며, 순서가 불리하게 걸린 것뿐입니다.

## 수정

같은 파일의 다른 감사 단언들(`:215`, `:303`, `:785`, `:820`)이 이미 쓰는 방식으로 맞췄습니다.

```java
assertThat(auditEventRepository.findByTenantIdAndProjectIdOrderByCreatedAtAsc("tenant-a", "project-a")).hasSize(1);
```

같은 idempotency 키로 두 번 호출하면 감사 이벤트가 정확히 하나라는 원래 의도는 그대로입니다.

## 검증

| 단계 | 결과 |
|---|---|
| `-Djunit.jupiter.testmethod.order.default=MethodName` 로 실패 재현 | `Expected 1 but was 39` — 결정적 재현 |
| 수정 후 같은 조건 | 60 tests, **0 failures** |
| 사보타주: 기대치를 `2` 로 변경 | `Expected 2 but was 1` — **단언이 여전히 유효** |
| 전체 스위트 | BUILD SUCCESS |

사보타주가 중요합니다. 범위를 좁히면서 단언을 무력화했다면 (예: 0건을 반환하는데 통과) 회귀를 못 잡습니다. 정확히 1을 반환함을 확인했습니다.

## 건드리지 않은 것

`:2752` 의 `findAll()` 은 `anyMatch` 존재 확인이라 순서에 영향받지 않습니다. 그대로 뒀습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)