### PR TITLE
fix(cashflow): 부가 조회 실패에도 월결산 화면을 살린다 + JVM liveness probe

### DIFF
--- a/.github/workflows/jvm-production-deploy.yml
+++ b/.github/workflows/jvm-production-deploy.yml
@@ -193,6 +193,7 @@ jobs:
             --tag candidate \
             --ingress all \
             --min-instances 1 \
+            --liveness-probe 'httpGet.path=/api/v1/health,initialDelaySeconds=30,periodSeconds=30,timeoutSeconds=5,failureThreshold=3' \
             --set-env-vars '^|^WEEKLY_API_PORT=8080|JVM_WEEKLY_DEPLOY_ENV=live|JVM_WEEKLY_EDIT_LEASES_ENABLED=true|JVM_WEEKLY_INTERNAL_API_TOKEN_ENABLED=true|JVM_WEEKLY_STORAGE_BACKEND=firestore|JVM_WEEKLY_PROJECT_ACCESS_BACKEND=firestore|JVM_WEEKLY_AUTH_MODE=strict|JVM_WEEKLY_WORKSPACE_EMAIL_DOMAIN=mysc.co.kr|JVM_WEEKLY_FIREBASE_PROJECT_ID=inner-platform-live-20260316|JVM_WEEKLY_FIRESTORE_PROJECT_ID=inner-platform-live-20260316|JVM_WEEKLY_FIREBASE_AUTH_PROJECT_ID=inner-platform-live-20260316|JVM_WEEKLY_ALLOWED_ORIGINS=https://myscube.myscguard.app' \
             --set-secrets 'JVM_WEEKLY_INTERNAL_API_TOKEN=innerplatform-weekly-api-token:latest,JVM_WEEKLY_CASHFLOW_SETTLED_WEEK_CONFIRMATION_KEY=innerplatform-cashflow-settled-week-confirmation-key:latest'
           revision="${SERVICE}-${revision_suffix}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "express": "^5.2.1",
         "firebase": "^12.9.0",
         "firebase-admin": "^13.6.1",
+        "google-auth-library": "^9.15.1",
         "input-otp": "1.4.2",
         "lottie-react": "^2.4.1",
         "lucide-react": "0.487.0",
@@ -6331,6 +6332,66 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.4.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.4",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.4.5",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.12.tgz",
@@ -12542,7 +12603,6 @@
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
       "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
@@ -12559,7 +12619,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "devOptional": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -12573,7 +12632,6 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
       "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "gaxios": "^6.1.1",
@@ -12754,7 +12812,6 @@
       "version": "9.15.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
       "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -12921,7 +12978,6 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
       "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -13069,7 +13125,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
       "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "gaxios": "^6.0.0",
@@ -13651,7 +13706,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15641,7 +15695,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -19239,7 +19292,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/traverse": {
@@ -20498,7 +20550,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "devOptional": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/websocket-driver": {
@@ -20535,7 +20586,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "express": "^5.2.1",
     "firebase": "^12.9.0",
     "firebase-admin": "^13.6.1",
+    "google-auth-library": "^9.15.1",
     "input-otp": "1.4.2",
     "lottie-react": "^2.4.1",
     "lucide-react": "0.487.0",

