### PR TITLE
fix(cashflow): 전사 고정 양식 좌표 계약 이행 (SPEC-22)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,20 @@ npm run build
 ## High-Priority Operating Policies
 These policies override lower-priority workflow suggestions when they apply.
 
+### 캐시플로 좌표 계약 (변경 불가)
+사업비 관리 시트는 전사 단일 고정 양식이다. 읽기는 고정 좌표에서 값을 꺼내는 것이고, 그 이상은 하지 않는다.
+계약의 단일 진실은 `server/bff/cashflow-coordinates.mjs` 이며 근거는
+`docs/architecture/contracts/2026-07-28-cashflow-formula-validation-contract.md` 다.
+
+- **주별 블록은 `E:BL` 60칸 하나뿐이다.** 그 연도는 프로젝트당 단일 상수다. "어느 연도들이 주별인가"는 집합 질문이 아니다. `weeklyYears` 배열·Set·연도 집합 유도를 새로 만들지 않는다.
+- **연간 열은 `C:D`(이전 2개)와 `BM:BR`(이후 6개) 고정이다.** 연간 값은 이 좌표에서 읽는다. 주차 문서를 합산해 연간값을 만들지 않는다.
+- **라인 정체성은 행 인덱스다** (`LINE_ROWS`). 라벨 문자열, alias, 동명이인 방어로 라인을 찾지 않는다.
+- **좌표 밖의 데이터는 존재하지 않는다.** `weekOrdinal(...) === -1` 이면 읽기 경로에 진입시키지 않는다. 문서 존재 여부로 구조를 유추하지 않는다.
+- **양식이 다르면 적응하지 않고 거부한다.** `CashflowTemplateMismatchError` 로 "양식이 다릅니다."를 낸다. 폴백 체인·보정·추론으로 메우지 않는다.
+- `EMPTY` 와 `ZERO` 는 절대 뭉개지 않는다. 셀 상태는 저장된 값이며 금액에서 역산하지 않는다.
+
+새 코드가 위 항목을 어기면 리뷰에서 반려한다. 기존 위반은 좌표 계약으로 대체하며, 대체 시 사보타주 검증(계약을 깨면 테스트가 실패하는지)을 함께 붙인다.
+
 ### QA Stage Gates
 - For implementation work that can affect users, data, integrations, permissions, deployment, or cross-screen behavior, run the work with an independent QA lens based on `/Users/boram/gstack/.agents/skills/gstack-qa/SKILL.md`.
 - Where subagents are available, assign a separate QA subagent to define stage pass criteria and challenge the implementation. If subagents are unavailable, perform a separate QA pass in the main thread using the same criteria.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,9 +66,35 @@ These policies override lower-priority workflow suggestions when they apply.
 
 새 코드가 위 항목을 어기면 리뷰에서 반려한다. 기존 위반은 좌표 계약으로 대체하며, 대체 시 사보타주 검증(계약을 깨면 테스트가 실패하는지)을 함께 붙인다.
 
+### 오케스트레이션 워커 수명주기 (Orca dispatch)
+
+Orca orchestration 하에서 일할 때만 적용된다. 이 절은 QA Stage Gates 보다 우선한다.
+
+**`worker_done` 은 dispatch 를 종료시킨다.** 종료된 dispatch 는 capability 가 회수되어
+그 뒤의 어떤 보고도 `Rejected worker_done: capability is revoked` 로 거부되고,
+코디네이터가 보내는 수정 지시도 받을 수 없다. 그래서 다음 두 규칙을 지킨다.
+
+1. **`worker_done` 은 담당 워커가 단 한 번, 맨 마지막에만 보낸다.**
+   - QA 서브에이전트·리뷰어·조사자는 **절대** `worker_done` 을 보내지 않는다. 그들의 결과는
+     담당 워커에게 돌려주고, 담당 워커가 자기 `worker_done` **하나**에 접어 넣는다.
+   - 진행 상황·중간 결과·QA 판정은 `--type status` 로 보낸다. 막히면 `escalation`, 물을 것은 `ask`.
+   - 실제 사고: QA 서브에이전트가 `worker_done` 으로 "QA FAIL" 을 보내 dispatch 가 조기 종료되었고,
+     그 뒤 담당 워커의 실제 구현 완료 보고가 두 번 거부되어 유실됐다.
+
+2. **구현이 끝나면 `worker_done` 전에 `ask` 로 코디네이터 리뷰를 요청한다.**
+   ```bash
+   orca orchestration ask --question "구현 완료. 리뷰 요청합니다. 변경: <파일>. 테스트: <n/n>. 사보타주: <결과>." --timeout-ms 1800000 --json
+   ```
+   - 코디네이터가 diff 를 직접 읽고 통과 또는 보완 지시를 회신한다.
+   - 보완 지시를 받으면 **같은 dispatch 안에서** 고치고 다시 `ask` 한다. 리뷰 라운드가 몇 번이든
+     dispatch 는 살아 있다.
+   - 코디네이터가 통과를 회신한 뒤에만 `worker_done` 을 보낸다.
+   - 테스트 통과와 QA PASS 는 리뷰 통과가 아니다. 테스트는 fixture 를 검증하지 프로덕션 데이터를
+     검증하지 않는다.
+
 ### QA Stage Gates
 - For implementation work that can affect users, data, integrations, permissions, deployment, or cross-screen behavior, run the work with an independent QA lens based on `/Users/boram/gstack/.agents/skills/gstack-qa/SKILL.md`.
-- Where subagents are available, assign a separate QA subagent to define stage pass criteria and challenge the implementation. If subagents are unavailable, perform a separate QA pass in the main thread using the same criteria.
+- Where subagents are available, assign a separate QA subagent to define stage pass criteria and challenge the implementation. If subagents are unavailable, perform a separate QA pass in the main thread using the same criteria. QA 서브에이전트는 결과를 담당 워커에게 돌려주며 `worker_done` 을 보내지 않는다 (위 수명주기 규칙 1).
 - Before coding, QA must decide whether the proposed fix is superficial or proves real behavior. It must identify the actual data path being affected: UI state, API/BFF calls, Firestore/store writes, sync jobs, persisted reads, and cross-screen visibility.
 - QA defines the pass criteria for each stage independently. Do not advance to the next stage until the current stage passes or a blocker is explicitly reported.
 - Required stages:

--- a/docs/architecture/contracts/2026-07-28-cashflow-formula-validation-contract.md
+++ b/docs/architecture/contracts/2026-07-28-cashflow-formula-validation-contract.md
@@ -50,7 +50,9 @@ Every imported accounting cell retains both its numeric meaning and its authorin
 
 | Sheet content | JVM state | Arithmetic value | Meaning |
 | --- | --- | ---: | --- |
-| Empty or `-` | `EMPTY` | 0 | Not entered |
+| Empty | `EMPTY` | 0 | Not entered |
+| `-` in Projection | `EMPTY` | 0 | Not entered |
+| `-` in Actual | `ZERO` | 0 | Accounting number format renders 0 as `-`; confirmed zero (2026-08-08 결정) |
 | Explicit `0` | `ZERO` | 0 | Entered and confirmed as zero |
 | Whole-won positive or negative number | `VALUE` | Original amount | Entered amount |
 | Decimal, malformed text, non-finite value | `INVALID` | None | Invalid source value |

--- a/docs/architecture/spec-22-coordinate-contract-migration.md
+++ b/docs/architecture/spec-22-coordinate-contract-migration.md
@@ -1,0 +1,232 @@
+# SPEC-22 — 좌표 계약 이행 (워커 공통 브리프)
+
+**작성:** 2026-08-08 · **상태:** 계약 확정, 이행 중
+**단일 진실:** `server/bff/cashflow-coordinates.mjs`
+**근거 계약:** `docs/architecture/contracts/2026-07-28-cashflow-formula-validation-contract.md`
+
+이 문서를 **먼저 전부 읽고** 작업을 시작하세요.
+
+---
+
+## 0. 왜 이 작업을 하는가 — 확정된 사고
+
+2026-08-07 라이브 확정, 프로젝트 `p1773651024850`:
+
+| 증상 | 값 |
+|---|---|
+| 시트의 2025 연간 열 Actual | **317,449,417** |
+| 화면에 표시된 2025 Actual | **7,582,243** |
+| 차이 | **약 3억 1천만 원** |
+
+원인은 **낙오 주차 문서** 1건입니다. `p1773651024850-2025-12-w4` 에 `SALES_IN 7,582,243` 이 저장되어 있습니다.
+2025 년은 시트에서 **연 단위 관리 연도**라 12월도 4주차도 존재하지 않습니다. 좌표에 대응 칸이 없는 문서입니다.
+
+그런데 읽기 경로가 **"문서가 있으니 2025 는 주별 관리 연도"** 로 유추합니다. 그러면:
+
+1. 2025 → 주별 연도로 분류
+2. → 연간 fallback 대상에서 제외
+3. → 시트의 2025 연간 열 무시
+4. → 낙오 문서 값이 그 자리를 차지
+
+**낙오 문서 1건이 연도 하나를 통째로 뒤집습니다.**
+
+---
+
+## 1. 좌표 계약 (변경 불가 · 재론 없음)
+
+사업비 관리 시트는 **전사 단일 고정 양식**입니다. 읽기는 고정 좌표에서 값을 꺼내는 것이고, 그 이상은 하지 않습니다.
+
+```
+좌표    C      D    │  E ─────────── BL  │  BM ──────── BR   │  BS
+연도   2024  2025   │      2026 주별      │   2027 … 2032    │ Total
+칸수    1     1     │   60 (12월 × 5주)   │       6          │
+```
+
+| # | 원칙 |
+|---|---|
+| 1 | **주별 블록은 `E:BL` 60칸 하나뿐.** 그 연도는 프로젝트당 **단일 상수**. "어느 연도들이 주별인가"는 집합 질문이 아니다 |
+| 2 | **연간 열은 `C:D`(이전 2개) + `BM:BR`(이후 6개) 고정.** 연간 값은 이 좌표에서 읽는다 |
+| 3 | **라인 정체성 = 행 인덱스** (`LINE_ROWS`). 라벨 문자열·alias 로 라인을 찾지 않는다 |
+| 4 | **좌표 밖 = 존재하지 않음.** `weekOrdinal(...) === -1` 이면 읽기 경로 진입 금지 |
+| 5 | **양식이 다르면 적응하지 않고 거부.** `CashflowTemplateMismatchError` → "양식이 다릅니다." |
+
+`lineRowIndexes[i]` ↔ `policies/cashflow-policy.json` 의 `lineEntries[i]` 가 **1:1 대응함이 테스트로 고정**되어 있습니다
+(`server/bff/cashflow-coordinates.test.mjs`). 라벨 매칭은 같은 사실을 두 번 구하는 중복입니다.
+
+### 계약 API
+
+```js
+import {
+  LINE_ROWS, LINE_IDS, WEEKS_PER_MONTH, WEEKS_PER_YEAR,
+  requireWeeklyYear, annualYearsFor, isWeeklyMonth,
+  weekOrdinal, weekColumnFor, annualColumnFor,
+  lineRowFor, lineIndexOfRow, CashflowTemplateMismatchError,
+} from './cashflow-coordinates.mjs';
+```
+
+`annualYearsFor(2026)` → `[2024, 2025, 2027, 2028, 2029, 2030, 2031, 2032]`
+`weekOrdinal(2026, '2025-12', 4)` → `-1` (낙오 문서 거부)
+`weekOrdinal(2026, '2026-03', 2)` → `11`
+
+### 주별 연도(`weeklyYear`)는 어디서 오는가
+
+시트 주차 라벨 행(`E12`/`E35`, 예: `26-1-1`)이 선언합니다. 수집 시점에 **한 번** 읽어
+`cashflow_sheet_mirrors/{projectId}.weeklyYear` 에 **단일 숫자**로 저장합니다.
+하류는 전부 그 필드 하나를 읽습니다. 재유도·집합화 금지.
+
+---
+
+## 2. 금지 사항 (공통)
+
+- 새 `weeklyYears` 배열/Set/연도 집합 유도를 만들지 않는다
+- 주차 문서를 합산해 **연간값을 만들지 않는다** (연간 열 좌표에서 읽는다)
+- `EMPTY` 와 `ZERO` 를 뭉개지 않는다. 셀 상태는 저장값이며 금액에서 역산하지 않는다
+- 폴백 체인·보정·추론으로 결손을 메우지 않는다 (거부한다)
+- 과거 `monthly_closes.snapshot`, `snapshotHash`, CLOSED 판정값 재작성·backfill 금지 (SPEC-04)
+- `LIVE_AMENDED` 전역 revision 검증 변경 금지 (SPEC-16 선행 필요)
+- **낙오 문서 삭제 금지.** 읽기에서 배제만 한다. 데이터 정리는 별도 승인 사안
+- 테스트만 통과시키는 우회 금지 — **사보타주 검증 필수**
+
+## 3. 공통 성공 조건
+
+각 워커는 완료 보고에 아래를 포함합니다.
+
+1. 변경 파일 목록
+2. 대상 테스트 결과 (통과 수 / 전체)
+3. **사보타주 결과** — 계약을 의도적으로 깼을 때 테스트가 실패하는지 확인하고 원복. 실패 건수를 보고
+4. 계약 위반 잔존 0건 근거 (해당 영역 grep 결과)
+5. 못 한 것 / 범위 밖으로 남긴 것
+
+커밋은 Conventional Commits (`fix(cashflow): ...`), 본문은 한국어로 **무엇이 왜 틀렸고 무엇으로 바꿨는지** 서술.
+
+---
+
+## 4. 워커 분담 (파일 충돌 없음)
+
+| 워커 | 항목 | 파일 영역 |
+|---|---|---|
+| **W-FE** | ① 프론트 연간 재계산 제거 | `src/app/components/cashflow/` |
+| **W-TPL** | ② 라벨 매칭 제거 | `server/bff/cashflow-sheet-template.mjs`, `cashflow-canonical-store.mjs`, `policies/cashflow-policy.json` |
+| **W-JVM** | ⑥⑦ 무범위 스캔 + weeklyYears 집합 | `server/jvm-weekly-api/**` |
+| **W-BFF** | ③④⑤ 유추·폴백·산술 인덱스 | `server/bff/routes/jvm-weekly-api.mjs` |
+
+**다른 워커의 파일 영역을 건드리지 마세요.** 필요하면 완료 보고에 "이 영역도 바꿔야 한다"고 적으세요.
+
+---
+
+## 5. 각 워커 상세
+
+### W-FE — 프론트 연간 재계산 제거 (3억 오차의 확정 경로)
+
+**위반:** `src/app/components/cashflow/cashflow-month-close.ts:40` `summarizeCanonicalCashflowYear`
+
+```ts
+const selected = months.filter((m) => Number(m.yearMonth.slice(0,4)) === year);
+if (!selected.length) return null;
+lineAmounts = ... selected.reduce(... week.amounts[lineId] ...)   // 주차를 합산해 연간값 생성
+lineStates: hasValue ? (lineAmounts[lineId] === 0 ? 'ZERO' : 'VALUE') : 'EMPTY'  // 상태 역산
+```
+
+두 가지를 다 어깁니다 — 주차 합산으로 연간값을 만들고, 셀 상태를 금액에서 역산합니다.
+2025 에 낙오 문서 1건이 있으면 `selected.length === 1` 이 되어 그 값이 2025 연간값이 됩니다.
+시트의 317,449,417 은 화면에 도달할 경로가 없습니다.
+
+**할 일:** 연간 값과 셀 상태를 **서버가 준 연간 열 DTO 그대로** 표시합니다. 클라이언트 재계산·역산 제거.
+서버 DTO 형태가 아직 없으면 **소비 지점을 먼저 DTO 기준으로 바꾸고**, 필요한 필드를 완료 보고에 명시하세요
+(W-BFF 가 그 필드를 채웁니다). 프론트에서 서버 필드를 재구현하지 마세요.
+
+**주의:** 이 저장소의 프론트 테스트 다수가 소스 문자열 매칭(`expect(source).toContain(...)`)이라 회귀를 못 잡습니다.
+값 동일성을 실제로 검증하는 테스트를 1건 이상 세우고 들어가세요.
+
+### W-TPL — 라벨 매칭 제거
+
+**위반:** `server/bff/cashflow-sheet-template.mjs:39,50,51,66,199`, `cashflow-canonical-store.mjs:61`
+
+`buildCashflowLineLookup` (약 32줄) 이 라벨 정규화 + alias 15개 + `ambiguousKeys`(동명이인 방어)로 라인을 찾습니다.
+행 인덱스가 이미 라인 정체성인데 같은 사실을 문자열로 다시 구합니다.
+고정 양식에서 동명이인은 발생할 수 없으므로 `ambiguousKeys` 는 **일어날 수 없는 일을 방어하는 코드**입니다.
+
+**할 일:** `lineRowFor` / `lineIndexOfRow` 로 대체. `buildCashflowLineLookup` 과 정책 JSON 의 `aliases` 필드 제거.
+라벨은 **표시용으로만** 남깁니다. 헤더 라벨이 예상과 다르면 보정하지 말고 `CashflowTemplateMismatchError` 로 거부.
+
+### W-JVM — 무범위 스캔 + weeklyYears 집합
+
+**위반 1:** `FirestoreInheritedWeeklyExpensePersistence.java` — `whereEqualTo("projectId", projectId)` 만 있고
+`yearMonth` 필터도 `limit` 도 없는 쿼리 **10곳**. 복합 인덱스(`projectId+yearMonth+weekNo`)는
+`firebase/firestore.indexes.json` 에 **이미 선언**되어 있는데 쿼리가 안 씁니다. Postgres 접근 패턴의 잔재입니다.
+
+**위반 2:** `WeeklyExpensePersistence.java:725-737` `findCashflowLedgerSource` 가 원장 문서에서 연도 집합을 재유도.
+`:756-824` `findCashflowOpeningBalance` 의 *"prior year uses weekly ledger lines when that year exists in the weekly ledger;
+the annual-total document is only a fallback"* 우선순위 규칙.
+
+이 우선순위 규칙이 **낙오 문서에 시트 연간 열보다 높은 권한을 줍니다.** 좌표 계약에서는 겹칠 수가 없으므로 규칙 자체가 소멸합니다.
+
+**할 일:**
+- 대시보드 원장 읽기를 주별 블록 연도 범위로 고정. `CashflowQueryScope.between()` 을 쓰는 bounded 오버로드가 이미 있습니다
+- `weeklyYears` 집합 유도 → 단일 `weeklyYear` 상수
+- 이전 연도는 **항상** `cashflow_sheet_year_totals` 에서 읽습니다 (fallback 아님, 유일 경로)
+- **`LIVE_AMENDED` 경로는 손대지 마세요.** `WeeklyExpenseController.java:506` 이 전역 해시를 검증하며 SPEC-16 선행이 필요합니다.
+  OPEN 과 일반 CLOSED 만 다룹니다
+
+**성공 조건 추가:** 가짜 persistence 로 OPEN 읽기 문서 수를 단언하는 테스트. 낙오 문서를 fixture 에 심고
+**읽히지 않음**을 단언하세요 (이게 이 워커의 핵심 사보타주입니다).
+
+### W-BFF — 유추 · 폴백 · 산술 인덱스
+
+**단일 파일 `server/bff/routes/jvm-weekly-api.mjs` 안이라 아래 순서대로 순차 진행하세요.**
+
+**③ `canonicalCashflowWeeks` (643-682) — 유추와 3단 폴백**
+
+```js
+for (const month of cashflow?.readModel?.months ?? []) { /* 있으면 5주로 펼침 */ }
+if (byKey.size > 0)      { ... }   // 폴백 1
+if (pinnedWeeks.length)  { ... }   // 폴백 2
+if (completeMonthCloseCells(cells)) { ... }  // 폴백 3
+```
+
+낙오 문서가 연도를 둔갑시키는 지점입니다. 폴백 3단은 자기 추론이 틀릴 때를 방어하는 코드입니다.
+→ `weekOrdinal` 로 좌표 밖을 배제. 폴백 제거하고 월 상태로 분기.
+
+**④ `.find()` 탐색 11건 — 613, 619, 620, 651, 657, 658, 1841 외**
+
+```js
+month?.projection?.weeks?.find((w) => Number(w?.weekNo) === weekNo)?.amounts || {}
+```
+
+주차 5칸이 고정인데 배열을 매번 순회합니다. `|| {}` 는 "없을 수도 있다"는 전제인데 고정 양식에선 항상 있습니다.
+→ 산술 인덱스. `server/bff/cashflow-template-index.mjs` (PR #482) 가 이 용도로 만들어졌으나 **아직 미배선**입니다.
+단, 그 모듈의 `weeklyYears` **배열/Set 부분은 좌표 계약의 단일 상수로 교체**하고 배선하세요.
+
+**⑤ `composeCashflowMonthDashboard` (1826-2204) — 구조 폴백 체인 14건+**
+
+```js
+const project    = closedSnapshot?.project || projectDocument || {};
+const sheetFacts = closedSnapshot?.sheetFacts || mirror?.sheetFacts || null;
+```
+
+같은 사실에 소스가 2~3개고 런타임에 고릅니다. 어느 게 진실인지 코드가 모릅니다.
+→ 월 상태(OPEN / 일반 CLOSED / LIVE_AMENDED)가 소스를 **결정**하도록 분기. 고르지 않습니다.
+
+**추가:** W-FE 가 요구하는 연간 열 DTO 필드를 서버에서 채웁니다. 연간 값은 연간 열 좌표에서 읽은 저장값을
+**원문 그대로** 전달하세요 — BFF 에서 연간 합계를 재구현하면 SSOT 위반입니다.
+
+---
+
+## 6. 보고
+
+막히면 추측하지 말고 코디네이터에게 물어보세요.
+
+```bash
+orca orchestration ask --question "<질문>" --timeout-ms 600000 --json
+```
+
+완료 시:
+
+```bash
+orca orchestration send --type worker_done --subject "<상태>" \
+  --body "<변경·테스트·사보타주·잔존·미완>" \
+  --task-id <task_id> --dispatch-id <dispatch_id> \
+  --outcome succeeded --files-modified "path/a,path/b" --json
+```
+
+실패는 산문에만 적지 말고 `--outcome failed` 로 표시하세요.

--- a/policies/cashflow-policy.json
+++ b/policies/cashflow-policy.json
@@ -24,8 +24,7 @@
       "projectionLabel": "MYSC 선입금 - 직접사업비 등",
       "actualLabel": "MYSC 선입금 - 직접사업비 등(입금)",
       "direction": "IN",
-      "defaultCategory": "CONTRACT_PAYMENT",
-      "aliases": ["MYSC선입금", "MYSC선입금(입금필요시)", "MYSC 선입금(입금필요시)", "MYSC 선입금 - 직접사업비 등", "MYSC 선입금 - 직접사업비 등(입금)"]
+      "defaultCategory": "CONTRACT_PAYMENT"
     },
     {
       "lineId": "MYSC_PREPAY_LABOR_IN",
@@ -33,8 +32,7 @@
       "projectionLabel": "MYSC 선입금 - MYSC 인건비",
       "actualLabel": "MYSC 선입금 - MYSC 인건비(입금)",
       "direction": "IN",
-      "defaultCategory": "CONTRACT_PAYMENT",
-      "aliases": []
+      "defaultCategory": "CONTRACT_PAYMENT"
     },
     {
       "lineId": "MYSC_PREPAY_INPUT_VAT_IN",
@@ -42,36 +40,31 @@
       "projectionLabel": "MYSC 선입금 - 매입부가세",
       "actualLabel": "MYSC 선입금 - 매입부가세(입금)",
       "direction": "IN",
-      "defaultCategory": "VAT_REFUND",
-      "aliases": ["MYSC 선입금 - 매입부가세", "MYSC 선입금 - 메입부가세"]
+      "defaultCategory": "VAT_REFUND"
     },
     {
       "lineId": "SALES_IN",
       "label": "매출액(입금)",
       "direction": "IN",
-      "defaultCategory": "CONTRACT_PAYMENT",
-      "aliases": ["매출액"]
+      "defaultCategory": "CONTRACT_PAYMENT"
     },
     {
       "lineId": "SALES_VAT_IN",
       "label": "매출부가세(입금)",
       "direction": "IN",
-      "defaultCategory": "VAT_REFUND",
-      "aliases": ["매출부가세"]
+      "defaultCategory": "VAT_REFUND"
     },
     {
       "lineId": "TEAM_SUPPORT_IN",
       "label": "팀지원금(입금)",
       "direction": "IN",
-      "defaultCategory": "MISC_INCOME",
-      "aliases": []
+      "defaultCategory": "MISC_INCOME"
     },
     {
       "lineId": "BANK_INTEREST_IN",
       "label": "은행이자(입금)",
       "direction": "IN",
-      "defaultCategory": "MISC_INCOME",
-      "aliases": []
+      "defaultCategory": "MISC_INCOME"
     },
     {
       "lineId": "MYSC_PREPAY_DIRECT_OUT",
@@ -79,8 +72,7 @@
       "projectionLabel": "MYSC 선입금 - 직접사업비 등",
       "actualLabel": "MYSC 선입금 - 직접사업비 등(출금)",
       "direction": "OUT",
-      "defaultCategory": "OUTSOURCING",
-      "aliases": []
+      "defaultCategory": "OUTSOURCING"
     },
     {
       "lineId": "MYSC_PREPAY_LABOR_OUT",
@@ -88,8 +80,7 @@
       "projectionLabel": "MYSC 선입금 - MYSC 인건비",
       "actualLabel": "MYSC 선입금 - MYSC 인건비(출금)",
       "direction": "OUT",
-      "defaultCategory": "LABOR_COST",
-      "aliases": []
+      "defaultCategory": "LABOR_COST"
     },
     {
       "lineId": "DIRECT_COST_OUT",
@@ -97,15 +88,13 @@
       "projectionLabel": "직접사업비(공급가액)",
       "actualLabel": "직접사업비(공급가액)",
       "direction": "OUT",
-      "defaultCategory": "OUTSOURCING",
-      "aliases": ["직접사업비(공급가액)", "직접사업비(공급가액)+매입부가세"]
+      "defaultCategory": "OUTSOURCING"
     },
     {
       "lineId": "INPUT_VAT_OUT",
       "label": "매입부가세",
       "direction": "OUT",
-      "defaultCategory": "TAX_PAYMENT",
-      "aliases": []
+      "defaultCategory": "TAX_PAYMENT"
     },
     {
       "lineId": "MYSC_LABOR_OUT",
@@ -113,8 +102,7 @@
       "projectionLabel": "MYSC인건비",
       "actualLabel": "MYSC인건비",
       "direction": "OUT",
-      "defaultCategory": "LABOR_COST",
-      "aliases": ["MYSC인건비"]
+      "defaultCategory": "LABOR_COST"
     },
     {
       "lineId": "MYSC_PROFIT_OUT",
@@ -122,29 +110,25 @@
       "projectionLabel": "MYSC수익",
       "actualLabel": "MYSC수익",
       "direction": "OUT",
-      "defaultCategory": "MISC_EXPENSE",
-      "aliases": ["MYSC수익(간접비등)", "MYSC 수익(간접비등)", "MYSC수익"]
+      "defaultCategory": "MISC_EXPENSE"
     },
     {
       "lineId": "SALES_VAT_OUT",
       "label": "매출부가세(출금)",
       "direction": "OUT",
-      "defaultCategory": "TAX_PAYMENT",
-      "aliases": []
+      "defaultCategory": "TAX_PAYMENT"
     },
     {
       "lineId": "TEAM_SUPPORT_OUT",
       "label": "팀지원금(출금)",
       "direction": "OUT",
-      "defaultCategory": "MISC_EXPENSE",
-      "aliases": []
+      "defaultCategory": "MISC_EXPENSE"
     },
     {
       "lineId": "BANK_INTEREST_OUT",
       "label": "은행이자(출금)",
       "direction": "OUT",
-      "defaultCategory": "MISC_EXPENSE",
-      "aliases": []
+      "defaultCategory": "MISC_EXPENSE"
     }
   ]
 }

