### PR TITLE
fix(cashflow): normalize forced apply evidence hash

### DIFF
--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -3897,7 +3897,7 @@ async function stagePinnedCashflowSheetLab({
       blockAllCandidates: false,
       differences: [],
       differenceCount: 0,
-      manifestHash: stableHash([]),
+      manifestHash: `sha256:${stableHash([])}`,
       contractIssues: [],
       evidence: [],
     }

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -3020,6 +3020,7 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
     expect(forceStage.body.status).toBe('READY');
     expect(forceStage.body.pendingApprovalDifferenceCount).toBe(0);
+    expect(forceStage.body.pendingApprovalDifferenceManifestHash).toMatch(/^sha256:[a-f0-9]{64}$/);
     await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
       .send({ stageRunId: forceStage.body.runId, replaceAllActualSources: true, idempotencyKey: 'apply-pending-force' })


### PR DESCRIPTION
Fixes the live 400 on explicit overwrite: the force path now emits the empty pending-approval manifest hash in the existing sha256:<64 hex> contract. No new function or pipeline. Added one regression assertion.\n\nVerified: BFF route/client tests 131 passed, production build passed, diff check passed.