### PR TITLE
fix(cashflow): 월 결산 승인이 장부 잠금 완료를 기다리지 않도록

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/boram/orca/MYSCube/node_modules

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -57,6 +57,11 @@ export { cashflowMonthCloseDeadline };
 const CASHFLOW_LINE_INDEX = new Map(CASHFLOW_ALL_LINES.map((lineId, index) => [lineId, index]));
 const CASHFLOW_MONTH_CLOSE_ROUTE_TIMEOUT_MS = 26_000;
 const CASHFLOW_MONTH_CLOSE_MUTATION_BUDGET_MS = 12_000;
+// 승인 클릭이 장부 잠금 완료까지 기다리는 시간. 빠르면 한 번에 끝나고, 넘어가면
+// "확정 진행 중"으로 돌려준 뒤 같은 멱등키의 다음 호출이 이어받는다. 결재는 사람이
+// 며칠에 걸쳐 하는 일이라 잠금을 같은 요청 안에서 끝낼 이유가 없다 - 승인자를
+// 26초 동안 붙잡아 두는 쪽이 오히려 승인 자체를 실패로 보이게 만들었다.
+const CASHFLOW_MONTH_CLOSE_SYNC_CONFIRM_MS = 9_000;
 const CASHFLOW_MONTH_CLOSE_REQUEST_MAX_BYTES = 900_000;
 
 function readWeeklyYear(value) {
@@ -4275,7 +4280,10 @@ export function mountJvmWeeklyApiRoutes(app, {
       const prepared = {
         projectId: encodeURIComponent(projectId),
         rawProjectId: projectId,
-        routeDeadlineAtMs: Date.now() + monthCloseRouteTimeoutMs,
+        routeDeadlineAtMs: Date.now() + Math.min(
+          monthCloseRouteTimeoutMs,
+          CASHFLOW_MONTH_CLOSE_SYNC_CONFIRM_MS,
+        ),
         closeBody: {
           idempotencyKey: jvmMutationIdempotencyKey,
           yearMonth: readOptionalText(claimed.yearMonth),
@@ -4298,24 +4306,44 @@ export function mountJvmWeeklyApiRoutes(app, {
         try {
           monthClose = await executePreparedCashflowMonthClose(req, prepared);
         } catch (error) {
-          if (readOptionalText(error?.code) === 'cashflow_month_close_reconciliation_pending') {
-            await db.runTransaction(async (transaction) => {
-              const snapshot = await transaction.get(requestRef);
-              const current = snapshot.exists ? snapshot.data() || {} : null;
-              if (
-                !current
-                || current.status !== 'APPROVING'
-                || Number(current.revision) !== expectedRevision
-                || current.reviewIdempotencyKey !== jvmMutationIdempotencyKey
-              ) return;
-              transaction.set(requestRef, {
-                ...current,
-                status: 'UNCERTAIN',
-                reconciliationEvidence: error.reconciliationEvidence,
-              });
-            });
-          }
-          throw error;
+          if (readOptionalText(error?.code) !== 'cashflow_month_close_reconciliation_pending') throw error;
+          // 승인은 사람이 하는 결재이고, 장부 잠금은 그 결정의 뒷정리다. 둘을 한 HTTP 요청에
+          // 묶어 두면 JVM 확정이 라우트 예산을 넘길 때 승인 자체가 실패한 것처럼 보인다.
+          // 실제로는 선점(APPROVING)이 이미 커밋됐고 JVM 이 처리 중일 수도 있다.
+          // 그래서 여기서는 "확정 진행 중"을 정직한 상태로 돌려주고, 같은 멱등키의 다음
+          // 호출이 reconcile 로 이어받아 APPROVED 로 마무리한다.
+          //
+          // 절대 하지 않는 것: JVM 확정 없이 APPROVED 로 넘기는 것. 그러면 결재는 끝났는데
+          // 원장은 열려 있어 마감 잠금·변경 경고가 통째로 동작하지 않는다.
+          let uncertain = null;
+          await db.runTransaction(async (transaction) => {
+            const snapshot = await transaction.get(requestRef);
+            const current = snapshot.exists ? snapshot.data() || {} : null;
+            if (
+              !current
+              || !['APPROVING', 'UNCERTAIN'].includes(readOptionalText(current.status))
+              || Number(current.revision) !== expectedRevision
+              || current.reviewIdempotencyKey !== jvmMutationIdempotencyKey
+            ) return;
+            uncertain = {
+              ...current,
+              status: 'UNCERTAIN',
+              reconciliationEvidence: error.reconciliationEvidence,
+            };
+            transaction.set(requestRef, uncertain);
+          });
+          if (!uncertain) throw error;
+          createCashflowPerformanceTrace({
+            requestId: req.context.requestId,
+            operation: 'cashflow.month_close.approval',
+            ...(performanceLogger ? { logger: performanceLogger } : {}),
+            ...(performanceNow ? { now: performanceNow } : {}),
+          }).emit('ledger_close_pending', { outcome: 'ok' });
+          res.status(200).json({
+            request: cashflowMonthCloseRequestView(uncertain),
+            pendingLedgerClose: true,
+          });
+          return;
         }
       }
       let approved;

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -4728,6 +4728,7 @@ describe('JVM weekly API BFF proxy', () => {
     const cashflow = { projectId: 'project-a', projection: [], actual: [], readModel: { months } };
     let closedMonthClose = null;
     let dashboardSourceUnavailable = false;
+    let closeMutationFails = false;
     const fetchImpl = vi.fn(async (url, init) => {
       if (url.endsWith('/month-close/reopen-decision')) {
         closedMonthClose = { ...closedMonthClose, status: 'OPEN', revision: 2 };
@@ -4745,6 +4746,7 @@ describe('JVM weekly API BFF proxy', () => {
         };
       }
       if (init.method === 'POST') {
+        if (closeMutationFails) throw new Error('JVM month-close confirmation is slow');
         const closeBody = JSON.parse(init.body);
         // JVM requireCumulativeCloseApproval 이 실제로 요구하는 것: 확정을 받는 순간 헤더가
         // APPROVING 이고 reviewIdempotencyKey 가 이번 확정 요청과 같아야 한다.
@@ -5149,6 +5151,48 @@ describe('JVM weekly API BFF proxy', () => {
       .send({ decision: 'REJECT', reason: '취소', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
       .expect(409);
 
+    // 장부 잠금이 승인 요청 안에서 안 끝나도 승인은 실패가 아니다. 결재는 사람이 하는 일이고
+    // 잠금은 그 뒤처리라, 승인자를 붙잡아 두는 대신 "확정 진행 중"으로 돌려주고 같은 멱등키의
+    // 다음 호출이 이어받는다. 단, 그 사이에도 APPROVED 로 앞서가지는 않는다.
+    closedMonthClose = null;
+    closeMutationFails = true;
+    source.documents.set(requestPath, {
+      ...source.documents.get(requestPath),
+      status: 'PENDING',
+      reviewedByUid: null,
+      reviewIdempotencyKey: null,
+    });
+    source.documents.delete('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r2-approved');
+    const pendingCloseCount = closePostCount();
+    await request(approver)
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
+      .set('idempotency-key', 'ledger-close-pending')
+      .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
+      .expect(200)
+      .expect((response) => {
+        expect(response.body.pendingLedgerClose).toBe(true);
+        expect(response.body.request).toMatchObject({ status: 'UNCERTAIN', revision: 2 });
+        expect(response.body.monthClose).toBeUndefined();
+      });
+    expect(closePostCount()).toBe(pendingCloseCount + 1);
+    // 원장이 안 닫혔으므로 승인 완료로 기록하지 않는다.
+    expect(source.documents.get(requestPath)).toMatchObject({ status: 'UNCERTAIN' });
+    expect(source.documents.has('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r2-approved')).toBe(false);
+
+    // 같은 멱등키로 이어받으면 마무리된다.
+    closeMutationFails = false;
+    await request(approver)
+      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
+      .set('idempotency-key', 'ledger-close-pending')
+      .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
+      .expect(200)
+      .expect((response) => {
+        expect(response.body.pendingLedgerClose).toBeUndefined();
+        expect(response.body.request).toMatchObject({ status: 'APPROVED', revision: 2 });
+      });
+    expect(source.documents.get('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r2-approved')).toMatchObject({
+      action: 'APPROVED', revision: 2,
+    });
   });
 
   it('lets only the requester withdraw a PENDING cumulative close request, and never after review starts', async () => {

--- a/src/app/components/cashflow/AxrMonthCloseQaPanel.tsx
+++ b/src/app/components/cashflow/AxrMonthCloseQaPanel.tsx
@@ -42,6 +42,11 @@ export interface QaControl {
 
 const apiClient = createPlatformApiClient();
 
+// 승인 접수 후 장부 잠금이 끝날 때까지 이어받는 간격과 횟수 (최대 약 2분).
+// 넘어가도 승인 선점은 살아 있어, 다음에 같은 버튼을 눌러 이어서 마무리할 수 있다.
+const CASHFLOW_LEDGER_CLOSE_POLL_MS = 4_000;
+const CASHFLOW_LEDGER_CLOSE_MAX_POLLS = 30;
+
 const ACTION_LABELS: Record<QaAction, string> = {
   REQUEST_CLOSE: '월 결산 요청 준비',
   APPROVE_REQUEST: '월 결산 승인',
@@ -116,19 +121,28 @@ export async function executeAxrMonthCloseQaAction({
 
   if (action === 'APPROVE_REQUEST' || action === 'REJECT_REQUEST') {
     if (!control.request) throw new Error('검토할 월 결산 요청이 없습니다.');
-    return clients.reviewRequest({
+    const reviewInput = {
       tenantId,
       actor,
       projectId,
       requestId: control.request.requestId,
       payload: {
-        decision: action === 'APPROVE_REQUEST' ? 'APPROVE' : 'REJECT',
+        decision: action === 'APPROVE_REQUEST' ? ('APPROVE' as const) : ('REJECT' as const),
         expectedRevision: control.request.revision,
         expectedManifestHash: control.request.manifestHash || undefined,
         reason: reason.trim(),
       },
+      // 결정적 키. 이어받기 호출이 같은 키를 써야 JVM 이 앞선 시도를 인식하고 reconcile 된다.
       idempotencyKey: `axr-month-close-qa:${action}:${control.request.requestId}:r${control.request.revision}`,
-    });
+    };
+    let result = await clients.reviewRequest(reviewInput);
+    // 승인은 접수됐고 장부 잠금만 남은 상태면 끝날 때까지 이어받는다. 승인자를 한 요청에
+    // 붙잡아 두지 않으면서도, 마무리를 사용자 손에 떠넘기지 않는다.
+    for (let attempt = 0; result?.pendingLedgerClose && attempt < CASHFLOW_LEDGER_CLOSE_MAX_POLLS; attempt += 1) {
+      await new Promise((resolve) => { setTimeout(resolve, CASHFLOW_LEDGER_CLOSE_POLL_MS); });
+      result = await clients.reviewRequest(reviewInput);
+    }
+    return result;
   }
   if (action === 'REQUEST_REOPEN') {
     return clients.requestReopen({

--- a/src/app/components/cashflow/AxrMonthCloseQaPanel.tsx
+++ b/src/app/components/cashflow/AxrMonthCloseQaPanel.tsx
@@ -18,6 +18,7 @@ import {
   createPlatformApiClient,
   decideCashflowMonthReopenViaBff,
   requestCashflowMonthReopenViaBff,
+  approveCashflowMonthCloseUntilLedgerClosed,
   reviewCashflowMonthCloseRequestViaBff,
   toRequestActor,
   type ActorLike,
@@ -41,11 +42,6 @@ export interface QaControl {
 }
 
 const apiClient = createPlatformApiClient();
-
-// 승인 접수 후 장부 잠금이 끝날 때까지 이어받는 간격과 횟수 (최대 약 2분).
-// 넘어가도 승인 선점은 살아 있어, 다음에 같은 버튼을 눌러 이어서 마무리할 수 있다.
-const CASHFLOW_LEDGER_CLOSE_POLL_MS = 4_000;
-const CASHFLOW_LEDGER_CLOSE_MAX_POLLS = 30;
 
 const ACTION_LABELS: Record<QaAction, string> = {
   REQUEST_CLOSE: '월 결산 요청 준비',
@@ -135,14 +131,10 @@ export async function executeAxrMonthCloseQaAction({
       // 결정적 키. 이어받기 호출이 같은 키를 써야 JVM 이 앞선 시도를 인식하고 reconcile 된다.
       idempotencyKey: `axr-month-close-qa:${action}:${control.request.requestId}:r${control.request.revision}`,
     };
-    let result = await clients.reviewRequest(reviewInput);
-    // 승인은 접수됐고 장부 잠금만 남은 상태면 끝날 때까지 이어받는다. 승인자를 한 요청에
-    // 붙잡아 두지 않으면서도, 마무리를 사용자 손에 떠넘기지 않는다.
-    for (let attempt = 0; result?.pendingLedgerClose && attempt < CASHFLOW_LEDGER_CLOSE_MAX_POLLS; attempt += 1) {
-      await new Promise((resolve) => { setTimeout(resolve, CASHFLOW_LEDGER_CLOSE_POLL_MS); });
-      result = await clients.reviewRequest(reviewInput);
-    }
-    return result;
+    if (action === 'REJECT_REQUEST') return clients.reviewRequest(reviewInput);
+    // 승인은 접수됐고 장부 잠금만 남은 상태면 끝날 때까지 이어받는다. 이어받기 규칙은
+    // platform-bff-client 한 곳에만 두고 승인 화면들이 공유한다.
+    return approveCashflowMonthCloseUntilLedgerClosed(reviewInput);
   }
   if (action === 'REQUEST_REOPEN') {
     return clients.requestReopen({

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -3298,10 +3298,15 @@ export async function reviewCashflowMonthCloseRequestViaBff(params: {
   payload: ReviewCashflowMonthCloseRequestPayload;
   idempotencyKey: string;
   client?: PlatformApiClientLike;
-}): Promise<{ request: CashflowMonthCloseRequest; monthClose?: CashflowMonthCloseResult }> {
+}): Promise<{
+  request: CashflowMonthCloseRequest;
+  monthClose?: CashflowMonthCloseResult;
+  pendingLedgerClose?: boolean;
+}> {
   const response = await resolveClient(params.client).post<{
     request: CashflowMonthCloseRequest;
     monthClose?: CashflowMonthCloseResult;
+    pendingLedgerClose?: boolean;
   }>(
     `/api/v1/cashflow/${encodeURIComponent(params.projectId)}/month-close/requests/${encodeURIComponent(params.requestId)}/${params.payload.expectedManifestHash ? 'status-review' : 'review'}`,
     {
@@ -3314,7 +3319,13 @@ export async function reviewCashflowMonthCloseRequestViaBff(params: {
       timeoutMs: 35_000,
     },
   );
-  if (params.payload.decision === 'APPROVE' && response.data.request.status !== 'APPROVED') {
+  // 승인 선점은 끝났고 장부 잠금만 진행 중인 상태(pendingLedgerClose)는 실패가 아니다.
+  // 호출자가 같은 멱등키로 다시 호출해 마무리한다.
+  if (
+    params.payload.decision === 'APPROVE'
+    && !response.data.pendingLedgerClose
+    && response.data.request.status !== 'APPROVED'
+  ) {
     throw new Error('월 결산 승인 상태를 확인하지 못했습니다.');
   }
   return response.data;

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -3000,7 +3000,7 @@ export async function transitionCashflowSettlementStatusViaBff(params: {
     if ((request.reviewWarnings ?? []).length > 0) {
       throw new Error('확인이 필요한 월 결산 항목이 있습니다. 해당 항목을 정리한 뒤 다시 승인해 주세요.');
     }
-    await reviewCashflowMonthCloseRequestViaBff({
+    await approveCashflowMonthCloseUntilLedgerClosed({
       ...params,
       requestId: request.requestId,
       payload: {
@@ -3329,6 +3329,32 @@ export async function reviewCashflowMonthCloseRequestViaBff(params: {
     throw new Error('월 결산 승인 상태를 확인하지 못했습니다.');
   }
   return response.data;
+}
+
+// 승인 선점(APPROVING)은 즉시 커밋되지만 JVM 장부 확정은 그보다 오래 걸릴 수 있다.
+// BFF 는 그때 pendingLedgerClose 를 실어 200 을 돌려주고, 같은 멱등키의 다음 호출이
+// reconcile 로 이어받아 APPROVED 로 마무리한다. 승인 화면이 여러 개라 이 이어받기
+// 규칙은 여기 한 곳에만 둔다 - 같은 규칙의 사본이 화면마다 생기면 조용히 갈린다.
+const CASHFLOW_LEDGER_CLOSE_POLL_MS = 4_000;
+const CASHFLOW_LEDGER_CLOSE_MAX_POLLS = 30;
+
+export async function approveCashflowMonthCloseUntilLedgerClosed(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectId: string;
+  requestId: string;
+  payload: ReviewCashflowMonthCloseRequestPayload;
+  idempotencyKey: string;
+  client?: PlatformApiClientLike;
+  onPending?: (attempt: number) => void;
+}) {
+  let result = await reviewCashflowMonthCloseRequestViaBff(params);
+  for (let attempt = 0; result?.pendingLedgerClose && attempt < CASHFLOW_LEDGER_CLOSE_MAX_POLLS; attempt += 1) {
+    params.onPending?.(attempt);
+    await new Promise((resolve) => { setTimeout(resolve, CASHFLOW_LEDGER_CLOSE_POLL_MS); });
+    result = await reviewCashflowMonthCloseRequestViaBff(params);
+  }
+  return result;
 }
 
 export async function withdrawCashflowMonthCloseRequestViaBff(params: {


### PR DESCRIPTION
## 문제
조직장이 월 결산을 승인하면 한 HTTP 요청 안에서 **JVM 장부 확정까지** 끝내야 했습니다. 확정이 26초 라우트 예산을 넘기면 `cashflow_month_close_reconciliation_pending` 503이 나가서 **승인 자체가 실패한 것처럼** 보였습니다. 실제로는 `APPROVING` 선점이 이미 커밋됐고 JVM이 처리 중일 수도 있는 상태였습니다.

## 접근
승인은 사람이 며칠에 걸쳐 하는 결재이고, 장부 잠금은 그 결정의 뒷정리입니다. 둘을 한 요청에 묶을 이유가 없습니다.

- 동기 확정 예산을 **9초**로 둡니다. 그 안에 끝나면 종전과 동일하게 `APPROVED`로 응답합니다.
- 넘어가면 `UNCERTAIN`을 **정직하게** 돌려주고 `pendingLedgerClose: true`를 실어 보냅니다. HTTP 200입니다.
- 같은 멱등키의 다음 호출이 기존 `reconcile` 경로로 이어받아 `APPROVED`로 마무리합니다. 이 재개 로직은 이미 있던 것이고, 새로 만들지 않았습니다.
- 프론트(AXR 패널)는 `pendingLedgerClose`면 4초 간격으로 같은 멱등키로 이어받습니다. 멱등키가 결정적(`...:${requestId}:r${revision}`)이라 재호출이 자동으로 같은 키를 씁니다.

## 하지 않은 것
**JVM 확정 없이 `APPROVED`로 넘기지 않습니다.** 그렇게 하면 결재는 끝났는데 원장은 열려 있어 마감 잠금·변경 경고가 통째로 동작하지 않고, 감사기록에는 승인 완료가 남습니다. 세션 초반에 고쳤던 결함과 같은 형태라 의도적으로 피했습니다.

## 검증
- [x] 새 테스트: 확정 미증명 시 200 + `pendingLedgerClose` + 문서 `UNCERTAIN` + **승인 감사기록 없음**, 이어받기 호출로 `APPROVED` 완료
- [x] Sabotage: 미확정인데 `APPROVED`로 흘려보내도록 고쳐 테스트 실패 확인 후 복원
- [x] `jvm-weekly-api.test.mjs` 200개 통과 (기존 503 경로는 레거시 계약이라 영향 없음)
- [x] 프론트 관련 스위트 411개 통과, `npm run typecheck` 신규 오류 0

## 후속 (이 PR 범위 아님)
일반 프로젝트에는 **조직장 승인 UI가 프론트에 없습니다.** 승인 화면은 AXR 전용 QA 패널 하나뿐이라, CMK 같은 프로젝트는 승인 대기함이 없습니다. BFF 수정은 경로와 무관하게 적용되지만 UI는 별도 확인이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)