### PR TITLE
test: 로컬 BFF→JVM 월결산 end-to-end 하네스

### DIFF
--- a/scripts/dump-cashflow-project-fixture.mjs
+++ b/scripts/dump-cashflow-project-fixture.mjs
@@ -1,0 +1,25 @@
+// 라이브 읽기 전용 덤프. 이 프로세스는 에뮬레이터 환경변수 없이 실행한다.
+import { writeFileSync } from 'node:fs';
+import { createFirestoreDb } from '/Users/boram/orca/workspaces/MYSCube/spec22-integration/server/bff/firestore.mjs';
+if (process.env.FIRESTORE_EMULATOR_HOST) throw new Error('dump 프로세스에는 에뮬레이터 환경변수가 있으면 안 된다');
+const TENANT = 'mysc';
+const PROJECT = 'p1773817948751';
+const live = createFirestoreDb({ projectId: 'inner-platform-live-20260316' });
+const out = [];
+async function grab(path) {
+  const snap = await live.doc(path).get();
+  if (snap.exists) out.push([path, snap.data()]);
+}
+const project = (await live.doc(`orgs/${TENANT}/projects/${PROJECT}`).get()).data();
+await grab(`orgs/${TENANT}/projects/${PROJECT}`);
+await grab(`orgs/${TENANT}/cashflow_sheet_mirrors/${PROJECT}`);
+await grab(`orgs/${TENANT}/cashflow_sheet_publications/${PROJECT}`);
+await grab(`orgs/${TENANT}/members/${project.executiveApproverId}`);
+const members = await live.collection(`orgs/${TENANT}/members`).get();
+for (const d of members.docs.slice(0, 60)) out.push([`orgs/${TENANT}/members/${d.id}`, d.data()]);
+const weeks = await live.collection(`orgs/${TENANT}/cashflow_weeks`).get();
+for (const d of weeks.docs) {
+  if (String((d.data() || {}).projectId) === PROJECT) out.push([`orgs/${TENANT}/cashflow_weeks/${d.id}`, d.data()]);
+}
+writeFileSync(process.argv[2], JSON.stringify(out));
+console.log(`덤프 ${out.length}건 -> ${process.argv[2]} (라이브 쓰기 0건)`);

--- a/scripts/dump-cashflow-project-fixture.mjs
+++ b/scripts/dump-cashflow-project-fixture.mjs
@@ -1,25 +1,142 @@
-// 라이브 읽기 전용 덤프. 이 프로세스는 에뮬레이터 환경변수 없이 실행한다.
+#!/usr/bin/env node
+// 라이브 캐시플로 프로젝트를 로컬 end-to-end 하네스용 고정물로 덤프한다. 읽기 전용.
+//
+// 이 프로세스는 에뮬레이터 환경변수 없이 실행해야 한다. getOrInitAdminApp 은 appName 없이
+// 부르면 getApps()[0] 을 돌려주므로, 한 프로세스에서 라이브와 에뮬레이터 핸들을 같이 만들면
+// 두 번째 핸들이 첫 번째 앱을 재사용해 라이브에 쓰게 된다. 그래서 덤프와 로드를 나눈다.
+//
+// 인적사항은 내보내지 않는다. 필요한 것은 사람이 아니라 데이터 모양과 인가 판정에 쓰이는
+// 역할·상태·프로젝트 배정이다.
+//
+// 여기서 지우는 방식(denylist)을 쓰지 않는 이유: 프로젝트 문서 하나에만 managerName,
+// executiveApproverName, teamMembersDetailed[].memberName, registeredByName,
+// managementPlanningReviewComment, contractAnalysis 자유서술이 들어 있다. 몇 개를 지우면
+// 다음에 생기는 필드를 놓친다. 그래서 (1) 문서 종류마다 내보낼 필드를 열거하고,
+// (2) 결과물을 다시 훑어 허용하지 않은 자리에 사람 이름이 보이면 파일을 쓰지 않고 실패한다.
+//
+//   node scripts/dump-cashflow-project-fixture.mjs <out.json> [--project <projectId>]
+
 import { writeFileSync } from 'node:fs';
