### PR TITLE
ci: main CI 초록이면 프로덕션 자동 배포

### DIFF
--- a/.github/workflows/jvm-production-deploy.yml
+++ b/.github/workflows/jvm-production-deploy.yml
@@ -1,7 +1,20 @@
 name: JVM Production Deploy
 
 on:
+  # main 의 CI 가 초록이고 JVM 소스가 실제로 바뀐 커밋일 때만 자동 배포한다.
+  # 매 커밋마다 Cloud Run 리비전을 새로 올리면 바뀐 것 없는 배포가 쌓이고,
+  # --min-instances 1 롤아웃 위험만 반복된다.
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
+    inputs:
+      force:
+        description: Deploy even when JVM sources did not change
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: inner-platform-jvm-production
@@ -12,9 +25,82 @@ permissions:
   contents: read
   id-token: write
 
+env:
+  JVM_SOURCE_PATHS: server/jvm-weekly-api .github/workflows/jvm-production-deploy.yml
+
 jobs:
+  preflight:
+    name: Resolve JVM deploy target
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || (github.event.workflow_run.conclusion == 'success'
+          && github.event.workflow_run.event == 'push')
+    outputs:
+      proceed: ${{ steps.resolve.outputs.proceed }}
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve deploy target
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_REF: ${{ github.ref }}
+          DISPATCH_SHA: ${{ github.sha }}
+          FORCE: ${{ inputs.force }}
+          CI_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            if [ "${DISPATCH_REF}" != "refs/heads/main" ]; then
+              echo "JVM production deploys must be dispatched from refs/heads/main. Current ref: ${DISPATCH_REF}" >&2
+              exit 1
+            fi
+            sha="${DISPATCH_SHA}"
+          else
+            sha="${CI_SHA}"
+          fi
+          head="$(git rev-parse origin/main)"
+          if [ "${sha}" != "${head}" ]; then
+            if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+              echo "main advanced to ${head} after dispatch; dispatch the current main commit instead." >&2
+              exit 1
+            fi
+            echo "main advanced to ${head}; skipping superseded ${sha}."
+            echo "proceed=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          if [ "${FORCE}" = "true" ]; then
+            echo "Forced deploy of ${sha}."
+            printf 'proceed=true\nsha=%s\n' "${sha}" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          # 마지막으로 성공한 JVM 배포 이후 JVM 소스가 바뀌었는지만 본다.
+          # 성공 이력이 없으면(첫 배포) 배포한다.
+          last="$(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/jvm-production-deploy.yml/runs" \
+            -f status=success -f branch=main -f per_page=1 --jq '.workflow_runs[0].head_sha // ""')"
+          if [ -z "${last}" ] || ! git cat-file -e "${last}^{commit}" 2>/dev/null; then
+            echo "No usable previous successful JVM deploy; deploying ${sha}."
+          elif git diff --quiet "${last}" "${sha}" -- ${JVM_SOURCE_PATHS}; then
+            echo "No JVM source change between ${last} and ${sha}; skipping."
+            echo "proceed=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          else
+            echo "JVM sources changed since ${last}:"
+            git diff --name-only "${last}" "${sha}" -- ${JVM_SOURCE_PATHS}
+          fi
+          printf 'proceed=true\nsha=%s\n' "${sha}" >> "${GITHUB_OUTPUT}"
+
   deploy:
     name: Deploy JVM candidate and promote
+    needs: preflight
+    if: needs.preflight.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: Production
@@ -26,16 +112,14 @@ jobs:
       IMAGE: asia-northeast3-docker.pkg.dev/inner-platform-live-20260316/jvm-images/innerplatform-jvm-weekly-api-live
       JVM_WEEKLY_API_ID_TOKEN_AUDIENCE: ${{ vars.JVM_WEEKLY_API_ID_TOKEN_AUDIENCE_LIVE }}
       JVM_WEEKLY_INTERNAL_API_TOKEN: ${{ secrets.JVM_WEEKLY_INTERNAL_API_TOKEN_LIVE }}
