### PR TITLE
fix: bound cashflow approval and authorization reads

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -3075,6 +3075,16 @@ export function mountJvmWeeklyApiRoutes(app, {
       );
     } catch (mutationError) {
       const evidence = await reconcileCashflowMonthClose(req, prepared, mutationError);
+      createCashflowPerformanceTrace({
+        requestId: req.context.requestId,
+        operation: 'cashflow.month_close.approval',
+        ...(performanceLogger ? { logger: performanceLogger } : {}),
+        ...(performanceNow ? { now: performanceNow } : {}),
+      }).emit('reconciliation', {
+        outcome: evidence.proven ? 'ok' : 'error',
+        errorCode: evidence.mutationErrorCode,
+        upstreamStatus: evidence.mutationUpstreamStatus,
+      });
       if (evidence.proven) return evidence.monthClose;
       const error = createHttpError(
         503,
@@ -3097,6 +3107,9 @@ export function mountJvmWeeklyApiRoutes(app, {
         revision: prepared.closeBody.expectedRevision + 1,
       },
       mutationErrorCode: readOptionalText(mutationError?.code) || null,
+      mutationUpstreamStatus: Number.isInteger(mutationError?.upstreamStatus)
+        ? mutationError.upstreamStatus
+        : null,
     };
     try {
       const source = await proxyJavaWeeklyRequest({

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseAuthorizationService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseAuthorizationService.java
@@ -125,13 +125,24 @@ public class WeeklyExpenseAuthorizationService {
     }
 
     public void requireProjectsAllowed(String commandName, TrustedActorContext actor, List<String> projectIds) {
-        requireAllowed(commandName, actor);
+        requireProjectsAllowedForCommands(List.of(commandName), actor, projectIds);
+    }
+
+    public void requireProjectsAllowedForCommands(
+        List<String> commandNames,
+        TrustedActorContext actor,
+        List<String> projectIds
+    ) {
+        if (commandNames == null || commandNames.isEmpty()) {
+            throw new IllegalArgumentException("At least one command is required for project authorization.");
+        }
+        for (String commandName : commandNames) requireAllowed(commandName, actor);
         if (projectIds == null || projectIds.isEmpty()
             || !projectExistenceRepository.existingProjectIds(actor.tenantId(), projectIds).containsAll(projectIds)) {
             throw new WeeklyExpenseForbiddenException("Project does not exist in this workspace.");
         }
         String role = actor.role() == null ? "" : actor.role().trim().toLowerCase(Locale.ROOT);
-        if ((isWorkspaceMode() && "workspace_user".equals(role) && WORKSPACE_COMMANDS.contains(commandName))
+        if ((isWorkspaceMode() && "workspace_user".equals(role) && commandNames.stream().allMatch(WORKSPACE_COMMANDS::contains))
             || TENANT_WIDE_PROJECT_ROLES.contains(role)) {
             return;
         }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -267,15 +267,9 @@ public class WeeklyExpenseCommandService {
         CashflowProjectionActualSummaryBatchRequest request
     ) {
         List<String> projectIds = request.requireUniqueProjectIds();
-        boolean forbidden = false;
-        for (String projectId : projectIds) {
-            try {
-                authorizationService.requireProjectAllowed(CASHFLOW_READ_COMMAND, actor, projectId);
-            } catch (WeeklyExpenseForbiddenException denied) {
-                forbidden = true;
-            }
-        }
-        if (forbidden) {
+        try {
+            authorizationService.requireProjectsAllowed(CASHFLOW_READ_COMMAND, actor, projectIds);
+        } catch (WeeklyExpenseForbiddenException denied) {
             throw new WeeklyExpenseForbiddenException("One or more projects are not accessible.");
         }
         CashflowProjectionActualSummaryCalculator.FinanceWeek boundary =
@@ -325,8 +319,9 @@ public class WeeklyExpenseCommandService {
         CashflowWeeklyOverviewRequest request
     ) {
         List<String> projectIds = request.requireUniqueProjectIds();
-        authorizationService.requireProjectsAllowed(CASHFLOW_READ_COMMAND, actor, projectIds);
-        authorizationService.requireProjectsAllowed(CASHFLOW_MONTH_CLOSE_READ_COMMAND, actor, projectIds);
+        authorizationService.requireProjectsAllowedForCommands(
+            List.of(CASHFLOW_READ_COMMAND, CASHFLOW_MONTH_CLOSE_READ_COMMAND), actor, projectIds
+        );
         CashflowProjectionActualSummaryCalculator.FinanceWeek boundary =
             CashflowProjectionActualSummaryCalculator.currentFinanceWeek(Clock.systemUTC());
         String throughMonth = request.yearMonth().compareTo(boundary.yearMonth()) > 0

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowProjectionActualSummaryServiceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowProjectionActualSummaryServiceTest.java
@@ -63,8 +63,9 @@ class CashflowProjectionActualSummaryServiceTest {
         assertThat(response.items().getLast().settlementMatches()).isTrue();
         assertThat(response.errors()).isEmpty();
         InOrder order = inOrder(authorization, persistence);
-        order.verify(authorization).requireProjectAllowed(WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, ACTOR, "project-a");
-        order.verify(authorization).requireProjectAllowed(WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, ACTOR, "project-b");
+        order.verify(authorization).requireProjectsAllowed(
+            WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, ACTOR, List.of("project-a", "project-b")
+        );
         order.verify(persistence).findCashflowDeclaredWeeklyYears("tenant-a", List.of("project-a", "project-b"));
         order.verify(persistence).findCashflowLedgerSources(
             "tenant-a", weeklyYears, "2023-01", response.items().getFirst().comparisonAsOfWeek().yearMonth()
@@ -127,11 +128,7 @@ class CashflowProjectionActualSummaryServiceTest {
         assertThat(response.errors()).singleElement()
             .returns("project-07", CashflowProjectionActualSummaryBatchResponse.ErrorItem::projectId)
             .returns("SUMMARY_UNAVAILABLE", CashflowProjectionActualSummaryBatchResponse.ErrorItem::code);
-        for (String projectId : projectIds) {
-            verify(authorization).requireProjectAllowed(
-                WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, ACTOR, projectId
-            );
-        }
+        verify(authorization).requireProjectsAllowed(WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, ACTOR, projectIds);
     }
 
     @Test
@@ -140,8 +137,8 @@ class CashflowProjectionActualSummaryServiceTest {
         WeeklyExpenseAuthorizationService authorization = mock(WeeklyExpenseAuthorizationService.class);
         WeeklyExpenseCommandService service = service(persistence, authorization);
         org.mockito.Mockito.doThrow(new WeeklyExpenseForbiddenException("Project does not exist."))
-            .when(authorization).requireProjectAllowed(
-                WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, ACTOR, "project-a"
+            .when(authorization).requireProjectsAllowed(
+                WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, ACTOR, List.of("project-a", "project-b")
             );
 
         assertThatThrownBy(() -> service.readCashflowProjectionActualSummaries(
@@ -152,8 +149,8 @@ class CashflowProjectionActualSummaryServiceTest {
         verify(persistence, never()).findCashflowLedgerSources(
             anyString(), org.mockito.ArgumentMatchers.<String, Integer>anyMap(), anyString(), anyString()
         );
-        verify(authorization).requireProjectAllowed(
-            WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, ACTOR, "project-b"
+        verify(authorization).requireProjectsAllowed(
+            WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, ACTOR, List.of("project-a", "project-b")
         );
     }
 

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowWeeklyOverviewServiceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowWeeklyOverviewServiceTest.java
@@ -52,8 +52,10 @@ class CashflowWeeklyOverviewServiceTest {
         assertThat(response.items().get(1).settlementStatuses().items().getFirst().status()).isEqualTo("PENDING_APPROVAL");
         assertThat(response.items()).allSatisfy(item -> assertThat(item.projectionActualSummary()).isNotNull());
         assertThat(response.errors()).isEmpty();
-        verify(authorization).requireProjectsAllowed(WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, ACTOR, projectIds);
-        verify(authorization).requireProjectsAllowed(WeeklyExpenseCommandService.CASHFLOW_MONTH_CLOSE_READ_COMMAND, ACTOR, projectIds);
+        verify(authorization).requireProjectsAllowedForCommands(
+            List.of(WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, WeeklyExpenseCommandService.CASHFLOW_MONTH_CLOSE_READ_COMMAND),
+            ACTOR, projectIds
+        );
         verify(persistence).findCashflowLedgerSources(anyString(), anyList(), anyString(), anyString());
     }
 }

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseAuthorizationServiceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseAuthorizationServiceTest.java
@@ -41,6 +41,29 @@ class WeeklyExpenseAuthorizationServiceTest {
     }
 
     @Test
+    void multipleCommandsReuseOneExistenceLookup() {
+        int[] batchCalls = {0};
+        WeeklyExpenseAuthorizationService service = new WeeklyExpenseAuthorizationService(
+            (actor, projectId) -> false,
+            new WeeklyProjectExistenceRepository() {
+                @Override public boolean exists(String tenantId, String projectId) { return false; }
+                @Override public Set<String> existingProjectIds(String tenantId, List<String> projectIds) {
+                    batchCalls[0] += 1;
+                    return Set.copyOf(projectIds);
+                }
+            },
+            "strict"
+        );
+        TrustedActorContext admin = new TrustedActorContext("tenant-a", "admin-1", "admin@example.com", "admin");
+
+        assertThatCode(() -> service.requireProjectsAllowedForCommands(
+            List.of(WeeklyExpenseCommandService.CASHFLOW_READ_COMMAND, WeeklyExpenseCommandService.CASHFLOW_MONTH_CLOSE_READ_COMMAND),
+            admin, List.of("project-a", "project-b")
+        )).doesNotThrowAnyException();
+        assertThat(batchCalls[0]).isEqualTo(1);
+    }
+
+    @Test
     void pmCanMutateOnlyAssignedProject() {
         WeeklyExpenseAuthorizationService service = new WeeklyExpenseAuthorizationService(
             (actor, projectId) -> "project-allowed".equals(projectId),

--- a/src/app/components/cashflow/CashflowWeeklyPage.tsx
+++ b/src/app/components/cashflow/CashflowWeeklyPage.tsx
@@ -219,48 +219,50 @@ export function CashflowWeeklyPage() {
     setOverviewLoading(true);
     setOverviewError('');
     setOverview(null);
-    recordDevtoolsLog({
-      kind: 'cashflow_transaction',
-      phase: 'start',
-      operation: 'cashflow.weekly_overview',
-      transport: 'bff',
-      yearMonth,
-      summary: { projectCount: projectIds.length },
-    });
-    void fetchCashflowWeeklyOverviewViaBff({
-      tenantId: orgId,
-      actor: overviewActor,
-      projectIds,
-      yearMonth,
-    }).then((result) => {
-      if (!active) return;
-      setOverview(result);
+    const requestTimer = window.setTimeout(() => {
       recordDevtoolsLog({
         kind: 'cashflow_transaction',
-        phase: 'success',
+        phase: 'start',
         operation: 'cashflow.weekly_overview',
         transport: 'bff',
         yearMonth,
-        durationMs: Date.now() - startedAt,
-        summary: { projectCount: projectIds.length, itemCount: result.items.length, issueCount: result.errors.length },
-      });
-    }).catch((error) => {
-      if (!active) return;
-      setOverviewError('현금흐름 현황을 불러오지 못했습니다. 다시 불러와 주세요.');
-      recordDevtoolsLog({
-        kind: 'cashflow_transaction',
-        phase: 'error',
-        operation: 'cashflow.weekly_overview',
-        transport: 'bff',
-        yearMonth,
-        durationMs: Date.now() - startedAt,
         summary: { projectCount: projectIds.length },
-        error: toDevtoolsError(error),
       });
-    }).finally(() => {
-      if (active) setOverviewLoading(false);
-    });
-    return () => { active = false; };
+      void fetchCashflowWeeklyOverviewViaBff({
+        tenantId: orgId,
+        actor: overviewActor,
+        projectIds,
+        yearMonth,
+      }).then((result) => {
+        if (!active) return;
+        setOverview(result);
+        recordDevtoolsLog({
+          kind: 'cashflow_transaction',
+          phase: 'success',
+          operation: 'cashflow.weekly_overview',
+          transport: 'bff',
+          yearMonth,
+          durationMs: Date.now() - startedAt,
+          summary: { projectCount: projectIds.length, itemCount: result.items.length, issueCount: result.errors.length },
+        });
+      }).catch((error) => {
+        if (!active) return;
+        setOverviewError('현금흐름 현황을 불러오지 못했습니다. 다시 불러와 주세요.');
+        recordDevtoolsLog({
+          kind: 'cashflow_transaction',
+          phase: 'error',
+          operation: 'cashflow.weekly_overview',
+          transport: 'bff',
+          yearMonth,
+          durationMs: Date.now() - startedAt,
+          summary: { projectCount: projectIds.length },
+          error: toDevtoolsError(error),
+        });
+      }).finally(() => {
+        if (active) setOverviewLoading(false);
+      });
+    }, 120);
+    return () => { active = false; window.clearTimeout(requestTimer); };
   }, [orgId, overviewActor, overviewProjectIdsKey, refreshSequence, yearMonth]);
 
   async function transition(projectId: string, period: CashflowSettlementPeriod, action: 'SUBMIT' | 'APPROVE') {

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -400,7 +400,7 @@ describe('platform-bff-client', () => {
     expect(client.post).toHaveBeenNthCalledWith(2, '/api/v1/cashflow/p001/month-close/requests/p001-2026-06/status-review', expect.objectContaining({
       idempotencyKey: 'month-close-review-1',
       body: { decision: 'APPROVE', expectedRevision: 1, expectedManifestHash: 'sha256:manifest', reason: '확인 완료' },
-      timeoutMs: 27_000,
+      timeoutMs: 35_000,
     }));
     expect(client.post).toHaveBeenNthCalledWith(
       3,

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -3310,7 +3310,8 @@ export async function reviewCashflowMonthCloseRequestViaBff(params: {
       body: params.payload,
       idempotencyKey: params.idempotencyKey,
       retries: 0,
-      timeoutMs: 27_000,
+      // BFF의 월 결산 확정·재확인 예산(26초)보다 길어야 최종 상태를 받을 수 있다.
+      timeoutMs: 35_000,
     },
   );
   if (params.payload.decision === 'APPROVE' && response.data.request.status !== 'APPROVED') {

--- a/src/app/platform/__snapshots__/api-error-messages.test.ts.snap
+++ b/src/app/platform/__snapshots__/api-error-messages.test.ts.snap
@@ -6,6 +6,10 @@ exports[`resolveApiErrorPresentation > keeps the approved guides reviewable as a
     "guide": "월 결산을 맡을 조직장이 지정되지 않았어요. 프로젝트에서 조직장을 지정해 주세요.",
     "resolution": "contact",
   },
+  "cashflow_month_close_reconciliation_pending": {
+    "guide": "승인 결과를 확인하고 있어요. 잠시 후 월 결산 상태를 확인해 주세요.",
+    "resolution": "wait",
+  },
   "cashflow_month_close_request_conflict": {
     "guide": "이미 같은 월의 결산 요청이 있어요. 기존 요청의 진행 상태를 확인해 주세요.",
     "resolution": "contact",

--- a/src/app/platform/api-error-messages.test.ts
+++ b/src/app/platform/api-error-messages.test.ts
@@ -13,6 +13,7 @@ const cases = [
   ['jvm_weekly_api_token_unconfigured', 'contact'],
   ['jvm_weekly_api_internal_error', 'retry'],
   ['cashflow_month_close_route_timeout', 'retry'],
+  ['cashflow_month_close_reconciliation_pending', 'wait'],
   ['internal_error', 'retry'],
   ['forbidden', 'contact'],
 ] as const;

--- a/src/app/platform/api-error-messages.ts
+++ b/src/app/platform/api-error-messages.ts
@@ -44,6 +44,10 @@ const presentations = new Map<string, ApiErrorPresentation>([
     guide: '월 결산 처리 시간이 초과됐어요. 잠시 후 진행 상태를 확인하고 다시 시도해 주세요.',
     resolution: 'retry',
   }],
+  ['cashflow_month_close_reconciliation_pending', {
+    guide: '승인 결과를 확인하고 있어요. 잠시 후 월 결산 상태를 확인해 주세요.',
+    resolution: 'wait',
+  }],
   ['internal_error', {
     guide: '요청을 처리하는 중 문제가 생겼어요. 잠시 후 다시 시도해 주세요.',
     resolution: 'retry',


### PR DESCRIPTION
Fixes the observed monthly-close timeout race and batch authorization read fan-out. Also records safe reconciliation telemetry for the next approval attempt.