### PR TITLE
chore(cashflow): freeze sheet one-way pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,33 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
+  cashflow-sheet-lab-one-way-freeze:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+
+      - name: Require owner approval for sheet one-way changes
+        env:
+          CASHFLOW_SHEET_LAB_FREEZE_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          CASHFLOW_SHEET_LAB_FREEZE_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CASHFLOW_SHEET_LAB_FREEZE_PULL_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/check_cashflow_sheet_lab_freeze.mjs
+
   test-and-build:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/scripts/check_cashflow_sheet_lab_freeze.mjs
+++ b/scripts/check_cashflow_sheet_lab_freeze.mjs
@@ -1,0 +1,89 @@
+import { execFileSync } from 'node:child_process';
+
+export const CASHFLOW_SHEET_LAB_FREEZE_APPROVER = 'merryAI-dev';
+export const CASHFLOW_SHEET_LAB_FREEZE_MARKER = 'CASHFLOW_SHEET_LAB_FREEZE_APPROVED';
+
+export const CASHFLOW_SHEET_LAB_FREEZE_PATHS = [
+  '.github/workflows/ci.yml',
+  'scripts/check_cashflow_sheet_lab_freeze.mjs',
+  'src/app/components/cashflow/CashflowProjectSheet.tsx',
+  'src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx',
+  'src/app/lib/sheets-cashflow-readonly-client.ts',
+  'server/bff/java-weekly-client.mjs',
+  'server/bff/routes/cashflow-sheet-lab.mjs',
+  'server/bff/google-sheets.mjs',
+  'server/bff/cashflow-sheet-template.mjs',
+  'server/bff/cashflow-sheet-snapshot.mjs',
+  'server/bff/cashflow-policy.mjs',
+  'server/bff/cashflow-annual-total.mjs',
+  'server/bff/cashflow-apply-lease.mjs',
+  'server/bff/cashflow-close-hash.mjs',
+  'server/bff/cashflow-close-calendar.mjs',
+  'server/bff/schemas.mjs',
+  'src/app/platform/cashflow-week-core.mjs',
+  'server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSheetLabApplyRequest.java',
+  'server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSheetLabApplyResponse.java',
+  'server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java',
+  'server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowMonthCellSet.java',
+  'server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java',
+  'server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java',
+  'server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java',
+];
+
+function latestReviewByLogin(reviews, login) {
+  return reviews
+    .filter((review) => review?.user?.login === login)
+    .sort((left, right) => String(left.submitted_at || '').localeCompare(String(right.submitted_at || '')))
+    .at(-1) || null;
+}
+
+export function evaluateCashflowSheetLabFreeze({ changedFiles, reviews, headSha }) {
+  const protectedFiles = changedFiles.filter((file) => CASHFLOW_SHEET_LAB_FREEZE_PATHS.includes(file));
+  if (protectedFiles.length === 0) return { ok: true, protectedFiles, approval: null };
+
+  const approval = latestReviewByLogin(reviews, CASHFLOW_SHEET_LAB_FREEZE_APPROVER);
+  const approved = approval?.state === 'APPROVED'
+    && approval?.commit_id === headSha
+    && String(approval?.body || '').includes(CASHFLOW_SHEET_LAB_FREEZE_MARKER);
+  return { ok: approved, protectedFiles, approval };
+}
+
+function changedFiles(baseSha, headSha) {
+  return execFileSync('git', ['diff', '--name-only', '--diff-filter=ACMR', baseSha, headSha], { encoding: 'utf8' })
+    .split('\n')
+    .map((file) => file.trim())
+    .filter(Boolean);
+}
+
+async function fetchReviews({ repository, pullNumber, token }) {
+  const response = await fetch(`https://api.github.com/repos/${repository}/pulls/${pullNumber}/reviews?per_page=100`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  });
+  if (!response.ok) throw new Error(`승인 기록을 읽지 못했습니다. GitHub 응답: ${response.status}`);
+  return response.json();
+}
+
+export async function runCashflowSheetLabFreeze(env = process.env) {
+  if (env.GITHUB_EVENT_NAME !== 'pull_request') return { ok: true, protectedFiles: [], approval: null };
+  const files = changedFiles(env.CASHFLOW_SHEET_LAB_FREEZE_BASE_SHA, env.CASHFLOW_SHEET_LAB_FREEZE_HEAD_SHA);
+  const reviews = await fetchReviews({
+    repository: env.GITHUB_REPOSITORY,
+    pullNumber: env.CASHFLOW_SHEET_LAB_FREEZE_PULL_NUMBER,
+    token: env.GITHUB_TOKEN,
+  });
+  return evaluateCashflowSheetLabFreeze({ changedFiles: files, reviews, headSha: env.CASHFLOW_SHEET_LAB_FREEZE_HEAD_SHA });
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const result = await runCashflowSheetLabFreeze();
+  if (!result.ok) {
+    console.error('시트 연동 one-way 루프 변경은 별도 승인 후에만 병합할 수 있습니다.');
+    console.error(`필요 승인: ${CASHFLOW_SHEET_LAB_FREEZE_APPROVER}의 ${CASHFLOW_SHEET_LAB_FREEZE_MARKER} 리뷰 (현재 PR HEAD 기준)`);
+    console.error(`보호 파일: ${result.protectedFiles.join(', ')}`);
+    process.exit(1);
+  }
+}

