### PR TITLE
feat(cashflow): 실무자 결재 요청 회수

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -229,6 +229,8 @@ function cashflowMonthCloseRequestView(record, partyNames = {}) {
       reviewedByName: record.reviewedByUid ? partyNames.reviewedByName || '구성원 이름 확인 불가' : null,
       reviewedAt: record.reviewedAt || null,
       decisionReason: record.decisionReason || null,
+      withdrawnAt: record.withdrawnAt || null,
+      withdrawReason: record.withdrawReason || null,
       reviewWarnings: Array.isArray(record.reviewWarnings) ? record.reviewWarnings : [],
       monthSnapshot: null,
       lockRange: {
@@ -3403,7 +3405,7 @@ export function mountJvmWeeklyApiRoutes(app, {
           revision = Number(existing.revision);
           ({ shards, manifest, totals, annualSummaries, payloadFingerprint } = replayEvidence);
           auditAction = revision === 1 ? 'REQUESTED' : 'RESUBMITTED';
-        } else if (!['REJECTED', 'REOPENED'].includes(existing.status)
+        } else if (!['REJECTED', 'REOPENED', 'WITHDRAWN'].includes(existing.status)
           && !(existing.status === 'APPROVED' && prepared.sourceCloseStatus === 'OPEN')) {
           throw createHttpError(409, '이미 이 월의 결산 요청이 존재합니다.', 'cashflow_month_close_request_conflict');
         } else {
@@ -4070,6 +4072,148 @@ export function mountJvmWeeklyApiRoutes(app, {
       );
     });
     res.status(202).json(cashflowMonthCloseRequestView(storedRecord));
+  }));
+
+  // 실무자가 올린 결산 요청을 조직장이 손대기 전에 스스로 되돌린다. 조직장이 검토를 시작한
+  // 뒤(APPROVING/UNCERTAIN)에는 JVM 확정이 이미 나갔을 수 있어 허용하지 않는다 - 여기서 회수를
+  // 받아주면 JVM 은 닫혔는데 BFF 는 회수된 상태가 되어 두 런타임이 갈린다.
+  app.post('/api/v1/cashflow/:projectId/month-close/requests/:requestId/withdraw', asyncHandler(async (req, res) => {
+    assertWeeklyWorkspaceOrRoleAllowed(req, ['admin', 'finance', 'pm', 'viewer'], 'withdraw cashflow month close request', authMode, workspaceEmailDomain);
+    assertAlignedCashflowMutation();
+    if (!db?.doc || !db?.runTransaction) {
+      throw createHttpError(503, '월 결산 요청 저장소에 연결하지 못했습니다.', 'cashflow_month_close_request_store_unavailable');
+    }
+    const projectId = readOptionalText(req.params.projectId);
+    const requestId = readOptionalText(req.params.requestId);
+    const expectedRevision = Number(req.body?.expectedRevision);
+    const expectedManifestHash = readOptionalText(req.body?.expectedManifestHash);
+    const reason = readOptionalText(req.body?.reason);
+    const withdrawIdempotencyKey = readOptionalText(req.context.idempotencyKey);
+    if (
+      !requestId
+      || !Number.isSafeInteger(expectedRevision)
+      || expectedRevision < 0
+      || reason.length > 1_000
+      || !withdrawIdempotencyKey
+    ) {
+      throw createHttpError(400, '월 결산 회수 입력값이 올바르지 않습니다.', 'cashflow_month_close_withdraw_invalid');
+    }
+    await readActiveCashflowMember({
+      db, tenantId: req.context.tenantId, actorId: req.context.actorId,
+    });
+    const requestRef = db.doc(cashflowMonthCloseRequestPath(req.context.tenantId, requestId));
+    const requesterRef = db.doc(`orgs/${req.context.tenantId}/members/${req.context.actorId}`);
+    const initialSnapshot = await requestRef.get();
+    if (!initialSnapshot.exists) {
+      throw createHttpError(404, '월 결산 요청을 찾을 수 없습니다.', 'cashflow_month_close_request_not_found');
+    }
+    const initialRecord = initialSnapshot.data() || {};
+    if (initialRecord.projectId !== projectId || initialRecord.requestId !== requestId) {
+      throw createHttpError(404, '월 결산 요청을 찾을 수 없습니다.', 'cashflow_month_close_request_not_found');
+    }
+    if (initialRecord.contractVersion !== CASHFLOW_CUMULATIVE_CLOSE_CONTRACT) {
+      throw createHttpError(409, '회수는 누적 월 결산 요청에만 사용할 수 있습니다.', 'cashflow_month_close_withdraw_unsupported');
+    }
+    if (readOptionalText(initialRecord.requestedByUid) !== readOptionalText(req.context.actorId)) {
+      throw createHttpError(403, '요청한 본인만 월 결산 요청을 회수할 수 있습니다.', 'cashflow_month_close_withdraw_forbidden');
+    }
+    if (initialRecord.manifestHash !== expectedManifestHash) {
+      throw createHttpError(409, '누적 월 결산 manifest가 변경되었습니다.', 'cashflow_month_close_request_manifest_invalid');
+    }
+    if (
+      initialRecord.status === 'WITHDRAWN'
+      && initialRecord.withdrawIdempotencyKey === withdrawIdempotencyKey
+      && Number(initialRecord.revision) === expectedRevision
+      && readOptionalText(initialRecord.withdrawReason) === reason
+    ) {
+      res.status(200).json({ request: cashflowMonthCloseRequestView(initialRecord) });
+      return;
+    }
+    if (initialRecord.status !== 'PENDING' || Number(initialRecord.revision) !== expectedRevision) {
+      throw createHttpError(
+        409,
+        '조직장 검토가 시작되었거나 변경된 월 결산 요청은 회수할 수 없습니다.',
+        'cashflow_month_close_request_already_reviewed',
+      );
+    }
+    const settlementStatusRef = db.doc(`orgs/${req.context.tenantId}/cashflow_settlement_statuses/${projectId}-${initialRecord.yearMonth}`);
+    const withdrawnAt = now().toISOString();
+    let withdrawn;
+    await db.runTransaction(async (transaction) => {
+      const [snapshot, requesterSnapshot, settlementSnapshot] = await Promise.all([
+        transaction.get(requestRef),
+        transaction.get(requesterRef),
+        transaction.get(settlementStatusRef),
+      ]);
+      const current = snapshot.exists ? snapshot.data() || {} : null;
+      const requester = requesterSnapshot.exists ? requesterSnapshot.data() || {} : {};
+      if (
+        !current
+        || current.status !== 'PENDING'
+        || Number(current.revision) !== expectedRevision
+        || current.manifestHash !== expectedManifestHash
+        || readOptionalText(current.requestedByUid) !== readOptionalText(req.context.actorId)
+        || readOptionalText(requester.uid) !== readOptionalText(req.context.actorId)
+        || readOptionalText(requester.status).toUpperCase() !== 'ACTIVE'
+      ) {
+        throw createHttpError(
+          409,
+          '조직장 검토가 시작되었거나 변경된 월 결산 요청은 회수할 수 없습니다.',
+          'cashflow_month_close_request_already_reviewed',
+        );
+      }
+      withdrawn = {
+        ...current,
+        status: 'WITHDRAWN',
+        withdrawnByUid: readOptionalText(req.context.actorId),
+        withdrawnAt,
+        withdrawReason: reason,
+        withdrawIdempotencyKey,
+      };
+      transaction.set(requestRef, withdrawn);
+      // 요청 때 PENDING_APPROVAL 로 잡아둔 정산 상태를 실무자 입력 대기로 되돌린다.
+      const settlementStatus = settlementSnapshot.exists ? settlementSnapshot.data() || {} : {};
+      const settlementPeriods = objectValue(settlementStatus.periods) || {};
+      const monthStatus = objectValue(settlementPeriods.MONTH) || {};
+      if (readOptionalText(monthStatus.status) === 'PENDING_APPROVAL') {
+        transaction.set(settlementStatusRef, {
+          tenantId: req.context.tenantId,
+          projectId,
+          yearMonth: current.yearMonth,
+          periods: {
+            ...settlementPeriods,
+            MONTH: {
+              ...monthStatus,
+              status: 'WAITING_FOR_UPDATE',
+              revision: Number.isSafeInteger(Number(monthStatus.revision)) ? Number(monthStatus.revision) + 1 : 1,
+              submittedAt: '',
+              submittedBy: '',
+              approvedAt: '',
+              approvedBy: '',
+            },
+          },
+          updatedAt: withdrawnAt,
+        }, { merge: true });
+      }
+      transaction.set(
+        db.doc(cashflowMonthCloseRequestAuditPath(
+          req.context.tenantId, requestId, expectedRevision, 'withdrawn',
+        )),
+        {
+          requestId,
+          projectId,
+          yearMonth: current.yearMonth,
+          action: 'WITHDRAWN',
+          revision: expectedRevision,
+          manifestHash: current.manifestHash,
+          actorUid: readOptionalText(req.context.actorId),
+          reason,
+          idempotencyKey: withdrawIdempotencyKey,
+          createdAt: withdrawnAt,
+        },
+      );
+    });
+    res.status(200).json({ request: cashflowMonthCloseRequestView(withdrawn) });
   }));
 
   app.post([

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -5027,6 +5027,127 @@ describe('JVM weekly API BFF proxy', () => {
 
   });
 
+  it('lets only the requester withdraw a PENDING cumulative close request, and never after review starts', async () => {
+    const source = fullMonthCloseSource();
+    source.closeInput.yearMonth = '2026-08';
+    const mirror = source.documents.get('orgs/tenant-a/cashflow_sheet_mirrors/project-a');
+    mirror.yearMonths = ['2026-08'];
+    mirror.cells.forEach((cell) => { cell.yearMonth = '2026-08'; });
+    mirror.sheetFacts.depositScheduleRows.forEach((row) => { row.yearMonth = '2026-08'; });
+    const months = [];
+    for (let year = 2023, month = 1; year < 2026 || month <= 8; month += 1) {
+      if (month === 13) { year += 1; month = 1; }
+      months.push({ yearMonth: `${year}-${String(month).padStart(2, '0')}`, projection: { weeks: [] }, actual: { weeks: [] } });
+    }
+    const cashflow = { projectId: 'project-a', projection: [], actual: [], readModel: { months } };
+    const fetchImpl = vi.fn(async (url) => {
+      if (url.includes('/dashboard-source')) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify(monthDashboardSource({
+            ok: true, projectId: 'project-a', yearMonth: '2026-08', status: 'OPEN', revision: 0,
+            reopenCount: 0, projectWarningCount: 0, snapshot: {},
+          }, cashflow)),
+        };
+      }
+      return { ok: true, status: 200, text: async () => JSON.stringify(cashflow) };
+    });
+    const appOptions = { env: runtimeEnv, db: source.db, now: () => new Date('2026-09-10T00:00:00.000Z') };
+    const requester = createApp(fetchImpl, createIdempotencyService(), { actorId: 'pm-1', actorRole: 'pm' }, appOptions).app;
+    const approver = createApp(fetchImpl, createIdempotencyService(), { actorId: 'finance-1', actorRole: 'finance' }, appOptions).app;
+
+    const dashboard = await request(requester).get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-08').expect(200);
+    const createPayload = {
+      contractVersion: 'cashflow-cumulative-close-v2',
+      yearMonth: '2026-08', expectedRevision: 0,
+      expectedApproverUid: 'finance-1', expectedProjectVersion: 0,
+      expectedOpeningBalances: dashboard.body.dashboard.openingBalances,
+      closeInput: { ...source.closeInput, managementChecks: dashboard.body.dashboard.managementChecks },
+    };
+    const created = await request(requester)
+      .post('/api/v1/cashflow/project-a/month-close/requests')
+      .set('idempotency-key', 'withdraw-create')
+      .send(createPayload)
+      .expect(202);
+    const settlementPath = 'orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-08';
+    expect(source.documents.get(settlementPath).periods.MONTH).toMatchObject({ status: 'PENDING_APPROVAL' });
+    const withdrawPayload = {
+      expectedRevision: created.body.revision,
+      expectedManifestHash: created.body.manifestHash,
+      reason: '기초잔액을 다시 확인하겠습니다.',
+    };
+
+    // 조직장은 회수할 수 없다. 반려는 사유가 남는 별도 행위다.
+    await request(approver)
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/withdraw')
+      .set('idempotency-key', 'withdraw-by-approver')
+      .send(withdrawPayload)
+      .expect(403)
+      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_withdraw_forbidden'));
+    // manifest 가 다르면 지금 화면이 보고 있는 요청이 아니다.
+    await request(requester)
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/withdraw')
+      .set('idempotency-key', 'withdraw-stale-manifest')
+      .send({ ...withdrawPayload, expectedManifestHash: 'sha256:' + '0'.repeat(64) })
+      .expect(409)
+      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_request_manifest_invalid'));
+
+    const withdrawn = await request(requester)
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/withdraw')
+      .set('idempotency-key', 'withdraw-once')
+      .send(withdrawPayload)
+      .expect(200)
+      .expect((response) => expect(response.body.request).toMatchObject({
+        status: 'WITHDRAWN', revision: created.body.revision, withdrawReason: '기초잔액을 다시 확인하겠습니다.',
+      }));
+    expect(source.documents.get(`orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r${created.body.revision}-withdrawn`)).toMatchObject({
+      action: 'WITHDRAWN', revision: created.body.revision, actorUid: 'pm-1', reason: '기초잔액을 다시 확인하겠습니다.',
+    });
+    // 정산 상태는 실무자 입력 대기로 되돌아간다.
+    expect(source.documents.get(settlementPath).periods.MONTH).toMatchObject({
+      status: 'WAITING_FOR_UPDATE', submittedBy: '', approvedBy: '',
+    });
+    // 회수된 요청은 조직장 대기함에서 사라진다.
+    await request(approver)
+      .get('/api/v1/cashflow/month-close/requests/pending')
+      .expect(200)
+      .expect((response) => expect(response.body.count).toBe(0));
+    // 같은 키 재전송은 같은 결과를 돌려준다.
+    await request(requester)
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/withdraw')
+      .set('idempotency-key', 'withdraw-once')
+      .send(withdrawPayload)
+      .expect(200)
+      .expect((response) => expect(response.body).toEqual(withdrawn.body));
+    // 다른 키로 다시 회수하면 이미 회수된 요청이라 거부한다.
+    await request(requester)
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/withdraw')
+      .set('idempotency-key', 'withdraw-twice')
+      .send(withdrawPayload)
+      .expect(409)
+      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_request_already_reviewed'));
+    // 회수 후에는 다시 요청할 수 있고 회차가 올라간다.
+    const resubmitted = await request(requester)
+      .post('/api/v1/cashflow/project-a/month-close/requests')
+      .set('idempotency-key', 'withdraw-resubmit')
+      .send(createPayload)
+      .expect(202);
+    expect(resubmitted.body).toMatchObject({ status: 'PENDING', revision: created.body.revision + 1 });
+
+    // 조직장이 검토를 시작한 뒤에는 회수 불가 - JVM 확정이 이미 나갔을 수 있다.
+    const requestPath = 'orgs/tenant-a/cashflow_month_close_requests/project-a-2026-08';
+    for (const status of ['APPROVING', 'UNCERTAIN', 'APPROVED']) {
+      source.documents.set(requestPath, { ...source.documents.get(requestPath), status });
+      await request(requester)
+        .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/withdraw')
+        .set('idempotency-key', `withdraw-after-${status.toLowerCase()}`)
+        .send({ ...withdrawPayload, expectedRevision: resubmitted.body.revision, expectedManifestHash: resubmitted.body.manifestHash })
+        .expect(409)
+        .expect((response) => expect(response.body.code).toBe('cashflow_month_close_request_already_reviewed'));
+    }
+  });
+
   it('blocks the legacy direct month-close mutation route', async () => {
     const source = fullMonthCloseSource();
     const fetchImpl = vi.fn(async () => ({

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -39,6 +39,7 @@ import { recordDevtoolsLog, toDevtoolsError } from '../../platform/devtools-tran
 import {
   fetchCashflowActivityViaBff,
   requestCashflowMonthCloseViaBff,
+  withdrawCashflowMonthCloseRequestViaBff,
   saveCashflowMonthCloseApproverViaBff,
   completeCashflowWeeklyUpdateViaBff,
   decideCashflowMonthReopenViaBff,
@@ -416,6 +417,8 @@ export function CashflowProjectSheet({
     () => createEmptyCashflowMonthCloseDepositRows(),
   );
   const [monthCloseReviewDirty, setMonthCloseReviewDirty] = useState(false);
+  const [monthCloseWithdrawOpen, setMonthCloseWithdrawOpen] = useState(false);
+  const [monthCloseWithdrawReason, setMonthCloseWithdrawReason] = useState('');
   const [reopenAction, setReopenAction] = useState<'request' | 'approve' | 'reject' | null>(null);
   const [reopenReason, setReopenReason] = useState('');
   const [sheetRefreshLoading, setSheetRefreshLoading] = useState(false);
@@ -470,6 +473,14 @@ export function CashflowProjectSheet({
   const selectedYearMonthRef = useRef(yearMonth);
   selectedYearMonthRef.current = yearMonth;
   const monthCloseRequestLocked = isCashflowMonthCloseRequestLocked(monthCloseRequest?.status);
+  // 조직장이 검토를 시작하면(APPROVING) JVM 확정이 이미 나갔을 수 있어 회수할 수 없다.
+  const canWithdrawMonthCloseRequest = Boolean(
+    monthCloseRequest
+    && monthCloseRequest.status === 'PENDING'
+    && monthCloseRequest.manifestHash
+    && user?.uid
+    && monthCloseRequest.requestedByUid === user.uid,
+  );
 
   const monthWeeks = useMemo(() => getMonthMondayWeeks(yearMonth), [yearMonth]);
   const selectedYear = useMemo(() => {
@@ -1315,6 +1326,65 @@ export function CashflowProjectSheet({
     projectId,
     project?.version,
     savedExecutiveApproverId,
+    resolveBffActor,
+    yearMonth,
+  ]);
+
+  const handleWithdrawMonthCloseRequest = useCallback(async (): Promise<void> => {
+    if (!monthCloseRequest || monthCloseRequest.status !== 'PENDING' || !monthCloseRequest.manifestHash) return;
+    const startedAt = Date.now();
+    setMonthCloseBusy(true);
+    try {
+      const actor = await resolveBffActor();
+      if (!actor?.idToken) throw new Error('로그인 세션이 만료되었습니다.');
+      const { request } = await withdrawCashflowMonthCloseRequestViaBff({
+        tenantId: orgId,
+        actor,
+        projectId,
+        requestId: monthCloseRequest.requestId,
+        payload: {
+          expectedRevision: monthCloseRequest.revision,
+          expectedManifestHash: monthCloseRequest.manifestHash,
+          reason: monthCloseWithdrawReason.trim(),
+        },
+        idempotencyKey: `cashflow-month-close-withdraw:${monthCloseRequest.requestId}:r${monthCloseRequest.revision}`,
+      });
+      monthCloseCurrentRequestGenerationRef.current += 1;
+      setMonthCloseRequest(request);
+      setMonthCloseWithdrawOpen(false);
+      setMonthCloseWithdrawReason('');
+      toast.success('월결산 결재 요청을 회수했습니다.');
+      await Promise.all([loadCashflowMonthClose(), loadMonthCloseRequest(), loadCashflowEvents()]);
+      logCashflowSettlement({
+        phase: 'success',
+        operation: 'cashflow.month_close.withdraw',
+        projectId,
+        yearMonth,
+        durationMs: Date.now() - startedAt,
+        summary: { status: request.status, revision: request.revision },
+      });
+    } catch (error) {
+      logCashflowSettlement({
+        phase: 'error',
+        operation: 'cashflow.month_close.withdraw',
+        projectId,
+        yearMonth,
+        durationMs: Date.now() - startedAt,
+        error,
+      });
+      toast.error(resolveApiErrorMessage(error, '월 결산 요청 회수에 실패했습니다. 최신 상태를 확인해 주세요.'));
+      await loadMonthCloseRequest();
+    } finally {
+      setMonthCloseBusy(false);
+    }
+  }, [
+    loadCashflowEvents,
+    loadCashflowMonthClose,
+    loadMonthCloseRequest,
+    monthCloseRequest,
+    monthCloseWithdrawReason,
+    orgId,
+    projectId,
     resolveBffActor,
     yearMonth,
   ]);
@@ -2797,6 +2867,8 @@ export function CashflowProjectSheet({
                         ? monthCloseRequest.status === 'UNCERTAIN' ? '서버 처리 결과를 다시 확인하고 있습니다.' : '지정 조직장의 검토를 기다리고 있습니다.'
                         : monthCloseRequest?.status === 'REJECTED'
                           ? `반려됨${monthCloseRequest.decisionReason ? ` · ${monthCloseRequest.decisionReason}` : ''}`
+                        : monthCloseRequest?.status === 'WITHDRAWN'
+                          ? `회수됨${monthCloseRequest.withdrawReason ? ` · ${monthCloseRequest.withdrawReason}` : ''} · 수정 후 다시 요청해 주세요.`
                         : monthCloseRequest?.status === 'REOPENED'
                           ? '재오픈됨 · 수정 후 월 결산을 다시 요청해 주세요.'
                       : monthClosePreparation.status === 'READY'
@@ -2814,7 +2886,19 @@ export function CashflowProjectSheet({
                         onClick={handleOpenMonthCloseReview}
                       >
                         <CheckCircle2 className="mr-1 h-3 w-3" />
-                        {monthCloseError || !monthCloseResult ? '월 결산 점검' : ['REJECTED', 'REOPENED'].includes(monthCloseRequest?.status || '') ? '월 결산 재요청' : '월 결산 요청'}
+                        {monthCloseError || !monthCloseResult ? '월 결산 점검' : ['REJECTED', 'REOPENED', 'WITHDRAWN'].includes(monthCloseRequest?.status || '') ? '월 결산 재요청' : '월 결산 요청'}
+                      </Button>
+                    ) : null}
+                    {canWithdrawMonthCloseRequest ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        className="h-8 rounded-md border-slate-300 bg-white px-3 text-[12px] text-slate-700"
+                        disabled={monthCloseBusy || monthCloseLoading}
+                        onClick={() => { setMonthCloseWithdrawReason(''); setMonthCloseWithdrawOpen(true); }}
+                      >
+                        결재 요청 회수
                       </Button>
                     ) : null}
                     {!monthCloseError && canRequestMonthReopen && monthCloseResult?.status === 'CLOSED' ? (
@@ -3298,6 +3382,48 @@ export function CashflowProjectSheet({
           void handleApplyStagedSheetValues(pending.stage, pending.closedMonthChangeReason, true);
         }}
       />
+
+      <AlertDialog
+        open={monthCloseWithdrawOpen}
+        onOpenChange={(open) => {
+          if (!open && !monthCloseBusy) {
+            setMonthCloseWithdrawOpen(false);
+            setMonthCloseWithdrawReason('');
+          }
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>월 결산 결재 요청 회수</AlertDialogTitle>
+            <AlertDialogDescription>
+              조직장 검토 전이라 회수할 수 있습니다. 회수하면 정산 상태가 입력 대기로 돌아가고, 수정 후 다시 요청해야 합니다.
+              회수 이력은 감사 기록에 남습니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <label className="grid gap-2 text-[12px] font-semibold text-slate-700">
+            사유 (선택)
+            <textarea
+              value={monthCloseWithdrawReason}
+              className="min-h-[96px] rounded-md border border-slate-200 p-3 text-[12px] font-normal outline-none focus:border-[#17324D]"
+              placeholder="회수하는 이유를 남겨 두면 이후 확인이 쉬워집니다."
+              disabled={monthCloseBusy}
+              onChange={(event) => setMonthCloseWithdrawReason(event.target.value)}
+            />
+          </label>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={monthCloseBusy}>닫기</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={monthCloseBusy}
+              onClick={(event) => {
+                event.preventDefault();
+                void handleWithdrawMonthCloseRequest();
+              }}
+            >
+              {monthCloseBusy ? '처리 중…' : '회수하기'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <AlertDialog
         open={reopenAction !== null}

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -1089,7 +1089,7 @@ export interface CloseCashflowMonthPayload {
   closeInput: CashflowMonthCloseDraftInput;
 }
 
-export type CashflowMonthCloseRequestStatus = 'BUILDING' | 'PENDING' | 'APPROVING' | 'UNCERTAIN' | 'APPROVED' | 'REJECTED' | 'REOPENED';
+export type CashflowMonthCloseRequestStatus = 'BUILDING' | 'PENDING' | 'APPROVING' | 'UNCERTAIN' | 'APPROVED' | 'REJECTED' | 'REOPENED' | 'WITHDRAWN';
 
 export interface CashflowMonthCloseStoredSource {
   sourceRevision: string | null;
@@ -1201,6 +1201,8 @@ export interface CashflowMonthCloseRequest {
   reviewedByName?: string | null;
   reviewedAt: string | null;
   decisionReason: string | null;
+  withdrawnAt?: string | null;
+  withdrawReason?: string | null;
   reviewWarnings: Array<{ code: string; message: string; details?: unknown }>;
   monthSnapshot: CashflowMonthCloseMonthSnapshot | null;
 }
@@ -3261,6 +3263,32 @@ export async function reviewCashflowMonthCloseRequestViaBff(params: {
   );
   if (params.payload.decision === 'APPROVE' && response.data.request.status !== 'APPROVED') {
     throw new Error('월 결산 승인 상태를 확인하지 못했습니다.');
+  }
+  return response.data;
+}
+
+export async function withdrawCashflowMonthCloseRequestViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectId: string;
+  requestId: string;
+  payload: { expectedRevision: number; expectedManifestHash: string; reason?: string };
+  idempotencyKey: string;
+  client?: PlatformApiClientLike;
+}): Promise<{ request: CashflowMonthCloseRequest }> {
+  const response = await resolveClient(params.client).post<{ request: CashflowMonthCloseRequest }>(
+    `/api/v1/cashflow/${encodeURIComponent(params.projectId)}/month-close/requests/${encodeURIComponent(params.requestId)}/withdraw`,
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      body: params.payload,
+      idempotencyKey: params.idempotencyKey,
+      retries: 0,
+      timeoutMs: 12000,
+    },
+  );
+  if (response.data.request.status !== 'WITHDRAWN') {
+    throw new Error('월 결산 요청 회수 결과를 확인하지 못했습니다.');
   }
   return response.data;
 }


### PR DESCRIPTION
#496 에 이어지는 ②. 결재 라인에 **회수**가 없었다.

실무자가 잘못 올린 결산 요청을 되돌리려면 조직장에게 반려를 부탁하는 수밖에 없었다. 반려는 조직장 이름으로 사유가 남는 별도 행위라 "내가 잘못 올렸다" 를 표현할 수단이 아니다. 코드베이스 어디에도 withdraw/cancel 상태도 라우트도 버튼도 없었다.

## API

```
POST /api/v1/cashflow/:projectId/month-close/requests/:requestId/withdraw
body: { expectedRevision, expectedManifestHash, reason? }
```

| 규칙 | 거부 코드 |
|---|---|
| 요청자 본인만 (조직장 불가) | 403 `cashflow_month_close_withdraw_forbidden` |
| `PENDING` 일 때만 | 409 `cashflow_month_close_request_already_reviewed` |
| revision 일치 | 409 `..._already_reviewed` |
| manifestHash 일치 | 409 `cashflow_month_close_request_manifest_invalid` |
| 누적 계약 요청만 | 409 `cashflow_month_close_withdraw_unsupported` |

**`APPROVING`/`UNCERTAIN` 에서 회수를 막는 이유**: 그 시점엔 JVM 확정이 이미 나갔을 수 있다. 회수를 받아주면 JVM 월은 닫혔는데 BFF 요청은 회수된 상태가 되어 두 런타임이 조용히 갈린다. `APPROVED` 는 더 말할 것도 없다.

## 부수 효과

- 요청 때 `PENDING_APPROVAL` 로 잡아둔 `cashflow_settlement_statuses.MONTH` 를 `WAITING_FOR_UPDATE` 로 되돌리고 `submittedBy`/`approvedBy` 를 비운다.
- 감사 doc `...-r{revision}-withdrawn` (action=`WITHDRAWN`). 사유는 선택이지만 남기면 기록된다.
- 같은 `idempotency-key` 재전송 → 같은 응답. 다른 키 → 409.
- 회수된 요청은 대기함 status 필터(`PENDING`/`APPROVING`/`UNCERTAIN`)에서 자동으로 빠진다.
- 회수 후 재요청은 `REJECTED`/`REOPENED` 와 같은 경로로 revision+1. (`persistCumulativeMonthCloseRequest` 허용 목록에 `WITHDRAWN` 추가)
- `isCashflowMonthCloseRequestLocked` 가 `WITHDRAWN` 을 잠금으로 보지 않으므로 시트가 바로 풀린다.

## 화면

요청자 본인에게 `PENDING` 동안만 **"결재 요청 회수"** 버튼. 확인 다이얼로그에서 사유(선택)를 받는다. 회수 후 상태 문구는 `회수됨 · {사유} · 수정 후 다시 요청해 주세요.` 로 바뀌고 버튼은 **"월 결산 재요청"** 으로 돌아간다.

## 검증

새 테스트 `lets only the requester withdraw a PENDING cumulative close request, and never after review starts` 가 위 표의 모든 행 + 정산 상태 복귀 + 대기함 제거 + 멱등 재전송 + 재요청 revision+1 + `APPROVING`/`UNCERTAIN`/`APPROVED` 각각의 거부를 확인한다.

**Sabotage 검증**
- 재요청 허용 목록에서 `WITHDRAWN` 제거 → 재요청이 202 대신 409 로 죽음
- 요청자 본인 게이트 제거 → 조직장 회수가 403 대신 409 (트랜잭션 가드가 잡음. 즉 403 은 메시지 품질용이고 실제 fail-closed 는 트랜잭션에 있다)

- `server/bff`: 1040 passed / 234 skipped
- `npm run typecheck`: no new type errors

`benchmark: fixed-template index vs sequential find-chains` 가 간헐적으로 실패하는데, **클린 main 에서도 6 회 중 1 회 재현**된다. `performance.now()` 벽시계 비교라 부하에 민감한 기존 테스트이고 이 변경과 무관하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)