--- a/server/bff/cashflow-performance.mjs
+++ b/server/bff/cashflow-performance.mjs
@@ -43,6 +43,7 @@ export function createCashflowPerformanceTrace({
       ...(Number.isSafeInteger(details.attempt) ? { attempt: details.attempt } : {}),
       ...(details.outcome ? { outcome: safeText(details.outcome) } : {}),
       ...(Number.isInteger(details.statusCode) ? { statusCode: details.statusCode } : {}),
+      ...(Number.isInteger(details.upstreamStatus) ? { upstreamStatus: details.upstreamStatus } : {}),
       ...(typeof details.retryable === 'boolean' ? { retryable: details.retryable } : {}),
       ...(details.errorCode ? { errorCode: safeErrorCode(details.errorCode) } : {}),
       durationMs: safeDuration(details.durationMs),

--- a/server/bff/java-weekly-auth.mjs
+++ b/server/bff/java-weekly-auth.mjs
@@ -31,20 +31,31 @@ async function fetchCredentialIdentityToken(audience, serviceAccountJson) {
   } catch {
     throw createHttpError(503, '서버 인증 정보가 올바르지 않습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_api_identity_token_unavailable');
   }
+  const cacheKey = `${credentials.client_email || ''}\n${audience}`;
   try {
-    const cacheKey = `${credentials.client_email || ''}\n${audience}`;
     let clientPromise = identityTokenClients.get(cacheKey);
     if (!clientPromise) {
       clientPromise = new GoogleAuth({ credentials }).getIdTokenClient(audience);
       identityTokenClients.set(cacheKey, clientPromise);
     }
     const client = await clientPromise;
-    const authorization = readOptionalText((await client.getRequestHeaders()).Authorization);
+    // google-auth-library v9 는 getRequestHeaders() 가 평범한 객체를, v10 은 Headers 를
+    // 반환한다. 이 패키지는 hoist 로 끌려오는 간접 의존성이라(직접 선언은 package.json 참고)
+    // 설치 트리가 바뀌면 반환 타입도 조용히 바뀐다. 둘 다 읽는다 - v10 에서 .Authorization 만
+    // 읽으면 undefined 가 되어 전 요청이 503 으로 죽는다.
+    const rawHeaders = await client.getRequestHeaders();
+    const authorization = readOptionalText(
+      typeof rawHeaders?.get === 'function'
+        ? rawHeaders.get('authorization')
+        : (rawHeaders?.Authorization ?? rawHeaders?.authorization),
+    );
     const token = authorization.replace(/^Bearer\s+/i, '');
     if (!token) throw new Error('Missing identity token');
     return token;
   } catch {
-    identityTokenClients.clear();
+    // 실패한 키만 버린다. Map 전체를 비우면 한 요청의 일시적 실패가 다른 audience 의
+    // 정상 클라이언트까지 축출해 동시 요청 전부가 토큰을 다시 서명하게 된다.
+    identityTokenClients.delete(cacheKey);
     throw createHttpError(503, '서버 인증에 실패했습니다. 담당자에게 문의해 주세요.', 'jvm_weekly_api_identity_token_unavailable');
   }
 }

--- a/server/bff/java-weekly-client.mjs
+++ b/server/bff/java-weekly-client.mjs
@@ -341,6 +341,9 @@ export function createJavaWeeklyClient({
           attempt,
           outcome: 'error',
           statusCode: error?.statusCode || upstreamStatus,
+          // readJavaError 가 5xx 를 503 으로 정규화하므로, 원래 JVM 이 뭘 반환했는지는
+          // 이 필드가 없으면 로그에서 복구할 수 없다.
+          upstreamStatus: error?.upstreamStatus ?? upstreamStatus,
           retryable: !Number.isInteger(error?.statusCode) || Boolean(error?.transportFailure),
           errorCode: error?.code || error?.name,
         });

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -2059,14 +2059,20 @@ async function composeCashflowMonthDashboard({
       monthState: 'LIVE_CURRENT',
     });
   }
