### PR TITLE
perf(cashflow): month-close 병렬화 + 토큰 캐시 + JVM 상주 인스턴스

### DIFF
--- a/.github/workflows/jvm-production-deploy.yml
+++ b/.github/workflows/jvm-production-deploy.yml
@@ -105,6 +105,7 @@ jobs:
             --no-traffic \
             --tag candidate \
             --ingress all \
+            --min-instances 1 \
             --set-env-vars '^|^WEEKLY_API_PORT=8080|JVM_WEEKLY_DEPLOY_ENV=live|JVM_WEEKLY_EDIT_LEASES_ENABLED=true|JVM_WEEKLY_INTERNAL_API_TOKEN_ENABLED=true|JVM_WEEKLY_STORAGE_BACKEND=firestore|JVM_WEEKLY_PROJECT_ACCESS_BACKEND=firestore|JVM_WEEKLY_AUTH_MODE=strict|JVM_WEEKLY_WORKSPACE_EMAIL_DOMAIN=mysc.co.kr|JVM_WEEKLY_FIREBASE_PROJECT_ID=inner-platform-live-20260316|JVM_WEEKLY_FIRESTORE_PROJECT_ID=inner-platform-live-20260316|JVM_WEEKLY_FIREBASE_AUTH_PROJECT_ID=inner-platform-live-20260316|JVM_WEEKLY_ALLOWED_ORIGINS=https://myscube.myscguard.app' \
             --set-secrets 'JVM_WEEKLY_INTERNAL_API_TOKEN=innerplatform-weekly-api-token:latest,JVM_WEEKLY_CASHFLOW_SETTLED_WEEK_CONFIRMATION_KEY=innerplatform-cashflow-settled-week-confirmation-key:latest'
           revision="${SERVICE}-${revision_suffix}"

--- a/server/bff/java-weekly-auth.mjs
+++ b/server/bff/java-weekly-auth.mjs
@@ -18,6 +18,12 @@ export function isWorkspaceUser(context, workspaceEmailDomain = 'mysc.co.kr') {
   return Boolean(domain) && email.endsWith(`@${domain}`);
 }
 
