### PR TITLE
fix(cashflow): 누적 월 결산 승인이 JVM 확정까지 가도록 복구

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -4219,13 +4219,21 @@ export function mountJvmWeeklyApiRoutes(app, {
         return;
       }
       await verifyCumulativeRequestShards(req.context.tenantId, initialRecord);
-      let approved;
+      // JVM 은 요청 헤더가 APPROVING 이고 reviewIdempotencyKey 가 이번 호출과 같을 때만 누적 확정을
+      // 받아준다 (requireCumulativeCloseApproval). 그래서 PENDING -> APPROVING -> JVM 확정 ->
+      // APPROVED 3 단계를 그대로 밟는다. 이 단계를 건너뛰면 JVM 월이 OPEN 으로 남고,
+      // cashflow_cumulative_close_heads.closedThrough 가 비어 시트 잠금과 변경 경고 누적이
+      // 통째로 동작하지 않는다.
+      const jvmMutationIdempotencyKey = readOptionalText(req.context.idempotencyKey);
+      if (!jvmMutationIdempotencyKey) {
+        throw createHttpError(400, '월 결산 승인에는 요청 키가 필요합니다.', 'cashflow_month_close_review_invalid');
+      }
+      let claimed;
       await db.runTransaction(async (transaction) => {
-        const [projectSnapshot, reviewerSnapshot, snapshot, settlementSnapshot] = await Promise.all([
+        const [projectSnapshot, reviewerSnapshot, snapshot] = await Promise.all([
           transaction.get(projectRef),
           transaction.get(reviewerRef),
           transaction.get(requestRef),
-          transaction.get(settlementStatusRef),
         ]);
         const currentProject = projectSnapshot.exists ? projectSnapshot.data() || {} : {};
         const reviewer = reviewerSnapshot.exists ? reviewerSnapshot.data() || {} : {};
@@ -4239,14 +4247,80 @@ export function mountJvmWeeklyApiRoutes(app, {
           || readOptionalText(reviewer.status).toUpperCase() !== 'ACTIVE') {
           throw createHttpError(409, '이미 검토가 시작되었거나 변경된 월 결산 요청입니다.', 'cashflow_month_close_request_already_reviewed');
         }
-        approved = {
+        claimed = {
           ...current,
-          status: 'APPROVED',
+          status: 'APPROVING',
           reviewedByUid: req.context.actorId,
           reviewedAt,
           decisionReason: reason || null,
-          reviewIdempotencyKey: req.context.idempotencyKey,
+          reviewIdempotencyKey: jvmMutationIdempotencyKey,
         };
+        transaction.set(requestRef, claimed);
+      });
+      // 셀은 JVM 이 저장된 샤드에서 직접 읽는다. 여기서는 어느 요청·회차를 확정하는지만 지목한다.
+      const prepared = {
+        projectId: encodeURIComponent(projectId),
+        rawProjectId: projectId,
+        routeDeadlineAtMs: Date.now() + monthCloseRouteTimeoutMs,
+        closeBody: {
+          idempotencyKey: jvmMutationIdempotencyKey,
+          yearMonth: readOptionalText(claimed.yearMonth),
+          expectedRevision: Number(claimed.expectedRevision),
+          expectedDraftRevision: 0,
+          humanReviewed: true,
+          requestId,
+          requestRevision: expectedRevision,
+          manifestHash: readOptionalText(claimed.manifestHash),
+        },
+      };
+      let monthClose;
+      if (['APPROVING', 'UNCERTAIN'].includes(initialRecord.status)) {
+        // 앞선 시도가 이미 APPROVING 을 잡아둔 상태다. JVM 이 그 시도를 받았는지 모르므로 먼저
+        // 확인한다. 확정돼 있는데 다시 POST 하면 닫힌 월이라 반드시 실패한다.
+        const evidence = await reconcileCashflowMonthClose(req, prepared);
+        if (evidence.proven) monthClose = evidence.monthClose;
+      }
+      if (!monthClose) {
+        try {
+          monthClose = await executePreparedCashflowMonthClose(req, prepared);
+        } catch (error) {
+          if (readOptionalText(error?.code) === 'cashflow_month_close_reconciliation_pending') {
+            await db.runTransaction(async (transaction) => {
+              const snapshot = await transaction.get(requestRef);
+              const current = snapshot.exists ? snapshot.data() || {} : null;
+              if (
+                !current
+                || current.status !== 'APPROVING'
+                || Number(current.revision) !== expectedRevision
+                || current.reviewIdempotencyKey !== jvmMutationIdempotencyKey
+              ) return;
+              transaction.set(requestRef, {
+                ...current,
+                status: 'UNCERTAIN',
+                reconciliationEvidence: error.reconciliationEvidence,
+              });
+            });
+          }
+          throw error;
+        }
+      }
+      let approved;
+      await db.runTransaction(async (transaction) => {
+        const [snapshot, settlementSnapshot] = await Promise.all([
+          transaction.get(requestRef),
+          transaction.get(settlementStatusRef),
+        ]);
+        const current = snapshot.exists ? snapshot.data() || {} : null;
+        if (
+          !current
+          || !['APPROVING', 'UNCERTAIN'].includes(current.status)
+          || Number(current.revision) !== expectedRevision
+          || current.reviewIdempotencyKey !== jvmMutationIdempotencyKey
+        ) {
+          throw createHttpError(409, '월 결산 승인 상태가 변경되었습니다.', 'cashflow_month_close_request_revision_stale');
+        }
+        approved = { ...current, status: 'APPROVED', monthCloseResult: monthClose };
+        delete approved.reconciliationEvidence;
         transaction.set(requestRef, approved);
         completeMonthSettlement(transaction, settlementSnapshot);
         transaction.set(
@@ -4262,12 +4336,13 @@ export function mountJvmWeeklyApiRoutes(app, {
             manifestHash: approved.manifestHash,
             actorUid: req.context.actorId,
             reason: reason || null,
-            idempotencyKey: req.context.idempotencyKey,
+            idempotencyKey: jvmMutationIdempotencyKey,
+            jvmMutationIdempotencyKey,
             createdAt: reviewedAt,
           },
         );
       });
-      res.status(200).json({ request: cashflowMonthCloseRequestView(approved) });
+      res.status(200).json({ request: cashflowMonthCloseRequestView(approved), monthClose });
       return;
     }
     if (['APPROVED', 'REJECTED'].includes(initialRecord.status)) {

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -4622,6 +4622,15 @@ describe('JVM weekly API BFF proxy', () => {
       }
       if (init.method === 'POST') {
         const closeBody = JSON.parse(init.body);
+        // JVM requireCumulativeCloseApproval 이 실제로 요구하는 것: 확정을 받는 순간 헤더가
+        // APPROVING 이고 reviewIdempotencyKey 가 이번 확정 요청과 같아야 한다.
+        const header = source.documents.get('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-08') || {};
+        expect({ status: header.status, reviewIdempotencyKey: header.reviewIdempotencyKey }).toEqual({
+          status: 'APPROVING',
+          reviewIdempotencyKey: closeBody.idempotencyKey,
+        });
+        expect(Number(header.revision)).toBe(closeBody.requestRevision);
+        expect(header.manifestHash).toBe(closeBody.manifestHash);
         closedMonthClose = {
           ok: true, projectId: 'project-a', requestId: 'project-a-2026-08', requestRevision: closeBody.requestRevision,
           manifestHash: closeBody.manifestHash, yearMonth: '2026-08', status: 'CLOSED',
@@ -4953,14 +4962,24 @@ describe('JVM weekly API BFF proxy', () => {
       status: 'COMPLETED', approvedBy: 'finance-1',
     });
     const closePostCount = () => fetchImpl.mock.calls.filter(([url, init]) => url.endsWith('/month-close') && init.method === 'POST').length;
-    expect(closePostCount()).toBe(0);
+    // 승인은 JVM 확정까지 가야 한다. 여기서 멈추면 cumulative close head 가 비어 시트가 잠기지 않는다.
+    expect(closePostCount()).toBe(1);
+    expect(JSON.parse(fetchImpl.mock.calls.findLast(([url, init]) => url.endsWith('/month-close') && init.method === 'POST')[1].body)).toMatchObject({
+      idempotencyKey: 'cumulative-v2-approve',
+      yearMonth: '2026-08',
+      requestId: 'project-a-2026-08',
+      requestRevision: 2,
+      manifestHash: resubmitted.body.manifestHash,
+    });
+    expect(approvedResponse.body.monthClose).toMatchObject({ status: 'CLOSED', revision: 1 });
+    expect(source.documents.get(requestPath).reviewIdempotencyKey).toBe('cumulative-v2-approve');
     await request(approver)
       .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
       .set('idempotency-key', 'cumulative-v2-approve')
       .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
       .expect(200)
       .expect((response) => expect(response.body).toEqual(approvedResponse.body));
-    expect(closePostCount()).toBe(0);
+    expect(closePostCount()).toBe(1);
     await request(approver)
       .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
       .set('idempotency-key', 'cumulative-v2-approve-duplicate')
@@ -4982,7 +5001,8 @@ describe('JVM weekly API BFF proxy', () => {
         .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
         .expect(200)
         .expect((response) => expect(response.body.request).toMatchObject({ status: 'APPROVED', revision: 2 }));
-      expect(closePostCount()).toBe(0);
+      // 이미 확정된 것이 조회로 증명되므로 JVM 을 다시 치지 않는다.
+      expect(closePostCount()).toBe(1);
     }
     closedMonthClose = null;
     dashboardSourceUnavailable = true;
@@ -4996,7 +5016,8 @@ describe('JVM weekly API BFF proxy', () => {
       .set('idempotency-key', 'resume-uncertain-repost')
       .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
       .expect(200);
-    expect(closePostCount()).toBe(0);
+    // 확정 여부를 조회로 증명하지 못하면 같은 회차를 다시 확정 요청한다.
+    expect(closePostCount()).toBe(2);
     dashboardSourceUnavailable = false;
     await request(approver)
       .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')


### PR DESCRIPTION
## 무엇이 깨져 있었나

누적 월 결산(v2) 승인이 Firestore 만 갱신하고 **JVM 확정을 호출하지 않았다.**

프론트는 항상 `contractVersion: 'cashflow-cumulative-close-v2'` 를 보내고(`CashflowProjectSheet.tsx:1259`), manifestHash 가 있으니 `/status-review` 로 간다(`platform-bff-client.ts:3252`). 그 누적 분기는 `PENDING → APPROVED` 로 건너뛰고 `return` 한다. JVM 을 부르는 `executePreparedCashflowMonthClose` 의 유일한 호출처는 레거시 `/review` 분기이고, 그 분기는 라이브에서 도달 불가다.

JVM `requireCumulativeCloseApproval`(`FirestoreInheritedWeeklyExpensePersistence.java:3112`)은 요청 헤더가 **`status == "APPROVING"`** 이고 **`reviewIdempotencyKey` 가 확정 요청과 같을 때만** 누적 확정을 받는다. `APPROVING` 이 한 번도 존재하지 않으니 확정이 성립할 수 없었다.

## 무엇이 죽어 있었나

JVM 월이 계속 `OPEN` 이고 `cashflow_cumulative_close_heads.closedThrough` 가 비어 있어서, 이미 구현돼 있는 아래가 전부 동작하지 않았다.

| 기능 | 구현 위치 | 상태 |
|---|---|---|
| 확정 월 시트 잠금 (`cashflow_month_closed` 409) | Persistence:2899 | 발동 안 함 |
| 변경 사유 강제 (`cashflow_closed_month_reason_required`) | Persistence:582 | 발동 안 함 |
| 변경 횟수 / 기한 후 경고 누적 | Persistence:608-609 | 카운트 안 됨 |
| 재오픈 요청·결정 | Persistence:1846, 1907 | 대상 없음 |
| 잠금 UI + 사유 입력 | `cashflow-sheet-lab.mjs:1757`, `CashflowSheetLabPage.tsx:940` | `closedThrough` 가 비어 아무것도 안 걸림 |

즉 **단일 결함 하나가 회계상 가장 중요한 안전장치 전체를 무력화**하고 있었다.

## 무엇을 고쳤나

승인 경로를 JVM 이 요구하는 3 단계로 되돌렸다.

```
PENDING ─(트랜잭션 A: 승인자·조직장·revision·manifest 검증)→ APPROVING
        ─(JVM POST /month-close: requestId/requestRevision/manifestHash)→ CLOSED + closedThrough
        ─(트랜잭션 B)→ APPROVED + 정산상태 COMPLETED + 감사 doc
```

- 셀은 JVM 이 저장된 샤드에서 직접 읽으므로 요청 본문은 어느 요청·회차를 확정하는지만 지목한다 (6 필드).
- 앞선 시도가 남긴 `APPROVING`/`UNCERTAIN` 은 다시 POST 하기 전에 조회로 확정 여부를 먼저 증명한다. 이미 닫힌 월에 POST 하면 `requireMutableMonthStatus` 로 반드시 실패하기 때문.
- JVM 호출 실패 시 `UNCERTAIN` + `reconciliationEvidence` 로 남기고 같은 키로 재시도하면 이어간다 (레거시 분기와 동일한 복구 모델).
- 응답에 `monthClose` 를 싣고 레코드에 `monthCloseResult` 를 저장한다. 멱등 재생 경로(`initialRecord.monthCloseResult`)가 이미 이 필드를 읽고 있었는데 아무도 쓰지 않던 상태였다.

## 테스트

기존 테스트는 **이 결함을 정상으로 박아두고 있었다** — `expect(closePostCount()).toBe(0)` 이 네 군데.

JVM 스텁이 확정을 받는 순간의 헤더 상태를 직접 검증하도록 바꿨다. 스텁 안에서 Firestore 문서를 읽어 `status === 'APPROVING'`, `reviewIdempotencyKey === closeBody.idempotencyKey`, `revision === requestRevision`, `manifestHash` 일치를 확인한다.

**Sabotage 검증**: 트랜잭션 A 의 `status: 'APPROVING'` 을 `'APPROVED'` 로 바꾸면 테스트가 죽는다 (1 failed). 되돌리면 194 통과.

- `server/bff` 전체: 1039 passed / 234 skipped
- `npm run typecheck`: no new type errors

## 배포 영향

프로덕션 JVM 에 수신 측 코드가 이미 배포돼 있다 (`88724db1` ⊂ `9abc44e0`, 2026-08-09 02:25 배포분). **BFF 만 올리면 핸드셰이크가 완성된다.**

기존에 "승인됐지만 JVM 미확정" 상태인 월들은 소급 잠기지 않는다 (head 가 없으므로). 배포 후 **다음 승인부터** 잠금이 걸리기 시작하고, 그 시점의 `closedThrough` 가 2023-01 부터 해당 월까지를 한 번에 덮는다.

배포 후 실제 프로젝트 1건으로 확정 → `cashflow_cumulative_close_heads` 생성 → 시트 수정 시 사유 요구까지 확인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)