### PR TITLE
fix(security): BFF 프로젝트 스코프 인가 추가 (계층 리팩터링 선행 조건)

### DIFF
--- a/scripts/backfill-member-project-scope.mjs
+++ b/scripts/backfill-member-project-scope.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+// 멤버 프로젝트 배정 백필 (#451 "give every member access to every project" 의 데이터 반영).
+//
+// BFF 에 프로젝트 스코프 인가를 세우면서, 지금까지 JVM 만 하던 검사가 모든 읽기 경로에
+// 적용된다. 라이브 활성 멤버 중 전 프로젝트를 가진 사람이 0명이므로 게이트를 그대로
+// 켜면 업무가 멈춘다. #451 의 의도대로 활성 멤버에게 전 프로젝트를 부여해 현재 동작을
+// 유지한 채 우회 통로만 닫는다. 권한을 조이는 결정은 이 데이터를 다시 좁히면 된다.
+//
+// 테넌트 전역 역할(admin/finance/auditor/tenant_admin/support/security)은 배정과 무관하게
+// 통과하므로 건드리지 않는다.
+//
+//   1) 사본:    node scripts/backfill-member-project-scope.mjs --project <id> --dump <dir>
+//   2) dry-run: node scripts/backfill-member-project-scope.mjs --project <id>
+//   3) 실행:    node scripts/backfill-member-project-scope.mjs --project <id> --apply
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createFirestoreDb, resolveProjectId } from '../server/bff/firestore.mjs';
+import { TENANT_WIDE_PROJECT_ROLES, isActiveActorMember, memberProjectIds } from '../server/bff/cashflow-project-scope.mjs';
+
+function readFlag(name, fallback = '') {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? fallback : (process.argv[index + 1] || fallback);
+}
+
+const firebaseProjectId = readFlag('--firebase-project', readFlag('--project', resolveProjectId()));
+const tenantId = readFlag('--tenant', 'mysc');
+const dumpDir = readFlag('--dump', '');
+const apply = process.argv.includes('--apply');
+
+async function main() {
+  const db = createFirestoreDb({ projectId: firebaseProjectId });
+  const [membersSnap, projectsSnap] = await Promise.all([
+    db.collection(`orgs/${tenantId}/members`).get(),
+    db.collection(`orgs/${tenantId}/projects`).get(),
+  ]);
+  const allProjectIds = projectsSnap.docs.map((doc) => doc.id).sort();
+
+  if (dumpDir) {
+    mkdirSync(dumpDir, { recursive: true });
+    const file = join(dumpDir, `members-${tenantId}-${firebaseProjectId}.json`);
+    writeFileSync(file, JSON.stringify(
+      membersSnap.docs.map((doc) => ({ id: doc.id, data: doc.data() })),
+      null,
+      2,
+    ));
+    console.log(`사본 저장: ${file} (${membersSnap.size}건)`);
+    return;
+  }
+
+  const plans = [];
+  const skipped = [];
+  for (const doc of membersSnap.docs) {
+    const member = doc.data() || {};
+    const role = String(member.role || '').toLowerCase();
+    if (!isActiveActorMember(member, member.uid || doc.id)) {
+      skipped.push(`${doc.id}: 비활성 — 건드리지 않음`);
+      continue;
+    }
+    if (TENANT_WIDE_PROJECT_ROLES.includes(role)) {
+      skipped.push(`${doc.id}: role=${role} 테넌트 전역 — 배정 불필요`);
+      continue;
+    }
+    const current = memberProjectIds(member);
+    const missing = allProjectIds.filter((id) => !current.has(id));
+    if (missing.length === 0) {
+      skipped.push(`${doc.id}: 이미 전 프로젝트 보유`);
+      continue;
+    }
+    plans.push({ id: doc.id, role, before: current.size, missing: missing.length });
+  }
+
+  console.log(`프로젝트 ${allProjectIds.length}개 · 멤버 ${membersSnap.size}건`);
+  console.log(`대상 ${plans.length}건 / 제외 ${skipped.length}건  (${apply ? 'APPLY' : 'DRY-RUN'})`);
+  for (const plan of plans) console.log(`  ${plan.id} role=${plan.role} ${plan.before} -> ${allProjectIds.length} (+${plan.missing})`);
+
+  if (!apply) return;
+  for (const plan of plans) {
+    // projectIds 만 전체로 교체한다. portalProfile 등 다른 필드는 그대로 둔다.
+    await db.doc(`orgs/${tenantId}/members/${plan.id}`).update({ projectIds: allProjectIds });
+  }
+  console.log(`\n적용 완료: ${plans.length}건 (projectIds 필드만 갱신)`);
+}
+
+main().catch((error) => {
+  console.error(error?.stack || String(error));
+  process.exitCode = 1;
+});

