### PR TITLE
fix(cashflow): 확정 예산을 시도마다 새로 잡아 이어받기가 멈추지 않도록

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -57,11 +57,6 @@ export { cashflowMonthCloseDeadline };
 const CASHFLOW_LINE_INDEX = new Map(CASHFLOW_ALL_LINES.map((lineId, index) => [lineId, index]));
 const CASHFLOW_MONTH_CLOSE_ROUTE_TIMEOUT_MS = 26_000;
 const CASHFLOW_MONTH_CLOSE_MUTATION_BUDGET_MS = 12_000;
-// 승인 클릭이 장부 잠금 완료까지 기다리는 시간. 빠르면 한 번에 끝나고, 넘어가면
-// "확정 진행 중"으로 돌려준 뒤 같은 멱등키의 다음 호출이 이어받는다. 결재는 사람이
-// 며칠에 걸쳐 하는 일이라 잠금을 같은 요청 안에서 끝낼 이유가 없다 - 승인자를
-// 26초 동안 붙잡아 두는 쪽이 오히려 승인 자체를 실패로 보이게 만들었다.
-const CASHFLOW_MONTH_CLOSE_SYNC_CONFIRM_MS = 9_000;
 const CASHFLOW_MONTH_CLOSE_REQUEST_MAX_BYTES = 900_000;
 
 function readWeeklyYear(value) {
@@ -4280,10 +4275,7 @@ export function mountJvmWeeklyApiRoutes(app, {
       const prepared = {
         projectId: encodeURIComponent(projectId),
         rawProjectId: projectId,
-        routeDeadlineAtMs: Date.now() + Math.min(
-          monthCloseRouteTimeoutMs,
-          CASHFLOW_MONTH_CLOSE_SYNC_CONFIRM_MS,
-        ),
+        routeDeadlineAtMs: Date.now() + monthCloseRouteTimeoutMs,
         closeBody: {
           idempotencyKey: jvmMutationIdempotencyKey,
           yearMonth: readOptionalText(claimed.yearMonth),
@@ -4304,6 +4296,10 @@ export function mountJvmWeeklyApiRoutes(app, {
       }
       if (!monthClose) {
         try {
+          // 확정 예산은 "확정 시도"에 준다. 재개 경로에서는 위 reconcile 이 먼저 도는데,
+          // 그것이 예산을 먹고 나면 executePrepared 가 JVM 을 치지도 못하고 즉시
+          // route_timeout 을 내며, 이어받기가 영원히 같은 자리를 맴돈다. 실제로 그렇게 돌았다.
+          prepared.routeDeadlineAtMs = Date.now() + monthCloseRouteTimeoutMs;
           monthClose = await executePreparedCashflowMonthClose(req, prepared);
         } catch (error) {
           if (readOptionalText(error?.code) !== 'cashflow_month_close_reconciliation_pending') throw error;


### PR DESCRIPTION
## 라이브 증상
조직장 승인이 끝나지 않고 계속 "처리 중"에 머물렀습니다.

## 원인 (프로덕션 문서 근거)
`orgs/mysc/cashflow_month_close_requests/p1773817948751-2026-08`:
```
status            : APPROVING        ← 승인 결정 자체는 기록됨
mutationErrorCode : cashflow_month_close_route_timeout
observed          : { status: OPEN, revision: 0 }   ← JVM 이 한 번도 안 닫음
```

재개 경로는 `reconcile`(JVM 조회)을 먼저 돕니다. 그런데 확정 예산(`routeDeadlineAtMs`)이 그보다 **앞서** 계산돼 있어서, 직전 PR(#526)이 그 예산을 9초로 줄이자 reconcile이 예산을 전부 소모했습니다. 그 결과 `executePreparedCashflowMonthClose`가 진입 즉시 `route_timeout`을 던지고 **JVM을 호출조차 하지 않았습니다.** 장부가 안 닫히니 이어받기는 영원히 같은 자리를 맴돌았습니다.

## 수정
- 확정 예산을 **확정 시도 직전에 다시 잡습니다.** reconcile이 쓴 시간이 확정 시도를 굶기지 않습니다.
- #526에서 넣은 9초 단축을 되돌립니다. 매 시도가 JVM 확정에 온전한 예산을 씁니다.

#526의 "미확정이면 200 + `pendingLedgerClose`" 동작은 유지합니다 — 승인자를 실패로 되돌려보내지 않는 부분은 옳았습니다.

## 검증
- [x] `jvm-weekly-api.test.mjs` 200개 통과
- [x] `npm run typecheck` 신규 오류 0

## 남은 문제
이 수정은 이어받기가 **진짜로 JVM을 시도하게** 만들 뿐입니다. AXR 프로젝트의 누적 확정이 26초 예산 안에 끝나는지는 별개 문제이며, 끝나지 않으면 여전히 여러 번 이어받아야 합니다. JVM 확정 소요 시간 측정이 후속으로 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)