### PR TITLE
feat(cashflow): 고정 양식 기반 O(1) 읽기 인덱스 (freeze 단위)

### DIFF
--- a/server/bff/cashflow-template-index.mjs
+++ b/server/bff/cashflow-template-index.mjs
@@ -1,0 +1,204 @@
+import { createHash } from 'node:crypto';
+import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES } from './cashflow-policy.mjs';
+
+// 전사 고정 양식(주차 그리드 12개월 × 5주, 라인 카탈로그)을 상수로 활용하는
+// 읽기 전용 인덱스. 셀 좌표를 문자열 키 탐색 대신 산술 인덱스로 바꾼다.
+export const WEEKS_PER_MONTH = 5;
+export const MONTHS_PER_YEAR = 12;
+export const WEEKS_PER_YEAR = WEEKS_PER_MONTH * MONTHS_PER_YEAR;
+
+export const CELL_STATE = Object.freeze({ EMPTY: 0, ZERO: 1, VALUE: 2, INVALID: 3 });
+const CELL_STATE_NAMES = ['EMPTY', 'ZERO', 'VALUE', 'INVALID'];
+
+// 템플릿 계약이 바뀌면 파생 캐시가 전부 자동 무효화되도록 버전을 해시로 만든다.
+export function computeCatalogVersion({ lines, weeklyYears, annualYears }) {
+  const canonical = JSON.stringify({
+    lines,
+    weeklyYears: [...weeklyYears].sort(),
+    annualYears: [...annualYears].sort(),
+    weeksPerMonth: WEEKS_PER_MONTH,
+  });
+  return createHash('sha256').update(canonical).digest('hex').slice(0, 12);
+}
+
+export function buildCashflowTemplateIndex({
+  lines = CASHFLOW_ALL_LINES,
+  inLines = CASHFLOW_IN_LINES,
+  outLines = CASHFLOW_OUT_LINES,
+  weeklyYears,
+  annualYears,
+  weekProvider,
+} = {}) {
+  if (!Array.isArray(weeklyYears) || !Array.isArray(annualYears)) {
+    throw new TypeError('weeklyYears and annualYears must come from the template contract.');
+  }
+  const lineIndex = new Map(lines.map((lineId, i) => [lineId, i]));
+  const weeklyYearSet = new Set(weeklyYears.map(Number));
+  const annualYearSet = new Set(annualYears.map(Number));
+  const calendarMemo = new Map();
+  const monthBaseMemo = new Map();
+  return {
+    catalogVersion: computeCatalogVersion({ lines, weeklyYears, annualYears }),
+    lineCount: lines.length,
+    lineIds: [...lines],
+    inLineIndexes: inLines.map((lineId) => lineIndex.get(lineId)).filter((i) => i !== undefined),
+    outLineIndexes: outLines.map((lineId) => lineIndex.get(lineId)).filter((i) => i !== undefined),
+    lineIndexOf: (lineId) => {
+      const i = lineIndex.get(lineId);
+      return i === undefined ? -1 : i;
+    },
+    isWeeklyManagedYear: (year) => weeklyYearSet.has(Number(year)),
+    isAnnualManagedYear: (year) => annualYearSet.has(Number(year)),
+    // "이 연도가 주별 관리인가"는 문서 존재 여부가 아니라 템플릿 계약이 답한다.
+    // 연월 문자열은 유한집합(주별 연도당 12개)이므로 검증 결과를 인터닝한다 —
+    // 정규식·파싱은 문자열당 1회, 이후 조회는 Map 1회 + 산술이다.
+    weekOrdinal(yearMonth, weekNo) {
+      const raw = String(yearMonth || '');
+      let monthBase = monthBaseMemo.get(raw);
+      if (monthBase === undefined) {
+        monthBase = /^20\d{2}-(0[1-9]|1[0-2])$/.test(raw) && weeklyYearSet.has(Number(raw.slice(0, 4)))
+          ? (Number(raw.slice(5, 7)) - 1) * WEEKS_PER_MONTH
+          : -1;
+        monthBaseMemo.set(raw, monthBase);
+      }
+      if (monthBase < 0) return -1;
+      const week = Number(weekNo);
+      if (!Number.isInteger(week) || week < 1 || week > WEEKS_PER_MONTH) return -1;
+      return monthBase + week - 1;
+    },
+    // 재무주차 달력은 결정적(SPEC-21)이므로 프로세스 수명 동안 무효화 없이 메모한다.
+    financeWeeks(yearMonth) {
+      if (calendarMemo.has(yearMonth)) return calendarMemo.get(yearMonth);
+      const weeks = typeof weekProvider === 'function' ? weekProvider(yearMonth) : [];
+      calendarMemo.set(yearMonth, weeks);
+      return weeks;
+    },
+  };
+}
+
+// 주별 관리 연도 한 해 = lineCount × 60 밀집 행렬. 셀 조회가 O(1) 산술이 된다.
+export function createYearMatrix(index) {
+  return new Float64Array(index.lineCount * WEEKS_PER_YEAR);
+}
+
+export function setCell(index, matrix, lineId, yearMonth, weekNo, amount) {
+  const line = index.lineIndexOf(lineId);
+  const week = index.weekOrdinal(yearMonth, weekNo);
+  if (line < 0 || week < 0) return false;
+  matrix[line * WEEKS_PER_YEAR + week] = Number(amount) || 0;
+  return true;
+}
+
+export function getCell(index, matrix, lineId, yearMonth, weekNo) {
+  const line = index.lineIndexOf(lineId);
+  const week = index.weekOrdinal(yearMonth, weekNo);
+  if (line < 0 || week < 0) return 0;
+  return matrix[line * WEEKS_PER_YEAR + week];
+}
+
+export function packYearMatrixFromMonths(index, months, mode) {
+  const matrix = createYearMatrix(index);
+  for (const month of Array.isArray(months) ? months : []) {
+    const yearMonth = month?.yearMonth;
+    for (const week of Array.isArray(month?.[mode]?.weeks) ? month[mode].weeks : []) {
+      const amounts = week?.amounts && typeof week.amounts === 'object' ? week.amounts : {};
+      for (const [lineId, amount] of Object.entries(amounts)) {
+        setCell(index, matrix, lineId, yearMonth, week.weekNo, amount);
+      }
+    }
+  }
+  return matrix;
+}
+
+// 주차별 입금/출금 합계와 누적 잔액 걷기. 검사 4종이 재순회 없이 이 결과를 공유한다.
+export function weekDirectionTotals(index, matrix) {
+  const totalIn = new Float64Array(WEEKS_PER_YEAR);
+  const totalOut = new Float64Array(WEEKS_PER_YEAR);
+  for (const line of index.inLineIndexes) {
+    const base = line * WEEKS_PER_YEAR;
+    for (let week = 0; week < WEEKS_PER_YEAR; week += 1) totalIn[week] += matrix[base + week];
+  }
+  for (const line of index.outLineIndexes) {
+    const base = line * WEEKS_PER_YEAR;
+    for (let week = 0; week < WEEKS_PER_YEAR; week += 1) totalOut[week] += matrix[base + week];
+  }
+  return { totalIn, totalOut };
+}
+
+export function walkWeeklyBalances(totalIn, totalOut, openingBalance = 0) {
+  const balances = new Float64Array(WEEKS_PER_YEAR);
+  let balance = Number(openingBalance) || 0;
+  for (let week = 0; week < WEEKS_PER_YEAR; week += 1) {
+    balance += totalIn[week] - totalOut[week];
+    balances[week] = balance;
+  }
+  return balances;
+}
+
+// 셀 상태 4종은 2비트면 충분하다. 960셀 = 240바이트 — 문자열 맵 대비 약 100배 절감.
+export function packCellStates(codes) {
+  const packed = new Uint8Array(Math.ceil(codes.length / 4));
+  for (let i = 0; i < codes.length; i += 1) {
+    packed[i >> 2] |= (codes[i] & 0b11) << ((i & 0b11) * 2);
+  }
+  return packed;
+}
+
+export function readCellState(packed, ordinal) {
+  return (packed[ordinal >> 2] >> ((ordinal & 0b11) * 2)) & 0b11;
+}
+
+export function countCellStates(packed, cellCount) {
+  const counts = { EMPTY: 0, ZERO: 0, VALUE: 0, INVALID: 0 };
+  for (let i = 0; i < cellCount; i += 1) {
+    counts[CELL_STATE_NAMES[readCellState(packed, i)]] += 1;
+  }
+  return counts;
+}
+
+// revision(저장된 식별자)을 키로 쓰는 캐시. 내용 해시를 재계산하지 않으므로
+// 판정 SSOT(JVM)를 침범하지 않는다. 키가 바뀌면 항목은 자연히 미적중이 된다.
+export function revisionCacheKey({ catalogVersion, tenantId, projectId, scope, revision }) {
+  return `${catalogVersion}|${tenantId}|${projectId}|${scope}|${revision}`;
+}
+
+export function createRevisionCache({ maxEntries = 128 } = {}) {
+  const entries = new Map();
+  return {
+    get(key) {
+      if (!entries.has(key)) return undefined;
+      const value = entries.get(key);
+      entries.delete(key);
+      entries.set(key, value);
+      return value;
+    },
+    set(key, value) {
+      if (entries.has(key)) entries.delete(key);
+      entries.set(key, value);
+      if (entries.size > maxEntries) entries.delete(entries.keys().next().value);
+    },
+    size: () => entries.size,
+  };
+}
+
+// 같은 (프로젝트, 범위, revision) 요청이 동시에 오면 Firestore 조회를 1회로 합친다.
+export function createSingleFlight() {
+  const inflight = new Map();
+  return function run(key, fetcher) {
+    if (inflight.has(key)) return inflight.get(key);
+    const promise = Promise.resolve()
+      .then(fetcher)
+      .finally(() => inflight.delete(key));
+    inflight.set(key, promise);
+    return promise;
+  };
+}
+
+// 브라우저 재검증용 강한 ETag. revision이 같으면 본문 재조립 없이 304.
+export function cashflowReadEtag({ catalogVersion, scope, revision }) {
+  const digest = createHash('sha256')
+    .update(`${catalogVersion}|${scope}|${revision}`)
+    .digest('base64url')
+    .slice(0, 16);
+  return `"cf-${digest}"`;
+}