+      DEPLOY_SHA: ${{ needs.preflight.outputs.sha }}
       CASHFLOW_PROJECT_ID: p1773817948751
       CASHFLOW_YEAR_MONTH: 2026-07
 
     steps:
-      - name: Require main
-        run: test "${GITHUB_REF}" = refs/heads/main
-
       - uses: actions/checkout@v5
         with:
-          ref: main
+          ref: ${{ needs.preflight.outputs.sha }}
           fetch-depth: 1
 
       - uses: actions/setup-java@v5
@@ -43,16 +127,19 @@ jobs:
           distribution: temurin
           java-version: '21'
 
-      - name: Verify dispatched main commit
-        run: test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+      - name: Verify checked out deploy target
+        env:
+          DEPLOY_SHA: ${{ needs.preflight.outputs.sha }}
+        run: test "$(git rev-parse HEAD)" = "${DEPLOY_SHA}"
 
       - name: Verify CI succeeded for this commit
         env:
           GH_TOKEN: ${{ github.token }}
+          DEPLOY_SHA: ${{ needs.preflight.outputs.sha }}
         run: |
           runs="$(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
-            -f head_sha="${GITHUB_SHA}" -f branch=main -f event=push -f per_page=20)"
-          jq -e --arg sha "${GITHUB_SHA}" '
+            -f head_sha="${DEPLOY_SHA}" -f branch=main -f event=push -f per_page=20)"
+          jq -e --arg sha "${DEPLOY_SHA}" '
             [.workflow_runs[] | select(.head_sha == $sha and .status == "completed" and .conclusion == "success")]
             | length > 0
           ' <<< "${runs}" >/dev/null
@@ -82,10 +169,10 @@ jobs:
           gcloud auth configure-docker asia-northeast3-docker.pkg.dev --quiet
           docker build \
             -f server/jvm-weekly-api/Dockerfile \
-            -t "${IMAGE}:${GITHUB_SHA}" \
+            -t "${IMAGE}:${DEPLOY_SHA}" \
             .
-          docker push "${IMAGE}:${GITHUB_SHA}"
-          digest="$(gcloud artifacts docker images describe "${IMAGE}:${GITHUB_SHA}" --format='value(image_summary.digest)')"
+          docker push "${IMAGE}:${DEPLOY_SHA}"
+          digest="$(gcloud artifacts docker images describe "${IMAGE}:${DEPLOY_SHA}" --format='value(image_summary.digest)')"
           test -n "${digest}"
           echo "uri=${IMAGE}@${digest}" >> "${GITHUB_OUTPUT}"
 
@@ -94,7 +181,7 @@ jobs:
         env:
           IMAGE_URI: ${{ steps.image.outputs.uri }}
         run: |
-          revision_suffix="hotfix-${GITHUB_SHA::8}"
+          revision_suffix="hotfix-${DEPLOY_SHA::8}"
           gcloud run deploy "${SERVICE}" \
             --project "${PROJECT_ID}" \
             --region "${REGION}" \

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -1,6 +1,14 @@
 name: Production Deploy
 
 on:
+  # main 의 CI 가 초록이면 자동으로 배포한다. 수동 dispatch 는 CI 가 끝나기 전에 눌리면
+  # "Verify CI succeeded" 가드에 걸려 실패하는데, 사람이 그 실패를 보고 다시 누를 때까지
+  # 배포된 줄 알았던 커밋이 라이브에 없는 시간이 생긴다. 초록을 기다렸다가 트리거하는
+  # 일은 사람이 아니라 GitHub 가 해야 한다.
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
       note:
@@ -23,8 +31,69 @@ permissions:
   deployments: write
 
 jobs:
