### PR TITLE
fix: bound cashflow dashboard reads

### DIFF
--- a/server/bff/java-weekly-auth.mjs
+++ b/server/bff/java-weekly-auth.mjs
@@ -185,6 +185,7 @@ export async function buildJavaWeeklyTrustedHeaders({
     'x-actor-id': context.actorId,
     'x-actor-role': actorRole,
   };
+  if (context.requestId) headers['x-request-id'] = context.requestId;
   if (context.actorEmail) headers['x-actor-email'] = context.actorEmail;
   if (context.actorName) headers['x-actor-name'] = encodeURIComponent(context.actorName);
   if (dataProjectId) headers['x-data-project-id'] = dataProjectId;

--- a/server/bff/java-weekly-auth.test.mjs
+++ b/server/bff/java-weekly-auth.test.mjs
@@ -7,7 +7,11 @@ vi.mock('google-auth-library', () => ({
 }));
 
 const { GoogleAuth } = await import('google-auth-library');
-const { fetchGoogleIdentityToken, __clearIdentityTokenCachesForTest } = await import('./java-weekly-auth.mjs');
+const {
+  buildJavaWeeklyTrustedHeaders,
+  fetchGoogleIdentityToken,
+  __clearIdentityTokenCachesForTest,
+} = await import('./java-weekly-auth.mjs');
 
 const serviceAccountJson = JSON.stringify({ client_email: 'bff@test.iam', private_key: 'k' });
 
@@ -34,6 +38,21 @@ describe('java weekly identity token cache', () => {
   });
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it('propagates the BFF request ID to the JVM without forwarding user credentials', async () => {
+    await expect(buildJavaWeeklyTrustedHeaders({
+      fetchImpl: fetch,
+      context: {
+        requestId: 'req_dashboard_trace', tenantId: 'tenant-1', actorId: 'actor-1', actorRole: 'admin',
+      },
+      serviceToken: 'internal-service-token',
+    })).resolves.toMatchObject({
+      'x-request-id': 'req_dashboard_trace',
+      'x-tenant-id': 'tenant-1',
+      'x-actor-id': 'actor-1',
+      'x-actor-role': 'admin',
+    });
   });
 
   it('mints once per token lifetime, not once per request', async () => {

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -2566,6 +2566,9 @@ export function mountJvmWeeklyApiRoutes(app, {
               context: req.context,
               method: 'GET',
               path: `/api/v1/cashflow/${projectId}/month-close/dashboard-source?yearMonth=${encodeURIComponent(yearMonth)}`,
+              // 이 읽기는 아래 publication fingerprint 재시도로만 다시 실행한다.
+              // 전송 timeout 재시도까지 겹치면 같은 무거운 JVM 읽기가 동시 두 번 돈다.
+              retry: false,
             }),
             { attempt: traceAttempt },
           ),

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -847,6 +847,7 @@ describe('JVM weekly API BFF proxy', () => {
     );
     expect(fetchImpl.mock.calls[0][1].method).toBe('GET');
     expect(fetchImpl.mock.calls[0][1].body).toBeUndefined();
+    expect(fetchImpl.mock.calls[0][1].headers).toMatchObject({ 'x-request-id': 'req-1' });
     await new Promise((resolve) => setImmediate(resolve));
     expect(performanceEvents).toEqual(expect.arrayContaining([
       expect.objectContaining({ operation: 'cashflow.month_close.read', phase: 'publication_before' }),

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -41,12 +41,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 @RestController
 @RequestMapping("/api/v1")
 public class WeeklyExpenseController {
     private static final ObjectMapper JSON = new ObjectMapper();
     private static final long MAX_SAFE_INTEGER = 9_007_199_254_740_991L;
+    private static final System.Logger LOGGER = System.getLogger(WeeklyExpenseController.class.getName());
     private final WeeklyExpenseCommandService commandService;
     private final CashflowReadService readService;
     private final boolean legacyWeekCloseEnabled;
@@ -461,15 +464,20 @@ public class WeeklyExpenseController {
         @RequestHeader("x-tenant-id") String tenantId,
         @RequestHeader("x-actor-id") String actorId,
         @RequestHeader("x-actor-role") String actorRole,
-        @RequestHeader(value = "x-actor-email", required = false) String actorEmail
+        @RequestHeader(value = "x-actor-email", required = false) String actorEmail,
+        HttpServletRequest httpRequest
     ) {
         TrustedActorContext actor = actorContext(tenantId, actorId, actorRole, actorEmail);
+        String requestId = httpRequest == null ? "" : httpRequest.getHeader("x-request-id");
+        requestId = requestId == null ? "" : requestId.trim();
         for (int attempt = 0; attempt < 2; attempt += 1) {
             CashflowMonthDashboardSourceResponse response = readCashflowMonthDashboardSourceAttempt(
                 actor,
                 tenantId,
                 projectId,
-                yearMonth
+                yearMonth,
+                requestId,
+                attempt + 1
             );
             if (response != null) {
                 return response;
@@ -480,13 +488,32 @@ public class WeeklyExpenseController {
         );
     }
 
+    public CashflowMonthDashboardSourceResponse readCashflowMonthDashboardSource(
+        String projectId,
+        String yearMonth,
+        String tenantId,
+        String actorId,
+        String actorRole,
+        String actorEmail
+    ) {
+        return readCashflowMonthDashboardSource(
+            projectId, yearMonth, tenantId, actorId, actorRole, actorEmail, null
+        );
+    }
+
     private CashflowMonthDashboardSourceResponse readCashflowMonthDashboardSourceAttempt(
         TrustedActorContext actor,
         String tenantId,
         String projectId,
-        String yearMonth
+        String yearMonth,
+        String requestId,
+        int attempt
     ) {
-        CashflowMonthCloseResponse monthClose = commandService.readCashflowMonthClose(actor, projectId, yearMonth);
+        long dashboardStartedAt = System.nanoTime();
+        CashflowMonthCloseResponse monthClose = dashboardRead(
+            requestId, projectId, attempt, "month_close",
+            () -> commandService.readCashflowMonthClose(actor, projectId, yearMonth)
+        );
         boolean open = "OPEN".equals(monthClose.status());
         String amendmentSnapshotHash = String.valueOf(
             monthClose.lastAmendmentEvidence().getOrDefault("closeSnapshotHash", "")
@@ -501,30 +528,35 @@ public class WeeklyExpenseController {
             : open
                 ? new CashflowMonthDashboardSourceResponse.SnapshotCompatibility("LIVE_CURRENT", List.of())
                 : frozenSnapshotCompatibility(monthClose);
-        Integer weeklyYear = open ? readService.declaredWeeklyYear(tenantId, projectId) : null;
+        CompletableFuture<Integer> weeklyYearFuture = open
+            ? dashboardReadAsync(requestId, projectId, attempt, "declared_weekly_year", () -> readService.declaredWeeklyYear(tenantId, projectId))
+            : CompletableFuture.completedFuture(null);
+        CompletableFuture<CashflowOpeningBalancesResponse> openingBalancesFuture = currentLedgerView
+            ? dashboardReadAsync(requestId, projectId, attempt, "opening_balance", () -> toOpeningBalancesResponse(readService.openingBalance(
+                tenantId, projectId, Integer.parseInt(yearMonth.substring(0, 4))
+            )))
+            : CompletableFuture.completedFuture(snapshotCompatibility.missingEvidence().contains("OPENING_BALANCES")
+                ? null
+                : frozenOpeningBalances(monthClose, yearMonth));
+        CompletableFuture<CashflowCumulativeCloseHead> cumulativeFuture = dashboardReadAsync(
+            requestId, projectId, attempt, "cumulative_close_head",
+            () -> readService.cumulativeCloseHead(tenantId, projectId)
+        );
+        CompletableFuture<CashflowLedgerSource> sourceFuture = amendedClosed
+            ? dashboardReadAsync(requestId, projectId, attempt, "global_ledger", () -> readService.globalLedgerSource(tenantId, projectId))
+            : weeklyYearFuture.thenCompose(weeklyYear -> weeklyYear == null
+                ? CompletableFuture.completedFuture(new CashflowLedgerSource(List.of(), List.of()))
+                : dashboardReadAsync(requestId, projectId, attempt, "weekly_ledger", () -> readCashflowSource(tenantId, projectId, weeklyYear)));
+        Integer weeklyYear = weeklyYearFuture.join();
         List<CashflowMonthDashboardSourceResponse.Blocker> blockers = open && weeklyYear == null
             ? List.of(new CashflowMonthDashboardSourceResponse.Blocker(
                 "SHEET_SOURCE_REQUIRED",
                 "먼저 시트값을 불러와 주세요."
             ))
             : List.of();
-        CashflowLedgerSource source = amendedClosed
-            ? readService.globalLedgerSource(tenantId, projectId)
-            : open && weeklyYear != null
-                ? readCashflowSource(tenantId, projectId, weeklyYear)
-                : open
-                    ? new CashflowLedgerSource(List.of(), List.of())
-                    : null;
+        CashflowLedgerSource source = currentLedgerView ? sourceFuture.join() : null;
         CashflowSnapshotResponse cashflow = currentLedgerView ? buildCashflowSnapshot(projectId, source) : null;
-        CashflowOpeningBalancesResponse openingBalances = currentLedgerView
-            ? toOpeningBalancesResponse(readService.openingBalance(
-                tenantId,
-                projectId,
-                Integer.parseInt(yearMonth.substring(0, 4))
-            ))
-            : snapshotCompatibility.missingEvidence().contains("OPENING_BALANCES")
-                ? null
-                : frozenOpeningBalances(monthClose, yearMonth);
+        CashflowOpeningBalancesResponse openingBalances = openingBalancesFuture.join();
         if (openingBalances != null) {
             CloseCashflowMonthRequest.requireOpeningBalances(openingBalances, yearMonth);
         }
@@ -545,7 +577,7 @@ public class WeeklyExpenseController {
             }
             monthClose = verified;
         }
-        CashflowCumulativeCloseHead cumulative = readService.cumulativeCloseHead(tenantId, projectId);
+        CashflowCumulativeCloseHead cumulative = cumulativeFuture.join();
         if (cumulative == null) {
             cumulative = new CashflowCumulativeCloseHead("OPEN", "2023-01", "", "", 0);
         }
@@ -563,7 +595,7 @@ public class WeeklyExpenseController {
             }
             projectionActualSummary = summaryResponse.items().getFirst();
         }
-        return new CashflowMonthDashboardSourceResponse(
+        CashflowMonthDashboardSourceResponse response = new CashflowMonthDashboardSourceResponse(
             monthClose,
             cashflow,
             openingBalances,
@@ -574,6 +606,41 @@ public class WeeklyExpenseController {
             ),
             projectionActualSummary,
             blockers
+        );
+        dashboardLog(requestId, projectId, attempt, "complete", (System.nanoTime() - dashboardStartedAt) / 1_000_000L);
+        return response;
+    }
+
+    private <T> CompletableFuture<T> dashboardReadAsync(
+        String requestId,
+        String projectId,
+        int attempt,
+        String phase,
+        Supplier<T> operation
+    ) {
+        return CompletableFuture.supplyAsync(() -> dashboardRead(requestId, projectId, attempt, phase, operation));
+    }
+
+    private <T> T dashboardRead(
+        String requestId,
+        String projectId,
+        int attempt,
+        String phase,
+        Supplier<T> operation
+    ) {
+        long startedAt = System.nanoTime();
+        try {
+            return operation.get();
+        } finally {
+            dashboardLog(requestId, projectId, attempt, phase, (System.nanoTime() - startedAt) / 1_000_000L);
+        }
+    }
+
+    private void dashboardLog(String requestId, String projectId, int attempt, String phase, long durationMs) {
+        LOGGER.log(
+            System.Logger.Level.INFO,
+            "cashflow_dashboard_source requestId={0} projectId={1} attempt={2} phase={3} durationMs={4}",
+            requestId, projectId, attempt, phase, durationMs
         );
     }
 

--- a/src/app/components/cashflow/CashflowWeeklyPage.tsx
+++ b/src/app/components/cashflow/CashflowWeeklyPage.tsx
@@ -171,6 +171,12 @@ export function CashflowWeeklyPage() {
   const departmentProjects = useMemo(() => filterCashflowProjectsByDepartment(projects, deptFilter), [deptFilter, projects]);
   const overviewProjectIds = useMemo(() => departmentProjects.map((project) => project.id), [departmentProjects]);
   const overviewProjectIdsKey = useMemo(() => JSON.stringify(overviewProjectIds), [overviewProjectIds]);
+  const overviewActor = useMemo(() => user ? {
+    uid: user.uid,
+    email: user.email,
+    role: user.role,
+    idToken: user.idToken,
+  } : null, [user?.uid, user?.email, user?.role, user?.idToken]);
   const statuses = useMemo<Record<string, CashflowSettlementStatusesResult>>(() => Object.fromEntries(
     (overview?.items || []).flatMap((item) => item.settlementStatuses ? [[item.projectId, item.settlementStatuses]] : []),
   ), [overview]);
@@ -202,7 +208,7 @@ export function CashflowWeeklyPage() {
 
   useEffect(() => {
     const projectIds = JSON.parse(overviewProjectIdsKey) as string[];
-    if (!user?.idToken || projectIds.length === 0) {
+    if (!overviewActor?.idToken || projectIds.length === 0) {
       setOverview(null);
       setOverviewLoading(false);
       setOverviewError('');
@@ -223,7 +229,7 @@ export function CashflowWeeklyPage() {
     });
     void fetchCashflowWeeklyOverviewViaBff({
       tenantId: orgId,
-      actor: user,
+      actor: overviewActor,
       projectIds,
       yearMonth,
     }).then((result) => {
@@ -255,7 +261,7 @@ export function CashflowWeeklyPage() {
       if (active) setOverviewLoading(false);
     });
     return () => { active = false; };
-  }, [orgId, overviewProjectIdsKey, refreshSequence, user, yearMonth]);
+  }, [orgId, overviewActor, overviewProjectIdsKey, refreshSequence, yearMonth]);
 
   async function transition(projectId: string, period: CashflowSettlementPeriod, action: 'SUBMIT' | 'APPROVE') {
     if (!user?.idToken) return;


### PR DESCRIPTION
Incident: project month-close dashboard request req_1786327018295_ad04a7ad49f445df timed out twice at the BFF-to-JVM boundary (24 seconds total).

Fix:
- Run independent dashboard source reads in parallel in the JVM.
- Prevent the Java client transport retry from duplicating this heavy read; preserve the existing publication-consistency retry.
- Propagate x-request-id to JVM and log dashboard phases without credentials.
- Stabilize the admin weekly-overview actor dependency to prevent auth-profile refresh duplicate reads.

Verification:
- BFF, frontend, and JVM targeted tests: 216 passed.
- JVM controller test, full JVM test suite, frontend production build, and typecheck passed.