--- a/server/bff/cashflow-template-index.test.mjs
+++ b/server/bff/cashflow-template-index.test.mjs
@@ -1,0 +1,253 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CELL_STATE,
+  WEEKS_PER_YEAR,
+  buildCashflowTemplateIndex,
+  cashflowReadEtag,
+  computeCatalogVersion,
+  countCellStates,
+  createRevisionCache,
+  createSingleFlight,
+  createYearMatrix,
+  getCell,
+  packCellStates,
+  packYearMatrixFromMonths,
+  readCellState,
+  revisionCacheKey,
+  setCell,
+  walkWeeklyBalances,
+  weekDirectionTotals,
+} from './cashflow-template-index.mjs';
+
+const TEMPLATE = { weeklyYears: [2026], annualYears: [2024, 2025, 2027, 2028, 2029, 2030, 2031, 2032] };
+
+function makeIndex(extra = {}) {
+  return buildCashflowTemplateIndex({ ...TEMPLATE, ...extra });
+}
+
+describe('catalog version', () => {
+  it('is stable for the same contract and changes when line order changes', () => {
+    const base = { lines: ['A_IN', 'B_OUT'], ...TEMPLATE };
+    expect(computeCatalogVersion(base)).toBe(computeCatalogVersion({ ...base }));
+    expect(computeCatalogVersion({ ...base, lines: ['B_OUT', 'A_IN'] }))
+      .not.toBe(computeCatalogVersion(base));
+  });
+});
+
+describe('week ordinal arithmetic', () => {
+  const index = makeIndex();
+
+  it('maps the fixed 60-cell grid to 0..59', () => {
+    expect(index.weekOrdinal('2026-01', 1)).toBe(0);
+    expect(index.weekOrdinal('2026-01', 5)).toBe(4);
+    expect(index.weekOrdinal('2026-12', 5)).toBe(WEEKS_PER_YEAR - 1);
+  });
+
+  it('rejects annual-managed years — a stray weekly document cannot flip a year to weekly', () => {
+    expect(index.weekOrdinal('2025-12', 4)).toBe(-1);
+    expect(index.weekOrdinal('2024-03', 2)).toBe(-1);
+    expect(index.isWeeklyManagedYear(2025)).toBe(false);
+    expect(index.isAnnualManagedYear(2025)).toBe(true);
+  });
+
+  it('rejects malformed input', () => {
+    expect(index.weekOrdinal('2026-13', 1)).toBe(-1);
+    expect(index.weekOrdinal('2026-01', 6)).toBe(-1);
+    expect(index.weekOrdinal('', 1)).toBe(-1);
+  });
+});
+
+describe('dense year matrix', () => {
+  const index = makeIndex();
+
+  it('round-trips readModel months into O(1) cell lookups', () => {
+    const months = [
+      { yearMonth: '2026-08', projection: { weeks: [{ weekNo: 4, amounts: { SALES_IN: 100_000_000 } }] } },
+      { yearMonth: '2026-08', projection: { weeks: [{ weekNo: 5, amounts: { TEAM_SUPPORT_OUT: 90_000_000 } }] } },
+      { yearMonth: '2025-12', projection: { weeks: [{ weekNo: 4, amounts: { SALES_IN: 7_582_243 } }] } },
+    ];
+    const matrix = packYearMatrixFromMonths(index, months, 'projection');
+    expect(getCell(index, matrix, 'SALES_IN', '2026-08', 4)).toBe(100_000_000);
+    expect(getCell(index, matrix, 'TEAM_SUPPORT_OUT', '2026-08', 5)).toBe(90_000_000);
+    // 연 단위 관리 연도의 낙오 주차 값은 행렬에 들어오지 못한다.
+    expect(getCell(index, matrix, 'SALES_IN', '2025-12', 4)).toBe(0);
+  });
+
+  it('matches a hand-computed balance walk', () => {
+    const matrix = createYearMatrix(index);
+    setCell(index, matrix, 'SALES_IN', '2026-01', 2, 1000);
+    setCell(index, matrix, 'DIRECT_COST_OUT', '2026-01', 1, 300);
+    const { totalIn, totalOut } = weekDirectionTotals(index, matrix);
+    const balances = walkWeeklyBalances(totalIn, totalOut, 0);
+    expect(balances[0]).toBe(-300);
+    expect(balances[1]).toBe(700);
+    expect(balances[WEEKS_PER_YEAR - 1]).toBe(700);
+  });
+});
+
+describe('2-bit cell states', () => {
+  it('round-trips all four states across a full 960-cell year', () => {
+    const cellCount = 16 * WEEKS_PER_YEAR;
+    const codes = Array.from({ length: cellCount }, (_, i) => i % 4);
+    const packed = packCellStates(codes);
+    expect(packed.byteLength).toBe(cellCount / 4);
+    for (let i = 0; i < cellCount; i += 1) expect(readCellState(packed, i)).toBe(i % 4);
+    expect(countCellStates(packed, cellCount)).toEqual({ EMPTY: 240, ZERO: 240, VALUE: 240, INVALID: 240 });
+  });
+
+  it('detects corruption — counts change when a byte flips', () => {
+    const packed = packCellStates([CELL_STATE.VALUE, CELL_STATE.VALUE, CELL_STATE.VALUE, CELL_STATE.VALUE]);
+    const before = countCellStates(packed, 4);
+    packed[0] ^= 0b11;
+    expect(countCellStates(packed, 4)).not.toEqual(before);
+  });
+});
+
+describe('calendar memo', () => {
+  it('calls the provider once per yearMonth', () => {
+    let calls = 0;
+    const index = makeIndex({ weekProvider: () => { calls += 1; return [{ weekNo: 1 }]; } });
+    index.financeWeeks('2026-08');
+    index.financeWeeks('2026-08');
+    index.financeWeeks('2026-09');
+    expect(calls).toBe(2);
+  });
+});
+
+describe('revision cache and single flight', () => {
+  it('evicts the least recently used entry and refreshes on hit', () => {
+    const cache = createRevisionCache({ maxEntries: 2 });
+    cache.set('a', 1);
+    cache.set('b', 2);
+    cache.get('a');
+    cache.set('c', 3);
+    expect(cache.get('b')).toBeUndefined();
+    expect(cache.get('a')).toBe(1);
+    expect(cache.get('c')).toBe(3);
+  });
+
+  it('coalesces concurrent identical fetches into one execution', async () => {
+    const flight = createSingleFlight();
+    let executions = 0;
+    const fetcher = async () => { executions += 1; return 'result'; };
+    const key = revisionCacheKey({ catalogVersion: 'v', tenantId: 'mysc', projectId: 'p1', scope: 'MONTH:2026-08', revision: 'r7' });
+    const results = await Promise.all([flight(key, fetcher), flight(key, fetcher), flight(key, fetcher)]);
+    expect(results).toEqual(['result', 'result', 'result']);
+    expect(executions).toBe(1);
+  });
+
+  it('produces a different etag when the revision moves', () => {
+    const base = { catalogVersion: 'v1', scope: 'MONTH:2026-08' };
+    expect(cashflowReadEtag({ ...base, revision: 'r1' })).not.toBe(cashflowReadEtag({ ...base, revision: 'r2' }));
+    expect(cashflowReadEtag({ ...base, revision: 'r1' })).toBe(cashflowReadEtag({ ...base, revision: 'r1' }));
+  });
+});
+
+describe('benchmark: fixed-template index vs sequential find-chains', () => {
+  it('reports the measured speedup for cell lookups', () => {
+    const index = makeIndex();
+    const lineIds = index.lineIds;
+    // 현행 canonicalCashflowWeeks 형태의 자료구조 재현: months[].projection.weeks[].amounts
+    const months = [];
+    for (let m = 1; m <= 12; m += 1) {
+      const weeks = [];
+      for (let w = 1; w <= 5; w += 1) {
+        const amounts = {};
+        for (const lineId of lineIds) amounts[lineId] = m * 100 + w;
+        weeks.push({ weekNo: w, amounts });
+      }
+      months.push({ yearMonth: `2026-${String(m).padStart(2, '0')}`, projection: { weeks } });
+    }
+    const matrix = packYearMatrixFromMonths(index, months, 'projection');
+
+    const probes = [];
+    for (let i = 0; i < 50_000; i += 1) {
+      probes.push({
+        lineId: lineIds[i % lineIds.length],
+        yearMonth: `2026-${String((i % 12) + 1).padStart(2, '0')}`,
+        weekNo: (i % 5) + 1,
+      });
+    }
+
+    const naiveStart = performance.now();
+    let naiveSum = 0;
+    for (const probe of probes) {
+      const month = months.find((item) => item.yearMonth === probe.yearMonth);
+      const week = month?.projection.weeks.find((item) => item.weekNo === probe.weekNo);
+      naiveSum += week?.amounts[probe.lineId] || 0;
+    }
+    const naiveMs = performance.now() - naiveStart;
+
+    const indexedStart = performance.now();
+    let indexedSum = 0;
+    for (const probe of probes) {
+      indexedSum += getCell(index, matrix, probe.lineId, probe.yearMonth, probe.weekNo);
+    }
+    const indexedMs = performance.now() - indexedStart;
+
+    expect(indexedSum).toBe(naiveSum);
+    const speedup = naiveMs / indexedMs;
+    console.log(`[bench] 50k lookups — find-chain: ${naiveMs.toFixed(1)}ms, indexed: ${indexedMs.toFixed(1)}ms, speedup: ${speedup.toFixed(1)}x`);
+    expect(indexedMs).toBeLessThan(naiveMs);
+  });
+
+  it('reports the measured speedup for the polling pipeline (rebuild-per-request vs revision cache)', () => {
+    const index = makeIndex();
+    const lineIds = index.lineIds;
+    const inLines = lineIds.filter((_, i) => index.inLineIndexes.includes(i));
+    const outLines = lineIds.filter((_, i) => index.outLineIndexes.includes(i));
+    const months = [];
+    for (let m = 1; m <= 12; m += 1) {
+      const weeks = [];
+      for (let w = 1; w <= 5; w += 1) {
+        const amounts = {};
+        for (const lineId of lineIds) amounts[lineId] = m * 100 + w;
+        weeks.push({ weekNo: w, amounts });
+      }
+      months.push({ yearMonth: `2026-${String(m).padStart(2, '0')}`, projection: { weeks } });
+    }
+    const REQUESTS = 1_000; // 폴링: revision 이 안 변한 채 반복되는 대시보드 요청
+
+    // 현행: 요청마다 주차 배열 재구축 + 라인 합산 + 잔액 걷기
+    const naiveStart = performance.now();
+    let naiveLast = 0;
+    for (let r = 0; r < REQUESTS; r += 1) {
+      const weeks = [];
+      for (const month of months) {
+        for (let w = 1; w <= 5; w += 1) {
+          const week = month.projection.weeks.find((item) => item.weekNo === w);
+          weeks.push({ yearMonth: month.yearMonth, weekNo: w, projection: week?.amounts || {} });
+        }
+      }
+      let balance = 0;
+      for (const week of weeks) {
+        const totalIn = inLines.reduce((sum, lineId) => sum + (week.projection[lineId] || 0), 0);
+        const totalOut = outLines.reduce((sum, lineId) => sum + (week.projection[lineId] || 0), 0);
+        balance += totalIn - totalOut;
+      }
+      naiveLast = balance;
+    }
+    const naiveMs = performance.now() - naiveStart;
+
+    // 인덱스 + revision 캐시: 같은 revision 이면 팩·합산·걷기를 재사용
+    const cache = createRevisionCache({ maxEntries: 8 });
+    const key = revisionCacheKey({ catalogVersion: index.catalogVersion, tenantId: 'mysc', projectId: 'p1', scope: 'YEAR:2026', revision: 'r1' });
+    const cachedStart = performance.now();
+    let cachedLast = 0;
+    for (let r = 0; r < REQUESTS; r += 1) {
+      let entry = cache.get(key);
+      if (!entry) {
+        const matrix = packYearMatrixFromMonths(index, months, 'projection');
+        const { totalIn, totalOut } = weekDirectionTotals(index, matrix);
+        entry = { balances: walkWeeklyBalances(totalIn, totalOut, 0) };
+        cache.set(key, entry);
+      }
+      cachedLast = entry.balances[WEEKS_PER_YEAR - 1];
+    }
+    const cachedMs = performance.now() - cachedStart;
+
+    expect(cachedLast).toBe(naiveLast);
+    console.log(`[bench] ${REQUESTS} polling requests — rebuild: ${naiveMs.toFixed(1)}ms, cached: ${cachedMs.toFixed(2)}ms, speedup: ${(naiveMs / cachedMs).toFixed(0)}x`);
+    expect(cachedMs).toBeLessThan(naiveMs);
+  });
+});


