### PR TITLE
Simplify cashflow sheet validation pipeline

### DIFF
--- a/server/bff/cashflow-close-calendar.mjs
+++ b/server/bff/cashflow-close-calendar.mjs
@@ -12,6 +12,10 @@ import { cashflowMonthCloseDeadline } from './cashflow-close-deadline.mjs';
 export const CASHFLOW_CUMULATIVE_CLOSE_CONTRACT = 'cashflow-cumulative-close-v2';
 export const CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH = '2023-01';
 
+function text(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
 export function monthsBetween(startYearMonth, endYearMonth) {
   const result = [];
   let cursor = new Date(`${startYearMonth}-01T00:00:00Z`);
@@ -41,6 +45,60 @@ export function cumulativeCloseMonthsOrNull(yearMonth) {
     return null;
   }
   return months;
+}
+
+/**
+ * 누적 결산 문서의 공통 범위 계약.
+ * cycleYearMonth 는 결산 회차, throughMonth 는 실제로 잠그는 마지막 월이다.
+ */
+export function cashflowCumulativeCloseScope(cycleYearMonth, throughMonth = previousYearMonth(cycleYearMonth)) {
+  const months = monthsBetween(CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH, throughMonth);
+  if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(String(cycleYearMonth))
+    || !/^20\d{2}-(0[1-9]|1[0-2])$/.test(String(throughMonth))
+    || throughMonth !== previousYearMonth(cycleYearMonth)
+    || months.length === 0
+    || months.at(-1) !== throughMonth) return null;
+  return {
+    contractVersion: CASHFLOW_CUMULATIVE_CLOSE_CONTRACT,
+    fromMonth: CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH,
+    cycleYearMonth,
+    throughMonth,
+    monthCount: months.length,
+    weekCount: months.length * 5,
+    cellCount: months.length * 160,
+  };
+}
+
+/** 저장 문서의 새 scope와 레거시 top-level 필드를 동일한 계약으로 읽는다. */
+export function readCashflowCumulativeCloseScope(record = {}) {
+  const nested = record?.scope && typeof record.scope === 'object' ? record.scope : {};
+  const explicitCycleYearMonth = text(nested.cycleYearMonth) || text(record.cycleYearMonth);
+  const explicitThroughMonth = text(nested.throughMonth) || text(record.throughMonth);
+  const cycleYearMonth = explicitCycleYearMonth || text(record.yearMonth);
+  // Older requests stored `yearMonth` as the last covered month. Keep reading
+  // those documents as-is; only the explicit v2 scope uses the previous-month
+  // horizon.
+  const legacy = !explicitCycleYearMonth && !explicitThroughMonth && !Object.hasOwn(record, 'scope');
+  const throughMonth = explicitThroughMonth
+    || (legacy ? cycleYearMonth : (cycleYearMonth ? previousYearMonth(cycleYearMonth) : ''));
+  const fromMonth = text(nested.fromMonth) || text(record.fromMonth) || CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH;
+  const contractVersion = text(nested.contractVersion) || text(record.contractVersion);
+  const expected = cashflowCumulativeCloseScope(cycleYearMonth, throughMonth);
+  const legacyRange = /^20\d{2}-(0[1-9]|1[0-2])$/.test(throughMonth)
+    && fromMonth === CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH
+    && monthsBetween(fromMonth, throughMonth).at(-1) === throughMonth;
+  return {
+    contractVersion,
+    fromMonth,
+    cycleYearMonth,
+    throughMonth,
+    monthCount: Number(nested.monthCount ?? record.monthCount),
+    weekCount: Number(nested.weekCount ?? record.weekCount),
+    cellCount: Number(nested.cellCount ?? record.cellCount),
+    validRange: Boolean(expected && fromMonth === expected.fromMonth) || (legacy && legacyRange),
+    strictRange: !legacy,
+    legacy,
+  };
 }
 
 export function cashflowCumulativeCloseCycle(yearMonth, businessDate) {

--- a/server/bff/cashflow-sheet-template.mjs
+++ b/server/bff/cashflow-sheet-template.mjs
@@ -10,6 +10,7 @@ const LINE_ENTRIES = Array.isArray(cashflowPolicyData.lineEntries) ? cashflowPol
 const WEEK_COLUMN_INDEXES = Array.from({ length: 60 }, (_, index) => index + 4); // E:BL
 const ANNUAL_COLUMN_INDEXES = [2, 3, 64, 65, 66, 67, 68, 69]; // C:D, BM:BR
 const SOURCE_YEAR_TOTAL_COLUMN_INDEX = 70; // BS
+export const CASHFLOW_SHEET_CONTRACT = 'cashflow-sheet-v1';
 const SECTION_LAYOUTS = [
   {
     mode: 'projection',
@@ -322,9 +323,17 @@ export function analyzeCashflowSheetTemplate(matrix) {
     && Number.isSafeInteger(sections[0].weeklyYear)
     ? sections[0].weeklyYear
     : undefined;
+  const contract = Number.isSafeInteger(weeklyYear) ? {
+    contractVersion: CASHFLOW_SHEET_CONTRACT,
+    weeklyYear,
+    weeklyColumnIndexes: WEEK_COLUMN_INDEXES,
+    annualColumnIndexes: ANNUAL_COLUMN_INDEXES,
+    annualYears: annualYearsFor(weeklyYear),
+  } : null;
   return {
     supported: reasons.length === 0,
     weeklyYear,
+    contract,
     policyVersion: cashflowPolicyData.version || 'cashflow-policy-v1',
     sectionOrder: ['projection', 'actual'],
     sections,

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -25,8 +25,11 @@ import { stableStringify } from '../utils.mjs';
 import { cashflowApplyLeaseMs, readCashflowApplyLeaseState } from '../cashflow-apply-lease.mjs';
 import { cashflowCloseHash } from '../cashflow-close-hash.mjs';
 import {
+  CASHFLOW_CUMULATIVE_CLOSE_CONTRACT,
   CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH,
+  readCashflowCumulativeCloseScope,
   monthsBetween,
+  previousYearMonth,
 } from '../cashflow-close-calendar.mjs';
 import { getMonthFinanceWeeks } from '../../../src/app/platform/cashflow-week-core.mjs';
 import {
@@ -54,7 +57,6 @@ const CASHFLOW_SHEET_STAGE_YEARS_COLLECTION_ID = 'cashflow_sheet_stage_years';
 const CASHFLOW_MODES = ['projection', 'actual'];
 const CASHFLOW_SHEET_SOURCE_KEY = 'cashflow-sheet-lab';
 const CASHFLOW_SHEET_APPLY_COMMAND = 'weeklyExpense.cashflowSheetLab.apply';
-const CASHFLOW_CUMULATIVE_CLOSE_CONTRACT = 'cashflow-cumulative-close-v2';
 const CASHFLOW_ACTIVE_CLOSE_REQUEST_STATUSES = new Set(['PENDING', 'APPROVING', 'UNCERTAIN']);
 const CASHFLOW_LINE_ORDER = new Map(CASHFLOW_ALL_LINES.map((lineId, index) => [lineId, index]));
 const FINANCIAL_YEAR_FIELDS = [
@@ -667,10 +669,8 @@ function selectCanonicalAnnualCells(cells = []) {
 }
 
 function mergeCashflowSourceMirror(previous, next, sourceYear) {
-  const weeklyYears = [...new Set((next.cells || [])
-    .map((cell) => Number(readOptionalText(cell?.yearMonth).slice(0, 4)))
-    .filter(Number.isSafeInteger))];
-  if (weeklyYears.some((year) => year !== sourceYear)) {
+  const sheetWeeklyYear = Number(next?.sheetContract?.weeklyYear ?? next?.weeklyYear);
+  if (sheetWeeklyYear !== sourceYear) {
     throw createHttpError(
       400,
       `${sourceYear}년 시트에는 ${sourceYear}-1-1 형식의 주차만 사용할 수 있습니다.`,
@@ -1763,7 +1763,7 @@ async function readCanonicalClosedCashflowMonths({ db, tenantId, projectId, year
   const head = headSnap.exists ? headSnap.data() || {} : {};
   const closedThrough = readOptionalText(head.closedThrough);
   if (headSnap.exists && (
-    readOptionalText(head.contractVersion) !== 'cashflow-cumulative-close-v2'
+    readOptionalText(head.contractVersion) !== CASHFLOW_CUMULATIVE_CLOSE_CONTRACT
     || readOptionalText(head.tenantId) !== tenantId
     || readOptionalText(head.projectId) !== projectId
     || !/^20\d{2}-(0[1-9]|1[0-2])$/.test(closedThrough)
@@ -1970,16 +1970,18 @@ async function buildPinnedAnnualChangeCandidates({
   now,
   forceFullReplacement = false,
 }) {
-  const weeklyYears = new Set((mirror?.cells || [])
-    .map((cell) => Number(readOptionalText(cell?.yearMonth).slice(0, 4)))
-    .filter(Number.isSafeInteger));
+  const weeklyYear = Number(mirror?.sheetContract?.weeklyYear ?? mirror?.weeklyYear);
+  const contractAnnualYears = Array.isArray(mirror?.sheetContract?.annualYears)
+    ? mirror.sheetContract.annualYears.map(Number).filter(Number.isSafeInteger)
+    : [];
   const annualYears = [...new Set((mirror?.annualCells || [])
     .map((cell) => Number(cell?.year))
-    .filter(Number.isSafeInteger))].sort((left, right) => left - right);
-  const years = annualYears.filter((year) => !weeklyYears.has(year));
+    .filter((year) => Number.isSafeInteger(year)
+      && (contractAnnualYears.length === 0 || contractAnnualYears.includes(year))
+      && year !== weeklyYear))].sort((left, right) => left - right);
   const documents = [];
   const candidates = [];
-  for (const year of years) {
+  for (const year of annualYears) {
     const sourceCells = (mirror?.annualCells || []).filter((cell) => Number(cell?.year) === year);
     const validated = validateCompletePinnedYear(year, sourceCells);
     if (!validated.ok) {
@@ -2079,6 +2081,28 @@ function buildPendingApprovalAffectedMonths(differences = []) {
   return [...byMonth.values()].sort((left, right) => left.yearMonth.localeCompare(right.yearMonth));
 }
 
+function pendingApprovalIssueMonths(request, candidates) {
+  const candidateMonths = [...new Set(candidates
+    .map((candidate) => readOptionalText(candidate.yearMonth))
+    .filter((yearMonth) => /^20\d{2}-(0[1-9]|1[0-2])$/.test(yearMonth)))].sort();
+  const throughMonth = readCashflowCumulativeCloseScope(request).throughMonth;
+  if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(throughMonth)) return candidateMonths;
+  return candidateMonths.filter((yearMonth) => yearMonth <= throughMonth);
+}
+
+function pendingApprovalContractIssue({ request, candidates, blockAllCandidates = false }) {
+  const blockedMonths = pendingApprovalIssueMonths(request, candidates);
+  const throughMonth = readCashflowCumulativeCloseScope(request).throughMonth;
+  return {
+    requestId: readOptionalText(request?.requestId) || 'unknown',
+    yearMonth: readOptionalText(request?.yearMonth) || undefined,
+    blockedMonths,
+    blockAllCandidates: Boolean(blockAllCandidates || !/^20\d{2}-(0[1-9]|1[0-2])$/.test(throughMonth)),
+    reasonCode: 'cashflow_pending_approval_contract_unsupported',
+    message: '시트 양식은 정상입니다. 기존 결재 요청의 근거 형식을 확인할 수 없어 해당 월은 반영하지 않았습니다. 결재 요청을 확인한 뒤 다시 시도해 주세요.',
+  };
+}
+
 async function readPendingApprovalDifferences({ db, tenantId, projectId, candidates = [] }) {
   const requestSnapshot = await db.collection(`orgs/${tenantId}/cashflow_month_close_requests`)
     .where('projectId', '==', projectId)
@@ -2089,77 +2113,87 @@ async function readPendingApprovalDifferences({ db, tenantId, projectId, candida
     .sort((left, right) => readOptionalText(left.requestId).localeCompare(readOptionalText(right.requestId)));
   const evidence = [];
   const differences = [];
+  const contractIssues = [];
   for (const request of requests) {
     const requestId = readOptionalText(request.requestId);
     const revision = Number(request.revision);
-    const fromMonth = readOptionalText(request.fromMonth);
-    const throughMonth = readOptionalText(request.yearMonth);
+    const scope = readCashflowCumulativeCloseScope(request);
+    const fromMonth = scope.fromMonth;
+    const cycleYearMonth = scope.cycleYearMonth;
+    const throughMonth = scope.throughMonth;
     const months = cumulativeCloseMonths(fromMonth, throughMonth);
     const incompleteHeader = (
-      request.contractVersion !== CASHFLOW_CUMULATIVE_CLOSE_CONTRACT
+      scope.contractVersion !== CASHFLOW_CUMULATIVE_CLOSE_CONTRACT
       || readOptionalText(request.projectId) !== projectId
       || !requestId
       || !Number.isSafeInteger(revision)
       || revision < 1
       || fromMonth !== CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH
-      || throughMonth > '2099-12'
+      || !/^20\d{2}-(0[1-9]|1[0-2])$/.test(cycleYearMonth)
+      || !/^20\d{2}-(0[1-9]|1[0-2])$/.test(throughMonth)
+      || (scope.strictRange && throughMonth !== previousYearMonth(cycleYearMonth))
       || months.length === 0
       || Number(request.monthCount) !== months.length
       || Number(request.weekCount) !== months.length * 5
       || Number(request.cellCount) !== months.length * 160
     );
     if (incompleteHeader) {
-      throw createHttpError(
-        409,
-        '결재 중인 월 결산 요청의 근거 형식을 확인할 수 없습니다. 결재 요청을 먼저 정리한 뒤 시트 값을 다시 불러와 주세요.',
-        'cashflow_pending_approval_contract_unsupported',
-      );
+      contractIssues.push(pendingApprovalContractIssue({ request, candidates }));
+      continue;
     }
-    const shards = await Promise.all(months.map(async (yearMonth) => {
-      const snapshot = await db.doc(
-        `orgs/${tenantId}/cashflow_month_close_request_months/${requestId}-r${revision}-${yearMonth}`,
-      ).get();
-      const shard = snapshot.exists ? snapshot.data() || {} : null;
-      const cells = Array.isArray(shard?.cells) ? shard.cells : [];
-      const expectedKeys = ['projection', 'actual'].flatMap((mode) => Array.from({ length: 5 }, (_unused, weekIndex) => (
-        CASHFLOW_ALL_LINES.map((lineId) => `${mode}|${weekIndex + 1}|${lineId}`)
-      )).flat());
-      const actualKeys = cells.map((cell) => `${readOptionalText(cell.mode)}|${Number(cell.weekNo)}|${readOptionalText(cell.cashflowLine)}`);
-      const validCells = cells.length === 160 && actualKeys.every((key, index) => key === expectedKeys[index])
-        && cells.every((cell) => (
-          ['EMPTY', 'ZERO', 'VALUE'].includes(readOptionalText(cell.cellState))
-          && (cell.cellState === 'EMPTY'
-            ? cell.amount === null
-            : Number.isSafeInteger(Number(cell.amount))
-              && (cell.cellState === 'ZERO' ? Number(cell.amount) === 0 : Number(cell.amount) !== 0))
-        ));
-      if (
-        !shard
-        || shard.contractVersion !== CASHFLOW_CUMULATIVE_CLOSE_CONTRACT
-        || readOptionalText(shard.requestId) !== requestId
-        || Number(shard.requestRevision) !== revision
-        || readOptionalText(shard.projectId) !== projectId
-        || readOptionalText(shard.yearMonth) !== yearMonth
-        || !validCells
-      ) throw pendingApprovalEvidenceError(`결재 중인 누적 결산 ${yearMonth} shard 구조가 완전하지 않습니다.`);
-      const { shardHash, ...base } = shard;
-      if (readOptionalText(shardHash) !== cashflowCloseHash(base)) {
-        throw pendingApprovalEvidenceError(`결재 중인 누적 결산 ${yearMonth} shard hash가 일치하지 않습니다.`);
+    let shards;
+    let manifestHash;
+    try {
+      shards = await Promise.all(months.map(async (yearMonth) => {
+        const snapshot = await db.doc(
+          `orgs/${tenantId}/cashflow_month_close_request_months/${requestId}-r${revision}-${yearMonth}`,
+        ).get();
+        const shard = snapshot.exists ? snapshot.data() || {} : null;
+        const cells = Array.isArray(shard?.cells) ? shard.cells : [];
+        const expectedKeys = ['projection', 'actual'].flatMap((mode) => Array.from({ length: 5 }, (_unused, weekIndex) => (
+          CASHFLOW_ALL_LINES.map((lineId) => `${mode}|${weekIndex + 1}|${lineId}`)
+        )).flat());
+        const actualKeys = cells.map((cell) => `${readOptionalText(cell.mode)}|${Number(cell.weekNo)}|${readOptionalText(cell.cashflowLine)}`);
+        const validCells = cells.length === 160 && actualKeys.every((key, index) => key === expectedKeys[index])
+          && cells.every((cell) => (
+            ['EMPTY', 'ZERO', 'VALUE'].includes(readOptionalText(cell.cellState))
+            && (cell.cellState === 'EMPTY'
+              ? cell.amount === null
+              : Number.isSafeInteger(Number(cell.amount))
+                && (cell.cellState === 'ZERO' ? Number(cell.amount) === 0 : Number(cell.amount) !== 0))
+          ));
+        if (
+          !shard
+          || shard.contractVersion !== CASHFLOW_CUMULATIVE_CLOSE_CONTRACT
+          || readOptionalText(shard.requestId) !== requestId
+          || Number(shard.requestRevision) !== revision
+          || readOptionalText(shard.projectId) !== projectId
+          || readOptionalText(shard.yearMonth) !== yearMonth
+          || !validCells
+        ) throw pendingApprovalEvidenceError(`결재 중인 누적 결산 ${yearMonth} 근거 구조가 완전하지 않습니다.`);
+        const { shardHash, ...base } = shard;
+        if (readOptionalText(shardHash) !== cashflowCloseHash(base)) {
+          throw pendingApprovalEvidenceError(`결재 중인 누적 결산 ${yearMonth} 근거 hash가 일치하지 않습니다.`);
+        }
+        return shard;
+      }));
+      const manifest = {
+        contractVersion: CASHFLOW_CUMULATIVE_CLOSE_CONTRACT,
+        requestId,
+        requestRevision: revision,
+        projectId,
+        fromMonth,
+        yearMonth: cycleYearMonth,
+        months: shards.map((shard) => ({ yearMonth: shard.yearMonth, shardHash: shard.shardHash })),
+      };
+      manifestHash = cashflowCloseHash(manifest);
+      if (manifestHash !== readOptionalText(request.manifestHash)) {
+        throw pendingApprovalEvidenceError('결재 중인 누적 결산 manifest hash가 일치하지 않습니다.');
       }
-      return shard;
-    }));
-    const manifest = {
-      contractVersion: CASHFLOW_CUMULATIVE_CLOSE_CONTRACT,
-      requestId,
-      requestRevision: revision,
-      projectId,
-      fromMonth,
-      yearMonth: throughMonth,
-      months: shards.map((shard) => ({ yearMonth: shard.yearMonth, shardHash: shard.shardHash })),
-    };
-    const manifestHash = cashflowCloseHash(manifest);
-    if (manifestHash !== readOptionalText(request.manifestHash)) {
-      throw pendingApprovalEvidenceError('결재 중인 누적 결산 manifest hash가 일치하지 않습니다.');
+    } catch (error) {
+      if (readOptionalText(error?.code) !== 'cashflow_pending_approval_evidence_stale') throw error;
+      contractIssues.push(pendingApprovalContractIssue({ request, candidates }));
+      continue;
     }
     evidence.push({
       requestId,
@@ -2167,7 +2201,7 @@ async function readPendingApprovalDifferences({ db, tenantId, projectId, candida
       revision,
       manifestHash,
       fromMonth,
-      yearMonth: throughMonth,
+      yearMonth: cycleYearMonth,
       monthCount: months.length,
     });
     const shardByMonth = new Map(shards.map((shard) => [shard.yearMonth, shard]));
@@ -2214,8 +2248,13 @@ async function readPendingApprovalDifferences({ db, tenantId, projectId, candida
   return {
     evidence,
     differences,
+    contractIssues,
+    blockedMonths: [...new Set(contractIssues.flatMap((issue) => issue.blockedMonths || []))].sort(),
+    blockAllCandidates: contractIssues.some((issue) => issue.blockAllCandidates),
     differenceCount: differences.reduce((sum, difference) => sum + difference.differenceCount, 0),
-    manifestHash: `sha256:${stableHash(differences)}`,
+    manifestHash: contractIssues.length > 0
+      ? `sha256:${stableHash({ differences, contractIssues })}`
+      : `sha256:${stableHash(differences)}`,
   };
 }
 
@@ -3019,29 +3058,16 @@ async function applyStagedCashflowSheetLab({
     ) {
       throw createHttpError(409, '검토 당시 고정한 월 시트 revision이 일치하지 않습니다.', 'cashflow_sheet_stage_month_revision_conflict');
     }
-    const validated = validateCompletePinnedMonth(yearMonth, (stagedMonth.cells || []).map((cell) => stripUndefinedDeep({
-      yearMonth,
-      mode: cell.mode,
-      weekNo: cell.weekNo,
-      lineId: cell.cashflowLine,
-      state: cell.cellState,
-      amount: ['VALUE', 'ZERO'].includes(cell.cellState) ? cell.amount : undefined,
-      sourceCell: cell.sourceCell,
-      sourceLabel: cell.sourceLabel,
-    })));
-    if (!validated.ok) {
-      throw createHttpError(409, '검토 당시 고정한 월 시트 구조가 완전하지 않습니다.', 'cashflow_sheet_stage_month_incomplete');
-    }
-    const calculationChecks = monthCalculationChecks(
-      { sheetFacts: { weeklyCalculationChecks: stagedMonth.calculationChecks } },
-      yearMonth,
-    );
-    if (calculationChecks.length !== 10) {
-      throw createHttpError(409, '검토 당시 고정한 월 계산 근거가 완전하지 않습니다. 시트 값을 다시 불러와 주세요.', 'cashflow_sheet_stage_calculation_incomplete');
+    // stage 단계에서 시트 셀·계산 근거를 검증하고 고정한다. apply는 그 고정본과
+    // revision만 확인하고 같은 160셀/10개 계산 검사를 다시 반복하지 않는다.
+    const cells = Array.isArray(stagedMonth.cells) ? stagedMonth.cells : [];
+    const calculationChecks = Array.isArray(stagedMonth.calculationChecks) ? stagedMonth.calculationChecks : [];
+    if (cells.length === 0 || calculationChecks.length !== 10) {
+      throw createHttpError(409, '검토 당시 고정한 시트 근거가 없습니다. 시트 값을 다시 불러와 주세요.', 'cashflow_sheet_stage_evidence_missing');
     }
     return {
       yearMonth,
-      cells: validated.cells,
+      cells,
       calculationChecks,
       apply: selectedMonthSet.has(yearMonth),
     };
@@ -3055,22 +3081,14 @@ async function applyStagedCashflowSheetLab({
     ) {
       throw createHttpError(409, '검토 당시 고정한 연간 합계 revision이 일치하지 않습니다.', 'cashflow_sheet_stage_year_revision_conflict');
     }
-    const validated = validateCompletePinnedYear(year, (stagedYear.cells || []).map((cell) => stripUndefinedDeep({
-      year,
-      mode: cell.mode,
-      lineId: cell.cashflowLine,
-      state: cell.cellState,
-      amount: ['VALUE', 'ZERO'].includes(cell.cellState) ? cell.amount : undefined,
-      sourceCell: cell.sourceCell,
-      sourceLabel: cell.sourceLabel,
-    })));
-    if (!validated.ok) {
-      throw createHttpError(409, '검토 당시 고정한 연간 합계 구조가 완전하지 않습니다.', 'cashflow_sheet_stage_year_incomplete');
+    const cells = Array.isArray(stagedYear.cells) ? stagedYear.cells : [];
+    if (cells.length === 0) {
+      throw createHttpError(409, '검토 당시 고정한 연간 합계가 없습니다. 시트 값을 다시 불러와 주세요.', 'cashflow_sheet_stage_evidence_missing');
     }
     return {
       year,
       expectedRevision: Math.max(0, Number(stagedYear.expectedRevision) || 0),
-      cells: validated.cells,
+      cells,
     };
   }));
   const openingBalanceCells = Array.isArray(stageRun.openingBalanceCells)
@@ -3786,9 +3804,7 @@ async function stagePinnedCashflowSheetLab({
   const calculationCells = (mirror.cells || []).filter((cell) => parsed.yearMonth
     ? readOptionalText(cell.yearMonth) >= '2023-01' && readOptionalText(cell.yearMonth) <= parsed.yearMonth
     : Number(readOptionalText(cell.yearMonth).slice(0, 4)) === stageYear);
-  const pinnedCells = parsed.yearMonth
-    ? calculationCells
-    : calculationCells;
+  const pinnedCells = calculationCells;
   const pinnedMonths = [...groupPinnedCellsByMonth(pinnedCells).keys()].sort();
   const calculationSourceMonths = [...groupPinnedCellsByMonth(calculationCells).keys()].sort();
   const firstWeeklyYear = calculationSourceMonths[0]?.endsWith('-01')
@@ -3856,12 +3872,24 @@ async function stagePinnedCashflowSheetLab({
   const pendingApproval = await readPendingApprovalDifferences({
     db, tenantId, projectId, candidates,
   });
-  const blockedMonths = weekly.blockedMonths;
-  const riskLineCount = weekly.riskLineCount;
-  const projectionLineCount = candidates.filter((candidate) => candidate.mode === 'projection').length;
-  const actualLineCount = candidates.filter((candidate) => candidate.mode === 'actual').length;
+  const pendingBlockedMonths = new Set(pendingApproval.blockedMonths || []);
+  const candidatesForStage = candidates.filter((candidate) => {
+    if (pendingApproval.blockAllCandidates) return false;
+    if (readOptionalText(candidate.scope) === 'annual') return true;
+    return !pendingBlockedMonths.has(readOptionalText(candidate.yearMonth));
+  });
+  const annualForStage = pendingApproval.blockAllCandidates
+    ? { candidates: [], documents: [], stagedYears: [] }
+    : annual;
+  const blockedMonths = [...new Set([
+    ...weekly.blockedMonths,
+    ...pendingApproval.blockedMonths,
+  ])].sort();
+  const riskLineCount = candidatesForStage.filter((candidate) => Array.isArray(candidate.riskFlags) && candidate.riskFlags.length > 0).length;
+  const projectionLineCount = candidatesForStage.filter((candidate) => candidate.mode === 'projection').length;
+  const actualLineCount = candidatesForStage.filter((candidate) => candidate.mode === 'actual').length;
   const cellsByMonth = groupPinnedCellsByMonth(calculationCells);
-  const stagedMonths = [...new Set(candidates
+  const stagedMonths = [...new Set(candidatesForStage
     .map((candidate) => readOptionalText(candidate.yearMonth))
     .filter(Boolean))].sort();
   const lastStagedMonth = stagedMonths.at(-1) || '';
@@ -3888,7 +3916,7 @@ async function stagePinnedCashflowSheetLab({
       now,
     });
   });
-  const responseCandidates = candidates.slice(0, 500);
+  const responseCandidates = candidatesForStage.slice(0, 500);
   const closedMonthDifferenceCount = weekly.closedMonthDifferences.reduce((sum, month) => sum + month.differenceCount, 0);
   const closedMonthDifferenceManifestHash = `sha256:${stableHash(weekly.closedMonthDifferences)}`;
   const response = {
@@ -3904,8 +3932,8 @@ async function stagePinnedCashflowSheetLab({
     replaceAllActualSources: Boolean(parsed.replaceAllActualSources),
     activeWeekRange: mirror.activeWeekRange,
     runId,
-    status: blockedMonths.length > 0 ? 'BLOCKED' : candidates.length === 0 ? 'NO_CHANGES' : 'READY',
-    stagedLineCount: candidates.length,
+    status: blockedMonths.length > 0 || pendingApproval.contractIssues.length > 0 ? 'BLOCKED' : candidatesForStage.length === 0 ? 'NO_CHANGES' : 'READY',
+    stagedLineCount: candidatesForStage.length,
     projectionLineCount,
     actualLineCount,
     riskLineCount,
@@ -3916,12 +3944,13 @@ async function stagePinnedCashflowSheetLab({
     pendingApprovalDifferences: pendingApproval.differences,
     pendingApprovalDifferenceCount: pendingApproval.differenceCount,
     pendingApprovalDifferenceManifestHash: pendingApproval.manifestHash,
+    pendingApprovalContractIssues: pendingApproval.contractIssues,
     stagedMonths,
     calculationMonths,
-    stagedYears: annual.stagedYears,
-    annualLineCount: annual.candidates.length,
+    stagedYears: annualForStage.stagedYears,
+    annualLineCount: annualForStage.candidates.length,
     candidates: responseCandidates,
-    omittedCandidateCount: Math.max(0, candidates.length - responseCandidates.length),
+    omittedCandidateCount: Math.max(0, candidatesForStage.length - responseCandidates.length),
     lastStagedAt: now,
     lastStagedBy: {
       uid: readOptionalText(context?.actorId),
@@ -3941,7 +3970,7 @@ async function stagePinnedCashflowSheetLab({
     targetRevisionAtFetch: mirror.targetRevisionAtFetch,
     replaceAllActualSources: Boolean(parsed.replaceAllActualSources),
     status: response.status,
-    stagedLineCount: candidates.length,
+    stagedLineCount: candidatesForStage.length,
     blockedMonths,
     closedMonthDifferences: weekly.closedMonthDifferences,
     closedMonthDifferenceCount,
@@ -3950,9 +3979,10 @@ async function stagePinnedCashflowSheetLab({
     pendingApprovalDifferences: pendingApproval.differences,
     pendingApprovalDifferenceCount: pendingApproval.differenceCount,
     pendingApprovalDifferenceManifestHash: pendingApproval.manifestHash,
+    pendingApprovalContractIssues: pendingApproval.contractIssues,
     stagedMonths,
     calculationMonths,
-    stagedYears: annual.stagedYears,
+    stagedYears: annualForStage.stagedYears,
     openingBalanceCells,
     appliedAnnualYears: Array.isArray(mirror.appliedAnnualYears) ? mirror.appliedAnnualYears.map(Number) : [],
     appliedWeeklyYears: Array.isArray(mirror.appliedWeeklyYears) ? mirror.appliedWeeklyYears.map(Number) : [],
@@ -4005,11 +4035,11 @@ async function stagePinnedCashflowSheetLab({
         }, { merge: true });
       });
     } else {
-      await saveCashflowChangeCandidates({ db, tenantId, candidates });
+      await saveCashflowChangeCandidates({ db, tenantId, candidates: candidatesForStage });
       await Promise.all(stagedMonthDocuments.map((month) => db
         .doc(cashflowSheetStageMonthDocPath(tenantId, runId, month.yearMonth))
         .set(month)));
-      await Promise.all(annual.documents.map((yearDocument) => db
+      await Promise.all(annualForStage.documents.map((yearDocument) => db
         .doc(cashflowSheetStageYearDocPath(tenantId, runId, yearDocument.year))
         .set(yearDocument)));
       await runRef.set(stripUndefinedDeep({
@@ -4039,7 +4069,7 @@ async function stagePinnedCashflowSheetLab({
   logger('ok', {
     projectId,
     sourceRevision: mirror.sourceRevision,
-    stagedLineCount: candidates.length,
+    stagedLineCount: candidatesForStage.length,
     projectionLineCount,
     actualLineCount,
     riskCount: riskLineCount,
@@ -4371,6 +4401,7 @@ export function mountCashflowSheetLabRoutes(app, {
         },
       }));
       mirror.weeklyYear = template.weeklyYear;
+      mirror.sheetContract = template.contract;
       mirror.activeWeekRange = {
         startWeek: weekRange.startWeek,
         endWeek: weekRange.endWeek,
@@ -4572,157 +4603,6 @@ export function mountCashflowSheetLabRoutes(app, {
     };
   };
 
-  const syncCashflowSheetProject = async ({
-    tenantId,
-    projectId,
-    runId,
-    context,
-    apply = false,
-  } = {}) => {
-    if (!authoritativeJavaClient) {
-      throw createHttpError(503, 'JVM cashflow API is not configured.', 'jvm_weekly_api_unconfigured');
-    }
-    const project = await readProjectDocument(db, tenantId, projectId);
-    const configs = readCashflowSheetLabConfigs(project);
-    if (configs.length === 0) {
-      throw createHttpError(400, 'Cashflow sheet URL is not configured.', 'cashflow_sheet_config_required');
-    }
-    const actorContext = context || {
-      tenantId,
-      actorId: 'cashflow-sheet-sync',
-      actorRole: 'admin',
-      actorEmail: 'cashflow-sheet-sync@mysc.co.kr',
-      requestId: runId,
-    };
-    const requestLike = (sourceYear, operation) => ({
-      context: actorContext,
-      requestId: actorContext.requestId,
-      params: { projectId },
-      body: {
-        sourceYear,
-        idempotencyKey: `${runId}:${projectId}:${operation}:${sourceYear}`,
-      },
-    });
-    let pendingChangeCount = 0;
-    let projectionChangeCount = 0;
-    let actualChangeCount = 0;
-    let appliedCount = 0;
-    let blocked = false;
-    let sourceRevision = '';
-    let targetRevision = '';
-
-    for (const config of configs) {
-      const sourceYear = config.sourceYear;
-      const mirror = await executeCashflowSheetMirrorRefresh(requestLike(sourceYear, 'refresh'));
-      if (readOptionalText(mirror?.status) !== 'FRESH') {
-        const refreshError = mirror?.lastRefreshError || {};
-        throw createHttpError(
-          Number(refreshError.statusCode) || 503,
-          readOptionalText(refreshError.message) || 'Cashflow sheet refresh failed.',
-          readOptionalText(refreshError.code) || 'cashflow_sheet_refresh_failed',
-        );
-      }
-      const beforeReadback = await authoritativeJavaClient.getCashflowSnapshot({
-        context: actorContext,
-        projectId,
-      });
-      if (readOptionalText(beforeReadback?.projectId) !== projectId) {
-        throw createHttpError(502, 'JVM cashflow readback project mismatch.', 'jvm_cashflow_readback_mismatch');
-      }
-      assertJavaCashflowMatchesFirestore(
-        beforeReadback,
-        await readCashflowWeeksSnapshot(db, tenantId, projectId),
-      );
-      const stage = await stagePinnedCashflowSheetLab({
-        db,
-        tenantId,
-        projectId,
-        parsed: {
-          expectedMirrorRevision: mirror.sourceRevision,
-          idempotencyKey: `${runId}:${projectId}:stage:${sourceYear}`,
-        },
-        context: actorContext,
-      });
-      pendingChangeCount += Math.max(0, Number(stage.stagedLineCount) || 0);
-      projectionChangeCount += Math.max(0, Number(stage.projectionLineCount) || 0);
-      actualChangeCount += Math.max(0, Number(stage.actualLineCount) || 0);
-      sourceRevision = readOptionalText(stage.sourceRevision);
-      targetRevision = readOptionalText(stage.targetRevisionAtFetch);
-
-      if (!apply || stage.status === 'NO_CHANGES') continue;
-      if (stage.status !== 'READY') {
-        blocked = true;
-        continue;
-      }
-      if (!javaWeeklyClient) assertCashflowMutationRuntime({}, env);
-      await applyStagedCashflowSheetLab({
-        db,
-        tenantId,
-        projectId,
-        parsed: {
-          stageRunId: stage.runId,
-          idempotencyKey: `${runId}:${projectId}:apply:${sourceYear}`,
-        },
-        context: actorContext,
-        javaWeeklyClient: authoritativeJavaClient,
-        editSession: null,
-        resolveEditSession: null,
-        idempotencyKey: `${runId}:${projectId}:apply:${sourceYear}`,
-      });
-      const afterReadback = await authoritativeJavaClient.getCashflowSnapshot({
-        context: actorContext,
-        projectId,
-      });
-      if (readOptionalText(afterReadback?.projectId) !== projectId) {
-        throw createHttpError(502, 'JVM cashflow readback project mismatch.', 'jvm_cashflow_readback_mismatch');
-      }
-      assertJavaCashflowMatchesFirestore(
-        afterReadback,
-        await readCashflowWeeksSnapshot(db, tenantId, projectId),
-      );
-      const verificationMirror = await executeCashflowSheetMirrorRefresh(
-        requestLike(sourceYear, 'verify-refresh'),
-      );
-      if (readOptionalText(verificationMirror?.status) !== 'FRESH') {
-        throw createHttpError(503, 'Post-apply sheet refresh failed.', 'cashflow_sheet_post_apply_refresh_failed');
-      }
-      const verificationStage = await stagePinnedCashflowSheetLab({
-        db,
-        tenantId,
-        projectId,
-        parsed: {
-          expectedMirrorRevision: verificationMirror.sourceRevision,
-          idempotencyKey: `${runId}:${projectId}:verify-stage:${sourceYear}`,
-        },
-        context: actorContext,
-      });
-      if (verificationStage.status !== 'NO_CHANGES') {
-        throw createHttpError(
-          503,
-          'Post-apply JVM readback does not match the pinned sheet.',
-          'cashflow_sheet_post_apply_mismatch',
-        );
-      }
-      sourceRevision = readOptionalText(verificationStage.sourceRevision);
-      targetRevision = readOptionalText(verificationStage.targetRevisionAtFetch);
-      appliedCount += 1;
-    }
-
-    return {
-      status: pendingChangeCount === 0 ? 'SYNCED' : blocked ? 'BLOCKED' : apply ? 'APPLIED' : 'CHANGED',
-      changedCount: pendingChangeCount,
-      pendingChangeCount,
-      projectionChangeCount,
-      actualChangeCount,
-      appliedCount,
-      sourceRevision,
-      targetRevision,
-      checkedAt: new Date().toISOString(),
-    };
-  };
-
-  // 진입 전용 경량 변경 감지. 검색엔진 원칙: 진입은 인덱스(고정본)만 읽고, 크롤(시트 풀
-  // 리드 + 3방향 diff)은 사용자가 '시트 불러오기'를 누를 때만 한다. 여기서는 Drive
   // modifiedTime(~수십 ms)만 저장된 고정본과 대조해 "변경됨/없음"만 판정한다 - 건수·diff
   // 는 계산하지 않는다. 판정 불능(probe 실패, 미러 없음)은 보수적으로 "불러오기 필요"로
   // 기울인다 - 낡은 값을 최신이라 말하지 않는다.
@@ -4944,5 +4824,5 @@ export function mountCashflowSheetLabRoutes(app, {
     }
   }));
 
-  return { compareProject: compareCashflowSheetProject, syncProject: syncCashflowSheetProject };
+  return { compareProject: compareCashflowSheetProject };
 }

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -90,8 +90,8 @@ function cumulativeMonths(throughMonth) {
   return months;
 }
 
-function cumulativeCloseRequestDocuments({ status = 'PENDING', throughMonth = '2026-01' } = {}) {
-  const requestId = `project-a-${throughMonth}`;
+function cumulativeCloseRequestDocuments({ status = 'PENDING', throughMonth = '2026-01', cycleYearMonth = throughMonth } = {}) {
+  const requestId = `project-a-${cycleYearMonth}`;
   const revision = 1;
   const source = { kind: 'PINNED_MIRROR', sourceRevision: 'source-a', targetRevision: 'target-a' };
   const shards = cumulativeMonths(throughMonth).map((yearMonth) => {
@@ -124,7 +124,7 @@ function cumulativeCloseRequestDocuments({ status = 'PENDING', throughMonth = '2
     requestRevision: revision,
     projectId: 'project-a',
     fromMonth: '2023-01',
-    yearMonth: throughMonth,
+    yearMonth: cycleYearMonth,
     months: shards.map((shard) => ({ yearMonth: shard.yearMonth, shardHash: shard.shardHash })),
   };
   return Object.fromEntries([
@@ -134,7 +134,8 @@ function cumulativeCloseRequestDocuments({ status = 'PENDING', throughMonth = '2
       tenantId: 'tenant-a',
       projectId: 'project-a',
       fromMonth: '2023-01',
-      yearMonth: throughMonth,
+      yearMonth: cycleYearMonth,
+      ...(cycleYearMonth !== throughMonth ? { throughMonth } : {}),
       status,
       revision,
       manifestHash: closeHash(manifest),
@@ -3088,11 +3089,40 @@ describe('cashflow sheet lab route', () => {
     expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(1);
   });
 
+  it('accepts the canonical cycle month plus separate throughMonth contract', async () => {
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        cashflowSheetLab: { value: 'saved-spreadsheet-a', sheetName: 'cashflow(사용내역 연동)' },
+      },
+      initialDocuments: cumulativeCloseRequestDocuments({ throughMonth: '2026-07', cycleYearMonth: '2026-08' }),
+    });
+    const app = createApp({
+      db,
+      googleSheetsService: {
+        previewSpreadsheet: vi.fn(async () => ({
+          spreadsheetId: 'spreadsheet-a',
+          selectedSheetName: 'cashflow(사용내역 연동)',
+          availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
+          matrix: buildMatrixWithWeekLabels(JANUARY_FINANCE_WEEKS),
+        })),
+      },
+    });
+    const mirror = await request(app).post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'refresh-canonical-horizon' }).expect(200);
+    const stage = await request(app).post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+      .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-08', idempotencyKey: 'stage-canonical-horizon' })
+      .expect(200);
+
+    expect(stage.body.pendingApprovalContractIssues).toEqual([]);
+  });
+
   it('does not mutate a malformed legacy PENDING close during sheet staging', async () => {
     const documents = cumulativeCloseRequestDocuments();
     const requestPath = 'orgs/tenant-a/cashflow_month_close_requests/project-a-2026-01';
     documents[requestPath] = {
       ...documents[requestPath],
+      fromMonth: '24-1-1',
       monthCount: 0,
       requestedByUid: 'pm-a',
     };
@@ -3119,9 +3149,16 @@ describe('cashflow sheet lab route', () => {
       .send({ idempotencyKey: 'refresh-malformed-close' }).expect(200);
     const stage = await request(app).post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
       .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-01', idempotencyKey: 'stage-malformed-close' })
-      .expect(409);
+      .expect(200);
 
-    expect(stage.body.code).toBe('cashflow_pending_approval_contract_unsupported');
+    expect(stage.body.status).toBe('BLOCKED');
+    expect(stage.body.pendingApprovalContractIssues).toEqual([expect.objectContaining({
+      requestId: 'project-a-2026-01',
+      reasonCode: 'cashflow_pending_approval_contract_unsupported',
+      blockedMonths: ['2026-01'],
+    })]);
+    expect(stage.body.stagedLineCount).toBe(0);
+    expect(stage.body.candidates).toEqual([]);
     expect(db.__getDocument(requestPath)).toMatchObject({
       status: 'PENDING', monthCount: 0,
     });

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -38,6 +38,7 @@ import {
 import {
   CASHFLOW_CUMULATIVE_CLOSE_CONTRACT,
   CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH,
+  cashflowCumulativeCloseScope,
   cashflowCumulativeCloseCycle,
   cumulativeCloseMonthsOrNull,
   monthsBetween,
@@ -208,15 +209,31 @@ export function buildCashflowMonthCloseRevisionChanges(previousCells, currentCel
 
 function cashflowMonthCloseRequestView(record, partyNames = {}) {
   if (record.contractVersion === CASHFLOW_CUMULATIVE_CLOSE_CONTRACT) {
-    const throughMonth = readOptionalText(record.throughMonth) || record.yearMonth;
+    const scope = record.scope && typeof record.scope === 'object' ? record.scope : {};
+    const cycleYearMonth = readOptionalText(scope.cycleYearMonth)
+      || readOptionalText(record.cycleYearMonth)
+      || record.yearMonth;
+    const throughMonth = readOptionalText(scope.throughMonth)
+      || readOptionalText(record.throughMonth)
+      || record.yearMonth;
     return {
       documentType: 'MONTHLY_CLOSE',
       contractVersion: record.contractVersion,
       requestId: record.requestId,
       projectId: record.projectId,
-      yearMonth: record.yearMonth,
+      yearMonth: cycleYearMonth,
+      cycleYearMonth,
       throughMonth,
-      fromMonth: record.fromMonth,
+      fromMonth: readOptionalText(scope.fromMonth) || record.fromMonth,
+      scope: {
+        contractVersion: record.contractVersion,
+        fromMonth: readOptionalText(scope.fromMonth) || record.fromMonth,
+        cycleYearMonth,
+        throughMonth,
+        monthCount: Number(scope.monthCount ?? record.monthCount),
+        weekCount: Number(scope.weekCount ?? record.weekCount),
+        cellCount: Number(scope.cellCount ?? record.cellCount),
+      },
       status: record.status,
       revision: record.revision,
       manifestHash: record.manifestHash,
@@ -240,7 +257,7 @@ function cashflowMonthCloseRequestView(record, partyNames = {}) {
       reviewWarnings: Array.isArray(record.reviewWarnings) ? record.reviewWarnings : [],
       monthSnapshot: null,
       lockRange: {
-        fromMonth: record.fromMonth,
+        fromMonth: readOptionalText(scope.fromMonth) || record.fromMonth,
         fromWeekNo: 1,
         throughMonth,
         throughWeekNo: 5,
@@ -1344,8 +1361,15 @@ function cumulativeCloseMonths(yearMonth) {
 }
 
 function buildCumulativeCloseScope(yearMonth, evidence = null) {
-  const months = cumulativeCloseMonths(yearMonth);
-  const throughMonth = months.at(-1);
+  const contract = cashflowCumulativeCloseScope(yearMonth);
+  if (!contract) {
+    throw createHttpError(
+      400,
+      '누적 월 결산 범위는 2023-01부터 최대 240개월까지 선택할 수 있습니다.',
+      'cashflow_month_close_request_invalid',
+    );
+  }
+  const { contractVersion, fromMonth, throughMonth } = contract;
   const nestedSource = objectValue(evidence?.source) || {};
   const sourceField = (...keys) => {
     for (const key of keys) {
@@ -1355,21 +1379,19 @@ function buildCumulativeCloseScope(yearMonth, evidence = null) {
     return null;
   };
   const spreadsheetId = sourceField('spreadsheetId');
-  const monthCount = months.length;
-  const weekCount = monthCount * 5;
   return {
-    contractVersion: CASHFLOW_CUMULATIVE_CLOSE_CONTRACT,
-    fromMonth: CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH,
+    contractVersion,
+    fromMonth,
     throughMonth,
+    monthCount: contract.monthCount,
+    weekCount: contract.weekCount,
+    cellCount: contract.cellCount,
     lockRange: {
       fromMonth: CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH,
       fromWeekNo: 1,
       throughMonth,
       throughWeekNo: 5,
     },
-    monthCount,
-    weekCount,
-    cellCount: weekCount * CASHFLOW_ALL_LINES.length * 2,
     source: {
       sourceRevision: sourceField('sourceRevision', 'sourceFingerprint'),
       targetRevision: sourceField('targetRevision', 'targetRevisionAtFetch'),
@@ -3252,6 +3274,7 @@ export function mountJvmWeeklyApiRoutes(app, {
         payloadFingerprint: fingerprint,
       };
     };
+    let preserveLegacyShape = false;
     return db.runTransaction(async (transaction) => {
       const settlementStatusRef = db.doc(`orgs/${req.context.tenantId}/cashflow_settlement_statuses/${prepared.rawProjectId}-${yearMonth}`);
       const [projectSnapshot, approverSnapshot, requesterSnapshot, requestSnapshot, settlementStatusSnapshot] = await Promise.all([
@@ -3306,6 +3329,7 @@ export function mountJvmWeeklyApiRoutes(app, {
           && existing.approverUid === approverUid
           && Number(existing.expectedRevision) === prepared.closeBody.expectedRevision;
         if (legacyBuildingReplay) replayEvidence = legacyBuildingEvidence;
+        preserveLegacyShape = legacyBuildingReplay;
         if (
           existing.createIdempotencyKey === req.context.idempotencyKey
           && (existing.requestFingerprint === requestFingerprint || legacyBuildingReplay)
@@ -3340,6 +3364,7 @@ export function mountJvmWeeklyApiRoutes(app, {
             );
           }
           if (!existingThroughMonth) {
+            preserveLegacyShape = true;
             ({ shards, manifest, totals, annualSummaries, payloadFingerprint } = buildRevisionEvidence(
               revision,
               monthsBetween(CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH, yearMonth),
@@ -3368,8 +3393,12 @@ export function mountJvmWeeklyApiRoutes(app, {
         tenantId: req.context.tenantId,
         projectId: prepared.rawProjectId,
         yearMonth,
-        ...(shards.at(-1)?.yearMonth === yearMonth ? {} : { throughMonth: shards.at(-1)?.yearMonth }),
         fromMonth: CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH,
+        ...(preserveLegacyShape ? {} : {
+          cycleYearMonth: yearMonth,
+          throughMonth: cumulativeMonths.at(-1),
+          scope: cashflowCumulativeCloseScope(yearMonth),
+        }),
         status: 'PENDING',
         revision,
         manifestHash: manifest.manifestHash,

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1731,7 +1731,11 @@ export function CashflowProjectSheet({
     });
     const applyStageResult = async (result: CashflowSheetLabStageResult) => {
       if (result.status === 'BLOCKED') {
-        toast.warning('시트 범위가 월 전체 구조와 맞지 않아 반영하지 않았습니다.');
+        const contractIssue = result.pendingApprovalContractIssues?.[0];
+        const blockedMonths = (contractIssue?.blockedMonths || result.blockedMonths || []).join(', ');
+        toast.warning(contractIssue
+          ? `${contractIssue.message}${blockedMonths ? ` 확인할 월: ${blockedMonths}` : ''}${contractIssue.requestId !== 'unknown' ? ` (요청 ID: ${contractIssue.requestId})` : ''}`
+          : `반영할 수 없는 시트 범위가 있습니다.${blockedMonths ? ` 확인할 월: ${blockedMonths}` : ''}`);
         return;
       }
       if (result.stagedLineCount <= 0) {

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
@@ -766,8 +766,11 @@ export function CashflowSheetLabPage() {
           riskLineCount: staged.riskLineCount,
           durationMs: Date.now() - startedAt,
         }, 'warn');
-        const blockedMonths = staged.blockedMonths?.join(', ');
-        setErrorMessage(`반영할 수 없는 시트 범위가 있습니다.${blockedMonths ? ` 확인할 월: ${blockedMonths}` : ''}`);
+        const contractIssue = staged.pendingApprovalContractIssues?.[0];
+        const blockedMonths = (contractIssue?.blockedMonths || staged.blockedMonths || []).join(', ');
+        setErrorMessage(contractIssue
+          ? `${contractIssue.message}${blockedMonths ? ` 확인할 월: ${blockedMonths}` : ''}${contractIssue.requestId !== 'unknown' ? ` (요청 ID: ${contractIssue.requestId})` : ''}`
+          : `반영할 수 없는 시트 범위가 있습니다.${blockedMonths ? ` 확인할 월: ${blockedMonths}` : ''}`);
         return;
       }
       if (staged.stagedLineCount === 0) {

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -559,6 +559,14 @@ export interface CashflowSheetLabStageResult {
   }>;
   pendingApprovalDifferenceCount?: number;
   pendingApprovalDifferenceManifestHash?: string;
+  pendingApprovalContractIssues?: Array<{
+    requestId: string;
+    yearMonth?: string;
+    blockedMonths: string[];
+    blockAllCandidates: boolean;
+    reasonCode: 'cashflow_pending_approval_contract_unsupported';
+    message: string;
+  }>;
   stagedMonths?: string[];
   stagedYears?: number[];
   annualLineCount?: number;


### PR DESCRIPTION
## 변경
- stage에서 검증·고정한 셀을 apply에서 다시 전체 재검증하지 않음
- 시트/월결산 기간 계약을 공통 SSOT로 통일
- 실제 호출되지 않던 syncProject의 재조회·재스테이징·재검증 경로 제거
- malformed pending approval은 전체 요청을 죽이지 않고 해당 월만 안내/차단

## 검증
- 332 BFF tests passed
- npm run build passed

운영 배포는 main 병합 후 자동 배포로 진행한다.