-import { createFirestoreDb } from '/Users/boram/orca/workspaces/MYSCube/spec22-integration/server/bff/firestore.mjs';
-if (process.env.FIRESTORE_EMULATOR_HOST) throw new Error('dump 프로세스에는 에뮬레이터 환경변수가 있으면 안 된다');
+import { createFirestoreDb } from '../server/bff/firestore.mjs';
+
+if (process.env.FIRESTORE_EMULATOR_HOST) {
+  throw new Error('덤프 프로세스에 FIRESTORE_EMULATOR_HOST 가 있으면 안 된다. 로드와 프로세스를 분리할 것.');
+}
+
+const outPath = process.argv[2];
+if (!outPath) throw new Error('사용: node scripts/dump-cashflow-project-fixture.mjs <out.json> [--project <id>]');
+const projectIndex = process.argv.indexOf('--project');
+const PROJECT = projectIndex === -1 ? 'p1773817948751' : process.argv[projectIndex + 1];
 const TENANT = 'mysc';
-const PROJECT = 'p1773817948751';
+
+// 한글이 정상적으로 남아 있어야 하는 자리. 시트 행 라벨은 좌표 계약의 일부이지 인적사항이 아니다.
+const HANGUL_ALLOWED_KEYS = new Set(['sourceLabel', 'selectedSheetName', 'sheetName']);
+
+function pick(source, keys) {
+  const result = {};
+  for (const key of keys) if (source[key] !== undefined) result[key] = source[key];
+  return result;
+}
+
+// 인가 판정에 실제로 읽히는 필드만 (cashflow-project-scope.mjs, requireStoredCashflowWriter).
+function maskMember(id, data) {
+  return {
+    ...pick(data, ['uid', 'role', 'status', 'projectId', 'projectIds']),
+    uid: data.uid ?? id,
+    portalProfile: data.portalProfile && typeof data.portalProfile === 'object'
+      ? pick(data.portalProfile, ['projectId', 'projectIds'])
+      : undefined,
+    name: `member-${String(id).slice(0, 6)}`,
+    email: `${String(id).toLowerCase()}@mysc.co.kr`,
+  };
+}
+
+// 조직장 지정과 프로젝트 정체성만. 계약 분석·결재 이력·팀원 명단은 하네스와 무관하다.
+function maskProject(id, data) {
+  return {
+    ...pick(data, ['id', 'tenantId', 'version', 'executiveApproverId', 'status']),
+    id: data.id ?? id,
+    name: `project-${String(id).slice(0, 8)}`,
+  };
+}
+
+// 주차 문서는 금액과 좌표가 본질이다. 누가 고쳤는지는 필요 없다.
+function maskWeek(id, data) {
+  const { updatedByName, updatedByUid, ...rest } = data;
+  return rest;
+}
+
+// 미러는 셀이 본질이다. 스프레드시트 제목과 시트 메타 문구는 사람 이름을 실어 나른다.
+function maskMirror(_id, data) {
+  const { spreadsheetTitle, sheetFacts, sources, ...rest } = data;
+  const maskedSources = sources && typeof sources === 'object'
+    ? Object.fromEntries(Object.entries(sources).map(([year, source]) => [
+      year,
+      source && typeof source === 'object'
+        ? { ...source, spreadsheetTitle: undefined }
+        : source,
+    ]))
+    : undefined;
+  return {
+    ...rest,
+    ...(maskedSources ? { sources: maskedSources } : {}),
+    ...(sheetFacts && typeof sheetFacts === 'object'
+      ? { sheetFacts: { ...sheetFacts, metadata: undefined } }
+      : {}),
+  };
+}
+
+function assertNoPersonalNames(rows) {
+  const offenders = [];
+  const walk = (path, value) => {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      for (const [key, next] of Object.entries(value)) walk(path ? `${path}.${key}` : key, next);
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach((next, index) => walk(`${path}[${index}]`, next));
+      return;
+    }
+    if (typeof value !== 'string' || !/[가-힣]/.test(value)) return;
+    const leaf = path.replace(/\[\d+\]/g, '').split('.').pop();
+    if (HANGUL_ALLOWED_KEYS.has(leaf)) return;
+    offenders.push(`${path} = ${value.slice(0, 40)}`);
+  };
+  for (const [docPath, data] of rows) walk(docPath, data);
+  if (offenders.length > 0) {
+    throw new Error(
+      `허용하지 않은 자리에 사람이 읽는 한글 문자열이 남아 있다. 마스킹을 넓히거나 필드를 빼야 한다:\n  ${
+        offenders.slice(0, 20).join('\n  ')}${offenders.length > 20 ? `\n  … 외 ${offenders.length - 20}건` : ''}`,
+    );
+  }
+}
+
 const live = createFirestoreDb({ projectId: 'inner-platform-live-20260316' });