+// audience+자격증명별 IdTokenClient 캐시. 클라이언트는 토큰 만료를 스스로 관리하며
+// 갱신하므로(google-auth-library), 요청마다 GoogleAuth 를 새로 만들어 RS256 서명
+// 왕복을 반복할 이유가 없다. month-close 한 번에 JVM 호출이 두 번이라 이 비용이
+// 요청마다 두 배로 들었다. 캐시 키에 자격증명을 포함해 SA 교체 시 자연히 분리된다.
+const identityTokenClients = new Map();
+
 async function fetchCredentialIdentityToken(audience, serviceAccountJson) {
   let credentials;
   try {
@@ -26,13 +32,19 @@ async function fetchCredentialIdentityToken(audience, serviceAccountJson) {
     throw createHttpError(503, '서버 인증 정보가 올바르지 않습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_api_identity_token_unavailable');
   }
   try {
-    const auth = new GoogleAuth({ credentials });
-    const client = await auth.getIdTokenClient(audience);
+    const cacheKey = `${credentials.client_email || ''}\n${audience}`;
+    let clientPromise = identityTokenClients.get(cacheKey);
+    if (!clientPromise) {
+      clientPromise = new GoogleAuth({ credentials }).getIdTokenClient(audience);
+      identityTokenClients.set(cacheKey, clientPromise);
+    }
+    const client = await clientPromise;
     const authorization = readOptionalText((await client.getRequestHeaders()).Authorization);
     const token = authorization.replace(/^Bearer\s+/i, '');
     if (!token) throw new Error('Missing identity token');
     return token;
   } catch {
+    identityTokenClients.clear();
     throw createHttpError(503, '서버 인증에 실패했습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_api_identity_token_unavailable');
   }
 }

--- a/server/bff/java-weekly-auth.test.mjs
+++ b/server/bff/java-weekly-auth.test.mjs
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getIdTokenClient = vi.fn();
+
+vi.mock('google-auth-library', () => ({
+  GoogleAuth: vi.fn(() => ({ getIdTokenClient })),
+}));
+
+const { GoogleAuth } = await import('google-auth-library');
+const { fetchGoogleIdentityToken } = await import('./java-weekly-auth.mjs');
+
+const serviceAccountJson = JSON.stringify({ client_email: 'bff@test.iam', private_key: 'k' });
+
+// 캐시는 모듈 수명이므로 테스트마다 고유한 audience 를 써서 서로 간섭하지 않게 한다.
+describe('java weekly identity token cache', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reuses one IdTokenClient per audience instead of signing on every request', async () => {
+    const getRequestHeaders = vi.fn(async () => ({ Authorization: 'Bearer cached-token' }));
+    getIdTokenClient.mockResolvedValue({ getRequestHeaders });
+    const audience = 'https://jvm-weekly.example/reuse';
+
+    const first = await fetchGoogleIdentityToken(fetch, audience, serviceAccountJson);
+    const second = await fetchGoogleIdentityToken(fetch, audience, serviceAccountJson);
+
+    expect(first).toBe('cached-token');
+    expect(second).toBe('cached-token');
+    // month-close 한 번에 JVM 호출이 두 번이라, 클라이언트를 캐시하지 않으면
+    // 요청마다 GoogleAuth 생성과 서명 왕복이 두 배로 든다.
+    expect(GoogleAuth).toHaveBeenCalledTimes(1);
+    expect(getIdTokenClient).toHaveBeenCalledTimes(1);
+    // 만료 갱신은 클라이언트에 위임한다 — 캐시된 클라이언트라도 호출마다
+    // getRequestHeaders 를 다시 물어 최신 토큰을 받는다.
+    expect(getRequestHeaders).toHaveBeenCalledTimes(2);
+  });
+
+  it('separates cache entries by audience', async () => {
+    getIdTokenClient.mockResolvedValue({
+      getRequestHeaders: async () => ({ Authorization: 'Bearer t' }),
+    });
+    await fetchGoogleIdentityToken(fetch, 'https://jvm-weekly.example/aud-a', serviceAccountJson);
+    await fetchGoogleIdentityToken(fetch, 'https://jvm-weekly.example/aud-b', serviceAccountJson);
+    expect(getIdTokenClient).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops the cache when token issuance fails so the next request can recover', async () => {
+    const audience = 'https://jvm-weekly.example/recover';
+    getIdTokenClient.mockRejectedValueOnce(new Error('signer down'));
+    await expect(fetchGoogleIdentityToken(fetch, audience, serviceAccountJson)).rejects.toMatchObject({
+      code: 'jvm_weekly_api_identity_token_unavailable',
+    });
+
+    getIdTokenClient.mockResolvedValue({
+      getRequestHeaders: async () => ({ Authorization: 'Bearer recovered' }),
+    });
+    await expect(fetchGoogleIdentityToken(fetch, audience, serviceAccountJson)).resolves.toBe('recovered');
+  });
+});

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -2662,25 +2662,36 @@ export function mountJvmWeeklyApiRoutes(app, {
       };
       for (let attempt = 0; attempt < 2; attempt += 1) {
         const traceAttempt = attempt + 1;
-        const publicationBefore = await trace.measure(
-          'publication_before',
-          () => readCashflowSheetPublicationState({
-            db,
-            tenantId: req.context.tenantId,
-            projectId: rawProjectId,
-            nowMs: currentNow.getTime(),
-          }),
-          { attempt: traceAttempt },
-        );
-        const source = await trace.measure(
-          'jvm_dashboard',
-          () => proxyJavaWeeklyRequest({
-            context: req.context,
-            method: 'GET',
-            path: `/api/v1/cashflow/${projectId}/month-close/dashboard-source?yearMonth=${encodeURIComponent(yearMonth)}`,
-          }),
-          { attempt: traceAttempt },
-        );
+        // 세 읽기는 서로 독립이라 함께 출발한다. 직렬이던 시절에는 왕복 지연이
+        // 세 번 겹겹이 쌓였다. publication 은 어차피 대시보드 읽기 뒤(after)에
+        // 한 번 더 확인해 변경 여부를 판정하므로, before 를 병렬로 시작해도
+        // 읽기 일관성 계약은 그 fingerprint 비교가 그대로 지킨다.
+        const [publicationBefore, source, weeklyCompliance] = await Promise.all([
+          trace.measure(
+            'publication_before',
+            () => readCashflowSheetPublicationState({
+              db,
+              tenantId: req.context.tenantId,
+              projectId: rawProjectId,
+              nowMs: currentNow.getTime(),
+            }),
+            { attempt: traceAttempt },
+          ),
+          trace.measure(
+            'jvm_dashboard',
+            () => proxyJavaWeeklyRequest({
+              context: req.context,
+              method: 'GET',
+              path: `/api/v1/cashflow/${projectId}/month-close/dashboard-source?yearMonth=${encodeURIComponent(yearMonth)}`,
+            }),
+            { attempt: traceAttempt },
+          ),
+          trace.measure(
+            'jvm_compliance',
+            () => readWeeklyCompliance(req.context, rawProjectId),
+            { attempt: traceAttempt },
+          ),
+        ]);
         const result = objectValue(source?.monthClose);
         const cashflow = objectValue(source?.cashflow);
         const snapshotCompatibility = objectValue(source?.snapshotCompatibility) || {
@@ -2712,11 +2723,6 @@ export function mountJvmWeeklyApiRoutes(app, {
           || typeof projectionActualSummary?.settlementMatches !== 'boolean') {
           throw createHttpError(502, 'JVM 누적 Projection-Actual 요약을 확인할 수 없습니다.', 'jvm_weekly_response_invalid');
         }
-        const weeklyCompliance = await trace.measure(
-          'jvm_compliance',
-          () => readWeeklyCompliance(req.context, rawProjectId),
-          { attempt: traceAttempt },
-        );
         const cycleBusinessDate = readOptionalText(result?.evaluatedBusinessDate) || comparisonBoundary.asOfDate;
         const cumulativeCycle = cashflowCumulativeCloseCycle(yearMonth, cycleBusinessDate);
         if (!cumulativeCycle) {

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -3399,8 +3399,12 @@ describe('JVM weekly API BFF proxy', () => {
       });
   });
 
+  // 계약 변경(2026-08-09): publication·JVM 대시보드·컴플라이언스는 서로 독립 읽기라
+  // 함께 출발한다. 이전에는 publication 이 매달리면 JVM 호출이 시작되지 않는 직렬
+  // 순서를 단언했지만, 그 순서가 왕복 지연을 겹겹이 쌓았다. 총 시간 보호는 라우트
+  // 데드라인(504)이 그대로 담당한다.
   it('bounds slow Firestore composition inside the full month-close route deadline', async () => {
-    const fetchImpl = vi.fn();
+    const fetchImpl = vi.fn(() => new Promise(() => {}));
     const stalledDb = {
       doc: () => ({ get: () => new Promise(() => {}) }),
     };
@@ -3416,8 +3420,6 @@ describe('JVM weekly API BFF proxy', () => {
       .expect((response) => {
         expect(response.body.code).toBe('cashflow_month_close_route_timeout');
       });
-
-    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
   it('never starts the final JVM close mutation after the preflight deadline', async () => {

--- a/src/app/components/cashflow/CashflowWeeklyPage.tsx
+++ b/src/app/components/cashflow/CashflowWeeklyPage.tsx
@@ -206,8 +206,18 @@ export function CashflowWeeklyPage() {
       setStatusesLoading(false);
     };
     void load(true);
-    const interval = window.setInterval(() => void load(false), 15_000);
-    return () => { active = false; window.clearInterval(interval); };
+    // 백그라운드 탭에서는 폴링을 멈추고, 다시 보일 때 즉시 한 번 갱신한다.
+    const interval = window.setInterval(() => {
+      if (document.visibilityState === 'hidden') return;
+      void load(false);
+    }, 15_000);
+    const onVisible = () => { if (document.visibilityState === 'visible') void load(false); };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      active = false;
+      window.clearInterval(interval);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
   }, [departmentProjects, orgId, user, yearMonth]);
 
   async function transition(projectId: string, period: CashflowSettlementPeriod, action: 'SUBMIT' | 'APPROVE') {


### PR DESCRIPTION
리전 이전(#486) 후 남은 지연 3종 제거.

1. **직렬 3단 → 병렬**: publication·JVM 대시보드·컴플라이언스는 독립 읽기 — 함께 출발. 일관성은 기존 publication fingerprint 비교(after)가 그대로 보장. 직렬 순서를 고정하던 테스트는 총 시간 보호(504)만 남기고 계약 갱신
2. **BFF→JVM ID 토큰 캐시**: 요청마다 GoogleAuth 생성·RS256 서명 왕복 ×2 → audience별 IdTokenClient 캐시(만료 갱신은 클라이언트 위임, 실패 시 캐시 드롭)
3. **JVM min-instances=1**: 콜드 14.58s(7/27 실측)를 유휴 후 첫 사용자가 매번 지불하던 것 제거. 부팅 다이어트(JPA·Flyway 제거)는 후속
4. 주간 화면 15s 폴링 — 백그라운드 탭 중지, 복귀 시 즉시 1회

검증: jvm-weekly-api 186/186 · auth 캐시 신규 3건(사보타주: 캐시 제거 시 1건 실패 후 원복) · client 55/55 · weekly shell 7/7 · build OK

⚠️ min-instances=1은 Cloud Run 유휴 인스턴스 1대 상시 비용 발생.

🤖 Generated with [Claude Code](https://claude.com/claude-code)