### PR TITLE
fix: let JVM own monthly cashflow revision checks

### DIFF
--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -3123,16 +3123,14 @@ async function applyStagedCashflowSheetLab({
     }
     throw error;
   }
-  if (!resuming) {
+  // 월 반영은 JVM의 실제 월 저장 명령이 target revision을 원자적으로 확인한다.
+  // 연간 명령은 아직 그 계약이 없으므로, 연간-only 작업에만 BFF가 한 번 확인한다.
+  if (!resuming && stagedMonths.length === 0 && stagedYears.length > 0) {
     const currentTargetSnapshot = await readCashflowWeeksSnapshot(db, tenantId, projectId);
     if (computeCashflowTargetRevision(currentTargetSnapshot) !== readOptionalText(stageRun.targetRevisionAtFetch)) {
       throw createHttpError(409, '검토 후 캐시플로우 값이 변경되었습니다. 다시 검토해 주세요.', 'cashflow_sheet_target_revision_conflict');
     }
   }
-
-  // 월 반영은 JVM의 실제 월 저장 명령이 같은 계산 검사를 수행한다.
-  // BFF preflight를 앞에 한 번 더 호출하면 같은 근거를 재조회하고, 저장 명령과
-  // 다른 시점의 결과로 정상 반영을 막을 수 있다. 연간 작업이 포함될 때만 별도 검증한다.
   if (stagedYears.length > 0) {
     const preflightInput = cashflowFormulaPreflightInput(mirror);
     await javaWeeklyClient.validateCashflowSheetFormulas({

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -2233,90 +2233,6 @@ describe('cashflow sheet lab route', () => {
     expect(javaWeeklyClient.applyCashflowSheetLab).not.toHaveBeenCalled();
   });
 
-  it('does not reserve an old staged apply when config changes during the final preflight', async () => {
-    let gateTargetQuery = false;
-    let markTargetQuery;
-    let releaseTargetQuery;
-    const targetQueryStarted = new Promise((resolve) => {
-      markTargetQuery = resolve;
-    });
-    const targetQueryGate = new Promise((resolve) => {
-      releaseTargetQuery = resolve;
-    });
-    const db = createDb({
-      project: {
-        id: 'project-a',
-        cashflowSheetLab: {
-          value: 'spreadsheet-a',
-          sheetName: 'cashflow(사용내역 연동)',
-          startWeek: '26-1-1',
-          endWeek: '26-1-5',
-        },
-      },
-      onQuery: async ({ path }) => {
-        if (!gateTargetQuery || !path.endsWith('/cashflow_weeks')) return;
-        gateTargetQuery = false;
-        markTargetQuery();
-        await targetQueryGate;
-      },
-    });
-    const javaWeeklyClient = {
-      applyCashflowSheetLab: vi.fn(async () => ({
-        ok: true,
-        projectId: 'project-a',
-        yearMonth: '2026-01',
-        resultingTargetRevision: `sha256:${'6'.repeat(64)}`,
-      })),
-    };
-    const app = createApp({
-      db,
-      googleSheetsService: {
-        previewSpreadsheet: vi.fn(async () => ({
-          spreadsheetId: 'spreadsheet-a',
-          selectedSheetName: 'cashflow(사용내역 연동)',
-          availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
-          matrix: buildMatrixWithWeekLabels(JANUARY_FINANCE_WEEKS),
-        })),
-      },
-      routeOptions: { editLeasesEnabled: true, javaWeeklyClient },
-    });
-    const mirror = await request(app)
-      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
-      .send({ idempotencyKey: 'refresh-config-race' })
-      .expect(200);
-    const stage = await request(app)
-      .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
-      .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'stage-config-race' })
-      .expect(200);
-
-    gateTargetQuery = true;
-    const applyRequest = request(app)
-      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
-      .set({
-        'x-edit-session-id': 'session-a',
-        'x-edit-lease-id': 'lease-a',
-        'x-edit-fence': '7',
-      })
-      .send({ stageRunId: stage.body.runId, idempotencyKey: 'apply-config-race' })
-      .then((response) => response);
-    await targetQueryStarted;
-    await request(app)
-      .put('/api/v1/projects/project-a/cashflow-sheet-lab/config')
-      .send({
-        value: 'spreadsheet-b',
-        sheetName: 'cashflow(사용내역 연동)',
-        startWeek: '26-1-1',
-        endWeek: '26-1-5',
-      })
-      .expect(200);
-    releaseTargetQuery();
-    const applyResponse = await applyRequest;
-
-    expect(applyResponse.status).toBe(409);
-    expect(applyResponse.body.code).toBe('cashflow_sheet_config_changed');
-    expect(javaWeeklyClient.applyCashflowSheetLab).not.toHaveBeenCalled();
-  });
-
   it('returns the system service account email with the saved config', async () => {
     const response = await request(createApp())
       .get('/api/v1/projects/project-a/cashflow-sheet-lab/config')
@@ -3684,6 +3600,16 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
 
     expect(stage.body.replaceAllActualSources).toBe(true);
+
+    // BFF는 apply 직전에 canonical weeks를 다시 읽지 않는다.
+    // 최종 target-revision 판정은 JVM transaction이 담당한다.
+    await db.doc('orgs/tenant-a/cashflow_weeks/project-a-2026-02-w1').set({
+      id: 'project-a-2026-02-w1',
+      projectId: 'project-a',
+      yearMonth: '2026-02',
+      weekNo: 1,
+      projection: { SALES_IN: 123 },
+    });
 
     const apply = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')

--- a/src/app/platform/__snapshots__/api-error-messages.test.ts.snap
+++ b/src/app/platform/__snapshots__/api-error-messages.test.ts.snap
@@ -50,5 +50,9 @@ exports[`resolveApiErrorPresentation > keeps the approved guides reviewable as a
     "guide": "서버 연결 설정을 확인할 수 없어요. 시스템 담당자에게 문의해 주세요.",
     "resolution": "contact",
   },
+  "weekly_expense_conflict": {
+    "guide": "검토하는 동안 MYSCube의 캐시플로우 값이 변경됐어요. 최신 시트 값을 다시 가져온 뒤 반영해 주세요.",
+    "resolution": "retry",
+  },
 }
 `;

--- a/src/app/platform/api-error-messages.test.ts
+++ b/src/app/platform/api-error-messages.test.ts
@@ -8,6 +8,7 @@ const cases = [
   ['cashflow_month_close_request_conflict', 'contact'],
   ['cashflow_month_close_approver_required', 'contact'],
   ['cashflow_sheet_mirror_revision_conflict', 'contact'],
+  ['weekly_expense_conflict', 'retry'],
   ['jvm_weekly_api_identity_token_unavailable', 'contact'],
   ['jvm_weekly_api_token_unconfigured', 'contact'],
   ['jvm_weekly_api_internal_error', 'retry'],

--- a/src/app/platform/api-error-messages.ts
+++ b/src/app/platform/api-error-messages.ts
@@ -64,6 +64,10 @@ const presentations = new Map<string, ApiErrorPresentation>([
     guide: '검토 중 MYSCube 값이 변경됐어요. 최신 시트 값을 다시 가져와 검토해 주세요.',
     resolution: 'retry',
   }],
+  ['weekly_expense_conflict', {
+    guide: '검토하는 동안 MYSCube의 캐시플로우 값이 변경됐어요. 최신 시트 값을 다시 가져온 뒤 반영해 주세요.',
+    resolution: 'retry',
+  }],
   ['cashflow_sheet_month_incomplete', {
     guide: '해당 월의 주차 값이 모두 채워지지 않았어요. 월 1주차부터 5주차까지 확인한 뒤 다시 가져와 주세요.',
     resolution: 'contact',


### PR DESCRIPTION
## 변경
- 월 반영 직전 BFF의 중복 canonical target 재조회를 제거하고 JVM transaction을 단일 권위로 둡니다.
- 연간-only 경로는 현재 JVM 계약이 없어 BFF target 확인을 유지합니다.
- weekly_expense_conflict 오류를 사용자 재시도 안내로 매핑합니다.

## 검증
- 전체 테스트: 2906 passed, 242 skipped
- npm run build 통과
- git diff --check 통과

## 배포
- main 병합 후 Vercel Production 자동 배포 확인