### PR TITLE
refactor: 해시 parity + JVM 계층 정리 2·3단계

### DIFF
--- a/server/bff/cashflow-close-hash.mjs
+++ b/server/bff/cashflow-close-hash.mjs
@@ -1,0 +1,22 @@
+// 월 결산 근거 해시의 단일 소스 (BFF 쪽).
+//
+// BFF 가 결산 요청의 샤드/manifest 에 이 해시를 써 두고, JVM 이 확정 직전에
+// 같은 규칙으로 다시 계산해 "거부 판정"에 쓴다
+// (FirestoreInheritedWeeklyExpensePersistence.requireCumulativeCloseApproval).
+// 두 런타임이 같은 규칙을 각자 구현하면 조용히 갈린다 - SPEC-16 의 revision 해시가
+// JVM a400f3… / BFF ea20de… 로 갈렸던 것이 정확히 이 종류다. 여기가 갈리면 조직장
+// 승인 자체가 "근거가 손상되었습니다"로 거부된다.
+//
+// 그래서 규칙을 이 모듈과 JVM 의 domain/CashflowCloseHash.java 두 곳에만 두고,
+// 같은 고정 fixture 표를 양쪽 테스트에 둔다 (cashflow-close-hash.test.mjs /
+// CashflowCloseHashTest). 한쪽을 고치면 다른 쪽 표가 깨지도록 한 것이다.
+//
+// 규칙: 맵 키를 재귀적으로 정렬(UTF-16 코드유닛 순) -> 압축 JSON -> SHA-256 -> "sha256:" 접두.
+// 숫자는 JS JSON.stringify 표현을 따른다. JVM 쪽은 BigDecimal.stripTrailingZeros 로
+// 1.0 -> 1 을 맞춘다.
+import { createHash } from 'node:crypto';
+import { stableStringify } from './utils.mjs';
+
+export function cashflowCloseHash(value) {
+  return `sha256:${createHash('sha256').update(stableStringify(value)).digest('hex')}`;
+}

--- a/server/bff/cashflow-close-hash.test.mjs
+++ b/server/bff/cashflow-close-hash.test.mjs
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { cashflowCloseHash } from './cashflow-close-hash.mjs';
+
+// BFF <-> JVM parity 표. JVM CashflowCloseHashTest 가 정확히 같은 입력과 기대값을 가진다.
+// 이 표를 고치면 반드시 JVM 쪽 표도 함께 고쳐야 한다 - 두 값이 갈리면 라이브에서
+// 조직장 승인이 "근거가 손상되었습니다"(409) 로 거부된다.
+//
+// 입력은 실제로 오가는 형태를 덮는다: 정렬 안 된 키, 중첩 맵/배열(샤드), 한글 문자열,
+// 정수/음수/0/소수, 빈 컬렉션과 null.
+const CLOSE_HASH_PARITY = [
+  {
+    name: 'simple unsorted keys',
+    value: { b: 1, a: 'x' },
+    hash: 'sha256:cdab067e9f3beb32d1252cfd63e492592fecbf591b0d08cadb24bb17f3864246',
+  },
+  {
+    name: 'cumulative close shard shape',
+    value: {
+      contractVersion: 'cashflow-cumulative-close-v2',
+      requestId: 'p123-2026-08',
+      requestRevision: 2,
+      projectId: 'p123',
+      yearMonth: '2023-01',
+      cells: [
+        { mode: 'projection', weekNo: 1, cashflowLine: 'SALES_IN', cellState: 'EMPTY', amount: null },
+        { mode: 'actual', weekNo: 5, cashflowLine: 'BANK_INTEREST_OUT', cellState: 'VALUE', amount: 7582243 },
+      ],
+      source: { spreadsheetId: 'sheet-a', sourceRevision: `sha256:${'ab'.repeat(32)}` },
+    },
+    hash: 'sha256:12b47306a6b0e03d565d5e549d21944e9a65565b6d1cab1e34729be887169da7',
+  },
+  {
+    name: 'korean keys and values',
+    value: { 사유: '감사 지적으로 정정', 상태: '확정' },
+    hash: 'sha256:66a3b9a944c4f4675af7c2066727da4d14136a6fd083c1e30fecd6849d8739b8',
+  },
+  {
+    name: 'number forms',
+    value: { zero: 0, negative: -5, big: 123456789, fraction: 1.5 },
+    hash: 'sha256:1ec728a405d2d92079835069029e55b8683ae5199d6a975bb4d1ca0bfa29716d',
+  },
+  {
+    name: 'empty collections and null',
+    value: { list: [], map: {}, nothing: null },
+    hash: 'sha256:92c9fb1a630c449e63f2a610dbd4e06d47d679ce8b711d185b765101c6943dc4',
+  },
+];
+
+describe('cashflowCloseHash', () => {
+  it.each(CLOSE_HASH_PARITY)('matches the JVM parity table: $name', ({ value, hash }) => {
+    expect(cashflowCloseHash(value)).toBe(hash);
+  });
+
+  it('is insensitive to key insertion order at every depth', () => {
+    const forward = cashflowCloseHash({ outer: { a: 1, b: [{ c: 2, d: 3 }] } });
+    const reversed = cashflowCloseHash({ outer: { b: [{ d: 3, c: 2 }], a: 1 } });
+    expect(forward).toBe(reversed);
+  });
+
+  it('treats array order as meaningful', () => {
+    expect(cashflowCloseHash({ cells: [1, 2] })).not.toBe(cashflowCloseHash({ cells: [2, 1] }));
+  });
+});

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -23,10 +23,10 @@ import { cashflowApplyLeaseMs, readCashflowApplyLeaseState } from '../cashflow-a
 import { getMonthFinanceWeeks } from '../../../src/app/platform/cashflow-week-core.mjs';
 import { WEEKS_PER_MONTH, annualYearsFor, weekOrdinal } from '../cashflow-coordinates.mjs';
 import { TENANT_WIDE_PROJECT_ROLES, isProjectInActorScope } from '../cashflow-project-scope.mjs';
