### PR TITLE
fix(cashflow): use one sheet import scope

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -326,7 +326,7 @@ describe('CashflowProjectSheet monthly close shell', () => {
       source.indexOf('void checkSheetChanges();'),
     );
     expect(checkFlow).not.toContain('applyCashflowSheetLabViaBff');
-    expect(source).toMatch(/expectedMirrorRevision: sourceMirror\.sourceRevision,\s*yearMonth,\s*\.\.\.\(replaceAllActualSources/);
+    expect(source).toMatch(/expectedMirrorRevision: sourceMirror\.sourceRevision,\s*\.\.\.\(replaceAllActualSources/);
     expect(checkFlow).not.toContain('refreshCashflowSheetLabMirrorViaBff');
   });
 

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1725,7 +1725,6 @@ export function CashflowProjectSheet({
       actor,
       projectId,
       expectedMirrorRevision: sourceMirror.sourceRevision,
-      yearMonth,
       ...(replaceAllActualSources ? { replaceAllActualSources: true } : {}),
       idempotencyKey: stageIdempotencyKey,
     });
@@ -1775,7 +1774,7 @@ export function CashflowProjectSheet({
     } finally {
       setSheetRefreshLoading(false);
     }
-  }, [cashflowSheetMirror, handleApplyStagedSheetValues, orgId, projectId, resolveBffActor, yearMonth]);
+  }, [cashflowSheetMirror, handleApplyStagedSheetValues, orgId, projectId, resolveBffActor]);
 
   const handleOpenSheetOnboarding = useCallback(() => {
     setSheetReviewDialogOpen(true);


### PR DESCRIPTION
프로젝트 현금흐름 화면의 시트 불러오기가 선택 월을 보내 부분 stage를 만들던 문제를 제거합니다.

- sheets-lab와 동일하게 전체 고정본 stage/apply
- 새 함수·새 검증 없음
- `CashflowProjectSheet.shell.test.ts` 60개 통과