### PR TITLE
test: BFF→JVM 월결산 확정 본문을 HTTP 이음매에서 고정

### DIFF
--- a/scripts/audit-cashflow-month-close-state.mjs
+++ b/scripts/audit-cashflow-month-close-state.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// 월 결산 확정/잠금 상태 감사 — 읽기 전용. 아무것도 쓰지 않는다.
+//
+// #496 이전에는 누적 결산 승인이 Firestore 만 갱신하고 JVM 확정을 부르지 않았다. 그래서
+// cashflow_cumulative_close_heads 가 비어 있고, 시트 잠금과 변경 경고 누적이 동작하지 않았다.
+// 이 스크립트는 그 흔적을 그대로 드러낸다.
+//
+//   - APPROVED 인데 JVM 월 결산이 CLOSED 가 아닌 요청 (= 과거 결함의 잔재)
+//   - cumulative close head 유무와 closedThrough
+//   - 승인 대기 중인 요청 (배포 후 첫 확정 후보)
+//
+// 사용:
+//   node scripts/audit-cashflow-month-close-state.mjs --project inner-platform-live-20260316
+
+import { createFirestoreDb, resolveProjectId } from '../server/bff/firestore.mjs';
+
+function readFlag(name, fallback = '') {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? fallback : (process.argv[index + 1] || fallback);
+}
+
+const firebaseProjectId = readFlag('--firebase-project', readFlag('--project', resolveProjectId()));
+const tenantId = readFlag('--tenant', 'mysc');
+
+async function main() {
+  const db = createFirestoreDb({ projectId: firebaseProjectId });
+  const [requestsSnap, headsSnap, closesSnap] = await Promise.all([
+    db.collection(`orgs/${tenantId}/cashflow_month_close_requests`).get(),
+    db.collection(`orgs/${tenantId}/cashflow_cumulative_close_heads`).get(),
+    db.collection(`orgs/${tenantId}/monthly_closes`).get(),
+  ]);
+
+  const heads = new Map(headsSnap.docs.map((doc) => [doc.id, doc.data() || {}]));
+  const closesByProject = new Map();
+  for (const doc of closesSnap.docs) {
+    const close = doc.data() || {};
+    const projectId = String(close.projectId || '');
+    if (!closesByProject.has(projectId)) closesByProject.set(projectId, []);
+    closesByProject.get(projectId).push(close);
+  }
+
+  const byStatus = new Map();
+  const approvedWithoutJvmClose = [];
+  const pending = [];
+  for (const doc of requestsSnap.docs) {
+    const record = doc.data() || {};
+    const status = String(record.status || 'UNKNOWN');
+    byStatus.set(status, (byStatus.get(status) || 0) + 1);
+    const projectId = String(record.projectId || '');
+    if (['PENDING', 'APPROVING', 'UNCERTAIN'].includes(status)) {
+      pending.push({
+        requestId: doc.id,
+        projectId,
+        yearMonth: record.yearMonth,
+        status,
+        revision: record.revision,
+        requestedAt: record.requestedAt,
+        approverUid: record.approverUid,
+        hasHead: heads.has(projectId),
+      });
+    }
+    if (status !== 'APPROVED') continue;
+    const closed = (closesByProject.get(projectId) || [])
+      .some((close) => close.yearMonth === record.yearMonth && String(close.status) === 'CLOSED');
+    if (!closed) {
+      approvedWithoutJvmClose.push({
+        requestId: doc.id,
+        projectId,
+        yearMonth: record.yearMonth,
+        reviewedAt: record.reviewedAt || null,
+        hasHead: heads.has(projectId),
+        storedMonthCloseResult: Boolean(record.monthCloseResult),
+      });
+    }
+  }
+
+  console.log(`테넌트 ${tenantId} · Firebase ${firebaseProjectId}`);
+  console.log(`\n결산 요청 ${requestsSnap.size}건`);
+  for (const [status, count] of [...byStatus].sort()) console.log(`  ${status.padEnd(12)} ${count}`);
+
+  console.log(`\ncumulative close head ${headsSnap.size}건 (= JVM 확정이 실제로 일어난 프로젝트)`);
+  for (const [projectId, head] of heads) {
+    console.log(`  ${projectId}  closedThrough=${head.closedThrough || '-'}  status=${head.status || '-'}  rev=${head.revision ?? '-'}  closedAt=${head.closedAt || '-'}`);
+  }
+
+  console.log(`\nAPPROVED 인데 JVM 월이 CLOSED 가 아닌 요청: ${approvedWithoutJvmClose.length}건`);
+  for (const row of approvedWithoutJvmClose) {
+    console.log(`  ${row.projectId} ${row.yearMonth}  head=${row.hasHead ? 'Y' : 'N'}  monthCloseResult=${row.storedMonthCloseResult ? 'Y' : 'N'}  reviewedAt=${row.reviewedAt || '-'}`);
+  }
+
+  console.log(`\n승인 대기 중인 요청: ${pending.length}건`);
+  for (const row of pending) {
+    console.log(`  ${row.projectId} ${row.yearMonth}  ${row.status} r${row.revision}  head=${row.hasHead ? 'Y' : 'N'}  requestedAt=${row.requestedAt || '-'}`);
+  }
+
+  const closedMonths = closesSnap.docs.filter((doc) => String((doc.data() || {}).status) === 'CLOSED').length;
+  console.log(`\nmonthly_closes ${closesSnap.size}건 중 CLOSED ${closedMonths}건`);
+}
+
+main().catch((error) => {
+  console.error(error?.stack || String(error));
+  process.exitCode = 1;
+});

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/CloseCashflowMonthRequestTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/CloseCashflowMonthRequestTest.java
@@ -25,6 +25,46 @@ class CloseCashflowMonthRequestTest {
         assertThat(validator.validate(request)).isEmpty();
     }
 
