### PR TITLE
refactor: 계층 정리 후속 1·2·3 — 관리검사 parity, record 승격, annual 커맨드 절단

### DIFF
--- a/server/bff/cashflow-amounts.mjs
+++ b/server/bff/cashflow-amounts.mjs
@@ -1,0 +1,16 @@
+// 금액 안전 연산 (BFF 쪽 도메인). 회계 금액은 정수 원 단위이고, 안전 정수 범위를
+// 벗어나는 합산은 값 대신 null 로 알린다 - 조용한 정밀도 손실을 금지한다.
+export function safeAmount(value) {
+  const amount = Number(value);
+  return Number.isSafeInteger(amount) ? amount : 0;
+}
+
+export function sumSafe(values) {
+  let total = 0;
+  for (const value of values) {
+    const next = total + safeAmount(value);
+    if (!Number.isSafeInteger(next)) return null;
+    total = next;
+  }
+  return total;
+}

--- a/server/bff/cashflow-management-checks.mjs
+++ b/server/bff/cashflow-management-checks.mjs
@@ -1,0 +1,158 @@
+// 월 결산 관리검사 4종 (BFF 쪽 도메인).
+//
+// 검사 "계산"은 BFF 가 소유하고, JVM 은 검사 ID 와 상태의 형태만 검증해 저장한다
+// (CloseCashflowMonthRequest 의 @Pattern). 그래서 여기의 parity 대상은 계산이 아니라
+// **ID 목록과 상태 어휘**다 - 한쪽이 검사를 추가/개명하면 JVM 의 패턴과 갈려 확정이
+// 400 으로 거부된다. 그 일치는 cashflow-management-checks.test.mjs 와 JVM
+// CloseCashflowMonthRequestTest 가 같은 리터럴 표로 고정한다.
+//
+// 이 모듈은 순수하다: HTTP 도 Firestore 도 모른다. 주차 데이터(weeks/cellStates)를
+// canonical 소스에서 어떻게 만드는지는 라우트의 buildCashflowManagementChecks 가 안다.
+import { readOptionalText } from './bff-utils.mjs';
+import { stableStringify } from './utils.mjs';
+import { safeAmount, sumSafe } from './cashflow-amounts.mjs';
+import { CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES } from './cashflow-policy.mjs';
+import { cashflowRangeSortKey } from './cashflow-range.mjs';
+
+export const CASHFLOW_MANAGEMENT_CHECK_IDS = [
+  'labor-transfer',
+  'profit-vat-after-deposit',
+  'negative-projection-balance',
+  'future-prepay-over-million',
+];
+
+export const CASHFLOW_MANAGEMENT_CHECK_STATUSES = ['OK', 'WARNING', 'REVIEW_REQUIRED'];
+
+function managementCheck(id, status, title, detail, findings = []) {
+  return findings.length > 0 ? { id, status, title, detail, findings } : { id, status, title, detail };
+}
+
+export function laborTransferCheck(weeks, cellStates, yearMonth) {
+  const yearMonths = [...new Set([yearMonth, ...weeks.map((week) => readOptionalText(week.yearMonth))])].sort();
+  const warnings = [];
+  const reviews = [];
+  for (const yearMonth of yearMonths) {
+    const projection = cellStates.get(`${yearMonth}:projection:3:MYSC_LABOR_OUT`);
+    if (!projection || projection.cellState === 'EMPTY') {
+      warnings.push(`${yearMonth} 3주차 인건비 미입력`);
+      continue;
+    }
+    const plannedAmount = safeAmount(projection.amount);
+    if (plannedAmount === 0) {
+      reviews.push(`${yearMonth} 3주차 인건비 미입력`);
+      continue;
+    }
+    const actual = cellStates.get(`${yearMonth}:actual:3:MYSC_LABOR_OUT`);
+    if (!actual || actual.cellState === 'EMPTY') {
+      warnings.push(`${yearMonth} 3주차 · 예정 ${plannedAmount.toLocaleString('ko-KR')}원 · Actual 인건비 미기입`);
+      continue;
+    }
+    const actualAmount = safeAmount(actual.amount);
+    if (actualAmount === 0) {
+      warnings.push(`${yearMonth} 3주차 · 예정 ${plannedAmount.toLocaleString('ko-KR')}원 · 실제 0원 · 실제 미이관`);
+    } else if (actualAmount < plannedAmount) {
+      warnings.push(`${yearMonth} 3주차 · 예정 ${plannedAmount.toLocaleString('ko-KR')}원 · 실제 ${actualAmount.toLocaleString('ko-KR')}원 · 일부 이관`);
+    }
+  }
+  const findings = warnings.length > 0 ? warnings : reviews;
+  return managementCheck(
+    'labor-transfer',
+    warnings.length > 0 ? 'WARNING' : reviews.length > 0 ? 'REVIEW_REQUIRED' : 'OK',
+    'MYSC 인건비 이관',
+    findings.length > 0 ? findings.join(', ') : '기준일까지 모든 3주차 인건비 이관을 확인했습니다.',
+    findings,
+  );
+}
+
+export function profitVatAfterDepositCheck(weeks) {
+  const due = [];
+  const deposits = weeks.filter((week) => safeAmount(week.projection?.SALES_IN) > 0);
+  for (const deposit of deposits) {
+    const index = weeks.indexOf(deposit);
+    const next = weeks[index + 1];
+    const gapMs = next?.weekStart && deposit.weekEnd
+      ? Date.parse(`${next.weekStart}T00:00:00Z`) - Date.parse(`${deposit.weekEnd}T00:00:00Z`)
+      : Number.POSITIVE_INFINITY;
+    const targets = [deposit, gapMs <= 8 * 86_400_000 ? next : null].filter(Boolean);
+    const hasProfit = targets.some((week) => safeAmount(week.projection?.MYSC_PROFIT_OUT) > 0);
+    const hasVat = targets.some((week) => safeAmount(week.projection?.SALES_VAT_OUT) > 0);
+    const missing = [hasProfit ? null : 'MYSC 수익', hasVat ? null : '매출부가세'].filter(Boolean);
+    if (missing.length > 0) {
+      due.push(`${deposit.yearMonth} ${deposit.weekNo}주차에 매출입금이 있으나 [${missing.join('·')}] 계획이 Projection에 없습니다.`);
+    }
+  }
+  if (deposits.length === 0) {
+    return managementCheck('profit-vat-after-deposit', 'REVIEW_REQUIRED', '입금 후 MYSC 수익·매출부가세 이관(해당 주, 차주)', 'Projection 매출입금이 없습니다. 해당 없음 여부를 사람이 확인해 주세요.');
+  }
+  return managementCheck(
+    'profit-vat-after-deposit',
+    due.length > 0 ? 'WARNING' : 'OK',
+    '입금 후 MYSC 수익·매출부가세 이관(해당 주, 차주)',
+    due.length > 0 ? `입금 주차 또는 다음 주차까지 미이관: ${due.join(', ')}` : 'Projection 매출입금의 같은 주차 또는 다음 주차 이관을 확인했습니다.',
+    due,
+  );
+}
+
+export function negativeProjectionCheck(weeks, openingBalance = 0) {
+  let balance = safeAmount(openingBalance);
+  let prepay = 0;
+  const findings = [];
+  for (const week of weeks) {
+    const totalIn = sumSafe(CASHFLOW_IN_LINES.map((lineId) => week.projection?.[lineId])) || 0;
+    const totalOut = sumSafe(CASHFLOW_OUT_LINES.map((lineId) => week.projection?.[lineId])) || 0;
+    balance += totalIn - totalOut;
+    prepay += safeAmount(week.projection?.MYSC_PREPAY_IN);
+    if (balance < 0) {
+      findings.push(`${week.yearMonth} ${week.weekNo}주차 · 잔액 ${balance.toLocaleString('ko-KR')}원${prepay > 0 ? '' : ' · MYSC 선입금 Projection 없음'}`);
+    }
+  }
+  if (findings.length > 0) {
+    return managementCheck(
+      'negative-projection-balance',
+      'WARNING',
+      'Projection 잔액 마이너스',
+      `${findings.length}개 주차에서 마이너스 · 최초 ${findings[0]}`,
+      findings,
+    );
+  }
+  return managementCheck('negative-projection-balance', 'OK', 'Projection 잔액 마이너스', 'Projection 누적 잔액이 0원 이상입니다.');
+}
+
+export function futurePrepayCheck(weeks, asOfKey) {
+  const occurrences = weeks.filter((week) => (
+    cashflowRangeSortKey(week) > asOfKey && safeAmount(week.projection?.MYSC_PREPAY_IN) > 1_000_000
+  ));
+  return managementCheck(
+    'future-prepay-over-million',
+    occurrences.length > 0 ? 'WARNING' : 'OK',
+    '금주 이후 선입금 요청 100만원 초과',
+    occurrences.length > 0
+      ? occurrences.map((week) => `${week.yearMonth} ${week.weekNo}주차 ${safeAmount(week.projection?.MYSC_PREPAY_IN).toLocaleString('ko-KR')}원`).join(', ')
+      : '금주 이후 100만원 초과 요청이 없습니다.',
+    occurrences.map((week) => `${week.yearMonth} ${week.weekNo}주차 · ${safeAmount(week.projection?.MYSC_PREPAY_IN).toLocaleString('ko-KR')}원`),
+  );
+}
+
+export function validManagementConfirmations(confirmations) {
+  const byId = new Map();
+  for (const item of Array.isArray(confirmations) ? confirmations : []) {
+    const checkId = readOptionalText(item?.checkId);
+    const decision = readOptionalText(item?.decision).toUpperCase();
+    if (!CASHFLOW_MANAGEMENT_CHECK_IDS.includes(checkId) || !['CONFIRMED', 'NOT_APPLICABLE'].includes(decision)) continue;
+    byId.set(checkId, { checkId, decision });
+  }
+  return byId;
+}
+
+export function matchingManagementChecks(expected, actual) {
+  const select = (items) => (Array.isArray(items) ? items : [])
+    .map((item) => ({
+      id: readOptionalText(item?.id),
+      status: readOptionalText(item?.status),
+      title: readOptionalText(item?.title),
+      detail: readOptionalText(item?.detail),
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id));
+  return select(expected).length === CASHFLOW_MANAGEMENT_CHECK_IDS.length
+    && stableStringify(select(expected)) === stableStringify(select(actual));
+}

--- a/server/bff/cashflow-management-checks.test.mjs
+++ b/server/bff/cashflow-management-checks.test.mjs
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CASHFLOW_MANAGEMENT_CHECK_IDS,
+  CASHFLOW_MANAGEMENT_CHECK_STATUSES,
+  laborTransferCheck,
+  matchingManagementChecks,
+  negativeProjectionCheck,
+  validManagementConfirmations,
+} from './cashflow-management-checks.mjs';
+
+describe('cashflow management checks', () => {
+  it('pins the check id and status vocabulary to the JVM pattern (parity table)', () => {
+    // JVM CloseCashflowMonthRequest 의 @Pattern 이 정확히 이 어휘를 강제한다
+    // (CloseCashflowMonthRequestTest.managementCheckVocabularyMatchesTheBffParityTable).
+    // 한쪽이 검사를 추가/개명하면 확정이 400 으로 거부되므로, 양쪽 표를 함께 고쳐야 한다.
+    expect(CASHFLOW_MANAGEMENT_CHECK_IDS).toEqual([
+      'labor-transfer',
+      'profit-vat-after-deposit',
+      'negative-projection-balance',
+      'future-prepay-over-million',
+    ]);
+    expect(CASHFLOW_MANAGEMENT_CHECK_STATUSES).toEqual(['OK', 'WARNING', 'REVIEW_REQUIRED']);
+  });
+
+  it('flags unentered week-3 labor as WARNING and zero-planned as REVIEW_REQUIRED', () => {
+    const empty = laborTransferCheck([], new Map(), '2026-07');
+    expect(empty).toMatchObject({ id: 'labor-transfer', status: 'WARNING' });
+
+    const zeroPlanned = laborTransferCheck([], new Map([
+      ['2026-07:projection:3:MYSC_LABOR_OUT', { cellState: 'ZERO', amount: 0 }],
+    ]), '2026-07');
+    expect(zeroPlanned).toMatchObject({ id: 'labor-transfer', status: 'REVIEW_REQUIRED' });
+
+    const transferred = laborTransferCheck([], new Map([
+      ['2026-07:projection:3:MYSC_LABOR_OUT', { cellState: 'VALUE', amount: 1_000_000 }],
+      ['2026-07:actual:3:MYSC_LABOR_OUT', { cellState: 'VALUE', amount: 1_000_000 }],
+    ]), '2026-07');
+    expect(transferred).toMatchObject({ id: 'labor-transfer', status: 'OK' });
+  });
+
+  it('accumulates the projection balance across weeks including the opening balance', () => {
+    const weeks = [
+      { yearMonth: '2026-07', weekNo: 1, projection: { SALES_IN: 100, DIRECT_COST_OUT: 300 } },
+      { yearMonth: '2026-07', weekNo: 2, projection: { SALES_IN: 500 } },
+    ];
+    expect(negativeProjectionCheck(weeks, 100)).toMatchObject({ status: 'WARNING' });
+    expect(negativeProjectionCheck(weeks, 200)).toMatchObject({ status: 'OK' });
+  });
+
+  it('keeps confirmation and comparison rules anchored to the id list', () => {
+    const confirmations = validManagementConfirmations([
+      { checkId: 'labor-transfer', decision: 'confirmed' },
+      { checkId: 'unknown-check', decision: 'CONFIRMED' },
+      { checkId: 'future-prepay-over-million', decision: 'NOT_APPLICABLE' },
+    ]);
+    expect([...confirmations.keys()]).toEqual(['labor-transfer', 'future-prepay-over-million']);
+
+    const checks = CASHFLOW_MANAGEMENT_CHECK_IDS.map((id) => ({ id, status: 'OK', title: 't', detail: 'd' }));
+    expect(matchingManagementChecks(checks, [...checks].reverse())).toBe(true);
+    expect(matchingManagementChecks(checks.slice(0, 3), checks.slice(0, 3))).toBe(false);
+    expect(matchingManagementChecks(checks, checks.map((c) => ({ ...c, status: 'WARNING' })))).toBe(false);
+  });
+});