### PR DESCRIPTION
## 전제

캐시플로 시트는 **전사 고정 양식**입니다: 라인 카탈로그(policy JSON) × 연간 열(2024·2025·2027~2032) × 주차 그리드(2026, 12개월×5주=60칸). 고정이라는 사실이 자료구조를 결정합니다 — 탐색할 필요가 없는 것은 탐색하지 않습니다.

## 무엇을

배선 없는 순수 모듈 + 테스트 (freeze 단위, F-1/F-2 — 호출부 0이어도 단독 존재·단독 revert):

| 장치 | 구조 | 효과 |
|---|---|---|
| 셀 좌표 | `Float64Array(16×60)`, `line*60+week` 산술 | 문자열 키·`find` 체인 제거, O(1) |
| 연월 검증 | 인터닝 (유한집합: 주별 연도당 12개) | 정규식은 문자열당 1회 |
| 셀 상태 4종 | **2비트 팩킹** — 960셀=240B | 문자열 맵 대비 ~100배 |
| 재무주차 달력 | 프로세스 수명 메모 (SPEC-21: 결정적) | 재계산 0 |
| 반복 요청 | **revision 키 LRU + single-flight** | 폴링 중 재조립·중복조회 제거 |
| 재방문 | revision 기반 **ETag** | 동일 revision → 304, 본문 0 |