+    /**
+     * BFF 가 조직장 승인 시 실제로 보내는 본문. 두 런타임의 테스트가 각자 객체를 손으로
+     * 만들면 JSON 이음매는 아무도 검증하지 않는다 - BFF 는 fetch 를 스텁하고 JVM 은 record 를
+     * 직접 만든다. 그래서 BFF 테스트가 캡처한 문자열을 그대로 여기에 둔다. 한쪽이 본문 모양을
+     * 바꾸면 이 테스트가 깨진다.
+     *
+     * 출처: server/bff/routes/jvm-weekly-api.test.mjs 의 status-review 승인 경로.
+     */
+    private static final String BFF_CUMULATIVE_APPROVAL_BODY = """
+        {"idempotencyKey":"cumulative-v2-approve","yearMonth":"2026-08","expectedRevision":0,\
+        "expectedDraftRevision":0,"humanReviewed":true,"requestId":"project-a-2026-08",\
+        "requestRevision":2,\
+        "manifestHash":"sha256:bf7b8f68cdbda3208c505fd76f7f642c08e8cf66abc31ddd11cfe6b1a93b2a08"}""";
+
+    @Test
+    void acceptsTheExactBodyTheBffSendsOnApproval() throws Exception {
+        CloseCashflowMonthRequest request = new ObjectMapper()
+            .readValue(BFF_CUMULATIVE_APPROVAL_BODY, CloseCashflowMonthRequest.class);
+
+        // 누적 계약으로 인식되어야 셀·입금일정·확인란 없이 통과한다.
+        assertThat(request.cumulativeV2()).isTrue();
+        assertThat(validator.validate(request)).isEmpty();
+
+        // requireCumulativeCloseApproval 이 헤더 대조에 쓰는 세 값이 그대로 도착해야 한다.
+        assertThat(request.requestId()).isEqualTo("project-a-2026-08");
+        assertThat(request.requestRevision()).isEqualTo(2);
+        assertThat(request.manifestHash())
+            .isEqualTo("sha256:bf7b8f68cdbda3208c505fd76f7f642c08e8cf66abc31ddd11cfe6b1a93b2a08");
+        assertThat(request.idempotencyKey()).isEqualTo("cumulative-v2-approve");
+        assertThat(request.yearMonth()).isEqualTo("2026-08");
+        assertThat(request.expectedRevision()).isEqualTo(0);
+
+        // 셀은 저장된 샤드에서 읽으므로 본문에는 없다. null 이 아니라 빈 목록으로 정규화된다.
+        assertThat(request.cells()).isEmpty();
+        assertThat(request.depositScheduleRows()).isEmpty();
+        assertThat(request.confirmations()).isEmpty();
+        assertThat(request.managementChecks()).isEmpty();
+        assertThat(request.openingBalances()).isNull();
+    }
+
     @Test
     void contractValidationFlagIsNotPartOfTheJvmJsonPayload() throws Exception {
         String json = new ObjectMapper().writeValueAsString(compactCumulativeRequest());


### PR DESCRIPTION
#496 검증 중 발견한 빈 곳을 메운다.

BFF 테스트는 `fetch` 를 스텁하고 JVM 테스트는 `CloseCashflowMonthRequest` record 를 손으로 만든다. **두 반쪽이 JSON 으로 실제로 맞물리는지는 어느 쪽도 검증하지 않았다.** #496 은 정확히 그 이음매를 새로 만든 변경인데, 필드 하나가 어긋나면 라이브 첫 확정 때 알게 된다.

BFF 테스트가 실제로 캡처한 본문을 JVM 테스트에 문자열 그대로 고정했다.

```json
{"idempotencyKey":"cumulative-v2-approve","yearMonth":"2026-08","expectedRevision":0,
 "expectedDraftRevision":0,"humanReviewed":true,"requestId":"project-a-2026-08",
 "requestRevision":2,"manifestHash":"sha256:bf7b8f…"}
```

이 본문이
- `cumulativeV2()` 로 인식되어 셀·입금일정·확인란 없이 bean validation 을 통과하고,
- `requireCumulativeCloseApproval` 이 헤더 대조에 쓰는 `requestId` / `requestRevision` / `manifestHash` 가 그대로 도착하며,
- 본문에 없는 목록들이 `null` 이 아니라 빈 목록으로 정규화되는지

를 확인한다. 한쪽이 본문 모양을 바꾸면 이 테스트가 깨진다 — 기한 규칙을 두 런타임 테스트에 같은 표로 둔 것과 같은 방식이다.

**Sabotage 검증**: 본문에서 `manifestHash` 를 빼면 깨진다 (`Tests run: 10, Failures: 1`). 되돌리면 10 통과.

## 함께 추가하는 감사 스크립트

`scripts/audit-cashflow-month-close-state.mjs` — 읽기 전용. 확정이 실제로 일어났는지(`cashflow_cumulative_close_heads` 유무), `APPROVED` 인데 JVM 이 `CLOSED` 가 아닌 잔재가 있는지, 승인 대기 요청이 뭔지 보고한다.

라이브(`inner-platform-live-20260316`)에 돌린 결과:

```
결산 요청 0건
cumulative close head 0건
APPROVED 인데 JVM 월이 CLOSED 가 아닌 요청: 0건
승인 대기 중인 요청: 0건
monthly_closes 0건
```

감사 문서 17건은 전부 `APPROVER_UPDATED`, 정산상태 15건은 전부 `MONTH: NONE`. **월 결산이 프로덕션에서 한 번도 실행된 적이 없다.** #496 의 결함이 사용자에게 관측되지 않은 이유이고, 동시에 첫 확정 때 바로 물렸을 결함이라는 뜻이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)