### PR TITLE
chore: 통장내역(은행 매칭) 라우트 제거

### DIFF
--- a/src/app/platform/shell-lab-visibility.test.ts
+++ b/src/app/platform/shell-lab-visibility.test.ts
@@ -40,7 +40,6 @@ describe('shell LAB visibility', () => {
       '/business-cards',
       '/board',
       '/evidence',
-      '/bank-reconciliation',
       '/payroll',
       '/budget-summary',
       '/expense-management',

--- a/src/app/platform/shell-lab-visibility.ts
+++ b/src/app/platform/shell-lab-visibility.ts
@@ -17,7 +17,6 @@ export const ADMIN_LAB_ROUTES = [
   '/business-cards',
   '/board',
   '/evidence',
-  '/bank-reconciliation',
   '/payroll',
   '/budget-summary',
   '/expense-management',

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -70,7 +70,6 @@ const UserManagementPage = lazyRoute(() => import('./components/users/UserManage
 const AdminHrAnnouncementPage = lazyRoute(() => import('./components/hr/AdminHrAnnouncementPage'), 'AdminHrAnnouncementPage');
 const AdminPayrollPage = lazyRoute(() => import('./components/payroll/AdminPayrollPage'), 'AdminPayrollPage');
 const TrainingManagePage = lazyRoute(() => import('./components/training/TrainingManagePage'), 'TrainingManagePage');
-const BankReconciliationPage = lazyRoute(() => import('./components/cashflow/BankReconciliationPage'), 'BankReconciliationPage');
 const NotFoundPage = lazyRoute(() => import('./components/layout/NotFoundPage'), 'NotFoundPage');
 
 // Portal pages
@@ -158,7 +157,6 @@ export const router = createBrowserRouter([
       { path: 'cashflow/projects', element: <S C={CashflowPage} /> },
       { path: 'cashflow/projects/:projectId', element: <S C={ProjectCashflowSheetPage} /> },
       { path: 'evidence', element: <S C={EvidenceQueuePage} /> },
-      { path: 'bank-reconciliation', element: <S C={BankReconciliationPage} /> },
       { path: 'participation', element: <S C={ParticipationPage} /> },
       { path: 'koica-personnel', element: <S C={KoicaPersonnelPage} /> },
       { path: 'personnel-changes', element: <S C={PersonnelChangePage} /> },


### PR DESCRIPTION
\`/bank-reconciliation\` 라우트와 LAB 노출 목록 항목을 제거한다.

- 이 화면은 전 프로젝트 거래를 한 화면에 펼치는 전역 관리자 화면이었다 (프로젝트 필터 기본값 \`ALL\`). "모든 프로젝트에서 통장내역이 보인다"는 관찰의 실체이고, 최근 배포와 무관한 이 페이지의 원래 설계다.
- 라우트 제거로 직접 URL 접근은 NotFound.
- 컴포넌트와 매칭 로직 파일은 남긴다 — 이 PR 의 범위는 노출 제거이고, 남은 참조 0 확인. 파일 삭제는 별도 결정.
- **PM 통장내역(\`/portal/bank-statements\`)은 다른 화면이라 영향 없다.** PortalPayrollPage 의 "통장내역 열기" 버튼도 그쪽을 가리킨다.

검증: shell-lab-visibility / CashflowMonitorPage shell 테스트 10 passed, typecheck no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)