### PR TITLE
refactor: 계층 분리 a·b·c — 카탈로그 parity, 달력 추출, 커맨드 역의존 절단

### DIFF
--- a/docs/wiki/patch-notes/log.md
+++ b/docs/wiki/patch-notes/log.md
@@ -289,3 +289,7 @@
 ## [2026-07-21] patch-note | portal-project-registration | 사업관리 폴더와 다년도 재무 입력 복구
 - pages: [shared-portal-architecture](./pages/shared-portal-architecture.md)
 - summary: 프로젝트 등록·수정의 계약 대상 아래에 사업관리 Google Drive 폴더 링크를 추가하고, 다년도 사업은 연도별 계약금액·매출부가세·수익·지원금의 합계만 상단에 반영하도록 정리했다. 계약기간의 한 해라도 빠지거나 확인하지 않으면 BFF가 저장을 거절한다.
+
+## [2026-08-09] patch-note | cashflow-month-cell-count | 결산 셀 수를 정책 파생 상수로 통합
+- pages: [shared-label-policy](./pages/shared-label-policy.md)
+- summary: 한 달 결산 셀 수를 policy JSON 파생 상수(`CASHFLOW_MONTH_CELL_COUNT`)로 통합했다. BFF 라우트의 리터럴 160과 안내 문구가 상수를 따르고, JVM 하드코딩 카탈로그는 같은 JSON 을 대조하는 parity 테스트로 고정된다. 라인이 추가되면 두 런타임이 함께 움직인다.

--- a/docs/wiki/patch-notes/pages/shared-label-policy.md
+++ b/docs/wiki/patch-notes/pages/shared-label-policy.md
@@ -3,7 +3,7 @@
 - route: `shared / policy`
 - primary users: 운영자, QA, 개발자
 - status: active
-- last updated: 2026-04-15
+- last updated: 2026-08-09
 
 ## Purpose
 
@@ -25,6 +25,8 @@
 - [ ] 다른 enum 도메인까지 같은 정책 구조로 확장됨
 
 ## Recent Changes
+
+- [2026-08-09] 한 달 결산 셀 수(라인 x 모드 2 x 주차 5)를 policy JSON 파생 상수 `CASHFLOW_MONTH_CELL_COUNT` 로 통합했다. BFF 라우트의 리터럴 160(샤드 검증 포함)과 사용자 문구가 전부 이 상수를 따르고, JVM `CashflowLineCatalog.monthCellCount()` 와의 일치는 양쪽 parity 테스트가 같은 JSON 을 대조해 고정한다.
 
 - [2026-04-15] `cashflow` label <-> enum <-> sheet line id <-> export label 기준을 JSON source of truth로 통합했다.
 - [2026-04-15] `bank-import-cashflow`, `settlement-csv`, `types`, `server/bff/cashflow-export`가 policy 데이터를 공유하도록 정리했다.

--- a/server/bff/cashflow-close-calendar.mjs
+++ b/server/bff/cashflow-close-calendar.mjs
@@ -1,0 +1,58 @@
+// 누적 월 결산의 달력 규칙 (BFF 쪽 도메인).
+//
+// 누적 결산은 2023-01 을 기점으로 "선택한 회차 월의 직전 월"까지를 한 번에 덮는다.
+// 이 모듈은 그 범위 계산만 안다 - HTTP 상태코드도, Firestore 도 모른다. 범위가
+// 성립하지 않으면 null 을 돌려주고, 사용자에게 뭐라고 말할지는 라우트가 정한다.
+//
+// 회차 기한(회차 월의 10일)은 기한 규칙의 단일 소스인 cashflow-close-deadline 에서
+// 파생한다. 회차 월의 10일 == "직전 월을 대상 월로 본 기한" 이며, JVM 의
+// CashflowCloseDeadline.forCumulativeCycle 과 같은 표현이다.
+import { cashflowMonthCloseDeadline } from './cashflow-close-deadline.mjs';
+
+export const CASHFLOW_CUMULATIVE_CLOSE_CONTRACT = 'cashflow-cumulative-close-v2';
+export const CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH = '2023-01';
+
+export function monthsBetween(startYearMonth, endYearMonth) {
+  const result = [];
+  let cursor = new Date(`${startYearMonth}-01T00:00:00Z`);
+  const end = new Date(`${endYearMonth}-01T00:00:00Z`);
+  while (cursor <= end && result.length < 240) {
+    result.push(cursor.toISOString().slice(0, 7));
+    cursor = new Date(Date.UTC(cursor.getUTCFullYear(), cursor.getUTCMonth() + 1, 1));
+  }
+  return result;
+}
+
+export function previousYearMonth(yearMonth) {
+  const month = new Date(`${yearMonth}-01T00:00:00Z`);
+  month.setUTCMonth(month.getUTCMonth() - 1);
+  return month.toISOString().slice(0, 7);
+}
+
+/** 회차 월이 덮는 누적 범위. 성립하지 않으면 null (2023-01 이전, 240개월 초과 등). */
+export function cumulativeCloseMonthsOrNull(yearMonth) {
+  const throughMonth = previousYearMonth(yearMonth);
+  const months = monthsBetween(CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH, throughMonth);
+  if (
+    throughMonth < CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH
+    || months.length === 0
+    || months.at(-1) !== throughMonth
+  ) {
+    return null;
+  }
+  return months;
+}
+
+export function cashflowCumulativeCloseCycle(yearMonth, businessDate) {
+  if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(String(yearMonth))
+    || !/^20\d{2}-(0[1-9]|1[0-2])-\d{2}$/.test(String(businessDate))) return null;
+  const targetYearMonth = previousYearMonth(yearMonth);
+  return {
+    cycleYearMonth: yearMonth,
+    targetYearMonth,
+    // 회차 월의 10일. 기한 규칙의 단일 소스에서 파생한다 - `${yearMonth}-10` 을
+    // 여기서 또 쓰면 기한 규칙이 세 번째로 복제된다.
+    deadline: cashflowMonthCloseDeadline(targetYearMonth),
+    eligible: targetYearMonth < String(businessDate).slice(0, 7),
+  };
+}