## 실측 (vitest 내장 벤치)

```
[bench] 50k lookups — find-chain: 18.9ms, indexed: 9.3ms, speedup: 2.0x
[bench] 1000 polling requests — rebuild: 33.3ms, cached: 0.94ms, speedup: 35x
```

정직하게: 단건 조회 2.0배는 크지 않습니다 — 12×5 배열의 `find`는 원래 쌉니다. **진짜 이득은 폴링 파이프라인 35배**입니다. 현행 구조는 revision이 안 변해도 요청마다 주차 배열·셀 맵·잔액 걷기를 전부 재구축합니다.

## 부수 효과 — 오늘 진단한 버그의 구조적 차단

p1773651024850 진단에서 확인: 연 단위 관리 연도(2025)에 낙오 주차 문서 5건이 있으면 그 해가 "주별 관리"로 둔갑해 `2025-12 4주차` 경고가 발생합니다. 원인은 주별/연간 구분을 **문서 존재로 유추**하는 것.

이 모듈은 그 구분을 **템플릿 계약 상수**로 명시합니다. `weekOrdinal('2025-12', 4) === -1` — 낙오 문서는 행렬에 들어올 수 없습니다 (테스트로 고정).

## SSOT 경계

캐시 키는 **저장된 revision 식별자**로만 만들고 내용 해시를 재계산하지 않습니다. 판정 SSOT는 JVM입니다 — 캐시가 그 경계를 넘으면 이중 계약이 되살아납니다.

## 검증

- 14/14 통과 (동등성·경계·LRU·single-flight·ETag·벤치 2종)
- 사보타주: 주차 산술 오프바이원 → **4건 실패** 확인 후 원복
- 잔액 걷기 결과가 naive 구현과 동일값 (동등성 단언)

## 배선 계획 (이 PR 아님)

19-B 워커의 대시보드 경로 완료 후: ①검사 4종이 이 인덱스 소비 ②route에 ETag/304 ③단계 응답 캐시. 같은 파일 충돌을 피하기 위해 의도적으로 분리했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)