### PR TITLE
perf(cashflow): 진입 시 시트 풀 리드 대신 modifiedTime probe (20초→0.1초)

### DIFF
--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -4723,6 +4723,64 @@ export function mountCashflowSheetLabRoutes(app, {
     };
   };
 
+  // 진입 전용 경량 변경 감지. 검색엔진 원칙: 진입은 인덱스(고정본)만 읽고, 크롤(시트 풀
+  // 리드 + 3방향 diff)은 사용자가 '시트 불러오기'를 누를 때만 한다. 여기서는 Drive
+  // modifiedTime(~수십 ms)만 저장된 고정본과 대조해 "변경됨/없음"만 판정한다 - 건수·diff
+  // 는 계산하지 않는다. 판정 불능(probe 실패, 미러 없음)은 보수적으로 "불러오기 필요"로
+  // 기울인다 - 낡은 값을 최신이라 말하지 않는다.
+  app.post('/api/v1/projects/:projectId/cashflow-sheet-lab/changes/probe', asyncHandler(async (req, res) => {
+    assertCashflowSheetLabAccess(req, workspaceEmailDomain);
+    const { tenantId } = req.context;
+    const { projectId } = req.params;
+    const checkedAt = new Date().toISOString();
+    try {
+      const project = await readProjectDocument(db, tenantId, projectId);
+      const configs = readCashflowSheetLabConfigs(project);
+      if (configs.length === 0) {
+        throw createHttpError(400, 'Cashflow sheet URL is not configured.', 'cashflow_sheet_config_required');
+      }
+      const mirror = await readCashflowSheetMirror(db, tenantId, projectId);
+      if (!mirror || readOptionalText(mirror.status) !== 'FRESH' || !readOptionalText(mirror.sourceRevision)) {
+        res.status(200).json({
+          status: 'AVAILABLE', mirrorLoaded: false, sheetChangedSinceMirror: true, checkedAt,
+        });
+        return;
+      }
+      // 미러의 sourceFileModifiedTime 은 마지막으로 불러온 소스 하나의 값이다. 단일 소스
+      // 프로젝트(대부분)는 정확하고, 멀티 소스는 하나라도 새로우면 changed 로 기운다.
+      const storedModifiedTime = readOptionalText(mirror.sourceFileModifiedTime);
+      if (!storedModifiedTime) {
+        res.status(200).json({
+          status: 'AVAILABLE', mirrorLoaded: true, sheetChangedSinceMirror: true, checkedAt,
+        });
+        return;
+      }
+      let changed = false;
+      for (const config of configs) {
+        const freshness = await loadSheetFreshness(config.value);
+        if (!freshness?.modifiedTime) { changed = true; break; }
+        if (configs.length > 1 || freshness.modifiedTime !== storedModifiedTime) {
+          if (freshness.modifiedTime !== storedModifiedTime) { changed = true; break; }
+        }
+      }
+      res.status(200).json({
+        status: 'AVAILABLE',
+        mirrorLoaded: true,
+        sheetChangedSinceMirror: changed,
+        checkedAt,
+      });
+    } catch (error) {
+      logCashflowSheetLab('changes.probe.unavailable', req, {
+        projectId,
+        ...routeErrorDetails(normalizeRouteError(error)),
+      }, 'warn');
+      // probe 실패는 판정 불능이다. 조용히 '변경 없음'이라 하지 않는다.
+      res.status(200).json({
+        status: 'UNAVAILABLE', mirrorLoaded: false, sheetChangedSinceMirror: false, checkedAt,
+      });
+    }
+  }));
+
   app.post('/api/v1/projects/:projectId/cashflow-sheet-lab/changes/check', asyncHandler(async (req, res) => {
     assertCashflowSheetLabAccess(req, workspaceEmailDomain);
     const { tenantId } = req.context;

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -1129,6 +1129,61 @@ describe('cashflow sheet lab route', () => {
     });
   });
 
+  it('probes freshness on entry without reading the sheet (cheap change badge)', async () => {
+    // 진입 전용 경량 엔드포인트. 시트 풀 리드 없이 modifiedTime 만 대조한다.
+    const projectDoc = {
+      id: 'project-a', contractStart: '2024-01-01', contractEnd: '2028-12-31',
+      cashflowSheetLab: {
+        value: 'https://docs.google.com/spreadsheets/d/spreadsheet-a/edit',
+        sheetName: 'cashflow(사용내역 연동)', startWeek: '26-1-1', endWeek: '26-1-1',
+      },
+    };
+    const previewSpreadsheet = vi.fn();
+    let modifiedTime = '2026-08-09T10:00:00.000Z';
+    const getSpreadsheetFreshness = vi.fn(async () => ({ spreadsheetId: 'spreadsheet-a', modifiedTime, version: '3' }));
+
+    // 미러가 없으면 '불러오기 필요'
+    const emptyDb = createDb({ project: projectDoc });
+    const before = await request(
+      createApp({ db: emptyDb, googleSheetsService: { previewSpreadsheet, getSpreadsheetFreshness } }),
+    ).post('/api/v1/projects/project-a/cashflow-sheet-lab/changes/probe').send({}).expect(200);
+    expect(before.body).toMatchObject({ status: 'AVAILABLE', mirrorLoaded: false, sheetChangedSinceMirror: true });
+
+    // 미러를 modifiedTime 과 함께 심은 db (불러온 상태)
+    const db = createDb({
+      project: projectDoc,
+      initialDocuments: {
+        'orgs/tenant-a/cashflow_sheet_mirrors/project-a': {
+          projectId: 'project-a', status: 'FRESH', sourceRevision: 'sha256:abc',
+          sourceFileModifiedTime: modifiedTime,
+        },
+      },
+    });
+    const app = createApp({ db, googleSheetsService: { previewSpreadsheet, getSpreadsheetFreshness } });
+
+    // 변경 없음 -> 시트 안 읽음
+    const unchanged = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/changes/probe')
+      .send({}).expect(200);
+    expect(unchanged.body).toMatchObject({ mirrorLoaded: true, sheetChangedSinceMirror: false });
+    expect(previewSpreadsheet).not.toHaveBeenCalled();
+
+    // 시트가 바뀌면 changed=true (여전히 풀 리드는 안 함)
+    modifiedTime = '2026-08-09T11:00:00.000Z';
+    const changed = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/changes/probe')
+      .send({}).expect(200);
+    expect(changed.body).toMatchObject({ mirrorLoaded: true, sheetChangedSinceMirror: true });
+    expect(previewSpreadsheet).not.toHaveBeenCalled();
+
+    // probe 실패는 '변경 없음'이라 하지 않는다 (판정 불능)
+    getSpreadsheetFreshness.mockRejectedValueOnce(new Error('drive down'));
+    const failed = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/changes/probe')
+      .send({}).expect(200);
+    expect(failed.body.status).toBe('UNAVAILABLE');
+  });
+
   it('skips the whole pipeline when the sheet has not changed (freshness fast-path)', async () => {
     // 검색엔진 원칙: 읽기 요청이 크롤링을 트리거하지 않는다. 시트가 안 바뀌었으면
     // 두 번째 불러오기는 Drive modifiedTime 한 번만 묻고 고정본을 그대로 돌려준다.

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -302,19 +302,18 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain('setInterval');
   });
 
-  it('checks linked sheet changes on entry without applying them', () => {
-    expect(source).toContain('checkCashflowSheetChangesViaBff');
-    expect(source).toContain("status: 'CHECKING'");
-    expect(source).toContain('setCashflowSheetChangeCheck(result)');
-    expect(source).toContain('const sheetChangeCount = [');
-    expect(source).toContain('cashflowSheetChangeCheck?.comparisons.jvmToFirestore');
-    expect(source).toContain('변경 ${sheetChangeCount.toLocaleString()}건');
-    expect(source).toContain('onClick={handleOpenSheetReviewDialog}');
-    expect(source).toMatch(/const handleOpenSheetReviewDialog = useCallback\(\(\) => \{\s*setSheetReviewDialogOpen\(true\);\s*\}, \[\]\);/);
-    expect(source).not.toContain("['시트↔JVM', cashflowSheetChangeCheck.comparisons.sheetToJvm]");
-    expect(source).not.toContain("['시트↔저장값', cashflowSheetChangeCheck.comparisons.sheetToFirestore]");
-    expect(source).not.toContain("['JVM↔저장값', cashflowSheetChangeCheck.comparisons.jvmToFirestore]");
-    expect(source).not.toContain('시트 변경 확인 불가');
+  it('probes sheet freshness on entry without a full read', () => {
+    // 진입은 modifiedTime 만 싸게 대조한다. 시트 풀 리드(checkCashflowSheetChangesViaBff)는
+    // 진입 경로에서 사라졌고, 사용자가 '시트 불러오기' 를 누를 때만 일어난다.
+    expect(source).toContain('probeCashflowSheetFreshnessViaBff');
+    expect(source).toContain('setCashflowSheetFreshness');
+    expect(source).toContain('sheetChangedSinceMirror');
+    expect(source).not.toContain('checkCashflowSheetChangesViaBff');
+    expect(source).not.toContain('const sheetChangeCount = [');
+    expect(source).not.toContain('변경 ${sheetChangeCount.toLocaleString()}건');
+    // 버튼 통일: '변경 N건' 별도 버튼 제거, 단일 '시트 불러오기' 가 배지를 겸한다.
+    expect(source).toContain('시트 변경됨 · 불러오기');
+    expect(source).not.toContain('onClick={handleOpenSheetReviewDialog}');
     expect(source).toContain('시트 이동');
     expect(source).toContain('href={configuredSheetUrl}');
     expect(source).toContain('target="_blank"');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -63,7 +63,7 @@ import type { CashflowOpsTone } from './cashflow-ops-summary';
 import {
   applyCashflowSheetLabViaBff,
   cashflowFormulaMismatchesFromError,
-  checkCashflowSheetChangesViaBff,
+  probeCashflowSheetFreshnessViaBff,
   getCashflowSheetLabApplyStatusViaBff,
   getCashflowSheetLabMirrorViaBff,
   getCashflowSheetLabShareAccountViaBff,
@@ -71,7 +71,7 @@ import {
   refreshCashflowSheetLabMirrorViaBff,
   stageCashflowSheetLabViaBff,
   type CashflowSheetLabMirrorResult,
-  type CashflowSheetChangeCheckResult,
+  type CashflowSheetFreshnessProbe,
   type CashflowSheetLabShareAccountResult,
   type CashflowSheetLabStageResult,
   type CashflowFormulaMismatch,
@@ -383,7 +383,7 @@ export function CashflowProjectSheet({
     lastActualLineCount?: number;
   } | null>(null);
   const [cashflowSheetConfigLoaded, setCashflowSheetConfigLoaded] = useState(false);
-  const [cashflowSheetChangeCheck, setCashflowSheetChangeCheck] = useState<CashflowSheetChangeCheckResult | null>(null);
+  const [cashflowSheetFreshness, setCashflowSheetFreshness] = useState<CashflowSheetFreshnessProbe | null>(null);
   const [cashflowSystemAccountEmail, setCashflowSystemAccountEmail] = useState('');
   const [cashflowSystemAccountError, setCashflowSystemAccountError] = useState(false);
   const [cashflowSheetMirror, setCashflowSheetMirror] = useState<CashflowSheetLabMirrorResult | null>(null);
@@ -587,63 +587,36 @@ export function CashflowProjectSheet({
 
   useEffect(() => {
     let cancelled = false;
-    setCashflowSheetChangeCheck(null);
+    setCashflowSheetFreshness(null);
     if (!cashflowSheetConfigLoaded || !cashflowSheetConfig?.value || !projectId || !orgId || !user?.uid) {
       return () => { cancelled = true; };
     }
 
-    setCashflowSheetChangeCheck({
-      status: 'CHECKING',
-      classification: 'PARTIAL',
-      checkedAt: '',
-      sheet: { status: 'AVAILABLE' },
-      comparisons: {
-        sheetToJvm: { status: 'UNAVAILABLE', changeCount: null, projectionChangeCount: null, actualChangeCount: null },
-        sheetToFirestore: { status: 'UNAVAILABLE', changeCount: null, projectionChangeCount: null, actualChangeCount: null },
-        jvmToFirestore: { status: 'UNAVAILABLE', changeCount: null, projectionChangeCount: null, actualChangeCount: null },
-      },
-    });
-    const checkSheetChanges = async (): Promise<void> => {
+    // 진입은 시트를 풀 리드하지 않는다. modifiedTime 만 싸게 대조해 '변경됨' 배지만 띄운다.
+    // 실제 diff 와 풀 리드는 사용자가 '시트 불러오기'를 누를 때만.
+    const probeFreshness = async (): Promise<void> => {
       try {
         let actor = await resolveBffActor();
-        if (!actor?.idToken) throw new Error('Cashflow sheet change check requires authentication.');
-        let result: CashflowSheetChangeCheckResult;
+        if (!actor?.idToken) throw new Error('Cashflow sheet freshness probe requires authentication.');
+        let result: CashflowSheetFreshnessProbe;
         try {
-          result = await checkCashflowSheetChangesViaBff({
-            tenantId: orgId,
-            actor,
-            projectId,
-            sourceYear: cashflowSheetConfig.sourceYear || selectedYear,
-          });
+          result = await probeCashflowSheetFreshnessViaBff({ tenantId: orgId, actor, projectId });
         } catch (error) {
           if (!isBffAuthRejection(error)) throw error;
           actor = await resolveBffActor({ forceRefresh: true });
           if (!actor?.idToken) throw error;
-          result = await checkCashflowSheetChangesViaBff({
-            tenantId: orgId,
-            actor,
-            projectId,
-            sourceYear: cashflowSheetConfig.sourceYear || selectedYear,
+          result = await probeCashflowSheetFreshnessViaBff({ tenantId: orgId, actor, projectId });
+        }
+        if (!cancelled) setCashflowSheetFreshness(result);
+      } catch {
+        if (!cancelled) {
+          setCashflowSheetFreshness({
+            status: 'UNAVAILABLE', mirrorLoaded: false, sheetChangedSinceMirror: false, checkedAt: '',
           });
         }
-        if (!cancelled) {
-          setCashflowSheetChangeCheck(result);
-        }
-      } catch {
-        if (!cancelled) setCashflowSheetChangeCheck({
-          status: 'UNAVAILABLE',
-          classification: 'PARTIAL',
-          checkedAt: '',
-          sheet: { status: 'UNAVAILABLE' },
-          comparisons: {
-            sheetToJvm: { status: 'UNAVAILABLE', changeCount: null, projectionChangeCount: null, actualChangeCount: null },
-            sheetToFirestore: { status: 'UNAVAILABLE', changeCount: null, projectionChangeCount: null, actualChangeCount: null },
-            jvmToFirestore: { status: 'UNAVAILABLE', changeCount: null, projectionChangeCount: null, actualChangeCount: null },
-          },
-        });
       }
     };
-    void checkSheetChanges();
+    void probeFreshness();
     return () => { cancelled = true; };
   }, [
     cashflowSheetConfig?.sourceYear,
@@ -1802,10 +1775,6 @@ export function CashflowProjectSheet({
     }
   }, [cashflowSheetMirror, handleApplyStagedSheetValues, orgId, projectId, resolveBffActor, yearMonth]);
 
-  const handleOpenSheetReviewDialog = useCallback(() => {
-    setSheetReviewDialogOpen(true);
-  }, []);
-
   const handleOpenSheetOnboarding = useCallback(() => {
     setSheetReviewDialogOpen(true);
   }, []);
@@ -1921,11 +1890,8 @@ export function CashflowProjectSheet({
   const sheetIdentityLabel = cashflowSheetConfig
     ? cashflowSheetConfig.spreadsheetTitle || cashflowSheetConfig.spreadsheetId || 'Google Sheet'
     : '시트 연결 필요';
-  const sheetChangeCount = [
-    cashflowSheetChangeCheck?.comparisons.jvmToFirestore,
-    cashflowSheetChangeCheck?.comparisons.sheetToFirestore,
-    cashflowSheetChangeCheck?.comparisons.sheetToJvm,
-  ].find((comparison) => comparison?.status === 'AVAILABLE' && Number(comparison.changeCount) > 0)?.changeCount || 0;
+  const sheetChangedSinceMirror = cashflowSheetFreshness?.status === 'AVAILABLE'
+    && cashflowSheetFreshness.sheetChangedSinceMirror === true;
   const sheetMirrorStatus = cashflowSheetMirror?.status || 'EMPTY';
   const configuredSheetUrl = (() => {
     try {
@@ -2731,17 +2697,6 @@ export function CashflowProjectSheet({
               >
                 {cashflowSheetConfig ? '시트 설정' : '시트 연결'}
               </Button>
-              {cashflowSheetConfig && sheetChangeCount > 0 ? (
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  className="h-7 shrink-0 rounded-md border-yellow-300 bg-yellow-50 px-2.5 text-[12px] font-semibold text-yellow-900 hover:bg-yellow-100"
-                  onClick={handleOpenSheetReviewDialog}
-                >
-                  {`변경 ${sheetChangeCount.toLocaleString()}건`}
-                </Button>
-              ) : null}
               {configuredSheetUrl ? (
                 <a
                   className="inline-flex h-7 shrink-0 items-center rounded-md px-2 text-[12px] font-semibold text-[#17324D] hover:bg-accent"
@@ -2754,16 +2709,22 @@ export function CashflowProjectSheet({
                 </a>
               ) : null}
               {cashflowSheetConfig ? (
+                // 단일 진입점: 평소엔 '시트 불러오기', 변경이 감지되면 상태 배지를 겸한다.
+                // 진입 시 풀 리드를 하지 않으므로 이 버튼을 눌러야 실제 diff·반영이 시작된다.
                 <Button
                   type="button"
                   size="sm"
                   variant="outline"
-                  className="h-7 shrink-0 rounded-md border-slate-300 bg-white px-2.5 text-[12px] font-semibold text-[#17324D]"
+                  className={`h-7 shrink-0 rounded-md px-2.5 text-[12px] font-semibold ${
+                    sheetChangedSinceMirror
+                      ? 'border-yellow-300 bg-yellow-50 text-yellow-900 hover:bg-yellow-100'
+                      : 'border-slate-300 bg-white text-[#17324D] hover:bg-accent'
+                  }`}
                   disabled={sheetRefreshLoading}
                   onClick={() => void handleRefreshSheetMirror()}
                 >
                   {sheetRefreshLoading ? <Loader2 className="mr-1 h-3 w-3 animate-spin" /> : <RefreshCw className="mr-1 h-3 w-3" />}
-                  시트 값 불러오기
+                  {sheetChangedSinceMirror ? '시트 변경됨 · 불러오기' : '시트 불러오기'}
                 </Button>
               ) : null}
               {project && members ? (

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -920,6 +920,34 @@ export async function getCashflowSheetLabShareAccountViaBff(params: {
   return response.data;
 }
 
+export interface CashflowSheetFreshnessProbe {
+  status: 'AVAILABLE' | 'UNAVAILABLE';
+  mirrorLoaded: boolean;
+  sheetChangedSinceMirror: boolean;
+  checkedAt: string;
+}
+
+// 진입 전용 경량 변경 감지. 시트 풀 리드 없이 modifiedTime 만 대조한다 (~0.1s).
+export async function probeCashflowSheetFreshnessViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectId: string;
+  client?: PlatformApiClientLike;
+}): Promise<CashflowSheetFreshnessProbe> {
+  const apiClient = params.client || createSameOriginBffClient();
+  const response = await apiClient.post<CashflowSheetFreshnessProbe>(
+    `/api/v1/projects/${encodeURIComponent(params.projectId)}/cashflow-sheet-lab/changes/probe`,
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      body: {},
+      timeoutMs: 12000,
+      retries: 0,
+    },
+  );
+  return response.data;
+}
+
 export async function checkCashflowSheetChangesViaBff(params: {
   tenantId: string;
   actor: ActorLike;


### PR DESCRIPTION
"아직도 20초" 진짜 원인을 잡았다. 직전 fast-path(#508)는 헛다리였고, 그 점은 인정한다.

## 진짜 원인

페이지 진입 시 `useEffect` 가 자동으로 `changes/check` 를 호출 → `compareCashflowSheetProject` → `executeCashflowSheetMirrorRefresh`(**시트 풀 리드**) + JVM + Firestore 3방향 diff. 버튼을 누르든 안 누르든 진입마다. #508 의 fast-path 는 refresh 버튼에만 걸려서 이 경로를 못 막았다.

## 재설계 (검색엔진 원칙)

진입 = 인덱스(고정본) 읽기. 크롤(풀 리드) = 명시적 액션.

| | 전 | 후 |
|---|---|---|
| 진입 (변경 없음) | 풀 리드 3방향 = **~20s** | `changes/probe`: modifiedTime 1회 = **~0.1s** |
| 진입 (변경 있음, "50건" 케이스) | ~20s + 건수 표시 | ~0.1s + **"시트 변경됨" 배지** (건수는 불러올 때) |
| 실제 diff/반영 | 진입 시 강제 | '시트 불러오기' 눌렀을 때만 |

## 버튼 통일 (요청사항)

"변경 N건"(풀 리드 유발) + "시트 값 불러오기" 두 버튼 → **단일 "시트 불러오기"**. 변경 감지되면 같은 버튼이 `시트 변경됨 · 불러오기` 로 노랗게 바뀜. "시트 이동"(구글 링크)은 그대로.

## 안전

- **고정(pin) 의미 불변** — 고정본은 사용자가 불러올 때만 움직인다.
- probe 실패/미러 없음 = 판정 불능 → 보수적으로 "불러오기 필요". 조용히 "변경 없음"이라 안 함.
- 기존 `changes/check`(풀 diff)는 삭제 안 함 — 불러온 뒤 검토 다이얼로그가 계속 씀.

## 검증

- 신규 서버 테스트: 미러 없음→불러오기 필요 / 변경 없음→시트 안 읽음 / 변경 있음→배지(풀 리드 X) / probe 실패→UNAVAILABLE
- Sabotage: modifiedTime 대조 무력화 → 테스트 사망 확인
- server/bff 1068 · 셸 60 · typecheck 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)