### PR TITLE
fix(cashflow): align project sheet apply with lab

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -494,6 +494,21 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('!sheetApplyResumeRequired && (');
   });
 
+  it('uses the sheets-lab one-way apply contract and does not turn post-apply reads into a failed save', () => {
+    const applyStart = source.indexOf('const handleApplyStagedSheetValues');
+    const applyFlow = source.slice(applyStart, source.indexOf('const handleStagePinnedSheetValues', applyStart));
+    expect(applyFlow).toContain('replaceAllActualSources: true');
+    expect(applyFlow).toContain('pendingApprovalDifferenceCount: stage.pendingApprovalDifferenceCount');
+    expect(applyFlow).toContain('pendingApprovalDifferenceManifestHash: stage.pendingApprovalDifferenceManifestHash');
+    expect(applyFlow).not.toContain('applyRiskCandidates: true');
+    expect(applyFlow).toContain('void Promise.allSettled([');
+    expect(applyFlow).not.toContain('await Promise.all([\n        loadCashflowEvents(),\n        loadCashflowMonthClose(),\n      ]);');
+    const refreshStart = source.indexOf('const handleRefreshSheetMirror');
+    const refreshFlow = source.slice(refreshStart, source.indexOf('const handleMonthClosePreparationAction', refreshStart));
+    expect(refreshFlow).toContain('sourceYear: cashflowSheetConfig.sourceYear');
+    expect(refreshFlow).not.toContain('sourceYear: selectedYear');
+  });
+
   it('stops after staging closed-month differences until a reason is explicitly confirmed', () => {
     const stageStart = source.indexOf('const applyStageResult = async');
     const stageFlow = source.slice(

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1439,7 +1439,7 @@ export function CashflowProjectSheet({
         tenantId: orgId,
         actor,
         projectId,
-        sourceYear: selectedYear,
+        sourceYear: cashflowSheetConfig.sourceYear,
         value: cashflowSheetConfig.value,
         sheetName: cashflowSheetConfig.sheetName || undefined,
         idempotencyKey: refreshIdempotencyKey,
@@ -1474,7 +1474,7 @@ export function CashflowProjectSheet({
       operation: 'cashflow.sheet_refresh',
       projectId,
       yearMonth,
-      summary: { sourceYear: selectedYear, hasSheetConfig: true },
+      summary: { sourceYear: cashflowSheetConfig.sourceYear, hasSheetConfig: true },
     });
     try {
       const actor = await resolveBffActor();
@@ -1591,16 +1591,18 @@ export function CashflowProjectSheet({
         actor,
         projectId,
         stageRunId: stage.runId,
-        applyRiskCandidates: true,
+        replaceAllActualSources: true,
         closedMonthChangeReason,
         closedMonthDifferenceCount: stage.closedMonthDifferenceCount,
         closedMonthDifferenceManifestHash: stage.closedMonthDifferenceManifestHash,
+        pendingApprovalDifferenceCount: stage.pendingApprovalDifferenceCount,
+        pendingApprovalDifferenceManifestHash: stage.pendingApprovalDifferenceManifestHash,
         acceptFormulaMismatches,
         idempotencyKey: applyIdempotencyKey,
       });
     };
     const rememberApplyResult = async (result: Awaited<ReturnType<typeof apply>>) => {
-      await Promise.all([
+      void Promise.allSettled([
         loadCashflowEvents(),
         loadCashflowMonthClose(),
       ]);


### PR DESCRIPTION
## What
- Make the project cashflow sheet action send the same one-way apply contract as Sheets Lab.
- Do not let post-apply activity/month-close reads turn a completed apply into a failure.
- Refresh using the connected sheet source year.

## Verification
- npm test -- --run src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
- npm run build