### PR TITLE
fix: correct cumulative-close month range in sheet-lab pending-approval check

### DIFF
--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -14,7 +14,17 @@ import {
   computeCashflowTargetRevision,
   createCashflowPinnedSnapshot,
 } from '../cashflow-sheet-snapshot.mjs';
-import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES } from '../cashflow-policy.mjs';
+import {
+  CASHFLOW_ALL_LINES,
+  CASHFLOW_IN_LINES,
+  CASHFLOW_MONTH_CELL_COUNT,
+  CASHFLOW_OUT_LINES,
+} from '../cashflow-policy.mjs';
+import {
+  CASHFLOW_CUMULATIVE_CLOSE_CONTRACT,
+  CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH,
+  cumulativeCloseMonthsOrNull,
+} from '../cashflow-close-calendar.mjs';
 import {
   cashflowAnnualTotalDocPath,
   summarizeCashflowAnnualMode,
@@ -49,7 +59,6 @@ const CASHFLOW_SHEET_STAGE_YEARS_COLLECTION_ID = 'cashflow_sheet_stage_years';
 const CASHFLOW_MODES = ['projection', 'actual'];
 const CASHFLOW_SHEET_SOURCE_KEY = 'cashflow-sheet-lab';
 const CASHFLOW_SHEET_APPLY_COMMAND = 'weeklyExpense.cashflowSheetLab.apply';
-const CASHFLOW_CUMULATIVE_CLOSE_CONTRACT = 'cashflow-cumulative-close-v2';
 const CASHFLOW_ACTIVE_CLOSE_REQUEST_STATUSES = new Set(['PENDING', 'APPROVING', 'UNCERTAIN']);
 const CASHFLOW_LINE_ORDER = new Map(CASHFLOW_ALL_LINES.map((lineId, index) => [lineId, index]));
 const FINANCIAL_YEAR_FIELDS = [
@@ -2055,22 +2064,6 @@ function cashflowCloseHash(value) {
   return `sha256:${createHash('sha256').update(stableStringify(value)).digest('hex')}`;
 }
 
-function cumulativeCloseMonths(fromMonth, throughMonth) {
-  if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(fromMonth) || !/^20\d{2}-(0[1-9]|1[0-2])$/.test(throughMonth)) return [];
-  const months = [];
-  for (let year = Number(fromMonth.slice(0, 4)), month = Number(fromMonth.slice(5));;) {
-    const yearMonth = `${year}-${String(month).padStart(2, '0')}`;
-    if (yearMonth > throughMonth || months.length >= 1000) break;
-    months.push(yearMonth);
-    month += 1;
-    if (month === 13) {
-      year += 1;
-      month = 1;
-    }
-  }
-  return months;
-}
-
 function pendingApprovalEvidenceError(message = '결재 중인 누적 결산 근거가 변경되었거나 완전하지 않습니다.') {
   return createHttpError(409, message, 'cashflow_pending_approval_evidence_stale');
 }
@@ -2102,20 +2095,25 @@ async function readPendingApprovalDifferences({ db, tenantId, projectId, candida
     const requestId = readOptionalText(request.requestId);
     const revision = Number(request.revision);
     const fromMonth = readOptionalText(request.fromMonth);
+    // request.yearMonth 는 회차 월(예: 2026-08 회차 = 8월 10일 마감)이다. 실제로 잠그는
+    // 범위는 그 직전 달까지(2023-01~2026-07) - 회차 월 자체는 아직 끝나지 않아 대상이
+    // 아니다. 이 파일이 그 범위를 독자적으로(그리고 회차 월을 포함해서, 틀리게) 계산하던
+    // 세 번째 사본이었다. 단일 소스(cashflow-close-calendar)로 대체한다.
     const throughMonth = readOptionalText(request.yearMonth);
-    const months = cumulativeCloseMonths(fromMonth, throughMonth);
+    const months = /^20\d{2}-(0[1-9]|1[0-2])$/.test(throughMonth)
+      ? cumulativeCloseMonthsOrNull(throughMonth)
+      : null;
     if (
-      request.contractVersion !== CASHFLOW_CUMULATIVE_CLOSE_CONTRACT
+      !months
+      || request.contractVersion !== CASHFLOW_CUMULATIVE_CLOSE_CONTRACT
       || readOptionalText(request.projectId) !== projectId
       || !requestId
       || !Number.isSafeInteger(revision)
       || revision < 1
-      || fromMonth !== '2023-01'
-      || throughMonth > '2099-12'
-      || months.length === 0
+      || fromMonth !== CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH
       || Number(request.monthCount) !== months.length
       || Number(request.weekCount) !== months.length * 5
-      || Number(request.cellCount) !== months.length * 160
+      || Number(request.cellCount) !== months.length * CASHFLOW_MONTH_CELL_COUNT
     ) {
       throw pendingApprovalEvidenceError('결재 중인 누적 결산 요청 header가 완전하지 않습니다.');
     }
@@ -2129,7 +2127,7 @@ async function readPendingApprovalDifferences({ db, tenantId, projectId, candida
         CASHFLOW_ALL_LINES.map((lineId) => `${mode}|${weekIndex + 1}|${lineId}`)
       )).flat());
       const actualKeys = cells.map((cell) => `${readOptionalText(cell.mode)}|${Number(cell.weekNo)}|${readOptionalText(cell.cashflowLine)}`);
-      const validCells = cells.length === 160 && actualKeys.every((key, index) => key === expectedKeys[index])
+      const validCells = cells.length === CASHFLOW_MONTH_CELL_COUNT && actualKeys.every((key, index) => key === expectedKeys[index])
         && cells.every((cell) => (
           ['EMPTY', 'ZERO', 'VALUE'].includes(readOptionalText(cell.cellState))
           && (cell.cellState === 'EMPTY'

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -90,8 +90,18 @@ function cumulativeMonths(throughMonth) {
   return months;
 }
 
+// 회차 월(request.yearMonth)은 아직 끝나지 않은 달이라 잠금 범위에서 제외된다 - 실제로
+// 잠기는 마지막 달은 회차 월의 직전 달이다. 이 픽스처는 "잠기는 마지막 달"(throughMonth)
+// 을 받아 그 다음 달을 회차 월로 저장한다. previousYearMonth 의 역함수다.
+function nextYearMonth(yearMonth) {
+  const month = new Date(`${yearMonth}-01T00:00:00Z`);
+  month.setUTCMonth(month.getUTCMonth() + 1);
+  return month.toISOString().slice(0, 7);
+}
+
 function cumulativeCloseRequestDocuments({ status = 'PENDING', throughMonth = '2026-01' } = {}) {
   const requestId = `project-a-${throughMonth}`;
+  const cycleYearMonth = nextYearMonth(throughMonth);
   const revision = 1;
   const source = { kind: 'PINNED_MIRROR', sourceRevision: 'source-a', targetRevision: 'target-a' };
   const shards = cumulativeMonths(throughMonth).map((yearMonth) => {
@@ -124,7 +134,7 @@ function cumulativeCloseRequestDocuments({ status = 'PENDING', throughMonth = '2
     requestRevision: revision,
     projectId: 'project-a',
     fromMonth: '2023-01',
-    yearMonth: throughMonth,
+    yearMonth: cycleYearMonth,
     months: shards.map((shard) => ({ yearMonth: shard.yearMonth, shardHash: shard.shardHash })),
   };
   return Object.fromEntries([
@@ -134,7 +144,7 @@ function cumulativeCloseRequestDocuments({ status = 'PENDING', throughMonth = '2
       tenantId: 'tenant-a',
       projectId: 'project-a',
       fromMonth: '2023-01',
-      yearMonth: throughMonth,
+      yearMonth: cycleYearMonth,
       status,
       revision,
       manifestHash: closeHash(manifest),


### PR DESCRIPTION
## Summary
- `cashflow-sheet-lab.mjs` had its own third, divergent implementation of the cumulative-close month-range calculation, separate from the canonical one in `cashflow-close-calendar.mjs` (already used by `jvm-weekly-api.mjs`) and from the JVM side.
- Its version incorrectly included the close request's *cycle* month (`request.yearMonth`) in the locked/covered range. Real cycle-month semantics exclude it (it hasn't ended yet) — the locked range is `fromMonth` through `previousYearMonth(yearMonth)`.
- Because of the off-by-one, `months.length` was always 1 higher than the real stored `request.monthCount`, so the header-completeness check (`request.monthCount !== months.length`, etc.) failed for every real, correctly-created pending cumulative-close request — surfacing live as `[cashflow_pending_approval_evidence_stale] 결재 중인 누적 결산 요청 header가 완전하지 않습니다.` (`req_1786333320446_7005f9e993ed4247`).
- This was dormant until now because no live pending cumulative-close request existed before the recent fix that made approval actually confirm through JVM.
- Replaced the local duplicate with the canonical `cumulativeCloseMonthsOrNull` / `CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH` from `cashflow-close-calendar.mjs`, and the remaining raw `160` cell-count literals with `CASHFLOW_MONTH_CELL_COUNT` from `cashflow-policy.mjs`, so this file can't silently re-diverge again.
- Fixed the test file's matching fixture bug (`cumulativeCloseRequestDocuments`), which had encoded the same wrong assumption (shard for the cycle month itself), masking this bug from the test suite.

## Test plan
- [x] Sabotage verification: reintroduced the off-by-one (`[...months, throughMonth]`), confirmed 2 of 3 targeted tests fail with the exact same `409`/`cashflow_pending_approval_evidence_stale` symptom, then restored the fix.
- [x] `npx vitest run server/bff/routes/cashflow-sheet-lab.test.mjs -t pending` → 3 passed
- [x] `npx vitest run server/bff` → 1071 passed, 234 skipped, 0 failed
- [x] `npm run typecheck` → no new type errors (203 known, baseline unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)