-const out = [];
-async function grab(path) {
+const rows = [];
+
+async function grab(path, mask) {
   const snap = await live.doc(path).get();
-  if (snap.exists) out.push([path, snap.data()]);
+  if (snap.exists) rows.push([path, mask(snap.id, snap.data())]);
 }
+
 const project = (await live.doc(`orgs/${TENANT}/projects/${PROJECT}`).get()).data();
-await grab(`orgs/${TENANT}/projects/${PROJECT}`);
-await grab(`orgs/${TENANT}/cashflow_sheet_mirrors/${PROJECT}`);
-await grab(`orgs/${TENANT}/cashflow_sheet_publications/${PROJECT}`);
-await grab(`orgs/${TENANT}/members/${project.executiveApproverId}`);
+if (!project) throw new Error(`프로젝트를 찾을 수 없다: ${PROJECT}`);
+
+await grab(`orgs/${TENANT}/projects/${PROJECT}`, maskProject);
+await grab(`orgs/${TENANT}/cashflow_sheet_mirrors/${PROJECT}`, maskMirror);
+await grab(`orgs/${TENANT}/cashflow_sheet_publications/${PROJECT}`, (_id, data) => data);
+
 const members = await live.collection(`orgs/${TENANT}/members`).get();
-for (const d of members.docs.slice(0, 60)) out.push([`orgs/${TENANT}/members/${d.id}`, d.data()]);
+for (const doc of members.docs) rows.push([`orgs/${TENANT}/members/${doc.id}`, maskMember(doc.id, doc.data())]);
+
 const weeks = await live.collection(`orgs/${TENANT}/cashflow_weeks`).get();
-for (const d of weeks.docs) {
-  if (String((d.data() || {}).projectId) === PROJECT) out.push([`orgs/${TENANT}/cashflow_weeks/${d.id}`, d.data()]);
+let weekCount = 0;
+for (const doc of weeks.docs) {
+  if (String((doc.data() || {}).projectId) !== PROJECT) continue;
+  rows.push([`orgs/${TENANT}/cashflow_weeks/${doc.id}`, maskWeek(doc.id, doc.data())]);
+  weekCount += 1;
 }
-writeFileSync(process.argv[2], JSON.stringify(out));
-console.log(`덤프 ${out.length}건 -> ${process.argv[2]} (라이브 쓰기 0건)`);
+
+assertNoPersonalNames(rows);
+writeFileSync(outPath, JSON.stringify(rows));
+console.log(`덤프 ${rows.length}건 -> ${outPath} (멤버 ${members.size} · 주차 ${weekCount} · 라이브 쓰기 0건)`);

--- a/scripts/load-cashflow-project-fixture.mjs
+++ b/scripts/load-cashflow-project-fixture.mjs
@@ -1,0 +1,9 @@
+// 에뮬레이터 전용 로드. 이 프로세스는 라이브 자격증명을 절대 만들지 않는다.
+import { readFileSync } from 'node:fs';
+import { createFirestoreDb } from '/Users/boram/orca/workspaces/MYSCube/spec22-integration/server/bff/firestore.mjs';
+if (!process.env.FIRESTORE_EMULATOR_HOST) throw new Error('load 프로세스에는 에뮬레이터 환경변수가 필요하다');
+const db = createFirestoreDb({ projectId: 'demo-axr-e2e' });
+const rows = JSON.parse(readFileSync(process.argv[2], 'utf8'));
+for (const [path, value] of rows) await db.doc(path).set(value);
+const probe = await db.doc('orgs/mysc/projects/p1773817948751').get();
+console.log(`로드 ${rows.length}건. 에뮬레이터 확인: ${probe.exists ? probe.data().name : 'MISSING'}`);

--- a/server/e2e-month-close.local.test.ts
+++ b/server/e2e-month-close.local.test.ts
@@ -100,7 +100,38 @@ describe.skipIf(!enabled)('AXR 프로젝트경비 월결산 end-to-end (BFF -> H
       expect(dashboard.status, JSON.stringify(dashboard.body).slice(0, 400)).toBe(200);
       expect(dashboard.body.status).toBe('OPEN');
 
-      const mirror = (await db.doc(`orgs/${TENANT}/cashflow_sheet_mirrors/${PROJECT}`).get()).data();
+      // 라이브에서 복사한 미러는 canonical 보다 낡아 있을 수 있다 (AXR프로젝트경비가 실제로
+      // 그렇다). 그 상태로 확정하면 JVM 이 "Cashflow target revision changed" 로 막는다.
+      // 월결산의 정상 전제는 "시트를 다시 불러와 반영한 직후" 이므로 그 상태로 맞춘다.
+      const canonical = await (await fetch(`${JVM}/api/v1/cashflow/${PROJECT}`, {
+        headers: {
+          'x-inner-platform-service-token': TOKEN,
+          'x-tenant-id': TENANT,
+          'x-actor-id': approverUid,
+          'x-actor-role': 'admin',
+          'x-actor-email': approver.email,
+        },
+      })).json();
+      const mirrorRef = db.doc(`orgs/${TENANT}/cashflow_sheet_mirrors/${PROJECT}`);
+      const pinned = (await mirrorRef.get()).data();
+      await mirrorRef.set({
+        ...pinned,
+        status: 'FRESH',
+        targetRevisionAtFetch: canonical.targetRevision,
+        appliedSourceRevision: pinned.sourceRevision,
+      });
+      const publicationRef = db.doc(`orgs/${TENANT}/cashflow_sheet_publications/${PROJECT}`);
+      const publication = (await publicationRef.get()).data();
+      await publicationRef.set({
+        ...publication,
+        status: 'APPLIED',
+        applyFailure: null,
+        applyFailedAt: null,
+        sourceRevision: pinned.sourceRevision,
+        appliedTargetRevision: canonical.targetRevision,
+        appliedAt: '2026-09-09T00:00:00.000Z',
+      });
+      const mirror = (await mirrorRef.get()).data();
       const closeInput = buildCashflowMonthCloseDraftInput({
         mirror: mirror as any,
         yearMonth: YEAR_MONTH,

--- a/server/e2e-month-close.local.test.ts
+++ b/server/e2e-month-close.local.test.ts
@@ -1,0 +1,170 @@
+// 로컬 전용 end-to-end: BFF(인프로세스) -> 진짜 HTTP -> 로컬 JVM -> Firestore 에뮬레이터.
+// AXR 프로젝트경비 실데이터를 에뮬레이터로 복사한 상태에서 돌린다. 라이브에는 쓰지 않는다.
+// 실행: E2E_MONTH_CLOSE=1 FIRESTORE_EMULATOR_HOST=127.0.0.1:8571 npx vitest run e2e-month-close.local.test.ts
+import express from 'express';
+import { describe, expect, it } from 'vitest';
+import { createFirestoreDb } from './bff/firestore.mjs';
+// @ts-expect-error - JS 모듈
+import { mountJvmWeeklyApiRoutes } from './bff/routes/jvm-weekly-api.mjs';
+import { buildCashflowMonthCloseDraftInput } from '../src/app/components/cashflow/cashflow-month-close';
+
+const TENANT = 'mysc';
+const PROJECT = 'p1773817948751';
+const JVM = 'http://127.0.0.1:8088';
+const TOKEN = 'e2e-local-token';
+const YEAR_MONTH = '2026-08';
+
+const enabled = process.env.E2E_MONTH_CLOSE === '1';
+if (enabled && !process.env.FIRESTORE_EMULATOR_HOST) {
+  throw new Error('이 하네스는 Firestore 에뮬레이터에서만 돈다. FIRESTORE_EMULATOR_HOST 를 설정할 것.');
+}
+
+const runtimeEnv = {
+  BFF_DEPLOY_ENV: 'live',
+  BFF_EDIT_LEASES_ENABLED: 'true',
+  BFF_LIVE_FIREBASE_PROJECT_ID: 'demo-axr-e2e',
+  VITE_FIREBASE_PROJECT_ID: 'demo-axr-e2e',
+  JVM_WEEKLY_FIRESTORE_PROJECT_ID: 'demo-axr-e2e',
+  JVM_WEEKLY_API_BASE_URL: JVM,
+  JVM_WEEKLY_AUTH_MODE: 'internal_saas_workspace',
+  JVM_WEEKLY_INTERNAL_API_TOKEN: TOKEN,
+  JVM_WEEKLY_WORKSPACE_EMAIL_DOMAIN: 'mysc.co.kr',
+};
+
+function listen(actor: Record<string, string>, db: unknown) {
+  const app = express();
+  app.use(express.json({ limit: '20mb' }));
+  app.use((req: any, _res: unknown, next: () => void) => {
+    req.context = {
+      tenantId: TENANT,
+      requestId: `req-${Math.random().toString(16).slice(2)}`,
+      idempotencyKey: req.header('idempotency-key') || undefined,
+      ...actor,
+    };
+    next();
+  });
+  mountJvmWeeklyApiRoutes(app, {
+    idempotencyService: {
+      async reserve() { return { replayed: false }; },
+      async complete() {}, async fail() {},
+    },
+    fetchImpl: (url: string, init: RequestInit) => fetch(url, init),
+    db,
+    env: runtimeEnv,
+    now: () => new Date('2026-09-10T00:00:00.000Z'),
+  });
+  return new Promise<{ server: any; base: string }>((resolve) => {
+    const server = app.listen(0, '127.0.0.1', () => resolve({
+      server, base: `http://127.0.0.1:${(server.address() as any).port}`,
+    }));
+  });
+}
+
+async function call(base: string, method: string, path: string, options: { body?: unknown; key?: string } = {}) {
+  const headers: Record<string, string> = { 'content-type': 'application/json' };
+  if (options.key) headers['idempotency-key'] = options.key;
+  const response = await fetch(`${base}${path}`, {
+    method, headers, body: options.body === undefined ? undefined : JSON.stringify(options.body),
+  });
+  const text = await response.text();
+  let body: any = text;
+  try { body = JSON.parse(text); } catch { /* keep text */ }
+  return { status: response.status, body };
+}
+
+describe.skipIf(!enabled)('AXR 프로젝트경비 월결산 end-to-end (BFF -> HTTP -> JVM -> Firestore emulator)', () => {
+  it('확정하면 cumulative close head 가 생기고 시트가 잠긴다', async () => {
+    const db: any = createFirestoreDb({ projectId: 'demo-axr-e2e' });
+    const project = (await db.doc(`orgs/${TENANT}/projects/${PROJECT}`).get()).data();
+    const approverUid = String(project.executiveApproverId);
+    const approver = (await db.doc(`orgs/${TENANT}/members/${approverUid}`).get()).data();
+    const members = await db.collection(`orgs/${TENANT}/members`).get();
+    const requesterDoc = members.docs.find((d: any) => {
+      const m = d.data() || {};
+      return d.id !== approverUid && String(m.status).toUpperCase() === 'ACTIVE';
+    });
+    const requester = requesterDoc.data();
+    // eslint-disable-next-line no-console
+    console.log(`요청자 ${requester.name}/${requester.role}  승인자 ${approver.name}/${approver.role}`);
+
+    const asRequester = await listen({
+      actorId: requesterDoc.id, actorRole: requester.role || 'pm', actorEmail: requester.email,
+    }, db);
+    const asApprover = await listen({
+      actorId: approverUid, actorRole: approver.role || 'admin', actorEmail: approver.email,
+    }, db);
+
+    try {
+      const dashboard = await call(asRequester.base, 'GET',
+        `/api/v1/cashflow/${PROJECT}/month-close?yearMonth=${YEAR_MONTH}`);
+      expect(dashboard.status, JSON.stringify(dashboard.body).slice(0, 400)).toBe(200);
+      expect(dashboard.body.status).toBe('OPEN');
+
+      const mirror = (await db.doc(`orgs/${TENANT}/cashflow_sheet_mirrors/${PROJECT}`).get()).data();
+      const closeInput = buildCashflowMonthCloseDraftInput({
+        mirror: mirror as any,
+        yearMonth: YEAR_MONTH,
+        humanReviewed: true,
+        // 화면이 입금일정 검토에서 만드는 것과 같은 5주차 행. 실데이터에 입금 예정/실적이
+        // 없으므로 전부 '해당 없음' 이다.
+        depositScheduleRows: [1, 2, 3, 4, 5].map((weekNo) => ({
+          weekNo,
+          taxInvoiceIssuedDate: '',
+          expectedDepositDate: '',
+          expectedDepositAmount: null,
+          actualDepositDate: '',
+          actualDepositAmount: null,
+          actualSource: 'NOT_APPLICABLE' as const,
+          decision: null,
+        })),
+        managementChecks: dashboard.body.dashboard?.managementChecks || [],
+        deadlineSummary: dashboard.body.dashboard?.deadlineSummary
+          || { trackingStartedAt: null, missedCount: 0, completedCount: 0, current: null },
+      });
+
+      const created = await call(asRequester.base, 'POST',
+        `/api/v1/cashflow/${PROJECT}/month-close/requests`, {
+          key: 'e2e-create',
+          body: {
+            contractVersion: 'cashflow-cumulative-close-v2',
+            yearMonth: YEAR_MONTH,
+            expectedRevision: dashboard.body.revision,
+            expectedApproverUid: approverUid,
+            expectedProjectVersion: project.version ?? 0,
+            expectedOpeningBalances: dashboard.body.dashboard?.openingBalances,
+            closeInput,
+          },
+        });
+      expect(created.status, JSON.stringify(created.body).slice(0, 600)).toBe(202);
+      expect(created.body.status).toBe('PENDING');
+      // eslint-disable-next-line no-console
+      console.log(`요청 생성: rev ${created.body.revision}, ${created.body.monthCount}개월, ${created.body.cellCount}셀`);
+
+      const headBefore = await db.doc(`orgs/${TENANT}/cashflow_cumulative_close_heads/${PROJECT}`).get();
+      expect(headBefore.exists).toBe(false);
+
+      const approved = await call(asApprover.base, 'POST',
+        `/api/v1/cashflow/${PROJECT}/month-close/requests/${PROJECT}-${YEAR_MONTH}/status-review`, {
+          key: 'e2e-approve',
+          body: {
+            decision: 'APPROVE',
+            expectedRevision: created.body.revision,
+            expectedManifestHash: created.body.manifestHash,
+          },
+        });
+      expect(approved.status, JSON.stringify(approved.body).slice(0, 800)).toBe(200);
+      expect(approved.body.request.status).toBe('APPROVED');
+      expect(approved.body.monthClose?.status).toBe('CLOSED');
+
+      const headAfter = await db.doc(`orgs/${TENANT}/cashflow_cumulative_close_heads/${PROJECT}`).get();
+      // eslint-disable-next-line no-console
+      console.log('cumulative close head:', JSON.stringify(headAfter.data(), null, 2));
+      expect(headAfter.exists).toBe(true);
+      expect(headAfter.data().closedThrough).toBe('2026-07');
+      expect(headAfter.data().status).toBe('CLOSED');
+    } finally {
+      asRequester.server.close();
+      asApprover.server.close();
+    }
+  }, 180_000);
+});


### PR DESCRIPTION
AXR프로젝트경비로 월결산을 실제로 돌려보라는 요청에 대한 결과물.

## 라이브에서는 확정을 돌릴 수 없다 (설계상)

두 가지 통제가 각각 막는다.

1. **자기 승인 금지** — `readCanonicalCashflowApprover` 가 요청자 == 승인자면 409 `cashflow_month_close_self_approval_forbidden`. AXR프로젝트경비의 조직장은 김세은(sekim@mysc.co.kr, admin, ACTIVE) 이다. 확정은 그 계정의 서명이다.
2. **라이브 밖에서 쓰기 금지** — BFF 의 캐시플로 쓰기 경로는 `BFF_DEPLOY_ENV=live` 를 요구하는데, `live` 부팅 검증은 `live BFF cannot use Firestore emulator` 로 거부한다. 즉 이 경로는 프로덕션에서만 돈다.

둘 다 올바른 통제다. 그래서 우회하지 않고, BFF 를 인프로세스로 올리고 **JVM 은 실제로 띄워 진짜 HTTP 로** 붙였다.

## 무엇이 증명됐나

라이브 AXR프로젝트경비(1920 cells / 288 annualCells / 93 week docs)를 에뮬레이터로 복사한 상태에서:

| 단계 | 결과 |
|---|---|
| BFF → HTTP → JVM `dashboard-source` | 200, `status: OPEN, revision: 0` |
| 결산 요청 생성 (실무자) | 202, **43개월 / 6880셀** 샤드 + manifest, 정산상태 `PENDING_APPROVAL` |
| 조직장 승인 → JVM 확정 | 200, `monthClose.status: CLOSED` |
| `cashflow_cumulative_close_heads` | **`closedThrough: "2026-07"`, `status: CLOSED`, `rootHash: sha256:d831dbb9…`, `closedByUid: PEBMtf…`** |
| `monthly_closes` | `status=CLOSED rev=1` |
| 정산상태 | `MONTH: COMPLETED`, approvedBy = 조직장 |

**#496 이 고친 이음매가 실제 네트워크 위에서 동작한다.** JVM 이 `requireCumulativeCloseApproval` 의 헤더 대조(contractVersion / requestId / projectId / yearMonth / fromMonth / **status=APPROVING** / requestRevision / manifestHash / approverUid / reviewIdempotencyKey)를 전부 통과했다.

BFF 의 실패 복구 경로도 우연히 실증됐다. 첫 시도에서 JVM 이 409 를 내자 BFF 가 조회로 확정 여부를 확인하려 시도했고, 증명하지 못하자 요청을 `UNCERTAIN` + `reconciliationEvidence` 로 남기고 503 `cashflow_month_close_reconciliation_pending` 을 반환했다. #496 에서 작성한 그대로다.

## 부수적으로 발견한 라이브 상태

AXR프로젝트경비의 **고정 시트가 canonical 보다 낡았다.**

- 미러 `targetRevisionAtFetch`: `sha256:5327467b…`
- JVM canonical `targetRevision`: `sha256:dcd1db6e…`
- publication: `applyFailedAt: 2026-08-01`, `appliedSourceRevision ≠ sourceRevision`

이 상태로 월결산을 시도하면 `Cashflow target revision changed. Refresh the sheet before applying.` 로 막힌다. 제품 결함이 아니라 전제 조건이다 — **닫기 전에 시트를 다시 불러와 반영해야 한다.** 하네스에서는 이 값을 "방금 다시 고정한" 상태로 맞춘 뒤 통과했다.

## 실행 방법

```
firebase emulators:start --only firestore --project demo-axr-e2e
node scripts/dump-cashflow-project-fixture.mjs out.json                       # 라이브 읽기 전용
FIRESTORE_EMULATOR_HOST=... node scripts/load-cashflow-project-fixture.mjs out.json
# JVM: storage-backend=firestore, deploy-env=live, 내부 토큰 모드, 8088
E2E_MONTH_CLOSE=1 FIRESTORE_EMULATOR_HOST=... npx vitest run server/e2e-month-close.local.test.ts
```

덤프와 로드를 **두 스크립트로 나눈 이유**가 중요하다. `getOrInitAdminApp` 은 `appName` 없이 부르면 `getApps()[0]` 을 돌려준다(`server/bff/firestore.mjs:71`). 한 프로세스에서 라이브 핸들을 먼저 만들면 그 뒤의 "에뮬레이터" 핸들이 같은 앱이 되어 **라이브에 쓴다.** 작업 중 실제로 이 실수를 했고(98건이 라이브에 되쓰였다 — 전부 직전에 같은 경로에서 읽은 값이라 변경은 0), 프로세스를 나누고 각 스크립트가 자기 환경변수를 검사하게 해서 구조적으로 막았다.

`E2E_MONTH_CLOSE=1` 이 아니면 건너뛴다. 켜져 있는데 에뮬레이터 환경변수가 없으면 즉시 던진다.

## 아직 안 본 것

확정 후 시트 수정 잠금(`cashflow_month_closed`)과 변경 경고 누적은 이 하네스로 직접 찍지 못했다 — `sheet-lab/apply` 본문(160셀 + calculationChecks 10 + openingBalanceCells)을 손으로 맞추다 `fail-on-unknown-properties` 에 걸렸다. 다만 그 동작은 `FirestoreCashflowLeaseGuardTest` 123개가 직접 검증한다 (`cashflow_closed_month_reason_required`, `amendmentCount: 1`, `postDeadlineAmendmentWarningCount: 1`). 잠금의 스위치인 `closedThrough` 가 기록되는 것까지가 이번에 새로 증명된 부분이다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)