--- a/server/bff/cashflow-project-scope.mjs
+++ b/server/bff/cashflow-project-scope.mjs
@@ -1,0 +1,72 @@
+import { readOptionalText } from './bff-utils.mjs';
+
+// 프로젝트 스코프 인가 판정. JVM WeeklyExpenseAuthorizationService.requireProjectAllowed
+// 및 FirestoreWeeklyProjectAccessRepository 와 같은 규칙을 따른다.
+//
+// 순수 함수다 — 멤버 문서를 인자로 받고 조회는 호출부(서비스 계층)가 한다.
+// 두 런타임의 판정이 갈리면 한쪽 경로만 뚫리므로 parity 테스트로 고정한다.
+
+// 테넌트 전역으로 모든 프로젝트를 보는 역할. JVM TENANT_WIDE_PROJECT_ROLES 와 같아야 한다.
+export const TENANT_WIDE_PROJECT_ROLES = Object.freeze([
+  'admin',
+  'finance',
+  'auditor',
+  'tenant_admin',
+  'support',
+  'security',
+]);
+
+function normalizedRole(role) {
+  return readOptionalText(role).toLowerCase();
+}
+
+function addText(ids, value) {
+  const text = readOptionalText(value);
+  if (text) ids.add(text);
+}
+
+function addTextList(ids, value) {
+  if (!Array.isArray(value)) return;
+  for (const entry of value) addText(ids, entry);
+}
+
+// JVM FirestoreWeeklyProjectAccessRepository.projectIds 와 같은 필드 집합을 본다.
+export function memberProjectIds(member) {
+  const ids = new Set();
+  addText(ids, member?.projectId);
+  addTextList(ids, member?.projectIds);
+  const profile = member?.portalProfile;
+  if (profile && typeof profile === 'object') {
+    addText(ids, profile.projectId);
+    addTextList(ids, profile.projectIds);
+  }
+  return ids;
+}
+
+// JVM isActiveActorMember 와 같다 — 비활성 멤버는 스코프를 갖지 않고,
+// uid 가 적힌 문서는 그 actor 의 것일 때만 인정한다.
+export function isActiveActorMember(member, actorId) {
+  if (!member || typeof member !== 'object') return false;
+  if (readOptionalText(member.status).toUpperCase() !== 'ACTIVE') return false;
+  const memberUid = readOptionalText(member.uid);
+  return memberUid === '' || memberUid === readOptionalText(actorId);
+}
+
+export function hasProjectAccess({ members, actorId, projectId }) {
+  const target = readOptionalText(projectId);
+  if (!target) return false;
+  for (const member of Array.isArray(members) ? members : []) {
+    if (!isActiveActorMember(member, actorId)) continue;
+    if (memberProjectIds(member).has(target)) return true;
+  }
+  return false;
+}
+
+// JVM requireProjectAllowed 의 스코프 판정 부분과 같은 순서다.
+// 역할 게이트(COMMAND_ROLES)는 BFF 의 기존 assertWeeklyWorkspaceOrRoleAllowed 가 담당하므로
+// 여기서는 프로젝트 스코프만 본다.
+export function isProjectInActorScope({ role, members, actorId, projectId, workspaceUser = false }) {
+  if (workspaceUser) return true;
+  if (TENANT_WIDE_PROJECT_ROLES.includes(normalizedRole(role))) return true;
+  return hasProjectAccess({ members, actorId, projectId });
+}