--- a/src/app/platform/cashflow-sheet-lab-freeze.test.ts
+++ b/src/app/platform/cashflow-sheet-lab-freeze.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import {
-  CASHFLOW_SHEET_LAB_FREEZE_MARKER,
-  evaluateCashflowSheetLabFreeze,
-} from '../../../scripts/check_cashflow_sheet_lab_freeze.mjs';
+// @ts-expect-error The guard is intentionally plain Node ESM and exercised here by Vitest.
+import * as freeze from '../../../scripts/check_cashflow_sheet_lab_freeze.mjs';
+
+const { CASHFLOW_SHEET_LAB_FREEZE_MARKER, evaluateCashflowSheetLabFreeze } = freeze;
 
 const headSha = 'head-123';
 const protectedFile = 'server/bff/routes/cashflow-sheet-lab.mjs';

--- a/src/app/platform/cashflow-sheet-lab-freeze.test.ts
+++ b/src/app/platform/cashflow-sheet-lab-freeze.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CASHFLOW_SHEET_LAB_FREEZE_MARKER,
+  evaluateCashflowSheetLabFreeze,
+} from '../../../scripts/check_cashflow_sheet_lab_freeze.mjs';
+
+const headSha = 'head-123';
+const protectedFile = 'server/bff/routes/cashflow-sheet-lab.mjs';
+
+describe('cashflow sheet-lab one-way freeze', () => {
+  it('allows unrelated changes without approval', () => {
+    expect(evaluateCashflowSheetLabFreeze({ changedFiles: ['README.md'], reviews: [], headSha }).ok).toBe(true);
+  });
+
+  it('blocks a protected change without a current-head approval', () => {
+    expect(evaluateCashflowSheetLabFreeze({ changedFiles: [protectedFile], reviews: [], headSha }).ok).toBe(false);
+    expect(evaluateCashflowSheetLabFreeze({
+      changedFiles: [protectedFile],
+      headSha,
+      reviews: [{
+        user: { login: 'merryAI-dev' }, state: 'APPROVED', commit_id: 'older-head',
+        body: CASHFLOW_SHEET_LAB_FREEZE_MARKER, submitted_at: '2026-08-10T00:00:00Z',
+      }],
+    }).ok).toBe(false);
+  });
+
+  it('allows a protected change only after the owner approves the current head', () => {
+    expect(evaluateCashflowSheetLabFreeze({
+      changedFiles: [protectedFile],
+      headSha,
+      reviews: [{
+        user: { login: 'merryAI-dev' }, state: 'APPROVED', commit_id: headSha,
+        body: CASHFLOW_SHEET_LAB_FREEZE_MARKER, submitted_at: '2026-08-10T00:00:00Z',
+      }],
+    }).ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## What
- Freeze the sheet-lab one-way pipeline behind a CI approval gate.
- A protected-path PR only passes after `merryAI-dev` approves the current PR head with `CASHFLOW_SHEET_LAB_FREEZE_APPROVED`.
- The CI workflow and guard script themselves are protected.

## Verification
- npm test -- --run src/app/platform/cashflow-sheet-lab-freeze.test.ts
- workflow YAML parsing

## Required owner action
- Review this PR at its current head with exactly: `CASHFLOW_SHEET_LAB_FREEZE_APPROVED`