### PR TITLE
fix(cashflow): 연간 합계 행 표시 보완 + BFF 리전 서울 이전

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -87,6 +87,7 @@ import {
   shouldApplyCashflowMonthCloseRequestResult,
   shouldHideCashflowValuesAfterLoadError,
   annualYearsFor,
+  annualSummaryAmountFor,
   canonicalCashflowAnnualTotalFor,
   type CashflowMonthCloseDepositReviewRow,
 } from './cashflow-month-close';
@@ -2135,14 +2136,14 @@ export function CashflowProjectSheet({
       actual: readServerSummary('actual'),
     };
     const projectTotalsFor = (mode: 'projection' | 'actual') => {
-      if (annualYears.some((year) => {
-        const total = annualTotalFor(year, mode);
-        return !total || total.totalIn === null || total.totalOut === null || total.net === null;
-      })) {
+      // 연간 열 하나라도 합계를 구할 수 없으면(라인까지 전부 미기입) Total 열도 없는 값으로 둔다.
+      const annualIn = annualYears.map((year) => annualSummaryAmountFor(annualTotalFor(year, mode), 'totalIn'));
+      const annualOut = annualYears.map((year) => annualSummaryAmountFor(annualTotalFor(year, mode), 'totalOut'));
+      if (annualYears.some((year) => !annualTotalFor(year, mode))) {
         return { totalIn: null, totalOut: null, net: null };
       }
-      const totalIn = annualYears.reduce((sum, year) => sum + Number(annualTotalFor(year, mode)?.totalIn), Number(derived[mode].monthTotals.totalIn || 0));
-      const totalOut = annualYears.reduce((sum, year) => sum + Number(annualTotalFor(year, mode)?.totalOut), Number(derived[mode].monthTotals.totalOut || 0));
+      const totalIn = annualIn.reduce<number>((sum, value) => sum + Number(value ?? 0), Number(derived[mode].monthTotals.totalIn || 0));
+      const totalOut = annualOut.reduce<number>((sum, value) => sum + Number(value ?? 0), Number(derived[mode].monthTotals.totalOut || 0));
       return { totalIn, totalOut, net: totalIn - totalOut };
     };
     const scrollBoard = (direction: -1 | 1) => {
@@ -2179,7 +2180,7 @@ export function CashflowProjectSheet({
       rowTone?: 'income' | 'expense',
     ) => renderSummaryCell({
       keyName: `${mode}-${kind}-${year}-annual`,
-      value: annualTotalFor(year, mode)?.[kind] ?? null,
+      value: annualSummaryAmountFor(annualTotalFor(year, mode), kind),
       mode,
       emphasis,
       rowTone,

--- a/src/app/components/cashflow/cashflow-month-close.test.ts
+++ b/src/app/components/cashflow/cashflow-month-close.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { CASHFLOW_ALL_LINES } from '../../platform/cashflow-sheet';
 import type { CashflowSheetLabMirrorResult } from '../../lib/sheets-cashflow-readonly-client';
 import type { CashflowDeadlineSummary, CashflowManagementCheck } from '../../lib/platform-bff-client';
+import type { CanonicalCashflowAnnualModeTotal } from '../../lib/platform-bff-client';
 import {
+  annualSummaryAmountFor,
   buildCashflowMonthCloseDraftInput,
   annualYearsFor,
   canonicalCashflowAnnualTotalFor,
@@ -351,5 +353,47 @@ describe('cashflow month close contract', () => {
     const source = mirror();
     source.cells = source.cells?.slice(0, -1);
     expect(() => normalizeCashflowMonthCloseCells(source, '2026-07')).toThrow('159/160');
+  });
+});
+
+describe('annual summary display fallback', () => {
+  const base: CanonicalCashflowAnnualModeTotal = {
+    lineStates: { SALES_IN: 'VALUE', SALES_VAT_IN: 'ZERO', TEAM_SUPPORT_IN: 'EMPTY', DIRECT_COST_OUT: 'VALUE' },
+    lineAmounts: { SALES_IN: 7_582_243, SALES_VAT_IN: 0, DIRECT_COST_OUT: 1_000_000 },
+    totalIn: null,
+    totalOut: null,
+    net: null,
+  };
+
+  it('falls back to the entered-line sum when the sheet totals row is not stored yet', () => {
+    expect(annualSummaryAmountFor(base, 'totalIn')).toBe(7_582_243);
+    expect(annualSummaryAmountFor(base, 'totalOut')).toBe(1_000_000);
+    expect(annualSummaryAmountFor(base, 'net')).toBe(6_582_243);
+  });
+
+  it('prefers the stored sheet totals over the line sum', () => {
+    const declared: CanonicalCashflowAnnualModeTotal = { ...base, totalIn: 8_340_487 };
+    expect(annualSummaryAmountFor(declared, 'totalIn')).toBe(8_340_487);
+  });
+
+  it('keeps the summary empty only when every line is empty', () => {
+    const empty: CanonicalCashflowAnnualModeTotal = {
+      lineStates: { SALES_IN: 'EMPTY', DIRECT_COST_OUT: 'EMPTY' },
+      lineAmounts: {},
+      totalIn: null, totalOut: null, net: null,
+    };
+    expect(annualSummaryAmountFor(empty, 'totalIn')).toBeNull();
+    expect(annualSummaryAmountFor(empty, 'net')).toBeNull();
+    expect(annualSummaryAmountFor(null, 'totalIn')).toBeNull();
+  });
+
+  it('treats all-zero lines as an entered zero, not as missing', () => {
+    const zero: CanonicalCashflowAnnualModeTotal = {
+      lineStates: { SALES_IN: 'ZERO', DIRECT_COST_OUT: 'ZERO' },
+      lineAmounts: { SALES_IN: 0, DIRECT_COST_OUT: 0 },
+      totalIn: null, totalOut: null, net: null,
+    };
+    expect(annualSummaryAmountFor(zero, 'totalIn')).toBe(0);
+    expect(annualSummaryAmountFor(zero, 'net')).toBe(0);
   });
 });

--- a/src/app/components/cashflow/cashflow-month-close.ts
+++ b/src/app/components/cashflow/cashflow-month-close.ts
@@ -1,4 +1,4 @@
-import { CASHFLOW_ALL_LINES } from '../../platform/cashflow-sheet';
+import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES } from '../../platform/cashflow-sheet';
 import type { CashflowSheetLineId } from '../../data/types';
 import type {
   CashflowMonthCloseCell,
@@ -38,6 +38,29 @@ export function canonicalCashflowAnnualTotalFor(
   mode: 'projection' | 'actual',
 ): CanonicalCashflowAnnualModeTotal | null {
   return annualTotals.find((total) => total.year === year)?.[mode] ?? null;
+}
+
+// 연간 열의 합계 표시값. 시트 합계 행에서 읽은 저장값이 우선이고, 아직 저장되지 않은
+// 문서는 기입된 라인의 합으로 보완한다 — Total 열의 buildCashflowSheetTotal 과 같은
+// 순서다. 라인이 전부 미기입일 때만 합계도 없는 값으로 남는다. 표시 전용이며 계약대비
+// Projection 합계 같은 판정 연산에는 쓰지 않는다.
+export function annualSummaryAmountFor(
+  total: CanonicalCashflowAnnualModeTotal | null,
+  kind: 'totalIn' | 'totalOut' | 'net',
+): number | null {
+  if (!total) return null;
+  if (typeof total[kind] === 'number') return total[kind];
+  const entered = (lineId: CashflowSheetLineId) => (
+    total.lineStates?.[lineId] === 'VALUE' || total.lineStates?.[lineId] === 'ZERO'
+  );
+  const sumOf = (lineIds: readonly CashflowSheetLineId[]) => (lineIds.some(entered)
+    ? lineIds.reduce((sum, lineId) => sum + (entered(lineId) ? Number(total.lineAmounts?.[lineId] || 0) : 0), 0)
+    : null);
+  if (kind === 'totalIn') return sumOf(CASHFLOW_IN_LINES);
+  if (kind === 'totalOut') return sumOf(CASHFLOW_OUT_LINES);
+  const totalIn = sumOf(CASHFLOW_IN_LINES);
+  const totalOut = sumOf(CASHFLOW_OUT_LINES);
+  return totalIn === null && totalOut === null ? null : (totalIn ?? 0) - (totalOut ?? 0);
 }
 
 export function shouldHideCashflowValuesAfterLoadError(error: string | null, hasCanonical: boolean): boolean {

--- a/vercel.json
+++ b/vercel.json
@@ -10,7 +10,10 @@
   },
   "functions": {
     "api/bff.js": {
-      "maxDuration": 300
+      "maxDuration": 300,
+      "regions": [
+        "icn1"
+      ]
     }
   },
   "crons": [
@@ -34,31 +37,56 @@
   "redirects": [
     {
       "source": "/:path*",
-      "has": [{ "type": "host", "value": "inner-platform.vercel.app" }],
+      "has": [
+        {
+          "type": "host",
+          "value": "inner-platform.vercel.app"
+        }
+      ],
       "destination": "https://myscube.myscguard.app/:path*",
       "permanent": false
     },
     {
       "source": "/:path*",
-      "has": [{ "type": "host", "value": "inner-platform-h799435np-merryai-devs-projects.vercel.app" }],
+      "has": [
+        {
+          "type": "host",
+          "value": "inner-platform-h799435np-merryai-devs-projects.vercel.app"
+        }
+      ],
       "destination": "https://myscube.myscguard.app/:path*",
       "permanent": false
     },
     {
       "source": "/:path*",
-      "has": [{ "type": "host", "value": "inner-platform-dsk6wdc3e-merryai-devs-projects.vercel.app" }],
+      "has": [
+        {
+          "type": "host",
+          "value": "inner-platform-dsk6wdc3e-merryai-devs-projects.vercel.app"
+        }
+      ],
       "destination": "https://myscube.myscguard.app/:path*",
       "permanent": false
     },
     {
       "source": "/:path*",
-      "has": [{ "type": "host", "value": "inner-platform-gq6813nqh-merryai-devs-projects.vercel.app" }],
+      "has": [
+        {
+          "type": "host",
+          "value": "inner-platform-gq6813nqh-merryai-devs-projects.vercel.app"
+        }
+      ],
       "destination": "https://myscube.myscguard.app/:path*",
       "permanent": false
     },
     {
       "source": "/:path*",
-      "has": [{ "type": "host", "value": "inner-platform-k2x121b33-merryai-devs-projects.vercel.app" }],
+      "has": [
+        {
+          "type": "host",
+          "value": "inner-platform-k2x121b33-merryai-devs-projects.vercel.app"
+        }
+      ],
       "destination": "https://myscube.myscguard.app/:path*",
       "permanent": false
     }
@@ -67,36 +95,81 @@
     {
       "source": "/sw.js",
       "headers": [
-        { "key": "Cache-Control", "value": "no-store, max-age=0, must-revalidate" }
+        {
+          "key": "Cache-Control",
+          "value": "no-store, max-age=0, must-revalidate"
+        }
       ]
     },
     {
       "source": "/__/auth/(.*)",
       "headers": [
-        { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin-allow-popups" }
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        },
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin-allow-popups"
+        }
       ]
     },
     {
       "source": "/__/firebase/(.*)",
       "headers": [
-        { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin-allow-popups" }
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        },
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin-allow-popups"
+        }
       ]
     },
     {
       "source": "/((?!(?:__/auth|__/firebase)/).*)",
       "headers": [
-        { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "X-Frame-Options", "value": "DENY" },
-        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Permissions-Policy", "value": "camera=(self), microphone=(), geolocation=()" },
-        { "key": "X-DNS-Prefetch-Control", "value": "on" },
-        { "key": "Cross-Origin-Opener-Policy", "value": "same-origin-allow-popups" }
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(self), microphone=(), geolocation=()"
+        },
+        {
+          "key": "X-DNS-Prefetch-Control",
+          "value": "on"
+        },
+        {
+          "key": "Cross-Origin-Opener-Policy",
+          "value": "same-origin-allow-popups"
+        }
       ]
     }
   ],


### PR DESCRIPTION
## 1. 연간 합계 행 '미입력' 문제 (#485 후속)

라인 값은 전부 표시되는데 합계 행(입금 합계·출금 합계·잔액)과 Total 열이 미입력. 원인: 구 `year_totals` 문서에는 시트 합계 행 좌표값이 없어 DTO `totalIn/totalOut/net`이 null.

표시 전용 `annualSummaryAmountFor` — 저장된 시트 합계 우선, 없으면 기입 라인 합, 전부 미기입일 때만 빈 값. **BFF DTO는 불변** — 합계를 서버에서 지어내면 계약대비 진행률이 조작된다는 기존 불변식 테스트(35%→100%)가 지켜준다.

## 2. BFF 리전: iad1 → icn1

라이브 실측 `x-vercel-id: hkg1::iad1` — 함수가 미국에서 돌며 서울 Firestore·JVM과 직렬 6~10왕복. month-close 웜 4s의 지배항. 데이터와 같은 서울(icn1)로 이전.

검증: month-close 25/25 · shell 60/60 · build OK · tsc 오류 main과 동일(203, 신규 0) · 사보타주 3건 실패 후 원복

🤖 Generated with [Claude Code](https://claude.com/claude-code)