--- a/server/bff/cashflow-close-calendar.test.mjs
+++ b/server/bff/cashflow-close-calendar.test.mjs
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH,
+  cashflowCumulativeCloseCycle,
+  cumulativeCloseMonthsOrNull,
+  monthsBetween,
+  previousYearMonth,
+} from './cashflow-close-calendar.mjs';
+import { cashflowMonthCloseDeadline } from './cashflow-close-deadline.mjs';
+
+describe('cashflow close calendar', () => {
+  it('walks months inclusively and wraps years', () => {
+    expect(monthsBetween('2025-11', '2026-02')).toEqual(['2025-11', '2025-12', '2026-01', '2026-02']);
+    expect(previousYearMonth('2026-01')).toBe('2025-12');
+  });
+
+  it('caps the cumulative range at 240 months', () => {
+    expect(monthsBetween('2023-01', '2099-12')).toHaveLength(240);
+  });
+
+  it('covers 2023-01 through the month before the cycle, or nothing', () => {
+    expect(cumulativeCloseMonthsOrNull('2026-08')).toHaveLength(43);
+    expect(cumulativeCloseMonthsOrNull('2026-08')?.at(0)).toBe(CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH);
+    expect(cumulativeCloseMonthsOrNull('2026-08')?.at(-1)).toBe('2026-07');
+    // 기점 이전 회차는 성립하지 않는다. HTTP 로 뭐라 말할지는 라우트의 일이다.
+    expect(cumulativeCloseMonthsOrNull('2023-01')).toBeNull();
+    expect(cumulativeCloseMonthsOrNull('2022-12')).toBeNull();
+  });
+
+  it('derives the cycle deadline from the single deadline rule', () => {
+    // 회차 월의 10일 == 직전 월을 대상 월로 본 기한. JVM CashflowCloseDeadline.forCumulativeCycle
+    // 과 같은 표현이며, 기한 규칙의 parity 표는 cashflow-close-deadline.test.mjs 가 가진다.
+    for (const cycle of ['2023-02', '2026-01', '2026-08', '2026-12']) {
+      const result = cashflowCumulativeCloseCycle(cycle, '2026-08-09');
+      expect(result?.deadline).toBe(`${cycle}-10`);
+      expect(result?.deadline).toBe(cashflowMonthCloseDeadline(previousYearMonth(cycle)));
+    }
+  });
+
+  it('marks the cycle eligible only after the target month has ended', () => {
+    expect(cashflowCumulativeCloseCycle('2026-08', '2026-08-09')?.eligible).toBe(true);
+    expect(cashflowCumulativeCloseCycle('2026-09', '2026-08-09')?.eligible).toBe(false);
+    expect(cashflowCumulativeCloseCycle('bad', '2026-08-09')).toBeNull();
+    expect(cashflowCumulativeCloseCycle('2026-08', 'bad')).toBeNull();
+  });
+});

--- a/server/bff/cashflow-policy.mjs
+++ b/server/bff/cashflow-policy.mjs
@@ -18,3 +18,11 @@ export function getCashflowLineLabel(lineId) {
   if (!lineId) return '';
   return CASHFLOW_SHEET_LINE_LABELS[lineId] || lineId;
 }
+
+// projection + actual 두 모드, 월당 5개 재무 주차. 한 달 결산 셀 수의 단일 소스 -
+// JVM 은 CashflowLineCatalog.monthCellCount() 로 같은 값을 파생하고, 두 값의 일치는
+// CashflowLineCatalogPolicyParityTest(JSON 대조)와 cashflow-policy.test.mjs 가 고정한다.
+// 라우트에 리터럴 160 을 쓰지 않는다 - 라인이 추가되면 여기만 따라 움직인다.
+export const CASHFLOW_MODE_COUNT = 2;
+export const CASHFLOW_WEEKS_PER_MONTH = 5;
+export const CASHFLOW_MONTH_CELL_COUNT = CASHFLOW_ALL_LINES.length * CASHFLOW_MODE_COUNT * CASHFLOW_WEEKS_PER_MONTH;

--- a/server/bff/cashflow-policy.test.mjs
+++ b/server/bff/cashflow-policy.test.mjs
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CASHFLOW_ALL_LINES,
+  CASHFLOW_IN_LINES,
+  CASHFLOW_MONTH_CELL_COUNT,
+  CASHFLOW_OUT_LINES,
+} from './cashflow-policy.mjs';
+
+describe('cashflow policy derivations', () => {
+  it('derives the month cell count from the policy JSON line catalog', () => {
+    // JVM CashflowLineCatalog.monthCellCount() 와 같은 값이어야 한다. JVM 쪽은
+    // CashflowLineCatalogPolicyParityTest 가 같은 JSON 과 대조한다 - 라인이 추가되면
+    // 양쪽이 함께 움직이고, 이 리터럴 표가 갱신을 강제한다.
+    expect(CASHFLOW_IN_LINES).toHaveLength(7);
+    expect(CASHFLOW_OUT_LINES).toHaveLength(9);
+    expect(CASHFLOW_ALL_LINES).toHaveLength(16);
+    expect(CASHFLOW_MONTH_CELL_COUNT).toBe(160);
+    expect(CASHFLOW_MONTH_CELL_COUNT).toBe(CASHFLOW_ALL_LINES.length * 2 * 5);
+  });
+});

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -24,6 +24,15 @@ import { getMonthFinanceWeeks } from '../../../src/app/platform/cashflow-week-co
 import { WEEKS_PER_MONTH, annualYearsFor, weekOrdinal } from '../cashflow-coordinates.mjs';
 import { TENANT_WIDE_PROJECT_ROLES, isProjectInActorScope } from '../cashflow-project-scope.mjs';
 import { cashflowCloseHash } from '../cashflow-close-hash.mjs';