+  preflight:
+    name: Resolve production deploy target
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # CI 가 실패했거나 PR 이벤트로 돈 CI 는 배포 대상이 아니다.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || (github.event.workflow_run.conclusion == 'success'
+          && github.event.workflow_run.event == 'push')
+    outputs:
+      proceed: ${{ steps.resolve.outputs.proceed }}
+      sha: ${{ steps.resolve.outputs.sha }}
+      promote: ${{ steps.resolve.outputs.promote }}
+      note: ${{ steps.resolve.outputs.note }}
+    steps:
+      - name: Resolve deploy target
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_REF: ${{ github.ref }}
+          DISPATCH_SHA: ${{ github.sha }}
+          DISPATCH_NOTE: ${{ inputs.note }}
+          DISPATCH_PROMOTE: ${{ inputs.promote_alias }}
+          CI_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            if [ "${DISPATCH_REF}" != "refs/heads/main" ]; then
+              echo "Production deploys must be dispatched from refs/heads/main. Current ref: ${DISPATCH_REF}" >&2
+              exit 1
+            fi
+            sha="${DISPATCH_SHA}"
+            promote="${DISPATCH_PROMOTE}"
+            note="${DISPATCH_NOTE}"
+          else
+            sha="${CI_SHA}"
+            promote=true
+            note="CI green on main"
+          fi
+          head="$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq .sha)"
+          if [ "${sha}" != "${head}" ]; then
+            if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+              echo "main advanced to ${head} after dispatch; dispatch the current main commit instead." >&2
+              exit 1
+            fi
+            # 자동 트리거는 뒤처진 커밋을 조용히 건너뛴다. 최신 커밋의 CI 가 자기 배포를 띄운다.
+            echo "main advanced to ${head}; skipping superseded ${sha}."
+            echo "proceed=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          echo "Deploy target ${sha} (promote_alias=${promote})"
+          {
+            echo "proceed=true"
+            echo "sha=${sha}"
+            echo "promote=${promote}"
+            echo "note=${note}"
+          } >> "${GITHUB_OUTPUT}"
+
   deploy:
     name: Deploy production from main
+    needs: preflight
+    if: needs.preflight.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment:
@@ -55,42 +124,39 @@ jobs:
       VERCEL_TOKEN: ${{ secrets.VERCEL_DEPLOY_TOKEN_PRODUCTION }}
 
     steps:
-      - name: Check production ref
-        run: |
-          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
-            echo "Production deploys must be dispatched from refs/heads/main. Current ref: ${GITHUB_REF}" >&2
-            exit 1
-          fi
-
       - uses: actions/checkout@v5
         with:
-          ref: main
+          ref: ${{ needs.preflight.outputs.sha }}
           fetch-depth: 1
 
-      - name: Verify dispatched main commit
+      - name: Verify checked out deploy target
+        env:
+          DEPLOY_SHA: ${{ needs.preflight.outputs.sha }}
         run: |
           set -euo pipefail
-          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}" || {
-            echo "main advanced after dispatch; dispatch the current main commit instead." >&2
+          test "$(git rev-parse HEAD)" = "${DEPLOY_SHA}" || {
+            echo "Checked out $(git rev-parse HEAD) but the resolved target is ${DEPLOY_SHA}." >&2
             exit 1
           }
 
+      # 자동 트리거에서는 사실상 자명하지만, 수동 dispatch 와 같은 가드를 통과해야 배포한다.
       - name: Verify CI succeeded for this commit
         env:
           GH_TOKEN: ${{ github.token }}
+          DEPLOY_SHA: ${{ needs.preflight.outputs.sha }}
         run: |
           set -euo pipefail
           runs="$(gh api -X GET "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
-            -f head_sha="${GITHUB_SHA}" \
+            -f head_sha="${DEPLOY_SHA}" \
             -f branch=main \
             -f event=push \
             -f per_page=20)"