-  const liveDeadlineSummary = deadlineSummaryFromCompliance(weeklyCompliance, weeklyComplianceBoundary, weeklyYear);
-  const deadlineSummary = closedSnapshot
-    ? {
-      ...(objectValue(closedSnapshot.deadlineSummary) || {}),
-      completedWeeks: liveDeadlineSummary.completedWeeks,
-      weeklyStatuses: liveDeadlineSummary.weeklyStatuses,
-    }
-    : liveDeadlineSummary;
+  // 준수 이력을 못 읽었으면 요약을 만들지 않는다. 빈 이력으로 만들면 "지각 0회" 라는
+  // 틀린 숫자가 표시된다 - 판정 불능과 "문제 없음" 은 다르다.
+  const liveDeadlineSummary = weeklyCompliance === null
+    ? null
+    : deadlineSummaryFromCompliance(weeklyCompliance, weeklyComplianceBoundary, weeklyYear);
+  const deadlineSummary = liveDeadlineSummary === null
+    ? null
+    : closedSnapshot
+      ? {
+        ...(objectValue(closedSnapshot.deadlineSummary) || {}),
+        completedWeeks: liveDeadlineSummary.completedWeeks,
+        weeklyStatuses: liveDeadlineSummary.weeklyStatuses,
+      }
+      : liveDeadlineSummary;
   const blockers = [];
   if (readOptionalText(close?.status) !== 'OPEN') {
     blockers.push({ code: 'MONTH_NOT_OPEN', message: '결산 또는 재오픈 검토 중인 월은 수정할 수 없습니다.' });
@@ -2705,6 +2711,12 @@ export function mountJvmWeeklyApiRoutes(app, {
         // 세 번 겹겹이 쌓였다. publication 은 어차피 대시보드 읽기 뒤(after)에
         // 한 번 더 확인해 변경 여부를 판정하므로, before 를 병렬로 시작해도
         // 읽기 일관성 계약은 그 fingerprint 비교가 그대로 지킨다.
+        // 본체는 jvm_dashboard 하나다. publication(시트 반영 배너)과 compliance(주간 준수
+        // 이력)는 독립 부가 조회라서, 실패하면 그 섹션만 비우고 화면은 그린다. 부가 조회
+        // 실패가 대시보드 전체를 503 으로 만들면 한 하위 시스템 장애가 전 프로젝트 화면을
+        // 동시에 죽인다 - 실제로 그렇게 죽었다. 확정(쓰기) 경로는 이 열화를 쓰지 않고
+        // 전부 fail-closed 를 유지한다.
+        const sectionErrors = [];
         const [publicationBefore, source, weeklyCompliance] = await Promise.all([
           trace.measure(
             'publication_before',
@@ -2713,6 +2725,9 @@ export function mountJvmWeeklyApiRoutes(app, {
               tenantId: req.context.tenantId,
               projectId: rawProjectId,
               nowMs: currentNow.getTime(),
+            }).catch(() => {
+              sectionErrors.push({ section: 'sheetPublication', code: 'sheet_publication_state_unavailable' });
+              return { blocked: false, fingerprint: null, unavailable: true };
             }),
             { attempt: traceAttempt },
           ),
@@ -2727,7 +2742,10 @@ export function mountJvmWeeklyApiRoutes(app, {
           ),
           trace.measure(
             'jvm_compliance',
-            () => readWeeklyCompliance(req.context, rawProjectId),
+            () => readWeeklyCompliance(req.context, rawProjectId).catch(() => {
+              sectionErrors.push({ section: 'deadlineSummary', code: 'weekly_compliance_unavailable' });
+              return null;
+            }),
             { attempt: traceAttempt },
           ),
         ]);
@@ -2795,6 +2813,8 @@ export function mountJvmWeeklyApiRoutes(app, {
           }),
           { attempt: traceAttempt },
         );
+        // 대시보드는 이미 완성됐다. 이 뒤는 "읽는 동안 시트 반영이 끼어들었는지" 일관성
+        // 표시용 확인이라, 실패해도 완성된 응답을 버리지 않는다.
         const publicationAfter = await trace.measure(
           'publication_after',
           () => readCashflowSheetPublicationState({
@@ -2802,6 +2822,11 @@ export function mountJvmWeeklyApiRoutes(app, {
             tenantId: req.context.tenantId,
             projectId: rawProjectId,
             nowMs: currentNow.getTime(),
+          }).catch(() => {
+            if (!sectionErrors.some((entry) => entry.section === 'sheetPublication')) {
+              sectionErrors.push({ section: 'sheetPublication', code: 'sheet_publication_state_unavailable' });
+            }
+            return { blocked: false, fingerprint: null, unavailable: true };
           }),
           { attempt: traceAttempt },
         );
@@ -2809,11 +2834,17 @@ export function mountJvmWeeklyApiRoutes(app, {
           startedAt: publicationAfter.applyStartedAt,
           expiresAt: publicationAfter.leaseExpiresAt,
         } : null;
-        if (publicationBefore.fingerprint === publicationAfter.fingerprint) {
-          return { ...cumulativeClose, dashboard, pendingApply, publicationChangedDuringRead: false };
+        const publicationStateUnavailable = Boolean(publicationBefore.unavailable || publicationAfter.unavailable);
+        if (publicationStateUnavailable
+          || publicationBefore.fingerprint === publicationAfter.fingerprint) {
+          return {
+            ...cumulativeClose, dashboard, pendingApply, publicationChangedDuringRead: false, sectionErrors,
+          };
         }
         if (attempt === 1) {
-          return { ...cumulativeClose, dashboard, pendingApply, publicationChangedDuringRead: true };
+          return {
+            ...cumulativeClose, dashboard, pendingApply, publicationChangedDuringRead: true, sectionErrors,
+          };
         }
       }
     }, monthCloseRouteTimeoutMs);

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -821,6 +821,89 @@ describe('JVM weekly API BFF proxy', () => {
     expect(performanceEvents.every((event) => event.requestId === 'req-1')).toBe(true);
   });
 
+  it('keeps the dashboard alive when the compliance side read fails, and says so', async () => {
+    // 부가 조회(주간 준수 이력) 실패는 그 섹션만 비운다. 전 프로젝트 화면을 503 으로
+    // 죽이면 한 하위 시스템 장애가 회사 자금 화면 전체를 잠근다.
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(monthDashboardSource({
+        ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN',
+      })),
+    }));
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, {
+      weeklyComplianceResponse: () => { throw new Error('compliance backend down'); },
+    });
+
+    await request(app)
+      .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
+      .expect(200)
+      .expect((response) => {
+        expect(response.body.status).toBe('OPEN');
+        // 판정 불능을 "지각 0회" 로 그리지 않도록 요약 자체를 비운다.
+        expect(response.body.dashboard.deadlineSummary).toBeNull();
+        expect(response.body.sectionErrors).toEqual([
+          { section: 'deadlineSummary', code: 'weekly_compliance_unavailable' },
+        ]);
+      });
+  });
+
+  it('keeps the dashboard alive when the sheet publication state read fails, and says so', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(monthDashboardSource({
+        ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN',
+      })),
+    }));
+    const db = {
+      doc: (path) => {
+        if (path.includes('cashflow_sheet_publications')) {
+          return { get: async () => { throw new Error('firestore unavailable'); } };
+        }
+        if (path.includes('/members/')) {
+          return {
+            get: async () => ({
+              exists: true,
+              data: () => ({ uid: 'pm-1', status: 'ACTIVE', role: 'pm', projectIds: ['project-a'] }),
+            }),
+          };
+        }
+        return { get: async () => ({ exists: false }) };
+      },
+    };
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { db });
+
+    await request(app)
+      .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
+      .expect(200)
+      .expect((response) => {
+        expect(response.body.status).toBe('OPEN');
+        expect(response.body.pendingApply).toBeNull();
+        expect(response.body.publicationChangedDuringRead).toBe(false);
+        expect(response.body.sectionErrors).toEqual([
+          { section: 'sheetPublication', code: 'sheet_publication_state_unavailable' },
+        ]);
+      });
+    // 확인 재읽기(publication_after)까지 실패해도 요청당 한 번만 알린다.
+    expect(fetchImpl.mock.calls.filter(([url]) => url.includes('/dashboard-source'))).toHaveLength(1);
+  });
+
+  it('still fails closed when the dashboard source itself is down', async () => {
+    // 본체가 없으면 대체 표시가 불가능하다. 이건 열화 대상이 아니다.
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      text: async () => JSON.stringify({ message: 'boom' }),
+    }));
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, {});
+
+    await request(app)
+      .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
+      .expect(503)
+      .expect((response) => expect(response.body.code).toBe('jvm_weekly_api_internal_error'));
+  });
+
   it('publishes the server-owned cumulative close scope and pinned sheet source for 2026-08', async () => {
     const source = fullMonthCloseSource();
     const fetchImpl = vi.fn(async () => ({

--- a/server/jvm-weekly-api/live-deploy-workflow.test.ts
+++ b/server/jvm-weekly-api/live-deploy-workflow.test.ts
@@ -50,6 +50,9 @@ describe('JVM production deploy workflow', () => {
     // JVM 소스가 바뀐 커밋일 때만. 무변경 재배포는 Cloud Run 롤아웃 위험만 반복한다.
     expect(workflow).toContain('JVM_SOURCE_PATHS: server/jvm-weekly-api');
     expect(workflow).toContain('git diff --quiet "${last}" "${sha}" -- ${JVM_SOURCE_PATHS}');
+    // min-instances 1 은 같은 인스턴스를 계속 살려둔다. 행이 걸리면 liveness probe 가
+    // 죽여서 교체해야 한다 - 이게 없으면 행 걸린 인스턴스가 장애를 영구 보존한다.
+    expect(workflow).toContain("--liveness-probe 'httpGet.path=/api/v1/health");
     expect(workflow).toContain('No JVM source change between');
     // 강제 배포는 dispatch 입력으로만. shell 안에서 직접 보간하지 않는다.
     expect(workflow).toContain('FORCE: ${{ inputs.force }}');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -2860,7 +2860,7 @@ export function CashflowProjectSheet({
                 </div>
               </div>
               {monthCloseSectionErrors.length > 0 ? (
-                <div role="status" className="flex flex-wrap items-center gap-2 border-t border-amber-200 bg-amber-50 px-4 py-2 text-[12px] text-amber-900">
+                <div role="status" className="flex flex-wrap items-center gap-2 border-t border-border bg-accent px-4 py-2 text-[12px] text-card-foreground">
                   <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
                   <span>
                     일부 정보를 불러오지 못했습니다

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { ArrowDownToLine, CheckCircle2, ChevronLeft, ChevronRight, ClipboardCheck, ClipboardList, Columns2, FileSpreadsheet, Loader2, LockKeyhole, RefreshCw, Save } from 'lucide-react';
+import { AlertTriangle, ArrowDownToLine, CheckCircle2, ChevronLeft, ChevronRight, ClipboardCheck, ClipboardList, Columns2, FileSpreadsheet, Loader2, LockKeyhole, RefreshCw, Save } from 'lucide-react';
 import { toast } from 'sonner';
 import { useBlocker, useNavigate } from 'react-router';
 import { Button } from '../ui/button';
@@ -473,6 +473,10 @@ export function CashflowProjectSheet({
   const selectedYearMonthRef = useRef(yearMonth);
   selectedYearMonthRef.current = yearMonth;
   const monthCloseRequestLocked = isCashflowMonthCloseRequestLocked(monthCloseRequest?.status);
+  // 본체는 성공했지만 부가 섹션 조회가 실패한 경우. 화면은 유지하고 안내 + 재시도를 준다.
+  const monthCloseSectionErrors = monthCloseResult?.sectionErrors || [];
+  const deadlineSummaryUnavailable = monthCloseSectionErrors.some((entry) => entry.section === 'deadlineSummary')
+    || (Boolean(monthCloseResult?.dashboard) && monthCloseResult?.dashboard?.deadlineSummary == null);
   // 조직장이 검토를 시작하면(APPROVING) JVM 확정이 이미 나갔을 수 있어 회수할 수 없다.
   const canWithdrawMonthCloseRequest = Boolean(
     monthCloseRequest
@@ -2850,11 +2854,29 @@ export function CashflowProjectSheet({
                   ) : null}
                 </div>
                 <div className="mt-3 flex items-center gap-4 text-[12px] text-muted-foreground">
-                  <span>누적 미준수 <strong className="ml-1 text-red-700">{monthCloseResult?.dashboard?.deadlineSummary?.missedCount || 0}회</strong></span>
-                  <span>기한 내 완료 <strong className="ml-1 text-primary">{monthCloseResult?.dashboard?.deadlineSummary?.completedCount || 0}회</strong></span>
+                  <span>누적 미준수 <strong className="ml-1 text-red-700">{deadlineSummaryUnavailable ? '확인 불가' : `${monthCloseResult?.dashboard?.deadlineSummary?.missedCount || 0}회`}</strong></span>
+                  <span>기한 내 완료 <strong className="ml-1 text-primary">{deadlineSummaryUnavailable ? '확인 불가' : `${monthCloseResult?.dashboard?.deadlineSummary?.completedCount || 0}회`}</strong></span>
                   <button type="button" className="font-semibold text-[#17324D] underline underline-offset-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#17324D]" onClick={() => setWeeklyHistoryOpen(true)}>자세히</button>
                 </div>
               </div>
+              {monthCloseSectionErrors.length > 0 ? (
+                <div role="status" className="flex flex-wrap items-center gap-2 border-t border-amber-200 bg-amber-50 px-4 py-2 text-[12px] text-amber-900">
+                  <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+                  <span>
+                    일부 정보를 불러오지 못했습니다
+                    {` (${monthCloseSectionErrors.map((entry) => entry.section === 'deadlineSummary' ? '주간 준수 이력' : entry.section === 'sheetPublication' ? '시트 반영 상태' : entry.section).join(', ')})`}
+                    . 아래 현금흐름 수치는 유효합니다.
+                  </span>
+                  <button
+                    type="button"
+                    className="font-semibold underline underline-offset-2"
+                    disabled={monthCloseLoading}
+                    onClick={() => { void loadCashflowMonthClose(); }}
+                  >
+                    다시 불러오기
+                  </button>
+                </div>
+              ) : null}
               <div className="bg-card px-4 py-3">
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div>

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -996,7 +996,8 @@ export interface CashflowMonthCloseDashboard {
     status: 'LIVE_CURRENT' | 'LIVE_AMENDED' | 'FROZEN_COMPLETE' | 'LEGACY_EVIDENCE_ONLY';
     missingEvidence: Array<'OPENING_BALANCES' | 'LEDGER_WEEKS'>;
   };
-  deadlineSummary: CashflowDeadlineSummary;
+  // 주간 준수 이력을 못 읽으면 서버가 null 로 내리고 sectionErrors 로 알린다.
+  deadlineSummary: CashflowDeadlineSummary | null;
   projectionActualSummary: CashflowProjectionActualSummary;
   cumulativeCloseScope: CashflowCumulativeCloseScope | null;
   monthCloseStatuses?: Array<{
@@ -1309,6 +1310,9 @@ export interface CashflowMonthCloseResult {
   reopenDecidedByUid: string | null;
   auditId: string | null;
   dashboard?: CashflowMonthCloseDashboard;
+  // 본체(dashboard-source)는 성공했지만 부가 조회가 실패해 일부 섹션이 비었을 때.
+  // 화면은 그대로 그리되 이 목록으로 사용자에게 알리고 재시도 경로를 준다.
+  sectionErrors?: Array<{ section: 'sheetPublication' | 'deadlineSummary' | string; code: string }>;
 }
 
 export interface CashflowWeeklyUpdateCompletionResult {


### PR DESCRIPTION
## 오늘 장애

JVM Cloud Run 인스턴스 하나가 행에 걸리자 **전 프로젝트의 월결산 화면이 동시에 503** 으로 죽었다. 직접 프로브로 확정: 유효한 ID 토큰으로 `/api/v1/health`(인증 불요)조차 60초 무응답, 무인증은 403 즉시. 강제 재배포로 복구 완료 (200/0.25s).

## 두 층의 원인과 수정

### 1. 인프라 — 행 걸린 인스턴스가 영구 보존됐다

`--min-instances 1` 은 같은 인스턴스를 계속 살려둔다. 프로브가 없으면 Cloud Run 이 죽은 컨테이너를 교체할 방법이 없다. 예전(min-instances 0)에는 유휴 재활용이 이걸 우연히 가려줬다.

→ `--liveness-probe httpGet.path=/api/v1/health` (30s 주기, 3연속 실패 시 교체). 다음 행은 ~90초짜리 self-healing 이벤트가 된다.

### 2. 구조 — 부가 조회가 본체와 동급으로 묶여 all-or-nothing

독립 에이전트 전수조사: 읽기 경로 **실패 지점 22개** 중 부가 조회 실패 **6곳이 부당하게 전체를 죽임**. 원칙: **본체(dashboard-source) 실패만 전체 실패. 독립 부가 조회는 섹션 열화.**

| 실패 | 기존 | 변경 |
|---|---|---|
| JVM dashboard-source 5xx | 503 전체 | **유지** (대체 표시 불가, 테스트로 고정) |
| 시트 반영 상태 읽기(전/후) 실패 | 500 전체 | 섹션 비움 + `sectionErrors` |
| 주간 준수 이력 실패 | 503 전체 | `deadlineSummary: null` + `sectionErrors` |
| **확정(쓰기) 경로 전부** | fail-closed | **그대로 fail-closed** |

**판정 불능 ≠ 문제 없음**: compliance 를 못 읽었을 때 빈 이력으로 "지각 0회"를 그리지 않는다. 화면은 준수 카운트를 "확인 불가"로 바꾸고, 배너로 어떤 섹션이 비었는지 + **"다시 불러오기"** 재시도 버튼 + "아래 수치는 유효합니다" 안내를 띄운다.

### 3. 인증 경로 지뢰 2건 (전수조사 부산물)

- **`google-auth-library` 가 유령 의존성이었다** — package.json 에 없이 hoist 로만 존재. v10 은 `getRequestHeaders()` 가 `Headers` 를 반환해 기존 `.Authorization` 읽기가 `undefined` → 전 요청 503. 설치 트리가 바뀌는 순간 터지는 시한폭탄. 직접 의존성 ^9.15.1 로 고정 + 두 반환 형태 모두 읽게 수정.
- **토큰 실패 시 `identityTokenClients.clear()`** 가 Map 전체를 비워 무관한 정상 클라이언트까지 축출 (thundering herd). 실패한 키만 `delete`.

### 4. 관측성

`readJavaError` 가 JVM 5xx 를 503 으로 정규화해서 **로그만으론 BFF 실패와 JVM 실패를 구분 못 했다** — 오늘 진단이 늦은 직접 원인. `attempt_complete` 에 `upstreamStatus` 를 싣는다.

## 검증

- 새 테스트 3: compliance 실패 → 200 + `deadlineSummary:null` + `sectionErrors` / publication 실패 → 200 + `pendingApply:null` + `sectionErrors` / 본체 5xx → **여전히 503**
- Sabotage: compliance 열화 catch 제거 → 테스트 사망 확인
- `server/bff` 1043 passed · typecheck no new errors · 워크플로 가드 테스트에 liveness probe 고정

🤖 Generated with [Claude Code](https://claude.com/claude-code)