### PR TITLE
fix: recover malformed pending cashflow close

### DIFF
--- a/server/bff/cashflow-month-close-withdrawal.mjs
+++ b/server/bff/cashflow-month-close-withdrawal.mjs
@@ -1,0 +1,121 @@
+import { createHttpError, readOptionalText } from './bff-utils.mjs';
+import { CASHFLOW_CUMULATIVE_CLOSE_CONTRACT } from './cashflow-close-calendar.mjs';
+
+export const CASHFLOW_CUMULATIVE_CLOSE_UNSUPPORTED_REASON_CODE = 'CUMULATIVE_EVIDENCE_CONTRACT_UNSUPPORTED';
+export const CASHFLOW_CUMULATIVE_CLOSE_UNSUPPORTED_REASON = '현재 시트는 연간·주차 혼합 양식이라 기존 누적 월 결산 근거를 검증할 수 없습니다. 시트 값은 변경되지 않았습니다.';
+
+export function cashflowMonthCloseRequestPath(tenantId, requestId) {
+  return `orgs/${tenantId}/cashflow_month_close_requests/${requestId}`;
+}
+
+export function cashflowMonthCloseRequestAuditPath(tenantId, requestId, revision, action) {
+  return `orgs/${tenantId}/cashflow_month_close_request_audits/${requestId}-r${revision}-${action}`;
+}
+
+function objectValue(value) {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+export async function withdrawPendingCumulativeCloseRequest({
+  db,
+  tenantId,
+  projectId,
+  requestId,
+  expectedRevision,
+  expectedManifestHash = '',
+  actorId,
+  actorRole = '',
+  reason,
+  reasonCode = '',
+  idempotencyKey,
+  now,
+  allowPrivilegedActor = false,
+}) {
+  const requestRef = db.doc(cashflowMonthCloseRequestPath(tenantId, requestId));
+  const withdrawnAt = now.toISOString();
+  let withdrawn;
+
+  await db.runTransaction(async (transaction) => {
+    const snapshot = await transaction.get(requestRef);
+    const current = snapshot.exists ? snapshot.data() || {} : null;
+    const requesterId = readOptionalText(current?.requestedByUid);
+    const privileged = allowPrivilegedActor && ['admin', 'finance'].includes(readOptionalText(actorRole).toLowerCase());
+    if (!current || current.projectId !== projectId || current.requestId !== requestId || current.contractVersion !== CASHFLOW_CUMULATIVE_CLOSE_CONTRACT) {
+      throw createHttpError(404, '월 결산 요청을 찾을 수 없습니다.', 'cashflow_month_close_request_not_found');
+    }
+    if (
+      current.status === 'WITHDRAWN'
+      && current.withdrawIdempotencyKey === idempotencyKey
+      && Number(current.revision) === expectedRevision
+      && readOptionalText(current.withdrawReason) === reason
+    ) {
+      withdrawn = current;
+      return;
+    }
+    if (requesterId !== readOptionalText(actorId) && !privileged) {
+      throw createHttpError(403, '요청한 본인 또는 재무 관리자만 이전 형식의 월 결산 요청을 회수할 수 있습니다.', 'cashflow_month_close_withdraw_forbidden');
+    }
+    if (
+      current.status !== 'PENDING'
+      || Number(current.revision) !== expectedRevision
+      || (expectedManifestHash && current.manifestHash !== expectedManifestHash)
+    ) {
+      throw createHttpError(409, '조직장 검토가 시작되었거나 변경된 월 결산 요청은 회수할 수 없습니다.', 'cashflow_month_close_request_already_reviewed');
+    }
+
+    const settlementStatusRef = db.doc(`orgs/${tenantId}/cashflow_settlement_statuses/${projectId}-${current.yearMonth}`);
+    const settlementSnapshot = await transaction.get(settlementStatusRef);
+
+    withdrawn = {
+      ...current,
+      status: 'WITHDRAWN',
+      withdrawnByUid: readOptionalText(actorId),
+      withdrawnAt,
+      withdrawReason: reason,
+      ...(reasonCode ? { withdrawReasonCode: reasonCode } : {}),
+      withdrawIdempotencyKey: idempotencyKey,
+    };
+    transaction.set(requestRef, withdrawn);
+
+    const settlementStatus = settlementSnapshot.exists ? settlementSnapshot.data() || {} : {};
+    const settlementPeriods = objectValue(settlementStatus.periods);
+    const monthStatus = objectValue(settlementPeriods.MONTH);
+    if (readOptionalText(monthStatus.status) === 'PENDING_APPROVAL') {
+      transaction.set(settlementStatusRef, {
+        tenantId,
+        projectId,
+        yearMonth: current.yearMonth,
+        periods: {
+          ...settlementPeriods,
+          MONTH: {
+            ...monthStatus,
+            status: 'WAITING_FOR_UPDATE',
+            revision: Number.isSafeInteger(Number(monthStatus.revision)) ? Number(monthStatus.revision) + 1 : 1,
+            submittedAt: '',
+            submittedBy: '',
+            approvedAt: '',
+            approvedBy: '',
+          },
+        },
+        updatedAt: withdrawnAt,
+      }, { merge: true });
+    }
+    transaction.set(
+      db.doc(cashflowMonthCloseRequestAuditPath(tenantId, requestId, expectedRevision, 'withdrawn')),
+      {
+        requestId,
+        projectId,
+        yearMonth: current.yearMonth,
+        action: 'WITHDRAWN',
+        revision: expectedRevision,
+        manifestHash: current.manifestHash || '',
+        actorUid: readOptionalText(actorId),
+        reason,
+        ...(reasonCode ? { reasonCode } : {}),
+        idempotencyKey,
+        createdAt: withdrawnAt,
+      },
+    );
+  });
+  return withdrawn;
+}

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -23,6 +23,11 @@ import { assertCashflowMutationRuntime, createJavaWeeklyClient } from '../java-w
 import { createCashflowPerformanceTrace } from '../cashflow-performance.mjs';
 import { stableStringify } from '../utils.mjs';
 import { cashflowApplyLeaseMs, readCashflowApplyLeaseState } from '../cashflow-apply-lease.mjs';
+import {
+  CASHFLOW_CUMULATIVE_CLOSE_UNSUPPORTED_REASON,
+  CASHFLOW_CUMULATIVE_CLOSE_UNSUPPORTED_REASON_CODE,
+  withdrawPendingCumulativeCloseRequest,
+} from '../cashflow-month-close-withdrawal.mjs';
 import { getMonthFinanceWeeks } from '../../../src/app/platform/cashflow-week-core.mjs';
 import {
   cashflowSheetLabApplySchema,
@@ -2088,7 +2093,7 @@ function buildPendingApprovalAffectedMonths(differences = []) {
   return [...byMonth.values()].sort((left, right) => left.yearMonth.localeCompare(right.yearMonth));
 }
 
-async function readPendingApprovalDifferences({ db, tenantId, projectId, candidates = [] }) {
+async function readPendingApprovalDifferences({ db, tenantId, projectId, candidates = [], context = null, idempotencyKey = '' }) {
   const requestSnapshot = await db.collection(`orgs/${tenantId}/cashflow_month_close_requests`)
     .where('projectId', '==', projectId)
     .get();
@@ -2098,13 +2103,14 @@ async function readPendingApprovalDifferences({ db, tenantId, projectId, candida
     .sort((left, right) => readOptionalText(left.requestId).localeCompare(readOptionalText(right.requestId)));
   const evidence = [];
   const differences = [];
+  const withdrawnUnsupportedCloseRequests = [];
   for (const request of requests) {
     const requestId = readOptionalText(request.requestId);
     const revision = Number(request.revision);
     const fromMonth = readOptionalText(request.fromMonth);
     const throughMonth = readOptionalText(request.yearMonth);
     const months = cumulativeCloseMonths(fromMonth, throughMonth);
-    if (
+    const incompleteHeader = (
       request.contractVersion !== CASHFLOW_CUMULATIVE_CLOSE_CONTRACT
       || readOptionalText(request.projectId) !== projectId
       || !requestId
@@ -2116,7 +2122,49 @@ async function readPendingApprovalDifferences({ db, tenantId, projectId, candida
       || Number(request.monthCount) !== months.length
       || Number(request.weekCount) !== months.length * 5
       || Number(request.cellCount) !== months.length * 160
-    ) {
+    );
+    if (incompleteHeader) {
+      if (
+        request.status === 'PENDING'
+        && request.contractVersion === CASHFLOW_CUMULATIVE_CLOSE_CONTRACT
+        && fromMonth === '2023-01'
+        && /^20\d{2}-(0[1-9]|1[0-2])$/.test(throughMonth)
+        && context?.actorId
+        && idempotencyKey
+      ) {
+        try {
+          const withdrawn = await withdrawPendingCumulativeCloseRequest({
+            db,
+            tenantId,
+            projectId,
+            requestId,
+            expectedRevision: revision,
+            actorId: context.actorId,
+            actorRole: context.actorRole,
+            reason: CASHFLOW_CUMULATIVE_CLOSE_UNSUPPORTED_REASON,
+            reasonCode: CASHFLOW_CUMULATIVE_CLOSE_UNSUPPORTED_REASON_CODE,
+            idempotencyKey: `${idempotencyKey}:withdraw-unsupported:${requestId}:r${revision}`,
+            now: new Date(),
+            allowPrivilegedActor: true,
+          });
+          withdrawnUnsupportedCloseRequests.push({
+            requestId,
+            yearMonth: withdrawn.yearMonth,
+            revision: withdrawn.revision,
+            reasonCode: CASHFLOW_CUMULATIVE_CLOSE_UNSUPPORTED_REASON_CODE,
+          });
+          continue;
+        } catch (error) {
+          if (readOptionalText(error?.code) === 'cashflow_month_close_withdraw_forbidden') {
+            throw createHttpError(
+              409,
+              '이전 형식의 월 결산 요청을 만든 담당자 또는 재무 관리자가 먼저 회수해야 시트 값을 반영할 수 있습니다.',
+              'cashflow_pending_approval_contract_unsupported',
+            );
+          }
+          throw error;
+        }
+      }
       throw pendingApprovalEvidenceError('결재 중인 누적 결산 요청 header가 완전하지 않습니다.');
     }
     const shards = await Promise.all(months.map(async (yearMonth) => {
@@ -2220,6 +2268,7 @@ async function readPendingApprovalDifferences({ db, tenantId, projectId, candida
     differences,
     differenceCount: differences.reduce((sum, difference) => sum + difference.differenceCount, 0),
     manifestHash: `sha256:${stableHash(differences)}`,
+    withdrawnUnsupportedCloseRequests,
   };
 }
 
@@ -3857,7 +3906,9 @@ async function stagePinnedCashflowSheetLab({
     forceFullReplacement: Boolean(parsed.replaceAllActualSources),
   });
   const candidates = [...weekly.candidates, ...annual.candidates];
-  const pendingApproval = await readPendingApprovalDifferences({ db, tenantId, projectId, candidates });
+  const pendingApproval = await readPendingApprovalDifferences({
+    db, tenantId, projectId, candidates, context, idempotencyKey: parsed.idempotencyKey,
+  });
   const blockedMonths = weekly.blockedMonths;
   const riskLineCount = weekly.riskLineCount;
   const projectionLineCount = candidates.filter((candidate) => candidate.mode === 'projection').length;
@@ -3918,6 +3969,7 @@ async function stagePinnedCashflowSheetLab({
     pendingApprovalDifferences: pendingApproval.differences,
     pendingApprovalDifferenceCount: pendingApproval.differenceCount,
     pendingApprovalDifferenceManifestHash: pendingApproval.manifestHash,
+    withdrawnUnsupportedCloseRequests: pendingApproval.withdrawnUnsupportedCloseRequests,
     stagedMonths,
     calculationMonths,
     stagedYears: annual.stagedYears,
@@ -3952,6 +4004,7 @@ async function stagePinnedCashflowSheetLab({
     pendingApprovalDifferences: pendingApproval.differences,
     pendingApprovalDifferenceCount: pendingApproval.differenceCount,
     pendingApprovalDifferenceManifestHash: pendingApproval.manifestHash,
+    withdrawnUnsupportedCloseRequests: pendingApproval.withdrawnUnsupportedCloseRequests,
     stagedMonths,
     calculationMonths,
     stagedYears: annual.stagedYears,

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -3395,6 +3395,52 @@ describe('cashflow sheet lab route', () => {
     expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(1);
   });
 
+  it('withdraws a malformed legacy PENDING close before sheet staging without changing sheet values', async () => {
+    const documents = cumulativeCloseRequestDocuments();
+    const requestPath = 'orgs/tenant-a/cashflow_month_close_requests/project-a-2026-01';
+    documents[requestPath] = {
+      ...documents[requestPath],
+      monthCount: 0,
+      requestedByUid: 'pm-a',
+    };
+    documents['orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-01'] = {
+      tenantId: 'tenant-a', projectId: 'project-a', yearMonth: '2026-01',
+      periods: { MONTH: { status: 'PENDING_APPROVAL', revision: 3 } },
+    };
+    const db = createDb({
+      project: { id: 'project-a', cashflowSheetLab: { value: 'saved-spreadsheet-a', sheetName: 'cashflow(사용내역 연동)' } },
+      initialDocuments: documents,
+    });
+    const app = createApp({
+      db,
+      context: { actorId: 'finance-a', actorRole: 'finance' },
+      googleSheetsService: {
+        previewSpreadsheet: vi.fn(async () => ({
+          spreadsheetId: 'spreadsheet-a', selectedSheetName: 'cashflow(사용내역 연동)',
+          availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
+          matrix: buildMatrixWithWeekLabels(JANUARY_FINANCE_WEEKS),
+        })),
+      },
+    });
+    const mirror = await request(app).post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'refresh-malformed-close' }).expect(200);
+    const stage = await request(app).post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-01', idempotencyKey: 'stage-malformed-close' })
+      .expect(200);
+
+    expect(stage.body.withdrawnUnsupportedCloseRequests).toEqual([{
+      requestId: 'project-a-2026-01', yearMonth: '2026-01', revision: 1,
+      reasonCode: 'CUMULATIVE_EVIDENCE_CONTRACT_UNSUPPORTED',
+    }]);
+    expect(db.__getDocument(requestPath)).toMatchObject({
+      status: 'WITHDRAWN', withdrawnByUid: 'finance-a', withdrawReasonCode: 'CUMULATIVE_EVIDENCE_CONTRACT_UNSUPPORTED',
+    });
+    expect(db.__getDocument('orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-01').periods.MONTH)
+      .toMatchObject({ status: 'WAITING_FOR_UPDATE', revision: 4, submittedBy: '', approvedBy: '' });
+    expect(db.__getDocument('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-01-r1-withdrawn'))
+      .toMatchObject({ action: 'WITHDRAWN', actorUid: 'finance-a', reasonCode: 'CUMULATIVE_EVIDENCE_CONTRACT_UNSUPPORTED' });
+  });
+
   it('rejects apply when an active close request status changes after staging', async () => {
     const requestDocuments = cumulativeCloseRequestDocuments();
     const db = createDb({

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -43,6 +43,11 @@ import {
   monthsBetween,
   previousYearMonth,
 } from '../cashflow-close-calendar.mjs';
+import {
+  cashflowMonthCloseRequestAuditPath,
+  cashflowMonthCloseRequestPath,
+  withdrawPendingCumulativeCloseRequest,
+} from '../cashflow-month-close-withdrawal.mjs';
 export { cashflowCumulativeCloseCycle };
 import { cashflowMonthCloseDeadline, isCashflowCloseOverdue } from '../cashflow-close-deadline.mjs';
 
@@ -145,10 +150,6 @@ function resolveBffDataProjectId(env = process.env) {
     || readOptionalText(env.GOOGLE_CLOUD_PROJECT);
 }
 
-function cashflowMonthCloseRequestPath(tenantId, requestId) {
-  return `orgs/${tenantId}/cashflow_month_close_requests/${requestId}`;
-}
-
 async function alignMonthSettlementStatus(db, tenantId, result) {
   const projects = Array.isArray(result?.items) && result.items.some((item) => item?.projectId)
     ? result.items
@@ -203,10 +204,6 @@ export function buildCashflowMonthCloseRevisionChanges(previousCells, currentCel
       amountDelta: previousAmount === null || currentAmount === null ? null : currentAmount - previousAmount,
     }];
   });
-}
-
-function cashflowMonthCloseRequestAuditPath(tenantId, requestId, revision, action) {
-  return `orgs/${tenantId}/cashflow_month_close_request_audits/${requestId}-r${revision}-${action}`;
 }
 
 function cashflowMonthCloseRequestView(record, partyNames = {}) {
@@ -4020,7 +4017,6 @@ export function mountJvmWeeklyApiRoutes(app, {
       db, tenantId: req.context.tenantId, actorId: req.context.actorId,
     });
     const requestRef = db.doc(cashflowMonthCloseRequestPath(req.context.tenantId, requestId));
-    const requesterRef = db.doc(`orgs/${req.context.tenantId}/members/${req.context.actorId}`);
     const initialSnapshot = await requestRef.get();
     if (!initialSnapshot.exists) {
       throw createHttpError(404, '월 결산 요청을 찾을 수 없습니다.', 'cashflow_month_close_request_not_found');
@@ -4054,82 +4050,17 @@ export function mountJvmWeeklyApiRoutes(app, {
         'cashflow_month_close_request_already_reviewed',
       );
     }
-    const settlementStatusRef = db.doc(`orgs/${req.context.tenantId}/cashflow_settlement_statuses/${projectId}-${initialRecord.yearMonth}`);
-    const withdrawnAt = now().toISOString();
-    let withdrawn;
-    await db.runTransaction(async (transaction) => {
-      const [snapshot, requesterSnapshot, settlementSnapshot] = await Promise.all([
-        transaction.get(requestRef),
-        transaction.get(requesterRef),
-        transaction.get(settlementStatusRef),
-      ]);
-      const current = snapshot.exists ? snapshot.data() || {} : null;
-      const requester = requesterSnapshot.exists ? requesterSnapshot.data() || {} : {};
-      if (
-        !current
-        || current.status !== 'PENDING'
-        || Number(current.revision) !== expectedRevision
-        || current.manifestHash !== expectedManifestHash
-        || readOptionalText(current.requestedByUid) !== readOptionalText(req.context.actorId)
-        || readOptionalText(requester.uid) !== readOptionalText(req.context.actorId)
-        || readOptionalText(requester.status).toUpperCase() !== 'ACTIVE'
-      ) {
-        throw createHttpError(
-          409,
-          '조직장 검토가 시작되었거나 변경된 월 결산 요청은 회수할 수 없습니다.',
-          'cashflow_month_close_request_already_reviewed',
-        );
-      }
-      withdrawn = {
-        ...current,
-        status: 'WITHDRAWN',
-        withdrawnByUid: readOptionalText(req.context.actorId),
-        withdrawnAt,
-        withdrawReason: reason,
-        withdrawIdempotencyKey,
-      };
-      transaction.set(requestRef, withdrawn);
-      // 요청 때 PENDING_APPROVAL 로 잡아둔 정산 상태를 실무자 입력 대기로 되돌린다.
-      const settlementStatus = settlementSnapshot.exists ? settlementSnapshot.data() || {} : {};
-      const settlementPeriods = objectValue(settlementStatus.periods) || {};
-      const monthStatus = objectValue(settlementPeriods.MONTH) || {};
-      if (readOptionalText(monthStatus.status) === 'PENDING_APPROVAL') {
-        transaction.set(settlementStatusRef, {
-          tenantId: req.context.tenantId,
-          projectId,
-          yearMonth: current.yearMonth,
-          periods: {
-            ...settlementPeriods,
-            MONTH: {
-              ...monthStatus,
-              status: 'WAITING_FOR_UPDATE',
-              revision: Number.isSafeInteger(Number(monthStatus.revision)) ? Number(monthStatus.revision) + 1 : 1,
-              submittedAt: '',
-              submittedBy: '',
-              approvedAt: '',
-              approvedBy: '',
-            },
-          },
-          updatedAt: withdrawnAt,
-        }, { merge: true });
-      }
-      transaction.set(
-        db.doc(cashflowMonthCloseRequestAuditPath(
-          req.context.tenantId, requestId, expectedRevision, 'withdrawn',
-        )),
-        {
-          requestId,
-          projectId,
-          yearMonth: current.yearMonth,
-          action: 'WITHDRAWN',
-          revision: expectedRevision,
-          manifestHash: current.manifestHash,
-          actorUid: readOptionalText(req.context.actorId),
-          reason,
-          idempotencyKey: withdrawIdempotencyKey,
-          createdAt: withdrawnAt,
-        },
-      );
+    const withdrawn = await withdrawPendingCumulativeCloseRequest({
+      db,
+      tenantId: req.context.tenantId,
+      projectId,
+      requestId,
+      expectedRevision,
+      expectedManifestHash,
+      actorId: req.context.actorId,
+      reason,
+      idempotencyKey: withdrawIdempotencyKey,
+      now: now(),
     });
     res.status(200).json({ request: cashflowMonthCloseRequestView(withdrawn) });
   }));

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
@@ -811,9 +811,12 @@ export function CashflowSheetLabPage() {
         setErrorMessage(`반영할 수 없는 시트 범위가 있습니다.${blockedMonths ? ` 확인할 월: ${blockedMonths}` : ''}`);
         return;
       }
+      const withdrawnUnsupportedNotice = staged.withdrawnUnsupportedCloseRequests?.length
+        ? `이전 근거 형식의 월 결산 요청 ${staged.withdrawnUnsupportedCloseRequests.length}건을 회수했습니다. 시트 값은 변경되지 않았습니다. `
+        : '';
       if (staged.stagedLineCount === 0) {
         setReflectResult({ appliedLineCount: 0, projectionLineCount: 0, actualLineCount: 0 });
-        setStatusMessage('MYSCube가 이미 시트 최신값과 같습니다.');
+        setStatusMessage(`${withdrawnUnsupportedNotice}MYSCube가 이미 시트 최신값과 같습니다.`);
         logCashflowLab('overwrite.sheet_values.noop', {
           projectId,
           spreadsheetId,
@@ -888,7 +891,7 @@ export function CashflowSheetLabPage() {
       setClosedMonthPendingApprovalAccepted(false);
       setPendingApprovalStage(null);
       setFormulaMismatchPrompt(null);
-      setStatusMessage(`시트 값 ${result.appliedLineCount.toLocaleString()}건으로 MYSCube를 덮어썼습니다.`);
+      setStatusMessage(`${withdrawnUnsupportedNotice}시트 값 ${result.appliedLineCount.toLocaleString()}건으로 MYSCube를 덮어썼습니다.`);
       logCashflowLab('apply.sheet_values.ok', {
         projectId,
         spreadsheetId: result.spreadsheetId,

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -564,6 +564,12 @@ export interface CashflowSheetLabStageResult {
   }>;
   pendingApprovalDifferenceCount?: number;
   pendingApprovalDifferenceManifestHash?: string;
+  withdrawnUnsupportedCloseRequests?: Array<{
+    requestId: string;
+    yearMonth: string;
+    revision: number;
+    reasonCode: 'CUMULATIVE_EVIDENCE_CONTRACT_UNSUPPORTED';
+  }>;
   stagedMonths?: string[];
   stagedYears?: number[];
   annualLineCount?: number;

--- a/src/app/platform/api-client.test.ts
+++ b/src/app/platform/api-client.test.ts
@@ -113,6 +113,23 @@ describe('PlatformApiClient', () => {
     );
   });
 
+  it('reads a safe BFF error identifier from its established error field', async () => {
+    const client = new PlatformApiClient({
+      fetchImpl: vi.fn(async () => new Response(JSON.stringify({
+        error: 'cashflow_month_close_reconciliation_pending',
+        message: '월 결산 저장 결과를 확정할 수 없습니다.',
+      }), {
+        status: 503,
+        headers: { 'content-type': 'application/json' },
+      })),
+    });
+
+    await expect(client.get('/api/v1/secure', {
+      tenantId: 'mysc',
+      actor: { id: 'u001' },
+    })).rejects.toMatchObject({ code: 'cashflow_month_close_reconciliation_pending' });
+  });
+
   it('keeps empty gateway responses safe and preserves the default message', async () => {
     const client = new PlatformApiClient({
       fetchImpl: vi.fn(async () => new Response('<html>bad gateway</html>', {
@@ -320,10 +337,10 @@ describe('PlatformApiClient', () => {
     }
   });
 
-  it('never copies body.error into the response-code transaction summary', async () => {
+  it('never copies an unsafe body.error into the response-code transaction summary', async () => {
     clearDevtoolsLogs();
     const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
-      error: 'sk_live_supersecret',
+      error: 'sk_live_1234567890',
       message: 'raw financial payload 2300000',
     }), {
       status: 400,

--- a/src/app/platform/api-client.ts
+++ b/src/app/platform/api-client.ts
@@ -80,7 +80,8 @@ function parseJwtClaims(token: string): JwtClaimsSummary | undefined {
 
 function readErrorCode(body: unknown): string | undefined {
   if (!body || typeof body !== 'object') return undefined;
-  return toSafeDiagnosticCode((body as { code?: unknown }).code);
+  const response = body as { code?: unknown; error?: unknown };
+  return toSafeDiagnosticCode(response.code) || toSafeDiagnosticCode(response.error);
 }
 
 function readErrorMessage(body: unknown): string | undefined {
@@ -129,7 +130,8 @@ export class PlatformApiError extends Error {
     this.status = status;
     this.requestId = requestId;
     this.body = body;
-    const responseCode = body && typeof body === 'object' ? (body as { code?: unknown }).code : undefined;
+    const responseCode = readErrorCode(body)
+      || (body && typeof body === 'object' ? (body as { code?: unknown }).code : undefined);
     this.code = typeof responseCode === 'string' ? responseCode : '';
     this.serverMessage = readErrorMessage(body) || '';
   }


### PR DESCRIPTION
## Hotfix

- PENDING 상태의 불완전한 누적 결산 header가 시트 연동을 막던 오류를 기존 WITHDRAWN 트랜잭션으로 회수합니다.
- 회수는 요청자 또는 admin/finance만 가능하며, APPROVING/UNCERTAIN은 JVM 확정 가능성 때문에 자동 회수하지 않습니다.
- 요청 상태, 정산 상태(PENDING_APPROVAL → WAITING_FOR_UPDATE), 감사 로그를 한 Firestore 트랜잭션으로 갱신합니다.
- 시트 값과 금액은 변경하지 않습니다.

## Verification

- `npm test -- --run server/bff/routes/cashflow-sheet-lab.test.mjs server/bff/routes/jvm-weekly-api.test.mjs`
- `npm run build`
- `npm run typecheck`