### PR TITLE
fix: unify cashflow weekly overview pipeline

### DIFF
--- a/.github/workflows/jvm-production-deploy.yml
+++ b/.github/workflows/jvm-production-deploy.yml
@@ -193,6 +193,7 @@ jobs:
             --tag candidate \
             --ingress all \
             --min-instances 1 \
+            --no-cpu-throttling \
             --liveness-probe 'httpGet.path=/api/v1/health,initialDelaySeconds=30,periodSeconds=30,timeoutSeconds=5,failureThreshold=3' \
             --set-env-vars '^|^WEEKLY_API_PORT=8080|JVM_WEEKLY_DEPLOY_ENV=live|JVM_WEEKLY_EDIT_LEASES_ENABLED=true|JVM_WEEKLY_INTERNAL_API_TOKEN_ENABLED=true|JVM_WEEKLY_STORAGE_BACKEND=firestore|JVM_WEEKLY_PROJECT_ACCESS_BACKEND=firestore|JVM_WEEKLY_AUTH_MODE=strict|JVM_WEEKLY_WORKSPACE_EMAIL_DOMAIN=mysc.co.kr|JVM_WEEKLY_FIREBASE_PROJECT_ID=inner-platform-live-20260316|JVM_WEEKLY_FIRESTORE_PROJECT_ID=inner-platform-live-20260316|JVM_WEEKLY_FIREBASE_AUTH_PROJECT_ID=inner-platform-live-20260316|JVM_WEEKLY_ALLOWED_ORIGINS=https://myscube.myscguard.app' \
             --set-secrets 'JVM_WEEKLY_INTERNAL_API_TOKEN=innerplatform-weekly-api-token:latest,JVM_WEEKLY_CASHFLOW_SETTLED_WEEK_CONFIRMATION_KEY=innerplatform-cashflow-settled-week-confirmation-key:latest'

