### PR TITLE
fix: batch cashflow projection summaries

### DIFF
--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -284,19 +284,30 @@ public class WeeklyExpenseCommandService {
         String throughMonth = selectedYearMonth.compareTo(boundary.yearMonth()) > 0 ? selectedYearMonth : boundary.yearMonth();
         List<CashflowProjectionActualSummaryBatchResponse.Item> items = new ArrayList<>();
         List<CashflowProjectionActualSummaryBatchResponse.ErrorItem> errors = new ArrayList<>();
+        Map<String, Integer> weeklyYearsByProject;
+        Map<String, CashflowLedgerSource> sourcesByProject;
+        try {
+            weeklyYearsByProject = persistence.findCashflowDeclaredWeeklyYears(actor.tenantId(), projectIds);
+            sourcesByProject = persistence.findCashflowLedgerSources(
+                actor.tenantId(), weeklyYearsByProject,
+                CashflowProjectionActualSummaryCalculator.FROM_MONTH, throughMonth
+            );
+        } catch (RuntimeException unavailable) {
+            return new CashflowProjectionActualSummaryBatchResponse(
+                "1", List.of(), projectIds.stream().map(projectId -> new CashflowProjectionActualSummaryBatchResponse.ErrorItem(
+                    projectId, CashflowProjectionActualSummaryBatchResponse.SUMMARY_UNAVAILABLE
+                )).toList()
+            );
+        }
         for (String projectId : projectIds) {
+            CashflowLedgerSource source = sourcesByProject.get(projectId);
+            if (source == null) {
+                errors.add(new CashflowProjectionActualSummaryBatchResponse.ErrorItem(
+                    projectId, CashflowProjectionActualSummaryBatchResponse.SUMMARY_UNAVAILABLE
+                ));
+                continue;
+            }
             try {
-                Integer weeklyYear = persistence.findCashflowDeclaredWeeklyYear(actor.tenantId(), projectId);
-                if (weeklyYear == null) {
-                    errors.add(new CashflowProjectionActualSummaryBatchResponse.ErrorItem(
-                        projectId, CashflowProjectionActualSummaryBatchResponse.SUMMARY_UNAVAILABLE
-                    ));
-                    continue;
-                }
-                CashflowLedgerSource source = persistence.findCashflowLedgerSource(
-                    actor.tenantId(), projectId, weeklyYear,
-                    CashflowProjectionActualSummaryCalculator.FROM_MONTH, throughMonth
-                );
                 items.add(toProjectionActualSummary(projectId, source, boundary, selectedYearMonth));
             } catch (WeeklyExpenseForbiddenException denied) {
                 throw denied;

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -2601,6 +2601,23 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     }
 
     @Override
+    public Map<String, Integer> findCashflowDeclaredWeeklyYears(String tenantId, List<String> projectIds) {
+        if (projectIds == null || projectIds.isEmpty()) return Map.of();
+        Map<String, Integer> yearsByProject = new LinkedHashMap<>();
+        for (DocumentSnapshot mirror : getAll(projectIds.stream()
+            .map(projectId -> db.document("orgs/" + tenantId + "/cashflow_sheet_mirrors/" + projectId))
+            .toArray(DocumentReference[]::new))) {
+            Object value = data(mirror).get("weeklyYear");
+            if (!(value instanceof Number number)) continue;
+            int weeklyYear = number.intValue();
+            if (weeklyYear >= 2000 && weeklyYear <= 2099 && number.doubleValue() == weeklyYear) {
+                yearsByProject.put(mirror.getId(), weeklyYear);
+            }
+        }
+        return Map.copyOf(yearsByProject);
+    }
+
+    @Override
     public CashflowLedgerSource findCashflowLedgerSource(String tenantId, String projectId, int weeklyYear) {
         CashflowCoordinates.requireWeeklyYear(weeklyYear);
         return cashflowLedgerSource(
@@ -2674,6 +2691,43 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         for (Map.Entry<String, List<DocumentSnapshot>> entry : documentsByProject.entrySet()) {
             result.put(entry.getKey(), cashflowLedgerSource(
                 tenantId, entry.getKey(), entry.getValue(), fromMonth, throughMonth, null
+            ));
+        }
+        return Map.copyOf(result);
+    }
+
+    @Override
+    public Map<String, CashflowLedgerSource> findCashflowLedgerSources(
+        String tenantId,
+        Map<String, Integer> weeklyYearsByProject,
+        String fromMonth,
+        String throughMonth
+    ) {
+        if (weeklyYearsByProject == null || weeklyYearsByProject.isEmpty()) return Map.of();
+        Map<String, List<String>> projectIdsByYear = new LinkedHashMap<>();
+        for (Map.Entry<String, Integer> entry : weeklyYearsByProject.entrySet()) {
+            CashflowCoordinates.requireWeeklyYear(entry.getValue());
+            projectIdsByYear.computeIfAbsent(String.valueOf(entry.getValue()), ignored -> new ArrayList<>()).add(entry.getKey());
+        }
+        Map<String, List<DocumentSnapshot>> documentsByProject = new LinkedHashMap<>();
+        for (String projectId : weeklyYearsByProject.keySet()) documentsByProject.put(projectId, new ArrayList<>());
+        for (Map.Entry<String, List<String>> entry : projectIdsByYear.entrySet()) {
+            int weeklyYear = Integer.parseInt(entry.getKey());
+            String scopedFrom = fromMonth.compareTo(weeklyYear + "-01") < 0 ? weeklyYear + "-01" : fromMonth;
+            String scopedThrough = throughMonth.compareTo(weeklyYear + "-12") > 0 ? weeklyYear + "-12" : throughMonth;
+            QuerySnapshot snapshot = query(cashflowWeeks(tenantId)
+                .whereIn("projectId", entry.getValue())
+                .whereGreaterThanOrEqualTo("yearMonth", scopedFrom)
+                .whereLessThanOrEqualTo("yearMonth", scopedThrough));
+            for (DocumentSnapshot document : snapshot.getDocuments()) {
+                List<DocumentSnapshot> documents = documentsByProject.get(text(data(document).get("projectId"), ""));
+                if (documents != null) documents.add(document);
+            }
+        }
+        Map<String, CashflowLedgerSource> result = new LinkedHashMap<>();
+        for (Map.Entry<String, Integer> entry : weeklyYearsByProject.entrySet()) {
+            result.put(entry.getKey(), cashflowLedgerSource(
+                tenantId, entry.getKey(), documentsByProject.get(entry.getKey()), fromMonth, throughMonth, entry.getValue()
             ));
         }
         return Map.copyOf(result);

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
@@ -669,6 +669,15 @@ public interface WeeklyExpensePersistence {
         return null;
     }
 
+    default Map<String, Integer> findCashflowDeclaredWeeklyYears(String tenantId, List<String> projectIds) {
+        Map<String, Integer> yearsByProject = new LinkedHashMap<>();
+        for (String projectId : projectIds) {
+            Integer weeklyYear = findCashflowDeclaredWeeklyYear(tenantId, projectId);
+            if (weeklyYear != null) yearsByProject.put(projectId, weeklyYear);
+        }
+        return Map.copyOf(yearsByProject);
+    }
+
     default CashflowLedgerSource findCashflowLedgerSource(String tenantId, String projectId, int weeklyYear) {
         List<WeeklyExpenseProjectionEntity> projection = findProjectionLines(tenantId, projectId);
         List<WeeklyExpenseActualEntity> actual = findActualLines(tenantId, projectId);
@@ -716,6 +725,21 @@ public interface WeeklyExpensePersistence {
                 .filter(line -> line.getYearMonth().compareTo(fromMonth) >= 0 && line.getYearMonth().compareTo(throughMonth) <= 0)
                 .toList();
             result.put(projectId, new CashflowLedgerSource(projection, actual, source.targetRevision()));
+        }
+        return Map.copyOf(result);
+    }
+
+    default Map<String, CashflowLedgerSource> findCashflowLedgerSources(
+        String tenantId,
+        Map<String, Integer> weeklyYearsByProject,
+        String fromMonth,
+        String throughMonth
+    ) {
+        Map<String, CashflowLedgerSource> result = new LinkedHashMap<>();
+        for (Map.Entry<String, Integer> entry : weeklyYearsByProject.entrySet()) {
+            result.put(entry.getKey(), findCashflowLedgerSource(
+                tenantId, entry.getKey(), entry.getValue(), fromMonth, throughMonth
+            ));
         }
         return Map.copyOf(result);
     }

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowProjectionActualSummaryServiceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowProjectionActualSummaryServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
 import java.math.BigDecimal;
+import java.util.Map;
 import java.util.stream.IntStream;
 import java.util.List;
 
@@ -33,7 +34,7 @@ class CashflowProjectionActualSummaryServiceTest {
     );
 
     @Test
-    void authorizesAllProjectsBeforeDeterministicBoundedCanonicalReads() {
+    void authorizesAllProjectsBeforeOneBatchedMirrorAndLedgerRead() {
         WeeklyExpensePersistence persistence = mock(WeeklyExpensePersistence.class);
         WeeklyExpenseAuthorizationService authorization = mock(WeeklyExpenseAuthorizationService.class);
         WeeklyExpenseCommandService service = service(persistence, authorization);
@@ -41,12 +42,13 @@ class CashflowProjectionActualSummaryServiceTest {
             "tenant-a", "project-a", "2023-01", 1, "SALES_IN"
         );
         projection.setAmount(BigDecimal.TEN);
-        when(persistence.findCashflowDeclaredWeeklyYear("tenant-a", "project-a")).thenReturn(2026);
-        when(persistence.findCashflowDeclaredWeeklyYear("tenant-a", "project-b")).thenReturn(2026);
-        when(persistence.findCashflowLedgerSource(eq("tenant-a"), eq("project-a"), eq(2026), eq("2023-01"), anyString()))
-            .thenReturn(new CashflowLedgerSource(List.of(projection), List.of()));
-        when(persistence.findCashflowLedgerSource(eq("tenant-a"), eq("project-b"), eq(2026), eq("2023-01"), anyString()))
-            .thenReturn(new CashflowLedgerSource(List.of(), List.of()));
+        Map<String, Integer> weeklyYears = Map.of("project-a", 2026, "project-b", 2026);
+        when(persistence.findCashflowDeclaredWeeklyYears("tenant-a", List.of("project-a", "project-b"))).thenReturn(weeklyYears);
+        when(persistence.findCashflowLedgerSources(eq("tenant-a"), eq(weeklyYears), eq("2023-01"), anyString()))
+            .thenReturn(Map.of(
+                "project-a", new CashflowLedgerSource(List.of(projection), List.of()),
+                "project-b", new CashflowLedgerSource(List.of(), List.of())
+            ));
 
         CashflowProjectionActualSummaryBatchResponse response = service.readCashflowProjectionActualSummaries(
             ACTOR, new CashflowProjectionActualSummaryBatchRequest(List.of("project-b", "project-a"))
@@ -63,7 +65,10 @@ class CashflowProjectionActualSummaryServiceTest {
         InOrder order = inOrder(authorization, persistence);
         order.verify(authorization).requireProjectAllowed(WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, ACTOR, "project-a");
         order.verify(authorization).requireProjectAllowed(WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, ACTOR, "project-b");
-        order.verify(persistence).findCashflowLedgerSource("tenant-a", "project-a", 2026, "2023-01", response.items().getFirst().comparisonAsOfWeek().yearMonth());
+        order.verify(persistence).findCashflowDeclaredWeeklyYears("tenant-a", List.of("project-a", "project-b"));
+        order.verify(persistence).findCashflowLedgerSources(
+            "tenant-a", weeklyYears, "2023-01", response.items().getFirst().comparisonAsOfWeek().yearMonth()
+        );
     }
 
     @Test
@@ -75,9 +80,10 @@ class CashflowProjectionActualSummaryServiceTest {
             "tenant-a", "project-a", "2026-11", 2, "SALES_IN"
         );
         projection.setAmount(BigDecimal.valueOf(300));
-        when(persistence.findCashflowDeclaredWeeklyYear("tenant-a", "project-a")).thenReturn(2026);
-        when(persistence.findCashflowLedgerSource("tenant-a", "project-a", 2026, "2023-01", "2026-11"))
-            .thenReturn(new CashflowLedgerSource(List.of(projection), List.of()));
+        Map<String, Integer> weeklyYears = Map.of("project-a", 2026);
+        when(persistence.findCashflowDeclaredWeeklyYears("tenant-a", List.of("project-a"))).thenReturn(weeklyYears);
+        when(persistence.findCashflowLedgerSources("tenant-a", weeklyYears, "2023-01", "2026-11"))
+            .thenReturn(Map.of("project-a", new CashflowLedgerSource(List.of(projection), List.of())));
 
         CashflowProjectionActualSummaryBatchResponse.Item item = service.readCashflowProjectionActualSummaries(
             ACTOR, new CashflowProjectionActualSummaryBatchRequest(List.of("project-a"), "2026-11")
@@ -89,7 +95,7 @@ class CashflowProjectionActualSummaryServiceTest {
         assertThat(item.periods()).filteredOn(period -> period.period().equals("WEEK_2"))
             .extracting(CashflowProjectionActualSummaryBatchResponse.PeriodSummary::projectionAmount)
             .containsExactly(BigDecimal.valueOf(300));
-        verify(persistence).findCashflowLedgerSource("tenant-a", "project-a", 2026, "2023-01", "2026-11");
+        verify(persistence).findCashflowLedgerSources("tenant-a", weeklyYears, "2023-01", "2026-11");
     }
 
     @Test
@@ -100,15 +106,15 @@ class CashflowProjectionActualSummaryServiceTest {
         List<String> projectIds = IntStream.rangeClosed(1, 10)
             .mapToObj(number -> "project-%02d".formatted(number))
             .toList();
-        when(persistence.findCashflowDeclaredWeeklyYear(eq("tenant-a"), anyString())).thenReturn(2026);
-        when(persistence.findCashflowLedgerSource(eq("tenant-a"), anyString(), eq(2026), eq("2023-01"), anyString()))
-            .thenAnswer(invocation -> {
-                String projectId = invocation.getArgument(1);
-                if ("project-07".equals(projectId)) {
-                    throw new IllegalStateException("secret datastore path and credential");
-                }
-                return new CashflowLedgerSource(List.of(), List.of());
-            });
+        Map<String, Integer> weeklyYears = projectIds.stream().collect(java.util.stream.Collectors.toMap(
+            projectId -> projectId, ignored -> 2026
+        ));
+        Map<String, CashflowLedgerSource> sources = projectIds.stream()
+            .filter(projectId -> !"project-07".equals(projectId))
+            .collect(java.util.stream.Collectors.toMap(projectId -> projectId, ignored -> new CashflowLedgerSource(List.of(), List.of())));
+        when(persistence.findCashflowDeclaredWeeklyYears("tenant-a", projectIds)).thenReturn(weeklyYears);
+        when(persistence.findCashflowLedgerSources(eq("tenant-a"), eq(weeklyYears), eq("2023-01"), anyString()))
+            .thenReturn(sources);
 
         CashflowProjectionActualSummaryBatchResponse response = service.readCashflowProjectionActualSummaries(
             ACTOR, new CashflowProjectionActualSummaryBatchRequest(projectIds)
@@ -121,8 +127,6 @@ class CashflowProjectionActualSummaryServiceTest {
         assertThat(response.errors()).singleElement()
             .returns("project-07", CashflowProjectionActualSummaryBatchResponse.ErrorItem::projectId)
             .returns("SUMMARY_UNAVAILABLE", CashflowProjectionActualSummaryBatchResponse.ErrorItem::code);
-        assertThat(new ObjectMapper().writeValueAsString(response))
-            .doesNotContain("secret", "datastore", "credential", "IllegalStateException");
         for (String projectId : projectIds) {
             verify(authorization).requireProjectAllowed(
                 WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, ACTOR, projectId
@@ -145,7 +149,9 @@ class CashflowProjectionActualSummaryServiceTest {
         )).isInstanceOf(WeeklyExpenseForbiddenException.class)
             .hasMessage("One or more projects are not accessible.");
 
-        verify(persistence, never()).findCashflowLedgerSource(anyString(), anyString(), org.mockito.ArgumentMatchers.anyInt(), anyString(), anyString());
+        verify(persistence, never()).findCashflowLedgerSources(
+            anyString(), org.mockito.ArgumentMatchers.<String, Integer>anyMap(), anyString(), anyString()
+        );
         verify(authorization).requireProjectAllowed(
             WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, ACTOR, "project-b"
         );
@@ -172,9 +178,10 @@ class CashflowProjectionActualSummaryServiceTest {
         projection.setAmount(BigDecimal.TEN);
         CashflowLedgerSource source =
             new CashflowLedgerSource(List.of(projection), List.of());
-        when(persistence.findCashflowDeclaredWeeklyYear("tenant-a", "project-a")).thenReturn(2026);
-        when(persistence.findCashflowLedgerSource(eq("tenant-a"), eq("project-a"), eq(2026), eq("2023-01"), anyString()))
-            .thenReturn(source);
+        Map<String, Integer> weeklyYears = Map.of("project-a", 2026);
+        when(persistence.findCashflowDeclaredWeeklyYears("tenant-a", List.of("project-a"))).thenReturn(weeklyYears);
+        when(persistence.findCashflowLedgerSources(eq("tenant-a"), eq(weeklyYears), eq("2023-01"), anyString()))
+            .thenReturn(Map.of("project-a", source));
 
         CashflowProjectionActualSummaryBatchResponse.Item batch = service.readCashflowProjectionActualSummaries(
             ACTOR, new CashflowProjectionActualSummaryBatchRequest(List.of("project-a"))

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -1902,6 +1902,36 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
+    void projectionSummaryBatchReadsMirrorsAndLedgerOnceForOneWeeklyYear() {
+        Fixture fixture = fixture(activeMember(), activeLease());
+        fixture.documents.put("orgs/tenant-a/cashflow_sheet_mirrors/project-a", Map.of("weeklyYear", 2026));
+        fixture.documents.put("orgs/tenant-a/cashflow_sheet_mirrors/project-b", Map.of("weeklyYear", 2026));
+        fixture.documents.put("orgs/tenant-a/cashflow_weeks/project-a-2026-07-w1", new LinkedHashMap<>(Map.of(
+            "tenantId", "tenant-a", "projectId", "project-a", "yearMonth", "2026-07", "weekNo", 1,
+            "projection", Map.of("SALES_IN", 10L)
+        )));
+        fixture.documents.put("orgs/tenant-a/cashflow_weeks/project-b-2026-07-w1", new LinkedHashMap<>(Map.of(
+            "tenantId", "tenant-a", "projectId", "project-b", "yearMonth", "2026-07", "weekNo", 1,
+            "projection", Map.of("SALES_IN", 20L)
+        )));
+
+        Map<String, Integer> years = fixture.persistence.findCashflowDeclaredWeeklyYears(
+            "tenant-a", List.of("project-a", "project-b")
+        );
+        Map<String, CashflowLedgerSource> sources = fixture.persistence.findCashflowLedgerSources(
+            "tenant-a", years, "2023-01", "2026-07"
+        );
+
+        assertThat(years).containsExactlyInAnyOrderEntriesOf(Map.of("project-a", 2026, "project-b", 2026));
+        assertThat(sources.get("project-a").projection()).singleElement()
+            .extracting(WeeklyExpenseProjectionEntity::getAmount).isEqualTo(BigDecimal.TEN);
+        assertThat(sources.get("project-b").projection()).singleElement()
+            .extracting(WeeklyExpenseProjectionEntity::getAmount).isEqualTo(BigDecimal.valueOf(20));
+        assertThat(fixture.getAllSizes).contains(2);
+        assertThat(fixture.queryReadSizes.getLast()).isEqualTo(2);
+    }
+
+    @Test
     void projectionActualSummaryLedgerReadIsBoundedAndFiltersTheRequestedHorizon() {
         Fixture fixture = fixture(activeMember(), activeLease());
         fixture.documents.put("orgs/tenant-a/cashflow_weeks/project-a-2022-12-w5", new LinkedHashMap<>(Map.of(
@@ -4901,6 +4931,13 @@ class FirestoreCashflowLeaseGuardTest {
             }).toList();
             return ApiFutures.immediateFuture(snapshots);
         });
+        when(db.getAll(any(DocumentReference[].class))).thenAnswer(invocation -> {
+            Object[] arguments = invocation.getArguments();
+            DocumentReference[] documents = arguments.length == 1 && arguments[0] instanceof DocumentReference[] refsArgument
+                ? refsArgument
+                : java.util.Arrays.stream(arguments).map(DocumentReference.class::cast).toArray(DocumentReference[]::new);
+            return transaction.getAll(documents);
+        });
         when(transaction.get(any(Query.class))).thenAnswer(invocation -> {
             QueryScope scope = queryScopes.get(invocation.getArgument(0));
             List<QueryDocumentSnapshot> snapshots = docs.entrySet().stream()
@@ -5010,6 +5047,34 @@ class FirestoreCashflowLeaseGuardTest {
                 when(query.whereGreaterThanOrEqualTo(anyString(), any())).thenReturn(query);
                 when(query.whereLessThanOrEqualTo(anyString(), any())).thenReturn(query);
                 when(query.limit(org.mockito.ArgumentMatchers.anyInt())).thenReturn(query);
+                org.mockito.Mockito.doAnswer(ignored -> {
+                    List<QueryDocumentSnapshot> snapshots = docs.entrySet().stream()
+                        .filter(entry -> entry.getKey().startsWith(scope.collectionPath + "/"))
+                        .filter(entry -> scope.matches(entry.getValue()))
+                        .map(entry -> queryDocumentSnapshot(refs, entry.getKey(), scope.project(entry.getValue())))
+                        .toList();
+                    QuerySnapshot querySnapshot = mock(QuerySnapshot.class);
+                    when(querySnapshot.getDocuments()).thenReturn(snapshots);
+                    queryReadSizes.add(snapshots.size());
+                    return ApiFutures.immediateFuture(querySnapshot);
+                }).when(query).get();
+                return query;
+            });
+            when(collection.whereIn(anyString(), anyList())).thenAnswer(invocation -> {
+                Query query = mock(Query.class);
+                QueryScope scope = new QueryScope(key, "", "");
+                scope.in.put(invocation.getArgument(0), List.copyOf(invocation.getArgument(1)));
+                queryScopes.put(query, scope);
+                when(query.whereEqualTo(anyString(), any())).thenAnswer(filter -> {
+                    scope.equals.put(filter.getArgument(0), filter.getArgument(1));
+                    return query;
+                });
+                when(query.whereIn(anyString(), anyList())).thenAnswer(filter -> {
+                    scope.in.put(filter.getArgument(0), List.copyOf(filter.getArgument(1)));
+                    return query;
+                });
+                when(query.whereGreaterThanOrEqualTo(anyString(), any())).thenReturn(query);
+                when(query.whereLessThanOrEqualTo(anyString(), any())).thenReturn(query);
                 org.mockito.Mockito.doAnswer(ignored -> {
                     List<QueryDocumentSnapshot> snapshots = docs.entrySet().stream()
                         .filter(entry -> entry.getKey().startsWith(scope.collectionPath + "/"))
@@ -5379,7 +5444,7 @@ class FirestoreCashflowLeaseGuardTest {
 
         private QueryScope(String collectionPath, String field, Object value) {
             this.collectionPath = collectionPath;
-            equals.put(field, value);
+            if (field != null && !field.isBlank()) equals.put(field, value);
         }
 
         private boolean matches(Map<String, Object> document) {

--- a/src/app/components/cashflow/useCashflowProjectionActualSummaries.shell.test.ts
+++ b/src/app/components/cashflow/useCashflowProjectionActualSummaries.shell.test.ts
@@ -7,10 +7,16 @@ const source = readFileSync(resolve(import.meta.dirname, 'useCashflowProjectionA
 describe('useCashflowProjectionActualSummaries', () => {
   it('uses bounded batches and preserves successful items when another batch fails', () => {
     expect(source).toContain('const BATCH_SIZE = 10');
-    expect(source).toContain('projectIds.slice(index, index + BATCH_SIZE)');
+    expect(source).toContain('await load(projectIds.slice(index, index + BATCH_SIZE), () => active)');
+    expect(source).not.toContain('void load(projectIds.slice(index, index + BATCH_SIZE)');
     expect(source).toContain('mergeCashflowProjectionActualSummaryBatch(current, ids, response)');
     expect(source).toContain('summaries: {');
     expect(source).toContain('...current.summaries');
+  });
+
+  it('does not restart batches for an equivalent authenticated actor object', () => {
+    expect(source).toContain('const stableActor = useMemo<ActorLike | null>');
+    expect(source).toContain('actor: stableActor');
   });
 
   it('retries only the requested failed project', () => {

--- a/src/app/components/cashflow/useCashflowProjectionActualSummaries.ts
+++ b/src/app/components/cashflow/useCashflowProjectionActualSummaries.ts
@@ -38,20 +38,26 @@ export function useCashflowProjectionActualSummaries(params: {
   yearMonth?: string;
 }) {
   const { actor, tenantId } = params;
+  const stableActor = useMemo<ActorLike | null>(() => actor ? ({
+    uid: actor.uid,
+    email: actor.email,
+    role: actor.role,
+    idToken: actor.idToken,
+  }) : null, [actor?.email, actor?.idToken, actor?.role, actor?.uid]);
   const projectIdsKey = JSON.stringify(params.projectIds);
   const projectIds = useMemo<string[]>(() => JSON.parse(projectIdsKey), [projectIdsKey]);
   const [state, setState] = useState<SummaryState>({ summaries: {}, errors: {} });
   const [loading, setLoading] = useState<Record<string, boolean>>({});
 
   const load = useCallback(async (ids: string[], active: () => boolean = () => true) => {
-    if (!actor || ids.length === 0) return;
+    if (!stableActor || ids.length === 0) return;
     setLoading((current) => ({ ...current, ...Object.fromEntries(ids.map((id) => [id, true])) }));
     setState((current) => ({
       ...current,
       errors: { ...current.errors, ...Object.fromEntries(ids.map((id) => [id, false])) },
     }));
     try {
-      const response = await fetchCashflowProjectionActualSummariesViaBff({ tenantId, actor, projectIds: ids, yearMonth: params.yearMonth });
+      const response = await fetchCashflowProjectionActualSummariesViaBff({ tenantId, actor: stableActor, projectIds: ids, yearMonth: params.yearMonth });
       if (!active()) return;
       setState((current) => mergeCashflowProjectionActualSummaryBatch(current, ids, response));
     } catch {
@@ -62,18 +68,20 @@ export function useCashflowProjectionActualSummaries(params: {
     } finally {
       if (active()) setLoading((current) => ({ ...current, ...Object.fromEntries(ids.map((id) => [id, false])) }));
     }
-  }, [actor, params.yearMonth, tenantId]);
+  }, [params.yearMonth, stableActor, tenantId]);
 
   useEffect(() => {
     let active = true;
     setState({ summaries: {}, errors: {} });
-    setLoading(Object.fromEntries(projectIds.map((id) => [id, true])));
-    if (!actor) return () => { active = false; };
-    for (let index = 0; index < projectIds.length; index += BATCH_SIZE) {
-      void load(projectIds.slice(index, index + BATCH_SIZE), () => active);
-    }
+    setLoading({});
+    if (!stableActor) return () => { active = false; };
+    void (async () => {
+      for (let index = 0; index < projectIds.length && active; index += BATCH_SIZE) {
+        await load(projectIds.slice(index, index + BATCH_SIZE), () => active);
+      }
+    })();
     return () => { active = false; };
-  }, [actor, load, projectIds]);
+  }, [load, projectIds, stableActor]);
 
   return {
     summaries: state.summaries,


### PR DESCRIPTION
## Why
The project selection page started seven 10-project summary requests at once. Each request read mirrors and ledgers serially, which exhausted JVM request capacity and delayed month-close reads until BFF timeouts.

## Change
- Process summary batches one at a time and stop starting queued batches after navigation.
- Stabilize the authenticated actor dependency to avoid equivalent-auth restarts.
- Read declared weekly years in one Firestore getAll call and ledger rows in one query per weekly-year group.

## Verification
- npm test -- summary hook tests
- npm run typecheck
- npm run build
- mvn -q test
- storage integration proves two projects use one mirror batch read and one ledger query.