### PR TITLE
fix: make JVM monthly formula validation authoritative

### DIFF
--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -3130,13 +3130,18 @@ async function applyStagedCashflowSheetLab({
     }
   }
 
-  const preflightInput = cashflowFormulaPreflightInput(mirror);
-  await javaWeeklyClient.validateCashflowSheetFormulas({
-    context,
-    projectId,
-    ...preflightInput,
-    acceptFormulaMismatches,
-  });
+  // 월 반영은 JVM의 실제 월 저장 명령이 같은 계산 검사를 수행한다.
+  // BFF preflight를 앞에 한 번 더 호출하면 같은 근거를 재조회하고, 저장 명령과
+  // 다른 시점의 결과로 정상 반영을 막을 수 있다. 연간 작업이 포함될 때만 별도 검증한다.
+  if (stagedYears.length > 0) {
+    const preflightInput = cashflowFormulaPreflightInput(mirror);
+    await javaWeeklyClient.validateCashflowSheetFormulas({
+      context,
+      projectId,
+      ...preflightInput,
+      acceptFormulaMismatches,
+    });
+  }
 
   if (!resuming) {
     const pendingApproval = await readPendingApprovalDifferences({ db, tenantId, projectId, candidates: selectedCandidates });

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -1220,6 +1220,7 @@ describe('cashflow sheet lab route', () => {
     });
     expect(javaWeeklyClient.applyCashflowSheetLab).not.toHaveBeenCalled();
     expect(javaWeeklyClient.applyCashflowSheetBatch).toHaveBeenCalledTimes(1);
+    expect(javaWeeklyClient.validateCashflowSheetFormulas).toHaveBeenCalledTimes(1);
     expect(javaWeeklyClient.applyCashflowSheetBatch).toHaveBeenCalledWith(expect.objectContaining({
       openingBalanceCells: expect.arrayContaining([
         expect.objectContaining({ year: 2025, mode: 'projection', cashflowLine: 'MYSC_PREPAY_IN', cellState: 'ZERO', amount: 0 }),
@@ -4539,7 +4540,7 @@ describe('cashflow sheet lab route', () => {
       sourceCell: 'BO12',
     };
     const javaWeeklyClient = {
-      validateCashflowSheetFormulas: vi.fn(async (input) => {
+      applyCashflowSheetLab: vi.fn(async (input) => {
         if (!input.acceptFormulaMismatches) {
           throw Object.assign(new Error('formula confirmation required'), {
             statusCode: 409,
@@ -4547,9 +4548,6 @@ describe('cashflow sheet lab route', () => {
             details: { mismatchCount: 1, mismatches: [mismatch] },
           });
         }
-        return { ok: true };
-      }),
-      applyCashflowSheetLab: vi.fn(async (input) => {
         return javaApplyResponse(input, resultingTargetRevision);
       }),
     };
@@ -4567,18 +4565,6 @@ describe('cashflow sheet lab route', () => {
       .send({ expectedMirrorRevision: mirror.body.sourceRevision, yearMonth: '2026-01', idempotencyKey: 'stage-formula-mismatch' })
       .expect(200);
 
-    const currentMirror = db.__getDocument('orgs/tenant-a/cashflow_sheet_mirrors/project-a');
-    const originalDerivedCell = currentMirror.annualDerivedCells[0];
-    currentMirror.annualDerivedCells[0] = { ...originalDerivedCell, sourceCell: '' };
-    await request(app)
-      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
-      .send({ stageRunId: stage.body.runId, idempotencyKey: 'apply-formula-evidence-incomplete' })
-      .expect(409)
-      .expect((response) => expect(response.body.code).toBe('cashflow_sheet_formula_evidence_incomplete'));
-    expect(javaWeeklyClient.validateCashflowSheetFormulas).not.toHaveBeenCalled();
-    expect(db.__getDocument(`orgs/tenant-a/cashflow_sheet_stage_runs/${stage.body.runId}`).status).toBe('READY');
-    currentMirror.annualDerivedCells[0] = originalDerivedCell;
-
     const rejected = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
       .send({ stageRunId: stage.body.runId, idempotencyKey: 'apply-formula-mismatch-first' })
@@ -4589,6 +4575,7 @@ describe('cashflow sheet lab route', () => {
     });
     expect(db.__getDocument(`orgs/tenant-a/cashflow_sheet_stage_runs/${stage.body.runId}`).status).toBe('READY');
 
+    const currentMirror = db.__getDocument('orgs/tenant-a/cashflow_sheet_mirrors/project-a');
     const originalSourceRevision = currentMirror.sourceRevision;
     currentMirror.sourceRevision = `sha256:${'9'.repeat(64)}`;
     await request(app)
@@ -4600,8 +4587,7 @@ describe('cashflow sheet lab route', () => {
       })
       .expect(409)
       .expect((response) => expect(response.body.code).toBe('cashflow_sheet_mirror_revision_conflict'));
-    expect(javaWeeklyClient.validateCashflowSheetFormulas).toHaveBeenCalledTimes(1);
-    expect(javaWeeklyClient.applyCashflowSheetLab).not.toHaveBeenCalled();
+    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(1);
     currentMirror.sourceRevision = originalSourceRevision;
 
     await request(app)
@@ -4613,12 +4599,9 @@ describe('cashflow sheet lab route', () => {
       })
       .expect(200);
 
-    expect(javaWeeklyClient.validateCashflowSheetFormulas).toHaveBeenCalledTimes(2);
-    expect(javaWeeklyClient.validateCashflowSheetFormulas.mock.calls[0][0].annualCells[0]).not.toHaveProperty('sourceCell');
-    expect(javaWeeklyClient.validateCashflowSheetFormulas.mock.calls[0][0].annualCells[0]).not.toHaveProperty('sourceLabel');
-    expect(javaWeeklyClient.validateCashflowSheetFormulas.mock.calls[0][0].acceptFormulaMismatches).toBe(false);
-    expect(javaWeeklyClient.validateCashflowSheetFormulas.mock.calls[1][0].acceptFormulaMismatches).toBe(true);
-    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(1);
+    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(2);
+    expect(javaWeeklyClient.applyCashflowSheetLab.mock.calls[0][0].acceptFormulaMismatches).toBe(false);
+    expect(javaWeeklyClient.applyCashflowSheetLab.mock.calls[1][0].acceptFormulaMismatches).toBe(true);
   });
 
   it('treats a monthly close missing only contractVersion as legacy v1 and reaches formula validation', async () => {
@@ -4642,7 +4625,7 @@ describe('cashflow sheet lab route', () => {
       },
     });
     const javaWeeklyClient = {
-      validateCashflowSheetFormulas: vi.fn(async () => {
+      applyCashflowSheetLab: vi.fn(async (input) => {
         throw Object.assign(new Error('formula confirmation required'), {
           statusCode: 409,
           code: 'cashflow_formula_mismatch_confirmation_required',
@@ -4665,7 +4648,7 @@ describe('cashflow sheet lab route', () => {
       .send({ stageRunId: stage.body.runId, idempotencyKey: 'apply-legacy-month-close' })
       .expect(409)
       .expect((response) => expect(response.body.code).toBe('cashflow_formula_mismatch_confirmation_required'));
-    expect(javaWeeklyClient.validateCashflowSheetFormulas).toHaveBeenCalledTimes(1);
+    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(1);
   });
 
   it.each([
@@ -5059,14 +5042,18 @@ describe('cashflow sheet apply lock release on failure', () => {
       .expect(200);
   }
 
-  // 예약 전에 실패하면 락 자체가 잡히지 않는다. 락 고착은 예약 이후에만 생긴다.
-  it('never takes an apply lock when validation fails before the reservation', async () => {
+  // 월 반영의 권위 있는 검증이 거부해도 예약 락은 즉시 해제된다.
+  it('releases the apply lock when authoritative monthly validation rejects before write', async () => {
     const db = labDb();
     const javaWeeklyClient = {
-      validateCashflowSheetFormulas: vi.fn(async () => {
-        throw new TypeError('unexpected internal failure');
+      validateCashflowSheetFormulas: vi.fn(),
+      applyCashflowSheetLab: vi.fn(async () => {
+        throw Object.assign(new Error('formula confirmation required'), {
+          statusCode: 409,
+          code: 'cashflow_formula_mismatch_confirmation_required',
+          details: { mismatchCount: 1, mismatches: [] },
+        });
       }),
-      applyCashflowSheetLab: vi.fn(),
     };
     const app = createApp({ db, googleSheetsService: { previewSpreadsheet: previewStub() }, routeOptions: { javaWeeklyClient } });
     const stage = await stageOne(app, 'internal-error');
@@ -5074,12 +5061,12 @@ describe('cashflow sheet apply lock release on failure', () => {
     await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
       .send({ stageRunId: stage.body.runId, idempotencyKey: 'apply-internal-error' })
-      .expect((response) => {
-        expect(response.status).toBeGreaterThanOrEqual(500);
-      });
+      .expect(409)
+      .expect((response) => expect(response.body.code).toBe('cashflow_formula_mismatch_confirmation_required'));
 
-    expect(javaWeeklyClient.applyCashflowSheetLab).not.toHaveBeenCalled();
-    expect(db.__getDocument('orgs/tenant-a/cashflow_sheet_publications/project-a')).toBeUndefined();
+    expect(javaWeeklyClient.validateCashflowSheetFormulas).not.toHaveBeenCalled();
+    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(1);
+    expect(db.__getDocument('orgs/tenant-a/cashflow_sheet_publications/project-a').status).toBe('READY');
     expect(db.__getDocument(`orgs/tenant-a/cashflow_sheet_stage_runs/${stage.body.runId}`).status).toBe('READY');
   });
 

--- a/src/app/platform/api-error-message.test.ts
+++ b/src/app/platform/api-error-message.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { PlatformApiError } from './api-client';
 import { resolveApiErrorMessage } from './api-error-message';
+import { resolveApiErrorPresentation } from './api-error-messages';
 
 describe('resolveApiErrorMessage', () => {
   it('prefers API body messages when available', () => {
@@ -18,5 +19,12 @@ describe('resolveApiErrorMessage', () => {
 
   it('returns the provided fallback for unknown values', () => {
     expect(resolveApiErrorMessage(null, 'fallback')).toBe('fallback');
+  });
+
+  it('gives formula mismatches an actionable guide instead of the generic 409 message', () => {
+    expect(resolveApiErrorPresentation('cashflow_formula_mismatch_confirmation_required', 409)).toEqual({
+      guide: '시트의 합계·잔액과 MYSCube 계산 결과가 달라요. 차이를 확인한 뒤 그대로 반영하거나 시트 값을 다시 가져와 주세요.',
+      resolution: 'contact',
+    });
   });
 });

--- a/src/app/platform/api-error-messages.ts
+++ b/src/app/platform/api-error-messages.ts
@@ -48,6 +48,38 @@ const presentations = new Map<string, ApiErrorPresentation>([
     guide: '먼저 시트 값을 가져와 최신 고정본을 만든 뒤 진행해 주세요.',
     resolution: 'contact',
   }],
+  ['cashflow_formula_mismatch_confirmation_required', {
+    guide: '시트의 합계·잔액과 MYSCube 계산 결과가 달라요. 차이를 확인한 뒤 그대로 반영하거나 시트 값을 다시 가져와 주세요.',
+    resolution: 'contact',
+  }],
+  ['cashflow_sheet_formula_evidence_incomplete', {
+    guide: '시트의 합계·잔액 확인 정보를 찾을 수 없어요. 시트 값을 다시 가져와 최신 검토본을 만들어 주세요.',
+    resolution: 'retry',
+  }],
+  ['cashflow_sheet_stage_evidence_missing', {
+    guide: '검토한 시트 고정본이 만료됐어요. 시트 값을 다시 가져온 뒤 반영해 주세요.',
+    resolution: 'retry',
+  }],
+  ['cashflow_sheet_target_revision_conflict', {
+    guide: '검토 중 MYSCube 값이 변경됐어요. 최신 시트 값을 다시 가져와 검토해 주세요.',
+    resolution: 'retry',
+  }],
+  ['cashflow_sheet_month_incomplete', {
+    guide: '해당 월의 주차 값이 모두 채워지지 않았어요. 월 1주차부터 5주차까지 확인한 뒤 다시 가져와 주세요.',
+    resolution: 'contact',
+  }],
+  ['cashflow_sheet_annual_incomplete', {
+    guide: '연간 합계의 Projection·Actual 항목이 모두 채워지지 않았어요. 시트의 연간 영역을 확인한 뒤 다시 가져와 주세요.',
+    resolution: 'contact',
+  }],
+  ['cashflow_jvm_calculation_verification_failed', {
+    guide: '저장 서버의 계산 근거가 완전하지 않아 반영하지 않았어요. 시트 값을 다시 가져와 다시 시도해 주세요.',
+    resolution: 'retry',
+  }],
+  ['cashflow_jvm_apply_verification_failed', {
+    guide: '저장 결과가 시트 값과 일치하는지 확인하지 못했어요. 같은 요청으로 다시 확인해 주세요.',
+    resolution: 'retry',
+  }],
   ['jvm_weekly_api_identity_token_unavailable', {
     guide: '서버 인증 설정을 확인할 수 없어요. 시스템 담당자에게 문의해 주세요.',
     resolution: 'contact',


### PR DESCRIPTION
## What changed
- Remove duplicate BFF formula preflight from monthly sheet apply.
- Keep preflight for annual and mixed operations until the annual JVM contract is migrated.
- Add actionable user guidance for formula/apply errors.
- Release the apply lock when authoritative monthly validation rejects before write.

## Verification
- Targeted cashflow route and error-message tests pass.
- Build passes.
- Full suite has one known benchmark wall-clock flake unrelated to this change.