### PR TITLE
perf(cashflow): 시트 무변경이면 파이프라인 전체 스킵 (freshness fast-path)

### DIFF
--- a/server/bff/google-sheets.mjs
+++ b/server/bff/google-sheets.mjs
@@ -4,6 +4,9 @@ import { resolveServiceAccount } from './firestore.mjs';
 
 const SHEETS_API_BASE_URL = 'https://sheets.googleapis.com/v4';
 const SHEETS_SCOPE = 'https://www.googleapis.com/auth/spreadsheets';
+// 변경 감지용. 시트 내용을 읽지 않고 파일 메타데이터(modifiedTime)만 본다.
+const DRIVE_METADATA_SCOPE = 'https://www.googleapis.com/auth/drive.metadata.readonly';
+const DRIVE_FILES_API_BASE_URL = 'https://www.googleapis.com/drive/v3';
 
 export class GoogleSheetsServiceError extends Error {
   constructor(message, options = {}) {
@@ -155,6 +158,40 @@ export function createGoogleSheetsService(options = {}) {
       });
     }
     return jwtClient.getRequestHeaders();
+  }
+
+  let driveMetadataJwtClient = null;
+
+  // 시트가 바뀌었는지 "싸게" 묻는다 (Drive files.get, ~수십 ms). 시트 본문 읽기(수 초)와
+  // 분리하는 것이 핵심이다 - 검색엔진이 쿼리마다 크롤링하지 않는 것과 같은 원리로,
+  // 변경이 없으면 고정본을 그대로 쓴다. 같은 서비스 계정을 쓰므로 시트가 SA 에
+  // 공유돼 있으면 메타데이터도 읽힌다.
+  async function getSpreadsheetFreshness(value) {
+    const spreadsheetId = extractSpreadsheetId(value);
+    if (!spreadsheetId) return null;
+    assertConfigured();
+    if (!driveMetadataJwtClient) {
+      driveMetadataJwtClient = new JWT({
+        email: config.serviceAccount.client_email,
+        key: config.serviceAccount.private_key,
+        scopes: [DRIVE_METADATA_SCOPE],
+      });
+    }
+    const authHeaders = await driveMetadataJwtClient.getRequestHeaders();
+    const response = await fetchImpl(
+      `${DRIVE_FILES_API_BASE_URL}/files/${encodeURIComponent(spreadsheetId)}?supportsAllDrives=true&fields=modifiedTime,version`,
+      { headers: { ...authHeaders } },
+    );
+    if (!response.ok) {
+      throw new GoogleSheetsServiceError(
+        '시트 변경 여부를 확인하지 못했습니다.',
+        { statusCode: response.status, code: 'spreadsheet_freshness_unavailable' },
+      );
+    }
+    const payload = await readJsonResponse(response);
+    const modifiedTime = readOptionalText(payload?.modifiedTime);
+    if (!modifiedTime) return null;
+    return { spreadsheetId, modifiedTime, version: readOptionalText(payload?.version) };
   }
 
   async function sheetsFetch(pathname, init = {}, accessToken) {
@@ -337,6 +374,7 @@ export function createGoogleSheetsService(options = {}) {
     serviceAccountEmail: readOptionalText(config.serviceAccount?.client_email),
     getServiceAccountEmail: () => readOptionalText(config.serviceAccount?.client_email),
     getSpreadsheetMeta,
+    getSpreadsheetFreshness,
     getSheetValues,
     batchUpdateValues,
     previewSpreadsheet,

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -4128,6 +4128,11 @@ export function mountCashflowSheetLabRoutes(app, {
     googleSheetsService,
     cacheTtlMs: sheetPreviewCacheTtlMs,
   });
+  const loadSheetFreshness = (value) => (
+    typeof googleSheetsService?.getSpreadsheetFreshness === 'function'
+      ? googleSheetsService.getSpreadsheetFreshness(value)
+      : Promise.resolve(null)
+  );
   const deployEnv = readOptionalText(env.BFF_DEPLOY_ENV).toLowerCase() || 'local';
   const authoritativeWritesEnabled = deployEnv === 'live'
     || (deployEnv === 'local' && Boolean(javaWeeklyClient));
@@ -4252,6 +4257,29 @@ export function mountCashflowSheetLabRoutes(app, {
     ) {
       throw createHttpError(409, '같은 idempotencyKey에 다른 시트 연동 요청을 사용할 수 없습니다.', 'idempotency_key_reused');
     }
+    // 시트 검색 원칙: 읽기 요청이 크롤링을 트리거하지 않는다. 시트가 안 바뀌었으면
+    // (Drive modifiedTime 대조, ~수십 ms) 풀 리드·파싱·JVM 대조·저장을 전부 건너뛰고
+    // 고정본을 그대로 돌려준다. 저장된 modifiedTime 은 항상 데이터 읽기 "이전"에 찍은
+    // 값이라, 경합이 나면 불필요한 풀 리드 쪽으로만 틀린다 - 낡은 데이터를 최신이라고
+    // 말하는 방향으로는 틀리지 않는다.
+    let freshness = null;
+    if (
+      previousMirror?.status === 'FRESH'
+      && readOptionalText(previousMirror?.sourceFileModifiedTime)
+      && readOptionalText(previousMirror?.lastRefreshRequestHash) === refreshRequestHash
+    ) {
+      freshness = await trace.measure(
+        'freshness_probe',
+        () => loadSheetFreshness(source.value).catch(() => null),
+      );
+      if (freshness?.modifiedTime && freshness.modifiedTime === previousMirror.sourceFileModifiedTime) {
+        logCashflowSheetLab('mirror.refresh.unchanged', req, {
+          projectId,
+          sourceFileModifiedTime: freshness.modifiedTime,
+        });
+        return { ...previousMirror, unchanged: true, freshnessCheckedAt: attemptedAt };
+      }
+    }
     const refreshRun = await trace.measure(
       'refresh_reserve',
       () => beginCashflowSheetRefreshRun({
@@ -4292,6 +4320,12 @@ export function mountCashflowSheetLabRoutes(app, {
     });
 
     try {
+      if (!freshness) {
+        freshness = await trace.measure(
+          'freshness_probe',
+          () => loadSheetFreshness(source.value).catch(() => null),
+        );
+      }
       const preview = await trace.measure(
         'google_sheet_fetch',
         () => loadSheetPreview({
@@ -4347,6 +4381,8 @@ export function mountCashflowSheetLabRoutes(app, {
         activeWeeks: buildActiveWeeksFromTemplate(template, weekRange),
       };
       mirror.configRevision = configRevision;
+      // 데이터 읽기 이전에 찍은 값. 다음 불러오기의 변경 감지 기준.
+      mirror.sourceFileModifiedTime = freshness?.modifiedTime || null;
       mirror.lastRefreshAttemptAt = attemptedAt;
       mirror.lastRefreshIdempotencyKey = parsed.idempotencyKey;
       mirror.lastRefreshRequestHash = refreshRequestHash;

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -1129,6 +1129,76 @@ describe('cashflow sheet lab route', () => {
     });
   });
 
+  it('skips the whole pipeline when the sheet has not changed (freshness fast-path)', async () => {
+    // 검색엔진 원칙: 읽기 요청이 크롤링을 트리거하지 않는다. 시트가 안 바뀌었으면
+    // 두 번째 불러오기는 Drive modifiedTime 한 번만 묻고 고정본을 그대로 돌려준다.
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        contractStart: '2024-01-01',
+        contractEnd: '2028-12-31',
+        cashflowSheetLab: {
+          value: 'https://docs.google.com/spreadsheets/d/spreadsheet-a/edit',
+          sheetName: 'cashflow(사용내역 연동)',
+          startWeek: '26-1-1',
+          endWeek: '26-1-1',
+        },
+      },
+    });
+    let modifiedTime = '2026-08-09T10:00:00.000Z';
+    const previewSpreadsheet = vi.fn(async () => ({
+      spreadsheetId: 'spreadsheet-a',
+      spreadsheetTitle: 'Cashflow workbook',
+      selectedSheetName: 'cashflow(사용내역 연동)',
+      availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
+      matrix: buildMatrix(),
+    }));
+    const getSpreadsheetFreshness = vi.fn(async () => ({
+      spreadsheetId: 'spreadsheet-a', modifiedTime, version: '7',
+    }));
+    const app = createApp({ db, googleSheetsService: { previewSpreadsheet, getSpreadsheetFreshness } });
+
+    const first = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'fresh-001' })
+      .expect(200);
+    expect(first.body.status).toBe('FRESH');
+    expect(first.body.unchanged).toBeUndefined();
+    expect(previewSpreadsheet).toHaveBeenCalledTimes(1);
+    expect(db.__getDocument('orgs/tenant-a/cashflow_sheet_mirrors/project-a').sourceFileModifiedTime)
+      .toBe(modifiedTime);
+
+    // 변경 없음 -> 풀 리드 없이 고정본 반환
+    const second = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'fresh-002' })
+      .expect(200);
+    expect(second.body.unchanged).toBe(true);
+    expect(second.body.sourceRevision).toBe(first.body.sourceRevision);
+    expect(previewSpreadsheet).toHaveBeenCalledTimes(1);
+    expect(getSpreadsheetFreshness).toHaveBeenCalledTimes(2);
+
+    // 시트가 바뀌면 다시 풀 리드
+    modifiedTime = '2026-08-09T11:00:00.000Z';
+    const third = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'fresh-003' })
+      .expect(200);
+    expect(third.body.unchanged).toBeUndefined();
+    expect(previewSpreadsheet).toHaveBeenCalledTimes(2);
+    expect(db.__getDocument('orgs/tenant-a/cashflow_sheet_mirrors/project-a').sourceFileModifiedTime)
+      .toBe(modifiedTime);
+
+    // probe 실패는 열화가 아니라 풀 리드로 폴백한다 - 낡은 데이터를 최신이라 말하지 않는다.
+    getSpreadsheetFreshness.mockRejectedValueOnce(new Error('drive down'));
+    const fourth = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'fresh-004' })
+      .expect(200);
+    expect(fourth.body.unchanged).toBeUndefined();
+    expect(previewSpreadsheet).toHaveBeenCalledTimes(3);
+  });
+
   it('reads Google Sheets only on explicit mirror refresh and pins the result', async () => {
     const performanceEvents = [];
     const db = createDb({

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1485,7 +1485,10 @@ export function CashflowProjectSheet({
             cells: mirror.cells || current.cells,
           }
         : mirror);
-      if (mirror.status === 'FRESH' && mirror.sourceRevision) {
+      if (mirror.status === 'FRESH' && mirror.unchanged) {
+        // 시트 변경 없음 - 서버가 풀 리드를 건너뛰고 고정본을 그대로 돌려준 경우.
+        toast.success('시트 변경이 없어 기존 고정값을 그대로 사용합니다.');
+      } else if (mirror.status === 'FRESH' && mirror.sourceRevision) {
         void loadCashflowEvents();
         toast.success('시트값을 불러왔습니다. MYSCube 시트 반영 전 금액을 확인합니다.');
       } else if (mirror.status === 'STALE') {

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -295,6 +295,10 @@ export interface CashflowSheetLabMirrorResult {
   schemaVersion?: number;
   projectId: string;
   status: 'EMPTY' | 'FRESH' | 'STALE' | 'ERROR';
+  // 서버가 Drive modifiedTime 대조로 풀 리드를 건너뛰고 고정본을 그대로 돌려준 경우.
+  unchanged?: boolean;
+  sourceFileModifiedTime?: string | null;
+  freshnessCheckedAt?: string;
   sourceYear?: number;
   sources?: Record<string, {
     sourceYear: number;


### PR DESCRIPTION
"불러오기 20초" 구조 개선 1단계. **검색엔진 원칙 — 읽기 요청이 크롤링을 트리거하지 않는다.**

## 무엇이 바뀌나

| 시나리오 | 전 | 후 |
|---|---|---|
| 시트 변경 없음 (대부분의 클릭) | 풀 리드+파싱+JVM 대조+저장 = **~20s** | Drive `files.get?fields=modifiedTime` 1회 = **~수십 ms** + `unchanged: true` |
| 시트 변경 있음 | ~20s | 동일 (풀 파이프라인 — 다음 단계에서 병렬화) |
| probe 실패 | — | 풀 리드로 폴백 (가용성 손실 없음) |

## 회계 안전장치

- **고정(pin) 의미 불변**: 고정본은 사용자가 불러올 때만 움직인다. 백그라운드가 몰래 바꾸지 않는다.
- **probe 는 데이터 읽기 "이전"에** 찍는다 → 경합 시 불필요한 풀 리드 쪽으로만 틀리고, 낡은 데이터를 최신이라 말하는 방향으로는 못 틀린다.
- 소스 설정(스프레드시트/탭/주차범위 requestHash)이 바뀌면 modifiedTime 이 같아도 풀 리드.

## 검증

- 신규 테스트: 1차 풀 리드 → 2차 unchanged(previewSpreadsheet 호출 0회 증가) → modifiedTime 변경 시 풀 리드 → probe 실패 시 폴백
- **Sabotage**: modifiedTime 대조 제거 → 테스트 사망 확인
- sheet-lab 121 통과 · shell 60 통과 · typecheck 0

## 다음 단계 (별도 PR)

- sync worker 에 같은 게이트 + 크론 주기 상향 (변경된 시트만 풀 리드 → 페이지 진입 시 이미 따뜻)
- 변경 있는 경우의 풀 파이프라인 병렬화 (Sheets 리드 ∥ JVM canonical 리드) — `freshness_probe` 단계가 로그에 찍히므로 실측 후
- push(files.watch) 는 15~30분 신선도로 부족할 때만

🤖 Generated with [Claude Code](https://claude.com/claude-code)