-          jq -e --arg sha "${GITHUB_SHA}" '
+          jq -e --arg sha "${DEPLOY_SHA}" '
             [.workflow_runs[]
               | select(.head_sha == $sha and .status == "completed" and .conclusion == "success")]
             | length > 0
           ' <<< "${runs}" >/dev/null || {
-            echo "CI must be green for ${GITHUB_SHA} before production deploy." >&2
+            echo "CI must be green for ${DEPLOY_SHA} before production deploy." >&2
             exit 1
           }
 
@@ -219,7 +285,7 @@ jobs:
           NODE
 
       - name: Promote canonical production alias
-        if: inputs.promote_alias
+        if: needs.preflight.outputs.promote == 'true'
         env:
           DEPLOYMENT_HOST: ${{ steps.vercel_deploy.outputs.deployment_host }}
         run: |
@@ -231,14 +297,14 @@ jobs:
             --scope merryai-devs-projects
 
       - name: Verify canonical production alias
-        if: inputs.promote_alias
+        if: needs.preflight.outputs.promote == 'true'
         env:
           DEPLOYMENT_URL: ${{ steps.vercel_deploy.outputs.deployment_url }}
         run: node deploy-prod-align.mjs --verify-only "${DEPLOYMENT_URL}"
 
       - name: Release summary
         env:
-          DEPLOY_NOTE: ${{ inputs.note }}
+          DEPLOY_NOTE: ${{ needs.preflight.outputs.note }}
           DEPLOYMENT_URL: ${{ steps.vercel_deploy.outputs.deployment_url }}
         run: |
           {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ npm run build
 - Deploy Firestore rules/indexes: `npm run firebase:deploy:firestore`.
 - One-shot Firebase setup (writes `.env`, `.firebaserc`, deploys): `npm run firebase:autosetup`.
 - Vercel preview deploy: `vercel deploy`.
-- Production deploy: use the GitHub Actions `Production Deploy` workflow on `main` only.
+- Production deploy: `main` 의 CI 가 초록이면 `Production Deploy` / `JVM Production Deploy` 가 자동으로 돈다. 수동 dispatch 는 예외 경로다 (아래 배포 정책 참고).
 - Local production deploy is forbidden. `vercel --prod` and `node deploy-prod-align.mjs` must not be used from a local worktree.
 - Local production verification only: `npm run deploy:prod:verify -- <deployment-url-or-host>`.
 
@@ -65,6 +65,29 @@ These policies override lower-priority workflow suggestions when they apply.
 - `EMPTY` 와 `ZERO` 는 절대 뭉개지 않는다. 셀 상태는 저장된 값이며 금액에서 역산하지 않는다.
 
 새 코드가 위 항목을 어기면 리뷰에서 반려한다. 기존 위반은 좌표 계약으로 대체하며, 대체 시 사보타주 검증(계약을 깨면 테스트가 실패하는지)을 함께 붙인다.
+
+### 프로덕션 배포는 CI 초록에 걸어 자동으로 나간다
+
+`Production Deploy` 와 `JVM Production Deploy` 는 `main` 의 `CI` 가 성공하면
+`workflow_run` 으로 스스로 트리거된다. **손으로 dispatch 하지 않는다.**
+
+수동 dispatch 는 사람이 "CI 가 끝났겠지" 를 추측하게 만든다. 실제로 머지 25 초 뒤에 배포를
+눌렀다가 `Verify CI succeeded` 가드에 걸려 실패했고, 그 실패를 알아채기 전까지 머지된 커밋이
+라이브에 없는 상태가 이어졌다. 초록을 기다리는 일은 사람이 아니라 GitHub 가 한다.
+
+- 배포 대상은 `github.event.workflow_run.head_sha` 이고, 그 SHA 가 아직 `main` 의 head 일 때만 나간다.
+  뒤처졌으면 조용히 건너뛴다 - 최신 커밋의 CI 가 자기 배포를 띄운다.
+- CI 가 실패했거나 PR 이벤트로 돈 CI 는 배포하지 않는다 (`conclusion == 'success' && event == 'push'`).
+- **JVM 은 `server/jvm-weekly-api/**` 가 실제로 바뀐 커밋일 때만 나간다.** 마지막으로 성공한 JVM
+  배포의 SHA 와 diff 를 떠서 판단한다. 바뀐 것 없이 Cloud Run 리비전을 올리면 `--min-instances 1`
+  롤아웃 위험만 반복된다.
+- `workflow_dispatch` 는 남겨두되 예외 경로다. 되돌리기·재시도·`force` (JVM 소스 변경 없이 강제
+  배포) 처럼 이유가 있을 때만 쓴다.
+- 가드는 자동 경로에서도 그대로 통과해야 한다. `Verify CI succeeded`, `Verify checked out deploy
+  target`, Vercel 작성자 정책을 자동 트리거라고 건너뛰지 않는다.
+
+배포되지 않은 채로 머지가 쌓이는 상황을 만들지 않는다. 머지했으면 배포 워크플로가 도는지 확인하고,
+안 돌았으면 트리거 조건부터 본다.
 
 ### 오케스트레이션 워커 수명주기 (Orca dispatch)
 

--- a/server/jvm-weekly-api/live-deploy-workflow.test.ts
+++ b/server/jvm-weekly-api/live-deploy-workflow.test.ts
@@ -25,10 +25,34 @@ describe('JVM production deploy workflow', () => {
     expect(workflow).toContain('.monthClose.yearMonth == env.CASHFLOW_YEAR_MONTH');
     expect(workflow).toContain('gcloud auth configure-docker asia-northeast3-docker.pkg.dev');
     expect(workflow).toContain('-f server/jvm-weekly-api/Dockerfile');
-    expect(workflow).toContain('docker push "${IMAGE}:${GITHUB_SHA}"');
+    // preflight 가 확정한 SHA 로 태그한다. workflow_run 의 github.sha 는 트리거 시점
+    // 기본 브랜치 head 라 배포 대상과 어긋날 수 있다.
+    expect(workflow).toContain('docker push "${IMAGE}:${DEPLOY_SHA}"');
+    expect(workflow).toContain('DEPLOY_SHA: ${{ needs.preflight.outputs.sha }}');
+    expect(workflow).not.toContain('${GITHUB_SHA}');
     expect(workflow).not.toContain('gcloud builds submit');
     expect(workflow.indexOf('Verify canonical service after promotion')).toBeGreaterThan(workflow.indexOf('update-traffic'));
     expect(workflow).toContain("if: failure() && steps.promote.outcome == 'success'");
     expect(workflow).toContain('--to-revisions "${PREVIOUS_REVISION}=100"');
+  });
+
+  it('auto-deploys only a green main commit whose JVM sources actually changed', () => {
+    // 자동 트리거: main 의 CI 가 초록일 때만, 그리고 push 로 돈 CI 만.
+    expect(workflow).toMatch(/workflow_run:\n\s+workflows: \[CI\]/);
+    expect(workflow).toContain('branches: [main]');
+    expect(workflow).toContain("github.event.workflow_run.conclusion == 'success'");
+    expect(workflow).toContain("github.event.workflow_run.event == 'push'");
+    // 배포 대상은 CI 가 검증한 SHA 이고, 그것이 아직 main head 일 때만 나간다.
+    expect(workflow).toContain('CI_SHA: ${{ github.event.workflow_run.head_sha }}');
+    expect(workflow).toContain('head="$(git rev-parse origin/main)"');
+    expect(workflow).toContain('skipping superseded');
+    expect(workflow).toContain("if: needs.preflight.outputs.proceed == 'true'");
+    // JVM 소스가 바뀐 커밋일 때만. 무변경 재배포는 Cloud Run 롤아웃 위험만 반복한다.
+    expect(workflow).toContain('JVM_SOURCE_PATHS: server/jvm-weekly-api');
+    expect(workflow).toContain('git diff --quiet "${last}" "${sha}" -- ${JVM_SOURCE_PATHS}');
+    expect(workflow).toContain('No JVM source change between');
+    // 강제 배포는 dispatch 입력으로만. shell 안에서 직접 보간하지 않는다.
+    expect(workflow).toContain('FORCE: ${{ inputs.force }}');
+    expect(workflow).not.toContain('${{ inputs.force }} ');
   });
 });