--- a/server/bff/cashflow-performance.mjs
+++ b/server/bff/cashflow-performance.mjs
@@ -46,10 +46,21 @@ export function createCashflowPerformanceTrace({
       ...(Number.isInteger(details.upstreamStatus) ? { upstreamStatus: details.upstreamStatus } : {}),
       ...(typeof details.retryable === 'boolean' ? { retryable: details.retryable } : {}),
       ...(details.errorCode ? { errorCode: safeErrorCode(details.errorCode) } : {}),
+      ...(Number.isSafeInteger(details.projectCount) ? { projectCount: details.projectCount } : {}),
+      ...(Number.isSafeInteger(details.itemCount) ? { itemCount: details.itemCount } : {}),
+      ...(Number.isSafeInteger(details.issueCount) ? { issueCount: details.issueCount } : {}),
       durationMs: safeDuration(details.durationMs),
       totalMs: safeDuration(now() - startedAt),
     };
     if (logger === defaultLogger && process.env.NODE_ENV === 'test') return;
+    if (logger === defaultLogger) {
+      try {
+        logger(payload);
+      } catch {
+        // Diagnostics must never affect the request being measured.
+      }
+      return;
+    }
     setImmediate(() => {
       try {
         logger(payload);

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -2814,6 +2814,48 @@ export function mountJvmWeeklyApiRoutes(app, {
     res.status(200).json(result);
   }));
 
+  app.post('/api/v1/cashflow/weekly-overview', asyncHandler(async (req, res) => {
+    const trace = createCashflowPerformanceTrace({
+      requestId: req.context?.requestId || req.requestId,
+      operation: 'cashflow.weekly_overview',
+      ...(performanceLogger ? { logger: performanceLogger } : {}),
+      ...(performanceNow ? { now: performanceNow } : {}),
+    });
+    const { projectIds, yearMonth } = trace.measureSync('request_validation', () => {
+      assertWeeklyWorkspaceOrRoleAllowed(req, ROUTE_ROLES.readCore, 'read cashflow weekly overview', authMode, workspaceEmailDomain);
+      const projectIds = req.body?.projectIds;
+      const yearMonth = readOptionalText(req.body?.yearMonth);
+      if (!Array.isArray(projectIds)
+        || projectIds.length < 1
+        || projectIds.length > 100
+        || projectIds.some((projectId) => typeof projectId !== 'string'
+          || projectId.length < 1
+          || projectId.length > 120
+          || projectId.includes('/')
+          || projectId.trim() !== projectId)
+        || new Set(projectIds).size !== projectIds.length
+        || !/^20\d{2}-(0[1-9]|1[0-2])$/.test(yearMonth)) {
+        throw createHttpError(400, '조회할 프로젝트와 결산 연월을 정확히 입력해 주세요.', 'cashflow_weekly_overview_request_invalid');
+      }
+      return { projectIds, yearMonth };
+    });
+    const result = await trace.measure('java_overview', () => proxyJavaWeeklyRequest({
+      context: req.context,
+      method: 'POST',
+      path: '/api/v1/cashflow/weekly-overview',
+      command: 'read_cashflow_weekly_overview',
+      body: { projectIds, yearMonth },
+      mutation: false,
+    }), { projectCount: projectIds.length });
+    trace.emit('response', {
+      outcome: 'ok',
+      projectCount: projectIds.length,
+      itemCount: Array.isArray(result?.items) ? result.items.length : 0,
+      issueCount: Array.isArray(result?.errors) ? result.errors.length : 0,
+    });
+    res.status(200).json(result);
+  }));
+
   app.post('/api/v1/cashflow/:projectId/weekly-update-complete', asyncHandler(async (req, res) => {
     assertWeeklyWorkspaceOrRoleAllowed(req, ['admin', 'finance', 'pm', 'viewer', 'tenant_admin'], 'complete weekly cashflow update', authMode, workspaceEmailDomain);
     const projectId = readOptionalText(req.params.projectId);

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -608,6 +608,43 @@ describe('JVM weekly API BFF proxy', () => {
     expect(new Headers(init.headers).get('x-tenant-id')).toBe('tenant-a');
   });
 
+  it('reads a 61-project weekly overview with one JVM request and no BFF status rewrite', async () => {
+    const projectIds = Array.from({ length: 61 }, (_, index) => `project-${index + 1}`);
+    const canonical = {
+      version: '1',
+      yearMonth: '2026-08',
+      items: [{ projectId: 'project-1', settlementStatuses: null, projectionActualSummary: null }],
+      errors: [{ projectId: 'project-1', code: 'STATUS_UNAVAILABLE' }],
+    };
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify(canonical), {
+      status: 200, headers: { 'content-type': 'application/json' },
+    }));
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { env: runtimeEnv });
+
+    await request(app)
+      .post('/api/v1/cashflow/weekly-overview')
+      .send({ projectIds, yearMonth: '2026-08' })
+      .expect(200, canonical);
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://jvm-weekly.local/api/v1/cashflow/weekly-overview',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ projectIds, yearMonth: '2026-08' }) }),
+    );
+  });
+
+  it('rejects invalid weekly overview scopes before JVM transport', async () => {
+    const fetchImpl = vi.fn();
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { env: runtimeEnv });
+
+    await request(app)
+      .post('/api/v1/cashflow/weekly-overview')
+      .send({ projectIds: Array.from({ length: 101 }, (_, index) => `project-${index}`), yearMonth: '2026-08' })
+      .expect(400)
+      .expect((response) => expect(response.body.code).toBe('cashflow_weekly_overview_request_invalid'));
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it('rejects projection-actual batch reads before JVM transport when the role is unauthorized', async () => {
     const fetchImpl = vi.fn();
     const { app } = createApp(fetchImpl, createIdempotencyService(), { actorRole: 'external' });

--- a/server/jvm-weekly-api/live-deploy-workflow.test.ts
+++ b/server/jvm-weekly-api/live-deploy-workflow.test.ts
@@ -52,6 +52,7 @@ describe('JVM production deploy workflow', () => {
     expect(workflow).toContain('git diff --quiet "${last}" "${sha}" -- ${JVM_SOURCE_PATHS}');
     // min-instances 1 은 같은 인스턴스를 계속 살려둔다. 행이 걸리면 liveness probe 가
     // 죽여서 교체해야 한다 - 이게 없으면 행 걸린 인스턴스가 장애를 영구 보존한다.
+    expect(workflow).toContain('--no-cpu-throttling');
     expect(workflow).toContain("--liveness-probe 'httpGet.path=/api/v1/health");
     expect(workflow).toContain('No JVM source change between');
     // 강제 배포는 dispatch 입력으로만. shell 안에서 직접 보간하지 않는다.

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowWeeklyOverviewRequest.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowWeeklyOverviewRequest.java
@@ -1,0 +1,29 @@
+package dev.merryai.innerplatform.weekly.api;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record CashflowWeeklyOverviewRequest(
+    @NotNull @Size(min = 1, max = MAX_PROJECT_COUNT)
+    List<@NotBlank @Size(max = MAX_PROJECT_ID_LENGTH) String> projectIds,
+    @NotBlank @Pattern(regexp = "20\\d{2}-(0[1-9]|1[0-2])") String yearMonth
+) {
+    public static final int MAX_PROJECT_COUNT = 100;
+    public static final int MAX_PROJECT_ID_LENGTH = 120;
+
+    public List<String> requireUniqueProjectIds() {
+        List<String> normalized = projectIds == null
+            ? List.of()
+            : projectIds.stream().map(id -> id == null ? "" : id.trim()).toList();
+        if (normalized.isEmpty() || normalized.size() > MAX_PROJECT_COUNT
+            || normalized.stream().anyMatch(id -> id.isBlank() || id.length() > MAX_PROJECT_ID_LENGTH || id.contains("/"))
+            || normalized.stream().distinct().count() != normalized.size()) {
+            throw new IllegalArgumentException("projectIds must contain 1 to 100 unique safe project IDs.");
+        }
+        return normalized;
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowWeeklyOverviewResponse.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowWeeklyOverviewResponse.java
@@ -1,0 +1,30 @@
+package dev.merryai.innerplatform.weekly.api;
+
+import java.util.List;
+
+public record CashflowWeeklyOverviewResponse(
+    String version,
+    String yearMonth,
+    List<Item> items,
+    List<ErrorItem> errors
+) {
+    public static final String STATUS_UNAVAILABLE = "STATUS_UNAVAILABLE";
+    public static final String SUMMARY_UNAVAILABLE = "SUMMARY_UNAVAILABLE";
+
+    public CashflowWeeklyOverviewResponse {
+        items = items == null ? List.of() : List.copyOf(items);
+        errors = errors == null ? List.of() : List.copyOf(errors);
+        if (items.size() > CashflowWeeklyOverviewRequest.MAX_PROJECT_COUNT
+            || errors.size() > CashflowWeeklyOverviewRequest.MAX_PROJECT_COUNT * 2) {
+            throw new IllegalArgumentException("Cashflow weekly overview response exceeds the project limit.");
+        }
+    }
+
+    public record Item(
+        String projectId,
+        CashflowSettlementStatusesResponse settlementStatuses,
+        CashflowProjectionActualSummaryBatchResponse.Item projectionActualSummary
+    ) {}
+
+    public record ErrorItem(String projectId, String code) {}
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -310,6 +310,19 @@ public class WeeklyExpenseController {
         );
     }
 
+    @PostMapping("/cashflow/weekly-overview")
+    public CashflowWeeklyOverviewResponse readCashflowWeeklyOverview(
+        @RequestHeader("x-tenant-id") String tenantId,
+        @RequestHeader("x-actor-id") String actorId,
+        @RequestHeader("x-actor-role") String actorRole,
+        @RequestHeader(value = "x-actor-email", required = false) String actorEmail,
+        @Valid @RequestBody CashflowWeeklyOverviewRequest request
+    ) {
+        return commandService.readCashflowWeeklyOverview(
+            actorContext(tenantId, actorId, actorRole, actorEmail), request
+        );
+    }
+
     private CashflowLedgerSource readCashflowSource(
         String tenantId,
         String projectId,

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowMonthSettlementLifecycle.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowMonthSettlementLifecycle.java
@@ -1,0 +1,17 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+/** Domain rule for the month settlement label shown across cashflow surfaces. */
+public final class CashflowMonthSettlementLifecycle {
+    private CashflowMonthSettlementLifecycle() {
+    }
+
+    public static String resolveMonthStatus(String persistedStatus, String monthCloseRequestStatus) {
+        if ("APPROVED".equals(monthCloseRequestStatus)) return "COMPLETED";
+        if ("PENDING".equals(monthCloseRequestStatus)
+            || "APPROVING".equals(monthCloseRequestStatus)
+            || "UNCERTAIN".equals(monthCloseRequestStatus)) {
+            return "PENDING_APPROVAL";
+        }
+        return persistedStatus;
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -23,6 +23,8 @@ import dev.merryai.innerplatform.weekly.api.CashflowSheetOperationStatusResponse
 import dev.merryai.innerplatform.weekly.api.CashflowPendingApprovalAffectedMonth;
 import dev.merryai.innerplatform.weekly.api.CashflowProjectionActualSummaryBatchRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowProjectionActualSummaryBatchResponse;
+import dev.merryai.innerplatform.weekly.api.CashflowWeeklyOverviewRequest;
+import dev.merryai.innerplatform.weekly.api.CashflowWeeklyOverviewResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetFormulaPreflightRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetFormulaPreflightResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowSnapshotResponse;
@@ -71,6 +73,7 @@ import dev.merryai.innerplatform.weekly.domain.CellAddress;
 import dev.merryai.innerplatform.weekly.domain.CellValidationStatus;
 import dev.merryai.innerplatform.weekly.domain.CashflowLineCatalog;
 import dev.merryai.innerplatform.weekly.domain.CashflowProjectionActualSummaryCalculator;
+import dev.merryai.innerplatform.weekly.domain.CashflowMonthSettlementLifecycle;
 import dev.merryai.innerplatform.weekly.domain.CashflowFormulaValidator;
 import dev.merryai.innerplatform.weekly.domain.ClipboardCell;
 import dev.merryai.innerplatform.weekly.domain.ClipboardPayload;
@@ -113,6 +116,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CompletableFuture;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -303,6 +307,88 @@ public class WeeklyExpenseCommandService {
             }
         }
         return new CashflowProjectionActualSummaryBatchResponse("1", items, errors);
+    }
+
+    public CashflowWeeklyOverviewResponse readCashflowWeeklyOverview(
+        TrustedActorContext actor,
+        CashflowWeeklyOverviewRequest request
+    ) {
+        List<String> projectIds = request.requireUniqueProjectIds();
+        authorizationService.requireProjectsAllowed(CASHFLOW_READ_COMMAND, actor, projectIds);
+        authorizationService.requireProjectsAllowed(CASHFLOW_MONTH_CLOSE_READ_COMMAND, actor, projectIds);
+        CashflowProjectionActualSummaryCalculator.FinanceWeek boundary =
+            CashflowProjectionActualSummaryCalculator.currentFinanceWeek(Clock.systemUTC());
+        String throughMonth = request.yearMonth().compareTo(boundary.yearMonth()) > 0
+            ? request.yearMonth() : boundary.yearMonth();
+        Map<String, List<WeeklyExpensePersistence.CashflowSettlementStatusRecord>> statusesByProject;
+        Map<String, String> monthCloseRequestStatuses;
+        Map<String, CashflowLedgerSource> sourcesByProject;
+        CompletableFuture<Map<String, List<WeeklyExpensePersistence.CashflowSettlementStatusRecord>>> statusesFuture =
+            CompletableFuture.supplyAsync(() -> persistence.findCashflowSettlementStatusesBatch(actor.tenantId(), projectIds, request.yearMonth()));
+        CompletableFuture<Map<String, String>> monthCloseRequestsFuture =
+            CompletableFuture.supplyAsync(() -> persistence.findCashflowMonthCloseRequestStatusesBatch(actor.tenantId(), projectIds, request.yearMonth()));
+        CompletableFuture<Map<String, CashflowLedgerSource>> sourcesFuture =
+            CompletableFuture.supplyAsync(() -> persistence.findCashflowLedgerSources(
+                actor.tenantId(), projectIds, CashflowProjectionActualSummaryCalculator.FROM_MONTH, throughMonth
+            ));
+        try {
+            statusesByProject = statusesFuture.join();
+        } catch (RuntimeException unavailable) {
+            statusesByProject = Map.of();
+        }
+        try {
+            monthCloseRequestStatuses = monthCloseRequestsFuture.join();
+        } catch (RuntimeException unavailable) {
+            monthCloseRequestStatuses = Map.of();
+        }
+        try {
+            sourcesByProject = sourcesFuture.join();
+        } catch (RuntimeException unavailable) {
+            sourcesByProject = Map.of();
+        }
+        List<CashflowWeeklyOverviewResponse.Item> items = new ArrayList<>();
+        List<CashflowWeeklyOverviewResponse.ErrorItem> errors = new ArrayList<>();
+        for (String projectId : projectIds) {
+            CashflowSettlementStatusesResponse statuses = null;
+            List<WeeklyExpensePersistence.CashflowSettlementStatusRecord> records = statusesByProject.get(projectId);
+            if (records == null) {
+                errors.add(new CashflowWeeklyOverviewResponse.ErrorItem(
+                    projectId, CashflowWeeklyOverviewResponse.STATUS_UNAVAILABLE
+                ));
+            } else {
+                statuses = settlementStatusesResponse(projectId, request.yearMonth(), records);
+                statuses = resolveMonthSettlementStatus(statuses, monthCloseRequestStatuses.get(projectId));
+            }
+            CashflowProjectionActualSummaryBatchResponse.Item summary = null;
+            CashflowLedgerSource source = sourcesByProject.get(projectId);
+            if (source == null) {
+                errors.add(new CashflowWeeklyOverviewResponse.ErrorItem(
+                    projectId, CashflowWeeklyOverviewResponse.SUMMARY_UNAVAILABLE
+                ));
+            } else {
+                summary = toProjectionActualSummary(projectId, source, boundary, request.yearMonth());
+            }
+            items.add(new CashflowWeeklyOverviewResponse.Item(projectId, statuses, summary));
+        }
+        return new CashflowWeeklyOverviewResponse("1", request.yearMonth(), items, errors);
+    }
+
+    private CashflowSettlementStatusesResponse resolveMonthSettlementStatus(
+        CashflowSettlementStatusesResponse response,
+        String monthCloseRequestStatus
+    ) {
+        return new CashflowSettlementStatusesResponse(
+            response.projectId(),
+            response.yearMonth(),
+            response.items().stream().map(item -> item.period().equals("MONTH")
+                ? new CashflowSettlementStatusesResponse.Item(
+                    item.period(),
+                    CashflowMonthSettlementLifecycle.resolveMonthStatus(item.status(), monthCloseRequestStatus),
+                    item.submittedAt(), item.submittedBy(), item.approvedAt(), item.approvedBy(), item.revision()
+                )
+                : item
+            ).toList()
+        );
     }
 
     public CashflowProjectionActualSummaryBatchResponse.Item readCashflowProjectionActualSummary(

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -362,6 +362,29 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         return Map.copyOf(result);
     }
 
+    @Override
+    public Map<String, String> findCashflowMonthCloseRequestStatusesBatch(
+        String tenantId,
+        List<String> projectIds,
+        String yearMonth
+    ) {
+        requireYearMonth(yearMonth);
+        DocumentReference[] refs = projectIds.stream()
+            .map(projectId -> db.document(
+                "orgs/" + tenantId + "/cashflow_month_close_requests/" + projectId + "-" + yearMonth
+            ))
+            .toArray(DocumentReference[]::new);
+        Map<String, String> result = new LinkedHashMap<>();
+        for (DocumentSnapshot snapshot : getAll(refs)) {
+            if (!snapshot.exists()) continue;
+            Map<String, Object> document = data(snapshot);
+            String projectId = text(document.get("projectId"), "");
+            if (!projectIds.contains(projectId)) continue;
+            result.put(projectId, text(document.get("status"), ""));
+        }
+        return Map.copyOf(result);
+    }
+
     private List<CashflowSettlementStatusRecord> settlementStatusRecords(Map<String, Object> stored) {
         Map<String, Object> periods = nestedMap(stored.get("periods"));
         List<CashflowSettlementStatusRecord> result = new ArrayList<>();
@@ -2618,6 +2641,42 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             throughMonth,
             weeklyYear
         );
+    }
+
+    @Override
+    public Map<String, CashflowLedgerSource> findCashflowLedgerSources(
+        String tenantId,
+        List<String> projectIds,
+        String fromMonth,
+        String throughMonth
+    ) {
+        if (projectIds == null || projectIds.isEmpty()) return Map.of();
+        int maximumCanonicalWeeks = (2099 - 2023 + 1) * 12 * CashflowSheetLabApplyRequest.FINANCE_WEEK_COUNT;
+        Map<String, List<DocumentSnapshot>> documentsByProject = new LinkedHashMap<>();
+        for (String projectId : projectIds) documentsByProject.put(projectId, new ArrayList<>());
+        for (int index = 0; index < projectIds.size(); index += 30) {
+            List<String> group = projectIds.subList(index, Math.min(index + 30, projectIds.size()));
+            QuerySnapshot snapshot = query(cashflowWeeks(tenantId)
+                .whereIn("projectId", group)
+                .whereGreaterThanOrEqualTo("yearMonth", fromMonth)
+                .whereLessThanOrEqualTo("yearMonth", throughMonth)
+                .limit(Math.addExact(Math.multiplyExact(maximumCanonicalWeeks, group.size()), 1)));
+            if (snapshot.size() > maximumCanonicalWeeks * group.size()) {
+                throw new WeeklyExpenseConflictException("Canonical cashflow ledger exceeds the bounded read limit.");
+            }
+            for (DocumentSnapshot document : snapshot.getDocuments()) {
+                String projectId = text(data(document).get("projectId"), "");
+                List<DocumentSnapshot> target = documentsByProject.get(projectId);
+                if (target != null) target.add(document);
+            }
+        }
+        Map<String, CashflowLedgerSource> result = new LinkedHashMap<>();
+        for (Map.Entry<String, List<DocumentSnapshot>> entry : documentsByProject.entrySet()) {
+            result.put(entry.getKey(), cashflowLedgerSource(
+                tenantId, entry.getKey(), entry.getValue(), fromMonth, throughMonth, null
+            ));
+        }
+        return Map.copyOf(result);
     }
 
     private CashflowLedgerSource cashflowLedgerSource(

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
@@ -367,6 +367,14 @@ public interface WeeklyExpensePersistence {
         return Map.copyOf(result);
     }
 
+    default Map<String, String> findCashflowMonthCloseRequestStatusesBatch(
+        String tenantId,
+        List<String> projectIds,
+        String yearMonth
+    ) {
+        return Map.of();
+    }
+
     default CashflowSettlementStatusRecord transitionCashflowSettlementStatus(
         TrustedActorContext actor,
         String projectId,
@@ -692,7 +700,31 @@ public interface WeeklyExpensePersistence {
         return new CashflowLedgerSource(projection, actual, source.targetRevision());
     }
 
-    /** Prior-year carry-forward comes only from the fixed annual columns. */
+    default Map<String, CashflowLedgerSource> findCashflowLedgerSources(
+        String tenantId,
+        List<String> projectIds,
+        String fromMonth,
+        String throughMonth
+    ) {
+        Map<String, CashflowLedgerSource> result = new LinkedHashMap<>();
+        for (String projectId : projectIds) {
+            CashflowLedgerSource source = findCashflowGlobalLedgerSource(tenantId, projectId);
+            List<WeeklyExpenseProjectionEntity> projection = source.projection().stream()
+                .filter(line -> line.getYearMonth().compareTo(fromMonth) >= 0 && line.getYearMonth().compareTo(throughMonth) <= 0)
+                .toList();
+            List<WeeklyExpenseActualEntity> actual = source.actual().stream()
+                .filter(line -> line.getYearMonth().compareTo(fromMonth) >= 0 && line.getYearMonth().compareTo(throughMonth) <= 0)
+                .toList();
+            result.put(projectId, new CashflowLedgerSource(projection, actual, source.targetRevision()));
+        }
+        return Map.copyOf(result);
+    }
+
+    /**
+     * Canonical carry-forward policy for cashflow reads and month-close snapshots.
+     * A prior year uses weekly ledger lines when that year exists in the weekly ledger;
+     * the annual-total document is only a fallback, so a year can never be counted twice.
+     */
     default CashflowOpeningBalance findCashflowOpeningBalance(
         String tenantId,
         String projectId,

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowWeeklyOverviewServiceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowWeeklyOverviewServiceTest.java
@@ -1,0 +1,59 @@
+package dev.merryai.innerplatform.weekly.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.merryai.innerplatform.weekly.api.CashflowWeeklyOverviewRequest;
+import dev.merryai.innerplatform.weekly.api.CashflowWeeklyOverviewResponse;
+import dev.merryai.innerplatform.weekly.api.TrustedActorContext;
+import dev.merryai.innerplatform.weekly.domain.CashflowLedgerSource;
+import dev.merryai.innerplatform.weekly.storage.WeeklyExpensePersistence;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CashflowWeeklyOverviewServiceTest {
+    private static final TrustedActorContext ACTOR = new TrustedActorContext(
+        "tenant-a", "viewer-a", "viewer@example.com", "viewer", "Viewer A"
+    );
+
+    @Test
+    void combinesCanonicalStatusesAndSummariesInOneApplicationRead() {
+        WeeklyExpensePersistence persistence = mock(WeeklyExpensePersistence.class);
+        WeeklyExpenseAuthorizationService authorization = mock(WeeklyExpenseAuthorizationService.class);
+        WeeklyExpenseCommandService service = new WeeklyExpenseCommandService(
+            persistence, authorization, new ObjectMapper(), false, "live"
+        );
+        List<String> projectIds = List.of("project-a", "project-b");
+        WeeklyExpensePersistence.CashflowSettlementStatusRecord month =
+            new WeeklyExpensePersistence.CashflowSettlementStatusRecord("MONTH", "WAITING_FOR_UPDATE", "", "", "", "", 1);
+        when(persistence.findCashflowSettlementStatusesBatch("tenant-a", projectIds, "2026-08"))
+            .thenReturn(Map.of("project-a", List.of(month), "project-b", List.of(month)));
+        when(persistence.findCashflowMonthCloseRequestStatusesBatch("tenant-a", projectIds, "2026-08"))
+            .thenReturn(Map.of("project-a", "APPROVED", "project-b", "PENDING"));
+        when(persistence.findCashflowLedgerSources(anyString(), anyList(), anyString(), anyString()))
+            .thenReturn(Map.of(
+                "project-a", new CashflowLedgerSource(List.of(), List.of()),
+                "project-b", new CashflowLedgerSource(List.of(), List.of())
+            ));
+
+        CashflowWeeklyOverviewResponse response = service.readCashflowWeeklyOverview(
+            ACTOR, new CashflowWeeklyOverviewRequest(projectIds, "2026-08")
+        );
+
+        assertThat(response.items()).hasSize(2);
+        assertThat(response.items().get(0).settlementStatuses().items().getFirst().status()).isEqualTo("COMPLETED");
+        assertThat(response.items().get(1).settlementStatuses().items().getFirst().status()).isEqualTo("PENDING_APPROVAL");
+        assertThat(response.items()).allSatisfy(item -> assertThat(item.projectionActualSummary()).isNotNull());
+        assertThat(response.errors()).isEmpty();
+        verify(authorization).requireProjectsAllowed(WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, ACTOR, projectIds);
+        verify(authorization).requireProjectsAllowed(WeeklyExpenseCommandService.CASHFLOW_MONTH_CLOSE_READ_COMMAND, ACTOR, projectIds);
+        verify(persistence).findCashflowLedgerSources(anyString(), anyList(), anyString(), anyString());
+    }
+}

--- a/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
+++ b/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
@@ -24,10 +24,10 @@ describe('CashflowWeeklyPage settlement status surface', () => {
     expect(source).not.toContain('>조회 오류</span>');
   });
 
-  it('uses the simple persisted status flow and updates only the affected project state', () => {
+  it('uses one overview snapshot and refreshes it after a status transition', () => {
     expect(source).toContain('sticky top-0');
     expect(source).toContain('sticky left-0');
-    expect(source).toContain('fetchCashflowSettlementStatusesBatchViaBff');
+    expect(source).toContain('fetchCashflowWeeklyOverviewViaBff');
     expect(source).toContain('transitionCashflowSettlementStatusViaBff');
     expect(source).toContain("onAction={(action) => void transition(project.id, 'MONTH', action)}");
     expect(source).toContain('주정산 이전');
@@ -35,7 +35,10 @@ describe('CashflowWeeklyPage settlement status surface', () => {
     expect(source).toContain('조직장 승인 필요');
     expect(source).toContain('승인 완료');
     expect(source).toContain("user?.uid === project.executiveApproverId");
-    expect(source).toContain("setStatuses((current) => ({ ...current, [projectId]: result }))");
+    expect(source).toContain('setRefreshSequence((current) => current + 1)');
+    expect(source).not.toContain('fetchCashflowSettlementStatusesBatchViaBff');
+    expect(source).not.toContain('useCashflowProjectionActualSummaries');
+    expect(source).not.toContain('window.setInterval');
     expect(source).not.toContain('window.location.reload');
     expect(source).not.toContain("onAction('SUBMIT')");
   });
@@ -46,7 +49,7 @@ describe('CashflowWeeklyPage settlement status surface', () => {
     expect(source).toContain('normalizeProjectDepartment(project.department)');
     expect(source).toContain('filterCashflowProjectsByDepartment(projects, deptFilter)');
     expect(source).not.toContain('Promise.allSettled(filteredProjects.map');
-    expect(source).toContain('projectIds.slice(index * 100, (index + 1) * 100)');
+    expect(source).toContain('const projectIds = JSON.parse(overviewProjectIdsKey) as string[]');
     expect(source).toContain('{filteredProjects.map((project) => {');
     expect(source).toContain('filteredProjects.length === 0');
     expect(source).toContain('>담당조직</Label>');

--- a/src/app/components/cashflow/CashflowWeeklyPage.tsx
+++ b/src/app/components/cashflow/CashflowWeeklyPage.tsx
@@ -12,16 +12,18 @@ import { useCashflowWeeks } from '../../data/cashflow-weeks-store';
 import { useAuth } from '../../data/auth-store';
 import { useFirebase } from '../../lib/firebase-context';
 import {
-  fetchCashflowSettlementStatusesBatchViaBff,
+  fetchCashflowWeeklyOverviewViaBff,
   transitionCashflowSettlementStatusViaBff,
+  type CashflowProjectionActualSummary,
   type CashflowSettlementPeriod,
   type CashflowSettlementStatus,
   type CashflowSettlementStatusItem,
   type CashflowSettlementStatusesResult,
+  type CashflowWeeklyOverviewResult,
 } from '../../lib/platform-bff-client';
 import { getMonthMondayWeeks } from '../../platform/cashflow-weeks';
 import { getProjectRegistrationCicOptions, normalizeProjectDepartment } from '../../platform/project-cic';
-import { useCashflowProjectionActualSummaries } from './useCashflowProjectionActualSummaries';
+import { recordDevtoolsLog, toDevtoolsError } from '../../platform/devtools-transaction-log';
 import type { OrgMember, Project } from '../../data/types';
 
 export function filterCashflowProjectsByDepartment<T extends { department?: unknown }>(projects: T[], department: string): T[] {
@@ -130,12 +132,12 @@ function PeriodAmounts({
   loading,
   error,
 }: {
-  summary: ReturnType<typeof useCashflowProjectionActualSummaries>['summaries'][string] | undefined;
+  summary: CashflowProjectionActualSummary | undefined;
   period: CashflowSettlementPeriod;
   loading?: boolean;
   error?: boolean;
 }) {
-  if (error) return null;
+  if (error) return <div className="mt-1 text-[9px] text-amber-700">금액 확인 필요</div>;
   if (loading) return <div className="mt-1 text-[9px] text-slate-400">금액 확인 중…</div>;
   const amounts = summary?.periods.find((item) => item.period === period);
   if (!amounts) return null;
@@ -154,9 +156,10 @@ export function CashflowWeeklyPage() {
   const { orgId } = useFirebase();
   const { yearMonth, isLoading, goPrevMonth, goNextMonth } = useCashflowWeeks();
   const monthWeeks = useMemo(() => getMonthMondayWeeks(yearMonth), [yearMonth]);
-  const [statuses, setStatuses] = useState<Record<string, CashflowSettlementStatusesResult>>({});
-  const [statusErrors, setStatusErrors] = useState<Record<string, string>>({});
-  const [statusesLoading, setStatusesLoading] = useState(false);
+  const [overview, setOverview] = useState<CashflowWeeklyOverviewResult | null>(null);
+  const [overviewLoading, setOverviewLoading] = useState(false);
+  const [overviewError, setOverviewError] = useState('');
+  const [refreshSequence, setRefreshSequence] = useState(0);
   const [actionKey, setActionKey] = useState('');
   const [deptFilter, setDeptFilter] = useState('ALL');
   const [monthStatusFilter, setMonthStatusFilter] = useState<SettlementStatusFilter>('ALL');
@@ -166,68 +169,101 @@ export function CashflowWeeklyPage() {
     ...projects.map((project) => normalizeProjectDepartment(project.department)).filter(Boolean),
   ])).sort((left, right) => left.localeCompare(right, 'ko')), [projects]);
   const departmentProjects = useMemo(() => filterCashflowProjectsByDepartment(projects, deptFilter), [deptFilter, projects]);
+  const overviewProjectIds = useMemo(() => departmentProjects.map((project) => project.id), [departmentProjects]);
+  const overviewProjectIdsKey = useMemo(() => JSON.stringify(overviewProjectIds), [overviewProjectIds]);
+  const statuses = useMemo<Record<string, CashflowSettlementStatusesResult>>(() => Object.fromEntries(
+    (overview?.items || []).flatMap((item) => item.settlementStatuses ? [[item.projectId, item.settlementStatuses]] : []),
+  ), [overview]);
+  const statusErrors = useMemo<Record<string, string>>(() => {
+    if (overviewError) return Object.fromEntries(overviewProjectIds.map((projectId) => [projectId, overviewError]));
+    return Object.fromEntries((overview?.errors || [])
+      .filter((error) => error.code === 'STATUS_UNAVAILABLE')
+      .map((error) => [error.projectId, '결산 상태를 불러오지 못했습니다. 다시 불러와 주세요.']));
+  }, [overview, overviewError, overviewProjectIds]);
+  const summaries = useMemo<Record<string, CashflowProjectionActualSummary>>(() => Object.fromEntries(
+    (overview?.items || []).flatMap((item) => item.projectionActualSummary ? [[item.projectId, item.projectionActualSummary]] : []),
+  ), [overview]);
+  const summaryErrors = useMemo<Record<string, boolean>>(() => {
+    if (overviewError) return Object.fromEntries(overviewProjectIds.map((projectId) => [projectId, true]));
+    return Object.fromEntries((overview?.errors || [])
+      .filter((error) => error.code === 'SUMMARY_UNAVAILABLE')
+      .map((error) => [error.projectId, true]));
+  }, [overview, overviewError, overviewProjectIds]);
   const filteredProjects = useMemo(() => filterCashflowProjectsBySettlementStatus(
     projects,
     deptFilter,
     statuses,
     statusErrors,
-    statusesLoading,
+    overviewLoading,
     monthWeeks.map((week) => week.weekNo),
     monthStatusFilter,
     weekStatusFilter,
-  ), [deptFilter, monthStatusFilter, monthWeeks, projects, statusErrors, statuses, statusesLoading, weekStatusFilter]);
-  const projectIds = useMemo(() => filteredProjects.map((project) => project.id), [filteredProjects]);
-  const projectionActual = useCashflowProjectionActualSummaries({ tenantId: orgId, actor: user, projectIds, yearMonth });
+  ), [deptFilter, monthStatusFilter, monthWeeks, overviewLoading, projects, statusErrors, statuses, weekStatusFilter]);
 
   useEffect(() => {
-    if (!user?.idToken || departmentProjects.length === 0) {
-      setStatuses({});
-      setStatusErrors({});
-      setStatusesLoading(false);
+    const projectIds = JSON.parse(overviewProjectIdsKey) as string[];
+    if (!user?.idToken || projectIds.length === 0) {
+      setOverview(null);
+      setOverviewLoading(false);
+      setOverviewError('');
       return;
     }
     let active = true;
-    const projectIds = departmentProjects.map((project) => project.id);
-    const batches = Array.from(
-      { length: Math.ceil(projectIds.length / 100) },
-      (_, index) => projectIds.slice(index * 100, (index + 1) * 100),
-    );
-    const load = async (showLoading: boolean) => {
-      if (showLoading) setStatusesLoading(true);
-      const results = await Promise.all(batches.map(async (batchProjectIds) => fetchCashflowSettlementStatusesBatchViaBff({
-        tenantId: orgId, actor: user, projectIds: batchProjectIds, yearMonth,
-      }).catch(() => ({
-        items: [],
-        errors: batchProjectIds.map((projectId) => ({ projectId, code: 'STATUS_UNAVAILABLE' as const })),
-      }))));
+    const startedAt = Date.now();
+    setOverviewLoading(true);
+    setOverviewError('');
+    setOverview(null);
+    recordDevtoolsLog({
+      kind: 'cashflow_transaction',
+      phase: 'start',
+      operation: 'cashflow.weekly_overview',
+      transport: 'bff',
+      yearMonth,
+      summary: { projectCount: projectIds.length },
+    });
+    void fetchCashflowWeeklyOverviewViaBff({
+      tenantId: orgId,
+      actor: user,
+      projectIds,
+      yearMonth,
+    }).then((result) => {
       if (!active) return;
-      setStatuses(Object.fromEntries(results.flatMap((result) => result.items).map((item) => [item.projectId, item])));
-      setStatusErrors(Object.fromEntries(results.flatMap((result) => result.errors).map((error) => [error.projectId, '결산 상태를 불러오지 못했습니다.'])));
-      setStatusesLoading(false);
-    };
-    void load(true);
-    // 백그라운드 탭에서는 폴링을 멈추고, 다시 보일 때 즉시 한 번 갱신한다.
-    const interval = window.setInterval(() => {
-      if (document.visibilityState === 'hidden') return;
-      void load(false);
-    }, 15_000);
-    const onVisible = () => { if (document.visibilityState === 'visible') void load(false); };
-    document.addEventListener('visibilitychange', onVisible);
-    return () => {
-      active = false;
-      window.clearInterval(interval);
-      document.removeEventListener('visibilitychange', onVisible);
-    };
-  }, [departmentProjects, orgId, user, yearMonth]);
+      setOverview(result);
+      recordDevtoolsLog({
+        kind: 'cashflow_transaction',
+        phase: 'success',
+        operation: 'cashflow.weekly_overview',
+        transport: 'bff',
+        yearMonth,
+        durationMs: Date.now() - startedAt,
+        summary: { projectCount: projectIds.length, itemCount: result.items.length, issueCount: result.errors.length },
+      });
+    }).catch((error) => {
+      if (!active) return;
+      setOverviewError('현금흐름 현황을 불러오지 못했습니다. 다시 불러와 주세요.');
+      recordDevtoolsLog({
+        kind: 'cashflow_transaction',
+        phase: 'error',
+        operation: 'cashflow.weekly_overview',
+        transport: 'bff',
+        yearMonth,
+        durationMs: Date.now() - startedAt,
+        summary: { projectCount: projectIds.length },
+        error: toDevtoolsError(error),
+      });
+    }).finally(() => {
+      if (active) setOverviewLoading(false);
+    });
+    return () => { active = false; };
+  }, [orgId, overviewProjectIdsKey, refreshSequence, user, yearMonth]);
 
   async function transition(projectId: string, period: CashflowSettlementPeriod, action: 'SUBMIT' | 'APPROVE') {
     if (!user?.idToken) return;
     const key = `${projectId}:${period}`;
     setActionKey(key);
     try {
-      const result = await transitionCashflowSettlementStatusViaBff({ tenantId: orgId, actor: user, projectId, yearMonth, period, action });
-      setStatuses((current) => ({ ...current, [projectId]: result }));
-      setStatusErrors((current) => ({ ...current, [projectId]: '' }));
+      await transitionCashflowSettlementStatusViaBff({ tenantId: orgId, actor: user, projectId, yearMonth, period, action });
+      setRefreshSequence((current) => current + 1);
       toast.success(action === 'APPROVE' ? '정산을 승인했습니다.' : '조직장 승인 대기로 변경했습니다.');
     } catch (error) {
       toast.error(error instanceof Error ? error.message : '결산 상태를 변경하지 못했습니다.');
@@ -255,6 +291,9 @@ export function CashflowWeeklyPage() {
             <Button variant="outline" size="sm" className="h-8 gap-1.5 text-[12px]" onClick={goNextMonth}>
               다음 달 <ChevronRight className="h-3.5 w-3.5" />
             </Button>
+            <Button variant="outline" size="sm" className="h-8 text-[12px]" onClick={() => setRefreshSequence((current) => current + 1)}>
+              다시 불러오기
+            </Button>
           </div>
         )}
       />
@@ -277,6 +316,7 @@ export function CashflowWeeklyPage() {
 
       <Card className="overflow-hidden">
         <CardContent className="p-0">
+          {overviewError ? <div role="alert" className="border-b border-amber-200 bg-amber-50 px-4 py-3 text-[11px] text-amber-900">{overviewError}</div> : null}
           <div className="max-h-[calc(100vh-190px)] overflow-auto">
             <table className="w-full min-w-[1320px] border-separate border-spacing-0 text-[11px]">
               <thead>
@@ -305,7 +345,7 @@ export function CashflowWeeklyPage() {
                       </td>
                       <td className="sticky left-[220px] z-20 bg-white px-3 py-3 font-medium">{formatCashflowProjectOwner(project, members)}</td>
                       <td className="px-3 py-3 text-center">
-                        {statusErrors[project.id] || (statusesLoading && !projectStatuses) ? <span className="text-muted-foreground">확인 중…</span> : (
+                        {statusErrors[project.id] ? <span className="text-amber-700">정보 확인 필요</span> : (overviewLoading && !projectStatuses) ? <span className="text-muted-foreground">확인 중…</span> : (
                           <SettlementStatusButton
                             item={statusItem(projectStatuses, 'MONTH')}
                             period="MONTH"
@@ -314,7 +354,7 @@ export function CashflowWeeklyPage() {
                             onAction={(action) => void transition(project.id, 'MONTH', action)}
                           />
                         )}
-                        <PeriodAmounts summary={projectionActual.summaries[project.id]} period="MONTH" loading={projectionActual.loading[project.id]} error={projectionActual.errors[project.id]} />
+                        <PeriodAmounts summary={summaries[project.id]} period="MONTH" loading={overviewLoading && !summaries[project.id]} error={summaryErrors[project.id]} />
                       </td>
                       <td className="px-3 py-3 text-center">
                         <Button size="sm" variant="outline" className="h-8 gap-1.5 text-[11px]" onClick={() => openProject(project.id)}>
@@ -325,7 +365,7 @@ export function CashflowWeeklyPage() {
                         const period = `WEEK_${week.weekNo}` as CashflowSettlementPeriod;
                         return (
                           <td key={week.weekNo} className="px-3 py-3 text-center">
-                            {statusErrors[project.id] || (statusesLoading && !projectStatuses) ? <span className="text-muted-foreground">확인 중…</span> : (
+                            {statusErrors[project.id] ? <span className="text-amber-700">정보 확인 필요</span> : (overviewLoading && !projectStatuses) ? <span className="text-muted-foreground">확인 중…</span> : (
                               <SettlementStatusButton
                                 item={statusItem(projectStatuses, period)}
                                 period={period}
@@ -334,7 +374,7 @@ export function CashflowWeeklyPage() {
                                 onAction={(action) => void transition(project.id, period, action)}
                               />
                             )}
-                            <PeriodAmounts summary={projectionActual.summaries[project.id]} period={period} loading={projectionActual.loading[project.id]} error={projectionActual.errors[project.id]} />
+                            <PeriodAmounts summary={summaries[project.id]} period={period} loading={overviewLoading && !summaries[project.id]} error={summaryErrors[project.id]} />
                           </td>
                         );
                       })}

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -43,6 +43,7 @@ import {
   fetchCashflowWeeklyComplianceViaBff,
   fetchCashflowProjectionActualSummariesViaBff,
   fetchCashflowSettlementStatusesBatchViaBff,
+  fetchCashflowWeeklyOverviewViaBff,
   transitionCashflowSettlementStatusViaBff,
   fetchCashflowActivityViaBff,
   fetchCashflowAppliedCellChangesViaBff,
@@ -166,6 +167,32 @@ describe('platform-bff-client', () => {
     }));
     expect(result.items).toHaveLength(9);
     expect(result.errors).toEqual([{ projectId: 'p010', code: 'SUMMARY_UNAVAILABLE' }]);
+  });
+
+  it('posts all visible projects once to the weekly overview without rejecting per-project unavailable data', async () => {
+    const projectIds = Array.from({ length: 61 }, (_, index) => `p${index + 1}`);
+    const data = {
+      version: '1',
+      yearMonth: '2026-08',
+      items: projectIds.map((projectId) => ({
+        projectId,
+        settlementStatuses: null,
+        projectionActualSummary: null,
+      })),
+      errors: projectIds.flatMap((projectId) => [
+        { projectId, code: 'STATUS_UNAVAILABLE' as const },
+        { projectId, code: 'SUMMARY_UNAVAILABLE' as const },
+      ]),
+    };
+    const client = asMockClient({ post: vi.fn(async () => ({ data })), get: vi.fn(), request: vi.fn() });
+
+    await expect(fetchCashflowWeeklyOverviewViaBff({
+      tenantId: 'mysc', actor: { uid: 'u001', role: 'pm' }, projectIds, yearMonth: '2026-08', client,
+    })).resolves.toBe(data);
+    expect(client.post).toHaveBeenCalledTimes(1);
+    expect(client.post).toHaveBeenCalledWith('/api/v1/cashflow/weekly-overview', expect.objectContaining({
+      body: { projectIds, yearMonth: '2026-08' }, retries: 0, timeoutMs: 12000,
+    }));
   });
 
   it.each([

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -1409,6 +1409,20 @@ export interface CashflowProjectionActualSummaryBatch {
   }>;
 }
 
+export interface CashflowWeeklyOverviewResult {
+  version: string;
+  yearMonth: string;
+  items: Array<{
+    projectId: string;
+    settlementStatuses: CashflowSettlementStatusesResult | null;
+    projectionActualSummary: CashflowProjectionActualSummary | null;
+  }>;
+  errors: Array<{
+    projectId: string;
+    code: 'STATUS_UNAVAILABLE' | 'SUMMARY_UNAVAILABLE';
+  }>;
+}
+
 export interface ProjectCashflowActualSyncResult {
   ok: boolean;
   skipped?: boolean;
@@ -3051,6 +3065,40 @@ export async function fetchCashflowProjectionActualSummariesViaBff(params: {
     || new Set(errorIds).size !== errorIds.length
     || errorIds.some((projectId) => itemIds.includes(projectId))) {
     throw new Error('JVM 누적 Projection-Actual 요약 응답이 올바르지 않습니다.');
+  }
+  return result;
+}
+
+export async function fetchCashflowWeeklyOverviewViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectIds: string[];
+  yearMonth: string;
+  client?: PlatformApiClientLike;
+}): Promise<CashflowWeeklyOverviewResult> {
+  const response = await resolveClient(params.client).post<CashflowWeeklyOverviewResult>(
+    '/api/v1/cashflow/weekly-overview',
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      body: { projectIds: params.projectIds, yearMonth: params.yearMonth },
+      retries: 0,
+      timeoutMs: 12000,
+    },
+  );
+  const result = response.data;
+  const requestedIds = new Set(params.projectIds);
+  const itemIds = Array.isArray(result?.items) ? result.items.map((item) => item?.projectId) : [];
+  if (typeof result?.version !== 'string'
+    || result?.yearMonth !== params.yearMonth
+    || !Array.isArray(result?.items)
+    || itemIds.length !== params.projectIds.length
+    || itemIds.some((projectId) => !requestedIds.has(projectId))
+    || new Set(itemIds).size !== itemIds.length
+    || !Array.isArray(result?.errors)
+    || result.errors.some((error) => !requestedIds.has(error?.projectId)
+      || !['STATUS_UNAVAILABLE', 'SUMMARY_UNAVAILABLE'].includes(error?.code))) {
+    throw new Error('현금흐름 현황 응답이 올바르지 않습니다.');
   }
   return result;
 }

--- a/src/app/platform/devtools-transaction-log.test.ts
+++ b/src/app/platform/devtools-transaction-log.test.ts
@@ -47,6 +47,25 @@ describe('devtools transaction log', () => {
     ]);
   });
 
+  it('exports a cashflow-only trace without tenant, actor, or project identifiers', () => {
+    clearDevtoolsLogs();
+    recordDevtoolsLog({
+      kind: 'cashflow_transaction', phase: 'success', operation: '/api/v1/cashflow/project-secret/month-close',
+      tenantId: 'tenant-secret', actorId: 'actor-secret', projectId: 'project-secret',
+      path: '/api/v1/cashflow/project-secret/month-close',
+      summary: { projectCount: 61 },
+    });
+    const trace = (globalThis as typeof globalThis & {
+      __MYSCUBE_DEVTOOLS__?: { cashflowTrace: () => unknown[] };
+    }).__MYSCUBE_DEVTOOLS__?.cashflowTrace();
+
+    expect(trace).toEqual([expect.objectContaining({ operation: 'cashflow.request', summary: { projectCount: 61 } })]);
+    const serialized = JSON.stringify(trace);
+    expect(serialized).not.toContain('tenant-secret');
+    expect(serialized).not.toContain('actor-secret');
+    expect(serialized).not.toContain('project-secret');
+  });
+
   it('redacts tokens, emails, and binary payload fields before exposing logs', () => {
     const sanitized = sanitizeDevtoolsValue({
       idToken: 'firebase-token',

--- a/src/app/platform/devtools-transaction-log.ts
+++ b/src/app/platform/devtools-transaction-log.ts
@@ -33,6 +33,10 @@ export interface DevtoolsLogEntry {
 
 interface DevtoolsApi {
   logs: () => DevtoolsLogEntry[];
+  cashflowTrace: () => Array<Pick<DevtoolsLogEntry,
+    'ts' | 'kind' | 'phase' | 'operation' | 'method' | 'requestId' | 'responseRequestId'
+    | 'status' | 'durationMs' | 'attempt' | 'maxRetries' | 'transport' | 'yearMonth' | 'weekNo' | 'mode'
+    | 'summary' | 'error'>>;
   clear: () => void;
   enable: () => void;
   disable: () => void;
@@ -212,6 +216,33 @@ function ensureDevtoolsApi(): DevtoolsApi {
   if (!globalState.__MYSCUBE_DEVTOOLS__) {
     globalState.__MYSCUBE_DEVTOOLS__ = {
       logs: () => [...(globalState.__MYSCUBE_DEVTOOLS_LOGS__ || [])],
+      cashflowTrace: () => (globalState.__MYSCUBE_DEVTOOLS_LOGS__ || [])
+        .filter((entry) => entry.kind === 'cashflow_transaction'
+          || entry.path?.includes('/cashflow/')
+          || entry.operation.includes('cashflow'))
+        .map((entry) => ({
+          ts: entry.ts,
+          kind: entry.kind,
+          phase: entry.phase,
+          operation: entry.operation === 'cashflow.weekly_overview'
+            ? entry.operation
+            : entry.path === '/api/v1/cashflow/weekly-overview'
+              ? 'cashflow.weekly_overview.transport'
+              : 'cashflow.request',
+          method: entry.method,
+          requestId: entry.requestId,
+          responseRequestId: entry.responseRequestId,
+          status: entry.status,
+          durationMs: entry.durationMs,
+          attempt: entry.attempt,
+          maxRetries: entry.maxRetries,
+          transport: entry.transport,
+          yearMonth: entry.yearMonth,
+          weekNo: entry.weekNo,
+          mode: entry.mode,
+          summary: entry.summary,
+          error: entry.error,
+        })),
       clear: () => {
         globalState.__MYSCUBE_DEVTOOLS_LOGS__ = [];
       },


### PR DESCRIPTION
## What
- Serve the weekly cashflow dashboard from one JVM overview snapshot, with independent status and summary failure reporting.
- Batch Firestore ledger reads and run dashboard read phases in parallel.
- Remove dashboard polling and add browser/server phase telemetry.
- Keep Cloud Run CPU allocated between requests (`--no-cpu-throttling`) alongside the existing min instance.

## Verification
- `mvn -f server/jvm-weekly-api/pom.xml -Dtest=CashflowWeeklyOverviewServiceTest,CashflowProjectionActualSummaryServiceTest,WeeklyExpenseControllerTest test`
- targeted Vitest: 285 passed
- `npm run typecheck` (no new type errors)