### PR TITLE
fix(cashflow): 연간 합계에서 사라지던 금액을 드러내기 (Tier 1-A)

### DIFF
--- a/server/bff/cashflow-annual-total.mjs
+++ b/server/bff/cashflow-annual-total.mjs
@@ -1,9 +1,8 @@
 import { readOptionalText } from './bff-utils.mjs';
 import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES } from './cashflow-policy.mjs';
 
-function wholeWon(value) {
-  const amount = Number(value);
-  return Number.isSafeInteger(amount) ? amount : 0;
+function isWholeWon(value) {
+  return Number.isSafeInteger(Number(value));
 }
 
 export function cashflowAnnualTotalDocPath(tenantId, projectId, year) {
@@ -16,13 +15,14 @@ export function summarizeCashflowAnnualMode(document, mode) {
   const states = document?.[`${mode}States`] && typeof document[`${mode}States`] === 'object'
     ? document[`${mode}States`]
     : {};
-  const lineAmounts = Object.fromEntries(CASHFLOW_ALL_LINES.flatMap((lineId) => (
-    ['VALUE', 'ZERO'].includes(readOptionalText(states[lineId])) && Number.isSafeInteger(Number(values[lineId]))
-      ? [[lineId, Number(values[lineId])]]
-      : []
-  )));
-  const totalIn = CASHFLOW_IN_LINES.reduce((sum, lineId) => sum + wholeWon(lineAmounts[lineId]), 0);
-  const totalOut = CASHFLOW_OUT_LINES.reduce((sum, lineId) => sum + wholeWon(lineAmounts[lineId]), 0);
+  // 금액이 있다고 표시된 줄만 합계 대상이다. 그 중 원 단위 정수가 아닌 값은
+  // 합계에서 빼되 조용히 버리지 않고 invalidCellCount 로 드러낸다.
+  const amountLineIds = CASHFLOW_ALL_LINES.filter((lineId) => ['VALUE', 'ZERO'].includes(readOptionalText(states[lineId])));
+  const lineAmounts = Object.fromEntries(amountLineIds
+    .filter((lineId) => isWholeWon(values[lineId]))
+    .map((lineId) => [lineId, Number(values[lineId])]));
+  const totalIn = CASHFLOW_IN_LINES.reduce((sum, lineId) => sum + (lineAmounts[lineId] ?? 0), 0);
+  const totalOut = CASHFLOW_OUT_LINES.reduce((sum, lineId) => sum + (lineAmounts[lineId] ?? 0), 0);
   return {
     source: 'ANNUAL',
     coverage: {
@@ -32,9 +32,9 @@ export function summarizeCashflowAnnualMode(document, mode) {
       monthCount: 0,
       expectedMonthCount: 12,
     },
-    valueCellCount: CASHFLOW_ALL_LINES.filter((lineId) => readOptionalText(states[lineId]) === 'VALUE').length,
+    valueCellCount: CASHFLOW_ALL_LINES.filter((lineId) => readOptionalText(states[lineId]) === 'VALUE' && isWholeWon(values[lineId])).length,
     emptyCellCount: CASHFLOW_ALL_LINES.filter((lineId) => readOptionalText(states[lineId]) === 'EMPTY').length,
-    invalidCellCount: 0,
+    invalidCellCount: amountLineIds.filter((lineId) => !isWholeWon(values[lineId])).length,
     lineAmounts,
     lineStates: Object.fromEntries(CASHFLOW_ALL_LINES.map((lineId) => [lineId, readOptionalText(states[lineId]) || 'EMPTY'])),
     totalIn,

--- a/server/bff/cashflow-annual-total.test.mjs
+++ b/server/bff/cashflow-annual-total.test.mjs
@@ -13,4 +13,37 @@ describe('cashflow annual total row states', () => {
     expect(summary.lineStates).toMatchObject({ SALES_IN: 'ZERO', TEAM_SUPPORT_IN: 'EMPTY' });
     expect(summary.net).toBe(0);
   });
+
+  it('reports a decimal amount as invalid instead of dropping it silently', () => {
+    const summary = summarizeCashflowAnnualMode({
+      projection: { SALES_IN: 1000.5 },
+      projectionStates: { SALES_IN: 'VALUE' },
+    }, 'projection');
+
+    expect(summary.invalidCellCount).toBe(1);
+    expect(summary.valueCellCount).toBe(0);
+    expect(summary.lineAmounts).not.toHaveProperty('SALES_IN');
+    expect(summary.lineStates).toMatchObject({ SALES_IN: 'VALUE' });
+  });
+
+  it('reports an amount beyond the safe whole-won range as invalid', () => {
+    const summary = summarizeCashflowAnnualMode({
+      actual: { DIRECT_COST_OUT: 9007199254740993 },
+      actualStates: { DIRECT_COST_OUT: 'VALUE' },
+    }, 'actual');
+
+    expect(summary.invalidCellCount).toBe(1);
+    expect(summary.totalOut).toBe(0);
+  });
+
+  it('keeps valid amounts when another line on the same mode is invalid', () => {
+    const summary = summarizeCashflowAnnualMode({
+      projection: { SALES_IN: 3000000, TEAM_SUPPORT_IN: 0.7 },
+      projectionStates: { SALES_IN: 'VALUE', TEAM_SUPPORT_IN: 'VALUE' },
+    }, 'projection');
+
+    expect(summary.totalIn).toBe(3000000);
+    expect(summary.valueCellCount).toBe(1);
+    expect(summary.invalidCellCount).toBe(1);
+  });
 });


### PR DESCRIPTION
## 증상

연간 합계 요약이 원 단위 정수가 아닌 저장값을 **조용히 버리고** 있었습니다.

줄 상태(`lineStates`)는 `VALUE` 로 남는데 금액(`lineAmounts`)에서만 사라집니다. 화면에는 "값이 있다"고 표시된 칸이 비어 보이고, 합계에는 0 이 반영됩니다. 그런데 `invalidCellCount` 가 `0` 으로 하드코딩되어 있어서 **이상을 알릴 방법도 없었습니다.**

같은 값을 JVM 은 `must be a whole-won value` 로 거부합니다. 최종 저장은 JVM 이 막지만, 그 전에 화면과 mirror 에는 이미 0 이 노출됩니다.

## 진단 정정

처음에는 `wholeWon()` 이 원인이라고 봤는데 호출부를 읽으니 아니었습니다.

```js
// 20번 줄이 이미 같은 술어로 걸러낸 뒤였음
&& Number.isSafeInteger(Number(values[lineId]))
```

`wholeWon` 의 `0` 분기는 사실상 "키 없음 → 합계에 0 기여"만 처리하고 있었습니다. 실제 누락은 그 위 필터에서 일어납니다.

## 수정

같은 판정을 하는 **형제 함수가 이미 정답을 갖고 있습니다.** `cashflow-sheet-snapshot.mjs:195-213` 의 `summarizeAnnualMode` 는 동일한 술어를 쓰지만 무효 셀을 버리지 않고 `invalidCellCount` 로 셉니다. 그 방식으로 맞췄습니다.

- 무효 셀을 `invalidCellCount` 로 드러냄 (하드코딩 `0` 제거)
- `valueCellCount` 는 실제로 유효한 칸만 셈 — 상태만 `VALUE` 인 칸은 제외
- 합계는 유효 금액만 더함 (동작 동일, 의도 명시)

## 던지지 않은 이유

이 함수는 `cashflow-sheet-lab.mjs:188-189` 의 **대시보드 읽기 경로**입니다. 예외를 올리면 연간 조회 전체가 멈춥니다. 형제도 셀 단위 무효에는 던지지 않고 셉니다. 작업 중단 로직을 늘리지 않는다는 원칙과도 맞습니다.

## 검증

테스트 우선으로 작성해 **먼저 3건 실패**를 확인하고 고쳤습니다.

| 케이스 | 수정 전 | 수정 후 |
|---|---|---|
| 소수점 `1000.5` | 조용히 누락, `invalidCellCount: 0` | `invalidCellCount: 1`, `valueCellCount: 0` |
| 2⁵³ 초과 | 조용히 누락, `totalOut` 에 미반영 | `invalidCellCount: 1` |
| 유효 + 무효 혼재 | `valueCellCount: 2` (거짓) | 유효 금액 유지, `valueCellCount: 1` |

- 대상 파일: **4/4 통과**
- BFF 전체: 942 통과. `jvm-weekly-api.test.mjs` 1건이 `socket hang up` 으로 실패했으나 **격리 실행 183/183 통과**. 스위트 동시 실행 플래키이며 해당 파일은 이 모듈을 임포트하지 않습니다.

## 건드리지 않은 것

합계 누산의 오버플로 처리가 형제(`addWholeWon` 은 `RangeError`)와 다르게 남아 있습니다. 이번 결함과 별개라 그대로 뒀습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)