--- a/server/production-deploy-workflow.test.ts
+++ b/server/production-deploy-workflow.test.ts
@@ -30,16 +30,36 @@ function extractRunBlocks(text: string) {
 describe('production deployment workflow safety', () => {
   it('deploys only through the Production environment from the full main ref', () => {
     expect(workflowText).toMatch(/environment:\n\s+name: Production/);
-    expect(workflowText).toContain('if [ "${GITHUB_REF}" != "refs/heads/main" ]; then');
-    expect(workflowText).toContain('ref: main');
-    expect(workflowText).toContain('test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"');
+    // 수동 dispatch 는 main 에서만.
+    expect(workflowText).toContain('if [ "${DISPATCH_REF}" != "refs/heads/main" ]; then');
+    // 자동/수동 모두 preflight 가 확정한 SHA 를 체크아웃하고, 그것과 일치하는지 다시 확인한다.
+    expect(workflowText).toContain('ref: ${{ needs.preflight.outputs.sha }}');
+    expect(workflowText).toContain('test "$(git rev-parse HEAD)" = "${DEPLOY_SHA}"');
+    // 배포 대상은 반드시 main 의 현재 head 여야 한다.
+    expect(workflowText).toContain('head="$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq .sha)"');
+  });
+
+  it('auto-deploys only a green main commit and skips superseded ones', () => {
+    expect(workflowText).toMatch(/workflow_run:\n\s+workflows: \[CI\]/);
+    expect(workflowText).toContain('branches: [main]');
+    // CI 가 실패했거나 PR 이벤트로 돈 CI 는 배포 대상이 아니다.
+    expect(workflowText).toContain("github.event.workflow_run.conclusion == 'success'");
+    expect(workflowText).toContain("github.event.workflow_run.event == 'push'");
+    expect(workflowText).toContain('CI_SHA: ${{ github.event.workflow_run.head_sha }}');
+    // 뒤처진 커밋은 조용히 건너뛴다. 최신 커밋의 CI 가 자기 배포를 띄운다.
+    expect(workflowText).toContain('skipping superseded');
+    expect(workflowText).toContain("if: needs.preflight.outputs.proceed == 'true'");
+    // 자동 경로라고 CI 초록 가드를 건너뛰지 않는다.
+    expect(workflowText).toContain('CI must be green for ${DEPLOY_SHA} before production deploy.');
   });
 
   it('does not interpolate manual workflow inputs directly inside shell run blocks', () => {
     const runBlocks = extractRunBlocks(workflowText);
 
     expect(runBlocks.some((block) => block.includes('${{ inputs.'))).toBe(false);
-    expect(workflowText).toContain('DEPLOY_NOTE: ${{ inputs.note }}');
+    expect(runBlocks.some((block) => block.includes('${{ needs.'))).toBe(false);
+    expect(workflowText).toContain('DISPATCH_NOTE: ${{ inputs.note }}');
+    expect(workflowText).toContain('DEPLOY_NOTE: ${{ needs.preflight.outputs.note }}');
     expect(workflowText).toContain('printf \'%s\\n\' "- Note: ${DEPLOY_NOTE}"');
   });
 
@@ -55,7 +75,7 @@ describe('production deployment workflow safety', () => {
   it('promotes the canonical production alias before verifying it', () => {
     expect(workflowText).toContain('promote_alias:');
     expect(workflowText).toContain('default: true');
-    expect(workflowText.match(/if: inputs\.promote_alias/g)).toHaveLength(2);
+    expect(workflowText.match(/if: needs\.preflight\.outputs\.promote == 'true'/g)).toHaveLength(2);
     expect(workflowText).toContain('deployment_host="${deployment_url#https://}"');
     expect(workflowText).toContain('echo "deployment_host=${deployment_host}" >> "${GITHUB_OUTPUT}"');
     expect(workflowText).toContain('Promote canonical production alias');


### PR DESCRIPTION
## 왜

수동 dispatch 는 사람이 "CI 가 끝났겠지" 를 추측하게 만든다.

방금 실제로 겪었다. #497 을 머지하고 25 초 뒤에 배포를 눌렀더니 `Verify CI succeeded` 가드가 잡아서 실패했다.

```
CI must be green for 5969f98f2e23e81fa8a65465be79dbe5834a4d15 before production deploy.
```

가드는 정확히 제 일을 했다. 문제는 **그 실패를 사람이 알아채고 다시 누를 때까지, 머지된 커밋이 라이브에 없는 상태가 이어진다**는 것이다. 초록을 기다리는 일은 사람이 아니라 GitHub 가 해야 한다.

## 무엇을

두 워크플로에 `workflow_run(CI, main, completed)` 트리거를 붙이고, 배포 대상을 고르는 `preflight` job 을 분리했다.

```yaml
on:
  workflow_run:
    workflows: [CI]
    types: [completed]
    branches: [main]
  workflow_dispatch: ...   # 예외 경로로 유지
```

| 규칙 | 동작 |
|---|---|
| 대상 SHA | `github.event.workflow_run.head_sha` |
| 그 SHA 가 main head 가 아니면 | 자동은 **조용히 skip** (최신 커밋의 CI 가 자기 배포를 띄운다) / 수동은 실패 |
| CI 실패 또는 PR 이벤트 CI | 배포 안 함 (`conclusion == 'success' && event == 'push'`) |
| 기존 가드 | 자동 경로에서도 전부 통과해야 함 |

`GITHUB_SHA` 대신 preflight 가 확정한 SHA 를 쓴다. `workflow_run` 의 `github.sha` 는 트리거 시점 기본 브랜치 head 라 대상과 어긋날 수 있어서, 체크아웃 ref·CI 검증·JVM 이미지 태그·리비전 접미사까지 전부 `needs.preflight.outputs.sha` 로 통일했다.

## JVM 은 바뀐 커밋일 때만

매 커밋마다 Cloud Run 리비전을 올리면 바뀐 것 없는 배포가 쌓이고 `--min-instances 1` 롤아웃 위험만 반복된다. 그래서 **마지막으로 성공한 JVM 배포의 SHA 와 diff** 를 떠서 `server/jvm-weekly-api/**` (와 이 워크플로 파일) 이 실제로 바뀐 경우에만 배포한다.

- 성공 이력이 없거나 그 SHA 를 찾을 수 없으면 배포한다 (fail-open 이지만 첫 배포·이력 정리 뒤를 막지 않기 위함).
- 소스 변경 없이 강제로 올려야 하면 dispatch 의 `force: true`.

## 검증

- 두 파일 YAML 파싱 확인, job 구성 `[preflight, deploy]`, 트리거 `[workflow_run, workflow_dispatch]`.
- 실제 동작 검증은 이 PR 이 머지되어 main 의 CI 가 돌 때다. **이 PR 자체가 첫 자동 배포 대상**이 된다. 머지 후 `Production Deploy` 가 dispatch 없이 뜨는지, `JVM Production Deploy` 가 JVM 소스 무변경으로 skip 되는지 확인한다.

`AGENTS.md` 에 정책으로 남겼다 — "배포되지 않은 채로 머지가 쌓이는 상황을 만들지 않는다."

🤖 Generated with [Claude Code](https://claude.com/claude-code)