### PR TITLE
fix(cashflow): make explicit sheet overwrite one-way

### DIFF
--- a/server/bff/java-weekly-client.mjs
+++ b/server/bff/java-weekly-client.mjs
@@ -581,6 +581,7 @@ export function createJavaWeeklyClient({
     expectedRevision,
     cells,
     amendmentReason = '',
+    replaceAllActualSources = false,
   }) {
     const normalizedProjectId = encodeURIComponent(readOptionalText(projectId));
     if (!normalizedProjectId) throw createHttpError(400, 'projectId is required.', 'project_id_required');
@@ -598,6 +599,7 @@ export function createJavaWeeklyClient({
         year,
         expectedRevision,
         cells,
+        ...(replaceAllActualSources === true ? { replaceAllActualSources: true } : {}),
         ...(readOptionalText(amendmentReason) ? { amendmentReason: readOptionalText(amendmentReason) } : {}),
       },
     });

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -2272,6 +2272,7 @@ async function reserveCashflowSheetApply({
   idempotencyKey,
   applyRequestHash,
   applyInput,
+  replaceAllActualSources = false,
   now,
 }) {
   const runRef = db.doc(`orgs/${tenantId}/${CASHFLOW_SHEET_STAGE_RUNS_COLLECTION_ID}/${stagedRunId}`);
@@ -2333,7 +2334,8 @@ async function reserveCashflowSheetApply({
     if (
       readOptionalText(mirror.configRevision) !== readOptionalText(stageRun.configRevision)
       || readOptionalText(mirror.sourceRevision) !== readOptionalText(stageRun.sourceRevision)
-      || readOptionalText(mirror.targetRevisionAtFetch) !== readOptionalText(stageRun.targetRevisionAtFetch)
+      || (!replaceAllActualSources
+        && readOptionalText(mirror.targetRevisionAtFetch) !== readOptionalText(stageRun.targetRevisionAtFetch))
     ) {
       throw createHttpError(409, '검토 후 시트 고정본이 변경되었습니다. 다시 검토해 주세요.', 'cashflow_sheet_mirror_revision_conflict');
     }
@@ -2688,7 +2690,10 @@ function assertCashflowSheetOperationStatus(status, expected) {
         && observed.resultingTargetRevision === null
         && observed.annualRevisions.length === 1
         && Number(observed.annualRevisions[0]?.year) === expected.appliedYears[0]
-        && Number(observed.annualRevisions[0]?.revision) === expected.annualRevision);
+        && (expected.annualRevision === null
+          ? Number.isSafeInteger(Number(observed.annualRevisions[0]?.revision))
+            && Number(observed.annualRevisions[0]?.revision) >= 1
+          : Number(observed.annualRevisions[0]?.revision) === expected.annualRevision));
   if (!validApplied) {
     throw Object.assign(new Error('적용된 작업 범위나 revision이 요청과 일치하지 않습니다.'), { observed });
   }
@@ -2715,10 +2720,13 @@ async function executeCashflowSheetOperation({
   idempotencyKey,
   expected,
   reconcileFirst,
+  oneWay = false,
   mutate,
   verifyMutation,
   checkpointFromStatus,
 }) {
+  if (oneWay) return verifyMutation(await mutate());
+
   const readStatus = async (mutationError) => {
     try {
       const status = await javaWeeklyClient.getCashflowSheetOperationStatus({
@@ -2826,7 +2834,7 @@ function javaAppliedLineIndex(lines, { mode, yearMonth }) {
 function verifyJavaMonthAppliedCells(result, month, {
   projectId,
   sourceRevision,
-  targetRevision,
+  targetRevision = null,
   commandName,
 }) {
   if (
@@ -2836,7 +2844,7 @@ function verifyJavaMonthAppliedCells(result, month, {
     || readOptionalText(result?.yearMonth) !== month.yearMonth
     || readOptionalText(result?.sourceSheetKey) !== CASHFLOW_SHEET_SOURCE_KEY
     || readOptionalText(result?.sourceRevision) !== sourceRevision
-    || readOptionalText(result?.targetRevision) !== targetRevision
+    || (targetRevision !== null && readOptionalText(result?.targetRevision) !== targetRevision)
   ) {
     throw createHttpError(502, '저장 대상 기간이 요청과 달라 저장을 취소했습니다. 시트 값을 다시 불러온 뒤 시도해 주세요.', 'cashflow_jvm_apply_verification_failed');
   }
@@ -2879,7 +2887,7 @@ function verifyJavaMonthAppliedCells(result, month, {
   return verifiedLineCount;
 }
 
-function verifyJavaAnnualAppliedCells(result, stagedYear, { projectId, sourceRevision }) {
+function verifyJavaAnnualAppliedCells(result, stagedYear, { projectId, sourceRevision, expectedRevision = null }) {
   if (
     result?.ok !== true
     || readOptionalText(result?.commandName) !== CASHFLOW_SHEET_APPLY_COMMAND
@@ -2887,7 +2895,9 @@ function verifyJavaAnnualAppliedCells(result, stagedYear, { projectId, sourceRev
     || Number(result?.year) !== stagedYear.year
     || readOptionalText(result?.sourceSheetKey) !== CASHFLOW_SHEET_SOURCE_KEY
     || readOptionalText(result?.sourceRevision) !== sourceRevision
-    || Number(result?.revision) !== Number(stagedYear.expectedRevision) + 1
+    || (expectedRevision === null
+      ? !Number.isSafeInteger(Number(result?.revision)) || Number(result.revision) < 1
+      : Number(result?.revision) !== Number(expectedRevision) + 1)
   ) {
     throw createHttpError(502, '연간 합계의 저장 대상 기간이 요청과 달라 저장을 취소했습니다. 시트 값을 다시 불러온 뒤 시도해 주세요.', 'cashflow_jvm_annual_apply_verification_failed');
   }
@@ -2965,7 +2975,7 @@ async function applyStagedCashflowSheetLab({
   const pendingApprovalDifferenceManifestHash = storedApplyInput
     ? readOptionalText(storedApplyInput.pendingApprovalDifferenceManifestHash)
     : readOptionalText(parsed.pendingApprovalDifferenceManifestHash);
-  const pendingApprovalAffectedMonths = acceptPendingApprovalDifferences
+  const pendingApprovalAffectedMonths = !replaceAllActualSources && acceptPendingApprovalDifferences
     ? buildPendingApprovalAffectedMonths(stageRun.pendingApprovalDifferences)
     : [];
   const acceptFormulaMismatches = storedApplyInput
@@ -3054,7 +3064,8 @@ async function applyStagedCashflowSheetLab({
     if (
       readOptionalText(stagedMonth.configRevision) !== readOptionalText(stageRun.configRevision)
       || readOptionalText(stagedMonth.sourceRevision) !== readOptionalText(stageRun.sourceRevision)
-      || readOptionalText(stagedMonth.targetRevisionAtFetch) !== readOptionalText(stageRun.targetRevisionAtFetch)
+      || (!replaceAllActualSources
+        && readOptionalText(stagedMonth.targetRevisionAtFetch) !== readOptionalText(stageRun.targetRevisionAtFetch))
     ) {
       throw createHttpError(409, '검토 당시 고정한 월 시트 revision이 일치하지 않습니다.', 'cashflow_sheet_stage_month_revision_conflict');
     }
@@ -3077,7 +3088,8 @@ async function applyStagedCashflowSheetLab({
     if (
       readOptionalText(stagedYear.configRevision) !== readOptionalText(stageRun.configRevision)
       || readOptionalText(stagedYear.sourceRevision) !== readOptionalText(stageRun.sourceRevision)
-      || readOptionalText(stagedYear.targetRevisionAtFetch) !== readOptionalText(stageRun.targetRevisionAtFetch)
+      || (!replaceAllActualSources
+        && readOptionalText(stagedYear.targetRevisionAtFetch) !== readOptionalText(stageRun.targetRevisionAtFetch))
     ) {
       throw createHttpError(409, '검토 당시 고정한 연간 합계 revision이 일치하지 않습니다.', 'cashflow_sheet_stage_year_revision_conflict');
     }
@@ -3125,7 +3137,7 @@ async function applyStagedCashflowSheetLab({
   }
   // 월 반영은 JVM의 실제 월 저장 명령이 target revision을 원자적으로 확인한다.
   // 연간 명령은 아직 그 계약이 없으므로, 연간-only 작업에만 BFF가 한 번 확인한다.
-  if (!resuming && stagedMonths.length === 0 && stagedYears.length > 0) {
+  if (!replaceAllActualSources && !resuming && stagedMonths.length === 0 && stagedYears.length > 0) {
     const currentTargetSnapshot = await readCashflowWeeksSnapshot(db, tenantId, projectId);
     if (computeCashflowTargetRevision(currentTargetSnapshot) !== readOptionalText(stageRun.targetRevisionAtFetch)) {
       throw createHttpError(409, '검토 후 캐시플로우 값이 변경되었습니다. 다시 검토해 주세요.', 'cashflow_sheet_target_revision_conflict');
@@ -3141,7 +3153,7 @@ async function applyStagedCashflowSheetLab({
     });
   }
 
-  if (!resuming) {
+  if (!replaceAllActualSources && !resuming) {
     const pendingApproval = await readPendingApprovalDifferences({ db, tenantId, projectId, candidates: selectedCandidates });
     if (stableHash(pendingApproval.evidence) !== stableHash(stageRun.pendingApprovalEvidence || [])) {
       throw pendingApprovalEvidenceError('검토 후 결재 중인 누적 결산 상태 또는 revision이 변경되었습니다. 다시 검토해 주세요.');
@@ -3199,6 +3211,7 @@ async function applyStagedCashflowSheetLab({
       acceptFormulaMismatches,
       replaceAllActualSources,
     },
+    replaceAllActualSources,
     now,
   });
   if (reservation.replay) return reservation.replay;
@@ -3272,6 +3285,7 @@ async function applyStagedCashflowSheetLab({
             appliedYears: [],
           },
           reconcileFirst: Boolean(applyOperations[operationKey]),
+          oneWay: replaceAllActualSources,
           mutate: () => javaWeeklyClient.applyCashflowSheetLab({
             context,
             projectId,
@@ -3293,7 +3307,7 @@ async function applyStagedCashflowSheetLab({
             const operationVerifiedLineCount = verifyJavaMonthAppliedCells(javaResult, month, {
               projectId,
               sourceRevision: readOptionalText(stageRun.sourceRevision),
-              targetRevision: monthTargetRevision,
+              targetRevision: replaceAllActualSources ? null : monthTargetRevision,
               commandName: CASHFLOW_SHEET_APPLY_COMMAND,
             });
             return {
@@ -3369,6 +3383,7 @@ async function applyStagedCashflowSheetLab({
             appliedYears: [],
           },
           reconcileFirst: Boolean(applyOperations[operationKey]),
+          oneWay: replaceAllActualSources,
           mutate: () => javaWeeklyClient.applyCashflowSheetBatch({
             context,
             projectId,
@@ -3395,7 +3410,7 @@ async function applyStagedCashflowSheetLab({
               || readOptionalText(batchResult?.projectId) !== projectId
               || readOptionalText(batchResult?.sourceSheetKey) !== CASHFLOW_SHEET_SOURCE_KEY
               || readOptionalText(batchResult?.sourceRevision) !== readOptionalText(stageRun.sourceRevision)
-              || readOptionalText(batchResult?.targetRevision) !== batchTargetRevision
+              || (!replaceAllActualSources && readOptionalText(batchResult?.targetRevision) !== batchTargetRevision)
             ) {
               throw createHttpError(502, '저장 형식이 올바르지 않아 저장을 취소했습니다. 담당자에게 문의해 주세요.', 'cashflow_jvm_apply_verification_failed');
             }
@@ -3425,7 +3440,7 @@ async function applyStagedCashflowSheetLab({
               operationVerifiedLineCount += verifyJavaMonthAppliedCells(compatibleResult, month, {
                 projectId,
                 sourceRevision: readOptionalText(stageRun.sourceRevision),
-                targetRevision: batchTargetRevision,
+                targetRevision: replaceAllActualSources ? null : batchTargetRevision,
                 commandName: CASHFLOW_SHEET_APPLY_COMMAND,
               });
               return summarizeJavaMonthResult(compatibleResult);
@@ -3498,9 +3513,10 @@ async function applyStagedCashflowSheetLab({
               expectedTargetRevision: null,
               appliedMonths: [],
               appliedYears: [stagedYear.year],
-              annualRevision: stagedYear.expectedRevision + 1,
+              annualRevision: replaceAllActualSources ? null : stagedYear.expectedRevision + 1,
             },
             reconcileFirst: Boolean(applyOperations[operationKey]),
+            oneWay: replaceAllActualSources,
             mutate: () => javaWeeklyClient.applyCashflowSheetAnnualTotal({
               context,
               projectId,
@@ -3511,6 +3527,7 @@ async function applyStagedCashflowSheetLab({
               expectedRevision: stagedYear.expectedRevision,
               cells: stagedYear.cells,
               amendmentReason: closedMonthChangeReason,
+              replaceAllActualSources,
             }),
             verifyMutation: (javaResult) => ({
               status: 'APPLIED',
@@ -3519,6 +3536,7 @@ async function applyStagedCashflowSheetLab({
               verifiedLineCount: verifyJavaAnnualAppliedCells(javaResult, stagedYear, {
                 projectId,
                 sourceRevision: readOptionalText(stageRun.sourceRevision),
+                expectedRevision: replaceAllActualSources ? null : stagedYear.expectedRevision,
               }),
               annualResult: javaResult,
               evidence: { outcome: 'MUTATION_RESPONSE' },
@@ -3535,7 +3553,8 @@ async function applyStagedCashflowSheetLab({
                 projectId,
                 year: stagedYear.year,
                 sourceRevision: stageRun.sourceRevision,
-                revision: stagedYear.expectedRevision + 1,
+                revision: Number(status.annualRevisions?.[0]?.revision)
+                  || (replaceAllActualSources ? undefined : stagedYear.expectedRevision + 1),
                 auditId: status.auditId,
               },
               evidence: { outcome: 'AUTHORITATIVE_STATUS', status },
@@ -3599,7 +3618,7 @@ async function applyStagedCashflowSheetLab({
 
   const appliedMonthSnapshots = stagedMonths.filter((month) => month.apply);
   let canonicalReadbackVerifiedCellCount = 0;
-  if (appliedMonthSnapshots.length > 0) {
+  if (appliedMonthSnapshots.length > 0 && !replaceAllActualSources) {
     let canonicalReadback;
     try {
       canonicalReadback = await javaWeeklyClient.getCashflowSnapshot({ context, projectId });
@@ -3835,7 +3854,7 @@ async function stagePinnedCashflowSheetLab({
 
   const cashflowSnapshot = await readCashflowWeeksSnapshot(db, tenantId, projectId);
   const currentTargetRevision = computeCashflowTargetRevision(cashflowSnapshot);
-  if (currentTargetRevision !== readOptionalText(mirror.targetRevisionAtFetch)) {
+  if (!parsed.replaceAllActualSources && currentTargetRevision !== readOptionalText(mirror.targetRevisionAtFetch)) {
     throw createHttpError(409, '시트 연동 후 캐시플로우 값이 변경되었습니다. 다시 연동해 주세요.', 'cashflow_sheet_target_revision_conflict');
   }
   const closedMonths = await readCanonicalClosedCashflowMonths({
@@ -3872,9 +3891,19 @@ async function stagePinnedCashflowSheetLab({
     forceFullReplacement: Boolean(parsed.replaceAllActualSources),
   });
   const candidates = [...weekly.candidates, ...annual.candidates];
-  const pendingApproval = await readPendingApprovalDifferences({
-    db, tenantId, projectId, candidates,
-  });
+  const pendingApproval = parsed.replaceAllActualSources
+    ? {
+      blockedMonths: [],
+      blockAllCandidates: false,
+      differences: [],
+      differenceCount: 0,
+      manifestHash: stableHash([]),
+      contractIssues: [],
+      evidence: [],
+    }
+    : await readPendingApprovalDifferences({
+      db, tenantId, projectId, candidates,
+    });
   const pendingBlockedMonths = new Set(pendingApproval.blockedMonths || []);
   const candidatesForStage = candidates.filter((candidate) => {
     if (pendingApproval.blockAllCandidates) return false;

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -3004,6 +3004,27 @@ describe('cashflow sheet lab route', () => {
       })
       .expect(200);
     expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(1);
+
+    const forceMirror = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'refresh-pending-force' })
+      .expect(200);
+    const forceStage = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+      .send({
+        expectedMirrorRevision: forceMirror.body.sourceRevision,
+        yearMonth: '2026-01',
+        replaceAllActualSources: true,
+        idempotencyKey: 'stage-pending-force',
+      })
+      .expect(200);
+    expect(forceStage.body.status).toBe('READY');
+    expect(forceStage.body.pendingApprovalDifferenceCount).toBe(0);
+    await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
+      .send({ stageRunId: forceStage.body.runId, replaceAllActualSources: true, idempotencyKey: 'apply-pending-force' })
+      .expect(200);
+    expect(javaWeeklyClient.applyCashflowSheetLab).toHaveBeenCalledTimes(2);
   });
 
   it('accepts the canonical cycle month plus separate throughMonth contract', async () => {
@@ -3531,6 +3552,16 @@ describe('cashflow sheet lab route', () => {
       .expect((response) => {
         expect(response.body.code).toBe('cashflow_sheet_target_revision_conflict');
       });
+
+    const overwriteStage = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+      .send({
+        expectedMirrorRevision: mirror.body.sourceRevision,
+        replaceAllActualSources: true,
+        idempotencyKey: 'stage-target-drift-overwrite',
+      })
+      .expect(200);
+    expect(overwriteStage.body.replaceAllActualSources).toBe(true);
     expect(previewSpreadsheet).toHaveBeenCalledTimes(1);
   });
 

--- a/server/bff/schemas.mjs
+++ b/server/bff/schemas.mjs
@@ -207,6 +207,7 @@ export const cashflowSheetLabApplySchema = z.object({
   startWeek: NON_EMPTY_STRING.optional(),
   endWeek: NON_EMPTY_STRING.optional(),
   stageRunId: NON_EMPTY_STRING.optional(),
+  replaceAllActualSources: z.boolean().optional(),
   applyRiskCandidates: z.boolean().optional(),
   settledWeekChangeConfirmationId: NON_EMPTY_STRING.optional(),
   closedMonthChangeReason: z.string().trim().max(1000).optional(),

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSheetAnnualApplyRequest.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSheetAnnualApplyRequest.java
@@ -22,7 +22,8 @@ public record CashflowSheetAnnualApplyRequest(
     @Min(2000) @Max(2099) int year,
     @Min(0) long expectedRevision,
     @Valid @NotNull @Size(min = 32, max = 32) List<Cell> cells,
-    @Size(max = 1000) String amendmentReason
+    @Size(max = 1000) String amendmentReason,
+    boolean replaceAllActualSources
 ) {
     public CashflowSheetAnnualApplyRequest {
         amendmentReason = amendmentReason == null ? "" : amendmentReason.trim();
@@ -35,7 +36,7 @@ public record CashflowSheetAnnualApplyRequest(
         long expectedRevision,
         List<Cell> cells
     ) {
-        this(idempotencyKey, sourceRevision, year, expectedRevision, cells, "");
+        this(idempotencyKey, sourceRevision, year, expectedRevision, cells, "", false);
     }
     public record Cell(
         @NotBlank @Pattern(regexp = "projection|actual") String mode,

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -920,7 +920,8 @@ public class WeeklyExpenseController {
                         cell.amount(), cell.sourceCell(), cell.sourceLabel()
                     ))
                     .toList(),
-                request.amendmentReason()
+                request.amendmentReason(),
+                request.replaceAllActualSources()
             )
         );
     }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/command/CashflowSheetAnnualApplyCommand.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/command/CashflowSheetAnnualApplyCommand.java
@@ -15,7 +15,8 @@ public record CashflowSheetAnnualApplyCommand(
     int year,
     long expectedRevision,
     List<CashflowAnnualCellSet.Cell> cells,
-    String amendmentReason
+    String amendmentReason,
+    boolean replaceAllActualSources
 ) {
     public CashflowSheetAnnualApplyCommand {
         amendmentReason = amendmentReason == null ? "" : amendmentReason.trim();
@@ -30,6 +31,6 @@ public record CashflowSheetAnnualApplyCommand(
         long expectedRevision,
         List<CashflowAnnualCellSet.Cell> cells
     ) {
-        this(idempotencyKey, sourceRevision, year, expectedRevision, cells, "");
+        this(idempotencyKey, sourceRevision, year, expectedRevision, cells, "", false);
     }
 }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -2306,16 +2306,16 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         }
         targetDocsByMonth.values().forEach(allProjectWeeks::putAll);
         String currentRevision = computeCashflowTargetRevision(allProjectWeeks.values());
-        if (!currentRevision.equals(targetRevision)) {
+        if (!replaceAllActualSources && !currentRevision.equals(targetRevision)) {
             throw new WeeklyExpenseConflictException("Cashflow target revision changed. Refresh the sheet before applying.");
         }
         DocumentReference mirrorRef = monthClose
             ? null
             : db.document("orgs/" + tenantId + "/cashflow_sheet_mirrors/" + projectId);
         DocumentSnapshot mirrorSnapshot = mirrorRef == null ? null : get(mirrorRef);
-        boolean mirrorTracksTargetRevision = mirrorSnapshot != null
+        boolean mirrorTracksTargetRevision = replaceAllActualSources || (mirrorSnapshot != null
             && mirrorSnapshot.exists()
-            && targetRevision.equals(text(data(mirrorSnapshot).get("targetRevisionAtFetch"), ""));
+            && targetRevision.equals(text(data(mirrorSnapshot).get("targetRevisionAtFetch"), "")));
 
         Instant now = clock.instant();
         Map<String, Map<String, Object>> replacements = new LinkedHashMap<>();
@@ -2506,7 +2506,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         DocumentSnapshot snapshot = get(ref);
         Map<String, Object> current = snapshot.exists() ? data(snapshot) : Map.of();
         long currentRevision = longValue(current.get("revision"), 0);
-        if (currentRevision != request.expectedRevision()) {
+        if (!request.replaceAllActualSources() && currentRevision != request.expectedRevision()) {
             throw new WeeklyExpenseConflictException("Cashflow annual total revision changed. Reload before applying.");
         }
 

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -1348,6 +1348,59 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
+    void annualTotalWriteKeepsRevisionGuardUnlessExplicitOverwriteIsRequested() {
+        Fixture fixture = fixture(activeMember(), activeLease());
+        CashflowSheetAnnualApplyCommand first = new CashflowSheetAnnualApplyCommand(
+            "annual-revision-2025-first",
+            SOURCE_REVISION,
+            2025,
+            0,
+            annualCells()
+        );
+        fixture.persistence.runCommandTransaction(() -> {
+            fixture.persistence.requireCashflowWritePermission(ACTOR, "project-a");
+            fixture.persistence.replaceCashflowSheetYearTotal(
+                "tenant-a", "project-a", "cashflow-sheet-lab", first
+            );
+            return null;
+        });
+
+        CashflowSheetAnnualApplyCommand stale = new CashflowSheetAnnualApplyCommand(
+            "annual-revision-2025-stale",
+            SOURCE_REVISION,
+            2025,
+            0,
+            annualCells()
+        );
+        assertThatThrownBy(() -> fixture.persistence.runCommandTransaction(() -> {
+            fixture.persistence.requireCashflowWritePermission(ACTOR, "project-a");
+            fixture.persistence.replaceCashflowSheetYearTotal(
+                "tenant-a", "project-a", "cashflow-sheet-lab", stale
+            );
+            return null;
+        }))
+            .isInstanceOf(WeeklyExpenseConflictException.class)
+            .hasMessageContaining("revision changed");
+
+        CashflowSheetAnnualApplyCommand overwrite = new CashflowSheetAnnualApplyCommand(
+            "annual-revision-2025-overwrite",
+            SOURCE_REVISION,
+            2025,
+            0,
+            annualCells(),
+            "",
+            true
+        );
+        assertThatCode(() -> fixture.persistence.runCommandTransaction(() -> {
+            fixture.persistence.requireCashflowWritePermission(ACTOR, "project-a");
+            fixture.persistence.replaceCashflowSheetYearTotal(
+                "tenant-a", "project-a", "cashflow-sheet-lab", overwrite
+            );
+            return null;
+        })).doesNotThrowAnyException();
+    }
+
+    @Test
     void annualTotalWritePreservesExplicitZeroAsARowValueAndState() {
         Fixture fixture = fixture(activeMember(), activeLease());
         List<CashflowAnnualCellSet.Cell> cells = annualCells().stream()
@@ -1403,6 +1456,33 @@ class FirestoreCashflowLeaseGuardTest {
             driftedRequest
         ))).isInstanceOf(WeeklyExpenseConflictException.class).hasMessageContaining("revision");
         assertThat(drifted.documents.keySet()).noneMatch(path -> path.contains("cashflow_weeks"));
+
+        Fixture overwrite = fixture(activeMember(), activeLease());
+        CashflowSheetLabApplyRequest overwriteBase = monthlyRequest(
+            "monthly-overwrite-base",
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            ""
+        );
+        CashflowSheetLabApplyRequest overwriteRequest = new CashflowSheetLabApplyRequest(
+            "monthly-overwrite",
+            overwriteBase.sourceRevision(),
+            overwriteBase.targetRevision(),
+            overwriteBase.yearMonth(),
+            true,
+            null,
+            null,
+            overwriteBase.calculationChecks(),
+            overwriteBase.cells()
+        );
+        assertThatCode(() -> overwrite.persistence.runCommandTransaction(() -> commandService(
+            overwrite.persistence
+        ).applyCashflowSheetLab(
+            ACTOR,
+            "project-a",
+            SESSION,
+            overwriteRequest
+        ))).doesNotThrowAnyException();
+        assertThat(overwrite.documents.keySet()).anyMatch(path -> path.contains("/cashflow_weeks/"));
 
         Fixture legacyClosed = fixture(activeMember(), activeLease());
         legacyClosed.documents.put("orgs/tenant-a/monthly_closes/project-a-2026-07", Map.of(

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1711,7 +1711,7 @@ export function CashflowProjectSheet({
   }, [orgId, projectId, resolveBffActor, user?.uid]);
 
   const handleStagePinnedSheetValues = useCallback(async (
-    replaceAllActualSources = false,
+    replaceAllActualSources = true,
     mirrorOverride?: CashflowSheetLabMirrorResult,
   ): Promise<void> => {
     const sourceMirror = mirrorOverride || cashflowSheetMirror;
@@ -1781,7 +1781,7 @@ export function CashflowProjectSheet({
     setSheetReviewDialogOpen(true);
   }, []);
 
-  const handleStartSheetChangeReview = useCallback(async (replaceAllActualSources = false): Promise<void> => {
+  const handleStartSheetChangeReview = useCallback(async (replaceAllActualSources = true): Promise<void> => {
     setSheetReviewDialogOpen(false);
     await handleStagePinnedSheetValues(replaceAllActualSources);
   }, [handleStagePinnedSheetValues]);
@@ -3539,7 +3539,7 @@ export function CashflowProjectSheet({
               </AlertDialogAction>
             ) : (
               <>
-                <Button type="button" variant="outline" onClick={() => void handleStartSheetChangeReview()} disabled={sheetRefreshLoading || sheetMirrorStatus !== 'FRESH'}>
+                <Button type="button" variant="outline" onClick={() => void handleStartSheetChangeReview(true)} disabled={sheetRefreshLoading || sheetMirrorStatus !== 'FRESH'}>
                   {sheetRefreshLoading ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="mr-1.5 h-3.5 w-3.5" />}
                   시트 값 반영
                 </Button>

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
@@ -731,6 +731,7 @@ export function CashflowSheetLabPage() {
             actor: requestActor,
             projectId,
             expectedMirrorRevision,
+            replaceAllActualSources: true,
             idempotencyKey: stageIdempotencyKey,
           })
         ));
@@ -813,6 +814,7 @@ export function CashflowSheetLabPage() {
           actor: requestActor,
           projectId,
           stageRunId: stagedRunId,
+          replaceAllActualSources: true,
           closedMonthChangeReason: monthCloseChangeReason,
           closedMonthDifferenceCount: stagedEvidence.closedMonthDifferenceCount,
           closedMonthDifferenceManifestHash: stagedEvidence.closedMonthDifferenceManifestHash,

--- a/src/app/lib/sheets-cashflow-readonly-client.test.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.test.ts
@@ -142,6 +142,7 @@ describe('sheets cashflow readonly client', () => {
       startWeek: '26-1-1',
       endWeek: '26-6-5',
       idempotencyKey: 'apply-001',
+      replaceAllActualSources: true,
       lease,
       finalize: true,
       client,
@@ -156,6 +157,7 @@ describe('sheets cashflow readonly client', () => {
           sheetName: 'cashflow(사용내역 연동)',
           startWeek: '26-1-1',
           endWeek: '26-6-5',
+          replaceAllActualSources: true,
           idempotencyKey: 'apply-001',
         },
         idempotencyKey: 'apply-001',
@@ -323,57 +325,10 @@ describe('sheets cashflow readonly client', () => {
     );
   });
 
-  it('recovers the persisted mirror when a successful refresh response has no usable body', async () => {
-    const persistedMirror = {
-      projectId: 'p001',
-      status: 'FRESH' as const,
-      sourceRevision: 'sha256:recovered',
-      targetRevisionAtFetch: 'sha256:target-001',
-      lastRefreshIdempotencyKey: 'refresh-recover-001',
-      capturedAt: '2026-07-23T01:21:27.063Z',
-      summary: { cellCount: 1920, valueCount: 1097, emptyCount: 823, invalidCount: 0 },
-      cells: [],
-      annualCells: [],
-    };
+  it('does not issue a recovery read when refresh returns an unusable response', async () => {
     const client = asMockClient({
       post: vi.fn(async () => ({ data: null })),
-      get: vi.fn(async () => ({ data: persistedMirror })),
-    });
-
-    const result = await refreshCashflowSheetLabMirrorViaBff({
-      tenantId: 'mysc',
-      actor: { uid: 'user-1', role: 'workspace_user', email: 'user@mysc.co.kr' },
-      projectId: 'p001',
-      sourceYear: 2026,
-      value: 'https://docs.google.com/spreadsheets/d/sheet-001/edit',
-      sheetName: 'cashflow(사용내역 연동)',
-      startWeek: '26-1-1',
-      endWeek: '26-12-5',
-      idempotencyKey: 'refresh-recover-001',
-      client,
-    });
-
-    expect(result).toEqual(persistedMirror);
-    expect(client.get).toHaveBeenCalledWith(
-      '/api/v1/projects/p001/cashflow-sheet-lab/mirror',
-      expect.objectContaining({ tenantId: 'mysc', retries: 0 }),
-    );
-  });
-
-  it('rejects persisted mirror recovery from another project', async () => {
-    const client = asMockClient({
-      post: vi.fn(async () => ({ data: null })),
-      get: vi.fn(async () => ({
-        data: {
-          status: 'FRESH',
-          sourceRevision: 'sha256:recovered',
-          lastRefreshIdempotencyKey: 'refresh-recover-001',
-          summary: { cellCount: 1, valueCount: 1, emptyCount: 0, invalidCount: 0 },
-          cells: [],
-          annualCells: [],
-          projectId: 'p999',
-        },
-      })),
+      get: vi.fn(),
     });
 
     await expect(refreshCashflowSheetLabMirrorViaBff({
@@ -381,57 +336,10 @@ describe('sheets cashflow readonly client', () => {
       actor: { uid: 'user-1', role: 'workspace_user', email: 'user@mysc.co.kr' },
       projectId: 'p001',
       value: 'https://docs.google.com/spreadsheets/d/sheet-001/edit',
-      idempotencyKey: 'refresh-recover-001',
+      idempotencyKey: 'refresh-invalid-001',
       client,
     })).rejects.toMatchObject({ code: 'cashflow_sheet_refresh_response_invalid' });
-  });
-
-  it('accepts a server mirror without optional display fields', async () => {
-    const client = asMockClient({
-      post: vi.fn(async () => ({ data: null })),
-      get: vi.fn(async () => ({
-        data: {
-          projectId: 'p001',
-          status: 'FRESH',
-          sourceRevision: 'sha256:recovered',
-        },
-      })),
-    });
-
-    await expect(refreshCashflowSheetLabMirrorViaBff({
-      tenantId: 'mysc',
-      actor: { uid: 'user-1', role: 'workspace_user', email: 'user@mysc.co.kr' },
-      projectId: 'p001',
-      value: 'https://docs.google.com/spreadsheets/d/sheet-001/edit',
-      idempotencyKey: 'refresh-recover-001',
-      client,
-    })).resolves.toMatchObject({ projectId: 'p001', sourceRevision: 'sha256:recovered' });
-  });
-
-  it('accepts a committed mirror even when another refresh won the race', async () => {
-    const client = asMockClient({
-      post: vi.fn(async () => ({ data: null })),
-      get: vi.fn(async () => ({
-        data: {
-          projectId: 'p001',
-          status: 'FRESH',
-          sourceRevision: 'sha256:recovered',
-          lastRefreshIdempotencyKey: 'refresh-older',
-          summary: { cellCount: 1, valueCount: 1, emptyCount: 0, invalidCount: 0 },
-          cells: [],
-          annualCells: [],
-        },
-      })),
-    });
-
-    await expect(refreshCashflowSheetLabMirrorViaBff({
-      tenantId: 'mysc',
-      actor: { uid: 'user-1', role: 'workspace_user', email: 'user@mysc.co.kr' },
-      projectId: 'p001',
-      value: 'https://docs.google.com/spreadsheets/d/sheet-001/edit',
-      idempotencyKey: 'refresh-recover-001',
-      client,
-    })).resolves.toMatchObject({ sourceRevision: 'sha256:recovered' });
+    expect(client.get).not.toHaveBeenCalled();
   });
 
   it('stages the explicitly selected pinned revision through the review endpoint', async () => {

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -697,6 +697,7 @@ export async function applyCashflowSheetLabViaBff(params: {
   startWeek?: string;
   endWeek?: string;
   stageRunId?: string;
+  replaceAllActualSources?: boolean;
   applyRiskCandidates?: boolean;
   settledWeekChangeConfirmationId?: string;
   closedMonthChangeReason?: string;
@@ -723,6 +724,7 @@ export async function applyCashflowSheetLabViaBff(params: {
         ...(params.startWeek ? { startWeek: params.startWeek } : {}),
         ...(params.endWeek ? { endWeek: params.endWeek } : {}),
         ...(params.stageRunId ? { stageRunId: params.stageRunId } : {}),
+        ...(params.replaceAllActualSources ? { replaceAllActualSources: true } : {}),
         ...(typeof params.applyRiskCandidates === 'boolean' ? { applyRiskCandidates: params.applyRiskCandidates } : {}),
         ...(params.settledWeekChangeConfirmationId
           ? { settledWeekChangeConfirmationId: params.settledWeekChangeConfirmationId }
@@ -872,20 +874,6 @@ export async function refreshCashflowSheetLabMirrorViaBff(params: {
   );
   const expectedMirror = { projectId: params.projectId };
   if (isCashflowSheetLabMirrorResult(response.data, expectedMirror)) return response.data;
-
-  // The refresh command is idempotent and may already be committed even if an
-  // intermediary returns an empty body. Recover the persisted server snapshot
-  // instead of treating a successful refresh as a UI failure.
-  const recovered = await apiClient.get<CashflowSheetLabMirrorResult>(
-    `/api/v1/projects/${encodeURIComponent(params.projectId)}/cashflow-sheet-lab/mirror`,
-    {
-      tenantId: params.tenantId,
-      actor: toRequestActor(params.actor),
-      timeoutMs: 15000,
-      retries: 0,
-    },
-  );
-  if (isCashflowSheetLabMirrorResult(recovered.data, expectedMirror)) return recovered.data;
   throw invalidCashflowSheetMirrorResponse();
 }
 


### PR DESCRIPTION
## What changed\n- Explicit sheet overwrite is carried as one-way intent from frontend through BFF, JVM, and Firestore for monthly, batch, and annual writes.\n- Force overwrite no longer vetoes on target revision drift, pending-approval re-read, or canonical readback.\n- Refresh invalid responses fail directly without recovery GET.\n- Format, required-cell/value/formula checks, auth, closed-month business lock, and atomic persistence remain.\n\n## Verification\n- BFF route + client: 131 passed\n- JVM targeted lease guard: 125 passed\n- Production build: passed\n- git diff --check: passed\n\nThe normal guarded path remains unchanged when explicit overwrite is not requested.