### PR TITLE
fix: stop rejecting valid cashflow sheet refreshes

### DIFF
--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -23,11 +23,11 @@ import { assertCashflowMutationRuntime, createJavaWeeklyClient } from '../java-w
 import { createCashflowPerformanceTrace } from '../cashflow-performance.mjs';
 import { stableStringify } from '../utils.mjs';
 import { cashflowApplyLeaseMs, readCashflowApplyLeaseState } from '../cashflow-apply-lease.mjs';
+import { cashflowCloseHash } from '../cashflow-close-hash.mjs';
 import {
-  CASHFLOW_CUMULATIVE_CLOSE_UNSUPPORTED_REASON,
-  CASHFLOW_CUMULATIVE_CLOSE_UNSUPPORTED_REASON_CODE,
-  withdrawPendingCumulativeCloseRequest,
-} from '../cashflow-month-close-withdrawal.mjs';
+  CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH,
+  monthsBetween,
+} from '../cashflow-close-calendar.mjs';
 import { getMonthFinanceWeeks } from '../../../src/app/platform/cashflow-week-core.mjs';
 import {
   cashflowSheetLabApplySchema,
@@ -2056,24 +2056,10 @@ function stableHash(value) {
   return createHash('sha256').update(JSON.stringify(value)).digest('hex');
 }
 
-function cashflowCloseHash(value) {
-  return `sha256:${createHash('sha256').update(stableStringify(value)).digest('hex')}`;
-}
-
 function cumulativeCloseMonths(fromMonth, throughMonth) {
-  if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(fromMonth) || !/^20\d{2}-(0[1-9]|1[0-2])$/.test(throughMonth)) return [];
-  const months = [];
-  for (let year = Number(fromMonth.slice(0, 4)), month = Number(fromMonth.slice(5));;) {
-    const yearMonth = `${year}-${String(month).padStart(2, '0')}`;
-    if (yearMonth > throughMonth || months.length >= 1000) break;
-    months.push(yearMonth);
-    month += 1;
-    if (month === 13) {
-      year += 1;
-      month = 1;
-    }
-  }
-  return months;
+  if (fromMonth !== CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH
+    || !/^20\d{2}-(0[1-9]|1[0-2])$/.test(throughMonth)) return [];
+  return monthsBetween(fromMonth, throughMonth);
 }
 
 function pendingApprovalEvidenceError(message = '결재 중인 누적 결산 근거가 변경되었거나 완전하지 않습니다.') {
@@ -2093,7 +2079,7 @@ function buildPendingApprovalAffectedMonths(differences = []) {
   return [...byMonth.values()].sort((left, right) => left.yearMonth.localeCompare(right.yearMonth));
 }
 
-async function readPendingApprovalDifferences({ db, tenantId, projectId, candidates = [], context = null, idempotencyKey = '' }) {
+async function readPendingApprovalDifferences({ db, tenantId, projectId, candidates = [] }) {
   const requestSnapshot = await db.collection(`orgs/${tenantId}/cashflow_month_close_requests`)
     .where('projectId', '==', projectId)
     .get();
@@ -2103,7 +2089,6 @@ async function readPendingApprovalDifferences({ db, tenantId, projectId, candida
     .sort((left, right) => readOptionalText(left.requestId).localeCompare(readOptionalText(right.requestId)));
   const evidence = [];
   const differences = [];
-  const withdrawnUnsupportedCloseRequests = [];
   for (const request of requests) {
     const requestId = readOptionalText(request.requestId);
     const revision = Number(request.revision);
@@ -2116,7 +2101,7 @@ async function readPendingApprovalDifferences({ db, tenantId, projectId, candida
       || !requestId
       || !Number.isSafeInteger(revision)
       || revision < 1
-      || fromMonth !== '2023-01'
+      || fromMonth !== CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH
       || throughMonth > '2099-12'
       || months.length === 0
       || Number(request.monthCount) !== months.length
@@ -2124,48 +2109,11 @@ async function readPendingApprovalDifferences({ db, tenantId, projectId, candida
       || Number(request.cellCount) !== months.length * 160
     );
     if (incompleteHeader) {
-      if (
-        request.status === 'PENDING'
-        && request.contractVersion === CASHFLOW_CUMULATIVE_CLOSE_CONTRACT
-        && fromMonth === '2023-01'
-        && /^20\d{2}-(0[1-9]|1[0-2])$/.test(throughMonth)
-        && context?.actorId
-        && idempotencyKey
-      ) {
-        try {
-          const withdrawn = await withdrawPendingCumulativeCloseRequest({
-            db,
-            tenantId,
-            projectId,
-            requestId,
-            expectedRevision: revision,
-            actorId: context.actorId,
-            actorRole: context.actorRole,
-            reason: CASHFLOW_CUMULATIVE_CLOSE_UNSUPPORTED_REASON,
-            reasonCode: CASHFLOW_CUMULATIVE_CLOSE_UNSUPPORTED_REASON_CODE,
-            idempotencyKey: `${idempotencyKey}:withdraw-unsupported:${requestId}:r${revision}`,
-            now: new Date(),
-            allowPrivilegedActor: true,
-          });
-          withdrawnUnsupportedCloseRequests.push({
-            requestId,
-            yearMonth: withdrawn.yearMonth,
-            revision: withdrawn.revision,
-            reasonCode: CASHFLOW_CUMULATIVE_CLOSE_UNSUPPORTED_REASON_CODE,
-          });
-          continue;
-        } catch (error) {
-          if (readOptionalText(error?.code) === 'cashflow_month_close_withdraw_forbidden') {
-            throw createHttpError(
-              409,
-              '이전 형식의 월 결산 요청을 만든 담당자 또는 재무 관리자가 먼저 회수해야 시트 값을 반영할 수 있습니다.',
-              'cashflow_pending_approval_contract_unsupported',
-            );
-          }
-          throw error;
-        }
-      }
-      throw pendingApprovalEvidenceError('결재 중인 누적 결산 요청 header가 완전하지 않습니다.');
+      throw createHttpError(
+        409,
+        '결재 중인 월 결산 요청의 근거 형식을 확인할 수 없습니다. 결재 요청을 먼저 정리한 뒤 시트 값을 다시 불러와 주세요.',
+        'cashflow_pending_approval_contract_unsupported',
+      );
     }
     const shards = await Promise.all(months.map(async (yearMonth) => {
       const snapshot = await db.doc(
@@ -2268,7 +2216,6 @@ async function readPendingApprovalDifferences({ db, tenantId, projectId, candida
     differences,
     differenceCount: differences.reduce((sum, difference) => sum + difference.differenceCount, 0),
     manifestHash: `sha256:${stableHash(differences)}`,
-    withdrawnUnsupportedCloseRequests,
   };
 }
 
@@ -3907,7 +3854,7 @@ async function stagePinnedCashflowSheetLab({
   });
   const candidates = [...weekly.candidates, ...annual.candidates];
   const pendingApproval = await readPendingApprovalDifferences({
-    db, tenantId, projectId, candidates, context, idempotencyKey: parsed.idempotencyKey,
+    db, tenantId, projectId, candidates,
   });
   const blockedMonths = weekly.blockedMonths;
   const riskLineCount = weekly.riskLineCount;
@@ -3969,7 +3916,6 @@ async function stagePinnedCashflowSheetLab({
     pendingApprovalDifferences: pendingApproval.differences,
     pendingApprovalDifferenceCount: pendingApproval.differenceCount,
     pendingApprovalDifferenceManifestHash: pendingApproval.manifestHash,
-    withdrawnUnsupportedCloseRequests: pendingApproval.withdrawnUnsupportedCloseRequests,
     stagedMonths,
     calculationMonths,
     stagedYears: annual.stagedYears,
@@ -4004,7 +3950,6 @@ async function stagePinnedCashflowSheetLab({
     pendingApprovalDifferences: pendingApproval.differences,
     pendingApprovalDifferenceCount: pendingApproval.differenceCount,
     pendingApprovalDifferenceManifestHash: pendingApproval.manifestHash,
-    withdrawnUnsupportedCloseRequests: pendingApproval.withdrawnUnsupportedCloseRequests,
     stagedMonths,
     calculationMonths,
     stagedYears: annual.stagedYears,

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -3088,7 +3088,7 @@ describe('cashflow sheet lab route', () => {
     expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(1);
   });
 
-  it('withdraws a malformed legacy PENDING close before sheet staging without changing sheet values', async () => {
+  it('does not mutate a malformed legacy PENDING close during sheet staging', async () => {
     const documents = cumulativeCloseRequestDocuments();
     const requestPath = 'orgs/tenant-a/cashflow_month_close_requests/project-a-2026-01';
     documents[requestPath] = {
@@ -3119,19 +3119,15 @@ describe('cashflow sheet lab route', () => {
       .send({ idempotencyKey: 'refresh-malformed-close' }).expect(200);
     const stage = await request(app).post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
       .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-01', idempotencyKey: 'stage-malformed-close' })
-      .expect(200);
+      .expect(409);
 
-    expect(stage.body.withdrawnUnsupportedCloseRequests).toEqual([{
-      requestId: 'project-a-2026-01', yearMonth: '2026-01', revision: 1,
-      reasonCode: 'CUMULATIVE_EVIDENCE_CONTRACT_UNSUPPORTED',
-    }]);
+    expect(stage.body.code).toBe('cashflow_pending_approval_contract_unsupported');
     expect(db.__getDocument(requestPath)).toMatchObject({
-      status: 'WITHDRAWN', withdrawnByUid: 'finance-a', withdrawReasonCode: 'CUMULATIVE_EVIDENCE_CONTRACT_UNSUPPORTED',
+      status: 'PENDING', monthCount: 0,
     });
     expect(db.__getDocument('orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-01').periods.MONTH)
-      .toMatchObject({ status: 'WAITING_FOR_UPDATE', revision: 4, submittedBy: '', approvedBy: '' });
-    expect(db.__getDocument('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-01-r1-withdrawn'))
-      .toMatchObject({ action: 'WITHDRAWN', actorUid: 'finance-a', reasonCode: 'CUMULATIVE_EVIDENCE_CONTRACT_UNSUPPORTED' });
+      .toMatchObject({ status: 'PENDING_APPROVAL', revision: 3 });
+    expect(db.__getDocument('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-01-r1-withdrawn')).toBeUndefined();
   });
 
   it('rejects apply when an active close request status changes after staging', async () => {

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
@@ -34,12 +34,13 @@ import {
 } from '../../components/ui/dialog';
 import { rememberRecentPortalProject } from '../../platform/portal-recent-projects';
 import { recordDevtoolsLog } from '../../platform/devtools-transaction-log';
+import { resolveApiErrorPresentation } from '../../platform/api-error-messages';
 import { resolvePortalProjectContextSync, resolvePortalProjectResourcePath } from '../../platform/portal-project-selection';
 import { CashflowSheetSyncOverlay, type CashflowSheetSyncOperation } from '../../components/cashflow/CashflowSheetSyncOverlay';
 import { CashflowFormulaMismatchDialog } from '../../components/cashflow/CashflowFormulaMismatchDialog';
 
 function formatError(error: unknown) {
-  const apiError = error as { body?: { code?: string; error?: string; message?: string }; requestId?: string; status?: number };
+  const apiError = error as { body?: { code?: string; error?: string; message?: string; statusCode?: number }; requestId?: string; status?: number };
   const code = getErrorCode(error);
   if (code === 'google_sheets_not_configured') {
     return '서버의 Google Sheets 서비스 계정이 설정되지 않았습니다. 관리자에게 환경 변수 설정을 요청하세요.';
@@ -48,12 +49,15 @@ function formatError(error: unknown) {
     return '시트를 시스템 계정에 공유해 주세요. 공유 후 다시 연동하면 됩니다.';
   }
   const bodyMessage = apiError?.body?.message;
+  if (code) {
+    const presentation = resolveApiErrorPresentation(
+      code,
+      Number(apiError.status || apiError.body?.statusCode || 0),
+    );
+    return `${presentation.guide}${apiError.requestId ? ` (요청 ID: ${apiError.requestId})` : ''}`;
+  }
   if (bodyMessage) {
-    return [
-      code ? `[${code}]` : '',
-      bodyMessage,
-      apiError.requestId ? `(requestId: ${apiError.requestId})` : '',
-    ].filter(Boolean).join(' ');
+    return bodyMessage;
   }
   if (error instanceof Error) return error.message;
   return '시트 구조를 확인하지 못했습니다.';
@@ -766,12 +770,9 @@ export function CashflowSheetLabPage() {
         setErrorMessage(`반영할 수 없는 시트 범위가 있습니다.${blockedMonths ? ` 확인할 월: ${blockedMonths}` : ''}`);
         return;
       }
-      const withdrawnUnsupportedNotice = staged.withdrawnUnsupportedCloseRequests?.length
-        ? `이전 근거 형식의 월 결산 요청 ${staged.withdrawnUnsupportedCloseRequests.length}건을 회수했습니다. 시트 값은 변경되지 않았습니다. `
-        : '';
       if (staged.stagedLineCount === 0) {
         setReflectResult({ appliedLineCount: 0, projectionLineCount: 0, actualLineCount: 0 });
-        setStatusMessage(`${withdrawnUnsupportedNotice}MYSCube가 이미 시트 최신값과 같습니다.`);
+        setStatusMessage('MYSCube가 이미 시트 최신값과 같습니다.');
         logCashflowLab('overwrite.sheet_values.noop', {
           projectId,
           spreadsheetId,
@@ -846,7 +847,7 @@ export function CashflowSheetLabPage() {
       setClosedMonthPendingApprovalAccepted(false);
       setPendingApprovalStage(null);
       setFormulaMismatchPrompt(null);
-      setStatusMessage(`${withdrawnUnsupportedNotice}시트 값 ${result.appliedLineCount.toLocaleString()}건으로 MYSCube를 덮어썼습니다.`);
+      setStatusMessage(`시트 값 ${result.appliedLineCount.toLocaleString()}건으로 MYSCube를 덮어썼습니다.`);
       logCashflowLab('apply.sheet_values.ok', {
         projectId,
         spreadsheetId: result.spreadsheetId,

--- a/src/app/lib/sheets-cashflow-readonly-client.test.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.test.ts
@@ -360,27 +360,18 @@ describe('sheets cashflow readonly client', () => {
     );
   });
 
-  it.each([
-    ['another project', { projectId: 'p999', lastRefreshIdempotencyKey: 'refresh-recover-001' }],
-    ['an older refresh', { projectId: 'p001', lastRefreshIdempotencyKey: 'refresh-older' }],
-    ['a partial snapshot', {
-      projectId: 'p001',
-      lastRefreshIdempotencyKey: 'refresh-recover-001',
-      cells: undefined,
-    }],
-  ])('rejects persisted mirror recovery from %s', async (_label, override) => {
+  it('rejects persisted mirror recovery from another project', async () => {
     const client = asMockClient({
       post: vi.fn(async () => ({ data: null })),
       get: vi.fn(async () => ({
         data: {
-          projectId: 'p001',
           status: 'FRESH',
           sourceRevision: 'sha256:recovered',
           lastRefreshIdempotencyKey: 'refresh-recover-001',
           summary: { cellCount: 1, valueCount: 1, emptyCount: 0, invalidCount: 0 },
           cells: [],
           annualCells: [],
-          ...override,
+          projectId: 'p999',
         },
       })),
     });
@@ -393,6 +384,54 @@ describe('sheets cashflow readonly client', () => {
       idempotencyKey: 'refresh-recover-001',
       client,
     })).rejects.toMatchObject({ code: 'cashflow_sheet_refresh_response_invalid' });
+  });
+
+  it('accepts a server mirror without optional display fields', async () => {
+    const client = asMockClient({
+      post: vi.fn(async () => ({ data: null })),
+      get: vi.fn(async () => ({
+        data: {
+          projectId: 'p001',
+          status: 'FRESH',
+          sourceRevision: 'sha256:recovered',
+        },
+      })),
+    });
+
+    await expect(refreshCashflowSheetLabMirrorViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'user-1', role: 'workspace_user', email: 'user@mysc.co.kr' },
+      projectId: 'p001',
+      value: 'https://docs.google.com/spreadsheets/d/sheet-001/edit',
+      idempotencyKey: 'refresh-recover-001',
+      client,
+    })).resolves.toMatchObject({ projectId: 'p001', sourceRevision: 'sha256:recovered' });
+  });
+
+  it('accepts a committed mirror even when another refresh won the race', async () => {
+    const client = asMockClient({
+      post: vi.fn(async () => ({ data: null })),
+      get: vi.fn(async () => ({
+        data: {
+          projectId: 'p001',
+          status: 'FRESH',
+          sourceRevision: 'sha256:recovered',
+          lastRefreshIdempotencyKey: 'refresh-older',
+          summary: { cellCount: 1, valueCount: 1, emptyCount: 0, invalidCount: 0 },
+          cells: [],
+          annualCells: [],
+        },
+      })),
+    });
+
+    await expect(refreshCashflowSheetLabMirrorViaBff({
+      tenantId: 'mysc',
+      actor: { uid: 'user-1', role: 'workspace_user', email: 'user@mysc.co.kr' },
+      projectId: 'p001',
+      value: 'https://docs.google.com/spreadsheets/d/sheet-001/edit',
+      idempotencyKey: 'refresh-recover-001',
+      client,
+    })).resolves.toMatchObject({ sourceRevision: 'sha256:recovered' });
   });
 
   it('stages the explicitly selected pinned revision through the review endpoint', async () => {

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -419,19 +419,14 @@ export interface CashflowSheetLabMirrorResult {
 
 function isCashflowSheetLabMirrorResult(
   value: unknown,
-  expected: { projectId: string; idempotencyKey?: string },
+  expected: { projectId: string },
 ): value is CashflowSheetLabMirrorResult {
   if (!value || typeof value !== 'object') return false;
   const candidate = value as Partial<CashflowSheetLabMirrorResult>;
   if (candidate.projectId !== expected.projectId) return false;
   if (!['EMPTY', 'FRESH', 'STALE', 'ERROR'].includes(String(candidate.status || ''))) return false;
-  if (expected.idempotencyKey && candidate.lastRefreshIdempotencyKey !== expected.idempotencyKey) return false;
   if (candidate.status === 'FRESH' || candidate.status === 'STALE') {
-    return typeof candidate.sourceRevision === 'string'
-      && candidate.sourceRevision.length > 0
-      && Array.isArray(candidate.cells)
-      && Array.isArray(candidate.annualCells)
-      && Boolean(candidate.summary && typeof candidate.summary === 'object');
+    return typeof candidate.sourceRevision === 'string' && candidate.sourceRevision.length > 0;
   }
   return true;
 }
@@ -564,12 +559,6 @@ export interface CashflowSheetLabStageResult {
   }>;
   pendingApprovalDifferenceCount?: number;
   pendingApprovalDifferenceManifestHash?: string;
-  withdrawnUnsupportedCloseRequests?: Array<{
-    requestId: string;
-    yearMonth: string;
-    revision: number;
-    reasonCode: 'CUMULATIVE_EVIDENCE_CONTRACT_UNSUPPORTED';
-  }>;
   stagedMonths?: string[];
   stagedYears?: number[];
   annualLineCount?: number;
@@ -873,7 +862,7 @@ export async function refreshCashflowSheetLabMirrorViaBff(params: {
       retries: 0,
     },
   );
-  const expectedMirror = { projectId: params.projectId, idempotencyKey: params.idempotencyKey };
+  const expectedMirror = { projectId: params.projectId };
   if (isCashflowSheetLabMirrorResult(response.data, expectedMirror)) return response.data;
 
   // The refresh command is idempotent and may already be committed even if an

--- a/src/app/platform/api-error-messages.ts
+++ b/src/app/platform/api-error-messages.ts
@@ -20,8 +20,32 @@ const presentations = new Map<string, ApiErrorPresentation>([
     guide: '월 결산을 맡을 조직장이 지정되지 않았어요. 프로젝트에서 조직장을 지정해 주세요.',
     resolution: 'contact',
   }],
+  ['cashflow_month_close_approver_locked', {
+    guide: '승인 대기 중인 월 결산이 있어 조직장을 바꿀 수 없어요. 현재 결재를 먼저 마친 뒤 다시 지정해 주세요.',
+    resolution: 'wait',
+  }],
+  ['cashflow_pending_approval_contract_unsupported', {
+    guide: '기존 결재 요청의 근거 형식을 확인할 수 없어요. 결재 요청을 먼저 정리한 뒤 시트 값을 다시 불러와 주세요.',
+    resolution: 'contact',
+  }],
+  ['cashflow_sheet_refresh_response_invalid', {
+    guide: '시트 값은 저장됐지만 화면 확인이 끝나지 않았어요. 최신 시트 값을 다시 불러와 주세요.',
+    resolution: 'retry',
+  }],
   ['cashflow_sheet_mirror_revision_conflict', {
     guide: '검토한 뒤 시트 고정본이 변경됐어요. 최신 시트 내용을 다시 검토해 주세요.',
+    resolution: 'contact',
+  }],
+  ['cashflow_sheet_template_unsupported', {
+    guide: '시트 양식이 표준과 달라요. cashflow(사용내역 연동) 탭의 고정된 행과 열을 확인한 뒤 다시 불러와 주세요.',
+    resolution: 'contact',
+  }],
+  ['cashflow_sheet_config_required', {
+    guide: '먼저 프로젝트의 시트 링크와 탭 이름을 저장해 주세요.',
+    resolution: 'contact',
+  }],
+  ['cashflow_sheet_mirror_required', {
+    guide: '먼저 시트 값을 가져와 최신 고정본을 만든 뒤 진행해 주세요.',
     resolution: 'contact',
   }],
   ['jvm_weekly_api_identity_token_unavailable', {


### PR DESCRIPTION
## Summary
- stop frontend from rejecting a valid committed sheet mirror when another refresh wins the race
- remove duplicate cashflow close hash/month calculation implementations
- remove automatic withdrawal of pending month-close requests during sheet staging
- map cashflow sheet/approver errors to user guidance

## Verification
- targeted Vitest: 161 passed after rerun (one transient socket hang up, then server suite 117/117)
- typecheck: passed
- production build: passed
- git diff --check: passed

## Rollout note
This PR does not remove persistence/audit stages used by the authoritative apply path. Those require measured production read/write counts and a separate migration.