--- a/server/bff/cashflow-range.mjs
+++ b/server/bff/cashflow-range.mjs
@@ -1,0 +1,4 @@
+// 연월-주차 순서 키 (BFF 쪽 도메인). 주차 비교는 전부 이 키 하나로 한다.
+export function cashflowRangeSortKey(boundary) {
+  return Number(boundary.yearMonth.replace('-', '')) * 10 + Number(boundary.weekNo);
+}

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -24,6 +24,17 @@ import { getMonthFinanceWeeks } from '../../../src/app/platform/cashflow-week-co
 import { WEEKS_PER_MONTH, annualYearsFor, weekOrdinal } from '../cashflow-coordinates.mjs';
 import { TENANT_WIDE_PROJECT_ROLES, isProjectInActorScope } from '../cashflow-project-scope.mjs';
 import { cashflowCloseHash } from '../cashflow-close-hash.mjs';
+import { safeAmount, sumSafe } from '../cashflow-amounts.mjs';
+import { cashflowRangeSortKey } from '../cashflow-range.mjs';
+import {
+  CASHFLOW_MANAGEMENT_CHECK_IDS,
+  futurePrepayCheck,
+  laborTransferCheck,
+  matchingManagementChecks,
+  negativeProjectionCheck,
+  profitVatAfterDepositCheck,
+  validManagementConfirmations,
+} from '../cashflow-management-checks.mjs';
 import {
   CASHFLOW_CUMULATIVE_CLOSE_CONTRACT,
   CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH,
@@ -37,12 +48,6 @@ import { cashflowMonthCloseDeadline, isCashflowCloseOverdue } from '../cashflow-
 
 export { cashflowMonthCloseDeadline };
 
-const CASHFLOW_MANAGEMENT_CHECK_IDS = [
-  'labor-transfer',
-  'profit-vat-after-deposit',
-  'negative-projection-balance',
-  'future-prepay-over-million',
-];
 const CASHFLOW_LINE_INDEX = new Map(CASHFLOW_ALL_LINES.map((lineId, index) => [lineId, index]));
 const CASHFLOW_MONTH_CLOSE_ROUTE_TIMEOUT_MS = 26_000;
 const CASHFLOW_MONTH_CLOSE_MUTATION_BUDGET_MS = 12_000;
@@ -553,10 +558,6 @@ async function readCashflowActivity(db, tenantId, projectId, source = '') {
     .sort((left, right) => readOptionalText(right.createdAt).localeCompare(readOptionalText(left.createdAt)));
 }
 
-function safeAmount(value) {
-  const amount = Number(value);
-  return Number.isSafeInteger(amount) ? amount : 0;
-}
 
 function normalizeMonthCloseCell(cell, yearMonth) {
   const value = objectValue(cell);
@@ -600,15 +601,6 @@ function completeMonthCloseCells(cells) {
   return keys.size === CASHFLOW_MONTH_CELL_COUNT;
 }
 
-function sumSafe(values) {
-  let total = 0;
-  for (const value of values) {
-    const next = total + safeAmount(value);
-    if (!Number.isSafeInteger(next)) return null;
-    total = next;
-  }
-  return total;
-}
 
 function indexMonthCells(cells) {
   const indexed = Array(CASHFLOW_ALL_LINES.length * 2 * WEEKS_PER_MONTH);
@@ -819,116 +811,6 @@ function canonicalCashflowCellStates(cashflow, cells, yearMonth, pinnedSheetCell
   return byKey;
 }
 
-function managementCheck(id, status, title, detail, findings = []) {
-  return findings.length > 0 ? { id, status, title, detail, findings } : { id, status, title, detail };
-}
-
-function laborTransferCheck(weeks, cellStates, yearMonth) {
-  const yearMonths = [...new Set([yearMonth, ...weeks.map((week) => readOptionalText(week.yearMonth))])].sort();
-  const warnings = [];
-  const reviews = [];
-  for (const yearMonth of yearMonths) {
-    const projection = cellStates.get(`${yearMonth}:projection:3:MYSC_LABOR_OUT`);
-    if (!projection || projection.cellState === 'EMPTY') {
-      warnings.push(`${yearMonth} 3주차 인건비 미입력`);
-      continue;
-    }
-    const plannedAmount = safeAmount(projection.amount);
-    if (plannedAmount === 0) {
-      reviews.push(`${yearMonth} 3주차 인건비 미입력`);
-      continue;
-    }
-    const actual = cellStates.get(`${yearMonth}:actual:3:MYSC_LABOR_OUT`);
-    if (!actual || actual.cellState === 'EMPTY') {
-      warnings.push(`${yearMonth} 3주차 · 예정 ${plannedAmount.toLocaleString('ko-KR')}원 · Actual 인건비 미기입`);
-      continue;
-    }
-    const actualAmount = safeAmount(actual.amount);
-    if (actualAmount === 0) {
-      warnings.push(`${yearMonth} 3주차 · 예정 ${plannedAmount.toLocaleString('ko-KR')}원 · 실제 0원 · 실제 미이관`);
-    } else if (actualAmount < plannedAmount) {
-      warnings.push(`${yearMonth} 3주차 · 예정 ${plannedAmount.toLocaleString('ko-KR')}원 · 실제 ${actualAmount.toLocaleString('ko-KR')}원 · 일부 이관`);
-    }
-  }
-  const findings = warnings.length > 0 ? warnings : reviews;
-  return managementCheck(
-    'labor-transfer',
-    warnings.length > 0 ? 'WARNING' : reviews.length > 0 ? 'REVIEW_REQUIRED' : 'OK',
-    'MYSC 인건비 이관',
-    findings.length > 0 ? findings.join(', ') : '기준일까지 모든 3주차 인건비 이관을 확인했습니다.',
-    findings,
-  );
-}
-
-function profitVatAfterDepositCheck(weeks) {
-  const due = [];
-  const deposits = weeks.filter((week) => safeAmount(week.projection?.SALES_IN) > 0);
-  for (const deposit of deposits) {
-    const index = weeks.indexOf(deposit);
-    const next = weeks[index + 1];
-    const gapMs = next?.weekStart && deposit.weekEnd
-      ? Date.parse(`${next.weekStart}T00:00:00Z`) - Date.parse(`${deposit.weekEnd}T00:00:00Z`)
-      : Number.POSITIVE_INFINITY;
-    const targets = [deposit, gapMs <= 8 * 86_400_000 ? next : null].filter(Boolean);
-    const hasProfit = targets.some((week) => safeAmount(week.projection?.MYSC_PROFIT_OUT) > 0);
-    const hasVat = targets.some((week) => safeAmount(week.projection?.SALES_VAT_OUT) > 0);
-    const missing = [hasProfit ? null : 'MYSC 수익', hasVat ? null : '매출부가세'].filter(Boolean);
-    if (missing.length > 0) {
-      due.push(`${deposit.yearMonth} ${deposit.weekNo}주차에 매출입금이 있으나 [${missing.join('·')}] 계획이 Projection에 없습니다.`);
-    }
-  }
-  if (deposits.length === 0) {
-    return managementCheck('profit-vat-after-deposit', 'REVIEW_REQUIRED', '입금 후 MYSC 수익·매출부가세 이관(해당 주, 차주)', 'Projection 매출입금이 없습니다. 해당 없음 여부를 사람이 확인해 주세요.');
-  }
-  return managementCheck(
-    'profit-vat-after-deposit',
-    due.length > 0 ? 'WARNING' : 'OK',
-    '입금 후 MYSC 수익·매출부가세 이관(해당 주, 차주)',
-    due.length > 0 ? `입금 주차 또는 다음 주차까지 미이관: ${due.join(', ')}` : 'Projection 매출입금의 같은 주차 또는 다음 주차 이관을 확인했습니다.',
-    due,
-  );
-}
-
-function negativeProjectionCheck(weeks, openingBalance = 0) {
-  let balance = safeAmount(openingBalance);
-  let prepay = 0;
-  const findings = [];
-  for (const week of weeks) {
-    const totalIn = sumSafe(CASHFLOW_IN_LINES.map((lineId) => week.projection?.[lineId])) || 0;
-    const totalOut = sumSafe(CASHFLOW_OUT_LINES.map((lineId) => week.projection?.[lineId])) || 0;
-    balance += totalIn - totalOut;
-    prepay += safeAmount(week.projection?.MYSC_PREPAY_IN);
-    if (balance < 0) {
-      findings.push(`${week.yearMonth} ${week.weekNo}주차 · 잔액 ${balance.toLocaleString('ko-KR')}원${prepay > 0 ? '' : ' · MYSC 선입금 Projection 없음'}`);
-    }
-  }
-  if (findings.length > 0) {
-    return managementCheck(
-      'negative-projection-balance',
-      'WARNING',
-      'Projection 잔액 마이너스',
-      `${findings.length}개 주차에서 마이너스 · 최초 ${findings[0]}`,
-      findings,
-    );
-  }
-  return managementCheck('negative-projection-balance', 'OK', 'Projection 잔액 마이너스', 'Projection 누적 잔액이 0원 이상입니다.');
-}
-
-function futurePrepayCheck(weeks, asOfKey) {
-  const occurrences = weeks.filter((week) => (
-    cashflowRangeSortKey(week) > asOfKey && safeAmount(week.projection?.MYSC_PREPAY_IN) > 1_000_000
-  ));
-  return managementCheck(
-    'future-prepay-over-million',
-    occurrences.length > 0 ? 'WARNING' : 'OK',
-    '금주 이후 선입금 요청 100만원 초과',
-    occurrences.length > 0
-      ? occurrences.map((week) => `${week.yearMonth} ${week.weekNo}주차 ${safeAmount(week.projection?.MYSC_PREPAY_IN).toLocaleString('ko-KR')}원`).join(', ')
-      : '금주 이후 100만원 초과 요청이 없습니다.',
-    occurrences.map((week) => `${week.yearMonth} ${week.weekNo}주차 · ${safeAmount(week.projection?.MYSC_PREPAY_IN).toLocaleString('ko-KR')}원`),
-  );
-}
-
 export function buildCashflowManagementChecks({
   cashflow, cells, yearMonth, depositScheduleRows, comparisonBoundary, pinnedSheetCells,
   projectionOpeningBalance = 0, weeklyYear = null, monthState = null,
@@ -955,29 +837,6 @@ export function buildCashflowManagementChecks({
   ];
 }
 
-function validManagementConfirmations(confirmations) {
-  const byId = new Map();
-  for (const item of Array.isArray(confirmations) ? confirmations : []) {
-    const checkId = readOptionalText(item?.checkId);
-    const decision = readOptionalText(item?.decision).toUpperCase();
-    if (!CASHFLOW_MANAGEMENT_CHECK_IDS.includes(checkId) || !['CONFIRMED', 'NOT_APPLICABLE'].includes(decision)) continue;
-    byId.set(checkId, { checkId, decision });
-  }
-  return byId;
-}
-
-function matchingManagementChecks(expected, actual) {
-  const select = (items) => (Array.isArray(items) ? items : [])
-    .map((item) => ({
-      id: readOptionalText(item?.id),
-      status: readOptionalText(item?.status),
-      title: readOptionalText(item?.title),
-      detail: readOptionalText(item?.detail),
-    }))
-    .sort((left, right) => left.id.localeCompare(right.id));
-  return select(expected).length === CASHFLOW_MANAGEMENT_CHECK_IDS.length
-    && stableStringify(select(expected)) === stableStringify(select(actual));
-}
 
 function actualWrittenProgressPercent(cells, yearMonth, comparisonBoundary) {
   const asOfYearMonth = readOptionalText(comparisonBoundary?.asOfWeek?.yearMonth);
@@ -1078,9 +937,6 @@ function parseCashflowRangeBoundary(value, fieldName) {
   };
 }
 
-function cashflowRangeSortKey(boundary) {
-  return Number(boundary.yearMonth.replace('-', '')) * 10 + Number(boundary.weekNo);
-}
 
 function cashflowReadModelBoundaries(months) {
   const boundaries = [];

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSheetAnnualApplyRequest.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSheetAnnualApplyRequest.java
@@ -1,5 +1,6 @@
 package dev.merryai.innerplatform.weekly.api;
 
+import dev.merryai.innerplatform.weekly.domain.CashflowAnnualCellSet;
 import dev.merryai.innerplatform.weekly.domain.CashflowLineCatalog;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -47,45 +48,18 @@ public record CashflowSheetAnnualApplyRequest(
     }
 
     public static List<Cell> requireCompleteYear(List<Cell> cells) {
-        if (cells == null || cells.size() != 32) {
-            throw new IllegalArgumentException("Cashflow annual total must contain complete Projection and Actual cells.");
-        }
-        Map<String, Cell> cellsByKey = new LinkedHashMap<>();
-        for (Cell cell : cells) {
-            String lineId = CashflowLineCatalog.canonicalize(cell == null ? null : cell.cashflowLine());
-            if (cell == null || lineId.isBlank() || !CashflowLineCatalog.ALL_LINES.contains(lineId)) {
-                throw new IllegalArgumentException("Unsupported cashflow line.");
-            }
-            String mode = cell.mode() == null ? "" : cell.mode().trim().toLowerCase(Locale.ROOT);
-            String state = cell.cellState() == null ? "" : cell.cellState().trim().toUpperCase(Locale.ROOT);
-            if (!List.of("projection", "actual").contains(mode)) {
-                throw new IllegalArgumentException("Cashflow annual mode must be projection or actual.");
-            }
-            if (List.of("VALUE", "ZERO").contains(state)) {
-                if (cell.amount() == null) throw new IllegalArgumentException("VALUE cashflow cells require an amount.");
-                try {
-                    cell.amount().longValueExact();
-                } catch (ArithmeticException error) {
-                    throw new IllegalArgumentException("Cashflow amounts must be whole won values in the supported range.");
-                }
-                if ("ZERO".equals(state) && cell.amount().compareTo(BigDecimal.ZERO) != 0) {
-                    throw new IllegalArgumentException("ZERO cashflow cells require an explicit zero amount.");
-                }
-            } else if (!"EMPTY".equals(state) || cell.amount() != null) {
-                throw new IllegalArgumentException("EMPTY cashflow cells must not include an amount.");
-            }
-            Cell canonical = new Cell(mode, lineId, state, cell.amount(), cell.sourceCell(), cell.sourceLabel());
-            if (cellsByKey.putIfAbsent(mode + ":" + lineId, canonical) != null) {
-                throw new IllegalArgumentException("Cashflow annual total contains duplicate cells.");
-            }
-        }
-        for (String mode : List.of("projection", "actual")) {
-            for (String lineId : CashflowLineCatalog.ALL_LINES) {
-                if (!cellsByKey.containsKey(mode + ":" + lineId)) {
-                    throw new IllegalArgumentException("Cashflow annual total must contain every cashflow line.");
-                }
-            }
-        }
-        return List.copyOf(cellsByKey.values());
+        // 규칙은 domain/CashflowAnnualCellSet 에 있다. 여기는 표현 <-> 도메인 매핑만 한다.
+        List<CashflowAnnualCellSet.Cell> domainCells = cells == null ? null : cells.stream()
+            .map(cell -> cell == null ? null : new CashflowAnnualCellSet.Cell(
+                cell.mode(), cell.cashflowLine(), cell.cellState(),
+                cell.amount(), cell.sourceCell(), cell.sourceLabel()
+            ))
+            .toList();
+        return CashflowAnnualCellSet.requireComplete(domainCells).stream()
+            .map(cell -> new Cell(
+                cell.mode(), cell.cashflowLine(), cell.cellState(),
+                cell.amount(), cell.sourceCell(), cell.sourceLabel()
+            ))
+            .toList();
     }
 }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -1,5 +1,8 @@
 package dev.merryai.innerplatform.weekly.api;
 
+import dev.merryai.innerplatform.weekly.domain.CashflowCumulativeCloseHead;
+import dev.merryai.innerplatform.weekly.domain.CashflowLedgerSource;
+import dev.merryai.innerplatform.weekly.domain.CashflowOpeningBalance;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import dev.merryai.innerplatform.weekly.domain.CashflowLineCatalog;
@@ -26,7 +29,6 @@ import org.springframework.web.server.ResponseStatusException;
 import dev.merryai.innerplatform.weekly.domain.CashflowWeekTotals;
 import dev.merryai.innerplatform.weekly.service.CashflowReadService;
 import dev.merryai.innerplatform.weekly.service.command.CashflowMonthReopenCommands;
-import dev.merryai.innerplatform.weekly.storage.WeeklyExpensePersistence;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -287,8 +289,8 @@ public class WeeklyExpenseController {
     ) {
         commandService.requireProjectAllowed(WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, actorContext(tenantId, actorId, actorRole, actorEmail), projectId);
         Integer weeklyYear = readService.declaredWeeklyYear(tenantId, projectId);
-        WeeklyExpensePersistence.CashflowLedgerSource source = weeklyYear == null
-            ? new WeeklyExpensePersistence.CashflowLedgerSource(List.of(), List.of())
+        CashflowLedgerSource source = weeklyYear == null
+            ? new CashflowLedgerSource(List.of(), List.of())
             : readCashflowSource(tenantId, projectId, weeklyYear);
         return buildCashflowSnapshot(projectId, source);
     }
@@ -306,7 +308,7 @@ public class WeeklyExpenseController {
         );
     }
 
-    private WeeklyExpensePersistence.CashflowLedgerSource readCashflowSource(
+    private CashflowLedgerSource readCashflowSource(
         String tenantId,
         String projectId,
         int weeklyYear
@@ -316,7 +318,7 @@ public class WeeklyExpenseController {
 
     private CashflowSnapshotResponse buildCashflowSnapshot(
         String projectId,
-        WeeklyExpensePersistence.CashflowLedgerSource source
+        CashflowLedgerSource source
     ) {
         List<CashflowSnapshotResponse.ProjectionLine> projection = source.projection().stream()
             .map(line -> new CashflowSnapshotResponse.ProjectionLine(
@@ -491,12 +493,12 @@ public class WeeklyExpenseController {
                 "먼저 시트값을 불러와 주세요."
             ))
             : List.of();
-        WeeklyExpensePersistence.CashflowLedgerSource source = amendedClosed
+        CashflowLedgerSource source = amendedClosed
             ? readService.globalLedgerSource(tenantId, projectId)
             : open && weeklyYear != null
                 ? readCashflowSource(tenantId, projectId, weeklyYear)
                 : open
-                    ? new WeeklyExpensePersistence.CashflowLedgerSource(List.of(), List.of())
+                    ? new CashflowLedgerSource(List.of(), List.of())
                     : null;
         CashflowSnapshotResponse cashflow = currentLedgerView ? buildCashflowSnapshot(projectId, source) : null;
         CashflowOpeningBalancesResponse openingBalances = currentLedgerView
@@ -528,9 +530,9 @@ public class WeeklyExpenseController {
             }
             monthClose = verified;
         }
-        WeeklyExpensePersistence.CashflowCumulativeCloseHead cumulative = readService.cumulativeCloseHead(tenantId, projectId);
+        CashflowCumulativeCloseHead cumulative = readService.cumulativeCloseHead(tenantId, projectId);
         if (cumulative == null) {
-            cumulative = new WeeklyExpensePersistence.CashflowCumulativeCloseHead("OPEN", "2023-01", "", "", 0);
+            cumulative = new CashflowCumulativeCloseHead("OPEN", "2023-01", "", "", 0);
         }
         CashflowProjectionActualSummaryBatchResponse.Item projectionActualSummary;
         if (source != null) {
@@ -942,7 +944,7 @@ public class WeeklyExpenseController {
     }
 
     private CashflowOpeningBalancesResponse toOpeningBalancesResponse(
-        WeeklyExpensePersistence.CashflowOpeningBalance opening
+        CashflowOpeningBalance opening
     ) {
         return new CashflowOpeningBalancesResponse(
             opening.selectedYear(),
@@ -952,7 +954,7 @@ public class WeeklyExpenseController {
     }
 
     private CashflowOpeningBalancesResponse.Mode toOpeningBalanceMode(
-        WeeklyExpensePersistence.CashflowOpeningBalance.Mode mode
+        CashflowOpeningBalance.Mode mode
     ) {
         return new CashflowOpeningBalancesResponse.Mode(
             mode.amount(),

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -29,6 +29,8 @@ import org.springframework.web.server.ResponseStatusException;
 import dev.merryai.innerplatform.weekly.domain.CashflowWeekTotals;
 import dev.merryai.innerplatform.weekly.service.CashflowReadService;
 import dev.merryai.innerplatform.weekly.service.command.CashflowMonthReopenCommands;
+import dev.merryai.innerplatform.weekly.service.command.CashflowSheetAnnualApplyCommand;
+import dev.merryai.innerplatform.weekly.domain.CashflowAnnualCellSet;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -822,11 +824,24 @@ public class WeeklyExpenseController {
         HttpServletRequest httpRequest,
         @Valid @RequestBody CashflowSheetAnnualApplyRequest request
     ) {
+        // HTTP 표현은 여기까지다. 서비스에는 런타임 중립 커맨드와 도메인 셀만 넘긴다.
         return commandService.applyCashflowSheetAnnualTotal(
             actorContext(tenantId, actorId, actorRole, actorEmail),
             projectId,
             editSession(httpRequest),
-            request
+            new CashflowSheetAnnualApplyCommand(
+                request.idempotencyKey(),
+                request.sourceRevision(),
+                request.year(),
+                request.expectedRevision(),
+                request.cells().stream()
+                    .map(cell -> new CashflowAnnualCellSet.Cell(
+                        cell.mode(), cell.cashflowLine(), cell.cellState(),
+                        cell.amount(), cell.sourceCell(), cell.sourceLabel()
+                    ))
+                    .toList(),
+                request.amendmentReason()
+            )
         );
     }
 

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowAnnualCellSet.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowAnnualCellSet.java
@@ -1,0 +1,79 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * 연간 열 셀 집합의 완전성 규칙. 연간 값은 주차가 없는 단일 셀이라
+ * 라인 16종 x 모드 2 = 32셀이 전부 있어야 한다. 상태/금액 정합과 중복 금지는
+ * {@link CashflowMonthCellSet} 과 같은 원칙이다.
+ *
+ * <p>원래 api DTO(CashflowSheetAnnualApplyRequest.requireCompleteYear)에 있던 규칙을
+ * 도메인으로 옮겼다. 예외 메시지는 이동 전과 문자 그대로 동일하다 - 행동 보존.
+ */
+public final class CashflowAnnualCellSet {
+
+    public record Cell(
+        String mode,
+        String cashflowLine,
+        String cellState,
+        BigDecimal amount,
+        String sourceCell,
+        String sourceLabel
+    ) {
+    }
+
+    private CashflowAnnualCellSet() {
+    }
+
+    /** 라인 x 모드. 연간 열은 주차가 없다. */
+    public static int yearCellCount() {
+        return CashflowLineCatalog.ALL_LINES.size() * CashflowLineCatalog.MODE_COUNT;
+    }
+
+    public static List<Cell> requireComplete(List<Cell> cells) {
+        if (cells == null || cells.size() != yearCellCount()) {
+            throw new IllegalArgumentException("Cashflow annual total must contain complete Projection and Actual cells.");
+        }
+        Map<String, Cell> cellsByKey = new LinkedHashMap<>();
+        for (Cell cell : cells) {
+            String lineId = CashflowLineCatalog.canonicalize(cell == null ? null : cell.cashflowLine());
+            if (cell == null || lineId.isBlank() || !CashflowLineCatalog.ALL_LINES.contains(lineId)) {
+                throw new IllegalArgumentException("Unsupported cashflow line.");
+            }
+            String mode = cell.mode() == null ? "" : cell.mode().trim().toLowerCase(Locale.ROOT);
+            String state = cell.cellState() == null ? "" : cell.cellState().trim().toUpperCase(Locale.ROOT);
+            if (!List.of("projection", "actual").contains(mode)) {
+                throw new IllegalArgumentException("Cashflow annual mode must be projection or actual.");
+            }
+            if (List.of("VALUE", "ZERO").contains(state)) {
+                if (cell.amount() == null) throw new IllegalArgumentException("VALUE cashflow cells require an amount.");
+                try {
+                    cell.amount().longValueExact();
+                } catch (ArithmeticException error) {
+                    throw new IllegalArgumentException("Cashflow amounts must be whole won values in the supported range.");
+                }
+                if ("ZERO".equals(state) && cell.amount().compareTo(BigDecimal.ZERO) != 0) {
+                    throw new IllegalArgumentException("ZERO cashflow cells require an explicit zero amount.");
+                }
+            } else if (!"EMPTY".equals(state) || cell.amount() != null) {
+                throw new IllegalArgumentException("EMPTY cashflow cells must not include an amount.");
+            }
+            Cell canonical = new Cell(mode, lineId, state, cell.amount(), cell.sourceCell(), cell.sourceLabel());
+            if (cellsByKey.putIfAbsent(mode + ":" + lineId, canonical) != null) {
+                throw new IllegalArgumentException("Cashflow annual total contains duplicate cells.");
+            }
+        }
+        for (String mode : List.of("projection", "actual")) {
+            for (String lineId : CashflowLineCatalog.ALL_LINES) {
+                if (!cellsByKey.containsKey(mode + ":" + lineId)) {
+                    throw new IllegalArgumentException("Cashflow annual total must contain every cashflow line.");
+                }
+            }
+        }
+        return List.copyOf(cellsByKey.values());
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowCumulativeCloseHead.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowCumulativeCloseHead.java
@@ -1,0 +1,10 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+/** 누적 결산 헤드 읽기 모델. 영속 인터페이스의 중첩 record 에서 도메인으로 승격. */
+public record CashflowCumulativeCloseHead(
+    String status,
+    String fromMonth,
+    String closedThrough,
+    String rootHash,
+    long headRevision
+) {}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowLedgerSource.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowLedgerSource.java
@@ -1,0 +1,27 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+import java.util.List;
+
+/**
+ * 원장(주간 Projection/Actual) 스냅샷. 원래 영속 인터페이스의 중첩 record 였다 -
+ * 서비스와 컨트롤러가 이 타입 때문에 storage 를 import 해야 했다. 이제 세 계층이
+ * 전부 도메인 타입을 본다.
+ */
+public record CashflowLedgerSource(
+    List<WeeklyExpenseProjectionEntity> projection,
+    List<WeeklyExpenseActualEntity> actual,
+    String targetRevision
+) {
+    public CashflowLedgerSource(
+        List<WeeklyExpenseProjectionEntity> projection,
+        List<WeeklyExpenseActualEntity> actual
+    ) {
+        this(projection, actual, "");
+    }
+
+    public CashflowLedgerSource {
+        projection = projection == null ? List.of() : List.copyOf(projection);
+        actual = actual == null ? List.of() : List.copyOf(actual);
+        targetRevision = targetRevision == null ? "" : targetRevision;
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowOpeningBalance.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowOpeningBalance.java
@@ -1,0 +1,39 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+/** 기초잔액 읽기 모델. 영속 인터페이스의 중첩 record 에서 도메인으로 승격. */
+public record CashflowOpeningBalance(
+    int selectedYear,
+    Mode projection,
+    Mode actual
+) {
+    public record Mode(
+        BigDecimal amount,
+        Map<String, BigDecimal> lineAmounts,
+        List<YearSource> sources,
+        List<Integer> includedYears,
+        List<Integer> excludedWeeklyYears
+    ) {
+        public Mode {
+            amount = amount == null ? BigDecimal.ZERO : amount;
+            lineAmounts = lineAmounts == null ? Map.of() : Map.copyOf(lineAmounts);
+            sources = sources == null ? List.of() : List.copyOf(sources);
+            includedYears = includedYears == null ? List.of() : List.copyOf(includedYears);
+            excludedWeeklyYears = excludedWeeklyYears == null ? List.of() : List.copyOf(excludedWeeklyYears);
+        }
+    }
+
+    public record YearSource(
+        int year,
+        Map<String, BigDecimal> lineAmounts,
+        Map<String, String> lineStates
+    ) {
+        public YearSource {
+            lineAmounts = lineAmounts == null ? Map.of() : Map.copyOf(lineAmounts);
+            lineStates = lineStates == null ? Map.of() : Map.copyOf(lineStates);
+        }
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/CashflowReadService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/CashflowReadService.java
@@ -1,5 +1,8 @@
 package dev.merryai.innerplatform.weekly.service;
 
+import dev.merryai.innerplatform.weekly.domain.CashflowCumulativeCloseHead;
+import dev.merryai.innerplatform.weekly.domain.CashflowLedgerSource;
+import dev.merryai.innerplatform.weekly.domain.CashflowOpeningBalance;
 import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseWeeklyStatusEntity;
 import dev.merryai.innerplatform.weekly.storage.WeeklyExpensePersistence;
 import org.springframework.stereotype.Service;
@@ -27,7 +30,7 @@ public class CashflowReadService {
         return persistence.findCashflowDeclaredWeeklyYear(tenantId, projectId);
     }
 
-    public WeeklyExpensePersistence.CashflowLedgerSource ledgerSource(
+    public CashflowLedgerSource ledgerSource(
         String tenantId,
         String projectId,
         Integer weeklyYear
@@ -35,11 +38,11 @@ public class CashflowReadService {
         return persistence.findCashflowLedgerSource(tenantId, projectId, weeklyYear);
     }
 
-    public WeeklyExpensePersistence.CashflowLedgerSource globalLedgerSource(String tenantId, String projectId) {
+    public CashflowLedgerSource globalLedgerSource(String tenantId, String projectId) {
         return persistence.findCashflowGlobalLedgerSource(tenantId, projectId);
     }
 
-    public WeeklyExpensePersistence.CashflowOpeningBalance openingBalance(
+    public CashflowOpeningBalance openingBalance(
         String tenantId,
         String projectId,
         int year
@@ -47,7 +50,7 @@ public class CashflowReadService {
         return persistence.findCashflowOpeningBalance(tenantId, projectId, year);
     }
 
-    public WeeklyExpensePersistence.CashflowCumulativeCloseHead cumulativeCloseHead(
+    public CashflowCumulativeCloseHead cumulativeCloseHead(
         String tenantId,
         String projectId
     ) {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -1,5 +1,7 @@
 package dev.merryai.innerplatform.weekly.service;
 
+import dev.merryai.innerplatform.weekly.domain.CashflowAnnualCellSet;
+import dev.merryai.innerplatform.weekly.service.command.CashflowSheetAnnualApplyCommand;
 import dev.merryai.innerplatform.weekly.domain.CashflowCumulativeCloseHead;
 import dev.merryai.innerplatform.weekly.domain.CashflowLedgerSource;
 import dev.merryai.innerplatform.weekly.domain.CashflowOpeningBalance;
@@ -16,7 +18,6 @@ import dev.merryai.innerplatform.weekly.api.CashflowSheetLabApplyRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetLabApplyResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetBatchApplyRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetBatchApplyResponse;
-import dev.merryai.innerplatform.weekly.api.CashflowSheetAnnualApplyRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetAnnualApplyResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetOperationStatusResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowPendingApprovalAffectedMonth;
@@ -2088,7 +2089,7 @@ public class WeeklyExpenseCommandService {
         TrustedActorContext actor,
         String projectId,
         CashflowEditSession editSession,
-        CashflowSheetAnnualApplyRequest request
+        CashflowSheetAnnualApplyCommand request
     ) {
         TrustedActorContext writer = requireCashflowWritePermission(
             CASHFLOW_SHEET_LAB_APPLY_COMMAND,
@@ -2106,7 +2107,7 @@ public class WeeklyExpenseCommandService {
         );
         if (replay.isPresent()) return replay.get();
 
-        CashflowSheetAnnualApplyRequest.requireCompleteYear(request.cells());
+        CashflowAnnualCellSet.requireComplete(request.cells());
         assertAtomicWriteBudget(1, 2, "Cashflow annual total apply");
         String sourceSheetKey = CASHFLOW_SHEET_LAB_ACTUAL_SOURCE;
         List<String> annualMonths = java.util.stream.IntStream.rangeClosed(1, 12)

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -1,5 +1,8 @@
 package dev.merryai.innerplatform.weekly.service;
 
+import dev.merryai.innerplatform.weekly.domain.CashflowCumulativeCloseHead;
+import dev.merryai.innerplatform.weekly.domain.CashflowLedgerSource;
+import dev.merryai.innerplatform.weekly.domain.CashflowOpeningBalance;
 import dev.merryai.innerplatform.weekly.service.command.CashflowMonthReopenCommands;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -285,7 +288,7 @@ public class WeeklyExpenseCommandService {
                     ));
                     continue;
                 }
-                WeeklyExpensePersistence.CashflowLedgerSource source = persistence.findCashflowLedgerSource(
+                CashflowLedgerSource source = persistence.findCashflowLedgerSource(
                     actor.tenantId(), projectId, weeklyYear,
                     CashflowProjectionActualSummaryCalculator.FROM_MONTH, throughMonth
                 );
@@ -304,7 +307,7 @@ public class WeeklyExpenseCommandService {
     public CashflowProjectionActualSummaryBatchResponse.Item readCashflowProjectionActualSummary(
         TrustedActorContext actor,
         String projectId,
-        WeeklyExpensePersistence.CashflowLedgerSource source
+        CashflowLedgerSource source
     ) {
         authorizationService.requireProjectAllowed(CASHFLOW_READ_COMMAND, actor, projectId);
         CashflowProjectionActualSummaryCalculator.FinanceWeek boundary =
@@ -314,7 +317,7 @@ public class WeeklyExpenseCommandService {
 
     private CashflowProjectionActualSummaryBatchResponse.Item toProjectionActualSummary(
         String projectId,
-        WeeklyExpensePersistence.CashflowLedgerSource source,
+        CashflowLedgerSource source,
         CashflowProjectionActualSummaryCalculator.FinanceWeek boundary,
         String selectedYearMonth
     ) {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/command/CashflowSheetAnnualApplyCommand.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/command/CashflowSheetAnnualApplyCommand.java
@@ -1,0 +1,35 @@
+package dev.merryai.innerplatform.weekly.service.command;
+
+import dev.merryai.innerplatform.weekly.domain.CashflowAnnualCellSet;
+
+import java.util.List;
+
+/**
+ * 연간 열 반영 커맨드 - 런타임 중립 입력. HTTP 표현(Bean Validation)은 api DTO 가
+ * 소유하고, 서비스와 영속 계층은 이 record 와 도메인 셀만 안다.
+ * {@link CashflowMonthReopenCommands} 와 같은 절단 패턴이다.
+ */
+public record CashflowSheetAnnualApplyCommand(
+    String idempotencyKey,
+    String sourceRevision,
+    int year,
+    long expectedRevision,
+    List<CashflowAnnualCellSet.Cell> cells,
+    String amendmentReason
+) {
+    public CashflowSheetAnnualApplyCommand {
+        amendmentReason = amendmentReason == null ? "" : amendmentReason.trim();
+        cells = cells == null ? List.of() : List.copyOf(cells);
+    }
+
+    /** 변경 사유 없는 일반 반영. DTO 의 편의 생성자와 같은 모양. */
+    public CashflowSheetAnnualApplyCommand(
+        String idempotencyKey,
+        String sourceRevision,
+        int year,
+        long expectedRevision,
+        List<CashflowAnnualCellSet.Cell> cells
+    ) {
+        this(idempotencyKey, sourceRevision, year, expectedRevision, cells, "");
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -1,5 +1,8 @@
 package dev.merryai.innerplatform.weekly.storage;
 
+import dev.merryai.innerplatform.weekly.domain.CashflowCumulativeCloseHead;
+import dev.merryai.innerplatform.weekly.domain.CashflowLedgerSource;
+import dev.merryai.innerplatform.weekly.domain.CashflowOpeningBalance;
 import dev.merryai.innerplatform.weekly.service.command.CashflowMonthReopenCommands;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -1,5 +1,7 @@
 package dev.merryai.innerplatform.weekly.storage;
 
+import dev.merryai.innerplatform.weekly.domain.CashflowAnnualCellSet;
+import dev.merryai.innerplatform.weekly.service.command.CashflowSheetAnnualApplyCommand;
 import dev.merryai.innerplatform.weekly.domain.CashflowCumulativeCloseHead;
 import dev.merryai.innerplatform.weekly.domain.CashflowLedgerSource;
 import dev.merryai.innerplatform.weekly.domain.CashflowOpeningBalance;
@@ -23,7 +25,6 @@ import dev.merryai.innerplatform.weekly.api.CashflowEditSession;
 import dev.merryai.innerplatform.weekly.api.CashflowVarianceRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetBatchApplyRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetLabApplyRequest;
-import dev.merryai.innerplatform.weekly.api.CashflowSheetAnnualApplyRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowPendingApprovalAffectedMonth;
 import dev.merryai.innerplatform.weekly.api.CloseCashflowMonthRequest;
 import dev.merryai.innerplatform.weekly.api.CompleteCashflowWeeklyUpdateRequest;
@@ -2474,7 +2475,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         String tenantId,
         String projectId,
         String sourceSheetKey,
-        CashflowSheetAnnualApplyRequest request
+        CashflowSheetAnnualApplyCommand request
     ) {
         requireValidatedCashflowWriteScope(tenantId, projectId);
         requireCashflowMonthsOpen(
@@ -2484,8 +2485,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                 .mapToObj(month -> "%04d-%02d".formatted(request.year(), month))
                 .toList()
         );
-        List<CashflowSheetAnnualApplyRequest.Cell> cells = CashflowSheetAnnualApplyRequest
-            .requireCompleteYear(request.cells());
+        List<CashflowAnnualCellSet.Cell> cells = CashflowAnnualCellSet.requireComplete(request.cells());
         DocumentReference ref = cashflowYearTotalRef(tenantId, projectId, request.year());
         DocumentSnapshot snapshot = get(ref);
         Map<String, Object> current = snapshot.exists() ? data(snapshot) : Map.of();
@@ -2499,7 +2499,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         Map<String, String> projectionStates = new TreeMap<>();
         Map<String, String> actualStates = new TreeMap<>();
         List<Map<String, Object>> sourceCells = new ArrayList<>();
-        for (CashflowSheetAnnualApplyRequest.Cell cell : cells) {
+        for (CashflowAnnualCellSet.Cell cell : cells) {
             Map<String, BigDecimal> amounts = "projection".equals(cell.mode()) ? projection : actual;
             Map<String, String> states = "projection".equals(cell.mode()) ? projectionStates : actualStates;
             states.put(cell.cashflowLine(), cell.cellState());

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
@@ -1,5 +1,8 @@
 package dev.merryai.innerplatform.weekly.storage;
 
+import dev.merryai.innerplatform.weekly.domain.CashflowCumulativeCloseHead;
+import dev.merryai.innerplatform.weekly.domain.CashflowLedgerSource;
+import dev.merryai.innerplatform.weekly.domain.CashflowOpeningBalance;
 import dev.merryai.innerplatform.weekly.service.command.CashflowMonthReopenCommands;
 import dev.merryai.innerplatform.weekly.api.SaveDraftResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowEditSession;
@@ -159,57 +162,7 @@ public interface WeeklyExpensePersistence {
     }
 
     /** One authoritative read of the single weekly cashflow block. */
-    record CashflowLedgerSource(
-        List<WeeklyExpenseProjectionEntity> projection,
-        List<WeeklyExpenseActualEntity> actual,
-        String targetRevision
-    ) {
-        public CashflowLedgerSource(
-            List<WeeklyExpenseProjectionEntity> projection,
-            List<WeeklyExpenseActualEntity> actual
-        ) {
-            this(projection, actual, "");
-        }
 
-        public CashflowLedgerSource {
-            projection = projection == null ? List.of() : List.copyOf(projection);
-            actual = actual == null ? List.of() : List.copyOf(actual);
-            targetRevision = targetRevision == null ? "" : targetRevision;
-        }
-    }
-
-    record CashflowOpeningBalance(
-        int selectedYear,
-        Mode projection,
-        Mode actual
-    ) {
-        public record Mode(
-            BigDecimal amount,
-            Map<String, BigDecimal> lineAmounts,
-            List<YearSource> sources,
-            List<Integer> includedYears,
-            List<Integer> excludedWeeklyYears
-        ) {
-            public Mode {
-                amount = amount == null ? BigDecimal.ZERO : amount;
-                lineAmounts = lineAmounts == null ? Map.of() : Map.copyOf(lineAmounts);
-                sources = sources == null ? List.of() : List.copyOf(sources);
-                includedYears = includedYears == null ? List.of() : List.copyOf(includedYears);
-                excludedWeeklyYears = excludedWeeklyYears == null ? List.of() : List.copyOf(excludedWeeklyYears);
-            }
-        }
-
-        public record YearSource(
-            int year,
-            Map<String, BigDecimal> lineAmounts,
-            Map<String, String> lineStates
-        ) {
-            public YearSource {
-                lineAmounts = lineAmounts == null ? Map.of() : Map.copyOf(lineAmounts);
-                lineStates = lineStates == null ? Map.of() : Map.copyOf(lineStates);
-            }
-        }
-    }
 
     record CashflowMonthCloseRecord(
         String projectId,
@@ -328,13 +281,6 @@ public interface WeeklyExpensePersistence {
         long missedCount
     ) {}
 
-    record CashflowCumulativeCloseHead(
-        String status,
-        String fromMonth,
-        String closedThrough,
-        String rootHash,
-        long headRevision
-    ) {}
 
     record CashflowWeekScope(String yearMonth, int weekNo) {
     }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
@@ -1,5 +1,7 @@
 package dev.merryai.innerplatform.weekly.storage;
 
+import dev.merryai.innerplatform.weekly.domain.CashflowAnnualCellSet;
+import dev.merryai.innerplatform.weekly.service.command.CashflowSheetAnnualApplyCommand;
 import dev.merryai.innerplatform.weekly.domain.CashflowCumulativeCloseHead;
 import dev.merryai.innerplatform.weekly.domain.CashflowLedgerSource;
 import dev.merryai.innerplatform.weekly.domain.CashflowOpeningBalance;
@@ -12,7 +14,6 @@ import dev.merryai.innerplatform.weekly.api.CompleteCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.ReopenCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetLabApplyRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetBatchApplyRequest;
-import dev.merryai.innerplatform.weekly.api.CashflowSheetAnnualApplyRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowPendingApprovalAffectedMonth;
 import dev.merryai.innerplatform.weekly.api.TrustedActorContext;
 import dev.merryai.innerplatform.weekly.api.WeeklyExpenseEditLeaseException;
@@ -643,7 +644,7 @@ public interface WeeklyExpensePersistence {
         String tenantId,
         String projectId,
         String sourceSheetKey,
-        CashflowSheetAnnualApplyRequest request
+        CashflowSheetAnnualApplyCommand request
     ) {
         throw new WeeklyExpenseEditLeaseException(
             503,

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/CloseCashflowMonthRequestTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/CloseCashflowMonthRequestTest.java
@@ -231,4 +231,22 @@ class CloseCashflowMonthRequestTest {
         }
         return rows;
     }
+
+    @Test
+    void managementCheckVocabularyMatchesTheBffParityTable() throws Exception {
+        // BFF cashflow-management-checks.mjs 가 정확히 이 어휘를 계산의 소스로 쓴다
+        // (cashflow-management-checks.test.mjs 의 parity 표). 여기의 @Pattern 이 갈리면
+        // BFF 가 만든 검사 결과가 Bean Validation 에서 400 으로 거부된다.
+        java.lang.reflect.RecordComponent id = java.util.Arrays.stream(
+            CloseCashflowMonthRequest.ManagementCheck.class.getRecordComponents()
+        ).filter(component -> component.getName().equals("id")).findFirst().orElseThrow();
+        java.lang.reflect.RecordComponent status = java.util.Arrays.stream(
+            CloseCashflowMonthRequest.ManagementCheck.class.getRecordComponents()
+        ).filter(component -> component.getName().equals("status")).findFirst().orElseThrow();
+
+        assertThat(id.getAccessor().getAnnotation(jakarta.validation.constraints.Pattern.class).regexp())
+            .isEqualTo("labor-transfer|profit-vat-after-deposit|negative-projection-balance|future-prepay-over-million");
+        assertThat(status.getAccessor().getAnnotation(jakarta.validation.constraints.Pattern.class).regexp())
+            .isEqualTo("OK|WARNING|REVIEW_REQUIRED");
+    }
 }

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
@@ -1,5 +1,8 @@
 package dev.merryai.innerplatform.weekly.api;
 
+import dev.merryai.innerplatform.weekly.domain.CashflowCumulativeCloseHead;
+import dev.merryai.innerplatform.weekly.domain.CashflowLedgerSource;
+import dev.merryai.innerplatform.weekly.domain.CashflowOpeningBalance;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.merryai.innerplatform.weekly.domain.CashflowLineCatalog;
@@ -1569,8 +1572,8 @@ class WeeklyExpenseControllerTest {
         ));
         when(dashboardPersistence.findCashflowDeclaredWeeklyYear("tenant-month-dashboard", "project-month-dashboard"))
             .thenReturn(2026);
-        WeeklyExpensePersistence.CashflowLedgerSource dashboardSource =
-            new WeeklyExpensePersistence.CashflowLedgerSource(List.of(), List.of());
+        CashflowLedgerSource dashboardSource =
+            new CashflowLedgerSource(List.of(), List.of());
         when(dashboardPersistence.findCashflowLedgerSource("tenant-month-dashboard", "project-month-dashboard", 2026))
             .thenReturn(dashboardSource);
         when(dashboardCommandService.readCashflowProjectionActualSummary(
@@ -1588,12 +1591,12 @@ class WeeklyExpenseControllerTest {
             "tenant-month-dashboard",
             "project-month-dashboard",
             2026
-        )).thenReturn(new WeeklyExpensePersistence.CashflowOpeningBalance(
+        )).thenReturn(new CashflowOpeningBalance(
             2026,
-            new WeeklyExpensePersistence.CashflowOpeningBalance.Mode(
+            new CashflowOpeningBalance.Mode(
                 new java.math.BigDecimal("2000000"),
                 Map.of("SALES_IN", new java.math.BigDecimal("2000000")),
-                List.of(new WeeklyExpensePersistence.CashflowOpeningBalance.YearSource(
+                List.of(new CashflowOpeningBalance.YearSource(
                     2025,
                     Map.of("SALES_IN", new java.math.BigDecimal("2000000")),
                     completeAnnualStates
@@ -1601,10 +1604,10 @@ class WeeklyExpenseControllerTest {
                 List.of(2025),
                 List.of()
             ),
-            new WeeklyExpensePersistence.CashflowOpeningBalance.Mode(
+            new CashflowOpeningBalance.Mode(
                 new java.math.BigDecimal("1800000"),
                 Map.of("SALES_IN", new java.math.BigDecimal("1800000")),
-                List.of(new WeeklyExpensePersistence.CashflowOpeningBalance.YearSource(
+                List.of(new CashflowOpeningBalance.YearSource(
                     2025,
                     Map.of("SALES_IN", new java.math.BigDecimal("1800000")),
                     completeAnnualStates
@@ -1661,17 +1664,17 @@ class WeeklyExpenseControllerTest {
                 null, null, null, null, null, null, null, null, null, null, null
             ));
         when(dashboardPersistence.findCashflowOpeningBalance("tenant-no-year", "project-no-year", 2026))
-            .thenReturn(new WeeklyExpensePersistence.CashflowOpeningBalance(
+            .thenReturn(new CashflowOpeningBalance(
                 2026,
-                new WeeklyExpensePersistence.CashflowOpeningBalance.Mode(
+                new CashflowOpeningBalance.Mode(
                     java.math.BigDecimal.ZERO, Map.of(), List.of(), List.of(), List.of()
                 ),
-                new WeeklyExpensePersistence.CashflowOpeningBalance.Mode(
+                new CashflowOpeningBalance.Mode(
                     java.math.BigDecimal.ZERO, Map.of(), List.of(), List.of(), List.of()
                 )
             ));
         when(dashboardCommandService.readCashflowProjectionActualSummary(
-            any(), eq("project-no-year"), any(WeeklyExpensePersistence.CashflowLedgerSource.class)
+            any(), eq("project-no-year"), any(CashflowLedgerSource.class)
         )).thenReturn(new CashflowProjectionActualSummaryBatchResponse.Item(
             "project-no-year", "2023-01",
             new CashflowProjectionActualSummaryBatchResponse.ComparisonAsOfWeek("2026-07", 4),
@@ -1778,8 +1781,8 @@ class WeeklyExpenseControllerTest {
                 "2026-07-08T00:00:00Z", "finance-1", "재무",
                 null, null, null, null, null, null, null, "audit-amended"
             ));
-        WeeklyExpensePersistence.CashflowLedgerSource liveSource =
-            new WeeklyExpensePersistence.CashflowLedgerSource(
+        CashflowLedgerSource liveSource =
+            new CashflowLedgerSource(
                 List.of(),
                 List.of(),
                 targetRevision
@@ -1790,12 +1793,12 @@ class WeeklyExpenseControllerTest {
             "tenant-amended",
             "project-amended",
             2026
-        )).thenReturn(new WeeklyExpensePersistence.CashflowOpeningBalance(
+        )).thenReturn(new CashflowOpeningBalance(
             2026,
-            new WeeklyExpensePersistence.CashflowOpeningBalance.Mode(
+            new CashflowOpeningBalance.Mode(
                 java.math.BigDecimal.ZERO, Map.of(), List.of(), List.of(), List.of()
             ),
-            new WeeklyExpensePersistence.CashflowOpeningBalance.Mode(
+            new CashflowOpeningBalance.Mode(
                 java.math.BigDecimal.ZERO, Map.of(), List.of(), List.of(), List.of()
             )
         ));
@@ -1870,17 +1873,17 @@ class WeeklyExpenseControllerTest {
         when(dashboardCommandService.readCashflowMonthClose(any(), eq("project-drift"), eq("2026-06")))
             .thenReturn(first, drifted, first, drifted);
         when(dashboardPersistence.findCashflowGlobalLedgerSource("tenant-drift", "project-drift"))
-            .thenReturn(new WeeklyExpensePersistence.CashflowLedgerSource(
+            .thenReturn(new CashflowLedgerSource(
                 List.of(), List.of(), targetRevision
             ));
         when(dashboardPersistence.findCashflowOpeningBalance(
             "tenant-drift", "project-drift", 2026
-        )).thenReturn(new WeeklyExpensePersistence.CashflowOpeningBalance(
+        )).thenReturn(new CashflowOpeningBalance(
             2026,
-            new WeeklyExpensePersistence.CashflowOpeningBalance.Mode(
+            new CashflowOpeningBalance.Mode(
                 java.math.BigDecimal.ZERO, Map.of(), List.of(), List.of(), List.of()
             ),
-            new WeeklyExpensePersistence.CashflowOpeningBalance.Mode(
+            new CashflowOpeningBalance.Mode(
                 java.math.BigDecimal.ZERO, Map.of(), List.of(), List.of(), List.of()
             )
         ));

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowProjectionActualSummaryServiceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowProjectionActualSummaryServiceTest.java
@@ -1,5 +1,8 @@
 package dev.merryai.innerplatform.weekly.service;
 
+import dev.merryai.innerplatform.weekly.domain.CashflowCumulativeCloseHead;
+import dev.merryai.innerplatform.weekly.domain.CashflowLedgerSource;
+import dev.merryai.innerplatform.weekly.domain.CashflowOpeningBalance;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.merryai.innerplatform.weekly.api.CashflowProjectionActualSummaryBatchRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowProjectionActualSummaryBatchResponse;
@@ -41,9 +44,9 @@ class CashflowProjectionActualSummaryServiceTest {
         when(persistence.findCashflowDeclaredWeeklyYear("tenant-a", "project-a")).thenReturn(2026);
         when(persistence.findCashflowDeclaredWeeklyYear("tenant-a", "project-b")).thenReturn(2026);
         when(persistence.findCashflowLedgerSource(eq("tenant-a"), eq("project-a"), eq(2026), eq("2023-01"), anyString()))
-            .thenReturn(new WeeklyExpensePersistence.CashflowLedgerSource(List.of(projection), List.of()));
+            .thenReturn(new CashflowLedgerSource(List.of(projection), List.of()));
         when(persistence.findCashflowLedgerSource(eq("tenant-a"), eq("project-b"), eq(2026), eq("2023-01"), anyString()))
-            .thenReturn(new WeeklyExpensePersistence.CashflowLedgerSource(List.of(), List.of()));
+            .thenReturn(new CashflowLedgerSource(List.of(), List.of()));
 
         CashflowProjectionActualSummaryBatchResponse response = service.readCashflowProjectionActualSummaries(
             ACTOR, new CashflowProjectionActualSummaryBatchRequest(List.of("project-b", "project-a"))
@@ -74,7 +77,7 @@ class CashflowProjectionActualSummaryServiceTest {
         projection.setAmount(BigDecimal.valueOf(300));
         when(persistence.findCashflowDeclaredWeeklyYear("tenant-a", "project-a")).thenReturn(2026);
         when(persistence.findCashflowLedgerSource("tenant-a", "project-a", 2026, "2023-01", "2026-11"))
-            .thenReturn(new WeeklyExpensePersistence.CashflowLedgerSource(List.of(projection), List.of()));
+            .thenReturn(new CashflowLedgerSource(List.of(projection), List.of()));
 
         CashflowProjectionActualSummaryBatchResponse.Item item = service.readCashflowProjectionActualSummaries(
             ACTOR, new CashflowProjectionActualSummaryBatchRequest(List.of("project-a"), "2026-11")
@@ -104,7 +107,7 @@ class CashflowProjectionActualSummaryServiceTest {
                 if ("project-07".equals(projectId)) {
                     throw new IllegalStateException("secret datastore path and credential");
                 }
-                return new WeeklyExpensePersistence.CashflowLedgerSource(List.of(), List.of());
+                return new CashflowLedgerSource(List.of(), List.of());
             });
 
         CashflowProjectionActualSummaryBatchResponse response = service.readCashflowProjectionActualSummaries(
@@ -167,8 +170,8 @@ class CashflowProjectionActualSummaryServiceTest {
             "tenant-a", "project-a", "2023-01", 1, "SALES_IN"
         );
         projection.setAmount(BigDecimal.TEN);
-        WeeklyExpensePersistence.CashflowLedgerSource source =
-            new WeeklyExpensePersistence.CashflowLedgerSource(List.of(projection), List.of());
+        CashflowLedgerSource source =
+            new CashflowLedgerSource(List.of(projection), List.of());
         when(persistence.findCashflowDeclaredWeeklyYear("tenant-a", "project-a")).thenReturn(2026);
         when(persistence.findCashflowLedgerSource(eq("tenant-a"), eq("project-a"), eq(2026), eq("2023-01"), anyString()))
             .thenReturn(source);

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowSheetAnnualApplyServiceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowSheetAnnualApplyServiceTest.java
@@ -1,8 +1,9 @@
 package dev.merryai.innerplatform.weekly.service;
 
+import dev.merryai.innerplatform.weekly.domain.CashflowAnnualCellSet;
+import dev.merryai.innerplatform.weekly.service.command.CashflowSheetAnnualApplyCommand;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.merryai.innerplatform.weekly.api.CashflowEditSession;
-import dev.merryai.innerplatform.weekly.api.CashflowSheetAnnualApplyRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetAnnualApplyResponse;
 import dev.merryai.innerplatform.weekly.api.TrustedActorContext;
 import dev.merryai.innerplatform.weekly.domain.CashflowLineCatalog;
@@ -49,7 +50,7 @@ class CashflowSheetAnnualApplyServiceTest {
         ));
         when(persistence.saveAuditEvent(any())).thenAnswer(invocation -> invocation.getArgument(0));
         when(persistence.saveIdempotency(any())).thenAnswer(invocation -> invocation.getArgument(0));
-        CashflowSheetAnnualApplyRequest request = new CashflowSheetAnnualApplyRequest(
+        CashflowSheetAnnualApplyCommand request = new CashflowSheetAnnualApplyCommand(
             "annual-apply-1", SOURCE_REVISION, 2025, 3, completeCells()
         );
 
@@ -65,12 +66,12 @@ class CashflowSheetAnnualApplyServiceTest {
         );
     }
 
-    private static List<CashflowSheetAnnualApplyRequest.Cell> completeCells() {
-        List<CashflowSheetAnnualApplyRequest.Cell> cells = new ArrayList<>();
+    private static List<CashflowAnnualCellSet.Cell> completeCells() {
+        List<CashflowAnnualCellSet.Cell> cells = new ArrayList<>();
         for (String mode : List.of("projection", "actual")) {
             for (String lineId : CashflowLineCatalog.ALL_LINES) {
                 boolean explicitValue = "MYSC_PREPAY_IN".equals(lineId);
-                cells.add(new CashflowSheetAnnualApplyRequest.Cell(
+                cells.add(new CashflowAnnualCellSet.Cell(
                     mode,
                     lineId,
                     explicitValue ? ("projection".equals(mode) ? "ZERO" : "VALUE") : "EMPTY",

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -1,5 +1,8 @@
 package dev.merryai.innerplatform.weekly.storage;
 
+import dev.merryai.innerplatform.weekly.domain.CashflowCumulativeCloseHead;
+import dev.merryai.innerplatform.weekly.domain.CashflowLedgerSource;
+import dev.merryai.innerplatform.weekly.domain.CashflowOpeningBalance;
 import dev.merryai.innerplatform.weekly.service.command.CashflowMonthReopenCommands;
 import com.google.api.core.ApiFutures;
 import com.google.cloud.firestore.CollectionReference;
@@ -1859,7 +1862,7 @@ class FirestoreCashflowLeaseGuardTest {
             ))
         );
 
-        WeeklyExpensePersistence.CashflowLedgerSource source = fixture.persistence
+        CashflowLedgerSource source = fixture.persistence
             .findCashflowLedgerSource("tenant-a", "project-a", 2026);
 
         assertThat(source.projection()).singleElement().satisfies(line ->
@@ -1913,7 +1916,7 @@ class FirestoreCashflowLeaseGuardTest {
             "projection", Map.of("SALES_IN", 88L)
         )));
 
-        WeeklyExpensePersistence.CashflowLedgerSource source = fixture.persistence
+        CashflowLedgerSource source = fixture.persistence
             .findCashflowLedgerSource("tenant-a", "project-a", 2026, "2023-01", "2026-07");
 
         assertThat(source.projection()).singleElement().satisfies(line -> {

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -1,5 +1,7 @@
 package dev.merryai.innerplatform.weekly.storage;
 
+import dev.merryai.innerplatform.weekly.domain.CashflowAnnualCellSet;
+import dev.merryai.innerplatform.weekly.service.command.CashflowSheetAnnualApplyCommand;
 import dev.merryai.innerplatform.weekly.domain.CashflowCumulativeCloseHead;
 import dev.merryai.innerplatform.weekly.domain.CashflowLedgerSource;
 import dev.merryai.innerplatform.weekly.domain.CashflowOpeningBalance;
@@ -21,7 +23,6 @@ import dev.merryai.innerplatform.weekly.api.CashflowOpeningBalancesResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowOpeningBalanceCell;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetBatchApplyRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetBatchApplyResponse;
-import dev.merryai.innerplatform.weekly.api.CashflowSheetAnnualApplyRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetLabApplyRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetLabApplyResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowVarianceRequest;
@@ -1312,7 +1313,7 @@ class FirestoreCashflowLeaseGuardTest {
     @Test
     void annualTotalWriteDoesNotRequireAMonthKey() {
         Fixture fixture = fixture(activeMember(), activeLease());
-        CashflowSheetAnnualApplyRequest request = new CashflowSheetAnnualApplyRequest(
+        CashflowSheetAnnualApplyCommand request = new CashflowSheetAnnualApplyCommand(
             "annual-2025",
             SOURCE_REVISION,
             2025,
@@ -1349,14 +1350,14 @@ class FirestoreCashflowLeaseGuardTest {
     @Test
     void annualTotalWritePreservesExplicitZeroAsARowValueAndState() {
         Fixture fixture = fixture(activeMember(), activeLease());
-        List<CashflowSheetAnnualApplyRequest.Cell> cells = annualCells().stream()
+        List<CashflowAnnualCellSet.Cell> cells = annualCells().stream()
             .map(cell -> "projection".equals(cell.mode()) && "SALES_IN".equals(cell.cashflowLine())
-                ? new CashflowSheetAnnualApplyRequest.Cell(
+                ? new CashflowAnnualCellSet.Cell(
                     cell.mode(), cell.cashflowLine(), "ZERO", BigDecimal.ZERO, "A1", cell.sourceLabel()
                 )
                 : cell)
             .toList();
-        CashflowSheetAnnualApplyRequest request = new CashflowSheetAnnualApplyRequest(
+        CashflowSheetAnnualApplyCommand request = new CashflowSheetAnnualApplyCommand(
             "annual-zero-2025",
             SOURCE_REVISION,
             2025,
@@ -3165,7 +3166,7 @@ class FirestoreCashflowLeaseGuardTest {
     @Test
     void monthCloseRejectsChangedOpeningRowsEvenWhenTheNetTotalIsUnchanged() {
         Fixture fixture = fixture(activeMember(), activeLease());
-        CashflowSheetAnnualApplyRequest annual = new CashflowSheetAnnualApplyRequest(
+        CashflowSheetAnnualApplyCommand annual = new CashflowSheetAnnualApplyCommand(
             "annual-opening-rows",
             SOURCE_REVISION,
             2025,
@@ -4104,11 +4105,11 @@ class FirestoreCashflowLeaseGuardTest {
         );
     }
 
-    private static List<CashflowSheetAnnualApplyRequest.Cell> annualCells() {
-        List<CashflowSheetAnnualApplyRequest.Cell> cells = new ArrayList<>();
+    private static List<CashflowAnnualCellSet.Cell> annualCells() {
+        List<CashflowAnnualCellSet.Cell> cells = new ArrayList<>();
         for (String mode : List.of("projection", "actual")) {
             for (String lineId : CashflowLineCatalog.ALL_LINES) {
-                cells.add(new CashflowSheetAnnualApplyRequest.Cell(
+                cells.add(new CashflowAnnualCellSet.Cell(
                     mode,
                     lineId,
                     "EMPTY",
@@ -4639,13 +4640,13 @@ class FirestoreCashflowLeaseGuardTest {
         }
     }
 
-    private static List<CashflowSheetAnnualApplyRequest.Cell> annualCellsWithProjection(
+    private static List<CashflowAnnualCellSet.Cell> annualCellsWithProjection(
         String lineId,
         BigDecimal amount
     ) {
         return annualCells().stream()
             .map(cell -> "projection".equals(cell.mode()) && lineId.equals(cell.cashflowLine())
-                ? new CashflowSheetAnnualApplyRequest.Cell(
+                ? new CashflowAnnualCellSet.Cell(
                     cell.mode(), cell.cashflowLine(), "VALUE", amount, "A1", cell.sourceLabel()
                 )
                 : cell)

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistenceOpeningBalanceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistenceOpeningBalanceTest.java
@@ -1,5 +1,8 @@
 package dev.merryai.innerplatform.weekly.storage;
 
+import dev.merryai.innerplatform.weekly.domain.CashflowCumulativeCloseHead;
+import dev.merryai.innerplatform.weekly.domain.CashflowLedgerSource;
+import dev.merryai.innerplatform.weekly.domain.CashflowOpeningBalance;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -21,7 +24,7 @@ class WeeklyExpensePersistenceOpeningBalanceTest {
             annual(2027, "7000000", "7000000")
         ));
 
-        WeeklyExpensePersistence.CashflowOpeningBalance result = persistence.findCashflowOpeningBalance(
+        CashflowOpeningBalance result = persistence.findCashflowOpeningBalance(
             "tenant-a",
             "project-a",
             2026
@@ -32,7 +35,7 @@ class WeeklyExpensePersistenceOpeningBalanceTest {
         assertThat(result.projection().includedYears()).containsExactly(2024, 2025);
         assertThat(result.projection().excludedWeeklyYears()).isEmpty();
         assertThat(result.projection().lineAmounts()).containsEntry("SALES_IN", new BigDecimal("9500000"));
-        assertThat(result.projection().sources()).extracting(WeeklyExpensePersistence.CashflowOpeningBalance.YearSource::year)
+        assertThat(result.projection().sources()).extracting(CashflowOpeningBalance.YearSource::year)
             .containsExactly(2024, 2025);
     }
 


### PR DESCRIPTION
재스코어링이 지목한 top 3 를 순서대로. 전부 **행동 변화 없음** (예외 메시지 문자까지 보존).

## 1 — 관리검사 4종 추출 + ID/상태 parity (마지막 큰 parity 갭)

검사 계산은 BFF 소유, JVM 은 `@Pattern` 으로 어휘만 강제 — 갈리면 확정이 400. `cashflow-management-checks.mjs` 로 검사 4종+확인 규칙을 자구 그대로 추출 (`cashflow-amounts`/`cashflow-range` 헬퍼 분리 포함). **BFF 리터럴 표 ↔ JVM record 애노테이션 리플렉션 대조**로 양방향 고정. 검사 동작(미입력 WARNING / 0원 계획 REVIEW_REQUIRED / 기초잔액 누적)도 처음으로 단위 테스트화. 라우트 파일 4814→4670줄.

## 2 — 읽기 모델 record 3종을 storage → domain 승격

`CashflowLedgerSource`/`CashflowOpeningBalance`/`CashflowCumulativeCloseHead` 가 영속 인터페이스의 중첩 record 라 ReadService 가 storage 타입을 재수출했다. 참조 47곳 치환. **컨트롤러의 storage 참조 0** — api→storage 는 런타임(#506)에 이어 컴파일 의존까지 닫혔다.

## 3 — annual apply 커맨드 절단 (수직 2회차)

`domain/CashflowAnnualCellSet` (연간 32셀 = 라인×모드, 주차 없음 — 셀 수는 카탈로그 파생) + `service/command/CashflowSheetAnnualApplyCommand`. service/영속이 api DTO 대신 커맨드·도메인 셀만 안다.

## 위반 카운트 델타 (이번 PR 만)

| 항목 | 전 | 후 |
|---|---|---|
| api→storage 컴파일 의존 (컨트롤러) | 11 | **0** |
| service→api import | 58 | 56 |
| storage→api import | 29 | 27 |
| BFF 라우트 파일 | 4814줄 | 4670줄 |

## 체크포인트

JVM **345** · BFF **1065** (실패 1은 클린 main 재현되는 벤치마크 벽시계 flake) · typecheck 0 · **e2e 확정 `rootHash` 4세대째 바이트 동일** (`sha256:0741f8d7…`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)