--- a/scripts/audit-cashflow-stray-weekly-docs.mjs
+++ b/scripts/audit-cashflow-stray-weekly-docs.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+// 좌표 계약(SPEC-22) 위반 데이터 감사 — 읽기 전용.
+//
+// 시트는 전사 고정 양식이고 주별 블록은 E:BL 60칸 하나뿐이다. 따라서 한 프로젝트의
+// cashflow_weeks 는 한 연도만 가져야 한다. 다른 연도의 주차 문서는 낙오 문서이며,
+// 읽기 경로가 "문서가 있으니 그 해는 주별 관리"로 유추해 시트의 연간 열을 무시하게 만든다.
+//
+// 이 스크립트는 아무것도 쓰지 않는다. 영향 범위만 보고한다.
+//
+// 사용:
+//   node scripts/audit-cashflow-stray-weekly-docs.mjs --project inner-platform-live-20260316
+//   node scripts/audit-cashflow-stray-weekly-docs.mjs --project <id> --json > audit.json
+
+import { createFirestoreDb, resolveProjectId } from '../server/bff/firestore.mjs';
+
+function readFlag(name, fallback = '') {
+  const index = process.argv.indexOf(name);
+  if (index === -1) return fallback;
+  return process.argv[index + 1] || fallback;
+}
+
+const asJson = process.argv.includes('--json');
+const firebaseProjectId = readFlag('--firebase-project', readFlag('--project', resolveProjectId()));
+const onlyTenant = readFlag('--tenant', '');
+
+function yearOf(yearMonth) {
+  const match = /^(20\d{2})-(0[1-9]|1[0-2])$/.exec(String(yearMonth ?? ''));
+  return match ? Number(match[1]) : null;
+}
+
+function num(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+async function listTenants(db) {
+  if (onlyTenant) return [onlyTenant];
+  const orgs = await db.collection('orgs').listDocuments();
+  return orgs.map((doc) => doc.id);
+}
+
+// 시트가 선언한 연간 열 값 (mirror.annualCells) — 화면에 떠야 할 진짜 값
+function declaredAnnualByYear(mirror) {
+  const byYear = new Map();
+  for (const cell of Array.isArray(mirror?.annualCells) ? mirror.annualCells : []) {
+    const year = num(cell?.year);
+    if (year === null) continue;
+    const key = `${year}:${cell?.mode}`;
+    const bucket = byYear.get(key) || { year, mode: cell?.mode, total: 0, cellCount: 0 };
+    if (cell?.state === 'VALUE' || cell?.state === 'ZERO') {
+      bucket.total += num(cell?.amount) ?? 0;
+      bucket.cellCount += 1;
+    }
+    byYear.set(key, bucket);
+  }
+  return byYear;
+}
+
+async function auditTenant(db, tenantId) {
+  const weeksSnap = await db.collection(`orgs/${tenantId}/cashflow_weeks`).get();
+  if (weeksSnap.empty) return [];
+
+  // 프로젝트별 · 연도별 주차 문서 수
+  const byProject = new Map();
+  for (const doc of weeksSnap.docs) {
+    const data = doc.data() || {};
+    const projectId = String(data.projectId ?? '');
+    const year = yearOf(data.yearMonth);
+    if (!projectId || year === null) continue;
+    const entry = byProject.get(projectId) || { projectId, byYear: new Map() };
+    const bucket = entry.byYear.get(year) || { year, docCount: 0, docIds: [] };
+    bucket.docCount += 1;
+    if (bucket.docIds.length < 5) bucket.docIds.push(doc.id);
+    entry.byYear.set(year, bucket);
+    byProject.set(projectId, entry);
+  }
+
+  const findings = [];
+  for (const entry of byProject.values()) {
+    const years = [...entry.byYear.values()].sort((left, right) => right.docCount - left.docCount);
+    if (years.length <= 1) continue; // 주별 연도 하나뿐 — 계약 준수
+
+    // 문서 수가 가장 많은 연도를 주별 블록으로 본다(정상이면 60 근처).
+    const [weeklyYear, ...strayYears] = years;
+
+    const [mirrorSnap, ...totalSnaps] = await Promise.all([
+      db.doc(`orgs/${tenantId}/cashflow_sheet_mirrors/${entry.projectId}`).get(),
+      ...strayYears.map((stray) => db
+        .collection(`orgs/${tenantId}/cashflow_sheet_year_totals`)
+        .where('projectId', '==', entry.projectId)
+        .where('year', '==', stray.year)
+        .limit(1)
+        .get()),
+    ]);
+
+    const mirror = mirrorSnap.exists ? mirrorSnap.data() || {} : null;
+    const declared = declaredAnnualByYear(mirror);
+
+    findings.push({
+      tenantId,
+      projectId: entry.projectId,
+      weeklyYear: { year: weeklyYear.year, docCount: weeklyYear.docCount },
+      declaredWeeklyYear: num(mirror?.weeklyYear), // SPEC-22 이후에만 존재
+      mirrorStatus: mirror?.status ?? null,
+      strayYears: strayYears.map((stray, index) => {
+        const totalDocs = totalSnaps[index]?.docs ?? [];
+        const stored = totalDocs.length > 0 ? totalDocs[0].data() || {} : null;
+        return {
+          year: stray.year,
+          strayDocCount: stray.docCount,
+          sampleDocIds: stray.docIds,
+          storedYearTotalExists: Boolean(stored),
+          sheetDeclaredActual: declared.get(`${stray.year}:actual`)?.total ?? null,
+          sheetDeclaredProjection: declared.get(`${stray.year}:projection`)?.total ?? null,
+        };
+      }),
+    });
+  }
+  return findings;
+}
+
+async function main() {
+  const db = createFirestoreDb({ projectId: firebaseProjectId });
+  const tenants = await listTenants(db);
+  const all = [];
+  for (const tenantId of tenants) {
+    all.push(...await auditTenant(db, tenantId));
+  }
+
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify({ firebaseProjectId, findings: all }, null, 2)}\n`);
+    return;
+  }
+
+  console.log(`Firestore project: ${firebaseProjectId}`);
+  console.log(`낙오 주차 문서가 있는 프로젝트: ${all.length}건\n`);
+  for (const finding of all) {
+    const strayTotal = finding.strayYears.reduce((sum, stray) => sum + stray.strayDocCount, 0);
+    console.log(`■ ${finding.projectId}  (org=${finding.tenantId})`);
+    console.log(`  주별 블록 추정: ${finding.weeklyYear.year} (${finding.weeklyYear.docCount}건)`
+      + `  mirror.weeklyYear=${finding.declaredWeeklyYear ?? '미기록'}  mirror.status=${finding.mirrorStatus ?? '없음'}`);
+    console.log(`  낙오 주차 문서 합계: ${strayTotal}건`);
+    for (const stray of finding.strayYears) {
+      console.log(`    - ${stray.year}년: 주차문서 ${stray.strayDocCount}건`
+        + `  year_totals=${stray.storedYearTotalExists ? '있음' : '없음'}`
+        + `  시트연간(actual)=${stray.sheetDeclaredActual ?? '없음'}`
+        + `  시트연간(projection)=${stray.sheetDeclaredProjection ?? '없음'}`);
+      console.log(`      예시 문서: ${stray.sampleDocIds.join(', ')}`);
+    }
+    console.log('');
+  }
+}
+
+main().catch((error) => {
+  console.error(error?.stack || String(error));
+  process.exitCode = 1;
+});

--- a/scripts/backfill-mirror-weekly-year.mjs
+++ b/scripts/backfill-mirror-weekly-year.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// mirror.weeklyYear 1회 백필 (SPEC-22 롤아웃 준비).
+//
+// 새 코드는 mirror.weeklyYear 를 읽어 동작하고, 없으면 blocker 로 강등한다.
+// 라이브 mirror 에는 이 필드가 없으므로, 배포 전에 시트가 선언한 값으로 채운다.
+//
+// 값의 출처는 유추가 아니라 시트 선언이다: mirror.cells 의 yearMonth 는 수집 시점에
+// 시트 주차 라벨 행(E12/E35)에서 파싱된 값이므로, 그 연도가 곧 주별 블록의 연도다.
+// 연도가 단일하지 않거나 주차 셀이 없으면 건드리지 않는다 (다음 수집이 채운다).
+//
+//   1) 사본:    node scripts/backfill-mirror-weekly-year.mjs --project <id> --dump <dir>
+//   2) dry-run: node scripts/backfill-mirror-weekly-year.mjs --project <id>
+//   3) 실행:    node scripts/backfill-mirror-weekly-year.mjs --project <id> --apply
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createFirestoreDb, resolveProjectId } from '../server/bff/firestore.mjs';
+
+function readFlag(name, fallback = '') {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? fallback : (process.argv[index + 1] || fallback);
+}
+
+const firebaseProjectId = readFlag('--firebase-project', readFlag('--project', resolveProjectId()));
+const tenantId = readFlag('--tenant', 'mysc');
+const dumpDir = readFlag('--dump', '');
+const apply = process.argv.includes('--apply');
+
+async function main() {
+  const db = createFirestoreDb({ projectId: firebaseProjectId });
+  const snap = await db.collection(`orgs/${tenantId}/cashflow_sheet_mirrors`).get();
+
+  if (dumpDir) {
+    mkdirSync(dumpDir, { recursive: true });
+    const file = join(dumpDir, `cashflow_sheet_mirrors-${tenantId}-${firebaseProjectId}.json`);
+    writeFileSync(file, JSON.stringify(
+      snap.docs.map((doc) => ({ id: doc.id, data: doc.data() })),
+      null,
+      2,
+    ));
+    console.log(`사본 저장: ${file} (${snap.size}건)`);
+    return;
+  }
+
+  const plans = [];
+  const skipped = [];
+  for (const doc of snap.docs) {
+    const mirror = doc.data() || {};
+    if (Number.isSafeInteger(Number(mirror.weeklyYear))) {
+      skipped.push(`${doc.id}: weeklyYear=${mirror.weeklyYear} 이미 있음`);
+      continue;
+    }
+    const years = [...new Set((mirror.cells || [])
+      .map((cell) => Number(String(cell?.yearMonth).slice(0, 4)))
+      .filter(Number.isSafeInteger))];
+    if (years.length !== 1) {
+      skipped.push(`${doc.id}: 주차 셀 연도 ${years.join('/') || '없음'} — 건드리지 않음`);
+      continue;
+    }
+    plans.push({ id: doc.id, weeklyYear: years[0] });
+  }
+
+  console.log(`대상 ${plans.length}건 / 제외 ${skipped.length}건  (${apply ? 'APPLY' : 'DRY-RUN'})`);
+  for (const plan of plans) console.log(`  ${plan.id} <- weeklyYear=${plan.weeklyYear}`);
+  for (const line of skipped) console.log(`  [제외] ${line}`);
+
+  if (!apply) return;
+  for (const plan of plans) {
+    await db.doc(`orgs/${tenantId}/cashflow_sheet_mirrors/${plan.id}`).update({ weeklyYear: plan.weeklyYear });
+  }
+  console.log(`\n적용 완료: ${plans.length}건 (weeklyYear 필드 1개 추가, 다른 필드 무변경)`);
+}
+
+main().catch((error) => {
+  console.error(error?.stack || String(error));
+  process.exitCode = 1;
+});

--- a/server/bff/cashflow-canonical-store.mjs
+++ b/server/bff/cashflow-canonical-store.mjs
@@ -55,12 +55,10 @@ function normalizePolicyLabel(value) {
 }
 
 for (const entry of cashflowPolicyData.lineEntries || []) {
-  LINE_BY_LABEL.set(normalizePolicyLabel(entry.lineId), entry.lineId);
-  LINE_BY_LABEL.set(normalizePolicyLabel(entry.label), entry.lineId);
-  LINE_BY_LABEL.set(normalizePolicyLabel(entry.label).replace(/\s+/g, ''), entry.lineId);
-  for (const alias of entry.aliases || []) {
-    LINE_BY_LABEL.set(normalizePolicyLabel(alias), entry.lineId);
-    LINE_BY_LABEL.set(normalizePolicyLabel(alias).replace(/\s+/g, ''), entry.lineId);
+  for (const label of [entry.lineId, entry.label, entry.actualLabel]) {
+    if (!label) continue;
+    LINE_BY_LABEL.set(normalizePolicyLabel(label), entry.lineId);
+    LINE_BY_LABEL.set(normalizePolicyLabel(label).replace(/\s+/g, ''), entry.lineId);
   }
 }
 

--- a/server/bff/cashflow-canonical-store.test.mjs
+++ b/server/bff/cashflow-canonical-store.test.mjs
@@ -41,9 +41,10 @@ describe('cashflow canonical BFF helpers', () => {
     });
   });
 
-  it('parses cashflow labels and aliases without relying on frontend code', () => {
+  it('parses canonical and Actual labels without legacy aliases', () => {
     expect(parseCashflowLineLabel('직접사업비(공급가액)')).toBe('DIRECT_COST_OUT');
     expect(parseCashflowLineLabel('MYSC인건비')).toBe('MYSC_LABOR_OUT');
+    expect(parseCashflowLineLabel('MYSC선입금')).toBeUndefined();
   });
 
   it('aggregates actuals from persisted expense rows without injecting zero lines', () => {

--- a/server/bff/cashflow-coordinates.mjs
+++ b/server/bff/cashflow-coordinates.mjs
@@ -1,0 +1,104 @@
+import cashflowPolicyData from '../../policies/cashflow-policy.json' with { type: 'json' };
+
+// 전사 고정 양식의 좌표 계약. 이 파일이 유일한 진실이다.
+//
+// 원칙 (흔들지 않는다):
+//   1. 주별 블록은 E:BL 60칸 하나뿐이고, 그 연도는 프로젝트당 단일 상수다.
+//   2. 연간 열은 C:D(이전 2개)와 BM:BR(이후 6개) 고정이다.
+//   3. 라인 정체성은 행 인덱스다. 라벨 문자열로 라인을 찾지 않는다.
+//   4. 좌표 밖의 데이터는 존재하지 않는 것으로 취급한다.
+//   5. 양식이 다르면 적응하지 않고 거부한다.
+//
+// 근거: docs/architecture/contracts/2026-07-28-cashflow-formula-validation-contract.md
+//   "2024 annual -> 2025 annual -> 2026 week 1..60 -> 2027 annual -> ... -> 2032 annual"
+
+export const SHEET_RANGE = 'A1:BT60';
+
+export const WEEKS_PER_MONTH = 5;
+export const MONTHS_PER_YEAR = 12;
+export const WEEKS_PER_YEAR = WEEKS_PER_MONTH * MONTHS_PER_YEAR;
+
+// 주별 블록: E:BL (열 인덱스 4..63)
+export const WEEK_FIRST_COLUMN = 4;
+
+// 연간 열: C:D 는 주별 연도 이전, BM:BR 은 이후.
+export const ANNUAL_COLUMNS_BEFORE = Object.freeze([2, 3]);
+export const ANNUAL_COLUMNS_AFTER = Object.freeze([64, 65, 66, 67, 68, 69]);
+export const SOURCE_YEAR_TOTAL_COLUMN = 70;
+
+// 라인 = 행. 배열 순서가 정책 lineEntries 순서와 1:1 대응한다.
+export const LINE_ROWS = Object.freeze({
+  projection: Object.freeze([14, 15, 16, 17, 18, 19, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30]),
+  actual: Object.freeze([37, 38, 39, 40, 41, 42, 43, 45, 46, 47, 48, 49, 50, 51, 52, 53]),
+});
+
+export const LINE_IDS = Object.freeze(cashflowPolicyData.lineEntries.map((entry) => entry.lineId));
+
+const YEAR_MONTH_RE = /^(20\d{2})-(0[1-9]|1[0-2])$/;
+
+export class CashflowTemplateMismatchError extends Error {
+  constructor(detail) {
+    super('양식이 다릅니다.');
+    this.name = 'CashflowTemplateMismatchError';
+    this.code = 'cashflow_sheet_template_mismatch';
+    this.detail = detail;
+  }
+}
+
+export function requireWeeklyYear(value) {
+  const year = Number(value);
+  if (!Number.isSafeInteger(year) || year < 2000 || year > 2099) {
+    throw new CashflowTemplateMismatchError(`주별 연도가 좌표 계약을 벗어났습니다: ${value}`);
+  }
+  return year;
+}
+
+// 주별 블록 이전 2개 연도, 이후 6개 연도. 좌표가 개수를 결정한다.
+export function annualYearsFor(weeklyYear) {
+  const year = requireWeeklyYear(weeklyYear);
+  return Object.freeze([
+    ...ANNUAL_COLUMNS_BEFORE.map((_, offset) => year - ANNUAL_COLUMNS_BEFORE.length + offset),
+    ...ANNUAL_COLUMNS_AFTER.map((_, offset) => year + 1 + offset),
+  ]);
+}
+
+export function isWeeklyMonth(weeklyYear, yearMonth) {
+  const match = YEAR_MONTH_RE.exec(String(yearMonth ?? ''));
+  return Boolean(match) && Number(match[1]) === requireWeeklyYear(weeklyYear);
+}
+
+// 좌표 밖(연 단위 관리 연도, 범위 밖 주차)은 -1. 낙오 문서는 여기서 걸러진다.
+export function weekOrdinal(weeklyYear, yearMonth, weekNo) {
+  if (!isWeeklyMonth(weeklyYear, yearMonth)) return -1;
+  const week = Number(weekNo);
+  if (!Number.isInteger(week) || week < 1 || week > WEEKS_PER_MONTH) return -1;
+  const month = Number(String(yearMonth).slice(5, 7));
+  return (month - 1) * WEEKS_PER_MONTH + (week - 1);
+}
+
+export function weekColumnFor(weeklyYear, yearMonth, weekNo) {
+  const ordinal = weekOrdinal(weeklyYear, yearMonth, weekNo);
+  return ordinal === -1 ? -1 : WEEK_FIRST_COLUMN + ordinal;
+}
+
+export function annualColumnFor(weeklyYear, year) {
+  const index = annualYearsFor(weeklyYear).indexOf(Number(year));
+  if (index === -1) return -1;
+  return index < ANNUAL_COLUMNS_BEFORE.length
+    ? ANNUAL_COLUMNS_BEFORE[index]
+    : ANNUAL_COLUMNS_AFTER[index - ANNUAL_COLUMNS_BEFORE.length];
+}
+
+export function lineRowFor(mode, lineIndex) {
+  const rows = LINE_ROWS[mode];
+  if (!rows) throw new CashflowTemplateMismatchError(`알 수 없는 모드입니다: ${mode}`);
+  const row = rows[Number(lineIndex)];
+  if (row === undefined) throw new CashflowTemplateMismatchError(`라인 인덱스가 범위를 벗어났습니다: ${lineIndex}`);
+  return row;
+}
+
+export function lineIndexOfRow(mode, rowIndex) {
+  const rows = LINE_ROWS[mode];
+  if (!rows) throw new CashflowTemplateMismatchError(`알 수 없는 모드입니다: ${mode}`);
+  return rows.indexOf(Number(rowIndex));
+}

--- a/server/bff/cashflow-coordinates.test.mjs
+++ b/server/bff/cashflow-coordinates.test.mjs
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import cashflowPolicyData from '../../policies/cashflow-policy.json' with { type: 'json' };
+import {
+  ANNUAL_COLUMNS_AFTER,
+  ANNUAL_COLUMNS_BEFORE,
+  CashflowTemplateMismatchError,
+  LINE_IDS,
+  LINE_ROWS,
+  WEEKS_PER_YEAR,
+  annualColumnFor,
+  annualYearsFor,
+  isWeeklyMonth,
+  lineIndexOfRow,
+  lineRowFor,
+  weekColumnFor,
+  weekOrdinal,
+} from './cashflow-coordinates.mjs';
+
+const WEEKLY_YEAR = 2026;
+
+describe('좌표 계약', () => {
+  it('주별 블록은 60칸이고 E:BL 을 채운다', () => {
+    expect(WEEKS_PER_YEAR).toBe(60);
+    expect(weekColumnFor(WEEKLY_YEAR, '2026-01', 1)).toBe(4);
+    expect(weekColumnFor(WEEKLY_YEAR, '2026-12', 5)).toBe(63);
+  });
+
+  it('연간 연도는 주별 연도 이전 2개 · 이후 6개로 좌표가 결정한다', () => {
+    expect(annualYearsFor(WEEKLY_YEAR)).toEqual([2024, 2025, 2027, 2028, 2029, 2030, 2031, 2032]);
+    expect(annualColumnFor(WEEKLY_YEAR, 2024)).toBe(ANNUAL_COLUMNS_BEFORE[0]);
+    expect(annualColumnFor(WEEKLY_YEAR, 2025)).toBe(ANNUAL_COLUMNS_BEFORE[1]);
+    expect(annualColumnFor(WEEKLY_YEAR, 2027)).toBe(ANNUAL_COLUMNS_AFTER[0]);
+    expect(annualColumnFor(WEEKLY_YEAR, 2032)).toBe(ANNUAL_COLUMNS_AFTER[5]);
+  });
+
+  it('라인 정체성은 행 인덱스이며 정책 순서와 1:1 대응한다', () => {
+    expect(LINE_IDS).toHaveLength(16);
+    expect(LINE_ROWS.projection).toHaveLength(LINE_IDS.length);
+    expect(LINE_ROWS.actual).toHaveLength(LINE_IDS.length);
+    for (const [index, lineId] of LINE_IDS.entries()) {
+      expect(lineIndexOfRow('projection', lineRowFor('projection', index))).toBe(index);
+      expect(lineIndexOfRow('actual', lineRowFor('actual', index))).toBe(index);
+      expect(cashflowPolicyData.lineEntries[index].lineId).toBe(lineId);
+    }
+  });
+
+  it('입금 7행 · 출금 9행 배치가 시트 계약과 같다', () => {
+    expect(LINE_IDS.filter((id) => id.endsWith('_IN'))).toHaveLength(7);
+    expect(LINE_IDS.filter((id) => id.endsWith('_OUT'))).toHaveLength(9);
+    // 21/31/32 (합계·잔액) 과 44/54/55 는 라인 행이 아니다.
+    for (const derived of [21, 31, 32]) expect(LINE_ROWS.projection).not.toContain(derived);
+    for (const derived of [44, 54, 55]) expect(LINE_ROWS.actual).not.toContain(derived);
+  });
+});
+
+describe('좌표 밖은 존재하지 않는다', () => {
+  it.each([
+    ['연 단위 관리 이전 연도', '2025-12', 4],
+    ['연 단위 관리 이후 연도', '2027-01', 1],
+    ['5주를 넘는 주차', '2026-03', 6],
+    ['0주차', '2026-03', 0],
+  ])('낙오 문서 %s 는 행렬에 진입하지 못한다', (_label, yearMonth, weekNo) => {
+    expect(weekOrdinal(WEEKLY_YEAR, yearMonth, weekNo)).toBe(-1);
+    expect(weekColumnFor(WEEKLY_YEAR, yearMonth, weekNo)).toBe(-1);
+  });
+
+  it('실제 낙오 문서 p1773651024850-2025-12-w4 를 거부한다', () => {
+    expect(isWeeklyMonth(WEEKLY_YEAR, '2025-12')).toBe(false);
+    expect(weekOrdinal(WEEKLY_YEAR, '2025-12', 4)).toBe(-1);
+  });
+
+  it('양식이 다르면 적응하지 않고 거부한다', () => {
+    expect(() => annualYearsFor(1999)).toThrow(CashflowTemplateMismatchError);
+    expect(() => lineRowFor('projection', 16)).toThrow(CashflowTemplateMismatchError);
+    expect(() => lineRowFor('unknown', 0)).toThrow(CashflowTemplateMismatchError);
+    expect(() => annualYearsFor(1999)).toThrow('양식이 다릅니다.');
+  });
+});
+
+describe('사보타주', () => {
+  it('주차 산술에 오프바이원이 있으면 좌표가 어긋난다', () => {
+    // (month-1)*5 + (week-1) 이 아닌 값이면 마지막 칸이 BL(63)을 벗어난다.
+    const last = weekOrdinal(WEEKLY_YEAR, '2026-12', 5);
+    expect(last).toBe(59);
+    expect(last + 1).toBe(WEEKS_PER_YEAR);
+  });
+
+  it('연간 연도 하나가 빠지면 열 매핑이 깨진다', () => {
+    const years = annualYearsFor(WEEKLY_YEAR);
+    expect(years).toHaveLength(ANNUAL_COLUMNS_BEFORE.length + ANNUAL_COLUMNS_AFTER.length);
+    expect(new Set(years).size).toBe(years.length);
+    expect(years).not.toContain(WEEKLY_YEAR);
+  });
+});

--- a/server/bff/cashflow-sheet-snapshot.mjs
+++ b/server/bff/cashflow-sheet-snapshot.mjs
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto';
 import { toA1 } from './cashflow-sheet-template.mjs';
+import { annualYearsFor, requireWeeklyYear, weekOrdinal } from './cashflow-coordinates.mjs';
 
 function canonicalize(value) {
   if (Array.isArray(value)) return value.map(canonicalize);
@@ -224,37 +225,61 @@ function summarizeAnnualMode(cells, source) {
   };
 }
 
-function reconcileAnnualMode(weekly, annual) {
-  if (weekly.source !== 'WEEKLY' || annual.source !== 'ANNUAL') {
-    return { status: 'NOT_APPLICABLE', mismatchedLineIds: [] };
+const DERIVED_FIELD_BY_KIND = {
+  deposit_total: 'depositTotal',
+  withdrawal_total: 'withdrawalTotal',
+  balance: 'balance',
+};
+
+// 연 단위 연도의 합계는 시트 합계 행 좌표(입금 합계 / 출금 합계 / 잔액)에서 읽는다.
+// 좌표 칸이 금액을 담고 있지 않으면 값이 없는 것이며, 라인 합으로 대체하지 않는다.
+function declaredAnnualTotals(annualDerivedCells, year, mode) {
+  const result = { depositTotal: null, withdrawalTotal: null, balance: null };
+  for (const [kind, field] of Object.entries(DERIVED_FIELD_BY_KIND)) {
+    const cell = annualDerivedCells.find((candidate) => (
+      Number(candidate?.year) === year
+      && candidate?.mode === mode
+      && candidate?.derivedKind === kind
+    ));
+    if (!['VALUE', 'ZERO'].includes(cell?.state) || !Number.isSafeInteger(Number(cell.amount))) continue;
+    result[field] = Number(cell.amount);
   }
-  if (weekly.coverage.status !== 'COMPLETE') {
-    return { status: 'PARTIAL_WEEKLY', mismatchedLineIds: [] };
-  }
-  const lineIds = new Set([...Object.keys(weekly.lineAmounts), ...Object.keys(annual.lineAmounts)]);
-  const mismatchedLineIds = [...lineIds]
-    .filter((lineId) => (weekly.lineAmounts[lineId] || 0) !== (annual.lineAmounts[lineId] || 0))
-    .sort(compareCodeUnits);
-  return { status: mismatchedLineIds.length > 0 ? 'MISMATCH' : 'MATCH', mismatchedLineIds };
+  return result;
 }
 
-export function buildAnnualCashflowTotals({ cells, annualCells }) {
-  const years = new Set([
-    ...cells.map((cell) => Number(String(cell.yearMonth).slice(0, 4))),
-    ...annualCells.map((cell) => Number(cell.year)),
-  ].filter(Number.isSafeInteger));
-  return [...years]
-    .sort((left, right) => left - right)
+// 좌표 계약상 한 연도가 주별과 연간을 겸할 수 없으므로 둘을 대조할 일이 없다.
+const NO_RECONCILIATION = Object.freeze({ status: 'NOT_APPLICABLE', mismatchedLineIds: [] });
+
+export function buildAnnualCashflowTotals({ cells = [], annualCells = [], annualDerivedCells = [], weeklyYear }) {
+  const year0 = requireWeeklyYear(weeklyYear);
+  const years = [...annualYearsFor(year0), year0].sort((left, right) => left - right);
+  return years
     .map((year) => {
       const modeTotals = {};
       for (const mode of ['projection', 'actual']) {
-        const weeklyCells = cells.filter((cell) => cell.mode === mode && Number(String(cell.yearMonth).slice(0, 4)) === year);
-        const annualCellsForMode = annualCells.filter((cell) => cell.mode === mode && cell.year === year);
-        const weekly = summarizeAnnualMode(weeklyCells, weeklyCells.length > 0 ? 'WEEKLY' : 'NONE');
-        const annual = summarizeAnnualMode(annualCellsForMode, annualCellsForMode.length > 0 ? 'ANNUAL' : 'NONE');
+        if (year === year0) {
+          // 주별 연도: 주차 그리드가 그 해의 유일한 소스. 연간 열이 존재하지 않는다.
+          modeTotals[mode] = {
+            ...summarizeAnnualMode(
+              cells.filter((cell) => cell.mode === mode && weekOrdinal(year0, cell?.yearMonth, cell?.weekNo) !== -1),
+              'WEEKLY',
+            ),
+            reconciliation: NO_RECONCILIATION,
+          };
+          continue;
+        }
+        // 연 단위 연도: 연간 열 좌표가 유일한 소스. 주차 셀은 보지 않는다.
+        const annual = summarizeAnnualMode(
+          annualCells.filter((cell) => cell.mode === mode && Number(cell.year) === year && cell?.periodKind !== 'GRAND_TOTAL'),
+          'ANNUAL',
+        );
+        const declared = declaredAnnualTotals(annualDerivedCells, year, mode);
         modeTotals[mode] = {
-          ...(weeklyCells.length > 0 ? weekly : annual),
-          reconciliation: reconcileAnnualMode(weekly, annual),
+          ...annual,
+          totalIn: declared.depositTotal,
+          totalOut: declared.withdrawalTotal,
+          net: declared.balance,
+          reconciliation: NO_RECONCILIATION,
         };
       }
       return { year, ...modeTotals };
@@ -462,7 +487,9 @@ function annualSheetFinancialTotals({ depositScheduleRows, projectionControls })
     }));
 }
 
-export function extractCashflowSheetFacts({ template = {}, matrix = [], cells = [], annualCells = [], totalCells = [] } = {}) {
+export function extractCashflowSheetFacts({
+  template = {}, matrix = [], cells = [], annualCells = [], annualDerivedCells = [], totalCells = [], weeklyYear,
+} = {}) {
   const issues = [];
   const projectionSection = template?.sections?.find((section) => section.mode === 'projection');
   const weekColumns = (projectionSection?.weekColumns || [])
@@ -542,7 +569,9 @@ export function extractCashflowSheetFacts({ template = {}, matrix = [], cells = 
     },
     depositScheduleRows,
     annualFinancialTotals: annualSheetFinancialTotals({ depositScheduleRows, projectionControls }),
-    annualCashflowTotals: buildAnnualCashflowTotals({ cells, annualCells }),
+    annualCashflowTotals: cells.length || annualCells.length || annualDerivedCells.length
+      ? buildAnnualCashflowTotals({ cells, annualCells, annualDerivedCells, weeklyYear })
+      : [],
     ...(weeklyCalculationChecks.length > 0 ? { weeklyCalculationChecks } : {}),
     cashflowGrandTotals: {
       projection: buildCashflowSheetTotal(totalCells, 'projection'),
@@ -595,7 +624,11 @@ export function createCashflowPinnedSnapshot({
     .sort((left, right) => String(left.mode).localeCompare(String(right.mode))
       || String(left.kind).localeCompare(String(right.kind))
       || String(left.lineId || left.derivedKind || '').localeCompare(String(right.lineId || right.derivedKind || '')));
-  const sheetFacts = extractCashflowSheetFacts({ template, matrix, cells, annualCells, totalCells });
+  const weeklyYear = template?.sections?.flatMap((section) => section.weekColumns || [])[0]?.year
+    ?? Number(String(mappings[0]?.yearMonth || '').slice(0, 4));
+  const sheetFacts = extractCashflowSheetFacts({
+    template, matrix, cells, annualCells, annualDerivedCells, totalCells, weeklyYear,
+  });
   const sourceRevision = revisionOf({ spreadsheetId, selectedSheetName, cells, annualCells, annualDerivedCells, totalCells, sheetFacts });
   const summary = cells.reduce((counts, cell) => {
     counts.cellCount += 1;

--- a/server/bff/cashflow-sheet-snapshot.mjs
+++ b/server/bff/cashflow-sheet-snapshot.mjs
@@ -26,9 +26,11 @@ function compareCodeUnits(left, right) {
   return 0;
 }
 
+const DASH_ONLY_RE = /^[-–—―]+$/;
+
 export function classifyCashflowSheetCell(value) {
   const rawValue = normalizedText(value);
-  if (!rawValue || /^[-–—―]+$/.test(rawValue)) return { state: 'EMPTY' };
+  if (!rawValue || DASH_ONLY_RE.test(rawValue)) return { state: 'EMPTY' };
 
   const normalizedMinus = rawValue.replace(/[−﹣－]/g, '-');
   const parenthesizedNegative = /^\(.*\)$/.test(normalizedMinus);
@@ -82,11 +84,18 @@ export function computeCashflowTargetRevision(snapshot = {}) {
   return revisionOf({ weeks });
 }
 
-function snapshotCell(mapping, matrix) {
-  const classified = classifyCashflowSheetCell(matrix?.[mapping.rowIndex]?.[mapping.columnIndex]);
-  const cell = classified.state === 'VALUE' && classified.amount === 0
+// Actual 은 회계 서식이 0 을 '-' 로 그린다. 시트의 '-' 는 확정된 0원이므로 ZERO 로 읽는다.
+// Projection 의 '-' 는 기존 계약 그대로 미기입(EMPTY)이다.
+function classifyModeCell(mode, value) {
+  if (mode === 'actual' && DASH_ONLY_RE.test(normalizedText(value))) return { state: 'ZERO', amount: 0 };
+  const classified = classifyCashflowSheetCell(value);
+  return classified.state === 'VALUE' && classified.amount === 0
     ? { state: 'ZERO', amount: 0 }
     : classified;
+}
+
+function snapshotCell(mapping, matrix) {
+  const cell = classifyModeCell(mapping.mode, matrix?.[mapping.rowIndex]?.[mapping.columnIndex]);
   return {
     mode: mapping.mode,
     yearMonth: mapping.yearMonth,
@@ -100,10 +109,7 @@ function snapshotCell(mapping, matrix) {
 }
 
 function snapshotAnnualCell(mapping, matrix) {
-  const classified = classifyCashflowSheetCell(matrix?.[mapping.rowIndex]?.[mapping.columnIndex]);
-  const annualClassified = classified.state === 'VALUE' && classified.amount === 0
-    ? { state: 'ZERO', amount: 0 }
-    : classified;
+  const annualClassified = classifyModeCell(mapping.mode, matrix?.[mapping.rowIndex]?.[mapping.columnIndex]);
   return {
     mode: mapping.mode,
     year: Number(mapping.year),
@@ -117,24 +123,18 @@ function snapshotAnnualCell(mapping, matrix) {
 }
 
 function snapshotAnnualDerivedCell(mapping, matrix) {
-  const classified = classifyCashflowSheetCell(matrix?.[mapping.rowIndex]?.[mapping.columnIndex]);
   return {
     mode: mapping.mode,
     year: Number(mapping.year),
     periodKind: mapping.periodKind,
     derivedKind: mapping.derivedKind,
     sourceCell: mapping.a1,
-    ...(classified.state === 'VALUE' && classified.amount === 0
-      ? { state: 'ZERO', amount: 0 }
-      : classified),
+    ...classifyModeCell(mapping.mode, matrix?.[mapping.rowIndex]?.[mapping.columnIndex]),
   };
 }
 
 function snapshotTotalCell(mapping, matrix) {
-  const classified = classifyCashflowSheetCell(matrix?.[mapping.rowIndex]?.[mapping.columnIndex]);
-  const totalClassified = classified.state === 'VALUE' && classified.amount === 0
-    ? { state: 'ZERO', amount: 0 }
-    : classified;
+  const totalClassified = classifyModeCell(mapping.mode, matrix?.[mapping.rowIndex]?.[mapping.columnIndex]);
   return {
     mode: mapping.mode,
     kind: mapping.kind,

--- a/server/bff/cashflow-sheet-snapshot.test.mjs
+++ b/server/bff/cashflow-sheet-snapshot.test.mjs
@@ -127,6 +127,27 @@ describe('cashflow sheet pinned snapshot', () => {
     expect(zero.sourceRevision).not.toBe(empty.sourceRevision);
   });
 
+  it('reads an accounting-format dash as zero in Actual but as empty in Projection', () => {
+    const mappingFor = (mode) => ({
+      mode, year: 2025, lineId: 'SALES_IN', direction: 'IN',
+      rowIndex: 0, columnIndex: 0, a1: 'A1', label: '매출액(입금)',
+    });
+    const snapshotFor = (mode) => createCashflowPinnedSnapshot({
+      projectId: 'project-a',
+      spreadsheetId: 'sheet-a',
+      selectedSheetName: 'cashflow(사용내역 연동)',
+      template: { sections: [{ mode, weekColumns: [{ year: 2026 }], annualMappings: [mappingFor(mode)] }] },
+      matrix: [['-']],
+    });
+
+    // Actual 의 '-' 는 회계 서식이 0 을 그린 것이다. 확정된 0원(ZERO)으로 읽어 화면에 0 이 뜬다.
+    expect(snapshotFor('actual').annualCells)
+      .toEqual([expect.objectContaining({ state: 'ZERO', amount: 0 })]);
+    // Projection 의 '-' 는 기존 계약 그대로 미기입(EMPTY)이다.
+    expect(snapshotFor('projection').annualCells)
+      .toEqual([expect.objectContaining({ state: 'EMPTY' })]);
+  });
+
   it('pins annual totals and running balances as sheet evidence', () => {
     const snapshot = createCashflowPinnedSnapshot({
       projectId: 'project-a',

--- a/server/bff/cashflow-sheet-snapshot.test.mjs
+++ b/server/bff/cashflow-sheet-snapshot.test.mjs
@@ -1,10 +1,95 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildAnnualCashflowTotals,
   classifyCashflowSheetCell,
   computeCashflowTargetRevision,
   createCashflowPinnedSnapshot,
   extractCashflowSheetFacts,
 } from './cashflow-sheet-snapshot.mjs';
+import { CashflowTemplateMismatchError } from './cashflow-coordinates.mjs';
+
+const annualAccidentFixture = (overrides = {}) => ({
+  weeklyYear: 2026,
+  cells: [{
+    yearMonth: '2025-12', weekNo: 4, mode: 'actual', lineId: 'SALES_IN', direction: 'IN',
+    state: 'VALUE', amount: 7_582_243,
+  }],
+  annualCells: [{
+    year: 2025, mode: 'actual', lineId: 'SALES_IN', direction: 'IN',
+    state: 'VALUE', amount: 317_449_417,
+  }],
+  annualDerivedCells: [{
+    year: 2025, mode: 'actual', derivedKind: 'deposit_total',
+    state: 'VALUE', amount: 317_449_417,
+  }],
+  ...overrides,
+});
+
+describe('annual cashflow coordinate contract', () => {
+  it('T1 keeps the annual coordinate value when an orphan weekly cell exists', () => {
+    const totals = buildAnnualCashflowTotals(annualAccidentFixture());
+    expect(totals.find(({ year }) => year === 2025).actual.lineAmounts.SALES_IN).toBe(317_449_417);
+  });
+
+  it('T2 uses the declared sheet deposit total', () => {
+    const totals = buildAnnualCashflowTotals(annualAccidentFixture());
+    expect(totals.find(({ year }) => year === 2025).actual.totalIn).toBe(317_449_417);
+  });
+
+  it('T3 returns only the years declared by the coordinate contract', () => {
+    const totals = buildAnnualCashflowTotals(annualAccidentFixture());
+    expect(totals.map(({ year }) => year)).toEqual([2024, 2025, 2026, 2027, 2028, 2029, 2030, 2031, 2032]);
+  });
+
+  it('T4 preserves an empty declared total as null', () => {
+    const fixture = annualAccidentFixture();
+    fixture.annualDerivedCells[0] = { ...fixture.annualDerivedCells[0], state: 'EMPTY', amount: undefined };
+    const totals = buildAnnualCashflowTotals(fixture);
+    expect(totals.find(({ year }) => year === 2025).actual.totalIn).toBeNull();
+  });
+
+  it('T6 sums only weekly coordinates for the weekly year', () => {
+    const fixture = annualAccidentFixture({
+      cells: [
+        { yearMonth: '2026-01', weekNo: 1, mode: 'actual', lineId: 'SALES_IN', direction: 'IN', state: 'VALUE', amount: 100 },
+        { yearMonth: '2026-01', weekNo: 2, mode: 'actual', lineId: 'SALES_IN', direction: 'IN', state: 'VALUE', amount: 200 },
+      ],
+    });
+    const actual = buildAnnualCashflowTotals(fixture).find(({ year }) => year === 2026).actual;
+    expect(actual.totalIn).toBe(300);
+    expect(actual.reconciliation.status).toBe('NOT_APPLICABLE');
+  });
+
+  it('T7 excludes cells outside the coordinate years', () => {
+    const fixture = annualAccidentFixture({
+      cells: [{ yearMonth: '2023-12', weekNo: 4, mode: 'actual', lineId: 'SALES_IN', direction: 'IN', state: 'VALUE', amount: 1 }],
+      annualCells: [
+        ...annualAccidentFixture().annualCells,
+        { year: 2033, mode: 'actual', lineId: 'SALES_IN', direction: 'IN', state: 'VALUE', amount: 2, sourceCell: 'ZZ1' },
+      ],
+    });
+    const totals = buildAnnualCashflowTotals(fixture);
+    expect(totals.map(({ year }) => year)).not.toContain(2023);
+    expect(totals.map(({ year }) => year)).not.toContain(2033);
+  });
+
+  it('T8 rejects a missing weekly year', () => {
+    expect(() => buildAnnualCashflowTotals({ cells: [], annualCells: [] }))
+      .toThrow(CashflowTemplateMismatchError);
+  });
+
+  it('T9 preserves explicit zero and omits empty line amounts', () => {
+    const totals = buildAnnualCashflowTotals(annualAccidentFixture({
+      annualCells: [
+        { year: 2025, mode: 'actual', lineId: 'SALES_IN', direction: 'IN', state: 'ZERO', amount: 0 },
+        { year: 2025, mode: 'actual', lineId: 'TEAM_SUPPORT_IN', direction: 'IN', state: 'EMPTY' },
+      ],
+    }));
+    const amounts = totals.find(({ year }) => year === 2025).actual.lineAmounts;
+    expect(amounts).toHaveProperty('SALES_IN', 0);
+    expect(amounts).not.toHaveProperty('TEAM_SUPPORT_IN');
+  });
+});
 
 describe('cashflow sheet pinned snapshot', () => {
   it.each(['', '  ', '-', '―', '–'])('classifies %j as an empty cell', (rawValue) => {
@@ -26,14 +111,14 @@ describe('cashflow sheet pinned snapshot', () => {
       projectId: 'project-a',
       spreadsheetId: 'sheet-a',
       selectedSheetName: 'cashflow(사용내역 연동)',
-      template: { sections: [{ mode: 'projection', annualMappings: [annualMapping] }] },
+      template: { sections: [{ mode: 'projection', weekColumns: [{ year: 2026 }], annualMappings: [annualMapping] }] },
       matrix: [[0]],
     });
     const empty = createCashflowPinnedSnapshot({
       projectId: 'project-a',
       spreadsheetId: 'sheet-a',
       selectedSheetName: 'cashflow(사용내역 연동)',
-      template: { sections: [{ mode: 'projection', annualMappings: [annualMapping] }] },
+      template: { sections: [{ mode: 'projection', weekColumns: [{ year: 2026 }], annualMappings: [annualMapping] }] },
       matrix: [['']],
     });
 
@@ -50,6 +135,7 @@ describe('cashflow sheet pinned snapshot', () => {
       template: {
         sections: [{
           mode: 'projection',
+          weekColumns: [{ year: 2026 }],
           annualDerivedMappings: [
             { mode: 'projection', year: 2024, periodKind: 'ANNUAL', derivedKind: 'deposit_total', rowIndex: 0, columnIndex: 2, a1: 'C1' },
             { mode: 'projection', year: 2024, periodKind: 'ANNUAL', derivedKind: 'withdrawal_total', rowIndex: 1, columnIndex: 2, a1: 'C2' },
@@ -350,6 +436,7 @@ describe('cashflow sheet pinned snapshot', () => {
 
   it('sums repeated weekly line values and marks an incomplete year as partial', () => {
     const facts = extractCashflowSheetFacts({
+      weeklyYear: 2026,
       cells: [
         { mode: 'projection', yearMonth: '2026-01', weekNo: 1, lineId: 'SALES_IN', direction: 'IN', state: 'VALUE', amount: 100 },
         { mode: 'projection', yearMonth: '2026-01', weekNo: 2, lineId: 'SALES_IN', direction: 'IN', state: 'VALUE', amount: 200 },
@@ -357,7 +444,7 @@ describe('cashflow sheet pinned snapshot', () => {
       ],
     });
 
-    expect(facts.annualCashflowTotals).toEqual([
+    expect(facts.annualCashflowTotals).toEqual(expect.arrayContaining([
       expect.objectContaining({
         year: 2026,
         projection: expect.objectContaining({
@@ -375,29 +462,32 @@ describe('cashflow sheet pinned snapshot', () => {
           },
         }),
       }),
-    ]);
+    ]));
   });
 
   it('keeps the workbook 2,300,000 won prepayment separate by mode', () => {
     const facts = extractCashflowSheetFacts({
+      weeklyYear: 2026,
       cells: [
         { mode: 'projection', yearMonth: '2026-01', weekNo: 3, lineId: 'MYSC_PREPAY_IN', direction: 'IN', state: 'VALUE', amount: 2_300_000 },
         { mode: 'actual', yearMonth: '2026-01', weekNo: 3, lineId: 'MYSC_PREPAY_IN', direction: 'IN', state: 'VALUE', amount: 2_300_000 },
       ],
     });
 
-    expect(facts.annualCashflowTotals[0].projection.totalIn).toBe(2_300_000);
-    expect(facts.annualCashflowTotals[0].actual.totalIn).toBe(2_300_000);
+    const totals2026 = facts.annualCashflowTotals.find(({ year }) => year === 2026);
+    expect(totals2026.projection.totalIn).toBe(2_300_000);
+    expect(totals2026.actual.totalIn).toBe(2_300_000);
   });
 
   it('keeps annual-only values distinct from weekly coverage', () => {
     const facts = extractCashflowSheetFacts({
+      weeklyYear: 2026,
       annualCells: [
         { mode: 'actual', year: 2025, lineId: 'SALES_IN', direction: 'IN', state: 'VALUE', amount: 500 },
       ],
     });
 
-    expect(facts.annualCashflowTotals[0].actual).toMatchObject({
+    expect(facts.annualCashflowTotals.find(({ year }) => year === 2025).actual).toMatchObject({
       source: 'ANNUAL',
       lineAmounts: { SALES_IN: 500 },
       coverage: {
@@ -410,7 +500,7 @@ describe('cashflow sheet pinned snapshot', () => {
     });
   });
 
-  it('reports an item-level mismatch when a complete weekly year differs from its annual column', () => {
+  it('does not reconcile the weekly year against a non-annual total column', () => {
     const cells = Array.from({ length: 60 }, (_, index) => ({
       mode: 'projection',
       yearMonth: `2026-${String(Math.floor(index / 5) + 1).padStart(2, '0')}`,
@@ -421,6 +511,7 @@ describe('cashflow sheet pinned snapshot', () => {
       amount: 10,
     }));
     const facts = extractCashflowSheetFacts({
+      weeklyYear: 2026,
       cells,
       annualCells: [
         { mode: 'projection', year: 2026, lineId: 'SALES_IN', direction: 'IN', state: 'VALUE', amount: 599 },
@@ -428,9 +519,10 @@ describe('cashflow sheet pinned snapshot', () => {
     });
 
     expect(facts.annualCashflowTotals[0].projection).toMatchObject({
-      source: 'WEEKLY',
-      totalIn: 600,
-      reconciliation: { status: 'MISMATCH', mismatchedLineIds: ['SALES_IN'] },
+      source: 'ANNUAL',
+    });
+    expect(facts.annualCashflowTotals.find(({ year }) => year === 2026).projection).toMatchObject({
+      source: 'WEEKLY', totalIn: 600, reconciliation: { status: 'NOT_APPLICABLE' },
     });
   });
 

--- a/server/bff/cashflow-sheet-template.mjs
+++ b/server/bff/cashflow-sheet-template.mjs
@@ -1,8 +1,12 @@
 import cashflowPolicyData from '../../policies/cashflow-policy.json' with { type: 'json' };
+import {
+  CashflowTemplateMismatchError,
+  annualYearsFor,
+  lineIndexOfRow,
+  lineRowFor,
+} from './cashflow-coordinates.mjs';
 
 const WEEK_LABEL_RE = /^(\d{2})-(\d{1,2})-(\d{1,2})$/;
-const ANNUAL_YEAR_LABEL_RE = /^(\d{4})년$/;
-const MODES = ['projection', 'actual'];
 const LINE_ENTRIES = Array.isArray(cashflowPolicyData.lineEntries) ? cashflowPolicyData.lineEntries : [];
 const WEEK_COLUMN_INDEXES = Array.from({ length: 60 }, (_, index) => index + 4); // E:BL
 const ANNUAL_COLUMN_INDEXES = [2, 3, 64, 65, 66, 67, 68, 69]; // C:D, BM:BR
@@ -12,7 +16,6 @@ const SECTION_LAYOUTS = [
     mode: 'projection',
     headerRowIndex: 11,
     weekRowIndex: 12,
-    lineRowIndexes: [14, 15, 16, 17, 18, 19, 20, 22, 23, 24, 25, 26, 27, 28, 29, 30],
     derivedRows: [
       { rowIndex: 21, kind: 'deposit_total', label: '입금 합계' },
       { rowIndex: 31, kind: 'withdrawal_total', label: '출금 합계' },
@@ -23,7 +26,6 @@ const SECTION_LAYOUTS = [
     mode: 'actual',
     headerRowIndex: 34,
     weekRowIndex: 35,
-    lineRowIndexes: [37, 38, 39, 40, 41, 42, 43, 45, 46, 47, 48, 49, 50, 51, 52, 53],
     derivedRows: [
       { rowIndex: 44, kind: 'deposit_total', label: '입금 합계' },
       { rowIndex: 54, kind: 'withdrawal_total', label: '출금 합계' },
@@ -39,41 +41,6 @@ function normalizeText(value) {
 function normalizeLabelKey(value) {
   return normalizeText(value).replace(/\s+/g, '');
 }
-
-export function buildCashflowLineLookup(lineEntries) {
-  const entriesByKey = new Map();
-  const ambiguousKeys = new Set();
-
-  for (const entry of lineEntries) {
-    for (const mode of MODES) {
-      const modeLabel = mode === 'projection' ? entry.projectionLabel : entry.actualLabel;
-      for (const label of [entry.lineId, entry.label, ...(entry.aliases || []), modeLabel]) {
-        for (const normalized of new Set([normalizeText(label), normalizeLabelKey(label)].filter(Boolean))) {
-          const key = `${mode}|${entry.direction}|${normalized}`;
-          const existing = entriesByKey.get(key);
-          if (existing && existing.lineId !== entry.lineId) {
-            entriesByKey.delete(key);
-            ambiguousKeys.add(key);
-          } else if (!ambiguousKeys.has(key)) {
-            entriesByKey.set(key, entry);
-          }
-        }
-      }
-    }
-  }
-
-  return (label, mode, direction) => {
-    for (const normalized of [normalizeText(label), normalizeLabelKey(label)].filter(Boolean)) {
-      const key = `${mode}|${direction}|${normalized}`;
-      if (ambiguousKeys.has(key)) return null;
-      const entry = entriesByKey.get(key);
-      if (entry) return entry;
-    }
-    return null;
-  };
-}
-
-const resolveLineEntry = buildCashflowLineLookup(LINE_ENTRIES);
 
 function columnName(columnIndex) {
   let number = columnIndex + 1;
@@ -110,28 +77,18 @@ export function parseCashflowWeekLabel(value) {
   };
 }
 
-function annualColumn(matrix, rowIndex, columnIndex) {
-  const match = ANNUAL_YEAR_LABEL_RE.exec(normalizeText(matrix?.[rowIndex]?.[columnIndex]));
-  if (!match) return null;
-  return {
-    year: Number.parseInt(match[1], 10),
-    periodKind: 'ANNUAL',
-    columnIndex,
-    a1: toA1(rowIndex, columnIndex),
-  };
-}
-
 function fixedSection(matrix, layout, reasons) {
-  const weekColumns = WEEK_COLUMN_INDEXES.map((columnIndex) => {
-    const parsed = parseCashflowWeekLabel(matrix?.[layout.weekRowIndex]?.[columnIndex]);
-    if (!parsed) {
-      reasons.push({
-        code: 'cashflow_week_header_invalid',
-        mode: layout.mode,
-        sourceCell: toA1(layout.weekRowIndex, columnIndex),
-        message: `${layout.mode} 주차 헤더가 공식 양식과 다릅니다.`,
-      });
-      return null;
+  const sourceYear = parseCashflowWeekLabel(matrix?.[layout.weekRowIndex]?.[WEEK_COLUMN_INDEXES[0]])?.year;
+  const weekColumns = WEEK_COLUMN_INDEXES.map((columnIndex, index) => {
+    const header = String(matrix?.[layout.weekRowIndex]?.[columnIndex] ?? '');
+    const parsed = parseCashflowWeekLabel(header);
+    const expectedLabel = Number.isSafeInteger(sourceYear)
+      ? `${String(sourceYear).slice(-2)}-${Math.floor(index / 5) + 1}-${index % 5 + 1}`
+      : '';
+    if (!parsed || header !== expectedLabel) {
+      throw new CashflowTemplateMismatchError(
+        `${toA1(layout.weekRowIndex, columnIndex)} 주차 헤더가 좌표 계약과 다릅니다.`,
+      );
     }
     return {
       ...parsed,
@@ -139,19 +96,32 @@ function fixedSection(matrix, layout, reasons) {
       columnIndex,
       a1: toA1(layout.weekRowIndex, columnIndex),
     };
-  }).filter(Boolean);
+  });
 
-  const annualColumns = ANNUAL_COLUMN_INDEXES
-    .map((columnIndex) => annualColumn(matrix, layout.headerRowIndex, columnIndex))
-    .filter(Boolean);
-  const sourceYear = weekColumns[0]?.year;
-  const sourceTotalHeader = normalizeText(matrix?.[layout.headerRowIndex]?.[SOURCE_YEAR_TOTAL_COLUMN_INDEX]);
-  const totalColumn = Number.isSafeInteger(sourceYear) && ['Total', `${sourceYear}년 합계`].includes(sourceTotalHeader)
-    ? {
-      columnIndex: SOURCE_YEAR_TOTAL_COLUMN_INDEX,
-      a1: toA1(layout.headerRowIndex, SOURCE_YEAR_TOTAL_COLUMN_INDEX),
+  const annualYears = annualYearsFor(sourceYear);
+  const annualColumns = ANNUAL_COLUMN_INDEXES.map((columnIndex, index) => {
+    const year = annualYears[index];
+    if (matrix?.[layout.headerRowIndex]?.[columnIndex] !== `${year}년`) {
+      throw new CashflowTemplateMismatchError(
+        `${toA1(layout.headerRowIndex, columnIndex)} 연간 헤더가 좌표 계약과 다릅니다.`,
+      );
     }
-    : null;
+    return {
+      year,
+      periodKind: 'ANNUAL',
+      columnIndex,
+      a1: toA1(layout.headerRowIndex, columnIndex),
+    };
+  });
+  if (matrix?.[layout.headerRowIndex]?.[SOURCE_YEAR_TOTAL_COLUMN_INDEX] !== 'Total') {
+    throw new CashflowTemplateMismatchError(
+      `${toA1(layout.headerRowIndex, SOURCE_YEAR_TOTAL_COLUMN_INDEX)} 합계 헤더가 좌표 계약과 다릅니다.`,
+    );
+  }
+  const totalColumn = {
+    columnIndex: SOURCE_YEAR_TOTAL_COLUMN_INDEX,
+    a1: toA1(layout.headerRowIndex, SOURCE_YEAR_TOTAL_COLUMN_INDEX),
+  };
   // The source-year Total is retained as an annual reconciliation input as well as
   // a display-only grand total. It must never replace the weekly source of truth.
   if (totalColumn) {
@@ -162,26 +132,17 @@ function fixedSection(matrix, layout, reasons) {
       a1: totalColumn.a1,
     });
   }
-  if (annualColumns.length !== ANNUAL_COLUMN_INDEXES.length + 1 || !totalColumn) {
-    reasons.push({
-      code: 'cashflow_annual_header_invalid',
-      mode: layout.mode,
-      message: `${layout.mode} 연간 합계 헤더가 공식 양식과 다릅니다.`,
-    });
-  }
-
-  const lineRows = layout.lineRowIndexes.map((rowIndex, index) => {
-    const expected = LINE_ENTRIES[index];
-    const label = normalizeText(matrix?.[rowIndex]?.[0]);
-    const resolved = expected ? resolveLineEntry(label, layout.mode, expected.direction) : null;
-    if (!expected || resolved?.lineId !== expected.lineId) {
-      reasons.push({
-        code: 'cashflow_line_invalid',
-        mode: layout.mode,
-        sourceCell: toA1(rowIndex, 0),
-        lineIds: expected ? [expected.lineId] : [],
-        message: `${layout.mode} 항목 행이 공식 양식과 다릅니다.`,
-      });
+  const lineRows = LINE_ENTRIES.map((_, index) => {
+    const rowIndex = lineRowFor(layout.mode, index);
+    const expected = LINE_ENTRIES[lineIndexOfRow(layout.mode, rowIndex)];
+    const label = String(matrix?.[rowIndex]?.[0] ?? '');
+    const expectedLabel = layout.mode === 'projection'
+      ? expected?.projectionLabel || expected?.label
+      : expected?.actualLabel || expected?.label;
+    if (!expected || label !== expectedLabel) {
+      throw new CashflowTemplateMismatchError(
+        `${toA1(rowIndex, 0)} 항목 라벨이 좌표 계약과 다릅니다.`,
+      );
     }
     return {
       rowIndex,
@@ -298,20 +259,14 @@ export function analyzeCashflowSheetTemplate(matrix) {
   const sections = SECTION_LAYOUTS.map((layout) => fixedSection(rows, layout, reasons));
   const projectionWeeks = sections[0].weekColumns.map((week) => week.raw);
   const actualWeeks = sections[1].weekColumns.map((week) => week.raw);
-  if (projectionWeeks.length !== 60 || JSON.stringify(projectionWeeks) !== JSON.stringify(actualWeeks)) {
-    reasons.push({
-      code: 'cashflow_week_headers_mismatch',
-      message: 'Projection과 Actual 주차 헤더가 일치하지 않습니다.',
-    });
+  if (JSON.stringify(projectionWeeks) !== JSON.stringify(actualWeeks)) {
+    throw new CashflowTemplateMismatchError('Projection과 Actual 주차 헤더가 일치하지 않습니다.');
   }
 
   const projectionYears = sections[0].annualColumns.map((column) => column.year);
   const actualYears = sections[1].annualColumns.map((column) => column.year);
   if (JSON.stringify(projectionYears) !== JSON.stringify(actualYears)) {
-    reasons.push({
-      code: 'cashflow_annual_headers_mismatch',
-      message: 'Projection과 Actual 연간 합계 헤더가 일치하지 않습니다.',
-    });
+    throw new CashflowTemplateMismatchError('Projection과 Actual 연간 합계 헤더가 일치하지 않습니다.');
   }
 
   const mappingCandidates = sections.flatMap((section) => section.mappings);

--- a/server/bff/cashflow-sheet-template.mjs
+++ b/server/bff/cashflow-sheet-template.mjs
@@ -1,6 +1,5 @@
 import cashflowPolicyData from '../../policies/cashflow-policy.json' with { type: 'json' };
 import {
-  CashflowTemplateMismatchError,
   annualYearsFor,
   lineIndexOfRow,
   lineRowFor,
@@ -78,17 +77,45 @@ export function parseCashflowWeekLabel(value) {
 }
 
 function fixedSection(matrix, layout, reasons) {
-  const sourceYear = parseCashflowWeekLabel(matrix?.[layout.weekRowIndex]?.[WEEK_COLUMN_INDEXES[0]])?.year;
-  const weekColumns = WEEK_COLUMN_INDEXES.map((columnIndex, index) => {
-    const header = String(matrix?.[layout.weekRowIndex]?.[columnIndex] ?? '');
-    const parsed = parseCashflowWeekLabel(header);
-    const expectedLabel = Number.isSafeInteger(sourceYear)
-      ? `${String(sourceYear).slice(-2)}-${Math.floor(index / 5) + 1}-${index % 5 + 1}`
-      : '';
-    if (!parsed || header !== expectedLabel) {
-      throw new CashflowTemplateMismatchError(
-        `${toA1(layout.weekRowIndex, columnIndex)} 주차 헤더가 좌표 계약과 다릅니다.`,
-      );
+  const parsedWeekColumns = WEEK_COLUMN_INDEXES.map((columnIndex) => ({
+    columnIndex,
+    parsed: parseCashflowWeekLabel(matrix?.[layout.weekRowIndex]?.[columnIndex]),
+  }));
+  for (const { columnIndex, parsed } of parsedWeekColumns) {
+    if (!parsed) {
+      reasons.push({
+        code: 'cashflow_week_header_invalid',
+        mode: layout.mode,
+        sourceCell: toA1(layout.weekRowIndex, columnIndex),
+        message: `${toA1(layout.weekRowIndex, columnIndex)} 칸의 주차 표기를 26-1-1 형식으로 맞춰 주세요.`,
+      });
+    }
+  }
+  const parsedWeeks = parsedWeekColumns.filter(({ parsed }) => parsed);
+  const firstWeek = parsedWeeks[0];
+  const mixedYearWeek = parsedWeeks.find(({ parsed }) => parsed.year !== firstWeek?.parsed.year);
+  if (mixedYearWeek) {
+    reasons.push({
+      code: 'cashflow_week_years_mixed',
+      mode: layout.mode,
+      sourceCell: toA1(layout.weekRowIndex, mixedYearWeek.columnIndex),
+      message: `주차 헤더의 연도가 섞여 있습니다 (${toA1(layout.weekRowIndex, firstWeek.columnIndex)}=${firstWeek.parsed.year}, ${toA1(layout.weekRowIndex, mixedYearWeek.columnIndex)}=${mixedYearWeek.parsed.year}).`,
+    });
+  }
+  const sourceYear = parsedWeeks.length === WEEK_COLUMN_INDEXES.length && !mixedYearWeek
+    ? firstWeek?.parsed.year
+    : undefined;
+  const weekColumns = parsedWeekColumns.flatMap(({ columnIndex, parsed }, index) => {
+    if (!parsed) return [];
+    const expectedMonth = Math.floor(index / 5) + 1;
+    const expectedWeekNo = (index % 5) + 1;
+    if (parsed.month !== expectedMonth || parsed.weekNo !== expectedWeekNo) {
+      reasons.push({
+        code: 'cashflow_week_header_mismatch',
+        mode: layout.mode,
+        sourceCell: toA1(layout.weekRowIndex, columnIndex),
+        message: `${toA1(layout.weekRowIndex, columnIndex)} 칸의 주차 표기가 ${String(parsed.year).slice(-2)}-${expectedMonth}-${expectedWeekNo} 이어야 하는데 ${parsed.raw} 입니다. 표준 양식으로 맞춘 뒤 다시 불러와 주세요.`,
+      });
     }
     return {
       ...parsed,
@@ -98,25 +125,34 @@ function fixedSection(matrix, layout, reasons) {
     };
   });
 
-  const annualYears = annualYearsFor(sourceYear);
-  const annualColumns = ANNUAL_COLUMN_INDEXES.map((columnIndex, index) => {
+  const annualYears = Number.isSafeInteger(sourceYear) ? annualYearsFor(sourceYear) : [];
+  const annualColumns = ANNUAL_COLUMN_INDEXES.flatMap((columnIndex, index) => {
     const year = annualYears[index];
-    if (matrix?.[layout.headerRowIndex]?.[columnIndex] !== `${year}년`) {
-      throw new CashflowTemplateMismatchError(
-        `${toA1(layout.headerRowIndex, columnIndex)} 연간 헤더가 좌표 계약과 다릅니다.`,
-      );
+    if (!Number.isSafeInteger(year)) return [];
+    const header = normalizeText(matrix?.[layout.headerRowIndex]?.[columnIndex]);
+    if (header !== `${year}년`) {
+      reasons.push({
+        code: 'cashflow_annual_header_invalid',
+        mode: layout.mode,
+        sourceCell: toA1(layout.headerRowIndex, columnIndex),
+        message: `${toA1(layout.headerRowIndex, columnIndex)} 칸의 연간 표기가 ${year}년 이어야 하는데 ${header || '비어 있습니다'}.`,
+      });
     }
-    return {
+    return [{
       year,
       periodKind: 'ANNUAL',
       columnIndex,
       a1: toA1(layout.headerRowIndex, columnIndex),
-    };
+    }];
   });
-  if (matrix?.[layout.headerRowIndex]?.[SOURCE_YEAR_TOTAL_COLUMN_INDEX] !== 'Total') {
-    throw new CashflowTemplateMismatchError(
-      `${toA1(layout.headerRowIndex, SOURCE_YEAR_TOTAL_COLUMN_INDEX)} 합계 헤더가 좌표 계약과 다릅니다.`,
-    );
+  const totalHeader = normalizeText(matrix?.[layout.headerRowIndex]?.[SOURCE_YEAR_TOTAL_COLUMN_INDEX]);
+  if (totalHeader !== 'Total') {
+    reasons.push({
+      code: 'cashflow_total_header_invalid',
+      mode: layout.mode,
+      sourceCell: toA1(layout.headerRowIndex, SOURCE_YEAR_TOTAL_COLUMN_INDEX),
+      message: `${toA1(layout.headerRowIndex, SOURCE_YEAR_TOTAL_COLUMN_INDEX)} 칸의 합계 표기를 Total로 맞춰 주세요.`,
+    });
   }
   const totalColumn = {
     columnIndex: SOURCE_YEAR_TOTAL_COLUMN_INDEX,
@@ -124,7 +160,7 @@ function fixedSection(matrix, layout, reasons) {
   };
   // The source-year Total is retained as an annual reconciliation input as well as
   // a display-only grand total. It must never replace the weekly source of truth.
-  if (totalColumn) {
+  if (totalColumn && Number.isSafeInteger(sourceYear)) {
     annualColumns.push({
       year: sourceYear,
       periodKind: 'GRAND_TOTAL',
@@ -135,14 +171,18 @@ function fixedSection(matrix, layout, reasons) {
   const lineRows = LINE_ENTRIES.map((_, index) => {
     const rowIndex = lineRowFor(layout.mode, index);
     const expected = LINE_ENTRIES[lineIndexOfRow(layout.mode, rowIndex)];
-    const label = String(matrix?.[rowIndex]?.[0] ?? '');
+    const label = normalizeText(matrix?.[rowIndex]?.[0]);
     const expectedLabel = layout.mode === 'projection'
       ? expected?.projectionLabel || expected?.label
       : expected?.actualLabel || expected?.label;
-    if (!expected || label !== expectedLabel) {
-      throw new CashflowTemplateMismatchError(
-        `${toA1(rowIndex, 0)} 항목 라벨이 좌표 계약과 다릅니다.`,
-      );
+    if (!expected || label !== normalizeText(expectedLabel)) {
+      reasons.push({
+        code: 'cashflow_line_invalid',
+        mode: layout.mode,
+        sourceCell: toA1(rowIndex, 0),
+        lineIds: expected ? [expected.lineId] : [],
+        message: `${toA1(rowIndex, 0)} 칸의 항목명이 ${expectedLabel || '표준 항목'} 이어야 하는데 ${label || '비어 있습니다'}.`,
+      });
     }
     return {
       rowIndex,
@@ -236,6 +276,7 @@ function fixedSection(matrix, layout, reasons) {
     mode: layout.mode,
     headerRowIndex: layout.headerRowIndex,
     weekRowIndex: layout.weekRowIndex,
+    weeklyYear: sourceYear,
     weekColumns,
     annualColumns,
     totalColumn,
@@ -257,21 +298,33 @@ export function analyzeCashflowSheetTemplate(matrix) {
     : [];
   const reasons = [];
   const sections = SECTION_LAYOUTS.map((layout) => fixedSection(rows, layout, reasons));
-  const projectionWeeks = sections[0].weekColumns.map((week) => week.raw);
-  const actualWeeks = sections[1].weekColumns.map((week) => week.raw);
-  if (JSON.stringify(projectionWeeks) !== JSON.stringify(actualWeeks)) {
-    throw new CashflowTemplateMismatchError('Projection과 Actual 주차 헤더가 일치하지 않습니다.');
+  const projectionWeeks = sections[0].weekColumns.map((week) => [week.year, week.month, week.weekNo]);
+  const actualWeeks = sections[1].weekColumns.map((week) => [week.year, week.month, week.weekNo]);
+  if (projectionWeeks.length !== WEEK_COLUMN_INDEXES.length
+    || JSON.stringify(projectionWeeks) !== JSON.stringify(actualWeeks)) {
+    reasons.push({
+      code: 'cashflow_week_headers_mismatch',
+      message: 'Projection과 Actual 주차 표기가 일치하지 않습니다. 두 주차 행을 같은 연도와 순서로 맞춰 주세요.',
+    });
   }
 
   const projectionYears = sections[0].annualColumns.map((column) => column.year);
   const actualYears = sections[1].annualColumns.map((column) => column.year);
   if (JSON.stringify(projectionYears) !== JSON.stringify(actualYears)) {
-    throw new CashflowTemplateMismatchError('Projection과 Actual 연간 합계 헤더가 일치하지 않습니다.');
+    reasons.push({
+      code: 'cashflow_annual_headers_mismatch',
+      message: 'Projection과 Actual 연간 합계 표기가 일치하지 않습니다.',
+    });
   }
 
   const mappingCandidates = sections.flatMap((section) => section.mappings);
+  const weeklyYear = sections.every((section) => section.weeklyYear === sections[0].weeklyYear)
+    && Number.isSafeInteger(sections[0].weeklyYear)
+    ? sections[0].weeklyYear
+    : undefined;
   return {
     supported: reasons.length === 0,
+    weeklyYear,
     policyVersion: cashflowPolicyData.version || 'cashflow-policy-v1',
     sectionOrder: ['projection', 'actual'],
     sections,

--- a/server/bff/cashflow-sheet-template.test.mjs
+++ b/server/bff/cashflow-sheet-template.test.mjs
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import {
   analyzeCashflowSheetTemplate,
-  buildCashflowLineLookup,
   parseCashflowWeekLabel,
   toA1,
 } from './cashflow-sheet-template.mjs';
+import {
+  CashflowTemplateMismatchError,
+  lineIndexOfRow,
+  lineRowFor,
+} from './cashflow-coordinates.mjs';
 
 const PROJECTION_LABELS = [
   'MYSC 선입금 - 직접사업비 등',
@@ -120,41 +124,29 @@ describe('cashflow official fixed template', () => {
     ]));
   });
 
-  it('fails closed instead of guessing when an official coordinate changes', () => {
+  it('rejects instead of downgrading when a fixed row label changes', () => {
     const matrix = makeOfficialMatrix();
     matrix[14][0] = '';
 
-    const result = analyzeCashflowSheetTemplate(matrix);
-
-    expect(result.supported).toBe(false);
-    expect(result.reasons).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        code: 'cashflow_line_invalid',
-        mode: 'projection',
-        sourceCell: 'A15',
-        lineIds: ['MYSC_PREPAY_IN'],
-      }),
-    ]));
+    expect(() => analyzeCashflowSheetTemplate(matrix)).toThrow(CashflowTemplateMismatchError);
+    expect(() => analyzeCashflowSheetTemplate(matrix)).toThrow('양식이 다릅니다.');
   });
 
-  it('fails when Projection and Actual no longer describe the same 60 weeks', () => {
+  it('rejects when Projection and Actual no longer describe the same 60 weeks', () => {
     const matrix = makeOfficialMatrix();
     matrix[35][63] = '26-12-4';
 
-    const result = analyzeCashflowSheetTemplate(matrix);
-
-    expect(result.supported).toBe(false);
-    expect(result.reasons).toEqual(expect.arrayContaining([
-      expect.objectContaining({ code: 'cashflow_week_headers_mismatch' }),
-    ]));
+    expect(() => analyzeCashflowSheetTemplate(matrix)).toThrow(CashflowTemplateMismatchError);
   });
 
-  it('keeps ambiguous labels unresolved at the trust boundary', () => {
-    const resolve = buildCashflowLineLookup([
-      { lineId: 'LINE_A', label: '공 유 라벨', direction: 'IN', aliases: [] },
-      { lineId: 'LINE_B', label: '공유라벨', direction: 'IN', aliases: [] },
-    ]);
+  it('uses fixed row coordinates as line identity', () => {
+    const result = analyzeCashflowSheetTemplate(makeOfficialMatrix());
 
-    expect(resolve('공유라벨', 'projection', 'IN')).toBeNull();
+    for (const section of result.sections) {
+      section.lineRows.forEach((row, index) => {
+        expect(row.rowIndex).toBe(lineRowFor(section.mode, index));
+        expect(lineIndexOfRow(section.mode, row.rowIndex)).toBe(index);
+      });
+    }
   });
 });

--- a/server/bff/cashflow-sheet-template.test.mjs
+++ b/server/bff/cashflow-sheet-template.test.mjs
@@ -5,7 +5,6 @@ import {
   toA1,
 } from './cashflow-sheet-template.mjs';
 import {
-  CashflowTemplateMismatchError,
   lineIndexOfRow,
   lineRowFor,
 } from './cashflow-coordinates.mjs';
@@ -124,19 +123,73 @@ describe('cashflow official fixed template', () => {
     ]));
   });
 
-  it('rejects instead of downgrading when a fixed row label changes', () => {
+  it('collects every fixed-coordinate mismatch for one guided rejection', () => {
     const matrix = makeOfficialMatrix();
     matrix[14][0] = '';
+    matrix[15][0] = '';
+    matrix[12][4] = 'broken-week-header';
 
-    expect(() => analyzeCashflowSheetTemplate(matrix)).toThrow(CashflowTemplateMismatchError);
-    expect(() => analyzeCashflowSheetTemplate(matrix)).toThrow('양식이 다릅니다.');
+    const result = analyzeCashflowSheetTemplate(matrix);
+
+    expect(result.supported).toBe(false);
+    expect(result.reasons).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'cashflow_week_header_invalid', sourceCell: 'E13' }),
+      expect.objectContaining({ code: 'cashflow_line_invalid', sourceCell: 'A15' }),
+      expect.objectContaining({ code: 'cashflow_line_invalid', sourceCell: 'A16' }),
+    ]));
   });
 
   it('rejects when Projection and Actual no longer describe the same 60 weeks', () => {
     const matrix = makeOfficialMatrix();
     matrix[35][63] = '26-12-4';
 
-    expect(() => analyzeCashflowSheetTemplate(matrix)).toThrow(CashflowTemplateMismatchError);
+    const result = analyzeCashflowSheetTemplate(matrix);
+
+    expect(result.supported).toBe(false);
+    expect(result.reasons).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'cashflow_week_header_mismatch', sourceCell: 'BL36' }),
+      expect.objectContaining({ code: 'cashflow_week_headers_mismatch' }),
+    ]));
+  });
+
+  it('accepts equivalent week, annual, and total headers after normalization', () => {
+    const matrix = makeOfficialMatrix();
+    matrix[12][4] = ' 26-01-01 ';
+    matrix[35][4] = '26-1-1 ';
+    matrix[11][2] = '2024년 ';
+    matrix[34][2] = ' 2024년';
+    matrix[11][70] = 'Total ';
+    matrix[34][70] = ' Total';
+
+    const result = analyzeCashflowSheetTemplate(matrix);
+
+    expect(result.supported).toBe(true);
+    expect(result.weeklyYear).toBe(2026);
+  });
+
+  it('rejects a repeated week header even when all 60 labels parse', () => {
+    const matrix = makeOfficialMatrix();
+    matrix[12][5] = '26-1-1';
+
+    const result = analyzeCashflowSheetTemplate(matrix);
+
+    expect(result.supported).toBe(false);
+    expect(result.reasons).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'cashflow_week_header_mismatch', sourceCell: 'F13' }),
+    ]));
+  });
+
+  it('rejects mixed weekly years without anchoring the contract to E13', () => {
+    const matrix = makeOfficialMatrix();
+    matrix[12][31] = '25-6-3';
+
+    const result = analyzeCashflowSheetTemplate(matrix);
+
+    expect(result.supported).toBe(false);
+    expect(result.weeklyYear).toBeUndefined();
+    expect(result.reasons).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'cashflow_week_years_mixed', sourceCell: 'AF13' }),
+    ]));
   });
 
   it('uses fixed row coordinates as line identity', () => {
@@ -148,5 +201,18 @@ describe('cashflow official fixed template', () => {
         expect(lineIndexOfRow(section.mode, row.rowIndex)).toBe(index);
       });
     }
+  });
+
+  it('does not revive a removed alias as line identity', () => {
+    const matrix = makeOfficialMatrix();
+    matrix[14][0] = 'MYSC선입금';
+
+    const result = analyzeCashflowSheetTemplate(matrix);
+
+    expect(result.supported).toBe(false);
+    expect(result.sections[0].lineRows[0].lineId).toBe('MYSC_PREPAY_IN');
+    expect(result.reasons).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: 'cashflow_line_invalid', sourceCell: 'A15' }),
+    ]));
   });
 });

--- a/server/bff/java-weekly-client.mjs
+++ b/server/bff/java-weekly-client.mjs
@@ -572,10 +572,12 @@ export function createJavaWeeklyClient({
     context,
     projectId,
     idempotencyKey,
+    editSession,
     sourceRevision,
     year,
     expectedRevision,
     cells,
+    amendmentReason = '',
   }) {
     const normalizedProjectId = encodeURIComponent(readOptionalText(projectId));
     if (!normalizedProjectId) throw createHttpError(400, 'projectId is required.', 'project_id_required');
@@ -585,8 +587,16 @@ export function createJavaWeeklyClient({
       method: 'POST',
       path: `/api/v1/cashflow/${normalizedProjectId}/sheet-lab/annual/apply`,
       command: 'apply_cashflow_annual_total',
+      editSession,
       dataProjectId: bffDataProjectId,
-      body: { idempotencyKey, sourceRevision, year, expectedRevision, cells },
+      body: {
+        idempotencyKey,
+        sourceRevision,
+        year,
+        expectedRevision,
+        cells,
+        ...(readOptionalText(amendmentReason) ? { amendmentReason: readOptionalText(amendmentReason) } : {}),
+      },
     });
     if (readOptionalText(result?.projectId) !== readOptionalText(projectId)) {
       throw createHttpError(502, '다른 프로젝트의 자료가 도착했습니다. 화면을 새로고침해 주세요.', 'jvm_weekly_project_mismatch');

--- a/server/bff/java-weekly-client.test.mjs
+++ b/server/bff/java-weekly-client.test.mjs
@@ -115,6 +115,8 @@ describe('Java weekly cashflow client', () => {
       year: 2025,
       expectedRevision: 3,
       cells: [{ mode: 'projection', cashflowLine: 'SALES_IN', cellState: 'VALUE', amount: 2300000 }],
+      amendmentReason: '결산 후 실제 입금액 정정',
+      editSession: { sessionId: 'session-a', leaseId: 'lease-a', fence: 7, finalize: true },
     });
 
     const [url, init] = fetchImpl.mock.calls[0];
@@ -125,6 +127,13 @@ describe('Java weekly cashflow client', () => {
       year: 2025,
       expectedRevision: 3,
       cells: [{ mode: 'projection', cashflowLine: 'SALES_IN', cellState: 'VALUE', amount: 2300000 }],
+      amendmentReason: '결산 후 실제 입금액 정정',
+    });
+    expect(init.headers).toMatchObject({
+      'x-edit-session-id': 'session-a',
+      'x-edit-lease-id': 'lease-a',
+      'x-edit-fence': '7',
+      'x-edit-finalize': 'true',
     });
   });
 

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -3493,6 +3493,7 @@ async function applyStagedCashflowSheetLab({
               year: stagedYear.year,
               expectedRevision: stagedYear.expectedRevision,
               cells: stagedYear.cells,
+              amendmentReason: closedMonthChangeReason,
             }),
             verifyMutation: (javaResult) => ({
               status: 'APPLIED',

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -4308,7 +4308,7 @@ export function mountCashflowSheetLabRoutes(app, {
       if (!template.supported) {
         throw Object.assign(createHttpError(
           400,
-          '지원하지 않는 cashflow 시트 구조라 연동할 수 없습니다.',
+          '시트 양식이 표준과 다릅니다. 표시된 칸을 표준 양식으로 맞춘 뒤 다시 불러와 주세요.',
           'cashflow_sheet_template_unsupported',
         ), {
           diagnostics: template.reasons.slice(0, 20),
@@ -4337,6 +4337,7 @@ export function mountCashflowSheetLabRoutes(app, {
           role: req.context?.actorRole || 'workspace_user',
         },
       }));
+      mirror.weeklyYear = template.weeklyYear;
       mirror.activeWeekRange = {
         startWeek: weekRange.startWeek,
         endWeek: weekRange.endWeek,

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -749,7 +749,7 @@ function mergeCashflowSourceMirror(previous, next, sourceYear) {
     next?.sheetFacts?.annualFinancialTotals,
     (row) => Number(row?.year),
   );
-  const annualCashflowTotals = buildAnnualCashflowTotals({ cells, annualCells });
+  const annualCashflowTotals = buildAnnualCashflowTotals({ cells, annualCells, annualDerivedCells, weeklyYear: sourceYear });
   const cashflowGrandTotalsBySourceYear = [
     ...(previous?.sheetFacts?.cashflowGrandTotalsBySourceYear || [])
       .filter((row) => Number(row?.sourceYear) !== sourceYear),

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -1385,7 +1385,11 @@ describe('cashflow sheet lab route', () => {
 
     const applied = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
-      .send({ stageRunId: stage.body.runId, idempotencyKey: 'annual-apply-001' })
+      .send({
+        stageRunId: stage.body.runId,
+        closedMonthChangeReason: '결산 후 연간 합계 정정',
+        idempotencyKey: 'annual-apply-001',
+      })
       .expect(200);
     expect(applied.body).toMatchObject({
       appliedMonths: Array.from({ length: 12 }, (_unused, index) => `2026-${String(index + 1).padStart(2, '0')}`),
@@ -1405,6 +1409,7 @@ describe('cashflow sheet lab route', () => {
       projectId: 'project-a',
       year: 2025,
       expectedRevision: 0,
+      amendmentReason: '결산 후 연간 합계 정정',
       cells: expect.arrayContaining([
         expect.objectContaining({ mode: 'projection', cashflowLine: 'MYSC_PREPAY_IN', cellState: 'ZERO', amount: 0 }),
         expect.objectContaining({ mode: 'actual', cashflowLine: 'BANK_INTEREST_OUT', cellState: 'VALUE', amount: 50 }),

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -3128,7 +3128,8 @@ describe('cashflow sheet lab route', () => {
 
   it('shows legacy aggregate Actual removals for human review before the one-time sheet overwrite', async () => {
     const matrix = buildMatrixWithWeekLabels(JANUARY_FINANCE_WEEKS);
-    matrix[40][4] = '-';
+    // 진짜 빈칸이어야 미기입이다. Actual 의 '-' 는 회계 서식의 0 이라 제거가 아니라 0 변경 제안이 된다.
+    matrix[40][4] = '';
     const db = createDb({
       project: {
         id: 'project-a',

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -16,7 +16,7 @@ import { stableStringify } from '../utils.mjs';
 const PROJECTION_IN_LABELS = [
   'MYSC 선입금 - 직접사업비 등',
   'MYSC 선입금 - MYSC 인건비',
-  'MYSC 선입금 - 메입부가세',
+  'MYSC 선입금 - 매입부가세',
   '매출액(입금)',
   '매출부가세(입금)',
   '팀지원금(입금)',
@@ -403,6 +403,7 @@ async function loadSanitized260701FullYearFixture() {
       matrix[headerRowIndex][columnIndex] = columnIndex === 70 ? 'Total' : `${year}년`;
     }
   }
+  matrix[16][0] = 'MYSC 선입금 - 매입부가세';
   matrix[32][0] = '잔액 (※ 중요)';
   matrix[55][0] = '잔액';
   return matrix;
@@ -1169,6 +1170,7 @@ describe('cashflow sheet lab route', () => {
     expect(refreshed.body).toMatchObject({
       projectId: 'project-a',
       status: 'FRESH',
+      weeklyYear: 2026,
       sourceRevision: expect.stringMatching(/^sha256:/),
       targetRevisionAtFetch: expect.stringMatching(/^sha256:/),
       summary: { cellCount: 1920, valueCount: 1920, emptyCount: 0, invalidCount: 0 },
@@ -1180,6 +1182,7 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
     expect(pinned.body.sourceRevision).toBe(refreshed.body.sourceRevision);
     expect(pinned.body.cells).toHaveLength(1920);
+    expect(db.__getDocument('orgs/tenant-a/cashflow_sheet_mirrors/project-a')).toMatchObject({ weeklyYear: 2026 });
     expect(previewSpreadsheet).toHaveBeenCalledTimes(1);
     expect(db.__getDocument().cashflowSheetLab.activeWeeks).toBeUndefined();
     await new Promise((resolve) => setImmediate(resolve));
@@ -1869,6 +1872,44 @@ describe('cashflow sheet lab route', () => {
         code: 'cashflow_sheet_template_unsupported',
         diagnostics: expect.arrayContaining([
           expect.objectContaining({ code: 'cashflow_week_header_invalid', sourceCell: 'E13' }),
+        ]),
+      },
+    });
+  });
+
+  it('rejects a sheet whose weekly header row mixes years', async () => {
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        cashflowSheetLab: { value: 'spreadsheet-a', sheetName: 'cashflow(사용내역 연동)' },
+      },
+    });
+    const matrix = buildMatrix();
+    matrix[12][31] = '25-6-3';
+    const app = createApp({
+      db,
+      googleSheetsService: {
+        previewSpreadsheet: vi.fn(async () => ({
+          spreadsheetId: 'spreadsheet-a',
+          selectedSheetName: 'cashflow(사용내역 연동)',
+          availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
+          matrix,
+        })),
+      },
+    });
+
+    const response = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'mirror-mixed-weekly-years' })
+      .expect(200);
+
+    expect(response.body).toMatchObject({
+      status: 'ERROR',
+      lastRefreshError: {
+        code: 'cashflow_sheet_template_unsupported',
+        statusCode: 400,
+        diagnostics: expect.arrayContaining([
+          expect.objectContaining({ code: 'cashflow_week_years_mixed', sourceCell: 'AF13' }),
         ]),
       },
     });

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -1610,7 +1610,7 @@ describe('cashflow sheet lab route', () => {
     expect(retried2025[0].idempotencyKey).toBe(retried2025[1].idempotencyKey);
   });
 
-  it('warns but does not block when a complete weekly year conflicts with its annual total', async () => {
+  it('gives the weekly year no annual column so weekly and annual totals cannot conflict', async () => {
     const db = createDb({
       project: {
         id: 'project-a',
@@ -1639,9 +1639,16 @@ describe('cashflow sheet lab route', () => {
       .send({ idempotencyKey: 'conflicting-year-refresh' })
       .expect(200);
 
-    expect(mirror.body.reconciliationWarnings).toEqual(expect.arrayContaining([
-      expect.objectContaining({ year: 2026, mode: 'projection', status: 'MISMATCH' }),
-    ]));
+    // 좌표 계약: 주별 블록은 E:BL 하나뿐이고 연간 열은 그 해를 포함하지 않는다.
+    // 따라서 2026 은 주차 그리드에만 존재하고, 주차합과 연간값이 어긋날 자리가 없다.
+    const totals2026 = mirror.body.sheetFacts.annualCashflowTotals.find((row) => row.year === 2026);
+    expect(totals2026.projection.source).toBe('WEEKLY');
+    expect(totals2026.projection.reconciliation.status).toBe('NOT_APPLICABLE');
+    // 2026 으로 태깅된 셀은 Total 열(BS)의 GRAND_TOTAL 뿐이며 연간 열이 아니다.
+    expect(mirror.body.annualCells.some((cell) => (
+      Number(cell.year) === 2026 && cell.periodKind !== 'GRAND_TOTAL'
+    ))).toBe(false);
+    expect(mirror.body.reconciliationWarnings).toEqual([]);
 
     await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
@@ -2278,7 +2285,12 @@ describe('cashflow sheet lab route', () => {
     const cells2025 = mirror.body.annualCells.filter((cell) => cell.year === 2025);
     expect(cells2025).toHaveLength(32);
     expect(new Set(cells2025.map((cell) => cell.sourceYear))).toEqual(new Set([2026]));
-    expect(mirror.body.sheetFacts.annualCashflowTotals.find((row) => row.year === 2025).projection.totalIn).toBe(700);
+    const totals2025 = mirror.body.sheetFacts.annualCashflowTotals.find((row) => row.year === 2025).projection;
+    expect(totals2025.valueCellCount).toBe(16);
+    expect(totals2025.lineAmounts.SALES_IN).toBe(100);
+    // 합계는 시트의 입금 합계 행 좌표에서만 온다. 이 fixture 는 그 칸이 비어 있으므로
+    // 라인 합(700)으로 대체하지 않고 값이 없는 채로 둔다.
+    expect(totals2025.totalIn).toBeNull();
   });
 
   it('invalidates the pinned mirror and staged run when the saved sheet config changes', async () => {

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -880,11 +880,17 @@ function futurePrepayCheck(weeks, asOfKey) {
 
 export function buildCashflowManagementChecks({
   cashflow, cells, yearMonth, depositScheduleRows, comparisonBoundary, pinnedSheetCells,
-  projectionOpeningBalance = 0, weeklyYear = Number(yearMonth?.slice(0, 4)), monthState = 'LIVE_CURRENT',
+  projectionOpeningBalance = 0, weeklyYear = null, monthState = null,
 }) {
   const canonicalWeeklyYear = readWeeklyYear(weeklyYear);
-  const weeks = canonicalCashflowWeeks(cashflow, cells, yearMonth, pinnedSheetCells, canonicalWeeklyYear, monthState);
-  const cellStates = canonicalCashflowCellStates(cashflow, cells, yearMonth, pinnedSheetCells, canonicalWeeklyYear, monthState);
+  const hasCanonicalSource = canonicalWeeklyYear !== null
+    && ['FROZEN_COMPLETE', 'MONTH_CELLS', 'LIVE_CURRENT', 'LIVE_AMENDED'].includes(monthState);
+  const weeks = hasCanonicalSource
+    ? canonicalCashflowWeeks(cashflow, cells, yearMonth, pinnedSheetCells, canonicalWeeklyYear, monthState)
+    : [];
+  const cellStates = hasCanonicalSource
+    ? canonicalCashflowCellStates(cashflow, cells, yearMonth, pinnedSheetCells, canonicalWeeklyYear, monthState)
+    : new Map();
   const asOfKey = cashflowRangeSortKey(comparisonBoundary?.asOfWeek || { yearMonth, weekNo: 5 });
   const deposits = (Array.isArray(depositScheduleRows) ? depositScheduleRows : []).map((row) => ({
     ...row,
@@ -1733,32 +1739,19 @@ function annualModeFromStoredDocument(document, mode) {
   };
 }
 
-async function readAnnualTotals({ db, tenantId, projectId, weeklyYear, frozen }) {
+async function readAnnualTotals({ db, tenantId, projectId, weeklyYear }) {
   if (readWeeklyYear(weeklyYear) === null) return null;
   const years = annualYearsFor(weeklyYear);
-  if (frozen) {
-    return years.map((year) => ({ year, status: 'UNKNOWN', reason: 'annual_totals_not_frozen' }));
-  }
   const documents = await Promise.all(years.map((year) => (
     readDocument(db, cashflowAnnualTotalDocPath(tenantId, projectId, year))
-      .catch(() => ({ unavailable: true }))
+      .catch(() => null)
   )));
-  return years.map((year, index) => {
+  return years.flatMap((year, index) => {
     const document = documents[index];
     const identityMatches = document?.projectId === projectId && Number(document?.year) === year;
     const projection = identityMatches ? annualModeFromStoredDocument(document, 'projection') : null;
     const actual = identityMatches ? annualModeFromStoredDocument(document, 'actual') : null;
-    return projection && actual
-      ? { year, projection, actual }
-      : {
-        year,
-        status: 'UNKNOWN',
-        reason: document?.unavailable
-          ? 'annual_totals_unavailable'
-          : document
-            ? 'annual_totals_incomplete'
-            : 'annual_totals_missing',
-      };
+    return projection && actual ? [{ year, projection, actual }] : [];
   });
 }
 
@@ -1970,7 +1963,6 @@ async function composeCashflowMonthDashboard({
     tenantId,
     projectId,
     weeklyYear,
-    frozen: Boolean(closedSnapshot) && !amendedCurrent,
   });
   const projectionMode = buildMonthModeReadModel(cells, 'projection');
   const actualMode = buildMonthModeReadModel(cells, 'actual');
@@ -2060,6 +2052,9 @@ async function composeCashflowMonthDashboard({
     blockers.push(...monthSheetCalculationBlockers(sheetFacts, yearMonth));
     if (!completeMonthCloseCells(cells)) blockers.push({ code: 'SHEET_MONTH_INCOMPLETE', message: '선택한 월의 160개 캐시플로우 값을 다시 불러와 주세요.' });
     if (!projectionMode || !actualMode) blockers.push({ code: 'AMOUNT_OUT_OF_RANGE', message: '지원 범위를 넘는 금액이 있습니다.' });
+  }
+  if (weeklyYear !== null && annualTotals.length !== annualYearsFor(weeklyYear).length) {
+    blockers.push({ code: 'SHEET_SOURCE_REQUIRED', message: '먼저 시트값을 불러와 주세요.' });
   }
   const contractAmount = safeAmount(project?.contractAmount);
   let projectionComposition;

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -12,6 +12,7 @@ import {
 } from '../java-weekly-auth.mjs';
 import { assertCashflowMutationRuntime, createJavaWeeklyClient } from '../java-weekly-client.mjs';
 import { createCashflowPerformanceTrace } from '../cashflow-performance.mjs';
+import { cashflowAnnualTotalDocPath } from '../cashflow-annual-total.mjs';
 import {
   buildCashflowProjectionActualComparison,
   resolveCashflowComparisonAsOf,
@@ -20,6 +21,7 @@ import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES } from '../ca
 import { stableStringify } from '../utils.mjs';
 import { cashflowApplyLeaseMs, readCashflowApplyLeaseState } from '../cashflow-apply-lease.mjs';
 import { getMonthFinanceWeeks } from '../../../src/app/platform/cashflow-week-core.mjs';
+import { WEEKS_PER_MONTH, annualYearsFor, weekOrdinal } from '../cashflow-coordinates.mjs';
 import { createHash } from 'node:crypto';
 
 const CASHFLOW_MANAGEMENT_CHECK_IDS = [
@@ -28,11 +30,17 @@ const CASHFLOW_MANAGEMENT_CHECK_IDS = [
   'negative-projection-balance',
   'future-prepay-over-million',
 ];
+const CASHFLOW_LINE_INDEX = new Map(CASHFLOW_ALL_LINES.map((lineId, index) => [lineId, index]));
 const CASHFLOW_MONTH_CLOSE_ROUTE_TIMEOUT_MS = 26_000;
 const CASHFLOW_MONTH_CLOSE_MUTATION_BUDGET_MS = 12_000;
 const CASHFLOW_MONTH_CLOSE_REQUEST_MAX_BYTES = 900_000;
 const CASHFLOW_CUMULATIVE_CLOSE_CONTRACT = 'cashflow-cumulative-close-v2';
 const CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH = '2023-01';
+
+function readWeeklyYear(value) {
+  const year = Number(value);
+  return Number.isSafeInteger(year) && year >= 2000 && year <= 2099 ? year : null;
+}
 
 function cashflowMonthCloseTimeoutError() {
   return createHttpError(
@@ -551,16 +559,30 @@ function sumSafe(values) {
   return total;
 }
 
-function buildMonthModeReadModel(cells, mode) {
+function indexMonthCells(cells) {
+  const indexed = Array(CASHFLOW_ALL_LINES.length * 2 * WEEKS_PER_MONTH);
+  for (const cell of Array.isArray(cells) ? cells : []) {
+    const lineIndex = CASHFLOW_LINE_INDEX.get(cell?.cashflowLine);
+    const modeIndex = cell?.mode === 'projection' ? 0 : cell?.mode === 'actual' ? 1 : -1;
+    if (lineIndex === undefined || modeIndex === -1 || !Number.isInteger(cell?.weekNo)) continue;
+    indexed[(modeIndex * WEEKS_PER_MONTH + cell.weekNo - 1) * CASHFLOW_ALL_LINES.length + lineIndex] = cell;
+  }
+  return indexed;
+}
+
+function indexedMonthCell(indexed, mode, weekNo, lineId) {
+  const modeIndex = mode === 'projection' ? 0 : 1;
+  return indexed[(modeIndex * WEEKS_PER_MONTH + weekNo - 1) * CASHFLOW_ALL_LINES.length + CASHFLOW_LINE_INDEX.get(lineId)];
+}
+
+function buildMonthModeReadModel(cells, mode, indexed = indexMonthCells(cells)) {
   const rowTotals = Object.fromEntries(CASHFLOW_ALL_LINES.map((lineId) => [lineId, 0]));
   let runningIn = 0;
   let runningOut = 0;
-  const weeks = Array.from({ length: 5 }, (_, index) => {
+  const weeks = Array.from({ length: WEEKS_PER_MONTH }, (_, index) => {
     const weekNo = index + 1;
     const amounts = Object.fromEntries(CASHFLOW_ALL_LINES.map((lineId) => {
-      const cell = cells.find((candidate) => (
-        candidate.mode === mode && candidate.weekNo === weekNo && candidate.cashflowLine === lineId
-      ));
+      const cell = indexedMonthCell(indexed, mode, weekNo, lineId);
       return [lineId, ['VALUE', 'ZERO'].includes(cell?.cellState) ? safeAmount(cell.amount) : 0];
     }));
     for (const lineId of CASHFLOW_ALL_LINES) rowTotals[lineId] += amounts[lineId];
@@ -608,16 +630,17 @@ function monthWeeksFromCells(cells, yearMonth) {
     projection: buildMonthModeReadModel(cells, 'projection'),
     actual: buildMonthModeReadModel(cells, 'actual'),
   };
-  return Array.from({ length: 5 }, (_, index) => {
+  const financeWeeks = getMonthFinanceWeeks(yearMonth);
+  return Array.from({ length: WEEKS_PER_MONTH }, (_, index) => {
     const weekNo = index + 1;
-    const financeWeek = getMonthFinanceWeeks(yearMonth).find((week) => week.weekNo === weekNo) || {};
+    const financeWeek = financeWeeks[index];
     return {
       yearMonth,
       weekNo,
-      weekStart: financeWeek.weekStart || '',
-      weekEnd: financeWeek.weekEnd || '',
-      projection: modes.projection?.weeks?.find((week) => week.weekNo === weekNo)?.amounts || {},
-      actual: modes.actual?.weeks?.find((week) => week.weekNo === weekNo)?.amounts || {},
+      weekStart: financeWeek?.weekStart || '',
+      weekEnd: financeWeek?.weekEnd || '',
+      projection: modes.projection?.weeks?.[index]?.amounts || {},
+      actual: modes.actual?.weeks?.[index]?.amounts || {},
     };
   });
 }
@@ -640,41 +663,61 @@ function canonicalPinnedSheetWeeks(pinnedSheetCells) {
     .sort((left, right) => cashflowRangeSortKey(left) - cashflowRangeSortKey(right));
 }
 
-function canonicalCashflowWeeks(cashflow, cells, yearMonth, pinnedSheetCells) {
-  const pinnedWeeks = canonicalPinnedSheetWeeks(pinnedSheetCells);
-  const byKey = new Map();
-  for (const month of Array.isArray(cashflow?.readModel?.months) ? cashflow.readModel.months : []) {
-    const monthKey = readOptionalText(month?.yearMonth);
-    if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(monthKey)) continue;
-    const financeWeeks = getMonthFinanceWeeks(monthKey);
-    for (let weekNo = 1; weekNo <= 5; weekNo += 1) {
-      const financeWeek = financeWeeks.find((week) => week.weekNo === weekNo) || {};
-      byKey.set(`${monthKey}:${weekNo}`, {
-        yearMonth: monthKey,
-        weekNo,
-        weekStart: financeWeek.weekStart || '',
-        weekEnd: financeWeek.weekEnd || '',
-        projection: month?.projection?.weeks?.find((week) => Number(week?.weekNo) === weekNo)?.amounts || {},
-        actual: month?.actual?.weeks?.find((week) => Number(week?.weekNo) === weekNo)?.amounts || {},
-      });
-    }
+function cashflowMonthsByCoordinate(months, weeklyYear) {
+  if (readWeeklyYear(weeklyYear) === null) return [];
+  const indexed = Array(12);
+  for (const month of Array.isArray(months) ? months : []) {
+    const ordinal = weekOrdinal(weeklyYear, readOptionalText(month?.yearMonth), 1);
+    if (ordinal !== -1) indexed[Math.trunc(ordinal / WEEKS_PER_MONTH)] = month;
   }
-  if (byKey.size > 0) {
-    for (const pinnedWeek of pinnedWeeks) {
-      const key = `${pinnedWeek.yearMonth}:${pinnedWeek.weekNo}`;
-      if (!byKey.has(key)) byKey.set(key, { ...pinnedWeek, projection: {}, actual: {} });
+  return indexed;
+}
+
+function cashflowWeeksByCoordinate(weeks, weeklyYear, yearMonth) {
+  if (readWeeklyYear(weeklyYear) === null) return [];
+  const indexed = Array(WEEKS_PER_MONTH);
+  for (const week of Array.isArray(weeks) ? weeks : []) {
+    const ordinal = weekOrdinal(weeklyYear, yearMonth, week?.weekNo);
+    if (ordinal !== -1) indexed[ordinal % WEEKS_PER_MONTH] = week;
+  }
+  return indexed;
+}
+
+function canonicalCashflowWeeks(cashflow, cells, yearMonth, pinnedSheetCells, weeklyYear, monthState) {
+  if (readWeeklyYear(weeklyYear) === null) return [];
+  const byKey = new Map();
+  if (monthState === 'FROZEN_COMPLETE') {
+    for (const week of canonicalPinnedSheetWeeks(pinnedSheetCells)) {
+      if (weekOrdinal(weeklyYear, week.yearMonth, week.weekNo) !== -1) {
+        byKey.set(`${week.yearMonth}:${week.weekNo}`, week);
+      }
     }
     return [...byKey.values()].sort((left, right) => cashflowRangeSortKey(left) - cashflowRangeSortKey(right));
   }
-  if (pinnedWeeks.length > 0) {
-    const pinnedByKey = new Map(pinnedWeeks.map((week) => [`${week.yearMonth}:${week.weekNo}`, week]));
-    if (completeMonthCloseCells(cells)) {
-      for (const week of monthWeeksFromCells(cells, yearMonth)) pinnedByKey.set(`${yearMonth}:${week.weekNo}`, week);
+  if (monthState === 'MONTH_CELLS') {
+    if (weekOrdinal(weeklyYear, yearMonth, 1) !== -1) {
+      for (const week of monthWeeksFromCells(cells, yearMonth)) byKey.set(`${yearMonth}:${week.weekNo}`, week);
     }
-    return [...pinnedByKey.values()].sort((left, right) => cashflowRangeSortKey(left) - cashflowRangeSortKey(right));
+    return [...byKey.values()].sort((left, right) => cashflowRangeSortKey(left) - cashflowRangeSortKey(right));
   }
-  if (completeMonthCloseCells(cells)) {
-    for (const week of monthWeeksFromCells(cells, yearMonth)) byKey.set(`${yearMonth}:${week.weekNo}`, week);
+  for (const month of Array.isArray(cashflow?.readModel?.months) ? cashflow.readModel.months : []) {
+    const monthKey = readOptionalText(month?.yearMonth);
+    if (weekOrdinal(weeklyYear, monthKey, 1) === -1) continue;
+    const financeWeeks = getMonthFinanceWeeks(monthKey);
+    const projectionWeeks = cashflowWeeksByCoordinate(month?.projection?.weeks, weeklyYear, monthKey);
+    const actualWeeks = cashflowWeeksByCoordinate(month?.actual?.weeks, weeklyYear, monthKey);
+    for (let weekIndex = 0; weekIndex < WEEKS_PER_MONTH; weekIndex += 1) {
+      const weekNo = weekIndex + 1;
+      const financeWeek = financeWeeks[weekIndex];
+      byKey.set(`${monthKey}:${weekNo}`, {
+        yearMonth: monthKey,
+        weekNo,
+        weekStart: financeWeek?.weekStart || '',
+        weekEnd: financeWeek?.weekEnd || '',
+        projection: projectionWeeks[weekIndex]?.amounts || {},
+        actual: actualWeeks[weekIndex]?.amounts || {},
+      });
+    }
   }
   return [...byKey.values()].sort((left, right) => (
     cashflowRangeSortKey(left) - cashflowRangeSortKey(right)
@@ -685,13 +728,14 @@ function cashflowCellKey(yearMonth, cell) {
   return `${yearMonth}:${cell.mode}:${cell.weekNo}:${cell.cashflowLine}`;
 }
 
-function canonicalCashflowCellStates(cashflow, cells, yearMonth, pinnedSheetCells) {
+function canonicalCashflowCellStates(cashflow, cells, yearMonth, pinnedSheetCells, weeklyYear, monthState) {
+  if (readWeeklyYear(weeklyYear) === null) return new Map();
   const canonicalMonths = Array.isArray(cashflow?.readModel?.months) ? cashflow.readModel.months : [];
-  if (canonicalMonths.length > 0) {
+  if (['LIVE_CURRENT', 'LIVE_AMENDED'].includes(monthState)) {
     const canonical = new Map();
     for (const month of canonicalMonths) {
       const monthKey = readOptionalText(month?.yearMonth);
-      if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(monthKey)) continue;
+      if (weekOrdinal(weeklyYear, monthKey, 1) === -1) continue;
       for (const mode of ['projection', 'actual']) {
         for (const week of Array.isArray(month?.[mode]?.weeks) ? month[mode].weeks : []) {
           const weekNo = Number(week?.weekNo);
@@ -713,15 +757,13 @@ function canonicalCashflowCellStates(cashflow, cells, yearMonth, pinnedSheetCell
     return canonical;
   }
   const byKey = new Map();
-  for (const sourceCell of Array.isArray(pinnedSheetCells) ? pinnedSheetCells : []) {
+  const sourceCells = monthState === 'FROZEN_COMPLETE' ? pinnedSheetCells : cells;
+  for (const sourceCell of Array.isArray(sourceCells) ? sourceCells : []) {
     const source = objectValue(sourceCell);
-    const sourceYearMonth = readOptionalText(source?.yearMonth);
-    if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(sourceYearMonth)) continue;
+    const sourceYearMonth = monthState === 'MONTH_CELLS' ? yearMonth : readOptionalText(source?.yearMonth);
+    if (weekOrdinal(weeklyYear, sourceYearMonth, source?.weekNo) === -1) continue;
     const cell = normalizeMonthCloseCell(source, sourceYearMonth);
     if (cell) byKey.set(cashflowCellKey(sourceYearMonth, cell), cell);
-  }
-  for (const cell of Array.isArray(cells) ? cells : []) {
-    if (cell) byKey.set(cashflowCellKey(yearMonth, cell), cell);
   }
   return byKey;
 }
@@ -836,9 +878,13 @@ function futurePrepayCheck(weeks, asOfKey) {
   );
 }
 
-export function buildCashflowManagementChecks({ cashflow, cells, yearMonth, depositScheduleRows, comparisonBoundary, pinnedSheetCells, projectionOpeningBalance = 0 }) {
-  const weeks = canonicalCashflowWeeks(cashflow, cells, yearMonth, pinnedSheetCells);
-  const cellStates = canonicalCashflowCellStates(cashflow, cells, yearMonth, pinnedSheetCells);
+export function buildCashflowManagementChecks({
+  cashflow, cells, yearMonth, depositScheduleRows, comparisonBoundary, pinnedSheetCells,
+  projectionOpeningBalance = 0, weeklyYear = Number(yearMonth?.slice(0, 4)), monthState = 'LIVE_CURRENT',
+}) {
+  const canonicalWeeklyYear = readWeeklyYear(weeklyYear);
+  const weeks = canonicalCashflowWeeks(cashflow, cells, yearMonth, pinnedSheetCells, canonicalWeeklyYear, monthState);
+  const cellStates = canonicalCashflowCellStates(cashflow, cells, yearMonth, pinnedSheetCells, canonicalWeeklyYear, monthState);
   const asOfKey = cashflowRangeSortKey(comparisonBoundary?.asOfWeek || { yearMonth, weekNo: 5 });
   const deposits = (Array.isArray(depositScheduleRows) ? depositScheduleRows : []).map((row) => ({
     ...row,
@@ -1051,19 +1097,21 @@ function buildCashflowRangeTotals(months, mode, range) {
   return { rowTotals, totalIn, totalOut, net };
 }
 
-function cashflowReadModelForYear(readModel, selectedYear) {
+function cashflowReadModelForYear(readModel, weeklyYear) {
   const canonical = objectValue(readModel);
-  if (!canonical || !Array.isArray(canonical.months)) return null;
+  if (!canonical || !Array.isArray(canonical.months) || readWeeklyYear(weeklyYear) === null) return null;
+  const months = cashflowMonthsByCoordinate(canonical.months, weeklyYear).filter(Boolean);
   const range = {
-    start: { yearMonth: `${selectedYear}-01`, weekNo: 1 },
-    end: { yearMonth: `${selectedYear}-12`, weekNo: 5 },
+    start: { yearMonth: `${weeklyYear}-01`, weekNo: 1 },
+    end: { yearMonth: `${weeklyYear}-12`, weekNo: WEEKS_PER_MONTH },
   };
   return {
     ...canonical,
+    months,
     range: {
       ...range,
-      projection: buildCashflowRangeTotals(canonical.months, 'projection', range),
-      actual: buildCashflowRangeTotals(canonical.months, 'actual', range),
+      projection: buildCashflowRangeTotals(months, 'projection', range),
+      actual: buildCashflowRangeTotals(months, 'actual', range),
     },
   };
 }
@@ -1190,18 +1238,15 @@ function dashboardTotals(mode) {
 function buildCashflowMonthCloseMonthSnapshot({
   projectId, yearMonth, cells, sourceRevision, targetRevision, capturedAt, spreadsheetId, spreadsheetTitle, selectedSheetName,
 }) {
+  const indexedCells = indexMonthCells(cells);
   const modeSnapshot = (mode) => {
-    const totals = dashboardTotals(buildMonthModeReadModel(cells, mode));
+    const totals = dashboardTotals(buildMonthModeReadModel(cells, mode, indexedCells));
     return {
       ...totals,
       weeks: totals.weeks.map((week) => ({
         ...week,
         cells: CASHFLOW_ALL_LINES.map((cashflowLine) => {
-          const cell = cells.find((candidate) => (
-            candidate.mode === mode
-            && candidate.weekNo === week.weekNo
-            && candidate.cashflowLine === cashflowLine
-          ));
+          const cell = indexedMonthCell(indexedCells, mode, week.weekNo, cashflowLine);
           return { cashflowLine, cellState: cell.cellState, amount: cell.amount };
         }),
       })),
@@ -1230,10 +1275,10 @@ function buildCashflowMonthCloseMonthSnapshot({
   };
 }
 
-function canonicalWeeklyProjection(cashflow, fallback) {
-  const months = Array.isArray(cashflow?.readModel?.months) ? cashflow.readModel.months : [];
+function canonicalWeeklyProjection(cashflow, fallback, weeklyYear) {
+  const months = cashflowMonthsByCoordinate(cashflow?.readModel?.months, weeklyYear).filter(Boolean);
   const boundaries = cashflowReadModelBoundaries(months);
-  if (boundaries.length === 0) return { ...fallback, weeklyYears: [] };
+  if (boundaries.length === 0) return fallback;
   const totals = buildCashflowRangeTotals(months, 'projection', {
     start: boundaries[0],
     end: boundaries.at(-1),
@@ -1241,9 +1286,6 @@ function canonicalWeeklyProjection(cashflow, fallback) {
   return {
     totalIn: totals.totalIn,
     salesAndVatTotal: safeAmount(totals.rowTotals?.SALES_IN) + safeAmount(totals.rowTotals?.SALES_VAT_IN),
-    weeklyYears: [...new Set(months
-      .map((month) => Number(readOptionalText(month?.yearMonth).slice(0, 4)))
-      .filter(Number.isSafeInteger))],
   };
 }
 
@@ -1260,19 +1302,17 @@ function projectFinancialYears(project = {}) {
     .filter(Number.isSafeInteger))].sort((left, right) => left - right);
 }
 
-function composeProjectionTotal({ project, cashflow, mirror, fallback, weeklyYearsHint = [] }) {
-  const weekly = canonicalWeeklyProjection(cashflow, fallback);
-  weekly.weeklyYears = [...new Set([...weekly.weeklyYears, ...weeklyYearsHint])].sort((left, right) => left - right);
-  const annualYears = projectFinancialYears(project).filter((year) => !weekly.weeklyYears.includes(year));
-  const annualTotals = new Map((Array.isArray(mirror?.sheetFacts?.annualCashflowTotals)
-    ? mirror.sheetFacts.annualCashflowTotals
-    : []).map((row) => [Number(row?.year), row]));
-  const appliedAnnualYears = new Set((Array.isArray(mirror?.appliedAnnualYears)
-    ? mirror.appliedAnnualYears
-    : []).map(Number));
-  const sourceIsApplied = readOptionalText(mirror?.appliedSourceRevision) === readOptionalText(mirror?.sourceRevision);
+function composeProjectionTotal({ project, cashflow, annualTotals, fallback, weeklyYear }) {
+  const canonicalWeeklyYear = readWeeklyYear(weeklyYear);
+  if (canonicalWeeklyYear === null) return { ...fallback, years: [] };
+  const weekly = canonicalWeeklyProjection(cashflow, fallback, canonicalWeeklyYear);
+  const projectYears = projectFinancialYears(project);
+  const annualYears = annualYearsFor(canonicalWeeklyYear).filter((year) => projectYears.includes(year));
+  const annualByYear = new Map((Array.isArray(annualTotals) ? annualTotals : [])
+    .filter((row) => Number.isSafeInteger(row?.projection?.totalIn))
+    .map((row) => [Number(row.year), row]));
   const annual = annualYears.map((year) => {
-    const total = sourceIsApplied && appliedAnnualYears.has(year) ? annualTotals.get(year) : null;
+    const total = annualByYear.get(year);
     return {
       year,
       source: total ? 'ANNUAL' : 'MISSING',
@@ -1286,7 +1326,7 @@ function composeProjectionTotal({ project, cashflow, mirror, fallback, weeklyYea
     totalIn: weekly.totalIn + annual.reduce((sum, row) => sum + row.totalIn, 0),
     salesAndVatTotal: weekly.salesAndVatTotal + annual.reduce((sum, row) => sum + row.salesAndVatTotal, 0),
     years: [
-      ...weekly.weeklyYears.map((year) => ({ year, source: 'WEEKLY' })),
+      { year: canonicalWeeklyYear, source: 'WEEKLY' },
       ...annual,
     ].sort((left, right) => left.year - right.year),
   };
@@ -1676,6 +1716,52 @@ async function readDocument(db, path) {
   return snapshot.exists ? snapshot.data() || {} : null;
 }
 
+function annualModeFromStoredDocument(document, mode) {
+  const lineAmounts = objectValue(document?.[mode]);
+  const lineStates = objectValue(document?.[`${mode}States`]);
+  if (!lineAmounts || !lineStates || !CASHFLOW_ALL_LINES.every((lineId) => (
+    (lineStates[lineId] === 'EMPTY' && !Object.hasOwn(lineAmounts, lineId))
+    || (lineStates[lineId] === 'ZERO' && lineAmounts[lineId] === 0)
+    || (lineStates[lineId] === 'VALUE' && Number.isSafeInteger(lineAmounts[lineId]))
+  ))) return null;
+  return {
+    lineAmounts,
+    lineStates,
+    totalIn: null,
+    totalOut: null,
+    net: null,
+  };
+}
+
+async function readAnnualTotals({ db, tenantId, projectId, weeklyYear, frozen }) {
+  if (readWeeklyYear(weeklyYear) === null) return null;
+  const years = annualYearsFor(weeklyYear);
+  if (frozen) {
+    return years.map((year) => ({ year, status: 'UNKNOWN', reason: 'annual_totals_not_frozen' }));
+  }
+  const documents = await Promise.all(years.map((year) => (
+    readDocument(db, cashflowAnnualTotalDocPath(tenantId, projectId, year))
+      .catch(() => ({ unavailable: true }))
+  )));
+  return years.map((year, index) => {
+    const document = documents[index];
+    const identityMatches = document?.projectId === projectId && Number(document?.year) === year;
+    const projection = identityMatches ? annualModeFromStoredDocument(document, 'projection') : null;
+    const actual = identityMatches ? annualModeFromStoredDocument(document, 'actual') : null;
+    return projection && actual
+      ? { year, projection, actual }
+      : {
+        year,
+        status: 'UNKNOWN',
+        reason: document?.unavailable
+          ? 'annual_totals_unavailable'
+          : document
+            ? 'annual_totals_incomplete'
+            : 'annual_totals_missing',
+      };
+  });
+}
+
 function validOpeningBalanceMode(mode, selectedYear) {
   if (
     !objectValue(mode)
@@ -1773,13 +1859,21 @@ function requireUnchangedReviewedOpeningBalances(reviewed, current) {
   }
 }
 
-function deadlineSummaryFromCompliance(compliance, comparisonBoundary) {
-  const items = Array.isArray(compliance?.items) ? compliance.items : [];
+function deadlineSummaryFromCompliance(compliance, comparisonBoundary, weeklyYear) {
+  const canonicalWeeklyYear = readWeeklyYear(weeklyYear);
+  const items = canonicalWeeklyYear === null ? [] : Array.isArray(compliance?.items) ? compliance.items : [];
   const completedLateCount = items.filter((item) => readOptionalText(item?.status) === 'COMPLETED_LATE').length;
-  const current = items.find((item) => (
-    item.yearMonth === comparisonBoundary?.asOfWeek?.yearMonth
-    && Number(item.weekNo) === Number(comparisonBoundary?.asOfWeek?.weekNo)
-  )) || null;
+  const indexed = Array(12 * WEEKS_PER_MONTH);
+  for (const item of items) {
+    const ordinal = weekOrdinal(canonicalWeeklyYear, item?.yearMonth, item?.weekNo);
+    if (ordinal !== -1) indexed[ordinal] = item;
+  }
+  const currentOrdinal = canonicalWeeklyYear === null ? -1 : weekOrdinal(
+    canonicalWeeklyYear,
+    comparisonBoundary?.asOfWeek?.yearMonth,
+    comparisonBoundary?.asOfWeek?.weekNo,
+  );
+  const current = currentOrdinal === -1 ? null : indexed[currentOrdinal] || null;
   return {
     trackingStartedAt: null,
     onTimeCount: Number(compliance?.onTimeCount) || 0,
@@ -1823,26 +1917,61 @@ async function composeCashflowMonthDashboard({
       readDocument(db, `orgs/${tenantId}/projects/${projectId}`),
       readDocument(db, `orgs/${tenantId}/cashflow_sheet_mirrors/${projectId}`),
     ]);
-  const project = closedSnapshot?.project || projectDocument || {};
-  const sheetFacts = closedSnapshot?.sheetFacts || mirror?.sheetFacts || null;
-  const mirrorCells = normalizeMonthCloseCells(mirror?.cells, yearMonth);
-  const frozenCells = closedSnapshot
-    ? closeSnapshotCells(closedSnapshot, yearMonth)
-    : mirrorCells;
   const selectedYear = Number(yearMonth.slice(0, 4));
-  const frozenCanonical = closedSnapshot
-    ? objectValue(closedSnapshot?.canonical) || frozenCashflowReadModel(closedSnapshot?.ledgerWeeks)
-    : null;
+  const weeklyYear = closedSnapshot
+    ? readWeeklyYear(closedSnapshot.weeklyYear) ?? readWeeklyYear(selectedYear)
+    : readWeeklyYear(mirror?.weeklyYear);
+  let project;
+  let sheetFacts;
+  let cells;
+  let canonicalSource;
+  let confirmations;
+  let managementConfirmations;
+  let depositScheduleRows;
+  let openingBalanceCandidate;
+  if (amendedCurrent) {
+    project = objectValue(closedSnapshot?.project) || {};
+    sheetFacts = objectValue(closedSnapshot?.sheetFacts);
+    canonicalSource = objectValue(cashflow?.readModel);
+    const monthOrdinal = weeklyYear === null ? -1 : weekOrdinal(weeklyYear, yearMonth, 1);
+    const currentMonth = monthOrdinal !== -1
+      ? cashflowMonthsByCoordinate(canonicalSource?.months, weeklyYear)[Math.trunc(monthOrdinal / WEEKS_PER_MONTH)]
+      : null;
+    cells = canonicalMonthCells(currentMonth, yearMonth);
+    confirmations = Array.isArray(closedSnapshot?.confirmations) ? closedSnapshot.confirmations : [];
+    managementConfirmations = Array.isArray(closedSnapshot?.managementConfirmations) ? closedSnapshot.managementConfirmations : [];
+    depositScheduleRows = Array.isArray(closedSnapshot?.depositScheduleRows) ? closedSnapshot.depositScheduleRows : [];
+    openingBalanceCandidate = openingBalances;
+  } else if (closedSnapshot) {
+    project = objectValue(closedSnapshot.project) || {};
+    sheetFacts = objectValue(closedSnapshot.sheetFacts);
+    canonicalSource = frozenCashflowReadModel(closedSnapshot.ledgerWeeks);
+    cells = closeSnapshotCells(closedSnapshot, yearMonth);
+    confirmations = Array.isArray(closedSnapshot.confirmations) ? closedSnapshot.confirmations : [];
+    managementConfirmations = Array.isArray(closedSnapshot.managementConfirmations) ? closedSnapshot.managementConfirmations : [];
+    depositScheduleRows = Array.isArray(closedSnapshot.depositScheduleRows) ? closedSnapshot.depositScheduleRows : [];
+    openingBalanceCandidate = objectValue(closedSnapshot.openingBalances);
+  } else {
+    project = objectValue(projectDocument) || {};
+    sheetFacts = objectValue(mirror?.sheetFacts);
+    canonicalSource = objectValue(cashflow?.readModel);
+    cells = normalizeMonthCloseCells(mirror?.cells, yearMonth);
+    confirmations = [];
+    managementConfirmations = [];
+    depositScheduleRows = sourceDepositRows(sheetFacts, yearMonth);
+    openingBalanceCandidate = openingBalances;
+  }
   const canonicalReadModel = cashflowReadModelForYear(
-    amendedCurrent ? objectValue(cashflow?.readModel) : frozenCanonical || objectValue(cashflow?.readModel),
-    selectedYear,
+    canonicalSource,
+    weeklyYear,
   );
-  const currentCanonicalMonth = amendedCurrent
-    ? canonicalReadModel?.months?.find((month) => month.yearMonth === yearMonth) || null
-    : null;
-  const cells = amendedCurrent
-    ? canonicalMonthCells(currentCanonicalMonth, yearMonth)
-    : frozenCells;
+  const annualTotals = await readAnnualTotals({
+    db,
+    tenantId,
+    projectId,
+    weeklyYear,
+    frozen: Boolean(closedSnapshot) && !amendedCurrent,
+  });
   const projectionMode = buildMonthModeReadModel(cells, 'projection');
   const actualMode = buildMonthModeReadModel(cells, 'actual');
   const projection = dashboardTotals(projectionMode);
@@ -1854,15 +1983,7 @@ async function composeCashflowMonthDashboard({
       readModel: { months: [{ yearMonth, projection: projectionMode, actual: actualMode }] },
     }, comparisonBoundary).months[0] || null
     : null;
-  const confirmations = closedSnapshot?.confirmations || [];
-  const managementConfirmations = closedSnapshot?.managementConfirmations || [];
   const sourceRows = sourceDepositRows(sheetFacts, yearMonth);
-  const depositScheduleRows = closedSnapshot?.depositScheduleRows
-    || sourceRows
-    || [];
-  const openingBalanceCandidate = amendedCurrent
-    ? openingBalances
-    : objectValue(closedSnapshot?.openingBalances) || openingBalances;
   const authoritativeOpeningBalances = openingBalanceCandidate
     ? requireJvmOpeningBalances({ openingBalances: openingBalanceCandidate }, yearMonth)
     : null;
@@ -1871,40 +1992,47 @@ async function composeCashflowMonthDashboard({
     : null;
   const canonicalWithComparison = canonicalReadModel ? {
     ...canonicalReadModel,
-    months: canonicalReadModel.months.map((month) => ({
+    weeklyYear,
+    annualTotals,
+    months: canonicalReadModel.months.map((month, monthIndex) => ({
       ...month,
-      comparison: canonicalComparison?.months?.find((candidate) => candidate.yearMonth === month.yearMonth) || null,
+      comparison: canonicalComparison?.months?.[monthIndex] || null,
     })),
   } : null;
-  const managementChecks = amendedCurrent
-    ? buildCashflowManagementChecks({
+  let managementChecks;
+  if (amendedCurrent) {
+    managementChecks = buildCashflowManagementChecks({
       project,
       cashflow,
       cells,
       yearMonth,
-      depositScheduleRows: sheetFacts?.depositScheduleRows || depositScheduleRows,
+      depositScheduleRows,
       comparisonBoundary,
       pinnedSheetCells: null,
       projectionOpeningBalance: safeAmount(authoritativeOpeningBalances?.projection?.amount),
-    })
-    : Array.isArray(closedSnapshot?.managementChecks)
-      ? closedSnapshot.managementChecks
-      : legacyEvidenceOnly
-      ? []
-      : buildCashflowManagementChecks({
-        project,
-        cashflow,
-        cells,
-        yearMonth,
-        depositScheduleRows: sheetFacts?.depositScheduleRows || depositScheduleRows,
-        comparisonBoundary,
-        pinnedSheetCells: mirror?.cells,
-        projectionOpeningBalance: safeAmount(authoritativeOpeningBalances?.projection?.amount),
-      });
-  const liveDeadlineSummary = deadlineSummaryFromCompliance(weeklyCompliance, weeklyComplianceBoundary);
+      weeklyYear,
+      monthState: 'LIVE_AMENDED',
+    });
+  } else if (closedSnapshot) {
+    managementChecks = Array.isArray(closedSnapshot.managementChecks) ? closedSnapshot.managementChecks : [];
+  } else {
+    managementChecks = buildCashflowManagementChecks({
+      project,
+      cashflow,
+      cells,
+      yearMonth,
+      depositScheduleRows,
+      comparisonBoundary,
+      pinnedSheetCells: mirror?.cells,
+      projectionOpeningBalance: safeAmount(authoritativeOpeningBalances?.projection?.amount),
+      weeklyYear,
+      monthState: 'LIVE_CURRENT',
+    });
+  }
+  const liveDeadlineSummary = deadlineSummaryFromCompliance(weeklyCompliance, weeklyComplianceBoundary, weeklyYear);
   const deadlineSummary = closedSnapshot
     ? {
-      ...(closedSnapshot?.deadlineSummary || liveDeadlineSummary),
+      ...(objectValue(closedSnapshot.deadlineSummary) || {}),
       completedWeeks: liveDeadlineSummary.completedWeeks,
       weeklyStatuses: liveDeadlineSummary.weeklyStatuses,
     }
@@ -1918,6 +2046,10 @@ async function composeCashflowMonthDashboard({
     }
     if (!projectDocument) blockers.push({ code: 'PROJECT_NOT_FOUND', message: '프로젝트 등록 정보를 찾을 수 없습니다.' });
     if (!mirror) blockers.push({ code: 'SHEET_SOURCE_REQUIRED', message: '먼저 시트값을 불러와 주세요.' });
+    else if (weeklyYear === null) blockers.push({
+      code: 'SHEET_SOURCE_REQUIRED',
+      message: '시트에서 주별 관리 연도를 확인하지 못했습니다. 표준 양식으로 다시 불러와 주세요.',
+    });
     else if (mirror.status !== 'FRESH') blockers.push({ code: 'SHEET_SOURCE_STALE', message: '시트값을 다시 불러와 주세요.' });
     else if ((mirror.projectId && mirror.projectId !== projectId) || !mirror.yearMonths?.includes(yearMonth)) {
       blockers.push({ code: 'SHEET_SOURCE_SCOPE_MISMATCH', message: '고정한 시트값의 프로젝트 또는 월이 다릅니다.' });
@@ -1930,25 +2062,32 @@ async function composeCashflowMonthDashboard({
     if (!projectionMode || !actualMode) blockers.push({ code: 'AMOUNT_OUT_OF_RANGE', message: '지원 범위를 넘는 금액이 있습니다.' });
   }
   const contractAmount = safeAmount(project?.contractAmount);
-  const projectionComposition = closedSnapshot
-    ? {
-      totalIn: safeAmount(canonicalWithComparison?.range?.projection?.totalIn ?? projection.totalIn),
-      salesAndVatTotal: safeAmount(canonicalWithComparison?.range?.projection?.rowTotals?.SALES_IN ?? projection.rowTotals?.SALES_IN)
-        + safeAmount(canonicalWithComparison?.range?.projection?.rowTotals?.SALES_VAT_IN ?? projection.rowTotals?.SALES_VAT_IN),
-      years: Array.isArray(closedSnapshot?.projectionYears) ? closedSnapshot.projectionYears : [],
-    }
-    : composeProjectionTotal({
+  let projectionComposition;
+  if (closedSnapshot && !legacyEvidenceOnly) {
+    projectionComposition = {
+      totalIn: safeAmount(canonicalWithComparison?.range?.projection?.totalIn),
+      salesAndVatTotal: safeAmount(canonicalWithComparison?.range?.projection?.rowTotals?.SALES_IN)
+        + safeAmount(canonicalWithComparison?.range?.projection?.rowTotals?.SALES_VAT_IN),
+      years: Array.isArray(closedSnapshot.projectionYears) ? closedSnapshot.projectionYears : [],
+    };
+  } else if (legacyEvidenceOnly) {
+    projectionComposition = {
+      totalIn: projection.totalIn,
+      salesAndVatTotal: safeAmount(projection.rowTotals?.SALES_IN) + safeAmount(projection.rowTotals?.SALES_VAT_IN),
+      years: [],
+    };
+  } else {
+    projectionComposition = composeProjectionTotal({
       project,
       cashflow,
-      mirror,
+      annualTotals,
       fallback: {
         totalIn: projection.totalIn,
         salesAndVatTotal: safeAmount(projection.rowTotals?.SALES_IN) + safeAmount(projection.rowTotals?.SALES_VAT_IN),
       },
-      weeklyYearsHint: (Array.isArray(mirror?.appliedWeeklyYears) ? mirror.appliedWeeklyYears : mirror?.cells?.map((cell) => (
-        Number(readOptionalText(cell?.yearMonth).slice(0, 4))
-      )) || []).map(Number).filter(Number.isSafeInteger),
+      weeklyYear,
     });
+  }
   const projectionTotalIn = projectionComposition.totalIn;
   const projectionSalesAndVatTotal = projectionComposition.salesAndVatTotal;
   const contractDifference = contractAmount - projectionSalesAndVatTotal;
@@ -2152,6 +2291,8 @@ async function composeCashflowMonthCloseBody({ db, req, projectId, cashflow, ope
     comparisonBoundary,
     pinnedSheetCells: mirror?.cells,
     projectionOpeningBalance: safeAmount(openingBalances?.projection?.amount),
+    weeklyYear: readWeeklyYear(mirror?.weeklyYear),
+    monthState: 'LIVE_CURRENT',
   });
   const managementWarnings = matchingManagementChecks(managementChecks, closeInput.managementChecks) ? [] : [{
     code: 'MANAGEMENT_CHECKS_STALE',
@@ -2161,7 +2302,11 @@ async function composeCashflowMonthCloseBody({ db, req, projectId, cashflow, ope
   if (!completeMonthCloseConfirmations(closeInput.confirmations)) {
     throw createHttpError(409, '월 결산 대상 160개 항목을 모두 확인해 주세요.', 'cashflow_month_close_confirmations_incomplete');
   }
-  const deadlineSummary = deadlineSummaryFromCompliance(weeklyCompliance, comparisonBoundary);
+  const deadlineSummary = deadlineSummaryFromCompliance(
+    weeklyCompliance,
+    comparisonBoundary,
+    readWeeklyYear(mirror?.weeklyYear),
+  );
 
   const reviewWarnings = [
     ...sourceWarnings,

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -283,6 +283,7 @@ function fullMonthCloseSource({
     }],
     ['orgs/tenant-a/cashflow_sheet_mirrors/project-a', {
       projectId: 'project-a', status: mirrorStatus, sourceRevision, appliedSourceRevision: sourceRevision, targetRevisionAtFetch: targetRevision,
+      weeklyYear: 2026,
       spreadsheetId: 'spreadsheet-a', spreadsheetTitle: '2026 사업비 관리 시트', selectedSheetName: 'cashflow(사용내역 연동)',
       yearMonths: ['2026-06'], capturedAt: '2026-07-01T00:00:00.000Z', configRevision: `sha256:${'e'.repeat(64)}`,
       cells, sheetFacts,
@@ -336,6 +337,7 @@ function createMonthCloseDb() {
     }],
     ['orgs/tenant-a/cashflow_sheet_mirrors/project-a', {
       projectId: 'project-a', status: 'FRESH', sourceRevision, appliedSourceRevision: sourceRevision, targetRevisionAtFetch: targetRevision,
+      weeklyYear: 2026,
       yearMonths: ['2026-06'], capturedAt: '2026-07-01T00:00:00.000Z',
       sheetFacts: {
         metadata: {},
@@ -1931,6 +1933,7 @@ describe('JVM weekly API BFF proxy', () => {
       yearMonth: '2026-06',
       depositScheduleRows: draft.payload.monthClose.depositScheduleRows,
       comparisonBoundary: { asOfWeek: { yearMonth: '2026-07', weekNo: 2 } },
+      monthState: 'MONTH_CELLS',
     });
 
     expect(checks).toHaveLength(4);
@@ -2024,6 +2027,7 @@ describe('JVM weekly API BFF proxy', () => {
       yearMonth: '2026-06',
       depositScheduleRows: [],
       comparisonBoundary: { asOfWeek: { yearMonth: '2026-07', weekNo: 2 } },
+      monthState: 'MONTH_CELLS',
     });
 
     expect(checks.find((check) => check.id === 'labor-transfer')).toEqual({
@@ -2049,6 +2053,7 @@ describe('JVM weekly API BFF proxy', () => {
       yearMonth: '2026-06',
       depositScheduleRows: [],
       comparisonBoundary: { asOfWeek: { yearMonth: '2026-07', weekNo: 2 } },
+      monthState: 'MONTH_CELLS',
     });
 
     expect(checks.find((check) => check.id === 'labor-transfer')).toEqual({
@@ -2143,13 +2148,14 @@ describe('JVM weekly API BFF proxy', () => {
         yearMonth: '2026-07', weekNo: 1, actualDepositDate: '2026-07-01', actualDepositAmount: 1_000_000,
       }],
       comparisonBoundary: { asOfWeek: { yearMonth: '2026-08', weekNo: 3 } },
+      monthState: 'FROZEN_COMPLETE',
     });
 
     expect(checks.find((check) => check.id === 'labor-transfer')?.detail).toContain('2026-07 3주차 인건비 미입력');
     expect(checks.find((check) => check.id === 'profit-vat-after-deposit')?.detail).toContain('2026-07 1주차에 매출입금이 있으나 [MYSC 수익·매출부가세] 계획이 Projection에 없습니다.');
   });
 
-  it('uses the canonical JVM ledger instead of an unapplied pinned sheet for negative Projection balance', () => {
+  it('excludes an out-of-coordinate JVM ledger month from management checks', () => {
     const { documents } = fullMonthCloseSource();
     const mirror = documents.get('orgs/tenant-a/cashflow_sheet_mirrors/project-a');
     const pinnedSheetCells = mirror.cells.map((cell) => ({
@@ -2182,11 +2188,10 @@ describe('JVM weekly API BFF proxy', () => {
     const negative = checks.find((check) => check.id === 'negative-projection-balance');
     expect(negative).toMatchObject({
       id: 'negative-projection-balance',
-      status: 'WARNING',
+      status: 'OK',
       title: 'Projection 잔액 마이너스',
     });
-    expect(negative.findings[0]).toContain('2024-09 2주차');
-    expect(negative.findings).toHaveLength(9);
+    expect(negative).not.toHaveProperty('findings');
   });
 
   it('starts the negative Projection check from the prior-year opening balance', () => {
@@ -2213,7 +2218,7 @@ describe('JVM weekly API BFF proxy', () => {
     });
   });
 
-  it('uses the JVM-provided opening balance instead of recalculating annual totals in the BFF', async () => {
+  it('uses JVM opening balances and exposes stored annual columns without weekly reconstruction', async () => {
     const { db, documents } = fullMonthCloseSource();
     documents.get('orgs/tenant-a/projects/project-a').contractStart = '2025-01-01';
     documents.get('orgs/tenant-a/projects/project-a').contractEnd = '2026-12-31';
@@ -2225,9 +2230,9 @@ describe('JVM weekly API BFF proxy', () => {
       projectId: 'project-a',
       year: 2025,
       projection: { SALES_IN: 9_000_000 },
-      projectionStates: { SALES_IN: 'VALUE' },
+      projectionStates: Object.fromEntries(cashflowLineIds.map((lineId) => [lineId, lineId === 'SALES_IN' ? 'VALUE' : 'EMPTY'])),
       actual: { SALES_IN: 8_000_000 },
-      actualStates: { SALES_IN: 'VALUE' },
+      actualStates: Object.fromEntries(cashflowLineIds.map((lineId) => [lineId, lineId === 'SALES_IN' ? 'VALUE' : 'EMPTY'])),
     });
     const jvmOpeningBalances = {
       selectedYear: 2026,
@@ -2257,11 +2262,33 @@ describe('JVM weekly API BFF proxy', () => {
       .expect(200)
       .expect((response) => {
         expect(response.body.dashboard.openingBalances).toEqual(jvmOpeningBalances);
+        expect(response.body.dashboard.canonical.weeklyYear).toBe(2026);
+        expect(response.body.dashboard.canonical.annualTotals.map((row) => row.year)).toEqual([
+          2024, 2025, 2027, 2028, 2029, 2030, 2031, 2032,
+        ]);
+        expect(response.body.dashboard.canonical.annualTotals[1]).toMatchObject({
+          year: 2025,
+          projection: { lineStates: { SALES_IN: 'VALUE', BANK_INTEREST_IN: 'EMPTY' }, totalIn: null, totalOut: null, net: null },
+          actual: { lineStates: { SALES_IN: 'VALUE', BANK_INTEREST_IN: 'EMPTY' }, totalIn: null, totalOut: null, net: null },
+        });
+        expect(response.body.dashboard.canonical.annualTotals[1].projection.lineAmounts).toEqual({ SALES_IN: 9_000_000 });
+        expect(response.body.dashboard.canonical.annualTotals[0]).toEqual({
+          year: 2024, status: 'UNKNOWN', reason: 'annual_totals_missing',
+        });
       });
   });
 
-  it('keeps prior weekly running net and selected-year range in the dashboard fallback read model', async () => {
-    const { db } = fullMonthCloseSource();
+  it('excludes a stray annual-year week and keeps the stored annual column authoritative', async () => {
+    const { db, documents } = fullMonthCloseSource();
+    const annualId = Buffer.from('project-a\n2025', 'utf8').toString('base64url');
+    documents.set(`orgs/tenant-a/cashflow_sheet_year_totals/${annualId}`, {
+      projectId: 'project-a',
+      year: 2025,
+      projection: { SALES_IN: 317_449_417 },
+      projectionStates: Object.fromEntries(cashflowLineIds.map((lineId) => [lineId, lineId === 'SALES_IN' ? 'VALUE' : 'EMPTY'])),
+      actual: { SALES_IN: 317_449_417 },
+      actualStates: Object.fromEntries(cashflowLineIds.map((lineId) => [lineId, lineId === 'SALES_IN' ? 'VALUE' : 'EMPTY'])),
+    });
     const cashflow = {
       projectId: 'project-a',
       projection: [],
@@ -2270,7 +2297,7 @@ describe('JVM weekly API BFF proxy', () => {
         months: [
           {
             yearMonth: '2025-12',
-            projection: { weeks: [{ weekNo: 5, amounts: { SALES_IN: 3_000_000 }, net: 3_000_000 }] },
+            projection: { weeks: [{ weekNo: 4, amounts: { SALES_IN: 7_582_243 }, net: 7_582_243 }] },
             actual: { weeks: [] },
           },
           {
@@ -2299,7 +2326,16 @@ describe('JVM weekly API BFF proxy', () => {
       .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
       .expect(200)
       .expect((response) => {
-        expect(response.body.dashboard.canonical.months[0].projection.weeks[0].net).toBe(3_000_000);
+        expect(response.body.dashboard.canonical.months.map((month) => month.yearMonth)).toEqual(['2026-01']);
+        expect(response.body.dashboard.canonical.annualTotals[1].projection).toMatchObject({
+          lineAmounts: { SALES_IN: 317_449_417 },
+          lineStates: { SALES_IN: 'VALUE' },
+          totalIn: null,
+          totalOut: null,
+          net: null,
+        });
+        expect(response.body.dashboard.managementChecks.flatMap((check) => check.findings || []))
+          .not.toEqual(expect.arrayContaining([expect.stringContaining('2025-12')]));
         expect(response.body.dashboard.canonical.range).toMatchObject({
           start: { yearMonth: '2026-01', weekNo: 1 },
           end: { yearMonth: '2026-12', weekNo: 5 },
@@ -2351,6 +2387,31 @@ describe('JVM weekly API BFF proxy', () => {
         expect(response.body.dashboard.validation.blockers).toContainEqual(expect.objectContaining({
           code: 'SHEET_SOURCE_REQUIRED',
         }));
+      });
+  });
+
+  it('keeps the dashboard readable when the mirror has no weekly-year contract', async () => {
+    const { db, documents } = fullMonthCloseSource();
+    delete documents.get('orgs/tenant-a/cashflow_sheet_mirrors/project-a').weeklyYear;
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(monthDashboardSource({
+        ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0,
+        reopenCount: 0, projectWarningCount: 0, snapshot: {},
+      })),
+    }));
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { env: runtimeEnv, db });
+
+    await request(app)
+      .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
+      .expect(200)
+      .expect((response) => {
+        expect(response.body.dashboard.canonical).toBeNull();
+        expect(response.body.dashboard.validation.blockers).toContainEqual({
+          code: 'SHEET_SOURCE_REQUIRED',
+          message: '시트에서 주별 관리 연도를 확인하지 못했습니다. 표준 양식으로 다시 불러와 주세요.',
+        });
       });
   });
 
@@ -2428,7 +2489,7 @@ describe('JVM weekly API BFF proxy', () => {
     }
   });
 
-  it('adds future annual Projection until that year has a weekly ledger', async () => {
+  it('does not invent a future annual Projection total before the derived cells are stored', async () => {
     const { db, documents } = fullMonthCloseSource({ contractAmount: 1000 });
     const project = documents.get('orgs/tenant-a/projects/project-a');
     project.contractStart = '2026-01-01';
@@ -2438,9 +2499,20 @@ describe('JVM weekly API BFF proxy', () => {
     mirror.appliedWeeklyYears = [2026];
     mirror.sheetFacts.annualCashflowTotals = [{
       year: 2027,
-      projection: { totalIn: 650, lineAmounts: { SALES_IN: 500, SALES_VAT_IN: 150 } },
+      projection: { totalIn: 999, lineAmounts: { SALES_IN: 999, SALES_VAT_IN: 0 } },
       actual: { totalIn: 0 },
     }];
+    const annualId = Buffer.from('project-a\n2027', 'utf8').toString('base64url');
+    documents.set(`orgs/tenant-a/cashflow_sheet_year_totals/${annualId}`, {
+      projectId: 'project-a',
+      year: 2027,
+      projection: { SALES_IN: 500, SALES_VAT_IN: 150 },
+      projectionStates: Object.fromEntries(cashflowLineIds.map((lineId) => [
+        lineId, ['SALES_IN', 'SALES_VAT_IN'].includes(lineId) ? 'VALUE' : 'EMPTY',
+      ])),
+      actual: {},
+      actualStates: Object.fromEntries(cashflowLineIds.map((lineId) => [lineId, 'EMPTY'])),
+    });
     const cashflow = {
       projectId: 'project-a',
       readModel: {
@@ -2470,18 +2542,18 @@ describe('JVM weekly API BFF proxy', () => {
       .expect(200)
       .expect((response) => {
         expect(response.body.dashboard.summary).toMatchObject({
-          projectionProgressPercent: 100,
-          projectionTotalIn: 1000,
-          projectionSalesAndVatTotal: 1000,
-          contractDifference: 0,
-          contractCoveragePercent: 100,
+          projectionProgressPercent: 35,
+          projectionTotalIn: 350,
+          projectionSalesAndVatTotal: 350,
+          contractDifference: 650,
+          contractCoveragePercent: 35,
           projectionContractAmount: 1000,
           projectionYears: [
             { year: 2026, source: 'WEEKLY' },
-            { year: 2027, source: 'ANNUAL', totalIn: 650 },
+            { year: 2027, source: 'MISSING', totalIn: 0 },
           ],
         });
-        expect(response.body.dashboard.validation.warnings).not.toEqual(expect.arrayContaining([
+        expect(response.body.dashboard.validation.warnings).toEqual(expect.arrayContaining([
           expect.objectContaining({ code: 'CONTRACT_PROJECTION_MISMATCH' }),
         ]));
       });

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -289,6 +289,17 @@ function fullMonthCloseSource({
       cells, sheetFacts,
     }],
   ]);
+  for (const year of [2024, 2025, 2027, 2028, 2029, 2030, 2031, 2032]) {
+    const annualId = Buffer.from(`project-a\n${year}`, 'utf8').toString('base64url');
+    documents.set(`orgs/tenant-a/cashflow_sheet_year_totals/${annualId}`, {
+      projectId: 'project-a',
+      year,
+      projection: {},
+      projectionStates: Object.fromEntries(cashflowLineIds.map((lineId) => [lineId, 'EMPTY'])),
+      actual: {},
+      actualStates: Object.fromEntries(cashflowLineIds.map((lineId) => [lineId, 'EMPTY'])),
+    });
+  }
   return {
     db: {
       doc: (path) => memoryDoc(documents, path),
@@ -1933,6 +1944,7 @@ describe('JVM weekly API BFF proxy', () => {
       yearMonth: '2026-06',
       depositScheduleRows: draft.payload.monthClose.depositScheduleRows,
       comparisonBoundary: { asOfWeek: { yearMonth: '2026-07', weekNo: 2 } },
+      weeklyYear: 2026,
       monthState: 'MONTH_CELLS',
     });
 
@@ -1995,6 +2007,8 @@ describe('JVM weekly API BFF proxy', () => {
       yearMonth: '2026-06',
       depositScheduleRows,
       comparisonBoundary: { asOfWeek: { yearMonth: '2026-07', weekNo: 2 } },
+      weeklyYear: 2026,
+      monthState: 'LIVE_CURRENT',
     });
 
     expect(checks.map((check) => [check.id, check.status])).toEqual([
@@ -2027,6 +2041,7 @@ describe('JVM weekly API BFF proxy', () => {
       yearMonth: '2026-06',
       depositScheduleRows: [],
       comparisonBoundary: { asOfWeek: { yearMonth: '2026-07', weekNo: 2 } },
+      weeklyYear: 2026,
       monthState: 'MONTH_CELLS',
     });
 
@@ -2053,6 +2068,7 @@ describe('JVM weekly API BFF proxy', () => {
       yearMonth: '2026-06',
       depositScheduleRows: [],
       comparisonBoundary: { asOfWeek: { yearMonth: '2026-07', weekNo: 2 } },
+      weeklyYear: 2026,
       monthState: 'MONTH_CELLS',
     });
 
@@ -2085,6 +2101,8 @@ describe('JVM weekly API BFF proxy', () => {
       yearMonth: '2026-07',
       depositScheduleRows: [],
       comparisonBoundary: { asOfWeek: { yearMonth: '2026-07', weekNo: 4 } },
+      weeklyYear: 2026,
+      monthState: 'LIVE_CURRENT',
     });
 
     expect(checks.find((check) => check.id === 'profit-vat-after-deposit')?.findings).toEqual([
@@ -2112,6 +2130,8 @@ describe('JVM weekly API BFF proxy', () => {
       yearMonth: '2026-07',
       depositScheduleRows: [],
       comparisonBoundary: { asOfWeek: { yearMonth: '2026-07', weekNo: 3 } },
+      weeklyYear: 2026,
+      monthState: 'LIVE_CURRENT',
     });
 
     const transferCheck = checks.find((check) => check.id === 'profit-vat-after-deposit');
@@ -2148,6 +2168,7 @@ describe('JVM weekly API BFF proxy', () => {
         yearMonth: '2026-07', weekNo: 1, actualDepositDate: '2026-07-01', actualDepositAmount: 1_000_000,
       }],
       comparisonBoundary: { asOfWeek: { yearMonth: '2026-08', weekNo: 3 } },
+      weeklyYear: 2026,
       monthState: 'FROZEN_COMPLETE',
     });
 
@@ -2183,6 +2204,8 @@ describe('JVM weekly API BFF proxy', () => {
       pinnedSheetCells,
       depositScheduleRows: [],
       comparisonBoundary: { asOfWeek: { yearMonth: '2026-06', weekNo: 5 } },
+      weeklyYear: 2026,
+      monthState: 'LIVE_CURRENT',
     });
 
     const negative = checks.find((check) => check.id === 'negative-projection-balance');
@@ -2192,6 +2215,34 @@ describe('JVM weekly API BFF proxy', () => {
       title: 'Projection 잔액 마이너스',
     });
     expect(negative).not.toHaveProperty('findings');
+  });
+
+  it.each([
+    ['weeklyYear', undefined, 'LIVE_CURRENT'],
+    ['monthState', 2025, undefined],
+  ])('does not read p1773651024850-2025-12-w4 when %s is missing', (_missing, weeklyYear, monthState) => {
+    const checks = buildCashflowManagementChecks({
+      cashflow: {
+        readModel: {
+          months: [{
+            yearMonth: '2025-12',
+            projection: { weeks: [{ weekNo: 4, amounts: { DIRECT_COST_OUT: 1_773_651_024_850 } }] },
+            actual: { weeks: [] },
+          }],
+        },
+      },
+      cells: [],
+      yearMonth: '2025-12',
+      depositScheduleRows: [],
+      comparisonBoundary: { asOfWeek: { yearMonth: '2025-12', weekNo: 4 } },
+      weeklyYear,
+      monthState,
+    });
+
+    expect(checks.find((check) => check.id === 'negative-projection-balance')).toMatchObject({
+      status: 'OK',
+      detail: 'Projection 누적 잔액이 0원 이상입니다.',
+    });
   });
 
   it('starts the negative Projection check from the prior-year opening balance', () => {
@@ -2210,6 +2261,8 @@ describe('JVM weekly API BFF proxy', () => {
       depositScheduleRows: [],
       projectionOpeningBalance: 2_000_000,
       comparisonBoundary: { asOfWeek: { yearMonth: '2026-01', weekNo: 5 } },
+      weeklyYear: 2026,
+      monthState: 'LIVE_CURRENT',
     });
 
     expect(checks.find((check) => check.id === 'negative-projection-balance')).toMatchObject({
@@ -2225,6 +2278,8 @@ describe('JVM weekly API BFF proxy', () => {
     const mirror = documents.get('orgs/tenant-a/cashflow_sheet_mirrors/project-a');
     mirror.appliedAnnualYears = [2025];
     mirror.appliedWeeklyYears = [2026];
+    const missingAnnualId = Buffer.from('project-a\n2024', 'utf8').toString('base64url');
+    documents.delete(`orgs/tenant-a/cashflow_sheet_year_totals/${missingAnnualId}`);
     const annualId = Buffer.from('project-a\n2025', 'utf8').toString('base64url');
     documents.set(`orgs/tenant-a/cashflow_sheet_year_totals/${annualId}`, {
       projectId: 'project-a',
@@ -2264,16 +2319,16 @@ describe('JVM weekly API BFF proxy', () => {
         expect(response.body.dashboard.openingBalances).toEqual(jvmOpeningBalances);
         expect(response.body.dashboard.canonical.weeklyYear).toBe(2026);
         expect(response.body.dashboard.canonical.annualTotals.map((row) => row.year)).toEqual([
-          2024, 2025, 2027, 2028, 2029, 2030, 2031, 2032,
+          2025, 2027, 2028, 2029, 2030, 2031, 2032,
         ]);
-        expect(response.body.dashboard.canonical.annualTotals[1]).toMatchObject({
+        expect(response.body.dashboard.canonical.annualTotals[0]).toMatchObject({
           year: 2025,
           projection: { lineStates: { SALES_IN: 'VALUE', BANK_INTEREST_IN: 'EMPTY' }, totalIn: null, totalOut: null, net: null },
           actual: { lineStates: { SALES_IN: 'VALUE', BANK_INTEREST_IN: 'EMPTY' }, totalIn: null, totalOut: null, net: null },
         });
-        expect(response.body.dashboard.canonical.annualTotals[1].projection.lineAmounts).toEqual({ SALES_IN: 9_000_000 });
-        expect(response.body.dashboard.canonical.annualTotals[0]).toEqual({
-          year: 2024, status: 'UNKNOWN', reason: 'annual_totals_missing',
+        expect(response.body.dashboard.canonical.annualTotals[0].projection.lineAmounts).toEqual({ SALES_IN: 9_000_000 });
+        expect(response.body.dashboard.validation.blockers).toContainEqual({
+          code: 'SHEET_SOURCE_REQUIRED', message: '먼저 시트값을 불러와 주세요.',
         });
       });
   });
@@ -2561,6 +2616,15 @@ describe('JVM weekly API BFF proxy', () => {
 
   it('uses the CLOSED snapshot instead of current project or mirror values', async () => {
     const current = fullMonthCloseSource();
+    const annualId = Buffer.from('project-a\n2025', 'utf8').toString('base64url');
+    current.documents.set(`orgs/tenant-a/cashflow_sheet_year_totals/${annualId}`, {
+      projectId: 'project-a',
+      year: 2025,
+      projection: { SALES_IN: 900 },
+      projectionStates: Object.fromEntries(cashflowLineIds.map((lineId) => [lineId, lineId === 'SALES_IN' ? 'VALUE' : 'EMPTY'])),
+      actual: { SALES_IN: 800 },
+      actualStates: Object.fromEntries(cashflowLineIds.map((lineId) => [lineId, lineId === 'SALES_IN' ? 'VALUE' : 'EMPTY'])),
+    });
     const weeklyTotals = Array.from({ length: 5 }, (_, index) => ({
       weekNo: index + 1,
       projection: Object.fromEntries(cashflowLineIds.map((lineId) => [lineId, 20])),
@@ -2625,6 +2689,11 @@ describe('JVM weekly API BFF proxy', () => {
             actual: { totalIn: 350, totalOut: 450, balance: -100 },
           },
           canonical: {
+            annualTotals: expect.arrayContaining([expect.objectContaining({
+              year: 2025,
+              projection: expect.objectContaining({ lineAmounts: { SALES_IN: 900 } }),
+              actual: expect.objectContaining({ lineAmounts: { SALES_IN: 800 } }),
+            })]),
             range: {
               projection: { totalIn: 700, totalOut: 900, net: -200 },
               actual: { totalIn: 350, totalOut: 450, net: -100 },

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowMonthDashboardSourceResponse.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowMonthDashboardSourceResponse.java
@@ -8,16 +8,34 @@ public record CashflowMonthDashboardSourceResponse(
     CashflowOpeningBalancesResponse openingBalances,
     SnapshotCompatibility snapshotCompatibility,
     CumulativeClose cumulativeClose,
-    CashflowProjectionActualSummaryBatchResponse.Item projectionActualSummary
+    CashflowProjectionActualSummaryBatchResponse.Item projectionActualSummary,
+    List<Blocker> blockers
 ) {
+    public CashflowMonthDashboardSourceResponse(
+        CashflowMonthCloseResponse monthClose,
+        CashflowSnapshotResponse cashflow,
+        CashflowOpeningBalancesResponse openingBalances,
+        SnapshotCompatibility snapshotCompatibility,
+        CumulativeClose cumulativeClose,
+        CashflowProjectionActualSummaryBatchResponse.Item projectionActualSummary
+    ) {
+        this(monthClose, cashflow, openingBalances, snapshotCompatibility, cumulativeClose, projectionActualSummary, List.of());
+    }
+
     public CashflowMonthDashboardSourceResponse(
         CashflowMonthCloseResponse monthClose,
         CashflowSnapshotResponse cashflow,
         CashflowOpeningBalancesResponse openingBalances,
         SnapshotCompatibility snapshotCompatibility
     ) {
-        this(monthClose, cashflow, openingBalances, snapshotCompatibility, new CumulativeClose("OPEN", "2023-01", "", "", 0), null);
+        this(monthClose, cashflow, openingBalances, snapshotCompatibility, new CumulativeClose("OPEN", "2023-01", "", "", 0), null, List.of());
     }
+
+    public CashflowMonthDashboardSourceResponse {
+        blockers = blockers == null ? List.of() : List.copyOf(blockers);
+    }
+
+    public record Blocker(String code, String message) {}
 
     public record CumulativeClose(
         String status,

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -283,7 +283,10 @@ public class WeeklyExpenseController {
         @RequestHeader(value = "x-actor-email", required = false) String actorEmail
     ) {
         commandService.requireProjectAllowed(WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, actorContext(tenantId, actorId, actorRole, actorEmail), projectId);
-        WeeklyExpensePersistence.CashflowLedgerSource source = readCashflowSource(tenantId, projectId);
+        Integer weeklyYear = persistence.findCashflowDeclaredWeeklyYear(tenantId, projectId);
+        WeeklyExpensePersistence.CashflowLedgerSource source = weeklyYear == null
+            ? new WeeklyExpensePersistence.CashflowLedgerSource(List.of(), List.of())
+            : readCashflowSource(tenantId, projectId, weeklyYear);
         return buildCashflowSnapshot(projectId, source);
     }
 
@@ -300,8 +303,12 @@ public class WeeklyExpenseController {
         );
     }
 
-    private WeeklyExpensePersistence.CashflowLedgerSource readCashflowSource(String tenantId, String projectId) {
-        return persistence.findCashflowLedgerSource(tenantId, projectId);
+    private WeeklyExpensePersistence.CashflowLedgerSource readCashflowSource(
+        String tenantId,
+        String projectId,
+        int weeklyYear
+    ) {
+        return persistence.findCashflowLedgerSource(tenantId, projectId, weeklyYear);
     }
 
     private CashflowSnapshotResponse buildCashflowSnapshot(
@@ -474,16 +481,26 @@ public class WeeklyExpenseController {
             : open
                 ? new CashflowMonthDashboardSourceResponse.SnapshotCompatibility("LIVE_CURRENT", List.of())
                 : frozenSnapshotCompatibility(monthClose);
-        WeeklyExpensePersistence.CashflowLedgerSource source = currentLedgerView
-            ? readCashflowSource(tenantId, projectId)
-            : null;
+        Integer weeklyYear = open ? persistence.findCashflowDeclaredWeeklyYear(tenantId, projectId) : null;
+        List<CashflowMonthDashboardSourceResponse.Blocker> blockers = open && weeklyYear == null
+            ? List.of(new CashflowMonthDashboardSourceResponse.Blocker(
+                "SHEET_SOURCE_REQUIRED",
+                "먼저 시트값을 불러와 주세요."
+            ))
+            : List.of();
+        WeeklyExpensePersistence.CashflowLedgerSource source = amendedClosed
+            ? persistence.findCashflowGlobalLedgerSource(tenantId, projectId)
+            : open && weeklyYear != null
+                ? readCashflowSource(tenantId, projectId, weeklyYear)
+                : open
+                    ? new WeeklyExpensePersistence.CashflowLedgerSource(List.of(), List.of())
+                    : null;
         CashflowSnapshotResponse cashflow = currentLedgerView ? buildCashflowSnapshot(projectId, source) : null;
         CashflowOpeningBalancesResponse openingBalances = currentLedgerView
             ? toOpeningBalancesResponse(persistence.findCashflowOpeningBalance(
                 tenantId,
                 projectId,
-                Integer.parseInt(yearMonth.substring(0, 4)),
-                source.weeklyYears()
+                Integer.parseInt(yearMonth.substring(0, 4))
             ))
             : snapshotCompatibility.missingEvidence().contains("OPENING_BALANCES")
                 ? null
@@ -536,7 +553,8 @@ public class WeeklyExpenseController {
                 cumulative.status(), cumulative.fromMonth(), cumulative.closedThrough(), cumulative.rootHash(),
                 cumulative.headRevision()
             ),
-            projectionActualSummary
+            projectionActualSummary,
+            blockers
         );
     }
 

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -279,8 +279,16 @@ public class WeeklyExpenseCommandService {
         List<CashflowProjectionActualSummaryBatchResponse.ErrorItem> errors = new ArrayList<>();
         for (String projectId : projectIds) {
             try {
+                Integer weeklyYear = persistence.findCashflowDeclaredWeeklyYear(actor.tenantId(), projectId);
+                if (weeklyYear == null) {
+                    errors.add(new CashflowProjectionActualSummaryBatchResponse.ErrorItem(
+                        projectId, CashflowProjectionActualSummaryBatchResponse.SUMMARY_UNAVAILABLE
+                    ));
+                    continue;
+                }
                 WeeklyExpensePersistence.CashflowLedgerSource source = persistence.findCashflowLedgerSource(
-                    actor.tenantId(), projectId, CashflowProjectionActualSummaryCalculator.FROM_MONTH, throughMonth
+                    actor.tenantId(), projectId, weeklyYear,
+                    CashflowProjectionActualSummaryCalculator.FROM_MONTH, throughMonth
                 );
                 items.add(toProjectionActualSummary(projectId, source, boundary, selectedYearMonth));
             } catch (WeeklyExpenseForbiddenException denied) {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/CashflowCoordinates.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/CashflowCoordinates.java
@@ -1,0 +1,41 @@
+package dev.merryai.innerplatform.weekly.storage;
+
+import java.util.List;
+
+public final class CashflowCoordinates {
+    private CashflowCoordinates() {}
+
+    public static int weekOrdinal(int weeklyYear, String yearMonth, int weekNo) {
+        requireWeeklyYear(weeklyYear);
+        if (yearMonth == null || !yearMonth.matches("20\\d{2}-(0[1-9]|1[0-2])") || weekNo < 1 || weekNo > 5) {
+            return -1;
+        }
+        int year = Integer.parseInt(yearMonth.substring(0, 4));
+        if (year != weeklyYear) {
+            return -1;
+        }
+        int month = Integer.parseInt(yearMonth.substring(5, 7));
+        return (month - 1) * 5 + weekNo - 1;
+    }
+
+    public static List<Integer> annualYearsFor(int weeklyYear) {
+        requireWeeklyYear(weeklyYear);
+        return List.of(
+            weeklyYear - 2,
+            weeklyYear - 1,
+            weeklyYear + 1,
+            weeklyYear + 2,
+            weeklyYear + 3,
+            weeklyYear + 4,
+            weeklyYear + 5,
+            weeklyYear + 6
+        );
+    }
+
+    public static int requireWeeklyYear(int weeklyYear) {
+        if (weeklyYear < 2000 || weeklyYear > 2099) {
+            throw new IllegalArgumentException("Cashflow weeklyYear must be between 2000 and 2099.");
+        }
+        return weeklyYear;
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -1569,10 +1569,9 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             }
         }
 
-        // SPEC-12 approved full scan: completeCashflowWeeklyUpdate requires the global targetRevision.
-        QuerySnapshot projectWeekSnapshot = query(cashflowWeeks(actor.tenantId()).whereEqualTo("projectId", projectId));
+        List<DocumentSnapshot> projectWeekSnapshots = queryCashflowWeeklyYear(actor.tenantId(), projectId);
         Map<String, Map<String, Object>> projectWeeks = new LinkedHashMap<>();
-        for (DocumentSnapshot weekSnapshot : projectWeekSnapshot.getDocuments()) {
+        for (DocumentSnapshot weekSnapshot : projectWeekSnapshots) {
             Map<String, Object> week = data(weekSnapshot);
             WeekDocParts parts = parseCashflowWeekId(projectId, weekSnapshot.getId());
             projectWeeks.put(weekSnapshot.getId(), week);
@@ -2079,9 +2078,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         Set<String> writeDocumentIds = new java.util.LinkedHashSet<>(requestedWeekDocumentIds == null
             ? List.of()
             : requestedWeekDocumentIds);
-        // SPEC-12 approved full scan: countCashflowActualReplacementWrites budgets existing actual documents globally.
-        QuerySnapshot existing = query(cashflowWeeks(tenantId).whereEqualTo("projectId", projectId));
-        for (DocumentSnapshot doc : existing.getDocuments()) {
+        for (DocumentSnapshot doc : queryCashflowWeeklyYear(tenantId, projectId)) {
             if (data(doc).containsKey("weeklyExpenseActualBySheet")) {
                 writeDocumentIds.add(doc.getId());
             }
@@ -2264,10 +2261,8 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             targetMonthDocs.put(snap.getId(), document);
         }
 
-        // SPEC-12 approved full scan: replaceCashflowSheetMonthsInternal hashes the complete project ledger.
-        QuerySnapshot existingSnapshot = query(cashflowWeeks(tenantId).whereEqualTo("projectId", projectId));
         Map<String, Map<String, Object>> allProjectWeeks = new LinkedHashMap<>();
-        for (DocumentSnapshot doc : existingSnapshot.getDocuments()) {
+        for (DocumentSnapshot doc : queryCashflowWeeklyYear(tenantId, projectId)) {
             allProjectWeeks.put(doc.getId(), data(doc));
         }
         for (Map.Entry<String, Map<String, Object>> entry : allProjectWeeks.entrySet()) {
@@ -2562,14 +2557,20 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
 
     @Override
     public List<Integer> findCashflowWeeklyYears(String tenantId, String projectId) {
-        return findCashflowLedgerSource(tenantId, projectId).weeklyYears();
+        return List.of(requireCashflowWeeklyYear(tenantId, projectId));
     }
 
     @Override
     public CashflowLedgerSource findCashflowLedgerSource(String tenantId, String projectId) {
-        // SPEC-12 approved full scan: findCashflowLedgerSource serves the all-month dashboard and targetRevision.
-        QuerySnapshot snapshot = query(cashflowWeeks(tenantId).whereEqualTo("projectId", projectId));
-        return cashflowLedgerSource(tenantId, projectId, snapshot, null, null);
+        int weeklyYear = requireCashflowWeeklyYear(tenantId, projectId);
+        return cashflowLedgerSource(
+            tenantId,
+            projectId,
+            queryCashflowWeeks(tenantId, projectId, weeklyYearMonths(weeklyYear)),
+            null,
+            null,
+            weeklyYear
+        );
     }
 
     @Override
@@ -2579,23 +2580,19 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         String fromMonth,
         String throughMonth
     ) {
+        int weeklyYear = requireCashflowWeeklyYear(tenantId, projectId);
+        String firstMonth = weeklyYear + "-01";
+        String lastMonth = weeklyYear + "-12";
+        String scopedFrom = fromMonth.compareTo(firstMonth) < 0 ? firstMonth : fromMonth;
+        String scopedThrough = throughMonth.compareTo(lastMonth) > 0 ? lastMonth : throughMonth;
         return cashflowLedgerSource(
             tenantId,
             projectId,
-            queryCashflowWeeks(tenantId, projectId, CashflowQueryScope.between(fromMonth, throughMonth)),
+            queryCashflowWeeks(tenantId, projectId, CashflowQueryScope.between(scopedFrom, scopedThrough)),
             fromMonth,
-            throughMonth
+            throughMonth,
+            weeklyYear
         );
-    }
-
-    private CashflowLedgerSource cashflowLedgerSource(
-        String tenantId,
-        String projectId,
-        QuerySnapshot snapshot,
-        String fromMonth,
-        String throughMonth
-    ) {
-        return cashflowLedgerSource(tenantId, projectId, snapshot.getDocuments(), fromMonth, throughMonth);
     }
 
     private CashflowLedgerSource cashflowLedgerSource(
@@ -2603,11 +2600,11 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         String projectId,
         List<? extends DocumentSnapshot> snapshots,
         String fromMonth,
-        String throughMonth
+        String throughMonth,
+        int weeklyYear
     ) {
         List<WeeklyExpenseProjectionEntity> projection = new ArrayList<>();
         List<WeeklyExpenseActualEntity> actual = new ArrayList<>();
-        Set<Integer> weeklyYears = new java.util.TreeSet<>();
         List<Map<String, Object>> documents = new ArrayList<>();
         for (DocumentSnapshot doc : snapshots) {
             Map<String, Object> document = data(doc);
@@ -2616,9 +2613,6 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             int weekNo = intValue(document.get("weekNo"), 0);
             if (fromMonth != null && (yearMonth.compareTo(fromMonth) < 0 || yearMonth.compareTo(throughMonth) > 0)) {
                 continue;
-            }
-            if (yearMonth.matches("20\\d{2}-(0[1-9]|1[0-2])")) {
-                weeklyYears.add(Integer.parseInt(yearMonth.substring(0, 4)));
             }
             for (Map.Entry<String, Object> entry : nestedMap(document.get("projection")).entrySet()) {
                 WeeklyExpenseProjectionEntity line = new WeeklyExpenseProjectionEntity(
@@ -2646,7 +2640,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         return new CashflowLedgerSource(
             projection,
             actual,
-            List.copyOf(weeklyYears),
+            List.of(weeklyYear),
             computeCashflowTargetRevision(documents)
         );
     }
@@ -4031,9 +4025,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         }
 
         Map<String, Map<String, Object>> docs = new LinkedHashMap<>();
-        // SPEC-12 approved full scan: replaceExpenseRows reconciles actuals across the whole source sheet.
-        QuerySnapshot existing = query(cashflowWeeks(tenant(sheet)).whereEqualTo("projectId", sheet.getProjectId()));
-        for (DocumentSnapshot doc : existing.getDocuments()) {
+        for (DocumentSnapshot doc : queryCashflowWeeklyYear(tenant(sheet), sheet.getProjectId())) {
             docs.put(doc.getId(), data(doc));
         }
         for (String docId : deltasByDoc.keySet()) {
@@ -4114,9 +4106,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         }
 
         Map<String, Map<String, Object>> docs = new LinkedHashMap<>();
-        // SPEC-12 approved full scan: replaceActualLines reconciles every prior actual for the source sheet.
-        QuerySnapshot existing = query(cashflowWeeks(tenantId).whereEqualTo("projectId", projectId));
-        for (DocumentSnapshot doc : existing.getDocuments()) {
+        for (DocumentSnapshot doc : queryCashflowWeeklyYear(tenantId, projectId)) {
             docs.put(doc.getId(), data(doc));
         }
         for (String docId : deltasByDoc.keySet()) {
@@ -4532,10 +4522,9 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
 
     @Override
     public List<WeeklyExpenseWeeklyStatusEntity> findWeeklyStatuses(String tenantId, String projectId) {
-        // SPEC-12 approved full scan: findWeeklyStatuses returns the complete status history.
-        QuerySnapshot snap = query(cashflowWeeks(tenantId).whereEqualTo("projectId", projectId));
+        List<DocumentSnapshot> snapshots = queryCashflowWeeklyYear(tenantId, projectId);
         List<WeeklyExpenseWeeklyStatusEntity> statuses = new ArrayList<>();
-        for (DocumentSnapshot doc : snap.getDocuments()) {
+        for (DocumentSnapshot doc : snapshots) {
             Map<String, Object> data = data(doc);
             statuses.add(toWeeklyStatus(
                 tenantId,
@@ -4618,10 +4607,8 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     }
 
     private List<WeeklyExpenseProjectionEntity> readProjectionLines(String tenantId, String projectId) {
-        // SPEC-12 approved full scan: readProjectionLines backs the all-month persistence contract.
-        QuerySnapshot snap = query(cashflowWeeks(tenantId).whereEqualTo("projectId", projectId));
         List<WeeklyExpenseProjectionEntity> lines = new ArrayList<>();
-        for (DocumentSnapshot doc : snap.getDocuments()) {
+        for (DocumentSnapshot doc : queryCashflowWeeklyYear(tenantId, projectId)) {
             Map<String, Object> data = data(doc);
             String yearMonth = text(data.get("yearMonth"), "");
             int weekNo = intValue(data.get("weekNo"), 0);
@@ -4635,10 +4622,8 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     }
 
     private List<WeeklyExpenseActualEntity> readActualLines(String tenantId, String projectId, boolean auditOrder) {
-        // SPEC-12 approved full scan: readActualLines backs all-month reads and audit ordering.
-        QuerySnapshot snap = query(cashflowWeeks(tenantId).whereEqualTo("projectId", projectId));
         List<WeeklyExpenseActualEntity> lines = new ArrayList<>();
-        for (DocumentSnapshot doc : snap.getDocuments()) {
+        for (DocumentSnapshot doc : queryCashflowWeeklyYear(tenantId, projectId)) {
             Map<String, Object> data = data(doc);
             String yearMonth = text(data.get("yearMonth"), "");
             int weekNo = intValue(data.get("weekNo"), 0);
@@ -4717,6 +4702,25 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             documents.addAll(query(scoped).getDocuments());
         }
         return List.copyOf(documents);
+    }
+
+    private List<DocumentSnapshot> queryCashflowWeeklyYear(String tenantId, String projectId) {
+        return queryCashflowWeeks(tenantId, projectId, weeklyYearMonths(requireCashflowWeeklyYear(tenantId, projectId)));
+    }
+
+    private List<String> weeklyYearMonths(int weeklyYear) {
+        return CashflowQueryScope.between(weeklyYear + "-01", weeklyYear + "-12");
+    }
+
+    private int requireCashflowWeeklyYear(String tenantId, String projectId) {
+        DocumentSnapshot mirror = get(db.document(
+            "orgs/" + tenantId + "/cashflow_sheet_mirrors/" + projectId
+        ));
+        String declaredWeeklyYear = mirror.exists() ? String.valueOf(data(mirror).get("weeklyYear")) : "";
+        if (!declaredWeeklyYear.matches("20\\d{2}")) {
+            throw new WeeklyExpenseConflictException("양식이 다릅니다.");
+        }
+        return Integer.parseInt(declaredWeeklyYear);
     }
 
     private DocumentReference cashflowWeekRef(String tenantId, String docId) {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -1569,9 +1569,10 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             }
         }
 
-        List<DocumentSnapshot> projectWeekSnapshots = queryCashflowWeeklyYear(actor.tenantId(), projectId);
+        // SPEC-16: completion targetRevision remains global until the revision contract is migrated.
+        QuerySnapshot projectWeekSnapshot = query(cashflowWeeks(actor.tenantId()).whereEqualTo("projectId", projectId));
         Map<String, Map<String, Object>> projectWeeks = new LinkedHashMap<>();
-        for (DocumentSnapshot weekSnapshot : projectWeekSnapshots) {
+        for (DocumentSnapshot weekSnapshot : projectWeekSnapshot.getDocuments()) {
             Map<String, Object> week = data(weekSnapshot);
             WeekDocParts parts = parseCashflowWeekId(projectId, weekSnapshot.getId());
             projectWeeks.put(weekSnapshot.getId(), week);
@@ -2556,13 +2557,26 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     }
 
     @Override
-    public List<Integer> findCashflowWeeklyYears(String tenantId, String projectId) {
-        return List.of(requireCashflowWeeklyYear(tenantId, projectId));
+    public Integer findCashflowDeclaredWeeklyYear(String tenantId, String projectId) {
+        DocumentSnapshot mirror = get(db.document(
+            "orgs/" + tenantId + "/cashflow_sheet_mirrors/" + projectId
+        ));
+        if (!mirror.exists()) {
+            return null;
+        }
+        Object value = data(mirror).get("weeklyYear");
+        if (!(value instanceof Number number)) {
+            return null;
+        }
+        int weeklyYear = number.intValue();
+        return weeklyYear >= 2000 && weeklyYear <= 2099 && number.doubleValue() == weeklyYear
+            ? weeklyYear
+            : null;
     }
 
     @Override
-    public CashflowLedgerSource findCashflowLedgerSource(String tenantId, String projectId) {
-        int weeklyYear = requireCashflowWeeklyYear(tenantId, projectId);
+    public CashflowLedgerSource findCashflowLedgerSource(String tenantId, String projectId, int weeklyYear) {
+        CashflowCoordinates.requireWeeklyYear(weeklyYear);
         return cashflowLedgerSource(
             tenantId,
             projectId,
@@ -2574,13 +2588,21 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     }
 
     @Override
+    public CashflowLedgerSource findCashflowGlobalLedgerSource(String tenantId, String projectId) {
+        // SPEC-16: LIVE_AMENDED compares the historical global targetRevision.
+        QuerySnapshot snapshot = query(cashflowWeeks(tenantId).whereEqualTo("projectId", projectId));
+        return cashflowLedgerSource(tenantId, projectId, snapshot.getDocuments(), null, null, null);
+    }
+
+    @Override
     public CashflowLedgerSource findCashflowLedgerSource(
         String tenantId,
         String projectId,
+        int weeklyYear,
         String fromMonth,
         String throughMonth
     ) {
-        int weeklyYear = requireCashflowWeeklyYear(tenantId, projectId);
+        CashflowCoordinates.requireWeeklyYear(weeklyYear);
         String firstMonth = weeklyYear + "-01";
         String lastMonth = weeklyYear + "-12";
         String scopedFrom = fromMonth.compareTo(firstMonth) < 0 ? firstMonth : fromMonth;
@@ -2601,19 +2623,22 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         List<? extends DocumentSnapshot> snapshots,
         String fromMonth,
         String throughMonth,
-        int weeklyYear
+        Integer weeklyYear
     ) {
         List<WeeklyExpenseProjectionEntity> projection = new ArrayList<>();
         List<WeeklyExpenseActualEntity> actual = new ArrayList<>();
         List<Map<String, Object>> documents = new ArrayList<>();
         for (DocumentSnapshot doc : snapshots) {
             Map<String, Object> document = data(doc);
-            documents.add(document);
             String yearMonth = text(document.get("yearMonth"), "");
             int weekNo = intValue(document.get("weekNo"), 0);
+            if (weeklyYear != null && CashflowCoordinates.weekOrdinal(weeklyYear, yearMonth, weekNo) == -1) {
+                continue;
+            }
             if (fromMonth != null && (yearMonth.compareTo(fromMonth) < 0 || yearMonth.compareTo(throughMonth) > 0)) {
                 continue;
             }
+            documents.add(document);
             for (Map.Entry<String, Object> entry : nestedMap(document.get("projection")).entrySet()) {
                 WeeklyExpenseProjectionEntity line = new WeeklyExpenseProjectionEntity(
                     tenantId, projectId, yearMonth, weekNo, entry.getKey()
@@ -2640,7 +2665,6 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         return new CashflowLedgerSource(
             projection,
             actual,
-            List.of(weeklyYear),
             computeCashflowTargetRevision(documents)
         );
     }
@@ -4705,22 +4729,14 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     }
 
     private List<DocumentSnapshot> queryCashflowWeeklyYear(String tenantId, String projectId) {
-        return queryCashflowWeeks(tenantId, projectId, weeklyYearMonths(requireCashflowWeeklyYear(tenantId, projectId)));
+        Integer weeklyYear = findCashflowDeclaredWeeklyYear(tenantId, projectId);
+        return weeklyYear == null
+            ? List.of()
+            : queryCashflowWeeks(tenantId, projectId, weeklyYearMonths(weeklyYear));
     }
 
     private List<String> weeklyYearMonths(int weeklyYear) {
         return CashflowQueryScope.between(weeklyYear + "-01", weeklyYear + "-12");
-    }
-
-    private int requireCashflowWeeklyYear(String tenantId, String projectId) {
-        DocumentSnapshot mirror = get(db.document(
-            "orgs/" + tenantId + "/cashflow_sheet_mirrors/" + projectId
-        ));
-        String declaredWeeklyYear = mirror.exists() ? String.valueOf(data(mirror).get("weeklyYear")) : "";
-        if (!declaredWeeklyYear.matches("20\\d{2}")) {
-            throw new WeeklyExpenseConflictException("양식이 다릅니다.");
-        }
-        return Integer.parseInt(declaredWeeklyYear);
     }
 
     private DocumentReference cashflowWeekRef(String tenantId, String docId) {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
@@ -159,11 +159,7 @@ public interface WeeklyExpensePersistence {
     ) {
     }
 
-    /**
-     * One authoritative read of the weekly cashflow ledger. Projection, Actual,
-     * and the years used to suppress annual fallbacks must come from the same
-     * storage snapshot so carry-forward cannot observe three different versions.
-     */
+    /** One authoritative read of the single weekly cashflow block. */
     record CashflowLedgerSource(
         List<WeeklyExpenseProjectionEntity> projection,
         List<WeeklyExpenseActualEntity> actual,
@@ -719,22 +715,13 @@ public interface WeeklyExpensePersistence {
     }
 
     default List<Integer> findCashflowWeeklyYears(String tenantId, String projectId) {
-        return findCashflowLedgerSource(tenantId, projectId).weeklyYears();
+        return List.of();
     }
 
     default CashflowLedgerSource findCashflowLedgerSource(String tenantId, String projectId) {
         List<WeeklyExpenseProjectionEntity> projection = findProjectionLines(tenantId, projectId);
         List<WeeklyExpenseActualEntity> actual = findActualLines(tenantId, projectId);
-        List<Integer> weeklyYears = java.util.stream.Stream.concat(
-                projection.stream().map(WeeklyExpenseProjectionEntity::getYearMonth),
-                actual.stream().map(WeeklyExpenseActualEntity::getYearMonth)
-            )
-            .filter(value -> value != null && value.matches("20\\d{2}-(0[1-9]|1[0-2])"))
-            .map(value -> Integer.parseInt(value.substring(0, 4)))
-            .distinct()
-            .sorted()
-            .toList();
-        return new CashflowLedgerSource(projection, actual, weeklyYears);
+        return new CashflowLedgerSource(projection, actual, findCashflowWeeklyYears(tenantId, projectId));
     }
 
     default CashflowLedgerSource findCashflowLedgerSource(
@@ -753,11 +740,7 @@ public interface WeeklyExpensePersistence {
         return new CashflowLedgerSource(projection, actual, source.weeklyYears(), source.targetRevision());
     }
 
-    /**
-     * Canonical carry-forward policy for cashflow reads and month-close snapshots.
-     * A prior year uses weekly ledger lines when that year exists in the weekly ledger;
-     * the annual-total document is only a fallback, so a year can never be counted twice.
-     */
+    /** Prior-year carry-forward comes only from the fixed annual columns. */
     default CashflowOpeningBalance findCashflowOpeningBalance(
         String tenantId,
         String projectId,
@@ -767,7 +750,7 @@ public interface WeeklyExpensePersistence {
             tenantId,
             projectId,
             selectedYear,
-            findCashflowWeeklyYears(tenantId, projectId)
+            List.of()
         );
     }
 
@@ -780,13 +763,8 @@ public interface WeeklyExpensePersistence {
         if (selectedYear < 2000 || selectedYear > 2099) {
             throw new IllegalArgumentException("Cashflow opening-balance year must be between 2000 and 2099.");
         }
-        List<Integer> weeklyYears = (sourceWeeklyYears == null ? List.<Integer>of() : sourceWeeklyYears).stream()
-            .filter(year -> year < selectedYear)
-            .distinct()
-            .sorted()
-            .toList();
         List<CashflowSheetAnnualTotal> annualTotals = findCashflowSheetYearTotals(tenantId, projectId).stream()
-            .filter(total -> total.year() < selectedYear && !weeklyYears.contains(total.year()))
+            .filter(total -> total.year() < selectedYear)
             .sorted(java.util.Comparator.comparingInt(CashflowSheetAnnualTotal::year))
             .toList();
         List<Integer> includedYears = annualTotals.stream().map(CashflowSheetAnnualTotal::year).toList();
@@ -814,14 +792,14 @@ public interface WeeklyExpensePersistence {
                 projectionLines,
                 projectionSources,
                 includedYears,
-                weeklyYears
+                List.of()
             ),
             new CashflowOpeningBalance.Mode(
                 cashflowMapNet(actualLines),
                 actualLines,
                 actualSources,
                 includedYears,
-                weeklyYears
+                List.of()
             )
         );
     }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
@@ -163,21 +163,18 @@ public interface WeeklyExpensePersistence {
     record CashflowLedgerSource(
         List<WeeklyExpenseProjectionEntity> projection,
         List<WeeklyExpenseActualEntity> actual,
-        List<Integer> weeklyYears,
         String targetRevision
     ) {
         public CashflowLedgerSource(
             List<WeeklyExpenseProjectionEntity> projection,
-            List<WeeklyExpenseActualEntity> actual,
-            List<Integer> weeklyYears
+            List<WeeklyExpenseActualEntity> actual
         ) {
-            this(projection, actual, weeklyYears, "");
+            this(projection, actual, "");
         }
 
         public CashflowLedgerSource {
             projection = projection == null ? List.of() : List.copyOf(projection);
             actual = actual == null ? List.of() : List.copyOf(actual);
-            weeklyYears = weeklyYears == null ? List.of() : weeklyYears.stream().distinct().sorted().toList();
             targetRevision = targetRevision == null ? "" : targetRevision;
         }
     }
@@ -714,30 +711,39 @@ public interface WeeklyExpensePersistence {
         return List.of();
     }
 
-    default List<Integer> findCashflowWeeklyYears(String tenantId, String projectId) {
-        return List.of();
+    default Integer findCashflowDeclaredWeeklyYear(String tenantId, String projectId) {
+        return null;
     }
 
-    default CashflowLedgerSource findCashflowLedgerSource(String tenantId, String projectId) {
+    default CashflowLedgerSource findCashflowLedgerSource(String tenantId, String projectId, int weeklyYear) {
         List<WeeklyExpenseProjectionEntity> projection = findProjectionLines(tenantId, projectId);
         List<WeeklyExpenseActualEntity> actual = findActualLines(tenantId, projectId);
-        return new CashflowLedgerSource(projection, actual, findCashflowWeeklyYears(tenantId, projectId));
+        String yearPrefix = weeklyYear + "-";
+        return new CashflowLedgerSource(
+            projection.stream().filter(line -> line.getYearMonth().startsWith(yearPrefix)).toList(),
+            actual.stream().filter(line -> line.getYearMonth().startsWith(yearPrefix)).toList()
+        );
+    }
+
+    default CashflowLedgerSource findCashflowGlobalLedgerSource(String tenantId, String projectId) {
+        return new CashflowLedgerSource(findProjectionLines(tenantId, projectId), findActualLines(tenantId, projectId));
     }
 
     default CashflowLedgerSource findCashflowLedgerSource(
         String tenantId,
         String projectId,
+        int weeklyYear,
         String fromMonth,
         String throughMonth
     ) {
-        CashflowLedgerSource source = findCashflowLedgerSource(tenantId, projectId);
+        CashflowLedgerSource source = findCashflowLedgerSource(tenantId, projectId, weeklyYear);
         List<WeeklyExpenseProjectionEntity> projection = source.projection().stream()
             .filter(line -> line.getYearMonth().compareTo(fromMonth) >= 0 && line.getYearMonth().compareTo(throughMonth) <= 0)
             .toList();
         List<WeeklyExpenseActualEntity> actual = source.actual().stream()
             .filter(line -> line.getYearMonth().compareTo(fromMonth) >= 0 && line.getYearMonth().compareTo(throughMonth) <= 0)
             .toList();
-        return new CashflowLedgerSource(projection, actual, source.weeklyYears(), source.targetRevision());
+        return new CashflowLedgerSource(projection, actual, source.targetRevision());
     }
 
     /** Prior-year carry-forward comes only from the fixed annual columns. */
@@ -745,20 +751,6 @@ public interface WeeklyExpensePersistence {
         String tenantId,
         String projectId,
         int selectedYear
-    ) {
-        return findCashflowOpeningBalance(
-            tenantId,
-            projectId,
-            selectedYear,
-            List.of()
-        );
-    }
-
-    default CashflowOpeningBalance findCashflowOpeningBalance(
-        String tenantId,
-        String projectId,
-        int selectedYear,
-        Collection<Integer> sourceWeeklyYears
     ) {
         if (selectedYear < 2000 || selectedYear > 2099) {
             throw new IllegalArgumentException("Cashflow opening-balance year must be between 2000 and 2099.");

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
@@ -39,6 +39,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.same;
@@ -90,6 +91,7 @@ class WeeklyExpenseControllerTest {
 
     @BeforeEach
     void allowLegacyJpaFixtureWritesWithoutFirestoreLeaseBackend() {
+        doReturn(2026).when(weeklyExpensePersistence).findCashflowDeclaredWeeklyYear(any(), any());
         doAnswer(invocation -> ((TrustedActorContext) invocation.getArgument(0)).role())
             .when(weeklyExpensePersistence).requireCashflowWriteLease(any(), any(), any());
         doAnswer(invocation -> ((TrustedActorContext) invocation.getArgument(0)).role())
@@ -362,6 +364,28 @@ class WeeklyExpenseControllerTest {
     }
 
     @Test
+    void cashflowSnapshotWithoutDeclaredWeeklyYearDoesNotReadGlobalLedger() {
+        WeeklyExpenseCommandService snapshotCommandService = mock(WeeklyExpenseCommandService.class);
+        WeeklyExpensePersistence snapshotPersistence = mock(WeeklyExpensePersistence.class);
+        when(snapshotPersistence.findCashflowDeclaredWeeklyYear("tenant-no-year", "project-no-year"))
+            .thenReturn(null);
+        WeeklyExpenseController snapshotController = new WeeklyExpenseController(
+            snapshotCommandService, snapshotPersistence, false
+        );
+
+        CashflowSnapshotResponse response = snapshotController.cashflowSnapshot(
+            "project-no-year", "tenant-no-year", "viewer-no-year", "viewer", "viewer@example.com"
+        );
+
+        assertThat(response.projection()).isEmpty();
+        assertThat(response.actual()).isEmpty();
+        assertThat(response.readModel().months()).isEmpty();
+        verify(snapshotPersistence).findCashflowDeclaredWeeklyYear("tenant-no-year", "project-no-year");
+        verify(snapshotPersistence, never()).findCashflowLedgerSource(any(), any(), anyInt());
+        verify(snapshotPersistence, never()).findCashflowGlobalLedgerSource(any(), any());
+    }
+
+    @Test
     void saveDraftPersistsRowsActualsAuditAndIdempotentResponse() throws Exception {
         String body = """
             {
@@ -476,25 +500,21 @@ class WeeklyExpenseControllerTest {
     }
 
     @Test
-    void projectionActualSummaryBatchSerializesTheStrictThinBffContract() throws Exception {
-        dev.merryai.innerplatform.weekly.domain.CashflowProjectionActualSummaryCalculator.FinanceWeek boundary =
-            dev.merryai.innerplatform.weekly.domain.CashflowProjectionActualSummaryCalculator.currentFinanceWeek(
-                java.time.Clock.systemUTC()
-            );
+    void projectionActualSummaryBatchReturnsPerProjectErrorsWithoutDeclaredWeeklyYears() throws Exception {
+        doReturn(null).when(weeklyExpensePersistence)
+            .findCashflowDeclaredWeeklyYear(eq("tenant-summary"), any());
+
         mockMvc.perform(asActor(post("/api/v1/cashflow/projection-actual-summary/batch"),
                 "tenant-summary", "viewer-summary", "viewer")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"projectIds\":[\"project-b\",\"project-a\"]}"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.version").value("1"))
-            .andExpect(jsonPath("$.items[0].projectId").value("project-a"))
-            .andExpect(jsonPath("$.items[0].fromMonth").value("2023-01"))
-            .andExpect(jsonPath("$.items[0].comparisonAsOfWeek.yearMonth").value(boundary.yearMonth()))
-            .andExpect(jsonPath("$.items[0].comparisonAsOfWeek.weekNo").value(boundary.weekNo()))
-            .andExpect(jsonPath("$.items[0].settlementDifferenceAmount").value(0))
-            .andExpect(jsonPath("$.items[0].settlementMatches").value(true))
-            .andExpect(jsonPath("$.items[1].projectId").value("project-b"))
-            .andExpect(jsonPath("$.errors").isEmpty());
+            .andExpect(jsonPath("$.items").isEmpty())
+            .andExpect(jsonPath("$.errors[0].projectId").value("project-a"))
+            .andExpect(jsonPath("$.errors[0].code").value("SUMMARY_UNAVAILABLE"))
+            .andExpect(jsonPath("$.errors[1].projectId").value("project-b"))
+            .andExpect(jsonPath("$.errors[1].code").value("SUMMARY_UNAVAILABLE"));
 
         mockMvc.perform(asActor(post("/api/v1/cashflow/projection-actual-summary/batch"),
                 "tenant-summary", "viewer-summary", "viewer")
@@ -1548,9 +1568,11 @@ class WeeklyExpenseControllerTest {
             "2026-07-20", "2026-07-10", true,
             null, null, null, null, null, null, null, null, null, null, null
         ));
+        when(dashboardPersistence.findCashflowDeclaredWeeklyYear("tenant-month-dashboard", "project-month-dashboard"))
+            .thenReturn(2026);
         WeeklyExpensePersistence.CashflowLedgerSource dashboardSource =
-            new WeeklyExpensePersistence.CashflowLedgerSource(List.of(), List.of(), List.of(2024));
-        when(dashboardPersistence.findCashflowLedgerSource("tenant-month-dashboard", "project-month-dashboard"))
+            new WeeklyExpensePersistence.CashflowLedgerSource(List.of(), List.of());
+        when(dashboardPersistence.findCashflowLedgerSource("tenant-month-dashboard", "project-month-dashboard", 2026))
             .thenReturn(dashboardSource);
         when(dashboardCommandService.readCashflowProjectionActualSummary(
             any(), eq("project-month-dashboard"), same(dashboardSource)
@@ -1566,8 +1588,7 @@ class WeeklyExpenseControllerTest {
         when(dashboardPersistence.findCashflowOpeningBalance(
             "tenant-month-dashboard",
             "project-month-dashboard",
-            2026,
-            List.of(2024)
+            2026
         )).thenReturn(new WeeklyExpensePersistence.CashflowOpeningBalance(
             2026,
             new WeeklyExpensePersistence.CashflowOpeningBalance.Mode(
@@ -1579,7 +1600,7 @@ class WeeklyExpenseControllerTest {
                     completeAnnualStates
                 )),
                 List.of(2025),
-                List.of(2024)
+                List.of()
             ),
             new WeeklyExpensePersistence.CashflowOpeningBalance.Mode(
                 new java.math.BigDecimal("1800000"),
@@ -1590,7 +1611,7 @@ class WeeklyExpenseControllerTest {
                     completeAnnualStates
                 )),
                 List.of(2025),
-                List.of(2024)
+                List.of()
             )
         ));
 
@@ -1614,7 +1635,7 @@ class WeeklyExpenseControllerTest {
         assertThat(response.openingBalances().projection().amount()).isEqualByComparingTo("2000000");
         assertThat(response.openingBalances().actual().amount()).isEqualByComparingTo("1800000");
         assertThat(response.openingBalances().projection().includedYears()).containsExactly(2025);
-        assertThat(response.openingBalances().projection().excludedWeeklyYears()).containsExactly(2024);
+        assertThat(response.openingBalances().projection().excludedWeeklyYears()).isEmpty();
         assertThat(response.openingBalances().projection().lineAmounts()).containsEntry("SALES_IN", new java.math.BigDecimal("2000000"));
         assertThat(response.openingBalances().projection().sources()).singleElement().satisfies(source -> {
             assertThat(source.year()).isEqualTo(2025);
@@ -1623,11 +1644,60 @@ class WeeklyExpenseControllerTest {
         assertThat(response.projectionActualSummary().settlementDifferenceAmount())
             .isEqualByComparingTo("18371453");
         verify(dashboardPersistence, times(1))
-            .findCashflowLedgerSource("tenant-month-dashboard", "project-month-dashboard");
+            .findCashflowLedgerSource("tenant-month-dashboard", "project-month-dashboard", 2026);
         verify(dashboardCommandService).readCashflowProjectionActualSummary(
             any(), eq("project-month-dashboard"), same(dashboardSource)
         );
         verify(dashboardCommandService, never()).readCashflowProjectionActualSummaries(any(), any());
+    }
+
+    @Test
+    void openDashboardWithoutDeclaredWeeklyYearReturnsSourceBlockerAndKeepsOtherData() {
+        WeeklyExpenseCommandService dashboardCommandService = mock(WeeklyExpenseCommandService.class);
+        WeeklyExpensePersistence dashboardPersistence = mock(WeeklyExpensePersistence.class);
+        when(dashboardPersistence.findCashflowDeclaredWeeklyYear("tenant-no-year", "project-no-year"))
+            .thenReturn(null);
+        when(dashboardCommandService.readCashflowMonthClose(any(), eq("project-no-year"), eq("2026-06")))
+            .thenReturn(new CashflowMonthCloseResponse(
+                true, "cashflowMonth.read", "project-no-year", "2026-06", "OPEN",
+                0, 0, 0, 0, 0, null, null, null, null, null, false,
+                Map.of(), null, null, Map.of(), Map.of(), false,
+                "2026-07-20", "2026-07-10", true,
+                null, null, null, null, null, null, null, null, null, null, null
+            ));
+        when(dashboardPersistence.findCashflowOpeningBalance("tenant-no-year", "project-no-year", 2026))
+            .thenReturn(new WeeklyExpensePersistence.CashflowOpeningBalance(
+                2026,
+                new WeeklyExpensePersistence.CashflowOpeningBalance.Mode(
+                    java.math.BigDecimal.ZERO, Map.of(), List.of(), List.of(), List.of()
+                ),
+                new WeeklyExpensePersistence.CashflowOpeningBalance.Mode(
+                    java.math.BigDecimal.ZERO, Map.of(), List.of(), List.of(), List.of()
+                )
+            ));
+        when(dashboardCommandService.readCashflowProjectionActualSummary(
+            any(), eq("project-no-year"), any(WeeklyExpensePersistence.CashflowLedgerSource.class)
+        )).thenReturn(new CashflowProjectionActualSummaryBatchResponse.Item(
+            "project-no-year", "2023-01",
+            new CashflowProjectionActualSummaryBatchResponse.ComparisonAsOfWeek("2026-07", 4),
+            java.math.BigDecimal.ZERO, true
+        ));
+
+        CashflowMonthDashboardSourceResponse response = new WeeklyExpenseController(
+            dashboardCommandService, dashboardPersistence, false
+        ).readCashflowMonthDashboardSource(
+            "project-no-year", "2026-06", "tenant-no-year", "viewer-no-year", "viewer", "viewer@example.com"
+        );
+
+        assertThat(response.monthClose().status()).isEqualTo("OPEN");
+        assertThat(response.cashflow().readModel().months()).isEmpty();
+        assertThat(response.openingBalances().selectedYear()).isEqualTo(2026);
+        assertThat(response.blockers()).containsExactly(new CashflowMonthDashboardSourceResponse.Blocker(
+            "SHEET_SOURCE_REQUIRED", "먼저 시트값을 불러와 주세요."
+        ));
+        verify(dashboardPersistence, times(1))
+            .findCashflowDeclaredWeeklyYear("tenant-no-year", "project-no-year");
+        verify(dashboardPersistence, never()).findCashflowLedgerSource(any(), any(), anyInt());
     }
 
     @Test
@@ -1676,8 +1746,8 @@ class WeeklyExpenseControllerTest {
         assertThat(response.monthClose().status()).isEqualTo("CLOSED");
         assertThat(response.cashflow()).isNull();
         assertThat(response.openingBalances().selectedYear()).isEqualTo(2026);
-        verify(dashboardPersistence, never()).findCashflowLedgerSource(any(), any());
-        verify(dashboardPersistence, never()).findCashflowOpeningBalance(any(), any(), anyInt(), any());
+        verify(dashboardPersistence, never()).findCashflowLedgerSource(any(), any(), anyInt());
+        verify(dashboardPersistence, never()).findCashflowOpeningBalance(any(), any(), anyInt());
     }
 
     @Test
@@ -1723,16 +1793,14 @@ class WeeklyExpenseControllerTest {
             new WeeklyExpensePersistence.CashflowLedgerSource(
                 List.of(),
                 List.of(),
-                List.of(),
                 targetRevision
             );
-        when(dashboardPersistence.findCashflowLedgerSource("tenant-amended", "project-amended"))
+        when(dashboardPersistence.findCashflowGlobalLedgerSource("tenant-amended", "project-amended"))
             .thenReturn(liveSource);
         when(dashboardPersistence.findCashflowOpeningBalance(
             "tenant-amended",
             "project-amended",
-            2026,
-            List.of()
+            2026
         )).thenReturn(new WeeklyExpensePersistence.CashflowOpeningBalance(
             2026,
             new WeeklyExpensePersistence.CashflowOpeningBalance.Mode(
@@ -1765,12 +1833,11 @@ class WeeklyExpenseControllerTest {
             eq("project-amended"),
             eq("2026-06")
         );
-        verify(dashboardPersistence).findCashflowLedgerSource("tenant-amended", "project-amended");
+        verify(dashboardPersistence).findCashflowGlobalLedgerSource("tenant-amended", "project-amended");
         verify(dashboardPersistence).findCashflowOpeningBalance(
             "tenant-amended",
             "project-amended",
-            2026,
-            List.of()
+            2026
         );
     }
 
@@ -1817,12 +1884,12 @@ class WeeklyExpenseControllerTest {
         );
         when(dashboardCommandService.readCashflowMonthClose(any(), eq("project-drift"), eq("2026-06")))
             .thenReturn(first, drifted, first, drifted);
-        when(dashboardPersistence.findCashflowLedgerSource("tenant-drift", "project-drift"))
+        when(dashboardPersistence.findCashflowGlobalLedgerSource("tenant-drift", "project-drift"))
             .thenReturn(new WeeklyExpensePersistence.CashflowLedgerSource(
-                List.of(), List.of(), List.of(), targetRevision
+                List.of(), List.of(), targetRevision
             ));
         when(dashboardPersistence.findCashflowOpeningBalance(
-            "tenant-drift", "project-drift", 2026, List.of()
+            "tenant-drift", "project-drift", 2026
         )).thenReturn(new WeeklyExpensePersistence.CashflowOpeningBalance(
             2026,
             new WeeklyExpensePersistence.CashflowOpeningBalance.Mode(
@@ -1889,8 +1956,8 @@ class WeeklyExpenseControllerTest {
         assertThat(response.snapshotCompatibility().status()).isEqualTo("LEGACY_EVIDENCE_ONLY");
         assertThat(response.snapshotCompatibility().missingEvidence())
             .containsExactly("OPENING_BALANCES", "LEDGER_WEEKS");
-        verify(dashboardPersistence, never()).findCashflowLedgerSource(any(), any());
-        verify(dashboardPersistence, never()).findCashflowOpeningBalance(any(), any(), anyInt(), any());
+        verify(dashboardPersistence, never()).findCashflowLedgerSource(any(), any(), anyInt());
+        verify(dashboardPersistence, never()).findCashflowOpeningBalance(any(), any(), anyInt());
     }
 
     @Test

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseWorkspaceAuthorizationControllerTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseWorkspaceAuthorizationControllerTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -42,6 +43,7 @@ class WeeklyExpenseWorkspaceAuthorizationControllerTest {
 
     @BeforeEach
     void allowLegacyJpaFixtureWritesWithoutFirestoreLeaseBackend() {
+        doReturn(2026).when(weeklyExpensePersistence).findCashflowDeclaredWeeklyYear(any(), any());
         doAnswer(invocation -> ((TrustedActorContext) invocation.getArgument(0)).role())
             .when(weeklyExpensePersistence).requireCashflowWriteLease(any(), any(), any());
         doAnswer(invocation -> ((TrustedActorContext) invocation.getArgument(0)).role())

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowProjectionActualSummaryServiceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowProjectionActualSummaryServiceTest.java
@@ -38,10 +38,12 @@ class CashflowProjectionActualSummaryServiceTest {
             "tenant-a", "project-a", "2023-01", 1, "SALES_IN"
         );
         projection.setAmount(BigDecimal.TEN);
-        when(persistence.findCashflowLedgerSource(eq("tenant-a"), eq("project-a"), eq("2023-01"), anyString()))
-            .thenReturn(new WeeklyExpensePersistence.CashflowLedgerSource(List.of(projection), List.of(), List.of(2023)));
-        when(persistence.findCashflowLedgerSource(eq("tenant-a"), eq("project-b"), eq("2023-01"), anyString()))
-            .thenReturn(new WeeklyExpensePersistence.CashflowLedgerSource(List.of(), List.of(), List.of()));
+        when(persistence.findCashflowDeclaredWeeklyYear("tenant-a", "project-a")).thenReturn(2026);
+        when(persistence.findCashflowDeclaredWeeklyYear("tenant-a", "project-b")).thenReturn(2026);
+        when(persistence.findCashflowLedgerSource(eq("tenant-a"), eq("project-a"), eq(2026), eq("2023-01"), anyString()))
+            .thenReturn(new WeeklyExpensePersistence.CashflowLedgerSource(List.of(projection), List.of()));
+        when(persistence.findCashflowLedgerSource(eq("tenant-a"), eq("project-b"), eq(2026), eq("2023-01"), anyString()))
+            .thenReturn(new WeeklyExpensePersistence.CashflowLedgerSource(List.of(), List.of()));
 
         CashflowProjectionActualSummaryBatchResponse response = service.readCashflowProjectionActualSummaries(
             ACTOR, new CashflowProjectionActualSummaryBatchRequest(List.of("project-b", "project-a"))
@@ -58,7 +60,7 @@ class CashflowProjectionActualSummaryServiceTest {
         InOrder order = inOrder(authorization, persistence);
         order.verify(authorization).requireProjectAllowed(WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, ACTOR, "project-a");
         order.verify(authorization).requireProjectAllowed(WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, ACTOR, "project-b");
-        order.verify(persistence).findCashflowLedgerSource("tenant-a", "project-a", "2023-01", response.items().getFirst().comparisonAsOfWeek().yearMonth());
+        order.verify(persistence).findCashflowLedgerSource("tenant-a", "project-a", 2026, "2023-01", response.items().getFirst().comparisonAsOfWeek().yearMonth());
     }
 
     @Test
@@ -70,8 +72,9 @@ class CashflowProjectionActualSummaryServiceTest {
             "tenant-a", "project-a", "2026-11", 2, "SALES_IN"
         );
         projection.setAmount(BigDecimal.valueOf(300));
-        when(persistence.findCashflowLedgerSource("tenant-a", "project-a", "2023-01", "2026-11"))
-            .thenReturn(new WeeklyExpensePersistence.CashflowLedgerSource(List.of(projection), List.of(), List.of(2026)));
+        when(persistence.findCashflowDeclaredWeeklyYear("tenant-a", "project-a")).thenReturn(2026);
+        when(persistence.findCashflowLedgerSource("tenant-a", "project-a", 2026, "2023-01", "2026-11"))
+            .thenReturn(new WeeklyExpensePersistence.CashflowLedgerSource(List.of(projection), List.of()));
 
         CashflowProjectionActualSummaryBatchResponse.Item item = service.readCashflowProjectionActualSummaries(
             ACTOR, new CashflowProjectionActualSummaryBatchRequest(List.of("project-a"), "2026-11")
@@ -83,7 +86,7 @@ class CashflowProjectionActualSummaryServiceTest {
         assertThat(item.periods()).filteredOn(period -> period.period().equals("WEEK_2"))
             .extracting(CashflowProjectionActualSummaryBatchResponse.PeriodSummary::projectionAmount)
             .containsExactly(BigDecimal.valueOf(300));
-        verify(persistence).findCashflowLedgerSource("tenant-a", "project-a", "2023-01", "2026-11");
+        verify(persistence).findCashflowLedgerSource("tenant-a", "project-a", 2026, "2023-01", "2026-11");
     }
 
     @Test
@@ -94,13 +97,14 @@ class CashflowProjectionActualSummaryServiceTest {
         List<String> projectIds = IntStream.rangeClosed(1, 10)
             .mapToObj(number -> "project-%02d".formatted(number))
             .toList();
-        when(persistence.findCashflowLedgerSource(eq("tenant-a"), anyString(), eq("2023-01"), anyString()))
+        when(persistence.findCashflowDeclaredWeeklyYear(eq("tenant-a"), anyString())).thenReturn(2026);
+        when(persistence.findCashflowLedgerSource(eq("tenant-a"), anyString(), eq(2026), eq("2023-01"), anyString()))
             .thenAnswer(invocation -> {
                 String projectId = invocation.getArgument(1);
                 if ("project-07".equals(projectId)) {
                     throw new IllegalStateException("secret datastore path and credential");
                 }
-                return new WeeklyExpensePersistence.CashflowLedgerSource(List.of(), List.of(), List.of());
+                return new WeeklyExpensePersistence.CashflowLedgerSource(List.of(), List.of());
             });
 
         CashflowProjectionActualSummaryBatchResponse response = service.readCashflowProjectionActualSummaries(
@@ -138,7 +142,7 @@ class CashflowProjectionActualSummaryServiceTest {
         )).isInstanceOf(WeeklyExpenseForbiddenException.class)
             .hasMessage("One or more projects are not accessible.");
 
-        verify(persistence, never()).findCashflowLedgerSource(anyString(), anyString(), anyString(), anyString());
+        verify(persistence, never()).findCashflowLedgerSource(anyString(), anyString(), org.mockito.ArgumentMatchers.anyInt(), anyString(), anyString());
         verify(authorization).requireProjectAllowed(
             WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, ACTOR, "project-b"
         );
@@ -164,8 +168,9 @@ class CashflowProjectionActualSummaryServiceTest {
         );
         projection.setAmount(BigDecimal.TEN);
         WeeklyExpensePersistence.CashflowLedgerSource source =
-            new WeeklyExpensePersistence.CashflowLedgerSource(List.of(projection), List.of(), List.of(2023));
-        when(persistence.findCashflowLedgerSource(eq("tenant-a"), eq("project-a"), eq("2023-01"), anyString()))
+            new WeeklyExpensePersistence.CashflowLedgerSource(List.of(projection), List.of());
+        when(persistence.findCashflowDeclaredWeeklyYear("tenant-a", "project-a")).thenReturn(2026);
+        when(persistence.findCashflowLedgerSource(eq("tenant-a"), eq("project-a"), eq(2026), eq("2023-01"), anyString()))
             .thenReturn(source);
 
         CashflowProjectionActualSummaryBatchResponse.Item batch = service.readCashflowProjectionActualSummaries(

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/CashflowCoordinatesTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/CashflowCoordinatesTest.java
@@ -1,0 +1,19 @@
+package dev.merryai.innerplatform.weekly.storage;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CashflowCoordinatesTest {
+    @Test
+    void matchesTheBffCoordinateContract() {
+        assertThat(CashflowCoordinates.weekOrdinal(2026, "2025-12", 4)).isEqualTo(-1);
+        assertThat(CashflowCoordinates.weekOrdinal(2026, "2026-01", 1)).isZero();
+        assertThat(CashflowCoordinates.weekOrdinal(2026, "2026-12", 5)).isEqualTo(59);
+        assertThat(CashflowCoordinates.weekOrdinal(2026, "2026-03", 6)).isEqualTo(-1);
+        assertThat(CashflowCoordinates.annualYearsFor(2026))
+            .containsExactly(2024, 2025, 2027, 2028, 2029, 2030, 2031, 2032);
+        assertThat(CashflowCoordinates.annualYearsFor(2027))
+            .containsExactly(2025, 2026, 2028, 2029, 2030, 2031, 2032, 2033);
+    }
+}

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -1821,8 +1821,8 @@ class FirestoreCashflowLeaseGuardTest {
                 "orgs/tenant-a/cashflow_weeks/project-a-2026-07-w1",
                 "orgs/tenant-a/cashflow_weeks/project-a-2026-08-w1"
             );
-        assertThat(fixture.persistence.findCashflowWeeklyYears("tenant-a", "project-a"))
-            .containsExactly(2026);
+        assertThat(fixture.persistence.findCashflowDeclaredWeeklyYear("tenant-a", "project-a"))
+            .isEqualTo(2026);
     }
 
     @Test
@@ -1861,28 +1861,41 @@ class FirestoreCashflowLeaseGuardTest {
         );
 
         WeeklyExpensePersistence.CashflowLedgerSource source = fixture.persistence
-            .findCashflowLedgerSource("tenant-a", "project-a");
+            .findCashflowLedgerSource("tenant-a", "project-a", 2026);
 
-        assertThat(source.weeklyYears()).containsExactly(2026);
         assertThat(source.projection()).singleElement().satisfies(line ->
             assertThat(line.getAmount()).isEqualByComparingTo("2000000")
         );
         assertThat(source.actual()).singleElement().satisfies(line ->
             assertThat(line.getAmount()).isEqualByComparingTo("1800000")
         );
+        assertThat(source.targetRevision()).isEqualTo(FirestoreInheritedWeeklyExpensePersistence
+            .computeCashflowTargetRevision(List.of(fixture.documents.get(
+                "orgs/tenant-a/cashflow_weeks/project-a-2026-01-w1"
+            ))));
         assertThat(fixture.queryReadSizes.getLast()).isEqualTo(1);
     }
 
     @Test
-    void dashboardLedgerSourceRejectsAnInvalidWeeklyYearDeclaration() {
+    void absentWeeklyYearDeclarationReturnsNullForExistingAndMissingMirrors() {
+        Fixture fixture = fixture(activeMember(), activeLease());
+        String mirrorPath = "orgs/tenant-a/cashflow_sheet_mirrors/project-a";
+        fixture.documents.put(mirrorPath, Map.of("projectId", "project-a"));
+
+        assertThat(fixture.persistence.findCashflowDeclaredWeeklyYear("tenant-a", "project-a")).isNull();
+
+        fixture.documents.remove(mirrorPath);
+        assertThat(fixture.persistence.findCashflowDeclaredWeeklyYear("tenant-a", "project-a")).isNull();
+    }
+
+    @Test
+    void invalidWeeklyYearDeclarationIsUnavailableInsteadOfThrowingOnARead() {
         Fixture fixture = fixture(activeMember(), activeLease());
         fixture.documents.put("orgs/tenant-a/cashflow_sheet_mirrors/project-a", Map.of(
             "projectId", "project-a", "weeklyYear", "2026.0"
         ));
 
-        assertThatThrownBy(() -> fixture.persistence.findCashflowLedgerSource("tenant-a", "project-a"))
-            .isInstanceOf(WeeklyExpenseConflictException.class)
-            .hasMessage("양식이 다릅니다.");
+        assertThat(fixture.persistence.findCashflowDeclaredWeeklyYear("tenant-a", "project-a")).isNull();
     }
 
     @Test
@@ -1902,7 +1915,7 @@ class FirestoreCashflowLeaseGuardTest {
         )));
 
         WeeklyExpensePersistence.CashflowLedgerSource source = fixture.persistence
-            .findCashflowLedgerSource("tenant-a", "project-a", "2023-01", "2026-07");
+            .findCashflowLedgerSource("tenant-a", "project-a", 2026, "2023-01", "2026-07");
 
         assertThat(source.projection()).singleElement().satisfies(line -> {
             assertThat(line.getYearMonth()).isEqualTo("2026-07");
@@ -1927,11 +1940,11 @@ class FirestoreCashflowLeaseGuardTest {
             .as("unscoped baseline")
             .isEqualTo(540);
 
-        fixture.persistence.findCashflowLedgerSource("tenant-a", "project-a", "2026-07", "2026-07");
+        fixture.persistence.findCashflowLedgerSource("tenant-a", "project-a", 2026, "2026-07", "2026-07");
 
         assertThat(fixture.queryReadSizes.getLast()).isEqualTo(5).isLessThanOrEqualTo(10);
 
-        fixture.persistence.findCashflowLedgerSource("tenant-a", "project-a", "2026-07", "2026-09");
+        fixture.persistence.findCashflowLedgerSource("tenant-a", "project-a", 2026, "2026-07", "2026-09");
 
         assertThat(fixture.queryReadSizes.getLast()).isEqualTo(15);
     }
@@ -1942,9 +1955,14 @@ class FirestoreCashflowLeaseGuardTest {
             "src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java"
         ));
         assertThat(source).doesNotContain("SPEC-12 approved full scan:");
+        assertThat(source).contains(
+            "SPEC-16: completion targetRevision remains global",
+            "SPEC-16: LIVE_AMENDED compares the historical global targetRevision",
+            "QuerySnapshot projectWeekSnapshot = query(cashflowWeeks(actor.tenantId()).whereEqualTo(\"projectId\", projectId))"
+        );
         assertThat(source.split(Pattern.quote("cashflowWeeks(tenantId).whereEqualTo(\"projectId\", projectId)"), -1).length - 1)
-            .as("the bounded query helper adds yearMonth before execution")
-            .isEqualTo(1);
+            .as("only the bounded helper and SPEC-16 LIVE_AMENDED global read use this shape")
+            .isEqualTo(2);
     }
 
     @Test

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -860,6 +860,7 @@ class FirestoreCashflowLeaseGuardTest {
         String mirrorPath = "orgs/tenant-a/cashflow_sheet_mirrors/project-a";
         fixture.documents.put(mirrorPath, new LinkedHashMap<>(Map.of(
             "projectId", "project-a",
+            "weeklyYear", 2026,
             "status", "FRESH",
             "sourceRevision", SOURCE_REVISION,
             "targetRevisionAtFetch", targetRevision
@@ -1825,8 +1826,11 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
-    void dashboardLedgerSourceDerivesProjectionActualAndYearsFromOneFirestoreQuery() {
+    void dashboardLedgerSourceReadsOnlyTheDeclaredWeeklyYear() {
         Fixture fixture = fixture(activeMember(), activeLease());
+        fixture.documents.put("orgs/tenant-a/cashflow_sheet_mirrors/project-a", Map.of(
+            "projectId", "project-a", "weeklyYear", 2026
+        ));
         fixture.documents.put(
             "orgs/tenant-a/cashflow_weeks/project-a-2025-12-w5",
             new LinkedHashMap<>(Map.of(
@@ -1841,19 +1845,44 @@ class FirestoreCashflowLeaseGuardTest {
                 )
             ))
         );
+        fixture.documents.put(
+            "orgs/tenant-a/cashflow_weeks/project-a-2026-01-w1",
+            new LinkedHashMap<>(Map.of(
+                "tenantId", "tenant-a",
+                "projectId", "project-a",
+                "yearMonth", "2026-01",
+                "weekNo", 1,
+                "projection", Map.of("SALES_IN", 2_000_000L),
+                "weeklyExpenseActualBySheet", Map.of(
+                    "cashflow-sheet-lab",
+                    Map.of("SALES_IN", 1_800_000L)
+                )
+            ))
+        );
 
         WeeklyExpensePersistence.CashflowLedgerSource source = fixture.persistence
             .findCashflowLedgerSource("tenant-a", "project-a");
 
-        assertThat(source.weeklyYears()).containsExactly(2025);
+        assertThat(source.weeklyYears()).containsExactly(2026);
         assertThat(source.projection()).singleElement().satisfies(line ->
             assertThat(line.getAmount()).isEqualByComparingTo("2000000")
         );
         assertThat(source.actual()).singleElement().satisfies(line ->
             assertThat(line.getAmount()).isEqualByComparingTo("1800000")
         );
-        verify(fixture.collections.get("orgs/tenant-a/cashflow_weeks"), times(1))
-            .whereEqualTo("projectId", "project-a");
+        assertThat(fixture.queryReadSizes.getLast()).isEqualTo(1);
+    }
+
+    @Test
+    void dashboardLedgerSourceRejectsAnInvalidWeeklyYearDeclaration() {
+        Fixture fixture = fixture(activeMember(), activeLease());
+        fixture.documents.put("orgs/tenant-a/cashflow_sheet_mirrors/project-a", Map.of(
+            "projectId", "project-a", "weeklyYear", "2026.0"
+        ));
+
+        assertThatThrownBy(() -> fixture.persistence.findCashflowLedgerSource("tenant-a", "project-a"))
+            .isInstanceOf(WeeklyExpenseConflictException.class)
+            .hasMessage("양식이 다릅니다.");
     }
 
     @Test
@@ -1908,25 +1937,13 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
-    void unfilteredCashflowWeekScansStayPinnedToApprovedExceptions() throws Exception {
+    void cashflowWeekQueriesHaveNoProjectOnlyScanExceptions() throws Exception {
         String source = Files.readString(Path.of(
             "src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java"
         ));
-        Set<String> approved = Set.of(
-            "completeCashflowWeeklyUpdate", "countCashflowActualReplacementWrites",
-            "replaceCashflowSheetMonthsInternal", "findCashflowLedgerSource", "replaceExpenseRows",
-            "replaceActualLines", "findWeeklyStatuses", "readProjectionLines", "readActualLines"
-        );
-
-        assertThat(approved).allSatisfy(method ->
-            assertThat(source).contains("SPEC-12 approved full scan: " + method)
-        );
-        assertThat(source.split(Pattern.quote("SPEC-12 approved full scan:"), -1).length - 1).isEqualTo(approved.size());
+        assertThat(source).doesNotContain("SPEC-12 approved full scan:");
         assertThat(source.split(Pattern.quote("cashflowWeeks(tenantId).whereEqualTo(\"projectId\", projectId)"), -1).length - 1)
-            .isEqualTo(8);
-        assertThat(source.split(Pattern.quote("cashflowWeeks(actor.tenantId()).whereEqualTo(\"projectId\", projectId)"), -1).length - 1)
-            .isEqualTo(1);
-        assertThat(source.split(Pattern.quote("cashflowWeeks(tenant(sheet)).whereEqualTo(\"projectId\", sheet.getProjectId())"), -1).length - 1)
+            .as("the bounded query helper adds yearMonth before execution")
             .isEqualTo(1);
     }
 
@@ -2173,7 +2190,7 @@ class FirestoreCashflowLeaseGuardTest {
         putCompleteProjectionWindow(fixture, "2026-07", 3);
         fixture.documents.put(
             "orgs/tenant-a/cashflow_sheet_mirrors/project-a",
-            Map.of("projectId", "project-a", "sourceRevision", SOURCE_REVISION)
+            Map.of("projectId", "project-a", "weeklyYear", 2026, "sourceRevision", SOURCE_REVISION)
         );
         WeeklyExpenseCommandService service = commandService(fixture.persistence);
         CompleteCashflowWeeklyUpdateRequest firstRequest = new CompleteCashflowWeeklyUpdateRequest(
@@ -2775,15 +2792,18 @@ class FirestoreCashflowLeaseGuardTest {
     @Test
     void weeklyCompletionValidatesCanonicalSixteenWeekWindowAndAllowsAuditedOverride() {
         Fixture fixture = fixture(activeMember(), Map.of());
-        putCompleteProjectionWindow(fixture, "2026-12", 4);
-        String missingPath = "orgs/tenant-a/cashflow_weeks/project-a-2027-01-w2";
+        fixture.documents.put("orgs/tenant-a/cashflow_sheet_mirrors/project-a", Map.of(
+            "projectId", "project-a", "weeklyYear", 2026
+        ));
+        putCompleteProjectionWindow(fixture, "2026-09", 4);
+        String missingPath = "orgs/tenant-a/cashflow_weeks/project-a-2026-10-w2";
         Map<String, Object> missingWeek = new LinkedHashMap<>(fixture.documents.get(missingPath));
         Map<String, Object> projection = new LinkedHashMap<>((Map<String, Object>) missingWeek.get("projection"));
         projection.remove("SALES_IN");
         missingWeek.put("projection", projection);
         fixture.documents.put(missingPath, missingWeek);
         CompleteCashflowWeeklyUpdateRequest initial = new CompleteCashflowWeeklyUpdateRequest(
-            "window-cross-year", "2026-12", 4, "2026-12-24T14:59:00Z", "NO_CHANGES"
+            "window-in-weekly-year", "2026-09", 4, "2026-09-24T14:59:00Z", "NO_CHANGES"
         );
 
         Throwable failure = catchThrowable(() -> fixture.persistence.runCommandTransaction(() -> commandService(
@@ -2795,14 +2815,14 @@ class FirestoreCashflowLeaseGuardTest {
         assertThat(incomplete.details())
             .containsEntry("tenantId", "tenant-a")
             .containsEntry("projectId", "project-a")
-            .containsEntry("yearMonth", "2026-12")
+            .containsEntry("yearMonth", "2026-09")
             .containsEntry("weekNo", 4)
-            .containsEntry("windowStart", "2026-12-w4")
-            .containsEntry("windowEnd", "2027-03-w4")
+            .containsEntry("windowStart", "2026-09-w4")
+            .containsEntry("windowEnd", "2026-12-w4")
             .containsEntry("requiredWeekCount", 16)
             .containsEntry("requiredCellCount", 256);
         assertThat((List<Map<String, Object>>) incomplete.details().get("missingCells"))
-            .containsExactly(Map.of("yearMonth", "2027-01", "weekNo", 2, "lineId", "SALES_IN"));
+            .containsExactly(Map.of("yearMonth", "2026-10", "weekNo", 2, "lineId", "SALES_IN"));
         assertThat(fixture.documents.keySet()).noneMatch(path -> path.contains("/cashflow_weekly_update_completions/")
             || path.contains("/cashflow_weekly_update_completion_versions/")
             || path.contains("/weekly_api_audit_events/"));
@@ -2812,7 +2832,7 @@ class FirestoreCashflowLeaseGuardTest {
         Throwable staleOverride = catchThrowable(() -> fixture.persistence.runCommandTransaction(() -> commandService(
             fixture.persistence
         ).completeCashflowWeeklyUpdate(ACTOR, "project-a", new CompleteCashflowWeeklyUpdateRequest(
-            "window-cross-year-stale", "2026-12", 4, "2026-12-24T14:59:00Z", "NO_CHANGES",
+            "window-in-weekly-year-stale", "2026-09", 4, "2026-09-24T14:59:00Z", "NO_CHANGES",
             true, "sha256:" + "f".repeat(64), 1
         ))));
         assertThat(staleOverride).isInstanceOf(WeeklyExpenseEditLeaseException.class);
@@ -2828,7 +2848,7 @@ class FirestoreCashflowLeaseGuardTest {
         Throwable resolvedOverride = catchThrowable(() -> fixture.persistence.runCommandTransaction(() -> commandService(
             fixture.persistence
         ).completeCashflowWeeklyUpdate(ACTOR, "project-a", new CompleteCashflowWeeklyUpdateRequest(
-            "window-cross-year-resolved", "2026-12", 4, "2026-12-24T14:59:00Z", "NO_CHANGES",
+            "window-in-weekly-year-resolved", "2026-09", 4, "2026-09-24T14:59:00Z", "NO_CHANGES",
             true, evidenceHash, 1
         ))));
         assertThat(resolvedOverride).isInstanceOf(WeeklyExpenseEditLeaseException.class);
@@ -2840,7 +2860,7 @@ class FirestoreCashflowLeaseGuardTest {
         fixture.documents.put(missingPath, missingWeek);
 
         CompleteCashflowWeeklyUpdateRequest override = new CompleteCashflowWeeklyUpdateRequest(
-            "window-cross-year-override", "2026-12", 4, "2026-12-24T14:59:00Z", "NO_CHANGES",
+            "window-in-weekly-year-override", "2026-09", 4, "2026-09-24T14:59:00Z", "NO_CHANGES",
             true, evidenceHash, 1
         );
         CashflowWeeklyUpdateCompletionResponse completed = fixture.persistence.runCommandTransaction(() -> commandService(
@@ -2850,7 +2870,7 @@ class FirestoreCashflowLeaseGuardTest {
         assertThat(completed.updateResult()).isEqualTo("NO_CHANGES");
         assertThat(completed.complianceStatus()).isEqualTo("ON_TIME");
         assertThat(fixture.documents.get(
-            "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-12-w4"
+            "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-09-w4"
         ))
             .containsEntry("projectionValidationOverride", true)
             .containsEntry("projectionValidationIssueCount", 1)
@@ -2864,7 +2884,7 @@ class FirestoreCashflowLeaseGuardTest {
                 .contains("\"projectionValidationIssueCount\":1")
                 .contains(evidenceHash));
         Map<?, ?> periods = (Map<?, ?>) fixture.documents.get(
-            "orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-12"
+            "orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-09"
         ).get("periods");
         assertThat(((Map<?, ?>) periods.get("WEEK_4")).get("status")).isEqualTo("PENDING_APPROVAL");
 
@@ -3076,11 +3096,10 @@ class FirestoreCashflowLeaseGuardTest {
             .containsEntry("capturedAt", NOW.minusSeconds(120).toString());
         assertThat(snapshot.get("sourceReadAt")).isEqualTo(NOW.minusSeconds(120).toString());
         assertThat((Map<String, Object>) snapshot.get("sheetFacts")).isEmpty();
-        assertThat(fixture.refs).doesNotContainKey("orgs/tenant-a/cashflow_sheet_mirrors/project-a");
     }
 
     @Test
-    void monthCloseClosesWithoutMirrorAndRetainsApprovedRequestEvidence() {
+    void monthCloseRetainsApprovedRequestEvidenceWhenTheRequestTimeMirrorWasMissing() {
         CloseCashflowMonthRequest request = monthCloseRequest("month-close-missing-mirror", 0, 3);
         Fixture fixture = fixture(activeMember(), activeLease());
         fixture.documents.put(draftPath("project-a", "pm-1"), activeDraft("project-a", 3, request));
@@ -3121,7 +3140,6 @@ class FirestoreCashflowLeaseGuardTest {
         assertThat((Map<String, Object>) snapshot.get("approvedMonthSnapshot"))
             .containsEntry("projectId", "project-a")
             .containsEntry("yearMonth", "2026-06");
-        assertThat(fixture.refs).doesNotContainKey("orgs/tenant-a/cashflow_sheet_mirrors/project-a");
     }
 
     @Test
@@ -4783,6 +4801,9 @@ class FirestoreCashflowLeaseGuardTest {
         List<Integer> queryReadSizes = new ArrayList<>();
         docs.put("orgs/tenant-a/members/pm-1", member);
         docs.put(leasePath("project-a"), lease);
+        docs.put("orgs/tenant-a/cashflow_sheet_mirrors/project-a", Map.of(
+            "projectId", "project-a", "weeklyYear", 2026
+        ));
         for (String yearMonth : List.of("2026-06", "2026-07")) {
             docs.put("orgs/tenant-a/cashflow_month_close_requests/project-a-" + yearMonth, Map.of(
                 "requestId", "project-a-" + yearMonth,
@@ -5195,6 +5216,7 @@ class FirestoreCashflowLeaseGuardTest {
         facts.put("issues", List.of());
         Map<String, Object> mirror = new LinkedHashMap<>();
         mirror.put("projectId", "project-a");
+        mirror.put("weeklyYear", Integer.parseInt(request.yearMonth().substring(0, 4)));
         mirror.put("status", "FRESH");
         mirror.put("sourceRevision", request.sourceRevision());
         mirror.put("appliedSourceRevision", request.sourceRevision());

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistenceOpeningBalanceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistenceOpeningBalanceTest.java
@@ -15,7 +15,6 @@ class WeeklyExpensePersistenceOpeningBalanceTest {
     @Test
     void priorYearsAlwaysComeFromAnnualTotalsEvenWhenWeeklyDocumentsExist() {
         WeeklyExpensePersistence persistence = mock(WeeklyExpensePersistence.class, CALLS_REAL_METHODS);
-        when(persistence.findCashflowWeeklyYears("tenant-a", "project-a")).thenReturn(List.of(2024, 2026));
         when(persistence.findCashflowSheetYearTotals("tenant-a", "project-a")).thenReturn(List.of(
             annual(2024, "9000000", "9000000"),
             annual(2025, "500000", "400000"),

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistenceOpeningBalanceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistenceOpeningBalanceTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.when;
 
 class WeeklyExpensePersistenceOpeningBalanceTest {
     @Test
-    void weeklyLedgerIsExcludedBecauseItsRunningNetAlreadyOwnsThatYear() {
+    void priorYearsAlwaysComeFromAnnualTotalsEvenWhenWeeklyDocumentsExist() {
         WeeklyExpensePersistence persistence = mock(WeeklyExpensePersistence.class, CALLS_REAL_METHODS);
         when(persistence.findCashflowWeeklyYears("tenant-a", "project-a")).thenReturn(List.of(2024, 2026));
         when(persistence.findCashflowSheetYearTotals("tenant-a", "project-a")).thenReturn(List.of(
@@ -28,16 +28,13 @@ class WeeklyExpensePersistenceOpeningBalanceTest {
             2026
         );
 
-        assertThat(result.projection().amount()).isEqualByComparingTo("500000");
-        assertThat(result.actual().amount()).isEqualByComparingTo("400000");
-        assertThat(result.projection().includedYears()).containsExactly(2025);
-        assertThat(result.projection().excludedWeeklyYears()).containsExactly(2024);
-        assertThat(result.projection().lineAmounts()).containsEntry("SALES_IN", new BigDecimal("500000"));
-        assertThat(result.projection().sources()).singleElement().satisfies(source -> {
-            assertThat(source.year()).isEqualTo(2025);
-            assertThat(source.lineAmounts()).containsEntry("SALES_IN", new BigDecimal("500000"));
-            assertThat(source.lineStates()).containsEntry("SALES_IN", "VALUE");
-        });
+        assertThat(result.projection().amount()).isEqualByComparingTo("9500000");
+        assertThat(result.actual().amount()).isEqualByComparingTo("9400000");
+        assertThat(result.projection().includedYears()).containsExactly(2024, 2025);
+        assertThat(result.projection().excludedWeeklyYears()).isEmpty();
+        assertThat(result.projection().lineAmounts()).containsEntry("SALES_IN", new BigDecimal("9500000"));
+        assertThat(result.projection().sources()).extracting(WeeklyExpensePersistence.CashflowOpeningBalance.YearSource::year)
+            .containsExactly(2024, 2025);
     }
 
     private WeeklyExpensePersistence.CashflowSheetAnnualTotal annual(int year, String projection, String actual) {

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -598,15 +598,18 @@ describe('CashflowProjectSheet monthly close shell', () => {
   });
 
   it('renders annual carry-forward and future totals around the selected year weekly ledger', () => {
-    expect(source).toContain('CASHFLOW_STANDARD_ANNUAL_YEARS = [2024, 2025, 2027, 2028, 2029, 2030, 2031, 2032]');
+    expect(source).toContain('const weeklyYear = canonicalReadModel?.weeklyYear');
+    expect(source).toContain('annualYearsFor(weeklyYear)');
+    expect(source).not.toContain('CASHFLOW_STANDARD_ANNUAL_YEARS');
     expect(source).toContain('canonicalCashflowAnnualTotalFor(canonicalAnnualTotals, year, mode)');
-    expect(source).toContain('dashboard?.canonical as { annualTotals?: CanonicalCashflowAnnualTotal[] }');
+    expect(source).toContain('canonicalReadModel?.annualTotals || []');
+    expect(source).not.toContain('dashboard?.canonical as');
     expect(source).not.toContain('summarizeCanonicalCashflowYear');
-    expect(source).toContain('const previousAnnualYears = annualYears.filter((year) => year < selectedYear)');
-    expect(source).toContain('const followingAnnualYears = annualYears.filter((year) => year > selectedYear)');
+    expect(source).toContain('const previousAnnualYears = annualYears.filter((year) => year < Number(weeklyYear))');
+    expect(source).toContain('const followingAnnualYears = annualYears.filter((year) => year > Number(weeklyYear))');
     expect(source).toContain('const renderAnnualSummaryCell');
     expect(source).not.toContain('cashflowSheetMirror?.sheetFacts?.annualCashflowTotals');
-    expect(source).toContain('annualYears.some((year) => !annualTotalFor(year, mode))');
+    expect(source).toContain('annualYears.some((year) => !annualTotalFor(year, mode)?.lineStates?.[lineId])');
     expect(source).toContain('Total');
     expect(source).toContain('const visibleWeeks = annualWeeks');
     expect(source).toContain('openingBalances?.selectedYear === selectedYear');
@@ -614,7 +617,7 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain("'서버 값'");
     expect(source).not.toContain("'값 없음'");
     expect(source).toContain('>미입력</');
-    expect(source).toContain("cell.difference === null ? '미입력'");
+    expect(source).not.toContain('>확인 불가</');
   });
 
   it('never renders synthetic zero cashflow values after the canonical read fails', () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -599,7 +599,9 @@ describe('CashflowProjectSheet monthly close shell', () => {
 
   it('renders annual carry-forward and future totals around the selected year weekly ledger', () => {
     expect(source).toContain('CASHFLOW_STANDARD_ANNUAL_YEARS = [2024, 2025, 2027, 2028, 2029, 2030, 2031, 2032]');
-    expect(source).toContain('canonicalAnnualTotalFor');
+    expect(source).toContain('canonicalCashflowAnnualTotalFor(canonicalAnnualTotals, year, mode)');
+    expect(source).toContain('dashboard?.canonical as { annualTotals?: CanonicalCashflowAnnualTotal[] }');
+    expect(source).not.toContain('summarizeCanonicalCashflowYear');
     expect(source).toContain('const previousAnnualYears = annualYears.filter((year) => year < selectedYear)');
     expect(source).toContain('const followingAnnualYears = annualYears.filter((year) => year > selectedYear)');
     expect(source).toContain('const renderAnnualSummaryCell');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -86,8 +86,8 @@ import {
   resolveCashflowEvidenceScope,
   shouldApplyCashflowMonthCloseRequestResult,
   shouldHideCashflowValuesAfterLoadError,
+  annualYearsFor,
   canonicalCashflowAnnualTotalFor,
-  type CanonicalCashflowAnnualTotal,
   type CashflowMonthCloseDepositReviewRow,
 } from './cashflow-month-close';
 import { CashflowSheetSyncOverlay } from './CashflowSheetSyncOverlay';
@@ -97,8 +97,6 @@ import { AxrMonthCloseQaPanel } from './AxrMonthCloseQaPanel';
 import { MemberPicker } from '../ui/member-picker';
 import { buildOrgMemberPickerOptions } from '../../data/project-team-member-options';
 import { loadCashflowActivitySourcesSequentially } from './cashflow-activity-loader';
-
-const CASHFLOW_STANDARD_ANNUAL_YEARS = [2024, 2025, 2027, 2028, 2029, 2030, 2031, 2032] as const;
 
 function previousYearMonth(yearMonth: string): string {
   if (!/^\d{4}-(0[1-9]|1[0-2])$/.test(yearMonth)) return '';
@@ -1749,25 +1747,22 @@ export function CashflowProjectSheet({
       || `w${weekNo}`;
   }
 
-  const annualYears = useMemo(() => {
-    return CASHFLOW_STANDARD_ANNUAL_YEARS.filter((year) => year !== selectedYear);
-  }, [selectedYear]);
-  const previousAnnualYears = annualYears.filter((year) => year < selectedYear);
-  const followingAnnualYears = annualYears.filter((year) => year > selectedYear);
+  const canonicalReadModel = monthCloseResult?.dashboard?.canonical;
+  const weeklyYear = canonicalReadModel?.weeklyYear;
+  const annualYears = useMemo(() => annualYearsFor(weeklyYear), [weeklyYear]);
+  const previousAnnualYears = annualYears.filter((year) => year < Number(weeklyYear));
+  const followingAnnualYears = annualYears.filter((year) => year > Number(weeklyYear));
   const comparisonAsOfWeek = monthCloseResult?.dashboard?.summary?.comparisonAsOfWeek;
   const comparisonScope = useMemo(() => resolveCashflowComparisonScope({
-    selectedYear,
     annualYears,
     weeks: annualWeeks,
     comparisonAsOfWeek,
-  }), [annualWeeks, annualYears, comparisonAsOfWeek, selectedYear]);
+  }), [annualWeeks, annualYears, comparisonAsOfWeek]);
   const visibleComparisonWeeks = comparisonScope.weeks;
   const visibleComparisonAnnualYears = comparisonScope.annualYears;
-  const previousComparisonAnnualYears = visibleComparisonAnnualYears.filter((year) => year < selectedYear);
-  const followingComparisonAnnualYears = visibleComparisonAnnualYears.filter((year) => year > selectedYear);
-  const canonicalAnnualTotals = (
-    monthCloseResult?.dashboard?.canonical as { annualTotals?: CanonicalCashflowAnnualTotal[] } | null | undefined
-  )?.annualTotals || [];
+  const previousComparisonAnnualYears = visibleComparisonAnnualYears.filter((year) => year < Number(weeklyYear));
+  const followingComparisonAnnualYears = visibleComparisonAnnualYears.filter((year) => year > Number(weeklyYear));
+  const canonicalAnnualTotals = canonicalReadModel?.annualTotals || [];
   const annualTotalFor = (year: number, mode: 'projection' | 'actual') => (
     canonicalCashflowAnnualTotalFor(canonicalAnnualTotals, year, mode)
   );
@@ -1777,7 +1772,7 @@ export function CashflowProjectSheet({
       lineAmounts?: Record<CashflowSheetLineId, number>;
     } | null | undefined;
     const selectedYearTotal = rangeTotals?.rowTotals?.[lineId] ?? rangeTotals?.lineAmounts?.[lineId] ?? 0;
-    if (annualYears.some((year) => !annualTotalFor(year, mode))) return null;
+    if (annualYears.some((year) => !annualTotalFor(year, mode)?.lineStates?.[lineId])) return null;
     return annualYears.reduce(
       (sum, year) => sum + Number(annualTotalFor(year, mode)?.lineAmounts?.[lineId] || 0),
       Number(selectedYearTotal),
@@ -1809,7 +1804,8 @@ export function CashflowProjectSheet({
         const actualTotal = annualTotalFor(year, 'actual');
         const projectionState = projectionTotal?.lineStates?.[lineId];
         const actualState = actualTotal?.lineStates?.[lineId];
-        const hasValue = ['VALUE', 'ZERO'].includes(projectionState) || ['VALUE', 'ZERO'].includes(actualState);
+        const hasValue = projectionState === 'VALUE' || projectionState === 'ZERO'
+          || actualState === 'VALUE' || actualState === 'ZERO';
         const projection = Number(projectionTotal?.lineAmounts?.[lineId] || 0);
         const actual = Number(actualTotal?.lineAmounts?.[lineId] || 0);
         return { year, projection, actual, difference: hasValue ? projection - actual : null };
@@ -2090,7 +2086,6 @@ export function CashflowProjectSheet({
       return groups;
     }, []);
     const boardColumnCount = previousAnnualYears.length + visibleWeeks.length + followingAnnualYears.length + 2;
-    const canonicalReadModel = monthCloseResult?.dashboard?.canonical;
     const readServerSummary = (mode: 'projection' | 'actual') => {
       const openingBalance = monthCloseResult?.dashboard?.openingBalances?.selectedYear === selectedYear
         ? Number(monthCloseResult.dashboard.openingBalances[mode]?.amount || 0)
@@ -2140,11 +2135,14 @@ export function CashflowProjectSheet({
       actual: readServerSummary('actual'),
     };
     const projectTotalsFor = (mode: 'projection' | 'actual') => {
-      if (annualYears.some((year) => !annualTotalFor(year, mode))) {
+      if (annualYears.some((year) => {
+        const total = annualTotalFor(year, mode);
+        return !total || total.totalIn === null || total.totalOut === null || total.net === null;
+      })) {
         return { totalIn: null, totalOut: null, net: null };
       }
-      const totalIn = annualYears.reduce((sum, year) => sum + Number(annualTotalFor(year, mode)?.totalIn || 0), Number(derived[mode].monthTotals.totalIn || 0));
-      const totalOut = annualYears.reduce((sum, year) => sum + Number(annualTotalFor(year, mode)?.totalOut || 0), Number(derived[mode].monthTotals.totalOut || 0));
+      const totalIn = annualYears.reduce((sum, year) => sum + Number(annualTotalFor(year, mode)?.totalIn), Number(derived[mode].monthTotals.totalIn || 0));
+      const totalOut = annualYears.reduce((sum, year) => sum + Number(annualTotalFor(year, mode)?.totalOut), Number(derived[mode].monthTotals.totalOut || 0));
       return { totalIn, totalOut, net: totalIn - totalOut };
     };
     const scrollBoard = (direction: -1 | 1) => {
@@ -2192,6 +2190,7 @@ export function CashflowProjectSheet({
       tone: 'income' | 'expense',
     ) => lineIds.map((lineId, rowIndex) => {
       const emphasized = lineId === 'MYSC_PREPAY_IN' || lineId.startsWith('MYSC_PREPAY_');
+      const projectLineTotal = projectLineTotalFor(mode, lineId);
       return (
         <tr key={`${mode}-${lineId}`} data-cashflow-row="line" className="border-t border-white transition-colors hover:brightness-[0.98]">
           <td className={`sticky left-0 z-20 w-[192px] min-w-[192px] border-r-[6px] border-r-white px-3 py-2 text-[12px] leading-4 ${tone === 'income' ? 'text-emerald-700' : 'text-red-700'} ${rowIndex % 2 === 0 ? 'bg-white' : 'bg-slate-50'} ${emphasized ? 'font-bold' : 'font-medium'}`}>
@@ -2210,7 +2209,7 @@ export function CashflowProjectSheet({
           {followingAnnualYears.map((year) => renderAnnualLineCell(mode, lineId, year, rowIndex % 2 === 1))}
           {renderSummaryCell({
             keyName: `${mode}-${lineId}-range`,
-            value: projectLineTotalFor(mode, lineId),
+            value: projectLineTotal,
             mode,
             isAltRow: rowIndex % 2 === 1,
             stickyRight: true,

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -86,7 +86,8 @@ import {
   resolveCashflowEvidenceScope,
   shouldApplyCashflowMonthCloseRequestResult,
   shouldHideCashflowValuesAfterLoadError,
-  summarizeCanonicalCashflowYear,
+  canonicalCashflowAnnualTotalFor,
+  type CanonicalCashflowAnnualTotal,
   type CashflowMonthCloseDepositReviewRow,
 } from './cashflow-month-close';
 import { CashflowSheetSyncOverlay } from './CashflowSheetSyncOverlay';
@@ -1764,30 +1765,12 @@ export function CashflowProjectSheet({
   const visibleComparisonAnnualYears = comparisonScope.annualYears;
   const previousComparisonAnnualYears = visibleComparisonAnnualYears.filter((year) => year < selectedYear);
   const followingComparisonAnnualYears = visibleComparisonAnnualYears.filter((year) => year > selectedYear);
-  const canonicalAnnualTotalFor = (year: number, mode: 'projection' | 'actual') => summarizeCanonicalCashflowYear(
-    monthCloseResult?.dashboard?.canonical?.months || [],
-    year,
-    mode,
+  const canonicalAnnualTotals = (
+    monthCloseResult?.dashboard?.canonical as { annualTotals?: CanonicalCashflowAnnualTotal[] } | null | undefined
+  )?.annualTotals || [];
+  const annualTotalFor = (year: number, mode: 'projection' | 'actual') => (
+    canonicalCashflowAnnualTotalFor(canonicalAnnualTotals, year, mode)
   );
-  const annualTotalFor = (year: number, mode: 'projection' | 'actual') => {
-    const canonical = canonicalAnnualTotalFor(year, mode);
-    if (canonical) return canonical;
-    const jvmSource = monthCloseResult?.dashboard?.openingBalances?.selectedYear === selectedYear
-      ? monthCloseResult.dashboard.openingBalances[mode]?.sources?.find((source) => source.year === year)
-      : null;
-    if (jvmSource) {
-      const totalIn = CASHFLOW_IN_LINES.reduce((sum, lineId) => sum + Number(jvmSource.lineAmounts?.[lineId] || 0), 0);
-      const totalOut = CASHFLOW_OUT_LINES.reduce((sum, lineId) => sum + Number(jvmSource.lineAmounts?.[lineId] || 0), 0);
-      return {
-        lineAmounts: jvmSource.lineAmounts,
-        lineStates: jvmSource.lineStates,
-        totalIn,
-        totalOut,
-        net: totalIn - totalOut,
-      };
-    }
-    return null;
-  };
   const projectLineTotalFor = (mode: 'projection' | 'actual', lineId: CashflowSheetLineId) => {
     const rangeTotals = monthCloseResult?.dashboard?.canonical?.range?.[mode] as {
       rowTotals?: Record<CashflowSheetLineId, number>;
@@ -1824,10 +1807,8 @@ export function CashflowProjectSheet({
       const comparisonAnnualYears = visibleComparisonAnnualYears.map((year) => {
         const projectionTotal = annualTotalFor(year, 'projection');
         const actualTotal = annualTotalFor(year, 'actual');
-        const projectionState = projectionTotal?.lineStates?.[lineId]
-          || (Object.prototype.hasOwnProperty.call(projectionTotal?.lineAmounts || {}, lineId) ? 'VALUE' : 'EMPTY');
-        const actualState = actualTotal?.lineStates?.[lineId]
-          || (Object.prototype.hasOwnProperty.call(actualTotal?.lineAmounts || {}, lineId) ? 'VALUE' : 'EMPTY');
+        const projectionState = projectionTotal?.lineStates?.[lineId];
+        const actualState = actualTotal?.lineStates?.[lineId];
         const hasValue = ['VALUE', 'ZERO'].includes(projectionState) || ['VALUE', 'ZERO'].includes(actualState);
         const projection = Number(projectionTotal?.lineAmounts?.[lineId] || 0);
         const actual = Number(actualTotal?.lineAmounts?.[lineId] || 0);
@@ -2184,9 +2165,8 @@ export function CashflowProjectSheet({
     };
     const renderAnnualLineCell = (mode: 'projection' | 'actual', lineId: CashflowSheetLineId, year: number, isAltRow: boolean) => {
       const total = annualTotalFor(year, mode);
-      const state = total?.lineStates?.[lineId]
-        || (Object.prototype.hasOwnProperty.call(total?.lineAmounts || {}, lineId) ? 'VALUE' : 'EMPTY');
-      const value = Number(total?.lineAmounts?.[lineId] || 0);
+      const state = total?.lineStates?.[lineId];
+      const value = Number(total?.lineAmounts?.[lineId] ?? 0);
       return (
         <td key={`${mode}-${lineId}-${year}-annual`} data-cashflow-board-column="true" className={`min-w-[84px] border-l-[6px] border-l-white px-1 py-1 text-right align-middle text-[12px] tabular-nums text-slate-700 ${isAltRow ? 'bg-slate-50' : 'bg-white'}`}>
           {state === 'VALUE' || state === 'ZERO' ? fmt(value) : <span className="text-slate-400">미입력</span>}

--- a/src/app/components/cashflow/cashflow-month-close.test.ts
+++ b/src/app/components/cashflow/cashflow-month-close.test.ts
@@ -4,7 +4,7 @@ import type { CashflowSheetLabMirrorResult } from '../../lib/sheets-cashflow-rea
 import type { CashflowDeadlineSummary, CashflowManagementCheck } from '../../lib/platform-bff-client';
 import {
   buildCashflowMonthCloseDraftInput,
-  canonicalCashflowAnnualYears,
+  canonicalCashflowAnnualTotalFor,
   carryForwardCashflowRunningBalances,
   createEmptyCashflowMonthCloseDepositRows,
   isCashflowMonthCloseRequestLocked,
@@ -16,7 +16,6 @@ import {
   resolveCashflowEvidenceScope,
   shouldApplyCashflowMonthCloseRequestResult,
   shouldHideCashflowValuesAfterLoadError,
-  summarizeCanonicalCashflowYear,
 } from './cashflow-month-close';
 
 function mirror(): CashflowSheetLabMirrorResult {
@@ -56,22 +55,31 @@ const deadlineSummary: CashflowDeadlineSummary = {
 };
 
 describe('cashflow month close contract', () => {
-  it('deduplicates prior years and calculates exact canonical annual totals', () => {
-    const months = [
-      { yearMonth: '2024-01', projection: { weeks: [{ amounts: { SALES_IN: 100, DIRECT_COST_OUT: 30 } }] } },
-      { yearMonth: '2024-02', projection: { weeks: [{ amounts: { SALES_IN: 50, DIRECT_COST_OUT: 20 } }] } },
-      { yearMonth: '2025-01', projection: { weeks: [{ amounts: { SALES_IN: 900 } }] } },
-      { yearMonth: '2026-01', projection: { weeks: [{ amounts: { SALES_IN: 9999 } }] } },
-    ];
+  it('returns the server annual-column value and cell states unchanged', () => {
+    const actual = {
+      lineAmounts: { SALES_IN: 317_449_417, SALES_VAT_IN: 0, TEAM_SUPPORT_IN: 0 },
+      lineStates: { SALES_IN: 'VALUE', SALES_VAT_IN: 'ZERO', TEAM_SUPPORT_IN: 'EMPTY' } as const,
+      totalIn: 317_449_417,
+      totalOut: 0,
+      net: 317_449_417,
+    };
+    const annualTotals = [{
+      year: 2025,
+      projection: { ...actual, lineAmounts: { SALES_IN: 7_582_243 } },
+      actual,
+    }];
 
-    expect(canonicalCashflowAnnualYears(months, 2026)).toEqual([2024, 2025]);
-    expect(summarizeCanonicalCashflowYear(months, 2024, 'projection')).toMatchObject({
-      lineAmounts: { SALES_IN: 150, DIRECT_COST_OUT: 50 },
-      lineStates: { SALES_IN: 'VALUE', DIRECT_COST_OUT: 'VALUE', SALES_VAT_IN: 'EMPTY' },
-      totalIn: 150,
-      totalOut: 50,
-      net: 100,
+    const result = canonicalCashflowAnnualTotalFor(annualTotals, 2025, 'actual');
+
+    expect(result).toBe(actual);
+    expect(result).toEqual({
+      lineAmounts: { SALES_IN: 317_449_417, SALES_VAT_IN: 0, TEAM_SUPPORT_IN: 0 },
+      lineStates: { SALES_IN: 'VALUE', SALES_VAT_IN: 'ZERO', TEAM_SUPPORT_IN: 'EMPTY' },
+      totalIn: 317_449_417,
+      totalOut: 0,
+      net: 317_449_417,
     });
+    expect(canonicalCashflowAnnualTotalFor(annualTotals, 2032, 'actual')).toBeNull();
   });
 
   it('hides values only when canonical loading failed without a retained model', () => {

--- a/src/app/components/cashflow/cashflow-month-close.test.ts
+++ b/src/app/components/cashflow/cashflow-month-close.test.ts
@@ -4,6 +4,7 @@ import type { CashflowSheetLabMirrorResult } from '../../lib/sheets-cashflow-rea
 import type { CashflowDeadlineSummary, CashflowManagementCheck } from '../../lib/platform-bff-client';
 import {
   buildCashflowMonthCloseDraftInput,
+  annualYearsFor,
   canonicalCashflowAnnualTotalFor,
   carryForwardCashflowRunningBalances,
   createEmptyCashflowMonthCloseDepositRows,
@@ -55,29 +56,34 @@ const deadlineSummary: CashflowDeadlineSummary = {
 };
 
 describe('cashflow month close contract', () => {
+  it('derives the eight annual columns from the server weekly year', () => {
+    expect(annualYearsFor(2026)).toEqual([2024, 2025, 2027, 2028, 2029, 2030, 2031, 2032]);
+    expect(annualYearsFor(2027)).toEqual([2025, 2026, 2028, 2029, 2030, 2031, 2032, 2033]);
+    expect(annualYearsFor(undefined)).toEqual([]);
+  });
+
   it('returns the server annual-column value and cell states unchanged', () => {
     const actual = {
       lineAmounts: { SALES_IN: 317_449_417, SALES_VAT_IN: 0, TEAM_SUPPORT_IN: 0 },
       lineStates: { SALES_IN: 'VALUE', SALES_VAT_IN: 'ZERO', TEAM_SUPPORT_IN: 'EMPTY' } as const,
-      totalIn: 317_449_417,
+      totalIn: null,
       totalOut: 0,
-      net: 317_449_417,
+      net: null,
     };
     const annualTotals = [{
       year: 2025,
       projection: { ...actual, lineAmounts: { SALES_IN: 7_582_243 } },
       actual,
     }];
-
     const result = canonicalCashflowAnnualTotalFor(annualTotals, 2025, 'actual');
 
     expect(result).toBe(actual);
     expect(result).toEqual({
       lineAmounts: { SALES_IN: 317_449_417, SALES_VAT_IN: 0, TEAM_SUPPORT_IN: 0 },
       lineStates: { SALES_IN: 'VALUE', SALES_VAT_IN: 'ZERO', TEAM_SUPPORT_IN: 'EMPTY' },
-      totalIn: 317_449_417,
+      totalIn: null,
       totalOut: 0,
-      net: 317_449_417,
+      net: null,
     });
     expect(canonicalCashflowAnnualTotalFor(annualTotals, 2032, 'actual')).toBeNull();
   });
@@ -99,7 +105,6 @@ describe('cashflow month close contract', () => {
 
   it('limits Projection-Actual cells and Total to the server KST comparison week', () => {
     expect(resolveCashflowComparisonScope({
-      selectedYear: 2026,
       annualYears: [2024, 2025, 2026, 2027, 2032],
       weeks: [
         { yearMonth: '2026-07', weekNo: 5 },
@@ -121,11 +126,16 @@ describe('cashflow month close contract', () => {
     });
 
     expect(resolveCashflowComparisonScope({
-      selectedYear: 2026,
       annualYears: [],
       weeks: [{ yearMonth: '2026-01', weekNo: 1 }, { yearMonth: '2026-08', weekNo: 3 }],
       comparisonAsOfWeek: { yearMonth: '2026-08', weekNo: 3 },
     }).periodLabel).toBe('2026-01 1주차 ~ 2026-08 3주차');
+
+    expect(resolveCashflowComparisonScope({
+      annualYears: annualYearsFor(2027),
+      weeks: [{ yearMonth: '2027-01', weekNo: 1 }],
+      comparisonAsOfWeek: { yearMonth: '2027-01', weekNo: 1 },
+    }).annualYears).toEqual([2025, 2026]);
   });
 
   it('locks pending approval states and unlocks a rejected request', () => {

--- a/src/app/components/cashflow/cashflow-month-close.ts
+++ b/src/app/components/cashflow/cashflow-month-close.ts
@@ -1,4 +1,4 @@
-import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES } from '../../platform/cashflow-sheet';
+import { CASHFLOW_ALL_LINES } from '../../platform/cashflow-sheet';
 import type { CashflowSheetLineId } from '../../data/types';
 import type {
   CashflowMonthCloseCell,
@@ -24,39 +24,26 @@ export type CashflowMonthCloseDepositReviewRow = Omit<CashflowMonthCloseDepositS
 
 export const CASHFLOW_MONTH_CLOSE_WEEK_NOS = [1, 2, 3, 4, 5] as const;
 
-type CanonicalCashflowMonth = {
-  yearMonth: string;
-  projection?: { weeks?: Array<{ amounts?: Partial<Record<CashflowSheetLineId, number>> }> };
-  actual?: { weeks?: Array<{ amounts?: Partial<Record<CashflowSheetLineId, number>> }> };
+export type CanonicalCashflowAnnualModeTotal = {
+  lineAmounts: Partial<Record<CashflowSheetLineId, number>>;
+  lineStates: Partial<Record<CashflowSheetLineId, 'VALUE' | 'ZERO' | 'EMPTY'>>;
+  totalIn: number;
+  totalOut: number;
+  net: number;
 };
 
-export function canonicalCashflowAnnualYears(months: CanonicalCashflowMonth[], selectedYear: number): number[] {
-  return [...new Set(months
-    .map((month) => Number(month.yearMonth.slice(0, 4)))
-    .filter((year) => Number.isSafeInteger(year) && year !== selectedYear))]
-    .sort((left, right) => left - right);
-}
+export type CanonicalCashflowAnnualTotal = {
+  year: number;
+  projection: CanonicalCashflowAnnualModeTotal;
+  actual: CanonicalCashflowAnnualModeTotal;
+};
 
-export function summarizeCanonicalCashflowYear(
-  months: CanonicalCashflowMonth[],
+export function canonicalCashflowAnnualTotalFor(
+  annualTotals: CanonicalCashflowAnnualTotal[],
   year: number,
   mode: 'projection' | 'actual',
-) {
-  const selected = months.filter((month) => Number(month.yearMonth.slice(0, 4)) === year);
-  if (!selected.length) return null;
-  const lineAmounts = Object.fromEntries(CASHFLOW_ALL_LINES.map((lineId) => [
-    lineId,
-    selected.reduce((total, month) => total + (month[mode]?.weeks || [])
-      .reduce((monthTotal, week) => monthTotal + Number(week.amounts?.[lineId] || 0), 0), 0),
-  ])) as Record<CashflowSheetLineId, number>;
-  const lineStates = Object.fromEntries(CASHFLOW_ALL_LINES.map((lineId) => {
-    const hasValue = selected.some((month) => (month[mode]?.weeks || [])
-      .some((week) => Object.prototype.hasOwnProperty.call(week.amounts || {}, lineId)));
-    return [lineId, hasValue ? (lineAmounts[lineId] === 0 ? 'ZERO' : 'VALUE') : 'EMPTY'];
-  })) as Record<CashflowSheetLineId, 'VALUE' | 'ZERO' | 'EMPTY'>;
-  const totalIn = CASHFLOW_IN_LINES.reduce((sum, lineId) => sum + lineAmounts[lineId], 0);
-  const totalOut = CASHFLOW_OUT_LINES.reduce((sum, lineId) => sum + lineAmounts[lineId], 0);
-  return { lineAmounts, lineStates, totalIn, totalOut, net: totalIn - totalOut };
+): CanonicalCashflowAnnualModeTotal | null {
+  return annualTotals.find((total) => total.year === year)?.[mode] ?? null;
 }
 
 export function shouldHideCashflowValuesAfterLoadError(error: string | null, hasCanonical: boolean): boolean {

--- a/src/app/components/cashflow/cashflow-month-close.ts
+++ b/src/app/components/cashflow/cashflow-month-close.ts
@@ -9,6 +9,8 @@ import type {
   CashflowManagementCheck,
   CashflowManagementConfirmation,
   CashflowDeadlineSummary,
+  CanonicalCashflowAnnualModeTotal,
+  CanonicalCashflowAnnualTotal,
 } from '../../lib/platform-bff-client';
 import type {
   CashflowSheetLabMirrorResult,
@@ -24,19 +26,11 @@ export type CashflowMonthCloseDepositReviewRow = Omit<CashflowMonthCloseDepositS
 
 export const CASHFLOW_MONTH_CLOSE_WEEK_NOS = [1, 2, 3, 4, 5] as const;
 
-export type CanonicalCashflowAnnualModeTotal = {
-  lineAmounts: Partial<Record<CashflowSheetLineId, number>>;
-  lineStates: Partial<Record<CashflowSheetLineId, 'VALUE' | 'ZERO' | 'EMPTY'>>;
-  totalIn: number;
-  totalOut: number;
-  net: number;
-};
-
-export type CanonicalCashflowAnnualTotal = {
-  year: number;
-  projection: CanonicalCashflowAnnualModeTotal;
-  actual: CanonicalCashflowAnnualModeTotal;
-};
+export function annualYearsFor(weeklyYear: number | undefined): number[] {
+  if (!Number.isSafeInteger(weeklyYear)) return [];
+  const year = Number(weeklyYear);
+  return [year - 2, year - 1, ...Array.from({ length: 6 }, (_, index) => year + index + 1)];
+}
 
 export function canonicalCashflowAnnualTotalFor(
   annualTotals: CanonicalCashflowAnnualTotal[],
@@ -60,7 +54,6 @@ export function isCashflowComparisonWeekVisible(
 }
 
 export function resolveCashflowComparisonScope<T extends { yearMonth: string; weekNo: number }>(input: {
-  selectedYear: number;
   annualYears: number[];
   weeks: T[];
   comparisonAsOfWeek?: { yearMonth: string; weekNo: number };
@@ -68,7 +61,7 @@ export function resolveCashflowComparisonScope<T extends { yearMonth: string; we
   const asOf = input.comparisonAsOfWeek;
   if (!asOf) return { annualYears: [], weeks: [], periodLabel: '서버 기준 주차 확인 중' };
   const asOfYear = Number.parseInt(asOf.yearMonth.slice(0, 4), 10);
-  const annualYears = input.annualYears.filter((year) => year !== input.selectedYear && year < asOfYear);
+  const annualYears = input.annualYears.filter((year) => year < asOfYear);
   const weeks = input.weeks.filter((week) => isCashflowComparisonWeekVisible(week, asOf));
   const periodStart = annualYears.length > 0
     ? `${annualYears[0]}년`

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -689,6 +689,20 @@ export interface CashflowComparisonTotals {
   balance: number;
 }
 
+export interface CanonicalCashflowAnnualModeTotal {
+  lineAmounts: Record<string, number>;
+  lineStates: Record<string, 'VALUE' | 'ZERO' | 'EMPTY'>;
+  totalIn: number | null;
+  totalOut: number | null;
+  net: number | null;
+}
+
+export interface CanonicalCashflowAnnualTotal {
+  year: number;
+  projection: CanonicalCashflowAnnualModeTotal;
+  actual: CanonicalCashflowAnnualModeTotal;
+}
+
 export interface CashflowComparisonWeek {
   weekNo: number;
   amounts: Record<string, number>;
@@ -739,6 +753,8 @@ export interface CashflowSnapshotResult {
   actual: CashflowActualLine[];
   comparison: CashflowProjectionActualComparison;
   readModel: {
+    weeklyYear?: number;
+    annualTotals?: CanonicalCashflowAnnualTotal[];
     range: {
       start: CashflowRangeBoundary;
       end: CashflowRangeBoundary;

--- a/src/app/platform/policies/cashflow-policy.test.ts
+++ b/src/app/platform/policies/cashflow-policy.test.ts
@@ -25,10 +25,10 @@ describe('cashflow-policy', () => {
     expect(parseCashflowCategoryLabel('알 수 없음')).toBeUndefined();
   });
 
-  it('returns canonical line labels and aliases', () => {
+  it('returns canonical line labels without removed aliases', () => {
     expect(getCashflowLineLabel('DIRECT_COST_OUT')).toBe('직접사업비');
-    expect(parseCashflowLineLabelAlias('직접사업비(공급가액)+매입부가세')).toBe('DIRECT_COST_OUT');
-    expect(parseCashflowLineLabelAlias('MYSC선입금')).toBe('MYSC_PREPAY_IN');
+    expect(parseCashflowLineLabelAlias('직접사업비(공급가액)+매입부가세')).toBeUndefined();
+    expect(parseCashflowLineLabelAlias('MYSC선입금')).toBeUndefined();
   });
 
   it('returns the approved labels for projection and actual modes', () => {
@@ -58,12 +58,12 @@ describe('cashflow-policy', () => {
     expect(getCashflowExportLabel('MYSC_PROFIT_OUT')).toBe('MYSC 수익(간접비 등)');
   });
 
-  it('parses explicit sheet labels without overwriting ambiguous projection labels', () => {
-    expect(parseCashflowLineLabelAlias('MYSC 선입금 - 직접사업비 등')).toBe('MYSC_PREPAY_IN');
-    expect(parseCashflowLineLabelAlias('MYSC 선입금 - 직접사업비 등(입금)')).toBe('MYSC_PREPAY_IN');
+  it('parses canonical labels without reviving mode-specific aliases', () => {
+    expect(parseCashflowLineLabelAlias('MYSC 선입금 - 직접사업비 등')).toBeUndefined();
+    expect(parseCashflowLineLabelAlias('MYSC 선입금 - 직접사업비 등(입금)')).toBeUndefined();
     expect(parseCashflowLineLabelAlias('MYSC 선입금 - MYSC 인건비(입금)')).toBe('MYSC_PREPAY_LABOR_IN');
-    expect(parseCashflowLineLabelAlias('MYSC 선입금 - 매입부가세')).toBe('MYSC_PREPAY_INPUT_VAT_IN');
-    expect(parseCashflowLineLabelAlias('MYSC 선입금 - 메입부가세')).toBe('MYSC_PREPAY_INPUT_VAT_IN');
+    expect(parseCashflowLineLabelAlias('MYSC 선입금 - 매입부가세')).toBeUndefined();
+    expect(parseCashflowLineLabelAlias('MYSC 선입금 - 메입부가세')).toBeUndefined();
     expect(parseCashflowLineLabelAlias('MYSC 선입금 - 매입부가세(입금)')).toBe('MYSC_PREPAY_INPUT_VAT_IN');
     expect(parseCashflowLineLabelAlias('MYSC 선입금 - 직접사업비 등(출금)')).toBe('MYSC_PREPAY_DIRECT_OUT');
     expect(parseCashflowLineLabelAlias('MYSC 선입금 - MYSC 인건비(출금)')).toBe('MYSC_PREPAY_LABOR_OUT');

--- a/src/app/platform/settlement-csv.test.ts
+++ b/src/app/platform/settlement-csv.test.ts
@@ -82,9 +82,9 @@ describe('parseCashflowLineLabel', () => {
     expect(parseCashflowLineLabel('매입부가세')).toBe('INPUT_VAT_OUT');
   });
 
-  it('matches alias labels', () => {
-    expect(parseCashflowLineLabel('MYSC선입금')).toBe('MYSC_PREPAY_IN');
-    expect(parseCashflowLineLabel('MYSC 선입금(입금필요시)')).toBe('MYSC_PREPAY_IN');
+  it('does not match removed aliases', () => {
+    expect(parseCashflowLineLabel('MYSC선입금')).toBeUndefined();
+    expect(parseCashflowLineLabel('MYSC 선입금(입금필요시)')).toBeUndefined();
     expect(parseCashflowLineLabel('MYSC인건비')).toBe('MYSC_LABOR_OUT');
     expect(parseCashflowLineLabel('MYSC수익(간접비등)')).toBe('MYSC_PROFIT_OUT');
   });

--- a/src/app/platform/settlement-sheet-sync.test.ts
+++ b/src/app/platform/settlement-sheet-sync.test.ts
@@ -68,7 +68,7 @@ describe('buildSettlementActualSyncPayload', () => {
           '26-03-01',
         ),
         8,
-        '직접사업비(공급가액)+매입부가세',
+        '직접사업비',
       ),
     );
     row.cells[13] = '100,000';


### PR DESCRIPTION
## 무엇이 문제였나

시트는 전사 단일 고정 양식(주별 블록 E:BL 60칸 = 2026년 하나, 연간 열 C:D + BM:BR)인데, 코드는 그 사실을 쓰지 않고 **문서 존재 여부로 구조를 유추**했다. 연 단위 관리 연도에 낙오 주차 문서가 하나만 있어도 그 해가 "주별 관리"로 둔갑해 시트의 연간 열이 무시됐다.

라이브 확정 사고: `p1773651024850`(2026 다자간협력) 2025 Actual — 시트 7,582,243이 화면에 "미입력"으로 표시. 라이브 63개 프로젝트 중 15개에 낙오 주차 문서 304건 존재(감사 스크립트 포함).

## 좌표 계약 (단일 진실: `server/bff/cashflow-coordinates.mjs`)

1. 주별 블록 = E:BL 하나, 연도는 프로젝트당 단일 상수 (`mirror.weeklyYear`)
2. 연간 열 = C:D / BM:BR 좌표에서 읽는다 (주차 합산으로 만들지 않는다)
3. 라인 정체성 = 행 인덱스 (라벨 매칭 제거, alias 15개 삭제)
4. 좌표 밖 = 존재하지 않음 (`weekOrdinal === -1` → 낙오 문서 진입 불가)
5. 양식 불일치 = 거부 (reasons 수집 → 기존 400 + diagnostics)

JVM에 동일 도메인 `CashflowCoordinates` 신설, **BFF와 parity 표 동일** (SPEC-16을 막은 cross-runtime 불일치 재발 방지).

## 변경 요약

- **FE**: 연간 열을 주차에서 재계산하던 것 제거 → 서버 `canonical.annualTotals` 원문 표시. 셀 상태 역산 제거. 하드코딩 연도 목록 제거
- **BFF**: `canonicalCashflowWeeks` 유추·3단 폴백 제거, 월 상태 기반 분기, `weeklyYear`/`annualTotals` DTO 추가(필드 추가만, 제거 0)
- **JVM**: projectId-only 무범위 스캔 → 주별 연도 12개월 범위. weekly-wins carry-forward 규칙 제거. `weeklyYear` 부재 시 throw 아닌 blocker(작업 중단 0)
- **수집**: `buildAnnualCashflowTotals` weekly-wins 제거, 연간 합계는 시트 합계 행 좌표에서. 시트 헤더 60칸 구조 검증 + `mirror.weeklyYear` 저장
- **Actual의 `-`**: 회계 서식이 그린 0 → `ZERO`로 읽음 (Projection은 기존대로 EMPTY). 계약 문서 동기 갱신
- **연간 반영 사유**: BFF 구조분해에서 조용히 버려지던 `amendmentReason`·`editSession` 배선 복구 (JVM은 이미 완비)

## 검증

- JS 전체 2,814/2,814 (335파일) · JVM `mvn test` 323/323
- 각 단위 사보타주 검증 (제거한 유추·폴백·역산을 되살리면 실패)
- 라이브 읽기 전용 대조: `year_totals` 43개 전 프로젝트 mirror와 불일치 0 / 다자간협력 2025 = 7,582,243 [VALUE] 시트 원문 일치
- 롤아웃 준비: `mirror.weeklyYear` 백필 41건 완료(사본 확보), 시트 미연동 2건 제외
- 배포 창 호환: JVM DTO는 필드 추가만·구 BFF 호환 / 새 BFF는 JVM 신규 필드 미소비·구 JVM 호환 → **Vercel 먼저, JVM 나중**

알려진 기존 결함(이 PR과 무관): `jvm-weekly-api.test.mjs` 간헐 401/socket hang up — origin/main 30회 중 9회 재현되는 기존 스위트 결함. 격리 실행 시 0/20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)