+import {
+  CASHFLOW_CUMULATIVE_CLOSE_CONTRACT,
+  CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH,
+  cashflowCumulativeCloseCycle,
+  cumulativeCloseMonthsOrNull,
+  monthsBetween,
+  previousYearMonth,
+} from '../cashflow-close-calendar.mjs';
+export { cashflowCumulativeCloseCycle };
 import { cashflowMonthCloseDeadline, isCashflowCloseOverdue } from '../cashflow-close-deadline.mjs';
 
 export { cashflowMonthCloseDeadline };
@@ -38,8 +47,6 @@ const CASHFLOW_LINE_INDEX = new Map(CASHFLOW_ALL_LINES.map((lineId, index) => [l
 const CASHFLOW_MONTH_CLOSE_ROUTE_TIMEOUT_MS = 26_000;
 const CASHFLOW_MONTH_CLOSE_MUTATION_BUDGET_MS = 12_000;
 const CASHFLOW_MONTH_CLOSE_REQUEST_MAX_BYTES = 900_000;
-const CASHFLOW_CUMULATIVE_CLOSE_CONTRACT = 'cashflow-cumulative-close-v2';
-const CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH = '2023-01';
 
 function readWeeklyYear(value) {
   const year = Number(value);
@@ -1472,31 +1479,11 @@ function projectMetadata(project) {
   };
 }
 
-function monthsBetween(startYearMonth, endYearMonth) {
-  const result = [];
-  let cursor = new Date(`${startYearMonth}-01T00:00:00Z`);
-  const end = new Date(`${endYearMonth}-01T00:00:00Z`);
-  while (cursor <= end && result.length < 240) {
-    result.push(cursor.toISOString().slice(0, 7));
-    cursor = new Date(Date.UTC(cursor.getUTCFullYear(), cursor.getUTCMonth() + 1, 1));
-  }
-  return result;
-}
 
-function previousYearMonth(yearMonth) {
-  const month = new Date(`${yearMonth}-01T00:00:00Z`);
-  month.setUTCMonth(month.getUTCMonth() - 1);
-  return month.toISOString().slice(0, 7);
-}
-
+// 달력 규칙은 cashflow-close-calendar 에 있다. 여기는 "성립 불가"를 사용자 문구로 바꾼다.
 function cumulativeCloseMonths(yearMonth) {
-  const throughMonth = previousYearMonth(yearMonth);
-  const months = monthsBetween(CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH, throughMonth);
-  if (
-    throughMonth < CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH
-    || months.length === 0
-    || months.at(-1) !== throughMonth
-  ) {
+  const months = cumulativeCloseMonthsOrNull(yearMonth);
+  if (months === null) {
     throw createHttpError(
       400,
       '누적 월 결산 범위는 2023-01부터 최대 240개월까지 선택할 수 있습니다.',
@@ -1587,17 +1574,6 @@ function assertCashflowSheetPublicationReady(state) {
 }
 
 
-export function cashflowCumulativeCloseCycle(yearMonth, businessDate) {
-  if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(String(yearMonth))
-    || !/^20\d{2}-(0[1-9]|1[0-2])-\d{2}$/.test(String(businessDate))) return null;
-  const targetYearMonth = previousYearMonth(yearMonth);
-  return {
-    cycleYearMonth: yearMonth,
-    targetYearMonth,
-    deadline: `${yearMonth}-10`,
-    eligible: targetYearMonth < String(businessDate).slice(0, 7),
-  };
-}
 
 async function readCashflowMonthCloseStatuses({ db, tenantId, projectId, businessDate = '' }) {
   if (!db?.collection) return [];

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -17,7 +17,7 @@ import {
   buildCashflowProjectionActualComparison,
   resolveCashflowComparisonAsOf,
 } from '../cashflow-comparison.mjs';
-import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES } from '../cashflow-policy.mjs';
+import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES, CASHFLOW_MONTH_CELL_COUNT } from '../cashflow-policy.mjs';
 import { stableStringify } from '../utils.mjs';
 import { cashflowApplyLeaseMs, readCashflowApplyLeaseState } from '../cashflow-apply-lease.mjs';
 import { getMonthFinanceWeeks } from '../../../src/app/platform/cashflow-week-core.mjs';
@@ -595,9 +595,9 @@ function normalizeMonthCloseCells(cells, yearMonth) {
 }
 
 function completeMonthCloseCells(cells) {
-  if (cells.length !== CASHFLOW_ALL_LINES.length * 2 * 5) return false;
+  if (cells.length !== CASHFLOW_MONTH_CELL_COUNT) return false;
   const keys = new Set(cells.map((cell) => `${cell.mode}:${cell.weekNo}:${cell.cashflowLine}`));
-  return keys.size === CASHFLOW_ALL_LINES.length * 2 * 5;
+  return keys.size === CASHFLOW_MONTH_CELL_COUNT;
 }
 
 function sumSafe(values) {
@@ -1410,7 +1410,7 @@ function validConfirmationKeys(confirmations) {
 }
 
 function completeMonthCloseConfirmations(confirmations) {
-  const expectedCount = CASHFLOW_ALL_LINES.length * 2 * 5;
+  const expectedCount = CASHFLOW_MONTH_CELL_COUNT;
   return Array.isArray(confirmations)
     && confirmations.length === expectedCount
     && validConfirmationKeys(confirmations).size === expectedCount;
@@ -2067,7 +2067,7 @@ async function composeCashflowMonthDashboard({
     }
     blockers.push(...sheetControlBlockers(sheetFacts));
     blockers.push(...monthSheetCalculationBlockers(sheetFacts, yearMonth));
-    if (!completeMonthCloseCells(cells)) blockers.push({ code: 'SHEET_MONTH_INCOMPLETE', message: '선택한 월의 160개 캐시플로우 값을 다시 불러와 주세요.' });
+    if (!completeMonthCloseCells(cells)) blockers.push({ code: 'SHEET_MONTH_INCOMPLETE', message: `선택한 월의 ${CASHFLOW_MONTH_CELL_COUNT}개 캐시플로우 값을 다시 불러와 주세요.` });
     if (!projectionMode || !actualMode) blockers.push({ code: 'AMOUNT_OUT_OF_RANGE', message: '지원 범위를 넘는 금액이 있습니다.' });
   }
   if (weeklyYear !== null && annualTotals.length !== annualYearsFor(weeklyYear).length) {
@@ -2107,7 +2107,7 @@ async function composeCashflowMonthDashboard({
     ? 100
     : Math.round((projectionSalesAndVatTotal / contractAmount) * 10_000) / 100;
   const projectionProgressPercent = Math.max(0, rawProjectionProgressPercent);
-  const requiredCellConfirmationCount = CASHFLOW_ALL_LINES.length * 2 * 5;
+  const requiredCellConfirmationCount = CASHFLOW_MONTH_CELL_COUNT;
   const requiredManagementConfirmationCount = CASHFLOW_MANAGEMENT_CHECK_IDS.length;
   const confirmationProgressPercent = Math.round(
     Math.min(
@@ -2248,7 +2248,7 @@ async function composeCashflowMonthCloseBody({ db, req, projectId, cashflow, ope
   const project = projectSnap.exists ? projectSnap.data() || {} : {};
   const normalizedCells = normalizeMonthCloseCells(closeInput.cells, yearMonth);
   if (!completeMonthCloseCells(normalizedCells)) {
-    throw createHttpError(409, '월 결산 대상 160개 캐시플로우 값을 다시 확인해 주세요.', 'cashflow_month_close_cells_incomplete');
+    throw createHttpError(409, `월 결산 대상 ${CASHFLOW_MONTH_CELL_COUNT}개 캐시플로우 값을 다시 확인해 주세요.`, 'cashflow_month_close_cells_incomplete');
   }
   const sourceWarnings = [];
   if (!mirror) {
@@ -2312,7 +2312,7 @@ async function composeCashflowMonthCloseBody({ db, req, projectId, cashflow, ope
     details: { requested: closeInput.managementChecks || [], authoritative: managementChecks },
   }];
   if (!completeMonthCloseConfirmations(closeInput.confirmations)) {
-    throw createHttpError(409, '월 결산 대상 160개 항목을 모두 확인해 주세요.', 'cashflow_month_close_confirmations_incomplete');
+    throw createHttpError(409, `월 결산 대상 ${CASHFLOW_MONTH_CELL_COUNT}개 항목을 모두 확인해 주세요.`, 'cashflow_month_close_confirmations_incomplete');
   }
   const deadlineSummary = deadlineSummaryFromCompliance(
     weeklyCompliance,
@@ -3258,7 +3258,7 @@ export function mountJvmWeeklyApiRoutes(app, {
     ));
     const normalizedCells = normalizeMonthCloseCells(cells, yearMonth);
     if (!completeMonthCloseCells(normalizedCells)) {
-      throw createHttpError(409, '저장된 월 결산 160셀 근거를 확인할 수 없습니다.', 'cashflow_month_close_request_evidence_invalid');
+      throw createHttpError(409, `저장된 월 결산 ${CASHFLOW_MONTH_CELL_COUNT}셀 근거를 확인할 수 없습니다.`, 'cashflow_month_close_request_evidence_invalid');
     }
     return {
       projectId,
@@ -3467,7 +3467,7 @@ export function mountJvmWeeklyApiRoutes(app, {
         manifestHash: manifest.manifestHash,
         monthCount: shards.length,
         weekCount: shards.length * 5,
-        cellCount: shards.length * 160,
+        cellCount: shards.length * CASHFLOW_MONTH_CELL_COUNT,
         source: prepared.shardSource,
         totals,
         annualSummaries,
@@ -3535,7 +3535,7 @@ export function mountJvmWeeklyApiRoutes(app, {
       )).get();
       const stored = snapshot.exists ? snapshot.data() || {} : null;
       const { shardHash, ...base } = stored || {};
-      if (!stored || stored.cells?.length !== 160 || shardHash !== cashflowCloseHash(base)) {
+      if (!stored || stored.cells?.length !== CASHFLOW_MONTH_CELL_COUNT || shardHash !== cashflowCloseHash(base)) {
         throw createHttpError(409, '저장된 누적 월 결산 근거가 손상되었습니다.', 'cashflow_month_close_request_evidence_tampered');
       }
       shards.push(stored);
@@ -3779,7 +3779,7 @@ export function mountJvmWeeklyApiRoutes(app, {
       )).get();
       const stored = snapshot.exists ? snapshot.data() || {} : null;
       const { shardHash, ...base } = stored || {};
-      if (!stored || stored.cells?.length !== 160 || shardHash !== cashflowCloseHash(base)) {
+      if (!stored || stored.cells?.length !== CASHFLOW_MONTH_CELL_COUNT || shardHash !== cashflowCloseHash(base)) {
         throw createHttpError(409, '저장된 누적 월 결산 근거가 손상되었습니다.', 'cashflow_month_close_request_evidence_tampered');
       }
       months.push(stored);
@@ -3833,7 +3833,7 @@ export function mountJvmWeeklyApiRoutes(app, {
         || stored.projectId !== projectId
         || Number(stored.requestRevision) !== revision
         || stored.yearMonth !== throughMonth
-        || stored.cells?.length !== 160
+        || stored.cells?.length !== CASHFLOW_MONTH_CELL_COUNT
         || shardHash !== cashflowCloseHash(base)) {
         throw createHttpError(409, '저장된 revision 비교 근거가 손상되었습니다.', 'cashflow_month_close_request_evidence_tampered');
       }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -25,6 +25,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.server.ResponseStatusException;
 import dev.merryai.innerplatform.weekly.domain.CashflowWeekTotals;
 import dev.merryai.innerplatform.weekly.service.CashflowReadService;
+import dev.merryai.innerplatform.weekly.service.command.CashflowMonthReopenCommands;
 import dev.merryai.innerplatform.weekly.storage.WeeklyExpensePersistence;
 
 import java.math.BigDecimal;
@@ -707,11 +708,14 @@ public class WeeklyExpenseController {
         HttpServletRequest httpRequest,
         @Valid @RequestBody RequestCashflowMonthReopenRequest request
     ) {
+        // HTTP 표현은 여기까지다. 서비스에는 런타임 중립 커맨드만 넘긴다.
         return commandService.requestCashflowMonthReopen(
             actorContext(tenantId, actorId, actorRole, actorEmail),
             projectId,
             httpRequest.getHeader("x-data-project-id"),
-            request
+            new CashflowMonthReopenCommands.RequestReopen(
+                request.idempotencyKey(), request.yearMonth(), request.expectedRevision(), request.reason()
+            )
         );
     }
 
@@ -729,7 +733,10 @@ public class WeeklyExpenseController {
             actorContext(tenantId, actorId, actorRole, actorEmail),
             projectId,
             httpRequest.getHeader("x-data-project-id"),
-            request
+            new CashflowMonthReopenCommands.DecideReopen(
+                request.idempotencyKey(), request.yearMonth(), request.expectedRevision(),
+                request.decision(), request.reason()
+            )
         );
     }
 

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -1,5 +1,6 @@
 package dev.merryai.innerplatform.weekly.service;
 
+import dev.merryai.innerplatform.weekly.service.command.CashflowMonthReopenCommands;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -32,7 +33,6 @@ import dev.merryai.innerplatform.weekly.api.CloseCashflowMonthRequest;
 import dev.merryai.innerplatform.weekly.api.CompleteCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowWeeklyUpdateCompletionResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowWeeklyComplianceHistoryResponse;
-import dev.merryai.innerplatform.weekly.api.DecideCashflowMonthReopenRequest;
 import dev.merryai.innerplatform.weekly.api.ApplyBankStatementItemsRequest;
 import dev.merryai.innerplatform.weekly.api.ApplyBankStatementItemsResponse;
 import dev.merryai.innerplatform.weekly.api.BankStatementImportLinesResponse;
@@ -46,7 +46,6 @@ import dev.merryai.innerplatform.weekly.api.PasteCellsRequest;
 import dev.merryai.innerplatform.weekly.api.RowCommandResponse;
 import dev.merryai.innerplatform.weekly.api.RowDeleteRequest;
 import dev.merryai.innerplatform.weekly.api.RowInsertRequest;
-import dev.merryai.innerplatform.weekly.api.RequestCashflowMonthReopenRequest;
 import dev.merryai.innerplatform.weekly.api.ReopenCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.SaveDraftRequest;
 import dev.merryai.innerplatform.weekly.api.SaveDraftResponse;
@@ -1429,7 +1428,7 @@ public class WeeklyExpenseCommandService {
         TrustedActorContext actor,
         String projectId,
         String dataProjectId,
-        RequestCashflowMonthReopenRequest request
+        CashflowMonthReopenCommands.RequestReopen request
     ) {
         if (request.reason().isBlank()) {
             throw new IllegalArgumentException("A reason is required to request a cashflow month reopen.");
@@ -1483,7 +1482,7 @@ public class WeeklyExpenseCommandService {
         TrustedActorContext actor,
         String projectId,
         String dataProjectId,
-        DecideCashflowMonthReopenRequest request
+        CashflowMonthReopenCommands.DecideReopen request
     ) {
         if (!("APPROVE".equals(request.decision()) || "REJECT".equals(request.decision()))
             || request.reason().isBlank()) {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/command/CashflowMonthReopenCommands.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/command/CashflowMonthReopenCommands.java
@@ -1,0 +1,45 @@
+package dev.merryai.innerplatform.weekly.service.command;
+
+import java.util.Locale;
+
+/**
+ * 월 재오픈 커맨드 - 런타임 중립 입력.
+ *
+ * <p>애플리케이션 서비스가 api DTO 를 시그니처로 받으면 service → api 역의존이 되고,
+ * 그 역의존이 storage 까지 전염돼 있었다(영속 인터페이스가 api DTO 19개를 import).
+ * 서비스와 영속 계층은 이 record 만 알고, HTTP 표현(Bean Validation 애노테이션)은 api
+ * 계층이 소유한 채 DTO -> 커맨드 매핑만 한다. CommandService 의 api DTO 의존 47개를
+ * 걷어내는 방향의 첫 수직 절단이다.
+ *
+ * <p>정규화(트리밍, 대문자)는 DTO 의 compact constructor 와 동일하게 여기서도 한다 -
+ * 커맨드가 어디서 만들어지든 같은 형태가 되도록.
+ */
+public final class CashflowMonthReopenCommands {
+
+    private CashflowMonthReopenCommands() {
+    }
+
+    public record RequestReopen(
+        String idempotencyKey,
+        String yearMonth,
+        long expectedRevision,
+        String reason
+    ) {
+        public RequestReopen {
+            reason = reason == null ? "" : reason.trim();
+        }
+    }
+
+    public record DecideReopen(
+        String idempotencyKey,
+        String yearMonth,
+        long expectedRevision,
+        String decision,
+        String reason
+    ) {
+        public DecideReopen {
+            decision = decision == null ? "" : decision.trim().toUpperCase(Locale.ROOT);
+            reason = reason == null ? "" : reason.trim();
+        }
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -1,5 +1,6 @@
 package dev.merryai.innerplatform.weekly.storage;
 
+import dev.merryai.innerplatform.weekly.service.command.CashflowMonthReopenCommands;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.api.core.ApiFuture;
@@ -23,8 +24,6 @@ import dev.merryai.innerplatform.weekly.api.CashflowSheetAnnualApplyRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowPendingApprovalAffectedMonth;
 import dev.merryai.innerplatform.weekly.api.CloseCashflowMonthRequest;
 import dev.merryai.innerplatform.weekly.api.CompleteCashflowWeeklyUpdateRequest;
-import dev.merryai.innerplatform.weekly.api.DecideCashflowMonthReopenRequest;
-import dev.merryai.innerplatform.weekly.api.RequestCashflowMonthReopenRequest;
 import dev.merryai.innerplatform.weekly.api.ReopenCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.TrustedActorContext;
 import dev.merryai.innerplatform.weekly.api.WeeklyExpenseConflictException;
@@ -1846,7 +1845,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     public CashflowMonthCloseRecord requestCashflowMonthReopen(
         TrustedActorContext actor,
         String projectId,
-        RequestCashflowMonthReopenRequest request
+        CashflowMonthReopenCommands.RequestReopen request
     ) {
         requireYearMonth(request.yearMonth());
         Map<String, Object> cumulativeHead = cumulativeCloseHead(actor.tenantId(), projectId);
@@ -1907,7 +1906,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     public CashflowMonthCloseRecord decideCashflowMonthReopen(
         TrustedActorContext actor,
         String projectId,
-        DecideCashflowMonthReopenRequest request
+        CashflowMonthReopenCommands.DecideReopen request
     ) {
         requireYearMonth(request.yearMonth());
         Map<String, Object> cumulativeHead = cumulativeCloseHead(actor.tenantId(), projectId);

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
@@ -1,12 +1,11 @@
 package dev.merryai.innerplatform.weekly.storage;
 
+import dev.merryai.innerplatform.weekly.service.command.CashflowMonthReopenCommands;
 import dev.merryai.innerplatform.weekly.api.SaveDraftResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowEditSession;
 import dev.merryai.innerplatform.weekly.api.CashflowVarianceRequest;
 import dev.merryai.innerplatform.weekly.api.CloseCashflowMonthRequest;
 import dev.merryai.innerplatform.weekly.api.CompleteCashflowWeeklyUpdateRequest;
-import dev.merryai.innerplatform.weekly.api.DecideCashflowMonthReopenRequest;
-import dev.merryai.innerplatform.weekly.api.RequestCashflowMonthReopenRequest;
 import dev.merryai.innerplatform.weekly.api.ReopenCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetLabApplyRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetBatchApplyRequest;
@@ -549,7 +548,7 @@ public interface WeeklyExpensePersistence {
     default CashflowMonthCloseRecord requestCashflowMonthReopen(
         TrustedActorContext actor,
         String projectId,
-        RequestCashflowMonthReopenRequest request
+        CashflowMonthReopenCommands.RequestReopen request
     ) {
         throw new WeeklyExpenseEditLeaseException(
             503,
@@ -561,7 +560,7 @@ public interface WeeklyExpensePersistence {
     default CashflowMonthCloseRecord decideCashflowMonthReopen(
         TrustedActorContext actor,
         String projectId,
-        DecideCashflowMonthReopenRequest request
+        CashflowMonthReopenCommands.DecideReopen request
     ) {
         throw new WeeklyExpenseEditLeaseException(
             503,

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowLineCatalogPolicyParityTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowLineCatalogPolicyParityTest.java
@@ -1,0 +1,46 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 라인 카탈로그의 단일 소스는 레포 루트의 policies/cashflow-policy.json 이다. BFF 는
+ * 그 JSON 을 파생해서 쓰지만(server/bff/cashflow-policy.mjs) JVM 은 하드코딩 사본을
+ * 들고 있다. 사본이 갈리면 결산 셀 수부터 IN/OUT 합산까지 두 런타임이 조용히 어긋난다 -
+ * 라인 하나를 추가하면 BFF 는 170셀, JVM 은 160셀이 되는 구조였다.
+ *
+ * <p>이 테스트는 JSON 을 직접 읽어 사본과 문자 그대로 대조한다. JSON 을 고치면 여기가
+ * 깨지면서 CashflowLineCatalog 사본과 monthCellCount 계열 상수를 함께 갱신해야 함을
+ * 알린다. (JVM 이 런타임에 JSON 을 읽게 하는 것은 패키징 변경이라 별도 단계다.)
+ */
+class CashflowLineCatalogPolicyParityTest {
+
+    @Test
+    void hardcodedCatalogMatchesThePolicyJson() throws Exception {
+        Path policy = Path.of("..", "..", "policies", "cashflow-policy.json").normalize();
+        assertThat(policy).exists();
+        JsonNode root = new ObjectMapper().readTree(Files.readString(policy));
+
+        Set<String> jsonIn = new HashSet<>();
+        Set<String> jsonOut = new HashSet<>();
+        for (JsonNode entry : root.get("lineEntries")) {
+            String lineId = entry.get("lineId").asText();
+            String direction = entry.get("direction").asText();
+            if ("IN".equals(direction)) jsonIn.add(lineId);
+            else if ("OUT".equals(direction)) jsonOut.add(lineId);
+        }
+
+        assertThat(CashflowLineCatalog.IN_LINES).isEqualTo(jsonIn);
+        assertThat(CashflowLineCatalog.OUT_LINES).isEqualTo(jsonOut);
+        assertThat(CashflowLineCatalog.monthCellCount())
+            .isEqualTo((jsonIn.size() + jsonOut.size()) * CashflowLineCatalog.MODE_COUNT * CashflowLineCatalog.WEEKS_PER_MONTH);
+    }
+}

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandLeaseConfigurationTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandLeaseConfigurationTest.java
@@ -1,8 +1,8 @@
 package dev.merryai.innerplatform.weekly.service;
 
+import dev.merryai.innerplatform.weekly.service.command.CashflowMonthReopenCommands;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.merryai.innerplatform.weekly.api.CashflowEditSession;
-import dev.merryai.innerplatform.weekly.api.RequestCashflowMonthReopenRequest;
 import dev.merryai.innerplatform.weekly.api.TrustedActorContext;
 import dev.merryai.innerplatform.weekly.api.UpsertProjectionRequest;
 import dev.merryai.innerplatform.weekly.api.WeeklyExpenseAtomicWriteLimitException;
@@ -133,7 +133,7 @@ class WeeklyExpenseCommandLeaseConfigurationTest {
             new TrustedActorContext("tenant-a", "pm-1", "pm@example.com", "pm"),
             "project-a",
             "wrong-live-project",
-            new RequestCashflowMonthReopenRequest("reopen-live", "2026-06", 1, "정정 필요")
+            new CashflowMonthReopenCommands.RequestReopen("reopen-live", "2026-06", 1, "정정 필요")
         ))
             .isInstanceOf(WeeklyExpenseEditLeaseException.class)
             .satisfies(error -> assertThat(((WeeklyExpenseEditLeaseException) error).code())

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -1,5 +1,6 @@
 package dev.merryai.innerplatform.weekly.storage;
 
+import dev.merryai.innerplatform.weekly.service.command.CashflowMonthReopenCommands;
 import com.google.api.core.ApiFutures;
 import com.google.cloud.firestore.CollectionReference;
 import com.google.cloud.firestore.DocumentReference;
@@ -27,8 +28,6 @@ import dev.merryai.innerplatform.weekly.api.CompleteCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowWeeklyUpdateCompletionResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowWeeklyComplianceHistoryResponse;
 import dev.merryai.innerplatform.weekly.api.CloseWeekRequest;
-import dev.merryai.innerplatform.weekly.api.DecideCashflowMonthReopenRequest;
-import dev.merryai.innerplatform.weekly.api.RequestCashflowMonthReopenRequest;
 import dev.merryai.innerplatform.weekly.api.ReopenCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.SaveDraftResponse;
 import dev.merryai.innerplatform.weekly.api.SaveDraftRequest;
@@ -3694,7 +3693,7 @@ class FirestoreCashflowLeaseGuardTest {
             ACTOR,
             "project-a",
             "other-data-project",
-            new RequestCashflowMonthReopenRequest("reopen-wrong-project", "2026-06", 1, "정정 필요")
+            new CashflowMonthReopenCommands.RequestReopen("reopen-wrong-project", "2026-06", 1, "정정 필요")
         )))
             .isInstanceOf(WeeklyExpenseEditLeaseException.class)
             .satisfies(error -> assertThat(((WeeklyExpenseEditLeaseException) error).code())
@@ -3739,7 +3738,7 @@ class FirestoreCashflowLeaseGuardTest {
             ACTOR,
             "project-a",
             "stage-data-project",
-            new RequestCashflowMonthReopenRequest("reopen-request-1", "2026-06", 1, "6월 입금 반영 오류 수정")
+            new CashflowMonthReopenCommands.RequestReopen("reopen-request-1", "2026-06", 1, "6월 입금 반영 오류 수정")
         ));
         assertThat(requested.status()).isEqualTo("REOPEN_REQUESTED");
         assertThat(requested.reopenReason()).isEqualTo("6월 입금 반영 오류 수정");
@@ -3754,7 +3753,7 @@ class FirestoreCashflowLeaseGuardTest {
             "role", "finance",
             "projectIds", List.of()
         )));
-        DecideCashflowMonthReopenRequest decision = new DecideCashflowMonthReopenRequest(
+        CashflowMonthReopenCommands.DecideReopen decision = new CashflowMonthReopenCommands.DecideReopen(
             "reopen-decision-1",
             "2026-06",
             requested.revision(),
@@ -3830,7 +3829,7 @@ class FirestoreCashflowLeaseGuardTest {
         fixture.persistence.runCommandTransaction(() -> fixture.persistence.requestCashflowMonthReopen(
             ACTOR,
             "project-a",
-            new RequestCashflowMonthReopenRequest("legacy-request", "2026-06", 1, "레거시 정정")
+            new CashflowMonthReopenCommands.RequestReopen("legacy-request", "2026-06", 1, "레거시 정정")
         ));
         Map<String, Object> close = fixture.documents.get(monthClosePath("project-a", "2026-06"));
         ((Map<String, Object>) close.get("reopenRequest")).remove("requestedByUid");
@@ -3839,7 +3838,7 @@ class FirestoreCashflowLeaseGuardTest {
             fixture.persistence.decideCashflowMonthReopen(
                 ACTOR,
                 "project-a",
-                new DecideCashflowMonthReopenRequest("legacy-decision", "2026-06", 2, "APPROVE", "승인")
+                new CashflowMonthReopenCommands.DecideReopen("legacy-decision", "2026-06", 2, "APPROVE", "승인")
             )
         );
 
@@ -3915,7 +3914,7 @@ class FirestoreCashflowLeaseGuardTest {
             fixture.persistence.requestCashflowMonthReopen(
                 ACTOR,
                 "project-a",
-                new RequestCashflowMonthReopenRequest("legacy-write-guard", "2026-06", 1, "증빙 재확인")
+                new CashflowMonthReopenCommands.RequestReopen("legacy-write-guard", "2026-06", 1, "증빙 재확인")
             )
         ))
             .isInstanceOf(WeeklyExpenseConflictException.class)
@@ -3950,7 +3949,7 @@ class FirestoreCashflowLeaseGuardTest {
             revisionFixture.persistence.requestCashflowMonthReopen(
                 ACTOR,
                 "project-a",
-                new RequestCashflowMonthReopenRequest(
+                new CashflowMonthReopenCommands.RequestReopen(
                     "overflow-revision",
                     "2026-06",
                     Long.MAX_VALUE,
@@ -4355,12 +4354,12 @@ class FirestoreCashflowLeaseGuardTest {
         fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
             .closeCashflowMonth(ACTOR, "project-a", SESSION, first));
         fixture.persistence.runCommandTransaction(() -> fixture.persistence.requestCashflowMonthReopen(
-            ACTOR, "project-a", new RequestCashflowMonthReopenRequest(
+            ACTOR, "project-a", new CashflowMonthReopenCommands.RequestReopen(
                 "legacy-reopen-request", "2026-08", 1, "레거시 결산 정정"
             )
         ));
         fixture.persistence.runCommandTransaction(() -> fixture.persistence.decideCashflowMonthReopen(
-            FINANCE_ACTOR, "project-a", new DecideCashflowMonthReopenRequest(
+            FINANCE_ACTOR, "project-a", new CashflowMonthReopenCommands.DecideReopen(
                 "legacy-reopen-decision", "2026-08", 2, "APPROVE", "정정 승인"
             )
         ));
@@ -4419,15 +4418,15 @@ class FirestoreCashflowLeaseGuardTest {
         ));
 
         assertThatThrownBy(() -> fixture.persistence.runCommandTransaction(() -> fixture.persistence
-            .requestCashflowMonthReopen(ACTOR, "project-a", new RequestCashflowMonthReopenRequest(
+            .requestCashflowMonthReopen(ACTOR, "project-a", new CashflowMonthReopenCommands.RequestReopen(
                 "reopen-old", "2026-07", 1, "과거 월"
             )))).isInstanceOf(WeeklyExpenseConflictException.class).hasMessageContaining("latest");
 
         fixture.persistence.runCommandTransaction(() -> fixture.persistence.requestCashflowMonthReopen(
-            ACTOR, "project-a", new RequestCashflowMonthReopenRequest("reopen-latest", "2026-08", 1, "정정")
+            ACTOR, "project-a", new CashflowMonthReopenCommands.RequestReopen("reopen-latest", "2026-08", 1, "정정")
         ));
         fixture.persistence.runCommandTransaction(() -> fixture.persistence.decideCashflowMonthReopen(
-            FINANCE_ACTOR, "project-a", new DecideCashflowMonthReopenRequest("reopen-decision", "2026-08", 2, "APPROVE", "승인")
+            FINANCE_ACTOR, "project-a", new CashflowMonthReopenCommands.DecideReopen("reopen-decision", "2026-08", 2, "APPROVE", "승인")
         ));
 
         assertThat(fixture.documents.get("orgs/tenant-a/cashflow_cumulative_close_heads/project-a"))
@@ -4453,10 +4452,10 @@ class FirestoreCashflowLeaseGuardTest {
         fixture.documents.put(completionPath, lockedWeeklyCompletion("2026-07", 1, 1));
 
         fixture.persistence.runCommandTransaction(() -> fixture.persistence.requestCashflowMonthReopen(
-            ACTOR, "project-a", new RequestCashflowMonthReopenRequest("reopen-request", "2026-08", 1, "정정")
+            ACTOR, "project-a", new CashflowMonthReopenCommands.RequestReopen("reopen-request", "2026-08", 1, "정정")
         ));
         fixture.persistence.runCommandTransaction(() -> fixture.persistence.decideCashflowMonthReopen(
-            FINANCE_ACTOR, "project-a", new DecideCashflowMonthReopenRequest("reopen-decision", "2026-08", 2, "APPROVE", "승인")
+            FINANCE_ACTOR, "project-a", new CashflowMonthReopenCommands.DecideReopen("reopen-decision", "2026-08", 2, "APPROVE", "승인")
         ));
 
         assertThat(fixture.documents.get("orgs/tenant-a/cashflow_cumulative_close_heads/project-a"))


### PR DESCRIPTION
합의한 a→b→c. 전부 **행동 변화 없음**. 독립 에이전트 재스코어링 결과는 완료되는 대로 코멘트로 첨부.

## (a) 라인 카탈로그 ↔ policy JSON parity

JVM 하드코딩 사본이 `policies/cashflow-policy.json` 과 갈릴 수 없게 테스트로 대조. 라인 추가 시 BFF 170셀 vs JVM 160셀로 조용히 어긋나던 구조 → JSON 을 고치는 순간 JVM 테스트가 깨지며 사본 갱신 강제. (런타임 JSON 읽기는 패키징 변경이라 별도 단계)

## (b) BFF 달력 도메인 추출 — `cashflow-close-calendar.mjs`

`monthsBetween`/`previousYearMonth`/`cumulativeCloseMonths`/`cashflowCumulativeCloseCycle` 을 4800줄 라우트 파일에서 추출.
- **도메인은 HTTP 를 모른다**: 성립 불가는 `null`, 400 과 사용자 문구는 라우트 래퍼가 (호출부 무변경)
- 회차 기한 `${yearMonth}-10` 리터럴(기한 규칙의 3번째 복제)을 단일 소스 `cashflow-close-deadline` 파생으로 — 파생값==리터럴 동일성 실행 대조 + 테스트 고정

## (c) reopen 커맨드 역의존 절단 — 첫 수직

service 가 api DTO 를 시그니처로 받는 역의존이 storage 까지 전염돼 있었다. `service/command/CashflowMonthReopenCommands` 중립 record 로 교체, service/영속 인터페이스/Firestore 구현이 그것만 알게. HTTP 계약(DTO + Bean Validation)은 그대로, 컨트롤러가 매핑 한 줄. **CommandService 의 api import 47 → 45** — 남은 45개는 이 패턴으로.

## 체크포인트 테스트

| 검증 | 결과 |
|---|---|
| JVM 전체 | **344 통과** |
| BFF 전체 | **1061 통과** |
| typecheck | 신규 에러 0 |
| e2e (BFF→실HTTP→JVM→에뮬레이터, AXR 실데이터) | 요청→승인→확정 통과 |
| 해시 실전 parity | `rootHash` 가 원본→parity→abc 세 세대에 걸쳐 **바이트 동일** (`sha256:0741f8d7…`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)