+import { cashflowCloseHash } from '../cashflow-close-hash.mjs';
 import { cashflowMonthCloseDeadline, isCashflowCloseOverdue } from '../cashflow-close-deadline.mjs';
 
 export { cashflowMonthCloseDeadline };
-import { createHash } from 'node:crypto';
 
 const CASHFLOW_MANAGEMENT_CHECK_IDS = [
   'labor-transfer',
@@ -163,9 +163,6 @@ function cashflowMonthCloseRequestMonthPath(tenantId, requestId, revision, yearM
   return `orgs/${tenantId}/cashflow_month_close_request_months/${requestId}-r${revision}-${yearMonth}`;
 }
 
-function cashflowCloseHash(value) {
-  return `sha256:${createHash('sha256').update(stableStringify(value)).digest('hex')}`;
-}
 
 export function buildCashflowMonthCloseRevisionChanges(previousCells, currentCells) {
   const key = (cell) => `${cell.mode}|${cell.weekNo}|${cell.cashflowLine}`;

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSheetLabApplyRequest.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSheetLabApplyRequest.java
@@ -1,6 +1,7 @@
 package dev.merryai.innerplatform.weekly.api;
 
 import dev.merryai.innerplatform.weekly.domain.CashflowLineCatalog;
+import dev.merryai.innerplatform.weekly.domain.CashflowMonthCellSet;
 import dev.merryai.innerplatform.weekly.domain.CashflowFormulaValidator;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -196,73 +197,19 @@ public record CashflowSheetLabApplyRequest(
     }
 
     public static List<Cell> requireCompleteMonth(List<Cell> cells) {
-        if (cells == null || cells.size() != EXPECTED_CELL_COUNT) {
-            throw new IllegalArgumentException(
-                "Cashflow sheet month must contain exactly five weeks with complete cells (160 cells)."
-            );
-        }
-
-        Map<String, Cell> cellsByKey = new LinkedHashMap<>();
-        for (Cell cell : cells) {
-            if (cell == null || cell.weekNo() < 1 || cell.weekNo() > FINANCE_WEEK_COUNT) {
-                throw new IllegalArgumentException("Cashflow sheet month must contain exactly five weeks.");
-            }
-            String lineId = CashflowLineCatalog.canonicalize(cell.cashflowLine());
-            if (lineId.isBlank() || !CashflowLineCatalog.ALL_LINES.contains(lineId)) {
-                throw new IllegalArgumentException("Unsupported cashflow line.");
-            }
-            String state = cell.cellState() == null
-                ? ""
-                : cell.cellState().trim().toUpperCase(Locale.ROOT);
-            if (("VALUE".equals(state) || "ZERO".equals(state)) && cell.amount() == null) {
-                throw new IllegalArgumentException("VALUE cashflow cells require an amount.");
-            }
-            if ("VALUE".equals(state) || "ZERO".equals(state)) {
-                try {
-                    cell.amount().longValueExact();
-                } catch (ArithmeticException error) {
-                    throw new IllegalArgumentException(
-                        "Cashflow amounts must be whole won values in the supported range."
-                    );
-                }
-            }
-            if ("ZERO".equals(state) && cell.amount().compareTo(BigDecimal.ZERO) != 0) {
-                throw new IllegalArgumentException("ZERO cashflow cells require an explicit zero amount.");
-            }
-            if ("EMPTY".equals(state) && cell.amount() != null) {
-                throw new IllegalArgumentException("EMPTY cashflow cells must not include an amount.");
-            }
-            if (!"VALUE".equals(state) && !"ZERO".equals(state) && !"EMPTY".equals(state)) {
-                throw new IllegalArgumentException("Cashflow cellState must be VALUE, ZERO, or EMPTY.");
-            }
-
-            Cell canonical = new Cell(
-                cell.mode(),
-                cell.weekNo(),
-                lineId,
-                state,
-                cell.amount(),
-                cell.sourceCell(),
-                cell.sourceLabel()
-            );
-            String key = canonical.mode() + ":" + canonical.weekNo() + ":" + canonical.cashflowLine();
-            if (cellsByKey.putIfAbsent(key, canonical) != null) {
-                throw new IllegalArgumentException("Cashflow sheet month contains duplicate cells.");
-            }
-        }
-
-        for (int weekNo = 1; weekNo <= FINANCE_WEEK_COUNT; weekNo += 1) {
-            for (String mode : List.of("projection", "actual")) {
-                for (String lineId : CashflowLineCatalog.ALL_LINES) {
-                    if (!cellsByKey.containsKey(mode + ":" + weekNo + ":" + lineId)) {
-                        throw new IllegalArgumentException(
-                            "Cashflow sheet month must contain complete cells for exactly five weeks."
-                        );
-                    }
-                }
-            }
-        }
-        return List.copyOf(cellsByKey.values());
+        // 규칙은 domain/CashflowMonthCellSet 에 있다. 여기는 표현 <-> 도메인 매핑만 한다.
+        List<CashflowMonthCellSet.Cell> domainCells = cells == null ? null : cells.stream()
+            .map(cell -> cell == null ? null : new CashflowMonthCellSet.Cell(
+                cell.mode(), cell.weekNo(), cell.cashflowLine(), cell.cellState(),
+                cell.amount(), cell.sourceCell(), cell.sourceLabel()
+            ))
+            .toList();
+        return CashflowMonthCellSet.requireComplete(domainCells).stream()
+            .map(cell -> new Cell(
+                cell.mode(), cell.weekNo(), cell.cashflowLine(), cell.cellState(),
+                cell.amount(), cell.sourceCell(), cell.sourceLabel()
+            ))
+            .toList();
     }
 
     public static List<Map<String, Object>> recalculateCalculationChecks(

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -23,6 +23,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.server.ResponseStatusException;
+import dev.merryai.innerplatform.weekly.domain.CashflowWeekTotals;
+import dev.merryai.innerplatform.weekly.service.CashflowReadService;
 import dev.merryai.innerplatform.weekly.storage.WeeklyExpensePersistence;
 
 import java.math.BigDecimal;
@@ -41,16 +43,16 @@ public class WeeklyExpenseController {
     private static final ObjectMapper JSON = new ObjectMapper();
     private static final long MAX_SAFE_INTEGER = 9_007_199_254_740_991L;
     private final WeeklyExpenseCommandService commandService;
-    private final WeeklyExpensePersistence persistence;
+    private final CashflowReadService readService;
     private final boolean legacyWeekCloseEnabled;
 
     public WeeklyExpenseController(
         WeeklyExpenseCommandService commandService,
-        WeeklyExpensePersistence persistence,
+        CashflowReadService readService,
         @Value("${weekly.legacy-week-close-enabled:false}") boolean legacyWeekCloseEnabled
     ) {
         this.commandService = commandService;
-        this.persistence = persistence;
+        this.readService = readService;
         this.legacyWeekCloseEnabled = legacyWeekCloseEnabled;
     }
 
@@ -283,7 +285,7 @@ public class WeeklyExpenseController {
         @RequestHeader(value = "x-actor-email", required = false) String actorEmail
     ) {
         commandService.requireProjectAllowed(WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, actorContext(tenantId, actorId, actorRole, actorEmail), projectId);
-        Integer weeklyYear = persistence.findCashflowDeclaredWeeklyYear(tenantId, projectId);
+        Integer weeklyYear = readService.declaredWeeklyYear(tenantId, projectId);
         WeeklyExpensePersistence.CashflowLedgerSource source = weeklyYear == null
             ? new WeeklyExpensePersistence.CashflowLedgerSource(List.of(), List.of())
             : readCashflowSource(tenantId, projectId, weeklyYear);
@@ -308,7 +310,7 @@ public class WeeklyExpenseController {
         String projectId,
         int weeklyYear
     ) {
-        return persistence.findCashflowLedgerSource(tenantId, projectId, weeklyYear);
+        return readService.ledgerSource(tenantId, projectId, weeklyYear);
     }
 
     private CashflowSnapshotResponse buildCashflowSnapshot(
@@ -481,7 +483,7 @@ public class WeeklyExpenseController {
             : open
                 ? new CashflowMonthDashboardSourceResponse.SnapshotCompatibility("LIVE_CURRENT", List.of())
                 : frozenSnapshotCompatibility(monthClose);
-        Integer weeklyYear = open ? persistence.findCashflowDeclaredWeeklyYear(tenantId, projectId) : null;
+        Integer weeklyYear = open ? readService.declaredWeeklyYear(tenantId, projectId) : null;
         List<CashflowMonthDashboardSourceResponse.Blocker> blockers = open && weeklyYear == null
             ? List.of(new CashflowMonthDashboardSourceResponse.Blocker(
                 "SHEET_SOURCE_REQUIRED",
@@ -489,7 +491,7 @@ public class WeeklyExpenseController {
             ))
             : List.of();
         WeeklyExpensePersistence.CashflowLedgerSource source = amendedClosed
-            ? persistence.findCashflowGlobalLedgerSource(tenantId, projectId)
+            ? readService.globalLedgerSource(tenantId, projectId)
             : open && weeklyYear != null
                 ? readCashflowSource(tenantId, projectId, weeklyYear)
                 : open
@@ -497,7 +499,7 @@ public class WeeklyExpenseController {
                     : null;
         CashflowSnapshotResponse cashflow = currentLedgerView ? buildCashflowSnapshot(projectId, source) : null;
         CashflowOpeningBalancesResponse openingBalances = currentLedgerView
-            ? toOpeningBalancesResponse(persistence.findCashflowOpeningBalance(
+            ? toOpeningBalancesResponse(readService.openingBalance(
                 tenantId,
                 projectId,
                 Integer.parseInt(yearMonth.substring(0, 4))
@@ -525,8 +527,7 @@ public class WeeklyExpenseController {
             }
             monthClose = verified;
         }
-        WeeklyExpensePersistence.CashflowCumulativeCloseHead cumulative = persistence
-            .findCashflowCumulativeCloseHead(tenantId, projectId);
+        WeeklyExpensePersistence.CashflowCumulativeCloseHead cumulative = readService.cumulativeCloseHead(tenantId, projectId);
         if (cumulative == null) {
             cumulative = new WeeklyExpensePersistence.CashflowCumulativeCloseHead("OPEN", "2023-01", "", "", 0);
         }
@@ -873,7 +874,7 @@ public class WeeklyExpenseController {
         commandService.requireProjectAllowed(WeeklyExpenseCommandService.WEEKLY_STATUS_READ_COMMAND, actorContext(tenantId, actorId, actorRole, actorEmail), projectId);
         return new WeeklyExpenseStatusesResponse(
             projectId,
-            persistence.findWeeklyStatuses(tenantId, projectId).stream()
+            readService.weeklyStatuses(tenantId, projectId).stream()
                 .map(status -> new WeeklyExpenseStatusesResponse.WeeklyStatusLine(
                     status.getProjectId() + "-" + status.getYearMonth() + "-w" + status.getWeekNo(),
                     status.getProjectId(),
@@ -969,7 +970,7 @@ public class WeeklyExpenseController {
             amountsByMonth
                 .computeIfAbsent(line.yearMonth(), ignored -> new TreeMap<>())
                 .computeIfAbsent(line.weekNo(), ignored -> new LinkedHashMap<>())
-                .merge(lineId, safeAmount(line.amount()), BigDecimal::add);
+                .merge(lineId, CashflowWeekTotals.safeAmount(line.amount()), BigDecimal::add);
         }
 
         Map<String, CashflowSnapshotResponse.ModeReadModel> readModels = new LinkedHashMap<>();
@@ -985,8 +986,8 @@ public class WeeklyExpenseController {
                 for (Map.Entry<String, BigDecimal> amountEntry : weekAmounts.entrySet()) {
                     rowTotals.merge(amountEntry.getKey(), amountEntry.getValue(), BigDecimal::add);
                 }
-                BigDecimal weekIn = sumLines(weekAmounts, CashflowLineCatalog.IN_LINES);
-                BigDecimal weekOut = sumLines(weekAmounts, CashflowLineCatalog.OUT_LINES);
+                BigDecimal weekIn = CashflowWeekTotals.sumLines(weekAmounts, CashflowLineCatalog.IN_LINES);
+                BigDecimal weekOut = CashflowWeekTotals.sumLines(weekAmounts, CashflowLineCatalog.OUT_LINES);
                 monthIn = monthIn.add(weekIn);
                 monthOut = monthOut.add(weekOut);
                 runningIn = runningIn.add(weekIn);
@@ -1031,21 +1032,11 @@ public class WeeklyExpenseController {
             .sorted(Comparator.comparing(Map.Entry::getKey))
             .collect(
                 LinkedHashMap::new,
-                (target, entry) -> target.put(entry.getKey(), safeAmount(entry.getValue())),
+                (target, entry) -> target.put(entry.getKey(), CashflowWeekTotals.safeAmount(entry.getValue())),
                 LinkedHashMap::putAll
             );
     }
 
-    private BigDecimal sumLines(Map<String, BigDecimal> amounts, Set<String> lineIds) {
-        return amounts.entrySet().stream()
-            .filter(entry -> lineIds.contains(entry.getKey()))
-            .map(entry -> safeAmount(entry.getValue()))
-            .reduce(BigDecimal.ZERO, BigDecimal::add);
-    }
-
-    private BigDecimal safeAmount(BigDecimal amount) {
-        return amount == null ? BigDecimal.ZERO : amount;
-    }
 
     private void requireCashflowWeeklyUpdateScope(String yearMonth, int weekNo) {
         if (

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowCloseHash.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowCloseHash.java
@@ -1,0 +1,78 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * 월 결산 근거 해시의 단일 소스 (JVM 쪽).
+ *
+ * <p>BFF 가 결산 요청의 샤드/manifest 에 이 해시를 써 두고, JVM 이 확정 직전에 같은
+ * 규칙으로 다시 계산해 거부 판정에 쓴다. 두 런타임이 같은 규칙을 각자 구현하면 조용히
+ * 갈린다 - SPEC-16 의 revision 해시가 실제로 갈렸다. 여기가 갈리면 조직장 승인이
+ * "근거가 손상되었습니다"(409) 로 거부된다.
+ *
+ * <p>규칙을 이 클래스와 {@code server/bff/cashflow-close-hash.mjs} 두 곳에만 두고,
+ * 같은 고정 fixture 표를 양쪽 테스트에 둔다 (CashflowCloseHashTest /
+ * cashflow-close-hash.test.mjs). 한쪽을 고치면 다른 쪽 표가 깨지도록 한 것이다.
+ *
+ * <p>규칙: 맵 키를 재귀적으로 정렬(UTF-16 코드유닛 순) → 압축 JSON → SHA-256 →
+ * "sha256:" 접두. 숫자는 JS {@code JSON.stringify} 표현에 맞춘다 -
+ * {@code stripTrailingZeros} 로 1.0 → 1, 소수는 그대로.
+ */
+public final class CashflowCloseHash {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private CashflowCloseHash() {
+    }
+
+    public static String hash(Map<String, Object> value) {
+        try {
+            String json = JSON.writeValueAsString(canonicalValue(value));
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(json.getBytes(StandardCharsets.UTF_8));
+            return "sha256:" + HexFormat.of().formatHex(digest);
+        } catch (JsonProcessingException | NoSuchAlgorithmException error) {
+            throw new IllegalStateException("Could not hash cashflow close evidence.", error);
+        }
+    }
+
+    static Object canonicalValue(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            Map<String, Object> sorted = new TreeMap<>();
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                sorted.put(String.valueOf(entry.getKey()), canonicalValue(entry.getValue()));
+            }
+            return sorted;
+        }
+        if (value instanceof Iterable<?> iterable) {
+            List<Object> values = new ArrayList<>();
+            for (Object item : iterable) values.add(canonicalValue(item));
+            return values;
+        }
+        if (value instanceof Number number) return normalizedNumber(number);
+        return value;
+    }
+
+    /** JS 숫자 표현과의 parity: 1.0 → 1(long), 1.5 → 1.5(BigDecimal), -0 → 0. */
+    public static Object normalizedNumber(Number number) {
+        BigDecimal value = number instanceof BigDecimal decimal
+            ? decimal
+            : new BigDecimal(number.toString());
+        value = value.signum() == 0 ? BigDecimal.ZERO : value.stripTrailingZeros();
+        try {
+            return value.longValueExact();
+        } catch (ArithmeticException ignored) {
+            return value;
+        }
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowMonthCellSet.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowMonthCellSet.java
@@ -1,0 +1,104 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * 한 달 결산 셀 집합의 완전성 규칙. 라인 16종 x 모드 2 x 주차 5 = 160셀이 전부 있어야
+ * 하고, 상태(VALUE/ZERO/EMPTY)와 금액의 정합이 맞아야 하며, 중복이 없어야 한다.
+ *
+ * <p>이 규칙은 원래 api DTO(CashflowSheetLabApplyRequest.requireCompleteMonth)에 있었다.
+ * 업무 규칙이 HTTP 표현 계층에 있으면 service 가 api 를 의존하는 역방향이 강제된다.
+ * DTO 는 이제 표현 <-> 도메인 매핑만 하고, 규칙은 여기 있다. 예외 메시지는 이동 전과
+ * 문자 그대로 동일하다 - 행동 보존.
+ */
+public final class CashflowMonthCellSet {
+
+    public record Cell(
+        String mode,
+        int weekNo,
+        String cashflowLine,
+        String cellState,
+        BigDecimal amount,
+        String sourceCell,
+        String sourceLabel
+    ) {
+    }
+
+    private CashflowMonthCellSet() {
+    }
+
+    /** 검증 + 정규화(라인 canonicalize, 상태 대문자). 실패는 IllegalArgumentException. */
+    public static List<Cell> requireComplete(List<Cell> cells) {
+        if (cells == null || cells.size() != CashflowLineCatalog.monthCellCount()) {
+            throw new IllegalArgumentException(
+                "Cashflow sheet month must contain exactly five weeks with complete cells (160 cells)."
+            );
+        }
+
+        Map<String, Cell> cellsByKey = new LinkedHashMap<>();
+        for (Cell cell : cells) {
+            if (cell == null || cell.weekNo() < 1 || cell.weekNo() > CashflowLineCatalog.WEEKS_PER_MONTH) {
+                throw new IllegalArgumentException("Cashflow sheet month must contain exactly five weeks.");
+            }
+            String lineId = CashflowLineCatalog.canonicalize(cell.cashflowLine());
+            if (lineId.isBlank() || !CashflowLineCatalog.ALL_LINES.contains(lineId)) {
+                throw new IllegalArgumentException("Unsupported cashflow line.");
+            }
+            String state = cell.cellState() == null
+                ? ""
+                : cell.cellState().trim().toUpperCase(Locale.ROOT);
+            if (("VALUE".equals(state) || "ZERO".equals(state)) && cell.amount() == null) {
+                throw new IllegalArgumentException("VALUE cashflow cells require an amount.");
+            }
+            if ("VALUE".equals(state) || "ZERO".equals(state)) {
+                try {
+                    cell.amount().longValueExact();
+                } catch (ArithmeticException error) {
+                    throw new IllegalArgumentException(
+                        "Cashflow amounts must be whole won values in the supported range."
+                    );
+                }
+            }
+            if ("ZERO".equals(state) && cell.amount().compareTo(BigDecimal.ZERO) != 0) {
+                throw new IllegalArgumentException("ZERO cashflow cells require an explicit zero amount.");
+            }
+            if ("EMPTY".equals(state) && cell.amount() != null) {
+                throw new IllegalArgumentException("EMPTY cashflow cells must not include an amount.");
+            }
+            if (!"VALUE".equals(state) && !"ZERO".equals(state) && !"EMPTY".equals(state)) {
+                throw new IllegalArgumentException("Cashflow cellState must be VALUE, ZERO, or EMPTY.");
+            }
+
+            Cell canonical = new Cell(
+                cell.mode(),
+                cell.weekNo(),
+                lineId,
+                state,
+                cell.amount(),
+                cell.sourceCell(),
+                cell.sourceLabel()
+            );
+            String key = canonical.mode() + ":" + canonical.weekNo() + ":" + canonical.cashflowLine();
+            if (cellsByKey.putIfAbsent(key, canonical) != null) {
+                throw new IllegalArgumentException("Cashflow sheet month contains duplicate cells.");
+            }
+        }
+
+        for (int weekNo = 1; weekNo <= CashflowLineCatalog.WEEKS_PER_MONTH; weekNo += 1) {
+            for (String mode : List.of("projection", "actual")) {
+                for (String lineId : CashflowLineCatalog.ALL_LINES) {
+                    if (!cellsByKey.containsKey(mode + ":" + weekNo + ":" + lineId)) {
+                        throw new IllegalArgumentException(
+                            "Cashflow sheet month must contain complete cells for exactly five weeks."
+                        );
+                    }
+                }
+            }
+        }
+        return List.copyOf(cellsByKey.values());
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowWeekTotals.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowWeekTotals.java
@@ -1,0 +1,27 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 주차 금액 집계. 라인 합산은 도메인 규칙(IN/OUT 라인 분류에 의존)이라 컨트롤러의
+ * private 메서드가 아니라 여기 있어야 한다 - BFF 의 cashflow-amounts 계열과 나란히
+ * 비교할 수 있는 자리이기도 하다.
+ */
+public final class CashflowWeekTotals {
+
+    private CashflowWeekTotals() {
+    }
+
+    public static BigDecimal sumLines(Map<String, BigDecimal> amounts, Set<String> lineIds) {
+        return amounts.entrySet().stream()
+            .filter(entry -> lineIds.contains(entry.getKey()))
+            .map(entry -> safeAmount(entry.getValue()))
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    public static BigDecimal safeAmount(BigDecimal amount) {
+        return amount == null ? BigDecimal.ZERO : amount;
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/CashflowReadService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/CashflowReadService.java
@@ -1,0 +1,60 @@
+package dev.merryai.innerplatform.weekly.service;
+
+import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseWeeklyStatusEntity;
+import dev.merryai.innerplatform.weekly.storage.WeeklyExpensePersistence;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 컨트롤러의 읽기 경로가 통과하는 애플리케이션 서비스.
+ *
+ * <p>컨트롤러가 {@link WeeklyExpensePersistence} 를 직접 잡으면 api → storage 직행이 되어
+ * 서비스 계층이 유지해야 할 공통 인터페이스(팀 원칙 C)가 사라진다 - 쓰기 경로는 전부
+ * {@link WeeklyExpenseCommandService} 를 지나는데 읽기만 우회하고 있었다. 지금은 위임뿐이지만,
+ * 읽기 정책(스코프, 열화, 캐시)이 생길 자리는 여기다.
+ */
+@Service
+public class CashflowReadService {
+
+    private final WeeklyExpensePersistence persistence;
+
+    public CashflowReadService(WeeklyExpensePersistence persistence) {
+        this.persistence = persistence;
+    }
+
+    public Integer declaredWeeklyYear(String tenantId, String projectId) {
+        return persistence.findCashflowDeclaredWeeklyYear(tenantId, projectId);
+    }
+
+    public WeeklyExpensePersistence.CashflowLedgerSource ledgerSource(
+        String tenantId,
+        String projectId,
+        Integer weeklyYear
+    ) {
+        return persistence.findCashflowLedgerSource(tenantId, projectId, weeklyYear);
+    }
+
+    public WeeklyExpensePersistence.CashflowLedgerSource globalLedgerSource(String tenantId, String projectId) {
+        return persistence.findCashflowGlobalLedgerSource(tenantId, projectId);
+    }
+
+    public WeeklyExpensePersistence.CashflowOpeningBalance openingBalance(
+        String tenantId,
+        String projectId,
+        int year
+    ) {
+        return persistence.findCashflowOpeningBalance(tenantId, projectId, year);
+    }
+
+    public WeeklyExpensePersistence.CashflowCumulativeCloseHead cumulativeCloseHead(
+        String tenantId,
+        String projectId
+    ) {
+        return persistence.findCashflowCumulativeCloseHead(tenantId, projectId);
+    }
+
+    public List<WeeklyExpenseWeeklyStatusEntity> weeklyStatuses(String tenantId, String projectId) {
+        return persistence.findWeeklyStatuses(tenantId, projectId);
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -36,6 +36,7 @@ import dev.merryai.innerplatform.weekly.api.WeeklyExpenseEditLeaseException;
 import dev.merryai.innerplatform.weekly.domain.CashflowCloseDeadline;
 import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseActualEntity;
 import dev.merryai.innerplatform.weekly.domain.CashflowApplyLease;
+import dev.merryai.innerplatform.weekly.domain.CashflowCloseHash;
 import dev.merryai.innerplatform.weekly.domain.CashflowMonthReopenApprovalPolicy;
 import dev.merryai.innerplatform.weekly.domain.CashflowSettlementApproverPolicy;
 import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseAuditEventEntity;
@@ -2782,15 +2783,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     }
 
     private static Object normalizedRevisionNumber(Number number) {
-        BigDecimal value = number instanceof BigDecimal decimal
-            ? decimal
-            : new BigDecimal(number.toString());
-        value = value.signum() == 0 ? BigDecimal.ZERO : value.stripTrailingZeros();
-        try {
-            return value.longValueExact();
-        } catch (ArithmeticException ignored) {
-            return value;
-        }
+        return CashflowCloseHash.normalizedNumber(number);
     }
 
     private static boolean isFinite(Number number) {
@@ -3766,30 +3759,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     }
 
     String hashCanonicalJson(Map<String, Object> value) {
-        try {
-            String json = JSON.writeValueAsString(canonicalValue(value));
-            byte[] digest = MessageDigest.getInstance("SHA-256").digest(json.getBytes(StandardCharsets.UTF_8));
-            return "sha256:" + HexFormat.of().formatHex(digest);
-        } catch (JsonProcessingException | NoSuchAlgorithmException error) {
-            throw new IllegalStateException("Could not hash cashflow month close snapshot.", error);
-        }
-    }
-
-    private Object canonicalValue(Object value) {
-        if (value instanceof Map<?, ?> map) {
-            Map<String, Object> sorted = new TreeMap<>();
-            for (Map.Entry<?, ?> entry : map.entrySet()) {
-                sorted.put(String.valueOf(entry.getKey()), canonicalValue(entry.getValue()));
-            }
-            return sorted;
-        }
-        if (value instanceof Iterable<?> iterable) {
-            List<Object> values = new ArrayList<>();
-            for (Object item : iterable) values.add(canonicalValue(item));
-            return values;
-        }
-        if (value instanceof Number number) return normalizedRevisionNumber(number);
-        return value;
+        return CashflowCloseHash.hash(value);
     }
 
     private Map<String, Object> merge(Map<String, Object> current, Map<String, Object> patch) {

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerLegacyWeekCloseDisabledTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerLegacyWeekCloseDisabledTest.java
@@ -1,5 +1,6 @@
 package dev.merryai.innerplatform.weekly.api;
 
+import dev.merryai.innerplatform.weekly.service.CashflowReadService;
 import dev.merryai.innerplatform.weekly.service.WeeklyExpenseCommandService;
 import dev.merryai.innerplatform.weekly.storage.WeeklyExpensePersistence;
 import org.junit.jupiter.api.Test;
@@ -13,7 +14,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 class WeeklyExpenseControllerLegacyWeekCloseDisabledTest {
     private final WeeklyExpenseCommandService commandService = mock(WeeklyExpenseCommandService.class);
     private final WeeklyExpensePersistence persistence = mock(WeeklyExpensePersistence.class);
-    private final WeeklyExpenseController controller = new WeeklyExpenseController(commandService, persistence, false);
+    private final WeeklyExpenseController controller = new WeeklyExpenseController(commandService, new CashflowReadService(persistence), false);
 
     @Test
     void rejectsLegacyWeeklySubmitBeforeRunningACommand() {

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
@@ -10,6 +10,7 @@ import dev.merryai.innerplatform.weekly.repository.WeeklyExpenseBankImportLineRe
 import dev.merryai.innerplatform.weekly.repository.WeeklyExpenseIdempotencyRepository;
 import dev.merryai.innerplatform.weekly.repository.WeeklyExpenseProjectionRepository;
 import dev.merryai.innerplatform.weekly.repository.WeeklyExpenseSheetRepository;
+import dev.merryai.innerplatform.weekly.service.CashflowReadService;
 import dev.merryai.innerplatform.weekly.service.WeeklyExpenseCommandService;
 import dev.merryai.innerplatform.weekly.storage.JpaWeeklyExpensePersistence;
 import dev.merryai.innerplatform.weekly.storage.WeeklyExpensePersistence;
@@ -369,9 +370,7 @@ class WeeklyExpenseControllerTest {
         WeeklyExpensePersistence snapshotPersistence = mock(WeeklyExpensePersistence.class);
         when(snapshotPersistence.findCashflowDeclaredWeeklyYear("tenant-no-year", "project-no-year"))
             .thenReturn(null);
-        WeeklyExpenseController snapshotController = new WeeklyExpenseController(
-            snapshotCommandService, snapshotPersistence, false
-        );
+        WeeklyExpenseController snapshotController = new WeeklyExpenseController(snapshotCommandService, new CashflowReadService(snapshotPersistence), false);
 
         CashflowSnapshotResponse response = snapshotController.cashflowSnapshot(
             "project-no-year", "tenant-no-year", "viewer-no-year", "viewer", "viewer@example.com"
@@ -1615,11 +1614,7 @@ class WeeklyExpenseControllerTest {
             )
         ));
 
-        CashflowMonthDashboardSourceResponse response = new WeeklyExpenseController(
-            dashboardCommandService,
-            dashboardPersistence,
-            false
-        ).readCashflowMonthDashboardSource(
+        CashflowMonthDashboardSourceResponse response = new WeeklyExpenseController(dashboardCommandService, new CashflowReadService(dashboardPersistence), false).readCashflowMonthDashboardSource(
             "project-month-dashboard",
             "2026-06",
             "tenant-month-dashboard",
@@ -1683,9 +1678,7 @@ class WeeklyExpenseControllerTest {
             java.math.BigDecimal.ZERO, true
         ));
 
-        CashflowMonthDashboardSourceResponse response = new WeeklyExpenseController(
-            dashboardCommandService, dashboardPersistence, false
-        ).readCashflowMonthDashboardSource(
+        CashflowMonthDashboardSourceResponse response = new WeeklyExpenseController(dashboardCommandService, new CashflowReadService(dashboardPersistence), false).readCashflowMonthDashboardSource(
             "project-no-year", "2026-06", "tenant-no-year", "viewer-no-year", "viewer", "viewer@example.com"
         );
 
@@ -1730,11 +1723,7 @@ class WeeklyExpenseControllerTest {
                 null, null, null, null, null, null, null, "audit-1"
             ));
 
-        CashflowMonthDashboardSourceResponse response = new WeeklyExpenseController(
-            dashboardCommandService,
-            dashboardPersistence,
-            false
-        ).readCashflowMonthDashboardSource(
+        CashflowMonthDashboardSourceResponse response = new WeeklyExpenseController(dashboardCommandService, new CashflowReadService(dashboardPersistence), false).readCashflowMonthDashboardSource(
             "project-frozen",
             "2026-06",
             "tenant-frozen",
@@ -1811,11 +1800,7 @@ class WeeklyExpenseControllerTest {
             )
         ));
 
-        CashflowMonthDashboardSourceResponse response = new WeeklyExpenseController(
-            dashboardCommandService,
-            dashboardPersistence,
-            false
-        ).readCashflowMonthDashboardSource(
+        CashflowMonthDashboardSourceResponse response = new WeeklyExpenseController(dashboardCommandService, new CashflowReadService(dashboardPersistence), false).readCashflowMonthDashboardSource(
             "project-amended",
             "2026-06",
             "tenant-amended",
@@ -1900,11 +1885,7 @@ class WeeklyExpenseControllerTest {
             )
         ));
 
-        WeeklyExpenseController controller = new WeeklyExpenseController(
-            dashboardCommandService,
-            dashboardPersistence,
-            false
-        );
+        WeeklyExpenseController controller = new WeeklyExpenseController(dashboardCommandService, new CashflowReadService(dashboardPersistence), false);
         assertThatThrownBy(() -> controller.readCashflowMonthDashboardSource(
             "project-drift",
             "2026-06",
@@ -1937,11 +1918,7 @@ class WeeklyExpenseControllerTest {
                 null, null, null, null, null, null, null, "audit-legacy"
             ));
 
-        CashflowMonthDashboardSourceResponse response = new WeeklyExpenseController(
-            dashboardCommandService,
-            dashboardPersistence,
-            false
-        ).readCashflowMonthDashboardSource(
+        CashflowMonthDashboardSourceResponse response = new WeeklyExpenseController(dashboardCommandService, new CashflowReadService(dashboardPersistence), false).readCashflowMonthDashboardSource(
             "project-legacy-frozen",
             "2026-06",
             "tenant-frozen",

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowCloseHashTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowCloseHashTest.java
@@ -1,0 +1,94 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * BFF ↔ JVM parity 표. server/bff/cashflow-close-hash.test.mjs 가 정확히 같은 입력과
+ * 기대값을 가진다. 이 표를 고치면 반드시 BFF 쪽 표도 함께 고쳐야 한다 - 두 값이 갈리면
+ * 라이브에서 조직장 승인이 "근거가 손상되었습니다"(409) 로 거부된다.
+ */
+class CashflowCloseHashTest {
+
+    @Test
+    void simpleUnsortedKeysMatchTheBffParityTable() {
+        Map<String, Object> value = new LinkedHashMap<>();
+        value.put("b", 1L);
+        value.put("a", "x");
+        assertThat(CashflowCloseHash.hash(value))
+            .isEqualTo("sha256:cdab067e9f3beb32d1252cfd63e492592fecbf591b0d08cadb24bb17f3864246");
+    }
+
+    @Test
+    void cumulativeCloseShardShapeMatchesTheBffParityTable() {
+        Map<String, Object> projectionCell = new LinkedHashMap<>();
+        projectionCell.put("mode", "projection");
+        projectionCell.put("weekNo", 1L);
+        projectionCell.put("cashflowLine", "SALES_IN");
+        projectionCell.put("cellState", "EMPTY");
+        projectionCell.put("amount", null);
+        Map<String, Object> actualCell = new LinkedHashMap<>();
+        actualCell.put("mode", "actual");
+        actualCell.put("weekNo", 5L);
+        actualCell.put("cashflowLine", "BANK_INTEREST_OUT");
+        actualCell.put("cellState", "VALUE");
+        actualCell.put("amount", 7582243L);
+        Map<String, Object> value = new LinkedHashMap<>();
+        value.put("contractVersion", "cashflow-cumulative-close-v2");
+        value.put("requestId", "p123-2026-08");
+        value.put("requestRevision", 2L);
+        value.put("projectId", "p123");
+        value.put("yearMonth", "2023-01");
+        value.put("cells", List.of(projectionCell, actualCell));
+        value.put("source", Map.of(
+            "spreadsheetId", "sheet-a",
+            "sourceRevision", "sha256:" + "ab".repeat(32)
+        ));
+        assertThat(CashflowCloseHash.hash(value))
+            .isEqualTo("sha256:12b47306a6b0e03d565d5e549d21944e9a65565b6d1cab1e34729be887169da7");
+    }
+
+    @Test
+    void koreanKeysAndValuesMatchTheBffParityTable() {
+        assertThat(CashflowCloseHash.hash(Map.of(
+            "사유", "감사 지적으로 정정",
+            "상태", "확정"
+        ))).isEqualTo("sha256:66a3b9a944c4f4675af7c2066727da4d14136a6fd083c1e30fecd6849d8739b8");
+    }
+
+    @Test
+    void numberFormsMatchTheBffParityTable() {
+        // JS 에는 1.0 이라는 표현이 없다(JSON.stringify(1.0) === "1"). JVM 쪽은
+        // stripTrailingZeros 로 같은 표현에 도달해야 한다 - Double 로 넣어 그 경로를 지난다.
+        Map<String, Object> value = new LinkedHashMap<>();
+        value.put("zero", 0L);
+        value.put("negative", -5L);
+        value.put("big", 123456789L);
+        value.put("fraction", 1.5d);
+        assertThat(CashflowCloseHash.hash(value))
+            .isEqualTo("sha256:1ec728a405d2d92079835069029e55b8683ae5199d6a975bb4d1ca0bfa29716d");
+    }
+
+    @Test
+    void emptyCollectionsAndNullMatchTheBffParityTable() {
+        Map<String, Object> value = new LinkedHashMap<>();
+        value.put("list", List.of());
+        value.put("map", Map.of());
+        value.put("nothing", null);
+        assertThat(CashflowCloseHash.hash(value))
+            .isEqualTo("sha256:92c9fb1a630c449e63f2a610dbd4e06d47d679ce8b711d185b765101c6943dc4");
+    }
+
+    @Test
+    void doubleWholeNumbersCollapseToTheJsRepresentation() {
+        // Firestore 가 double 로 저장한 7582243.0 과 long 7582243 은 같은 해시여야 한다.
+        Map<String, Object> asDouble = Map.of("amount", 7582243.0d);
+        Map<String, Object> asLong = Map.of("amount", 7582243L);
+        assertThat(CashflowCloseHash.hash(asDouble)).isEqualTo(CashflowCloseHash.hash(asLong));
+    }
+}


### PR DESCRIPTION
합의한 순서대로 세 단계를 한 브랜치에 단계별 커밋으로 쌓았다. 전부 **행동 변화 없음**.

## 커밋 1 — 결산 근거 해시 BFF↔JVM parity 표 (스코어링 최우선 위험)

BFF 가 샤드/manifest 에 써 둔 해시를 JVM 이 확정 직전 **거부 판정**에 쓰는데, 두 구현이 각자였고 JVM 테스트는 기대값을 자기 구현으로 계산했다 — 갈리는 회귀를 구조적으로 못 잡았다.

- BFF `cashflow-close-hash.mjs` / JVM `domain/CashflowCloseHash` 로 각각 추출, 영속 계층 위임
- **같은 고정 fixture 5건**(정렬 안 된 키·샤드 모양·한글·숫자형·빈/널)을 양쪽 테스트에 리터럴로 — 두 런타임이 같은 해시를 내는 것을 처음으로 상호 검증
- Firestore double `7582243.0` == long `7582243` 동일성 고정
- Sabotage: JVM 숫자 정규화 제거 → parity 테스트 사망 확인

## 커밋 2 — 컨트롤러 읽기를 애플리케이션 서비스로 (api→storage 직행 제거)

쓰기는 전부 CommandService 를 지나는데 읽기만 컨트롤러가 영속 인스턴스를 직접 잡았다(7곳). `service/CashflowReadService` 신설, 컨트롤러의 영속 접근 전부 이관. 라인 합산(sumLines/safeAmount)은 IN/OUT 분류에 의존하는 도메인 규칙이라 `domain/CashflowWeekTotals` 로.

## 커밋 3 — 160셀 규칙을 api DTO 에서 도메인으로 (역의존 해소 첫 조각)

`requireCompleteMonth` 의 완전성·정합·중복 규칙 → `domain/CashflowMonthCellSet`. DTO 는 표현↔도메인 매핑만. 예외 타입·메시지 문자까지 동일. 셀 수는 리터럴 대신 `monthCellCount()` 파생.

남은 것: CommandService 의 api DTO 47개 import 해소는 runtime 중립 커맨드 record 와 함께 여러 PR — 이 커밋이 본보기.

## 검증

- JVM **343 테스트 3회 연속 전부 통과** (커밋마다)
- BFF 전체 통과 (신규 parity 표 7 포함)
- Persistence record 타입 참조는 컨트롤러에 남음 — record 추출은 후속

🤖 Generated with [Claude Code](https://claude.com/claude-code)