--- a/server/bff/cashflow-project-scope.test.mjs
+++ b/server/bff/cashflow-project-scope.test.mjs
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  TENANT_WIDE_PROJECT_ROLES,
+  hasProjectAccess,
+  isActiveActorMember,
+  isProjectInActorScope,
+  memberProjectIds,
+} from './cashflow-project-scope.mjs';
+
+// JVM 과 판정이 갈리면 한쪽 경로만 뚫린다. 아래 표는
+// WeeklyExpenseAuthorizationService.requireProjectAllowed 와
+// FirestoreWeeklyProjectAccessRepository 의 규칙을 그대로 옮긴 것이며,
+// Java 쪽을 고칠 때 이 표도 함께 고쳐야 한다.
+const member = (patch = {}) => ({
+  uid: 'pm-1', email: 'pm@example.com', status: 'ACTIVE', role: 'pm', ...patch,
+});
+
+describe('member project ids', () => {
+  it('reads the same four fields the JVM repository reads', () => {
+    const ids = memberProjectIds({
+      projectId: 'p-root',
+      projectIds: ['p-list-1', 'p-list-2'],
+      portalProfile: { projectId: 'p-profile', projectIds: ['p-profile-list'] },
+    });
+    expect([...ids]).toEqual(['p-root', 'p-list-1', 'p-list-2', 'p-profile', 'p-profile-list']);
+  });
+
+  it.each([
+    ['빈 문자열', { projectId: '' }],
+    ['공백', { projectId: '   ' }],
+    ['배열 아님', { projectIds: 'p-a' }],
+    ['portalProfile 이 객체 아님', { portalProfile: 'p-a' }],
+  ])('ignores %s', (_label, patch) => {
+    expect(memberProjectIds(patch).size).toBe(0);
+  });
+});
+
+describe('active actor member', () => {
+  it('requires ACTIVE status', () => {
+    expect(isActiveActorMember(member(), 'pm-1')).toBe(true);
+    expect(isActiveActorMember(member({ status: 'DISABLED' }), 'pm-1')).toBe(false);
+    expect(isActiveActorMember(member({ status: '' }), 'pm-1')).toBe(false);
+  });
+
+  it('accepts a blank uid but rejects another actor uid', () => {
+    expect(isActiveActorMember(member({ uid: '' }), 'pm-1')).toBe(true);
+    expect(isActiveActorMember(member({ uid: 'someone-else' }), 'pm-1')).toBe(false);
+  });
+
+  it('treats a missing member as inactive', () => {
+    expect(isActiveActorMember(null, 'pm-1')).toBe(false);
+  });
+});
+
+describe('project access', () => {
+  it('grants only when an active member document lists the project', () => {
+    const members = [member({ projectIds: ['project-a'] })];
+    expect(hasProjectAccess({ members, actorId: 'pm-1', projectId: 'project-a' })).toBe(true);
+    expect(hasProjectAccess({ members, actorId: 'pm-1', projectId: 'project-b' })).toBe(false);
+  });
+
+  it('ignores assignments carried by an inactive or foreign document', () => {
+    expect(hasProjectAccess({
+      members: [member({ status: 'DISABLED', projectIds: ['project-a'] })],
+      actorId: 'pm-1',
+      projectId: 'project-a',
+    })).toBe(false);
+    expect(hasProjectAccess({
+      members: [member({ uid: 'other-1', projectIds: ['project-a'] })],
+      actorId: 'pm-1',
+      projectId: 'project-a',
+    })).toBe(false);
+  });
+
+  it('rejects a blank project id and an empty member list', () => {
+    expect(hasProjectAccess({ members: [member({ projectIds: ['project-a'] })], actorId: 'pm-1', projectId: '' })).toBe(false);
+    expect(hasProjectAccess({ members: [], actorId: 'pm-1', projectId: 'project-a' })).toBe(false);
+  });
+});
+
+describe('scope decision — JVM requireProjectAllowed parity', () => {
+  it.each(TENANT_WIDE_PROJECT_ROLES)('lets tenant-wide role %s through without any assignment', (role) => {
+    expect(isProjectInActorScope({ role, members: [], actorId: 'x', projectId: 'project-a' })).toBe(true);
+  });
+
+  it.each(['pm', 'workspace_user', 'viewer', ''])('makes scoped role %j depend on the assignment', (role) => {
+    expect(isProjectInActorScope({ role, members: [], actorId: 'pm-1', projectId: 'project-a' })).toBe(false);
+    expect(isProjectInActorScope({
+      role,
+      members: [member({ role, projectIds: ['project-a'] })],
+      actorId: 'pm-1',
+      projectId: 'project-a',
+    })).toBe(true);
+  });
+
+  it('lets a workspace-mode workspace user through, matching the JVM WORKSPACE_COMMANDS branch', () => {
+    expect(isProjectInActorScope({
+      role: 'workspace_user', members: [], actorId: 'pm-1', projectId: 'project-a', workspaceUser: true,
+    })).toBe(true);
+  });
+
+  it('matches roles case-insensitively like the JVM lowercase normalization', () => {
+    expect(isProjectInActorScope({ role: 'Admin', members: [], actorId: 'x', projectId: 'project-a' })).toBe(true);
+    expect(isProjectInActorScope({ role: ' FINANCE ', members: [], actorId: 'x', projectId: 'project-a' })).toBe(true);
+  });
+});

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -22,6 +22,7 @@ import { stableStringify } from '../utils.mjs';
 import { cashflowApplyLeaseMs, readCashflowApplyLeaseState } from '../cashflow-apply-lease.mjs';
 import { getMonthFinanceWeeks } from '../../../src/app/platform/cashflow-week-core.mjs';
 import { WEEKS_PER_MONTH, annualYearsFor, weekOrdinal } from '../cashflow-coordinates.mjs';
+import { TENANT_WIDE_PROJECT_ROLES, isProjectInActorScope } from '../cashflow-project-scope.mjs';
 import { createHash } from 'node:crypto';
 
 const CASHFLOW_MANAGEMENT_CHECK_IDS = [
@@ -294,6 +295,47 @@ function assertCashflowMonthCloseRequestSize(record) {
     '월 결산 요청 자료가 너무 큽니다. 시트 범위를 확인해 주세요.',
     'cashflow_month_close_request_too_large',
   );
+}
+
+// JVM FirestoreWeeklyProjectAccessRepository.memberDocuments 와 같은 두 경로로 찾는다 —
+// uid 문서 1건과 email 로 조회한 최대 3건. 조회는 서비스 계층인 여기서 하고,
+// 판정은 순수 모듈(cashflow-project-scope)이 한다.
+async function readActorMemberDocuments({ db, tenantId, actorId, actorEmail }) {
+  const normalizedTenantId = readOptionalText(tenantId);
+  if (!normalizedTenantId) return [];
+  const normalizedActorId = readOptionalText(actorId);
+  const normalizedEmail = readOptionalText(actorEmail);
+  const documents = [];
+  if (normalizedActorId && !normalizedActorId.includes('/')) {
+    const snapshot = await db.doc(`orgs/${normalizedTenantId}/members/${normalizedActorId}`).get();
+    if (snapshot.exists) documents.push(snapshot.data() || {});
+  }
+  if (normalizedEmail && typeof db.collection === 'function') {
+    const snapshot = await db.collection(`orgs/${normalizedTenantId}/members`)
+      .where('email', '==', normalizedEmail)
+      .limit(3)
+      .get();
+    for (const doc of snapshot?.docs || []) documents.push(doc.data() || {});
+  }
+  return documents;
+}
+
+// 프로젝트 스코프 인가. 지금까지 이 검사는 JVM 에만 있었고 BFF 는 역할만 봤다.
+// BFF 가 Firestore 를 직접 읽는 경로가 늘어날수록 그 비대칭이 우회 통로가 되므로
+// 같은 규칙을 BFF 에도 세운다. 판정 규칙은 cashflow-project-scope 가 단일 소유한다.
+async function assertCashflowProjectInScope({ db, req, projectId, authMode, workspaceEmailDomain }) {
+  if (!db?.doc) return;
+  const workspaceUser = isWorkspaceAuthMode(authMode) && isWorkspaceUser(req.context, workspaceEmailDomain);
+  const role = readOptionalText(req.context?.actorRole);
+  if (workspaceUser || TENANT_WIDE_PROJECT_ROLES.includes(role.toLowerCase())) return;
+  const members = await readActorMemberDocuments({
+    db,
+    tenantId: req.context?.tenantId,
+    actorId: req.context?.actorId,
+    actorEmail: req.context?.actorEmail,
+  });
+  if (isProjectInActorScope({ role, members, actorId: req.context?.actorId, projectId, workspaceUser })) return;
+  throw createHttpError(403, '이 프로젝트에 접근할 권한이 없습니다.', 'cashflow_project_forbidden');
 }
 
 async function readActiveCashflowMember({ db, tenantId, actorId }) {
@@ -2650,6 +2692,7 @@ export function mountJvmWeeklyApiRoutes(app, {
       if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(yearMonth)) {
         throw createHttpError(400, 'Cashflow month close yearMonth must use YYYY-MM.', 'cashflow_month_close_request_invalid');
       }
+      await assertCashflowProjectInScope({ db, req, projectId: rawProjectId, authMode, workspaceEmailDomain });
       cumulativeCloseMonths(yearMonth);
       const currentNow = now();
       const comparisonBoundary = {

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -102,6 +102,12 @@ const emptyManagementChecks = [
   { id: 'future-prepay-over-million', status: 'OK', title: '금주 이후 선입금 요청 100만원 초과', detail: '금주 이후 100만원 초과 요청이 없습니다.' },
 ];
 
+// pm 역할은 테넌트 전역이 아니므로 프로젝트 스코프가 있어야 읽을 수 있다.
+// 라이브 멤버 문서와 같은 형태로 배정을 모델링한다.
+const ACTOR_MEMBER_ENTRY = ['orgs/tenant-a/members/pm-1', {
+  uid: 'pm-1', email: 'pm@example.com', status: 'ACTIVE', role: 'pm', projectIds: ['project-a'],
+}];
+
 function monthDashboardSource(
   monthClose,
   cashflow = { projectId: 'project-a', projection: [], actual: [], readModel: { months: [] } },
@@ -268,6 +274,7 @@ function fullMonthCloseSource({
   };
   const draftId = `v1_${Buffer.from(JSON.stringify(['cashflow', 'project-a', 'pm-1']), 'utf8').toString('base64url')}`;
   const documents = new Map([
+    ACTOR_MEMBER_ENTRY,
     ['orgs/tenant-a/projects/project-a', {
       id: 'project-a', settlementType: 'TYPE1', basis: '공급가액', accountType: 'DEDICATED',
       fundInputMode: 'BANK_UPLOAD', contractAmount, executiveApproverId: 'finance-1',
@@ -333,6 +340,7 @@ function createMonthCloseDb() {
   }));
   const draftId = `v1_${Buffer.from(JSON.stringify(['cashflow', 'project-a', 'pm-1']), 'utf8').toString('base64url')}`;
   const documents = new Map([
+    ACTOR_MEMBER_ENTRY,
     [`orgs/tenant-a/privateEditDrafts/${draftId}`, {
       tenantId: 'tenant-a', ownerUid: 'pm-1', resourceType: 'cashflow', resourceId: 'project-a',
       status: 'ACTIVE', draftRevision: 7,
@@ -2401,6 +2409,7 @@ describe('JVM weekly API BFF proxy', () => {
 
   it('returns an empty usable dashboard when the project has no linked sheet', async () => {
     const documents = new Map([
+      ACTOR_MEMBER_ENTRY,
       ['orgs/tenant-a/projects/project-a', { id: 'project-a', contractAmount: 1000 }],
     ]);
     const db = {
@@ -3480,8 +3489,67 @@ describe('JVM weekly API BFF proxy', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 
+  // 프로젝트 스코프 인가는 지금까지 JVM 에만 있었다. BFF 가 Firestore 를 직접 읽는
+  // 경로가 늘면서 그 비대칭이 우회 통로가 되므로 BFF 에도 같은 규칙을 세운다.
+  it('blocks a scoped actor from reading a project outside their assignment', async () => {
+    const source = fullMonthCloseSource();
+    source.documents.set('orgs/tenant-a/members/pm-1', {
+      uid: 'pm-1', email: 'pm@example.com', status: 'ACTIVE', role: 'pm', projectIds: ['project-b'],
+    });
+    const fetchImpl = vi.fn();
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { env: runtimeEnv, db: source.db });
+
+    await request(app)
+      .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
+      .expect(403)
+      .expect((response) => {
+        expect(response.body.code).toBe('cashflow_project_forbidden');
+      });
+    // JVM 까지 가기 전에 막혀야 한다 — 데이터가 프로세스 경계를 넘지 않는다.
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('blocks an inactive member even when the project is in their assignment', async () => {
+    const source = fullMonthCloseSource();
+    source.documents.set('orgs/tenant-a/members/pm-1', {
+      uid: 'pm-1', email: 'pm@example.com', status: 'DISABLED', role: 'pm', projectIds: ['project-a'],
+    });
+    const { app } = createApp(vi.fn(), createIdempotencyService(), {}, { env: runtimeEnv, db: source.db });
+    await request(app)
+      .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
+      .expect(403);
+  });
+
+  it.each(['admin', 'finance', 'auditor', 'tenant_admin', 'support', 'security'])(
+    'lets tenant-wide role %s read without a project assignment',
+    async (actorRole) => {
+      const source = fullMonthCloseSource();
+      source.documents.delete('orgs/tenant-a/members/pm-1');
+      const fetchImpl = vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify(monthDashboardSource({
+          ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0,
+          reopenCount: 0, projectWarningCount: 0, snapshot: {},
+        })),
+      }));
+      const { app } = createApp(fetchImpl, createIdempotencyService(), {
+        actorId: `${actorRole}-1`, actorRole, actorEmail: `${actorRole}@example.com`,
+      }, { env: runtimeEnv, db: source.db });
+      await request(app)
+        .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
+        .expect(200);
+    },
+  );
+
   it.each(['viewer', 'pm', 'finance', 'admin'])('blocks a reviewed %s direct month close after authoritative preflight', async (actorRole) => {
     const source = fullMonthCloseSource();
+    // 이 케이스만 actorId 가 역할별로 달라진다. viewer/pm 은 테넌트 전역이 아니므로
+    // 각자의 멤버 문서로 프로젝트 배정을 모델링한다.
+    source.documents.set(`orgs/tenant-a/members/${actorRole}-1`, {
+      uid: `${actorRole}-1`, email: `${actorRole}@example.com`, status: 'ACTIVE',
+      role: actorRole, projectIds: ['project-a'],
+    });
     const fetchImpl = vi.fn(async (url, init) => ({
       ok: true,
       status: 200,


### PR DESCRIPTION
## 발견

프로젝트 스코프 검사가 **JVM 에만** 있었다. BFF 는 역할(role)만 보고, Firestore 를 직접 읽는 경로는 그대로 통과했다. 좌표 계약 이행(#485)으로 BFF 직접 읽기가 늘면서 그 비대칭이 실제 우회 통로가 됐다 — 배정되지 않은 `projectId` 로 남의 프로젝트 재무 자료를 읽을 수 있었다.

| 계층 | 스코프 인가 |
|---|---|
| JVM | `requireProjectAllowed` → `hasProjectAccess` (멤버 문서 `projectIds` 검사, 라이브 `PROJECT_ACCESS_BACKEND=firestore`) |
| BFF | **없음** → 이 PR 에서 추가 |

## 설계

- 판정은 순수 모듈 `cashflow-project-scope.mjs` 단일 소유, 조회는 라우트(서비스 계층)
- 규칙은 JVM 을 그대로 이식: 테넌트 전역 역할 6종 무조건 통과 / 그 외는 **활성** 멤버 문서의 배정 / uid·status·portalProfile 처리까지 동일
- 두 런타임이 갈리면 한쪽만 뚫리므로 **parity 표를 테스트로 고정** (Java 수정 시 이 표도 함께 고쳐야 함)
- JVM 도달 전에 차단 — 데이터가 프로세스 경계를 넘지 않음

## 데이터 (선행 백필 완료)

라이브 확인 결과 **전 프로젝트를 가진 활성 멤버 0명** — 게이트만 켜면 43명이 자기 프로젝트 밖을 못 본다. `#451 give every member access to every project` 의 의도대로 데이터를 채워 **현재 동작을 유지한 채 우회 통로만 닫았다.** 권한을 조이는 결정은 이 데이터를 좁히면 된다.

```
사본: ~/Documents/MYSCube-cleanup-backups/spec24-member-scope-20260809-1040/ (88건)
적용: 43건 (projectIds 만 갱신) · 제외: 테넌트전역 29 + 비활성 16
검증: 적용 후 차단 대상 0명
```

## 검증

route 194/194 (스코프 강제 3종 신규) · scope 모듈 23/23 · build OK · tsc 기준선 동일(203)
사보타주: 비활성 판정 제거 2건 / 스코프 무조건 허용 4건 / 라우트 게이트 제거 2건 — 각각 실패 확인 후 원복

🤖 Generated with [Claude Code](https://claude.com/claude-code)