### PR TITLE
refactor(cashflow): make approval the month-close authority

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,18 @@ on:
     branches: [main]
 
 jobs:
+  cashflow-sheet-lab-one-way-freeze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Keep the Sheet Lab one-way pipeline frozen
+        run: |
+          changed="$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- server/bff/routes/cashflow-sheet-lab.mjs)"
+          test -z "$changed" || { echo "Frozen Sheet Lab pipeline changed:"; echo "$changed"; exit 1; }
+
   test-and-build:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -119,6 +119,8 @@ jobs:
       JVM_WEEKLY_API_ID_TOKEN_AUDIENCE: ${{ vars.JVM_WEEKLY_API_ID_TOKEN_AUDIENCE_LIVE }}
       JVM_WEEKLY_INTERNAL_API_TOKEN: ${{ secrets.JVM_WEEKLY_INTERNAL_API_TOKEN_LIVE }}
       JVM_WEEKLY_API_SERVICE_ACCOUNT_JSON: ${{ secrets.JVM_WEEKLY_API_SERVICE_ACCOUNT_JSON_LIVE }}
+      SLACK_ALERT_BOT_TOKEN: ${{ secrets.SLACK_ALERT_BOT_TOKEN }}
+      SLACK_ALERT_CHANNEL_ID: C0BQ6980HR6
       # Use a production-scoped secret name so a stale repository-level
       # VERCEL_TOKEN cannot be confused with the Production environment token.
       VERCEL_TOKEN: ${{ secrets.VERCEL_DEPLOY_TOKEN_PRODUCTION }}
@@ -189,6 +191,7 @@ jobs:
           test -n "${JVM_WEEKLY_API_ID_TOKEN_AUDIENCE}" || { echo "Missing Production variable: JVM_WEEKLY_API_ID_TOKEN_AUDIENCE_LIVE" >&2; exit 1; }
           test -n "${JVM_WEEKLY_INTERNAL_API_TOKEN}" || { echo "Missing Production secret: JVM_WEEKLY_INTERNAL_API_TOKEN_LIVE" >&2; exit 1; }
           test -n "${JVM_WEEKLY_API_SERVICE_ACCOUNT_JSON}" || { echo "Missing Production secret: JVM_WEEKLY_API_SERVICE_ACCOUNT_JSON_LIVE" >&2; exit 1; }
+          test -n "${SLACK_ALERT_BOT_TOKEN}" || { echo "Missing Production secret: SLACK_ALERT_BOT_TOKEN" >&2; exit 1; }
           npx --yes "${VERCEL_CLI_PACKAGE}" whoami --token "${VERCEL_TOKEN}" --scope merryai-devs-projects >/dev/null
 
       - name: Deploy to Vercel production
@@ -218,8 +221,8 @@ jobs:
             --env JVM_WEEKLY_INTERNAL_API_TOKEN="${JVM_WEEKLY_INTERNAL_API_TOKEN}" \
             --env JVM_WEEKLY_API_SERVICE_ACCOUNT_JSON="${JVM_WEEKLY_API_SERVICE_ACCOUNT_JSON}" \
             --env SLACK_ALERT_WEBHOOK_URL= \
-            --env SLACK_ALERT_BOT_TOKEN= \
-            --env SLACK_ALERT_CHANNEL_ID= \
+            --env SLACK_ALERT_BOT_TOKEN="${SLACK_ALERT_BOT_TOKEN}" \
+            --env SLACK_ALERT_CHANNEL_ID="${SLACK_ALERT_CHANNEL_ID}" \
             --env PROJECT_REGISTRATION_SLACK_WEBHOOK_URL= \
             --env PROJECT_REGISTRATION_SLACK_BOT_TOKEN= \
             --env PROJECT_REGISTRATION_SLACK_CHANNEL_ID= \

--- a/server/bff/app.mjs
+++ b/server/bff/app.mjs
@@ -175,6 +175,18 @@ export function resolveProjectRegistrationSlackConfig(options = {}, env = proces
   return { webhookUrl, botToken, channelId };
 }
 
+function resolveCashflowSlackConfig(options = {}, env = process.env) {
+  return {
+    botToken: readOptionalText(options.cashflowSlackBotToken)
+      || readOptionalText(env.CASHFLOW_SLACK_BOT_TOKEN)
+      || readOptionalText(env.SLACK_ALERT_BOT_TOKEN)
+      || undefined,
+    channelId: readOptionalText(options.cashflowSlackChannelId)
+      || readOptionalText(env.CASHFLOW_SLACK_CHANNEL_ID)
+      || 'C0BQ6980HR6',
+  };
+}
+
 function truncateText(value, maxLength = 500) {
   const text = readOptionalText(value);
   if (!text) return '';
@@ -789,6 +801,8 @@ export function createBffApp(options = {}) {
   const slackAlertService = options.slackAlertService || createSlackAlertService();
   const projectRegistrationSlackService = options.projectRegistrationSlackService
     || createSlackAlertService(resolveProjectRegistrationSlackConfig(options));
+  const cashflowSlackService = options.cashflowSlackService
+    || createSlackAlertService(resolveCashflowSlackConfig(options));
   const projectRegistrationOutboxHandler = options.projectRegistrationOutboxHandler
     || createProjectRegistrationSubmittedOutboxHandler({
       db,
@@ -1567,6 +1581,7 @@ export function createBffApp(options = {}) {
     jvmWeeklyApiIdTokenAudience: options.jvmWeeklyApiIdTokenAudience,
     jvmWeeklyAuthMode: options.jvmWeeklyAuthMode,
     jvmWeeklyWorkspaceEmailDomain: options.jvmWeeklyWorkspaceEmailDomain,
+    cashflowSlackService,
   });
   mountAxrMonthCloseQaRoutes(app, { db });
   mountLedgerRoutes(app, { db, now, idempotencyService, auditChainService, piiProtector });

--- a/server/bff/cashflow-month-state.mjs
+++ b/server/bff/cashflow-month-state.mjs
@@ -1,0 +1,54 @@
+import { createHttpError, readOptionalText } from './bff-utils.mjs';
+
+const LOCKED_STATUSES = new Set(['PENDING', 'APPROVED', 'REOPEN_REQUESTED', 'APPROVING', 'UNCERTAIN']);
+
+function isYearMonth(value) {
+  return /^\d{4}-(0[1-9]|1[0-2])$/.test(value);
+}
+
+function lockRange(record) {
+  const scope = record?.scope && typeof record.scope === 'object' && !Array.isArray(record.scope)
+    ? record.scope
+    : {};
+  const fromMonth = readOptionalText(scope.fromMonth) || readOptionalText(record?.fromMonth) || readOptionalText(record?.yearMonth);
+  const throughMonth = readOptionalText(scope.throughMonth) || readOptionalText(record?.throughMonth) || readOptionalText(record?.yearMonth);
+  return isYearMonth(fromMonth) && isYearMonth(throughMonth) && fromMonth <= throughMonth
+    ? { fromMonth, throughMonth }
+    : null;
+}
+
+export function cashflowMonthRequestCovers(record, { projectId, yearMonth }) {
+  if (readOptionalText(record?.projectId) !== projectId) return false;
+  const range = lockRange(record);
+  return Boolean(range && yearMonth >= range.fromMonth && yearMonth <= range.throughMonth);
+}
+
+export function cashflowMonthLockFor(records, { projectId, yearMonth }) {
+  for (const record of records) {
+    if (!cashflowMonthRequestCovers(record, { projectId, yearMonth })) continue;
+    const range = lockRange(record);
+    const status = readOptionalText(record?.status).toUpperCase();
+    if (LOCKED_STATUSES.has(status)) return { status, ...range, requestId: readOptionalText(record?.requestId) };
+  }
+  return null;
+}
+
+export async function assertCashflowMonthWritable({ db, transaction, tenantId, projectId, yearMonth }) {
+  if (!isYearMonth(yearMonth)) {
+    throw createHttpError(400, 'Cashflow month is invalid', 'cashflow_month_invalid');
+  }
+  const query = db.collection(`orgs/${tenantId}/cashflow_month_close_requests`)
+    .where('projectId', '==', projectId);
+  const snapshot = transaction ? await transaction.get(query) : await query.get();
+  const lock = cashflowMonthLockFor(snapshot.docs.map((doc) => doc.data() || {}), { projectId, yearMonth });
+  if (!lock) return;
+  throw createHttpError(
+    409,
+    `${yearMonth} 월은 ${lock.status === 'PENDING' ? '결재 대기' : '월 결산'} 상태라 수정할 수 없습니다.`,
+    'cashflow_month_locked',
+  );
+}
+
+export function isCashflowMonthLockedStatus(status) {
+  return LOCKED_STATUSES.has(readOptionalText(status).toUpperCase());
+}

--- a/server/bff/routes/cashflow-edit-drafts.mjs
+++ b/server/bff/routes/cashflow-edit-drafts.mjs
@@ -15,6 +15,7 @@ import {
 } from '../edit-lease.mjs';
 import { parseWithSchema } from '../schemas.mjs';
 import { buildRequestFingerprint, sha256 } from '../utils.mjs';
+import { assertCashflowMonthWritable } from '../cashflow-month-state.mjs';
 
 const RESOURCE_TYPE = 'cashflow';
 const CASHFLOW_DRAFT_ROLES = ['pm'];
@@ -178,41 +179,6 @@ function assertMetadataRevision(document, fieldName, expected) {
   return actual;
 }
 
-function assertCashflowMonthOpen(monthCloseSnap, { tenantId, projectId, yearMonth }) {
-  if (!monthCloseSnap.exists) return;
-  const monthClose = monthCloseSnap.data() || {};
-  if (
-    monthClose.contractVersion !== 'cashflow-month-close-v1'
-    || monthClose.tenantId !== tenantId
-    || monthClose.projectId !== projectId
-    || monthClose.yearMonth !== yearMonth
-    || !Number.isSafeInteger(monthClose.revision)
-    || monthClose.revision < 0
-    || !Number.isSafeInteger(monthClose.reopenCount)
-    || monthClose.reopenCount < 0
-  ) {
-    throw createHttpError(
-      409,
-      'Cashflow month close data requires migration before it can be changed',
-      'cashflow_month_close_migration_required',
-    );
-  }
-  const status = monthClose.status;
-  if (status === 'OPEN') return;
-  if (status === 'CLOSED' || status === 'REOPEN_REQUESTED') {
-    throw createHttpError(
-      409,
-      'Cashflow month is closed and cannot be changed',
-      'cashflow_month_closed',
-    );
-  }
-  throw createHttpError(
-    409,
-    'Cashflow month close data requires migration before it can be changed',
-    'cashflow_month_close_migration_required',
-  );
-}
-
 function draftMonthCloseScope(payload) {
   if (!payload || typeof payload !== 'object' || Array.isArray(payload) || !Object.hasOwn(payload, 'monthClose')) {
     return null;
@@ -227,10 +193,9 @@ function draftMonthCloseScope(payload) {
 async function assertDraftMonthsOpen(tx, db, current, ...payloads) {
   const yearMonths = new Set(payloads.map(draftMonthCloseScope).filter(Boolean));
   for (const yearMonth of yearMonths) {
-    const monthCloseSnap = await tx.get(db.doc(
-      `orgs/${current.tenantId}/monthly_closes/${current.projectId}-${yearMonth}`,
-    ));
-    assertCashflowMonthOpen(monthCloseSnap, {
+    await assertCashflowMonthWritable({
+      db,
+      transaction: tx,
       tenantId: current.tenantId,
       projectId: current.projectId,
       yearMonth,
@@ -693,15 +658,14 @@ export function createCashflowEditDraftService({
         const { actorRole, member } = await accessProject(tx, current);
         const statusRef = db.doc(`orgs/${current.tenantId}/weekly_submission_status/${statusId}`);
         const statusSnap = await tx.get(statusRef);
-        const monthCloseSnap = await tx.get(db.doc(
-          `orgs/${current.tenantId}/monthly_closes/${current.projectId}-${yearMonth}`,
-        ));
         const lock = await checkIdempotency(tx, current, fingerprint, nowDate);
         if (lock.mode === 'replay') return { status: lock.status, body: lock.body, replayed: true };
         const lockError = idempotencyError(lock);
         if (lockError) throw lockError;
         await assertLease(tx, current, nowDate);
-        assertCashflowMonthOpen(monthCloseSnap, {
+        await assertCashflowMonthWritable({
+          db,
+          transaction: tx,
           tenantId: current.tenantId,
           projectId: current.projectId,
           yearMonth,

--- a/server/bff/routes/cashflow-edit-drafts.test.mjs
+++ b/server/bff/routes/cashflow-edit-drafts.test.mjs
@@ -20,10 +20,29 @@ function createDb(seed = {}) {
   return {
     documents,
     doc: (path) => ({ path }),
+    collection: (path) => ({
+      where: (field, operator, value) => ({
+        queryPath: path,
+        field,
+        operator,
+        value,
+      }),
+    }),
     async runTransaction(callback) {
       const writes = [];
       const tx = {
-        get: async (ref) => snapshot(ref.path),
+        get: async (ref) => {
+          if (ref.queryPath) {
+            const prefix = `${ref.queryPath}/`;
+            const docs = [...documents.entries()]
+              .filter(([path, value]) => path.startsWith(prefix)
+                && !path.slice(prefix.length).includes('/')
+                && ref.operator === '==' && value?.[ref.field] === ref.value)
+              .map(([path, value]) => ({ id: path.slice(prefix.length), data: () => clone(value) }));
+            return { docs };
+          }
+          return snapshot(ref.path);
+        },
         set: (ref, value, options = {}) => writes.push({ ref, value: clone(value), options }),
         create: (ref, value) => writes.push({ ref, value: clone(value), options: {}, create: true }),
       };
@@ -179,9 +198,9 @@ describe('cashflow private edit drafts', () => {
       updatedAt: '2026-07-12T00:00:01.000Z',
       submittedAt: '2026-07-12T00:00:01.000Z',
     });
-    h.db.documents.set('orgs/tenant-a/monthly_closes/project-a-2026-07', {
-      contractVersion: 'cashflow-month-close-v1', tenantId: 'tenant-a', projectId: 'project-a',
-      yearMonth: '2026-07', status: 'OPEN', revision: 3, reopenCount: 1,
+    h.db.documents.set('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-07', {
+      requestId: 'project-a-2026-07', tenantId: 'tenant-a', projectId: 'project-a',
+      yearMonth: '2026-07', status: 'REOPENED', revision: 3,
     });
     const nextLease = buildActiveEditLeaseDocument({
       tenantId: 'tenant-a', resourceType: 'cashflow', resourceId: 'project-a',
@@ -224,27 +243,25 @@ describe('cashflow private edit drafts', () => {
     })).rejects.toMatchObject({ statusCode: 409, code: 'draft_version_conflict' });
   });
 
-  it('blocks month-close private draft open, update, and complete when the JVM month is locked', async () => {
-    const closedMonth = {
-      contractVersion: 'cashflow-month-close-v1', tenantId: 'tenant-a', projectId: 'project-a',
-      yearMonth: '2026-07', status: 'CLOSED', revision: 1, reopenCount: 0,
+  it('blocks month-close private drafts from the authoritative request even when monthly_closes is absent', async () => {
+    const closeRequest = {
+      requestId: 'project-a-2026-07', tenantId: 'tenant-a', projectId: 'project-a',
+      yearMonth: '2026-07', status: 'PENDING', revision: 1,
     };
     const monthClosePayload = { monthClose: { yearMonth: '2026-07' } };
 
-    for (const [status, code] of [
-      ['CLOSED', 'cashflow_month_closed'],
-      ['REOPEN_REQUESTED', 'cashflow_month_closed'],
-      ['DONE', 'cashflow_month_close_migration_required'],
+    for (const status of [
+      'PENDING', 'APPROVED', 'REOPEN_REQUESTED',
     ]) {
       const openHarness = harness();
-      openHarness.db.documents.set('orgs/tenant-a/monthly_closes/project-a-2026-07', {
-        ...closedMonth,
+      openHarness.db.documents.set('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-07', {
+        ...closeRequest,
         status,
       });
       await expect(openHarness.service.open({
         ...openHarness.base, idempotencyKey: `open-${status}`, baseSnapshot,
         payload: monthClosePayload,
-      })).rejects.toMatchObject({ statusCode: 409, code });
+      })).rejects.toMatchObject({ statusCode: 409, code: 'cashflow_month_locked' });
     }
 
     const updateHarness = harness();
@@ -252,11 +269,11 @@ describe('cashflow private edit drafts', () => {
       ...updateHarness.base, idempotencyKey: 'open-month-before-close', baseSnapshot,
       payload: monthClosePayload,
     });
-    updateHarness.db.documents.set('orgs/tenant-a/monthly_closes/project-a-2026-07', closedMonth);
+    updateHarness.db.documents.set('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-07', closeRequest);
     await expect(updateHarness.service.update({
       ...updateHarness.base, idempotencyKey: 'update-closed-month', expectedDraftRevision: 0,
       payload: {},
-    })).rejects.toMatchObject({ statusCode: 409, code: 'cashflow_month_closed' });
+    })).rejects.toMatchObject({ statusCode: 409, code: 'cashflow_month_locked' });
 
     updateHarness.db.documents.set(updateHarness.leasePath, {
       ...updateHarness.db.documents.get(updateHarness.leasePath),
@@ -265,7 +282,25 @@ describe('cashflow private edit drafts', () => {
     });
     await expect(updateHarness.service.complete({
       ...updateHarness.base, idempotencyKey: 'complete-closed-month', expectedDraftRevision: 0,
-    })).rejects.toMatchObject({ statusCode: 409, code: 'cashflow_month_closed' });
+    })).rejects.toMatchObject({ statusCode: 409, code: 'cashflow_month_locked' });
+  });
+
+  it('uses the request state even when the old monthly close says the opposite', async () => {
+    const closedLegacyOnly = harness();
+    closedLegacyOnly.db.documents.set('orgs/tenant-a/monthly_closes/project-a-2026-07', {
+      projectId: 'project-a', yearMonth: '2026-07', status: 'CLOSED',
+    });
+    await expect(openDraft(closedLegacyOnly, 'legacy-closed-only')).resolves.toMatchObject({ status: 200 });
+
+    const reopened = harness();
+    reopened.db.documents.set('orgs/tenant-a/monthly_closes/project-a-2026-07', {
+      projectId: 'project-a', yearMonth: '2026-07', status: 'CLOSED',
+    });
+    reopened.db.documents.set('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-07', {
+      requestId: 'project-a-2026-07', tenantId: 'tenant-a', projectId: 'project-a',
+      yearMonth: '2026-07', status: 'REOPENED', revision: 2,
+    });
+    await expect(openDraft(reopened, 'request-reopened')).resolves.toMatchObject({ status: 200 });
   });
 
   it('rejects writes after the exact cashflow lease expires', async () => {
@@ -366,28 +401,20 @@ describe('cashflow private edit drafts', () => {
     })).rejects.toMatchObject({ statusCode: 409, code: 'cashflow_metadata_version_conflict' });
   });
 
-  it('fails closed for weekly status writes when the month is closed or its state is non-canonical', async () => {
-    const cases = [
-      ['CLOSED', 'cashflow_month_closed'],
-      ['REOPEN_REQUESTED', 'cashflow_month_closed'],
-      ['DONE', 'cashflow_month_close_migration_required'],
-      ['BROKEN', 'cashflow_month_close_migration_required'],
-      ['open', 'cashflow_month_close_migration_required'],
-      [' OPEN ', 'cashflow_month_close_migration_required'],
-      ['', 'cashflow_month_close_migration_required'],
-    ];
+  it('locks weekly status writes only for canonical pending or approved requests', async () => {
+    const cases = ['PENDING', 'APPROVED', 'REOPEN_REQUESTED'];
 
-    for (const [status, code] of cases) {
+    for (const status of cases) {
       const h = harness();
-      h.db.documents.set('orgs/tenant-a/monthly_closes/project-a-2026-07', {
-        contractVersion: 'cashflow-month-close-v1', tenantId: 'tenant-a', projectId: 'project-a',
-        yearMonth: '2026-07', status, revision: 1, reopenCount: 0,
+      h.db.documents.set('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-07', {
+        requestId: 'project-a-2026-07', tenantId: 'tenant-a', projectId: 'project-a',
+        yearMonth: '2026-07', status, revision: 1,
       });
 
       await expect(h.service.applyWeeklySubmissionStatusIntent({
         ...h.base, idempotencyKey: `weekly-status-${status}`, yearMonth: '2026-07', weekNo: 1,
         expectedRevision: 0, changes: { projectionUpdated: true },
-      })).rejects.toMatchObject({ statusCode: 409, code });
+      })).rejects.toMatchObject({ statusCode: 409, code: 'cashflow_month_locked' });
       expect(h.db.documents.has(
         'orgs/tenant-a/weekly_submission_status/project-a-2026-07-w1',
       )).toBe(false);

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -51,6 +51,7 @@ import {
 } from '../cashflow-month-close-withdrawal.mjs';
 export { cashflowCumulativeCloseCycle };
 import { cashflowMonthCloseDeadline, isCashflowCloseOverdue } from '../cashflow-close-deadline.mjs';
+import { cashflowMonthRequestCovers, isCashflowMonthLockedStatus } from '../cashflow-month-state.mjs';
 
 export { cashflowMonthCloseDeadline };
 
@@ -165,7 +166,7 @@ async function alignMonthSettlementStatus(db, tenantId, result) {
     const requestStatus = readOptionalText(snapshot.data()?.status);
     const status = requestStatus === 'APPROVED'
       ? 'COMPLETED'
-      : ['PENDING', 'APPROVING', 'UNCERTAIN'].includes(requestStatus)
+      : ['PENDING', 'REOPEN_REQUESTED', 'APPROVING', 'UNCERTAIN'].includes(requestStatus)
         ? 'PENDING_APPROVAL'
         : 'WAITING_FOR_UPDATE';
     project.items = project.items.map((item) => item.period === 'MONTH' ? { ...item, status } : item);
@@ -235,6 +236,7 @@ function cashflowMonthCloseRequestView(record, partyNames = {}) {
         cellCount: Number(scope.cellCount ?? record.cellCount),
       },
       status: record.status,
+      locked: isCashflowMonthLockedStatus(record.status),
       revision: record.revision,
       manifestHash: record.manifestHash,
       monthCount: record.monthCount,
@@ -271,6 +273,7 @@ function cashflowMonthCloseRequestView(record, partyNames = {}) {
     projectId: record.projectId,
     yearMonth: record.yearMonth,
     status: record.status,
+    locked: isCashflowMonthLockedStatus(record.status),
     revision: record.revision,
     approverUid: record.approverUid,
     approverName: partyNames.approverName || '구성원 이름 확인 불가',
@@ -396,6 +399,20 @@ async function readCashflowRequestPartyNames({ db, tenantId, record }) {
     return [key, readOptionalText(member.status).toUpperCase() === 'ACTIVE' ? readOptionalText(member.name) : ''];
   }));
   return Object.fromEntries(entries);
+}
+
+async function readCashflowMonthCloseRequest({ db, tenantId, projectId, yearMonth }) {
+  if (!db?.doc) return null;
+  const direct = await db.doc(cashflowMonthCloseRequestPath(tenantId, `${projectId}-${yearMonth}`)).get();
+  if (direct.exists) return direct.data() || null;
+  if (typeof db.collection !== 'function') return null;
+  const candidates = await db.collection(`orgs/${tenantId}/cashflow_month_close_requests`)
+    .where('projectId', '==', projectId)
+    .limit(100)
+    .get();
+  return candidates.docs
+    .map((doc) => doc.data() || {})
+    .find((candidate) => cashflowMonthRequestCovers(candidate, { projectId, yearMonth })) || null;
 }
 
 async function readCanonicalCashflowApprover({ db, tenantId, projectId }) {
@@ -2268,6 +2285,7 @@ export function mountJvmWeeklyApiRoutes(app, {
   cashflowMonthCloseRouteTimeoutMs,
   performanceLogger,
   performanceNow,
+  cashflowSlackService,
   now = () => new Date(),
 } = {}) {
   const baseUrl = resolveJavaWeeklyApiBaseUrl({ jvmWeeklyApiBaseUrl }, env);
@@ -2283,6 +2301,11 @@ export function mountJvmWeeklyApiRoutes(app, {
     && Number(cashflowMonthCloseRouteTimeoutMs) > 0
     ? Math.min(Number(cashflowMonthCloseRouteTimeoutMs), CASHFLOW_MONTH_CLOSE_ROUTE_TIMEOUT_MS)
     : CASHFLOW_MONTH_CLOSE_ROUTE_TIMEOUT_MS;
+
+  function notifyCashflowSlack(text) {
+    if (!cashflowSlackService?.enabled || typeof cashflowSlackService.notifyMessage !== 'function') return;
+    void Promise.resolve().then(() => cashflowSlackService.notifyMessage({ text })).catch(() => {});
+  }
 
   async function readWeeklyCompliance(context, projectId, { limit = 100, cursor = '' } = {}) {
     const query = `limit=${limit}${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`;
@@ -2562,7 +2585,7 @@ export function mountJvmWeeklyApiRoutes(app, {
         // 동시에 죽인다 - 실제로 그렇게 죽었다. 확정(쓰기) 경로는 이 열화를 쓰지 않고
         // 전부 fail-closed 를 유지한다.
         const sectionErrors = [];
-        const [publicationBefore, source, weeklyCompliance] = await Promise.all([
+        const [publicationBefore, source, weeklyCompliance, monthCloseRequest] = await Promise.all([
           trace.measure(
             'publication_before',
             () => readCashflowSheetPublicationState({
@@ -2596,6 +2619,12 @@ export function mountJvmWeeklyApiRoutes(app, {
             }),
             { attempt: traceAttempt },
           ),
+          readCashflowMonthCloseRequest({
+            db,
+            tenantId: req.context.tenantId,
+            projectId: rawProjectId,
+            yearMonth,
+          }),
         ]);
         const result = objectValue(source?.monthClose);
         const cashflow = objectValue(source?.cashflow);
@@ -2643,6 +2672,7 @@ export function mountJvmWeeklyApiRoutes(app, {
           late: readOptionalText(result?.status) === 'OPEN'
             ? cycleBusinessDate > cumulativeCycle.deadline
             : Boolean(result?.late),
+          monthState: monthCloseRequest ? cashflowMonthCloseRequestView(monthCloseRequest) : null,
         };
         const dashboard = await trace.measure(
           'dashboard_compose',
@@ -2926,6 +2956,7 @@ export function mountJvmWeeklyApiRoutes(app, {
       },
       { cashflowWrite: true },
     );
+    notifyCashflowSlack(`*[MYSCube] 주정산 완료*\n프로젝트: ${projectId}\n대상: ${hasExplicitScope ? requestedYearMonth : boundary.asOfWeek.yearMonth} ${hasExplicitScope ? requestedWeekNo : boundary.asOfWeek.weekNo}주차\n처리자: ${req.context.actorId}`);
     res.status(200).json(result);
   }));
 
@@ -3501,7 +3532,7 @@ export function mountJvmWeeklyApiRoutes(app, {
       .get();
     const candidates = snapshot.docs
       .map((doc) => doc.data() || {})
-      .filter((record) => ['PENDING', 'APPROVING', 'UNCERTAIN'].includes(record.status) && record.approverUid === actorId);
+      .filter((record) => record.status === 'PENDING' && record.approverUid === actorId);
     const canonicalMatches = await Promise.all(candidates.map(async (record) => {
       const projectSnapshot = await db.doc(`orgs/${req.context.tenantId}/projects/${record.projectId}`).get();
       return projectSnapshot.exists
@@ -3573,7 +3604,7 @@ export function mountJvmWeeklyApiRoutes(app, {
         throw createHttpError(403, '같은 조직의 활성 구성원만 조직장으로 지정할 수 있습니다.', 'cashflow_month_close_member_inactive');
       }
       const hasPendingRequest = requestSnapshot.docs.some((doc) => (
-        ['PENDING', 'APPROVING', 'UNCERTAIN'].includes(readOptionalText(doc.data()?.status))
+        ['PENDING', 'REOPEN_REQUESTED', 'APPROVING', 'UNCERTAIN'].includes(readOptionalText(doc.data()?.status))
       ));
       if (hasPendingRequest) {
         throw createHttpError(409, '승인 대기 중인 월 결산의 조직장은 변경할 수 없습니다.', 'cashflow_month_close_approver_locked');
@@ -3641,13 +3672,18 @@ export function mountJvmWeeklyApiRoutes(app, {
     const actorId = readOptionalText(req.context.actorId);
     await readActiveCashflowMember({ db, tenantId: req.context.tenantId, actorId });
     const requestId = `${projectId}-${yearMonth}`;
-    const snapshot = await db.doc(cashflowMonthCloseRequestPath(req.context.tenantId, requestId)).get();
-    if (!snapshot.exists) {
+    const record = await readCashflowMonthCloseRequest({
+      db,
+      tenantId: req.context.tenantId,
+      projectId,
+      yearMonth,
+    });
+    if (!record) {
       res.status(200).json({ request: null });
       return;
     }
-    const record = snapshot.data() || {};
-    if (record.projectId !== projectId || record.yearMonth !== yearMonth) {
+    if (record.projectId !== projectId
+      || (record.yearMonth !== yearMonth && !cashflowMonthRequestCovers(record, { projectId, yearMonth }))) {
       throw createHttpError(403, '이 월 결산 요청을 조회할 권한이 없습니다.', 'cashflow_month_close_request_forbidden');
     }
     if (record.contractVersion === CASHFLOW_CUMULATIVE_CLOSE_CONTRACT && record.status === 'BUILDING') {
@@ -4011,9 +4047,7 @@ export function mountJvmWeeklyApiRoutes(app, {
     res.status(202).json(cashflowMonthCloseRequestView(storedRecord));
   }));
 
-  // 실무자가 올린 결산 요청을 조직장이 손대기 전에 스스로 되돌린다. 조직장이 검토를 시작한
-  // 뒤(APPROVING/UNCERTAIN)에는 JVM 확정이 이미 나갔을 수 있어 허용하지 않는다 - 여기서 회수를
-  // 받아주면 JVM 은 닫혔는데 BFF 는 회수된 상태가 되어 두 런타임이 갈린다.
+  // 실무자가 올린 결산 요청을 조직장이 검토하기 전에 스스로 되돌린다.
   app.post('/api/v1/cashflow/:projectId/month-close/requests/:requestId/withdraw', asyncHandler(async (req, res) => {
     assertWeeklyWorkspaceOrRoleAllowed(req, ['admin', 'finance', 'pm', 'viewer'], 'withdraw cashflow month close request', authMode, workspaceEmailDomain);
     assertAlignedCashflowMutation();
@@ -4161,407 +4195,81 @@ export function mountJvmWeeklyApiRoutes(app, {
         updatedAt: reviewedAt,
       }, { merge: true });
     };
-    if (initialRecord.contractVersion === CASHFLOW_CUMULATIVE_CLOSE_CONTRACT) {
-      const expectedManifestHash = readOptionalText(req.body?.expectedManifestHash);
-      if (expectedManifestHash !== initialRecord.manifestHash) {
-        throw createHttpError(409, '누적 월 결산 manifest가 변경되었습니다.', 'cashflow_month_close_request_manifest_invalid');
-      }
-      const terminalReplay = (
-        Boolean(readOptionalText(req.context.idempotencyKey))
-        && initialRecord.reviewIdempotencyKey === req.context.idempotencyKey
-        && Number(initialRecord.revision) === expectedRevision
-        && readOptionalText(initialRecord.decisionReason) === reason
-        && ((decision === 'REJECT' && initialRecord.status === 'REJECTED')
-          || (decision === 'APPROVE' && initialRecord.status === 'APPROVED'))
-      );
-      if (terminalReplay) {
-        res.status(200).json({
-          request: cashflowMonthCloseRequestView(initialRecord),
-          ...(decision === 'APPROVE' && objectValue(initialRecord.monthCloseResult)
-            ? { monthClose: initialRecord.monthCloseResult }
-            : {}),
-        });
-        return;
-      }
-      const resumesApproval = decision === 'APPROVE' && ['APPROVING', 'UNCERTAIN'].includes(initialRecord.status);
-      if (Number(initialRecord.revision) !== expectedRevision || (!resumesApproval && initialRecord.status !== 'PENDING')) {
-        throw createHttpError(409, '이미 검토가 시작되었거나 변경된 월 결산 요청입니다.', 'cashflow_month_close_request_already_reviewed');
-      }
-      if (decision === 'REJECT') {
-        if (initialRecord.status !== 'PENDING') {
-          throw createHttpError(409, '승인 처리가 시작된 월 결산 요청은 반려할 수 없습니다.', 'cashflow_month_close_request_already_reviewed');
-        }
-        let rejected;
-        await db.runTransaction(async (transaction) => {
-          const [projectSnapshot, reviewerSnapshot, snapshot] = await Promise.all([
-            transaction.get(projectRef), transaction.get(reviewerRef), transaction.get(requestRef),
-          ]);
-          const currentProject = projectSnapshot.exists ? projectSnapshot.data() || {} : {};
-          const current = snapshot.exists ? snapshot.data() || {} : null;
-          const reviewer = reviewerSnapshot.exists ? reviewerSnapshot.data() || {} : {};
-          if (!current || current.status !== 'PENDING' || current.manifestHash !== expectedManifestHash
-            || Number(current.revision) !== expectedRevision
-            || readOptionalText(currentProject.executiveApproverId) !== req.context.actorId
-            || readOptionalText(reviewer.uid) !== req.context.actorId
-            || readOptionalText(reviewer.status).toUpperCase() !== 'ACTIVE') {
-            throw createHttpError(409, '이미 검토가 끝났거나 변경된 월 결산 요청입니다.', 'cashflow_month_close_request_already_reviewed');
-          }
-          rejected = {
-            ...current, status: 'REJECTED', reviewedByUid: req.context.actorId,
-            reviewedAt, decisionReason: reason, reviewIdempotencyKey: req.context.idempotencyKey,
-          };
-          transaction.set(requestRef, rejected);
-          transaction.set(
-            db.doc(cashflowMonthCloseRequestAuditPath(
-              req.context.tenantId, requestId, expectedRevision, 'rejected',
-            )),
-            {
-              requestId,
-              projectId,
-              yearMonth: rejected.yearMonth,
-              action: 'REJECTED',
-              revision: expectedRevision,
-              manifestHash: rejected.manifestHash,
-              actorUid: req.context.actorId,
-              reason,
-              idempotencyKey: req.context.idempotencyKey,
-              createdAt: reviewedAt,
-            },
-          );
-        });
-        res.status(200).json({ request: cashflowMonthCloseRequestView(rejected) });
-        return;
-      }
-      await verifyCumulativeRequestShards(req.context.tenantId, initialRecord);
-      // JVM 은 요청 헤더가 APPROVING 이고 reviewIdempotencyKey 가 이번 호출과 같을 때만 누적 확정을
-      // 받아준다 (requireCumulativeCloseApproval). 그래서 PENDING -> APPROVING -> JVM 확정 ->
-      // APPROVED 3 단계를 그대로 밟는다. 이 단계를 건너뛰면 JVM 월이 OPEN 으로 남고,
-      // cashflow_cumulative_close_heads.closedThrough 가 비어 시트 잠금과 변경 경고 누적이
-      // 통째로 동작하지 않는다.
-      const jvmMutationIdempotencyKey = readOptionalText(req.context.idempotencyKey);
-      if (!jvmMutationIdempotencyKey) {
-        throw createHttpError(400, '월 결산 승인에는 요청 키가 필요합니다.', 'cashflow_month_close_review_invalid');
-      }
-      let claimed;
-      await db.runTransaction(async (transaction) => {
-        const [projectSnapshot, reviewerSnapshot, snapshot] = await Promise.all([
-          transaction.get(projectRef),
-          transaction.get(reviewerRef),
-          transaction.get(requestRef),
-        ]);
-        const currentProject = projectSnapshot.exists ? projectSnapshot.data() || {} : {};
-        const reviewer = reviewerSnapshot.exists ? reviewerSnapshot.data() || {} : {};
-        const current = snapshot.exists ? snapshot.data() || {} : null;
-        if (!current || !['PENDING', 'APPROVING', 'UNCERTAIN'].includes(current.status)
-          || current.manifestHash !== expectedManifestHash
-          || Number(current.revision) !== expectedRevision
-          || (current.status !== 'PENDING' && readOptionalText(current.reviewedByUid) !== req.context.actorId)
-          || readOptionalText(currentProject.executiveApproverId) !== req.context.actorId
-          || readOptionalText(reviewer.uid) !== req.context.actorId
-          || readOptionalText(reviewer.status).toUpperCase() !== 'ACTIVE') {
-          throw createHttpError(409, '이미 검토가 시작되었거나 변경된 월 결산 요청입니다.', 'cashflow_month_close_request_already_reviewed');
-        }
-        claimed = {
-          ...current,
-          status: 'APPROVING',
-          reviewedByUid: req.context.actorId,
-          reviewedAt,
-          decisionReason: reason || null,
-          reviewIdempotencyKey: jvmMutationIdempotencyKey,
-        };
-        transaction.set(requestRef, claimed);
-      });
-      // 셀은 JVM 이 저장된 샤드에서 직접 읽는다. 여기서는 어느 요청·회차를 확정하는지만 지목한다.
-      const prepared = {
-        projectId: encodeURIComponent(projectId),
-        rawProjectId: projectId,
-        routeDeadlineAtMs: Date.now() + monthCloseRouteTimeoutMs,
-        closeBody: {
-          idempotencyKey: jvmMutationIdempotencyKey,
-          yearMonth: readOptionalText(claimed.yearMonth),
-          expectedRevision: Number(claimed.expectedRevision),
-          expectedDraftRevision: 0,
-          humanReviewed: true,
-          requestId,
-          requestRevision: expectedRevision,
-          manifestHash: readOptionalText(claimed.manifestHash),
-        },
-      };
-      let monthClose;
-      if (['APPROVING', 'UNCERTAIN'].includes(initialRecord.status)) {
-        // 앞선 시도가 이미 APPROVING 을 잡아둔 상태다. JVM 이 그 시도를 받았는지 모르므로 먼저
-        // 확인한다. 확정돼 있는데 다시 POST 하면 닫힌 월이라 반드시 실패한다.
-        const evidence = await reconcileCashflowMonthClose(req, prepared);
-        if (evidence.proven) monthClose = evidence.monthClose;
-      }
-      if (!monthClose) {
-        try {
-          // 확정 예산은 "확정 시도"에 준다. 재개 경로에서는 위 reconcile 이 먼저 도는데,
-          // 그것이 예산을 먹고 나면 executePrepared 가 JVM 을 치지도 못하고 즉시
-          // route_timeout 을 내며, 이어받기가 영원히 같은 자리를 맴돈다. 실제로 그렇게 돌았다.
-          prepared.routeDeadlineAtMs = Date.now() + monthCloseRouteTimeoutMs;
-          monthClose = await executePreparedCashflowMonthClose(req, prepared);
-        } catch (error) {
-          if (readOptionalText(error?.code) !== 'cashflow_month_close_reconciliation_pending') throw error;
-          // 승인은 사람이 하는 결재이고, 장부 잠금은 그 결정의 뒷정리다. 둘을 한 HTTP 요청에
-          // 묶어 두면 JVM 확정이 라우트 예산을 넘길 때 승인 자체가 실패한 것처럼 보인다.
-          // 실제로는 선점(APPROVING)이 이미 커밋됐고 JVM 이 처리 중일 수도 있다.
-          // 그래서 여기서는 "확정 진행 중"을 정직한 상태로 돌려주고, 같은 멱등키의 다음
-          // 호출이 reconcile 로 이어받아 APPROVED 로 마무리한다.
-          //
-          // 절대 하지 않는 것: JVM 확정 없이 APPROVED 로 넘기는 것. 그러면 결재는 끝났는데
-          // 원장은 열려 있어 마감 잠금·변경 경고가 통째로 동작하지 않는다.
-          let uncertain = null;
-          await db.runTransaction(async (transaction) => {
-            const snapshot = await transaction.get(requestRef);
-            const current = snapshot.exists ? snapshot.data() || {} : null;
-            if (
-              !current
-              || !['APPROVING', 'UNCERTAIN'].includes(readOptionalText(current.status))
-              || Number(current.revision) !== expectedRevision
-              || current.reviewIdempotencyKey !== jvmMutationIdempotencyKey
-            ) return;
-            uncertain = {
-              ...current,
-              status: 'UNCERTAIN',
-              reconciliationEvidence: error.reconciliationEvidence,
-            };
-            transaction.set(requestRef, uncertain);
-          });
-          if (!uncertain) throw error;
-          createCashflowPerformanceTrace({
-            requestId: req.context.requestId,
-            operation: 'cashflow.month_close.approval',
-            ...(performanceLogger ? { logger: performanceLogger } : {}),
-            ...(performanceNow ? { now: performanceNow } : {}),
-          }).emit('ledger_close_pending', { outcome: 'ok' });
-          res.status(200).json({
-            request: cashflowMonthCloseRequestView(uncertain),
-            pendingLedgerClose: true,
-          });
-          return;
-        }
-      }
-      let approved;
-      await db.runTransaction(async (transaction) => {
-        const [snapshot, settlementSnapshot] = await Promise.all([
-          transaction.get(requestRef),
-          transaction.get(settlementStatusRef),
-        ]);
-        const current = snapshot.exists ? snapshot.data() || {} : null;
-        if (
-          !current
-          || !['APPROVING', 'UNCERTAIN'].includes(current.status)
-          || Number(current.revision) !== expectedRevision
-          || current.reviewIdempotencyKey !== jvmMutationIdempotencyKey
-        ) {
-          throw createHttpError(409, '월 결산 승인 상태가 변경되었습니다.', 'cashflow_month_close_request_revision_stale');
-        }
-        approved = { ...current, status: 'APPROVED', monthCloseResult: monthClose };
-        delete approved.reconciliationEvidence;
-        transaction.set(requestRef, approved);
-        completeMonthSettlement(transaction, settlementSnapshot);
-        transaction.set(
-          db.doc(cashflowMonthCloseRequestAuditPath(
-            req.context.tenantId, requestId, expectedRevision, 'approved',
-          )),
-          {
-            requestId,
-            projectId,
-            yearMonth: approved.yearMonth,
-            action: 'APPROVED',
-            revision: expectedRevision,
-            manifestHash: approved.manifestHash,
-            actorUid: req.context.actorId,
-            reason: reason || null,
-            idempotencyKey: jvmMutationIdempotencyKey,
-            jvmMutationIdempotencyKey,
-            createdAt: reviewedAt,
-          },
-        );
-      });
-      res.status(200).json({ request: cashflowMonthCloseRequestView(approved), monthClose });
-      return;
+    const expectedManifestHash = readOptionalText(req.body?.expectedManifestHash);
+    if (initialRecord.contractVersion === CASHFLOW_CUMULATIVE_CLOSE_CONTRACT
+      && expectedManifestHash !== initialRecord.manifestHash) {
+      throw createHttpError(409, '누적 월 결산 manifest가 변경되었습니다.', 'cashflow_month_close_request_manifest_invalid');
     }
-    if (['APPROVED', 'REJECTED'].includes(initialRecord.status)) {
-      throw createHttpError(409, '이미 검토가 끝난 월 결산 요청입니다.', 'cashflow_month_close_request_already_reviewed');
-    }
-    const resumesSameApproval = (
-      decision === 'APPROVE'
-      && ['APPROVING', 'UNCERTAIN'].includes(initialRecord.status)
+    const terminalStatus = decision === 'APPROVE' ? 'APPROVED' : 'REJECTED';
+    const terminalReplay = (
+      Boolean(readOptionalText(req.context.idempotencyKey))
+      && initialRecord.status === terminalStatus
       && initialRecord.reviewIdempotencyKey === req.context.idempotencyKey
       && Number(initialRecord.revision) === expectedRevision + 1
-      && objectValue(initialRecord.preparedCloseBody)
     );
-    if (!resumesSameApproval && Number(initialRecord.revision) !== expectedRevision) {
-      throw createHttpError(409, '월 결산 요청 revision이 변경되었습니다.', 'cashflow_month_close_request_revision_stale');
-    }
-
-    if (decision === 'REJECT') {
-      let rejected;
-      await db.runTransaction(async (transaction) => {
-        const [projectSnapshot, reviewerSnapshot, snapshot] = await Promise.all([
-          transaction.get(projectRef),
-          transaction.get(reviewerRef),
-          transaction.get(requestRef),
-        ]);
-        const current = snapshot.exists ? snapshot.data() || {} : null;
-        const currentProject = projectSnapshot.exists ? projectSnapshot.data() || {} : {};
-        const currentReviewer = reviewerSnapshot.exists ? reviewerSnapshot.data() || {} : {};
-        if (
-          !current
-          || current.status !== 'PENDING'
-          || Number(current.revision) !== expectedRevision
-          || readOptionalText(currentProject.executiveApproverId) !== req.context.actorId
-          || readOptionalText(currentReviewer.uid) !== req.context.actorId
-          || readOptionalText(currentReviewer.status).toUpperCase() !== 'ACTIVE'
-        ) {
-          throw createHttpError(409, '이미 검토가 끝났거나 변경된 월 결산 요청입니다.', 'cashflow_month_close_request_already_reviewed');
-        }
-        rejected = {
-          ...current,
-          status: 'REJECTED',
-          revision: expectedRevision + 1,
-          reviewedByUid: req.context.actorId,
-          reviewedAt,
-          decisionReason: reason || null,
-          reviewIdempotencyKey: req.context.idempotencyKey,
-        };
-        transaction.set(requestRef, rejected);
-        transaction.set(
-          db.doc(cashflowMonthCloseRequestAuditPath(req.context.tenantId, requestId, rejected.revision, 'rejected')),
-          {
-            requestId,
-            projectId,
-            yearMonth: rejected.yearMonth,
-            action: 'REJECTED',
-            revision: rejected.revision,
-            actorUid: req.context.actorId,
-            reason: reason || null,
-            idempotencyKey: req.context.idempotencyKey,
-            createdAt: reviewedAt,
-          },
-        );
-      });
-      res.status(200).json({ request: cashflowMonthCloseRequestView(rejected) });
+    if (terminalReplay) {
+      res.status(200).json({ request: cashflowMonthCloseRequestView(initialRecord) });
       return;
     }
-
-    let prepared;
-    let reviewRevision = expectedRevision + 1;
-    if (resumesSameApproval) {
-      prepared = {
-        projectId: encodeURIComponent(projectId),
-        rawProjectId: projectId,
-        closeBody: initialRecord.preparedCloseBody,
-        routeDeadlineAtMs: Date.now() + monthCloseRouteTimeoutMs,
-      };
-      reviewRevision = Number(initialRecord.revision);
-    } else {
-      if (initialRecord.status !== 'PENDING') {
-        throw createHttpError(409, '이미 검토 중이거나 끝난 월 결산 요청입니다.', 'cashflow_month_close_request_already_reviewed');
-      }
-      const stableApprovalKey = `cashflow-month-close-approval:${requestId}:r${reviewRevision}`;
-      prepared = prepareStoredCashflowMonthCloseApproval(initialRecord, stableApprovalKey);
-      await db.runTransaction(async (transaction) => {
-        const [projectSnapshot, reviewerSnapshot, snapshot] = await Promise.all([
-          transaction.get(projectRef),
-          transaction.get(reviewerRef),
-          transaction.get(requestRef),
-        ]);
-        const current = snapshot.exists ? snapshot.data() || {} : null;
-        const currentProject = projectSnapshot.exists ? projectSnapshot.data() || {} : {};
-        const currentReviewer = reviewerSnapshot.exists ? reviewerSnapshot.data() || {} : {};
-        if (
-          !current
-          || current.status !== 'PENDING'
-          || Number(current.revision) !== expectedRevision
-          || readOptionalText(currentProject.executiveApproverId) !== req.context.actorId
-          || readOptionalText(currentReviewer.uid) !== req.context.actorId
-          || readOptionalText(currentReviewer.status).toUpperCase() !== 'ACTIVE'
-        ) {
-          throw createHttpError(409, '이미 검토가 시작되었거나 변경된 월 결산 요청입니다.', 'cashflow_month_close_request_already_reviewed');
-        }
-        transaction.set(requestRef, {
-          ...current,
-          status: 'APPROVING',
-          revision: reviewRevision,
-          reviewedByUid: req.context.actorId,
-          reviewedAt,
-          decisionReason: reason || null,
-          reviewIdempotencyKey: req.context.idempotencyKey,
-          preparedCloseBody: prepared.closeBody,
-        });
-      });
+    if (initialRecord.status !== 'PENDING') {
+      throw createHttpError(409, '이미 검토가 시작되었거나 변경된 월 결산 요청입니다.', 'cashflow_month_close_request_already_reviewed');
     }
-
-    let monthClose;
-    if (initialRecord.status === 'UNCERTAIN') {
-      const evidence = await reconcileCashflowMonthClose(req, prepared);
-      if (evidence.proven) monthClose = evidence.monthClose;
+    if (decision === 'APPROVE' && initialRecord.contractVersion === CASHFLOW_CUMULATIVE_CLOSE_CONTRACT) {
+      await verifyCumulativeRequestShards(req.context.tenantId, initialRecord);
     }
-    if (!monthClose) {
-      try {
-        monthClose = await executePreparedCashflowMonthClose(req, prepared);
-      } catch (error) {
-        if (readOptionalText(error?.code) === 'cashflow_month_close_reconciliation_pending') {
-          await db.runTransaction(async (transaction) => {
-            const snapshot = await transaction.get(requestRef);
-            const current = snapshot.exists ? snapshot.data() || {} : null;
-            if (
-              !current
-              || !['APPROVING', 'UNCERTAIN'].includes(current.status)
-              || Number(current.revision) !== reviewRevision
-              || current.reviewIdempotencyKey !== req.context.idempotencyKey
-            ) return;
-            transaction.set(requestRef, {
-              ...current,
-              status: 'UNCERTAIN',
-              reconciliationEvidence: error.reconciliationEvidence,
-            });
-          });
-        }
-        throw error;
-      }
-    }
-    let approved;
+    let reviewed;
     await db.runTransaction(async (transaction) => {
-      const [snapshot, settlementSnapshot] = await Promise.all([
-        transaction.get(requestRef),
-        transaction.get(settlementStatusRef),
+      const [projectSnapshot, reviewerSnapshot, snapshot, settlementSnapshot] = await Promise.all([
+        transaction.get(projectRef), transaction.get(reviewerRef), transaction.get(requestRef), transaction.get(settlementStatusRef),
       ]);
-      const current = snapshot.exists ? snapshot.data() || {} : null;
+      const currentProject = projectSnapshot.exists ? projectSnapshot.data() || {} : {};
+      const currentReviewer = reviewerSnapshot.exists ? reviewerSnapshot.data() || {} : {};
+      const current = snapshot.exists ? snapshot.data() || null : null;
       if (
         !current
-        || !['APPROVING', 'UNCERTAIN'].includes(current.status)
-        || Number(current.revision) !== reviewRevision
-        || current.reviewIdempotencyKey !== req.context.idempotencyKey
+        || current.status !== 'PENDING'
+        || Number(current.revision) !== expectedRevision
+        || readOptionalText(currentProject.executiveApproverId) !== req.context.actorId
+        || readOptionalText(currentReviewer.uid) !== req.context.actorId
+        || readOptionalText(currentReviewer.status).toUpperCase() !== 'ACTIVE'
       ) {
-        throw createHttpError(409, '월 결산 승인 상태가 변경되었습니다.', 'cashflow_month_close_request_revision_stale');
+        throw createHttpError(409, '이미 검토가 끝났거나 변경된 월 결산 요청입니다.', 'cashflow_month_close_request_already_reviewed');
       }
-      approved = { ...current, status: 'APPROVED' };
-      delete approved.preparedCloseBody;
-      delete approved.publicationFingerprint;
-      delete approved.reconciliationEvidence;
-      transaction.set(requestRef, approved);
-      completeMonthSettlement(transaction, settlementSnapshot);
+      reviewed = {
+        ...current,
+        status: terminalStatus,
+        revision: expectedRevision + 1,
+        reviewedByUid: req.context.actorId,
+        reviewedAt,
+        decisionReason: reason || null,
+        reviewIdempotencyKey: req.context.idempotencyKey,
+      };
+      transaction.set(requestRef, reviewed);
+      if (terminalStatus === 'APPROVED') completeMonthSettlement(transaction, settlementSnapshot);
       transaction.set(
-        db.doc(cashflowMonthCloseRequestAuditPath(req.context.tenantId, requestId, reviewRevision, 'approved')),
+        db.doc(cashflowMonthCloseRequestAuditPath(
+          req.context.tenantId, requestId, reviewed.revision, terminalStatus.toLowerCase(),
+        )),
         {
           requestId,
           projectId,
-          yearMonth: approved.yearMonth,
-          action: 'APPROVED',
-          revision: reviewRevision,
+          yearMonth: reviewed.yearMonth,
+          action: terminalStatus,
+          revision: reviewed.revision,
+          manifestHash: reviewed.manifestHash || null,
           actorUid: req.context.actorId,
           reason: reason || null,
           idempotencyKey: req.context.idempotencyKey,
-          jvmMutationIdempotencyKey: prepared.closeBody.idempotencyKey,
           createdAt: reviewedAt,
         },
       );
     });
-    res.status(200).json({ request: cashflowMonthCloseRequestView(approved), monthClose });
+    if (terminalStatus === 'APPROVED') {
+      notifyCashflowSlack(`*[MYSCube] 월 결산 승인 완료*\n프로젝트: ${projectId}\n대상 월: ${reviewed.yearMonth}\n승인자: ${req.context.actorId}\n월 잠금: 활성화`);
+    }
+    res.status(200).json({ request: cashflowMonthCloseRequestView(reviewed) });
+    return;
+
   }));
 
   app.post('/api/v1/cashflow/:projectId/month-close', createJavaMutatingProxyRoute(async (req) => {
@@ -4575,63 +4283,105 @@ export function mountJvmWeeklyApiRoutes(app, {
     );
   }));
 
-  app.post('/api/v1/cashflow/:projectId/month-close/reopen-request', createJavaMutatingProxyRoute(async (req) => {
+  app.post('/api/v1/cashflow/:projectId/month-close/reopen-request', asyncHandler(async (req, res) => {
     assertWeeklyWorkspaceOrRoleAllowed(req, ['admin', 'finance', 'pm', 'viewer'], 'request cashflow month reopen', authMode, workspaceEmailDomain);
-    const projectId = encodeURIComponent(readOptionalText(req.params.projectId));
-    const result = await proxyMutation(
-      req,
-      `/api/v1/cashflow/${projectId}/month-close/reopen-request`,
-      commandBody(req),
-      { cashflowWrite: true },
-    );
-    return { status: 200, body: result };
+    assertAlignedCashflowMutation();
+    const projectId = readOptionalText(req.params.projectId);
+    const requestId = readOptionalText(req.body?.requestId);
+    const yearMonth = readOptionalText(req.body?.yearMonth);
+    const expectedRevision = Number(req.body?.expectedRevision);
+    const reason = readOptionalText(req.body?.reason);
+    if (!projectId || projectId.includes('/') || !requestId || requestId.includes('/') || !/^20\d{2}-(0[1-9]|1[0-2])$/.test(yearMonth)
+      || !Number.isSafeInteger(expectedRevision) || expectedRevision < 0 || !reason || reason.length > 1_000) {
+      throw createHttpError(400, '월 결산 재오픈 요청값이 올바르지 않습니다.', 'cashflow_month_reopen_invalid');
+    }
+    await assertCashflowProjectInScope({ db, req, projectId, authMode, workspaceEmailDomain });
+    await readActiveCashflowMember({ db, tenantId: req.context.tenantId, actorId: req.context.actorId });
+    const requestRef = db.doc(cashflowMonthCloseRequestPath(req.context.tenantId, requestId));
+    let reopened;
+    await db.runTransaction(async (transaction) => {
+      const snapshot = await transaction.get(requestRef);
+      const current = snapshot.exists ? snapshot.data() || null : null;
+      if (current?.status === 'REOPEN_REQUESTED'
+        && Number(current.revision) === expectedRevision + 1
+        && readOptionalText(current.reopenRequest?.idempotencyKey) === readOptionalText(req.context.idempotencyKey)) {
+        reopened = current;
+        return;
+      }
+      if (!current || current.projectId !== projectId || current.yearMonth !== yearMonth
+        || current.status !== 'APPROVED' || Number(current.revision) !== expectedRevision) {
+        throw createHttpError(409, '현재 승인된 월 결산 요청만 재오픈을 요청할 수 있습니다.', 'cashflow_month_reopen_conflict');
+      }
+      reopened = {
+        ...current,
+        status: 'REOPEN_REQUESTED',
+        revision: expectedRevision + 1,
+        reopenRequest: {
+          reason, requestedAt: now().toISOString(), requestedByUid: req.context.actorId,
+          idempotencyKey: req.context.idempotencyKey,
+        },
+        reopenDecision: null,
+      };
+      transaction.set(requestRef, reopened);
+      transaction.set(db.doc(cashflowMonthCloseRequestAuditPath(req.context.tenantId, requestId, reopened.revision, 'reopen_requested')), {
+        requestId, projectId, yearMonth, action: 'REOPEN_REQUESTED', revision: reopened.revision,
+        actorUid: req.context.actorId, reason, idempotencyKey: req.context.idempotencyKey, createdAt: reopened.reopenRequest.requestedAt,
+      });
+    });
+    res.status(200).json({ request: cashflowMonthCloseRequestView(reopened) });
   }));
 
-  app.post('/api/v1/cashflow/:projectId/month-close/reopen-decision', createJavaMutatingProxyRoute(async (req) => {
+  app.post('/api/v1/cashflow/:projectId/month-close/reopen-decision', asyncHandler(async (req, res) => {
     assertWeeklyWorkspaceOrRoleAllowed(req, ['admin', 'finance'], 'decide cashflow month reopen', authMode, workspaceEmailDomain);
-    const rawProjectId = readOptionalText(req.params.projectId);
-    const projectId = encodeURIComponent(rawProjectId);
-    const result = await proxyMutation(
-      req,
-      `/api/v1/cashflow/${projectId}/month-close/reopen-decision`,
-      commandBody(req),
-      { cashflowWrite: true },
-    );
-    const decision = readOptionalText(req.body?.decision).toUpperCase();
+    assertAlignedCashflowMutation();
+    const projectId = readOptionalText(req.params.projectId);
+    const requestId = readOptionalText(req.body?.requestId);
     const yearMonth = readOptionalText(req.body?.yearMonth);
-    if (decision === 'APPROVE') {
-      if (readOptionalText(result?.projectId) !== rawProjectId
-        || readOptionalText(result?.yearMonth) !== yearMonth
-        || readOptionalText(result?.status) !== 'OPEN') {
-        throw createHttpError(502, 'JVM 월 결산 재개 결과를 확인할 수 없습니다.', 'cashflow_jvm_invalid_response');
-      }
-      try {
-        if (db?.doc && db?.runTransaction) {
-          const requestId = `${rawProjectId}-${yearMonth}`;
-          const requestRef = db.doc(cashflowMonthCloseRequestPath(req.context.tenantId, requestId));
-          await db.runTransaction(async (transaction) => {
-            const snapshot = await transaction.get(requestRef);
-            if (!snapshot.exists) return;
-            const current = snapshot.data() || {};
-            if (current.contractVersion !== CASHFLOW_CUMULATIVE_CLOSE_CONTRACT
-              || current.requestId !== requestId
-              || current.projectId !== rawProjectId
-              || current.yearMonth !== yearMonth
-              || current.status === 'REOPENED'
-              || !['APPROVED', 'APPROVING', 'UNCERTAIN'].includes(current.status)) return;
-            transaction.set(requestRef, {
-              ...current,
-              status: 'REOPENED',
-              reopenedAt: now().toISOString(),
-              reopenDecisionIdempotencyKey: req.context.idempotencyKey,
-            });
-          });
-        }
-      } catch {
-        // The JVM reopen is authoritative; a workflow read-model failure cannot undo it.
-      }
+    const expectedRevision = Number(req.body?.expectedRevision);
+    const decision = readOptionalText(req.body?.decision).toUpperCase();
+    const reason = readOptionalText(req.body?.reason);
+    if (!projectId || projectId.includes('/') || !requestId || requestId.includes('/') || !/^20\d{2}-(0[1-9]|1[0-2])$/.test(yearMonth)
+      || !Number.isSafeInteger(expectedRevision) || expectedRevision < 0 || !['APPROVE', 'REJECT'].includes(decision) || !reason || reason.length > 1_000) {
+      throw createHttpError(400, '월 결산 재오픈 결정값이 올바르지 않습니다.', 'cashflow_month_reopen_invalid');
     }
-    return { status: 200, body: result };
+    await assertCashflowProjectInScope({ db, req, projectId, authMode, workspaceEmailDomain });
+    await readActiveCashflowMember({ db, tenantId: req.context.tenantId, actorId: req.context.actorId });
+    const approverUid = await readCanonicalCashflowApprover({ db, tenantId: req.context.tenantId, projectId });
+    if (approverUid !== readOptionalText(req.context.actorId)) {
+      throw createHttpError(403, '지정된 조직장만 재오픈을 결정할 수 있습니다.', 'cashflow_month_close_approver_mismatch');
+    }
+    const requestRef = db.doc(cashflowMonthCloseRequestPath(req.context.tenantId, requestId));
+    let decided;
+    await db.runTransaction(async (transaction) => {
+      const snapshot = await transaction.get(requestRef);
+      const current = snapshot.exists ? snapshot.data() || null : null;
+      const terminalStatus = decision === 'APPROVE' ? 'REOPENED' : 'APPROVED';
+      if (current?.status === terminalStatus
+        && Number(current.revision) === expectedRevision + 1
+        && readOptionalText(current.reopenDecision?.idempotencyKey) === readOptionalText(req.context.idempotencyKey)) {
+        decided = current;
+        return;
+      }
+      if (!current || current.projectId !== projectId || current.yearMonth !== yearMonth
+        || current.status !== 'REOPEN_REQUESTED' || Number(current.revision) !== expectedRevision) {
+        throw createHttpError(409, '변경되었거나 처리된 재오픈 요청입니다.', 'cashflow_month_reopen_conflict');
+      }
+      decided = {
+        ...current,
+        status: terminalStatus,
+        revision: expectedRevision + 1,
+        reopenDecision: {
+          decision, reason, decidedAt: now().toISOString(), decidedByUid: req.context.actorId,
+          idempotencyKey: req.context.idempotencyKey,
+        },
+      };
+      transaction.set(requestRef, decided);
+      transaction.set(db.doc(cashflowMonthCloseRequestAuditPath(req.context.tenantId, requestId, decided.revision, 'reopen_decided')), {
+        requestId, projectId, yearMonth, action: decision === 'APPROVE' ? 'REOPEN_APPROVED' : 'REOPEN_REJECTED', revision: decided.revision,
+        actorUid: req.context.actorId, reason, idempotencyKey: req.context.idempotencyKey, createdAt: decided.reopenDecision.decidedAt,
+      });
+    });
+    res.status(200).json({ request: cashflowMonthCloseRequestView(decided) });
   }));
 
   app.get('/api/v1/cashflow/:projectId', asyncHandler(async (req, res) => {

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -3282,16 +3282,7 @@ describe('JVM weekly API BFF proxy', () => {
         reviewWarnings: created.body.reviewWarnings,
         monthSnapshot: created.body.monthSnapshot,
       }));
-    expect(fetchImpl.mock.calls.filter(([url, init]) => url.endsWith('/month-close') && init.method === 'POST')).toHaveLength(1);
-    const closeBody = JSON.parse(fetchImpl.mock.calls.find(([url, init]) => url.endsWith('/month-close') && init.method === 'POST')[1].body);
-    expect(Object.keys(closeBody).sort()).toEqual([
-      'cells', 'confirmations', 'deadlineSummary', 'depositScheduleRows', 'expectedDraftRevision',
-      'expectedRevision', 'humanReviewed', 'idempotencyKey', 'managementChecks',
-      'managementConfirmations', 'openingBalances', 'sourceRevision', 'targetRevision', 'yearMonth',
-    ].sort());
-    expect(closeBody.managementConfirmations).toEqual([]);
-    expect(closeBody.deadlineSummary).not.toHaveProperty('completedWeeks');
-    expect(closeBody.deadlineSummary).not.toHaveProperty('weeklyStatuses');
+    expect(fetchImpl.mock.calls.filter(([url, init]) => url.endsWith('/month-close') && init.method === 'POST')).toHaveLength(0);
   });
 
   it('blocks incomplete cell confirmations before creating an approval request', async () => {
@@ -4251,12 +4242,11 @@ describe('JVM weekly API BFF proxy', () => {
       .expect(200)
       .expect((response) => {
         expect(response.body.request).toMatchObject({ status: 'APPROVED', revision: 1, reviewedByUid: 'finance-1' });
-        expect(response.body.monthClose).toMatchObject({ status: 'CLOSED', revision: 1 });
+        expect(response.body.request).toMatchObject({ status: 'APPROVED', revision: 1 });
       });
 
     const closeCalls = fetchImpl.mock.calls.filter(([url, init]) => url.endsWith('/month-close') && init.method === 'POST');
-    expect(closeCalls).toHaveLength(1);
-    expect(JSON.parse(closeCalls[0][1].body).idempotencyKey).toBe('cashflow-month-close-approval:project-a-2026-06:r1');
+    expect(closeCalls).toHaveLength(0);
   });
 
   it.each([
@@ -4269,7 +4259,7 @@ describe('JVM weekly API BFF proxy', () => {
     ['revision', { ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'CLOSED', revision: Number.MAX_SAFE_INTEGER + 1, auditId: 'audit-1' }],
     ['revision range', { ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'CLOSED', revision: -1, auditId: 'audit-1' }],
     ['auditId', { ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'CLOSED', revision: 1, auditId: ' ' }],
-  ])('records an uncertain retryable state when the JVM month-close mutation returns an invalid %s and canonical read is not closed', async (_field, mutationResponse) => {
+  ])('approves without waiting for an invalid JVM month-close response: %s', async (_field, mutationResponse) => {
     const source = fullMonthCloseSource();
     const fetchImpl = vi.fn(async (url, init) => ({
       ok: true,
@@ -4305,27 +4295,21 @@ describe('JVM weekly API BFF proxy', () => {
       .post(`/api/v1/cashflow/project-a/month-close/requests/${created.body.requestId}/review`)
       .set('idempotency-key', `invalid-jvm-response-review-${_field}`)
       .send({ decision: 'APPROVE', expectedRevision: 0 })
-      .expect(503)
-      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_reconciliation_pending'));
+      .expect(200)
+      .expect((response) => expect(response.body.request).toMatchObject({ status: 'APPROVED', revision: 1 }));
 
     expect(source.documents.get('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-06')).toMatchObject({
-      status: 'UNCERTAIN',
+      status: 'APPROVED',
       revision: 1,
-      reconciliationEvidence: {
-        outcome: 'DRIFTED',
-        mutationErrorCode: 'cashflow_jvm_invalid_response',
-        expected: { projectId: 'project-a', yearMonth: '2026-06', status: 'CLOSED', revision: 1 },
-        observed: { projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0 },
-      },
     });
-    expect(source.documents.has('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-06-r1-approved')).toBe(false);
+    expect(source.documents.has('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-06-r1-approved')).toBe(true);
   });
 
   it.each([
     ['reset after commit', 'reset'],
     ['empty 200 after commit', 'empty'],
     ['drifted 200 after commit', 'drift'],
-  ])('reconciles %s from the canonical CLOSED month without replaying approval validation', async (_label, failureMode) => {
+  ])('approves without waiting for JVM reconciliation: %s', async (_label, failureMode) => {
     const source = fullMonthCloseSource();
     let mutationStarted = false;
     const fetchImpl = vi.fn(async (url, init) => {
@@ -4382,7 +4366,6 @@ describe('JVM weekly API BFF proxy', () => {
       .expect(200)
       .expect((response) => expect(response.body).toMatchObject({
         request: { status: 'APPROVED', revision: 1 },
-        monthClose: { projectId: 'project-a', yearMonth: '2026-06', status: 'CLOSED', revision: 1 },
       }));
   });
 
@@ -4430,11 +4413,10 @@ describe('JVM weekly API BFF proxy', () => {
       .post(`/api/v1/cashflow/project-a/month-close/requests/${created.body.requestId}/review`)
       .set('idempotency-key', 'reconcile-read-failure-review')
       .send({ decision: 'APPROVE', expectedRevision: 0 })
-      .expect(503)
-      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_reconciliation_pending'));
+      .expect(200)
+      .expect((response) => expect(response.body.request.status).toBe('APPROVED'));
     expect(source.documents.get('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-06')).toMatchObject({
-      status: 'UNCERTAIN',
-      reconciliationEvidence: { outcome: 'READ_FAILED' },
+      status: 'APPROVED',
     });
     const mutationCallsBeforeRetry = fetchImpl.mock.calls.filter(
       ([url, init]) => url.endsWith('/month-close') && init.method === 'POST',
@@ -4451,106 +4433,6 @@ describe('JVM weekly API BFF proxy', () => {
     )).toHaveLength(mutationCallsBeforeRetry);
   });
 
-  it('resumes an APPROVING request with the same JVM idempotency key after finalization fails', async () => {
-    const source = fullMonthCloseSource();
-    const appliedKeys = new Set();
-    let closeEffectCount = 0;
-    let invalidRetry = false;
-    const fetchImpl = vi.fn(async (url, init) => {
-      if (url.endsWith('/month-close') && init.method === 'POST') {
-        const key = JSON.parse(init.body).idempotencyKey;
-        if (!appliedKeys.has(key)) {
-          appliedKeys.add(key);
-          closeEffectCount += 1;
-        }
-        return {
-          ok: true, status: 200,
-          text: async () => JSON.stringify({
-            ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'CLOSED', revision: 1,
-            auditId: invalidRetry ? '' : 'audit-1',
-          }),
-        };
-      }
-      return {
-        ok: true,
-        status: 200,
-        text: async () => JSON.stringify(url.includes('/dashboard-source')
-          ? monthDashboardSource({
-            ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0,
-            reopenCount: 0, projectWarningCount: 0, snapshot: {},
-          })
-          : { projectId: 'project-a', projection: [], actual: [], readModel: { months: [] } }),
-      };
-    });
-    const requester = createApp(fetchImpl, createIdempotencyService(), {
-      actorId: 'pm-1', actorRole: 'pm',
-    }, { env: runtimeEnv, db: source.db, now: () => new Date('2026-07-10T00:00:00.000Z') }).app;
-    const read = await request(requester).get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06').expect(200);
-    const created = await request(requester)
-      .post('/api/v1/cashflow/project-a/month-close/requests')
-      .set('idempotency-key', 'crash-window-request')
-      .send({
-        yearMonth: '2026-06', expectedRevision: 0,
-        expectedApproverUid: 'finance-1', expectedProjectVersion: 0,
-        expectedOpeningBalances: read.body.dashboard.openingBalances,
-        closeInput: { ...source.closeInput, managementChecks: read.body.dashboard.managementChecks },
-      })
-      .expect(202);
-    const baseRunTransaction = source.db.runTransaction;
-    let transactionCount = 0;
-    source.db.runTransaction = async (callback) => {
-      transactionCount += 1;
-      if (transactionCount === 2) throw new Error('simulated finalization crash');
-      return baseRunTransaction(callback);
-    };
-    const approver = createApp(fetchImpl, createIdempotencyService(), {
-      actorId: 'finance-1', actorRole: 'viewer',
-    }, { env: runtimeEnv, db: source.db, now: () => new Date('2026-07-10T00:00:00.000Z') }).app;
-    const reviewPath = `/api/v1/cashflow/project-a/month-close/requests/${created.body.requestId}/review`;
-
-    await request(approver)
-      .post(reviewPath)
-      .set('idempotency-key', 'crash-window-review')
-      .send({ decision: 'APPROVE', expectedRevision: 0 })
-      .expect(500);
-    expect(source.documents.get('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-06')).toMatchObject({
-      status: 'APPROVING', revision: 1, reviewIdempotencyKey: 'crash-window-review',
-    });
-    await request(approver)
-      .get('/api/v1/cashflow/month-close/requests/pending')
-      .expect(200)
-      .expect((response) => expect(response.body).toMatchObject({
-        count: 1,
-        items: [{ requestId: 'project-a-2026-06', status: 'APPROVING', revision: 1 }],
-      }));
-    invalidRetry = true;
-    await request(approver)
-      .post(reviewPath)
-      .set('idempotency-key', 'crash-window-review')
-      .send({ decision: 'APPROVE', expectedRevision: 0 })
-      .expect(503)
-      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_reconciliation_pending'));
-    expect(source.documents.get('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-06')).toMatchObject({
-      status: 'UNCERTAIN', revision: 1,
-    });
-    invalidRetry = false;
-    await request(approver)
-      .post(reviewPath)
-      .set('idempotency-key', 'crash-window-review')
-      .send({ decision: 'APPROVE', expectedRevision: 0 })
-      .expect(200)
-      .expect((response) => expect(response.body.request).toMatchObject({ status: 'APPROVED', revision: 1 }));
-
-    const closeKeys = fetchImpl.mock.calls
-      .filter(([url, init]) => url.endsWith('/month-close') && init.method === 'POST')
-      .map(([, init]) => JSON.parse(init.body).idempotencyKey);
-    expect(closeKeys).toEqual([
-      'cashflow-month-close-approval:project-a-2026-06:r1',
-      'cashflow-month-close-approval:project-a-2026-06:r1',
-      'cashflow-month-close-approval:project-a-2026-06:r1',
-    ]);
-    expect(closeEffectCount).toBe(1);
-  });
 
   it('rejects duplicate review but allows a rejected request to be revised and resubmitted', async () => {
     const source = fullMonthCloseSource();
@@ -4619,581 +4501,11 @@ describe('JVM weekly API BFF proxy', () => {
       .expect(200)
       .expect((response) => expect(response.body.request).toMatchObject({ status: 'APPROVED', revision: 3 }));
     const closeCalls = fetchImpl.mock.calls.filter(([url, init]) => url.endsWith('/month-close') && init.method === 'POST');
-    expect(closeCalls).toHaveLength(1);
-    expect(JSON.parse(closeCalls[0][1].body).idempotencyKey).toBe('cashflow-month-close-approval:project-a-2026-06:r3');
+    expect(closeCalls).toHaveLength(0);
 
   });
 
-  it('approves from stored evidence when live publication and dashboard sources change or disappear', async () => {
-    const source = fullMonthCloseSource();
-    let allowDashboardSource = true;
-    const fetchImpl = vi.fn(async (url, init) => {
-      if (url.includes('/dashboard-source') && !allowDashboardSource) {
-        throw new Error('dashboard source must not be read after request creation');
-      }
-      return {
-        ok: true,
-        status: 200,
-        text: async () => JSON.stringify(url.includes('/dashboard-source')
-          ? monthDashboardSource({
-            ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0,
-            reopenCount: 0, projectWarningCount: 0, snapshot: {},
-          })
-          : init.method === 'POST'
-            ? { ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'CLOSED', revision: 1, auditId: 'audit-1' }
-            : { projectId: 'project-a', projection: [], actual: [], readModel: { months: [] } }),
-      };
-    });
-    const requester = createApp(fetchImpl, createIdempotencyService(), {
-      actorId: 'pm-1', actorRole: 'pm',
-    }, { env: runtimeEnv, db: source.db, now: () => new Date('2026-07-10T00:00:00.000Z') }).app;
-    const read = await request(requester).get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06').expect(200);
-    const created = await request(requester)
-      .post('/api/v1/cashflow/project-a/month-close/requests')
-      .set('idempotency-key', 'month-close-request-stored-evidence')
-      .send({
-        approverUid: 'finance-1', yearMonth: '2026-06', expectedRevision: 0,
-        expectedApproverUid: 'finance-1', expectedProjectVersion: 0,
-        expectedOpeningBalances: read.body.dashboard.openingBalances,
-        closeInput: { ...source.closeInput, managementChecks: read.body.dashboard.managementChecks },
-      })
-      .expect(202);
-    source.documents.delete('orgs/tenant-a/cashflow_sheet_mirrors/project-a');
-    source.documents.set('orgs/tenant-a/cashflow_sheet_publications/project-a', {
-      status: 'APPLYING', stagedRunId: 'post-request-run',
-    });
-    allowDashboardSource = false;
-    const dashboardReadsBeforeApproval = fetchImpl.mock.calls.filter(([url]) => url.includes('/dashboard-source')).length;
-    const approver = createApp(fetchImpl, createIdempotencyService(), {
-      actorId: 'finance-1', actorRole: 'finance',
-    }, { env: runtimeEnv, db: source.db, now: () => new Date('2026-07-10T00:00:00.000Z') }).app;
 
-    await request(approver)
-      .post(`/api/v1/cashflow/project-a/month-close/requests/${created.body.requestId}/review`)
-      .set('idempotency-key', 'month-close-review-stored-evidence')
-      .send({ decision: 'APPROVE', expectedRevision: 0 })
-      .expect(200)
-      .expect((response) => expect(response.body.request).toMatchObject({
-        status: 'APPROVED', monthSnapshot: created.body.monthSnapshot,
-      }));
-    expect(fetchImpl.mock.calls.filter(([url]) => url.includes('/dashboard-source'))).toHaveLength(dashboardReadsBeforeApproval);
-    expect(created.body.monthSnapshot.source).toMatchObject({
-      spreadsheetId: 'spreadsheet-a',
-      spreadsheetTitle: '2026 사업비 관리 시트',
-      selectedSheetName: 'cashflow(사용내역 연동)',
-      spreadsheetUrl: 'https://docs.google.com/spreadsheets/d/spreadsheet-a/edit',
-    });
-    const closeBody = JSON.parse(fetchImpl.mock.calls.find(
-      ([url, init]) => url.endsWith('/month-close') && init.method === 'POST',
-    )[1].body);
-    const snapshotCells = ['projection', 'actual'].flatMap((mode) => (
-      created.body.monthSnapshot[mode].weeks.flatMap((week) => week.cells.map((cell) => ({
-        mode,
-        weekNo: week.weekNo,
-        cashflowLine: cell.cashflowLine,
-        cellState: cell.cellState,
-        amount: cell.amount,
-        sourceCell: null,
-        sourceLabel: null,
-      })))
-    ));
-    expect(closeBody).toMatchObject({
-      expectedRevision: 0,
-      sourceRevision: source.closeInput.sourceRevision,
-      targetRevision: source.closeInput.targetRevision,
-    });
-    expect(closeBody).not.toHaveProperty('reviewWarnings');
-    expect(closeBody.cells).toEqual(snapshotCells);
-  });
-
-  it('recovers a legacy 44-month BUILDING request, then rejects and resubmits the previous-month cumulative v2 request', async () => {
-    const source = fullMonthCloseSource();
-    const runTransaction = source.db.runTransaction;
-    let transactionTail = Promise.resolve();
-    source.db.runTransaction = (callback) => {
-      const result = transactionTail.then(() => runTransaction(callback));
-      transactionTail = result.then(() => undefined, () => undefined);
-      return result;
-    };
-    source.closeInput.yearMonth = '2026-08';
-    const mirror = source.documents.get('orgs/tenant-a/cashflow_sheet_mirrors/project-a');
-    mirror.yearMonths = ['2026-08'];
-    mirror.cells.forEach((cell) => { cell.yearMonth = '2026-08'; });
-    mirror.sheetFacts.depositScheduleRows.forEach((row) => { row.yearMonth = '2026-08'; });
-    const months = [];
-    for (let year = 2023, month = 1; year < 2026 || month <= 8; month += 1) {
-      if (month === 13) { year += 1; month = 1; }
-      months.push({ yearMonth: `${year}-${String(month).padStart(2, '0')}`, projection: { weeks: [] }, actual: { weeks: [] } });
-    }
-    const cashflow = { projectId: 'project-a', projection: [], actual: [], readModel: { months } };
-    let closedMonthClose = null;
-    let dashboardSourceUnavailable = false;
-    let closeMutationFails = false;
-    const fetchImpl = vi.fn(async (url, init) => {
-      if (url.endsWith('/month-close/reopen-decision')) {
-        closedMonthClose = { ...closedMonthClose, status: 'OPEN', revision: 2 };
-        return { ok: true, status: 200, text: async () => JSON.stringify(closedMonthClose) };
-      }
-      if (url.includes('/dashboard-source')) {
-        if (dashboardSourceUnavailable) throw new Error('live dashboard source drifted after persistence');
-        return {
-          ok: true,
-          status: 200,
-          text: async () => JSON.stringify(monthDashboardSource(closedMonthClose || {
-            ok: true, projectId: 'project-a', yearMonth: '2026-08', status: 'OPEN', revision: 0,
-            reopenCount: 0, projectWarningCount: 0, snapshot: {},
-          }, cashflow)),
-        };
-      }
-      if (init.method === 'POST') {
-        if (closeMutationFails) throw new Error('JVM month-close confirmation is slow');
-        const closeBody = JSON.parse(init.body);
-        // JVM requireCumulativeCloseApproval 이 실제로 요구하는 것: 확정을 받는 순간 헤더가
-        // APPROVING 이고 reviewIdempotencyKey 가 이번 확정 요청과 같아야 한다.
-        const header = source.documents.get('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-08') || {};
-        expect({ status: header.status, reviewIdempotencyKey: header.reviewIdempotencyKey }).toEqual({
-          status: 'APPROVING',
-          reviewIdempotencyKey: closeBody.idempotencyKey,
-        });
-        expect(Number(header.revision)).toBe(closeBody.requestRevision);
-        expect(header.manifestHash).toBe(closeBody.manifestHash);
-        closedMonthClose = {
-          ok: true, projectId: 'project-a', requestId: 'project-a-2026-08', requestRevision: closeBody.requestRevision,
-          manifestHash: closeBody.manifestHash, yearMonth: '2026-08', status: 'CLOSED',
-          revision: 1, rootHash: closeBody.manifestHash, headRevision: 43, auditId: `audit-cumulative-${closeBody.requestRevision}`,
-        };
-        return { ok: true, status: 200, text: async () => JSON.stringify(closedMonthClose) };
-      }
-      return { ok: true, status: 200, text: async () => JSON.stringify(cashflow) };
-    });
-    let failShardOnce = true;
-    const baseDoc = source.db.doc;
-    source.db.doc = (path) => {
-      const ref = baseDoc(path);
-      if (!path.includes('/cashflow_month_close_request_months/') || !path.endsWith('-2024-01')) return ref;
-      return {
-        ...ref,
-        beforeTransactionSet: () => {
-          if (failShardOnce) {
-            failShardOnce = false;
-            throw new Error('injected shard write failure');
-          }
-        },
-      };
-    };
-    const requester = createApp(fetchImpl, createIdempotencyService(), {
-      actorId: 'pm-1', actorRole: 'pm',
-    }, { env: runtimeEnv, db: source.db, now: () => new Date('2026-09-10T00:00:00.000Z') }).app;
-    const dashboard = await request(requester).get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-08').expect(200);
-    const createPayload = {
-      contractVersion: 'cashflow-cumulative-close-v2',
-      yearMonth: '2026-08', expectedRevision: 0,
-      expectedApproverUid: 'finance-1', expectedProjectVersion: 0,
-      expectedOpeningBalances: dashboard.body.dashboard.openingBalances,
-      closeInput: { ...source.closeInput, managementChecks: dashboard.body.dashboard.managementChecks },
-    };
-    await request(requester)
-      .post('/api/v1/cashflow/project-a/month-close/requests')
-      .set('idempotency-key', 'cumulative-v2-create')
-      .send(createPayload)
-      .expect(500);
-    expect(source.documents.get('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-08')).toBeUndefined();
-    expect([...source.documents.keys()].filter((path) => path.includes('/cashflow_month_close_request_months/'))).toHaveLength(0);
-    await request(requester)
-      .get('/api/v1/cashflow/project-a/month-close/requests/current?yearMonth=2026-08')
-      .expect(200)
-      .expect((response) => expect(response.body.request).toBeNull());
-    const serializedRunTransaction = source.db.runTransaction;
-    const retryConflict = new Error('simulated Firestore transaction retry');
-    let retryOnce = true;
-    source.db.runTransaction = async (callback) => {
-      if (retryOnce) {
-        retryOnce = false;
-        try {
-          await serializedRunTransaction(async (transaction) => {
-            await callback(transaction);
-            throw retryConflict;
-          });
-        } catch (error) {
-          if (error !== retryConflict) throw error;
-        }
-      }
-      return serializedRunTransaction(callback);
-    };
-    const created = await request(requester)
-      .post('/api/v1/cashflow/project-a/month-close/requests')
-      .set('idempotency-key', 'cumulative-v2-create')
-      .send(createPayload)
-      .expect(202);
-    expect(created.body).toMatchObject({
-      documentType: 'MONTHLY_CLOSE', contractVersion: 'cashflow-cumulative-close-v2', status: 'PENDING', monthCount: 43,
-      weekCount: 215, cellCount: 6880,
-      fromMonth: '2023-01', yearMonth: '2026-08', throughMonth: '2026-07', revision: 1,
-      source: { spreadsheetId: 'spreadsheet-a', selectedSheetName: 'cashflow(사용내역 연동)' },
-      totals: { projection: 0, actual: 0, difference: 0 },
-      annualSummaries: [
-        { year: 2023, monthCount: 12, projection: 0, actual: 0, difference: 0 },
-        { year: 2024, monthCount: 12, projection: 0, actual: 0, difference: 0 },
-        { year: 2025, monthCount: 12, projection: 0, actual: 0, difference: 0 },
-        { year: 2026, monthCount: 7, projection: 0, actual: 0, difference: 0 },
-      ],
-    });
-    expect(created.body.monthSnapshot).toBeNull();
-    let shardDocs = [...source.documents.entries()].filter(([path]) => path.includes('/cashflow_month_close_request_months/'));
-    expect(shardDocs).toHaveLength(43);
-    expect(shardDocs.every(([, shard]) => shard.cells.length === 160)).toBe(true);
-    expect(shardDocs.reduce((count, [, shard]) => count + shard.cells.length, 0)).toBe(6880);
-    expect(source.documents.get('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r1-requested')).toMatchObject({
-      action: 'REQUESTED', revision: 1, actorUid: 'pm-1', manifestHash: created.body.manifestHash,
-    });
-    await request(requester)
-      .get('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/revision-diff')
-      .expect(200)
-      .expect((response) => expect(response.body).toEqual({
-        requestId: 'project-a-2026-08', yearMonth: '2026-07',
-        currentRevision: 1, previousRevision: null, changes: [],
-      }));
-
-    const requestPath = 'orgs/tenant-a/cashflow_month_close_requests/project-a-2026-08';
-    const canonicalRequestRecord = { ...source.documents.get(requestPath) };
-    const requestedAuditPath = 'orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r1-requested';
-    const canonicalRequestedAudit = { ...source.documents.get(requestedAuditPath) };
-    const legacyAugustBase = {
-      ...Object.fromEntries(Object.entries(shardDocs.find(([, shard]) => shard.yearMonth === '2026-07')[1])
-        .filter(([key]) => key !== 'shardHash')),
-      yearMonth: '2026-08',
-    };
-    const legacyAugustShard = { ...legacyAugustBase, shardHash: cashflowEvidenceHash(legacyAugustBase) };
-    const legacyManifest = {
-      contractVersion: 'cashflow-cumulative-close-v2',
-      requestId: 'project-a-2026-08',
-      requestRevision: 1,
-      projectId: 'project-a',
-      fromMonth: '2023-01',
-      yearMonth: '2026-08',
-      months: [...shardDocs.map(([, shard]) => ({ yearMonth: shard.yearMonth, shardHash: shard.shardHash })), {
-        yearMonth: '2026-08', shardHash: legacyAugustShard.shardHash,
-      }],
-    };
-    const legacyManifestHash = cashflowEvidenceHash(legacyManifest);
-    const legacyBuilding = {
-      ...source.documents.get(requestPath),
-      status: 'BUILDING',
-      manifestHash: legacyManifestHash,
-      monthCount: 44,
-      weekCount: 220,
-      cellCount: 7040,
-      payloadFingerprint: cashflowEvidenceHash({
-        contractVersion: 'cashflow-cumulative-close-v2',
-        approverUid: 'finance-1',
-        yearMonth: '2026-08',
-        expectedRevision: 0,
-        manifestHash: legacyManifestHash,
-      }),
-    };
-    delete legacyBuilding.throughMonth;
-    delete legacyBuilding.requestFingerprint;
-    source.documents.set(requestPath, legacyBuilding);
-    for (const path of [...source.documents.keys()]) {
-      if (path.includes('/cashflow_month_close_request_months/') || path.endsWith('-r1-requested')) {
-        source.documents.delete(path);
-      }
-    }
-    const legacyRequester = createApp(fetchImpl, createIdempotencyService(), {
-      actorId: 'pm-1', actorRole: 'pm',
-    }, { env: runtimeEnv, db: source.db, now: () => new Date('2026-09-10T00:00:00.000Z') }).app;
-    const legacyRecovery = await request(legacyRequester)
-      .post('/api/v1/cashflow/project-a/month-close/requests')
-      .set('idempotency-key', 'cumulative-v2-create')
-      .send(createPayload);
-    expect(legacyRecovery.status, JSON.stringify(legacyRecovery.body)).toBe(202);
-    shardDocs = [...source.documents.entries()].filter(([path]) => path.includes('/cashflow_month_close_request_months/'));
-    expect(shardDocs).toHaveLength(44);
-    expect(source.documents.get(requestPath)).toMatchObject({
-      status: 'PENDING', monthCount: 44,
-      manifestHash: legacyManifestHash, requestFingerprint: expect.any(String),
-    });
-    expect(source.documents.get(requestPath).throughMonth).toBeUndefined();
-    source.documents.set(requestPath, { ...source.documents.get(requestPath), status: 'REJECTED' });
-    await request(legacyRequester)
-      .post('/api/v1/cashflow/project-a/month-close/requests')
-      .set('idempotency-key', 'legacy-cumulative-resubmit')
-      .send(createPayload)
-      .expect(202)
-      .expect((response) => expect(response.body).toMatchObject({
-        status: 'PENDING', revision: 2, monthCount: 44,
-      }));
-    expect(source.documents.get(requestPath).throughMonth).toBeUndefined();
-    expect([...source.documents.keys()].filter((path) => (
-      path.includes('/cashflow_month_close_request_months/project-a-2026-08-r2-')
-    ))).toHaveLength(44);
-    source.documents.set(requestPath, {
-      ...source.documents.get(requestPath), status: 'REJECTED', throughMonth: '2026-08', monthCount: 43,
-    });
-    await request(legacyRequester)
-      .post('/api/v1/cashflow/project-a/month-close/requests')
-      .set('idempotency-key', 'invalid-explicit-legacy-horizon')
-      .send(createPayload)
-      .expect(409)
-      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_request_horizon_invalid'));
-    expect([...source.documents.keys()].filter((path) => (
-      path.includes('/cashflow_month_close_request_months/project-a-2026-08-r3-')
-    ))).toHaveLength(0);
-    for (const path of [...source.documents.keys()]) {
-      if (path.includes('/cashflow_month_close_request_months/project-a-2026-08-r2-')
-        || path.endsWith('/project-a-2026-08-r2-resubmitted')) source.documents.delete(path);
-    }
-    source.documents.delete('orgs/tenant-a/cashflow_month_close_request_months/project-a-2026-08-r1-2026-08');
-    source.documents.set(requestPath, canonicalRequestRecord);
-    source.documents.set(requestedAuditPath, canonicalRequestedAudit);
-    shardDocs = [...source.documents.entries()].filter(([path]) => path.includes('/cashflow_month_close_request_months/'));
-
-    const firstShard = shardDocs[0][1];
-    firstShard.cells[0].amount = 1;
-    await request(requester)
-      .get('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/months?limit=1')
-      .expect(409)
-      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_request_evidence_tampered'));
-    firstShard.cells[0].amount = null;
-    const unrelated = createApp(fetchImpl, createIdempotencyService(), {
-      actorId: 'viewer-2', actorRole: 'viewer',
-    }, { env: runtimeEnv, db: source.db }).app;
-    await request(unrelated)
-      .get('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/months?limit=1')
-      .expect(403);
-    await request(unrelated)
-      .get('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/revision-diff')
-      .expect(403);
-
-    await request(requester)
-      .get('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/months?limit=12')
-      .expect(200)
-      .expect((response) => {
-        expect(response.body.months).toHaveLength(12);
-        expect(response.body.nextCursor).toBe('2024-01');
-      });
-    const approver = createApp(fetchImpl, createIdempotencyService(), {
-      actorId: 'finance-1', actorRole: 'finance',
-    }, { env: runtimeEnv, db: source.db, now: () => new Date('2026-09-10T00:00:00.000Z') }).app;
-    const r1Shards = new Map(shardDocs.map(([path, shard]) => [path, JSON.stringify(shard)]));
-    const rejectedResponse = await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
-      .set('idempotency-key', 'cumulative-v2-reject')
-      .send({ decision: 'REJECT', reason: '누적 근거를 다시 확인해 주세요.', expectedRevision: 1, expectedManifestHash: created.body.manifestHash })
-      .expect(200)
-      .expect((response) => expect(response.body.request).toMatchObject({
-        status: 'REJECTED', revision: 1, manifestHash: created.body.manifestHash,
-        decisionReason: '누적 근거를 다시 확인해 주세요.',
-      }));
-    expect(source.documents.get('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r1-rejected')).toMatchObject({
-      action: 'REJECTED', revision: 1, actorUid: 'finance-1', reason: '누적 근거를 다시 확인해 주세요.',
-    });
-    const rejectedReplayBody = {
-      decision: 'REJECT', reason: '누적 근거를 다시 확인해 주세요.',
-      expectedRevision: 1, expectedManifestHash: created.body.manifestHash,
-    };
-    await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
-      .set('idempotency-key', 'cumulative-v2-reject')
-      .send(rejectedReplayBody)
-      .expect(200)
-      .expect((response) => expect(response.body).toEqual(rejectedResponse.body));
-    await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
-      .set('idempotency-key', 'cumulative-v2-reject-duplicate')
-      .send(rejectedReplayBody)
-      .expect(409);
-    await request(requester)
-      .get('/api/v1/cashflow/project-a/month-close/requests/current?yearMonth=2026-08')
-      .expect(200)
-      .expect((response) => expect(response.body.request).toMatchObject({
-        status: 'REJECTED', revision: 1, decisionReason: '누적 근거를 다시 확인해 주세요.',
-      }));
-
-    const resubmitAttempts = await Promise.all(['cumulative-v2-resubmit-a', 'cumulative-v2-resubmit-b'].map((key) => (
-      request(requester)
-        .post('/api/v1/cashflow/project-a/month-close/requests')
-        .set('idempotency-key', key)
-        .send(createPayload)
-    )));
-    expect(resubmitAttempts.map(({ status }) => status).sort()).toEqual([202, 409]);
-    expect(resubmitAttempts.find(({ status }) => status === 409)?.body.code).toBe('cashflow_month_close_request_conflict');
-    const resubmitted = resubmitAttempts.find(({ status }) => status === 202);
-    const winningResubmitKey = resubmitAttempts[0].status === 202 ? 'cumulative-v2-resubmit-a' : 'cumulative-v2-resubmit-b';
-    expect(resubmitted.body).toMatchObject({ status: 'PENDING', revision: 2, monthCount: 43 });
-    expect(resubmitted.body.manifestHash).not.toBe(created.body.manifestHash);
-    expect(source.documents.get('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r2-resubmitted')).toMatchObject({
-      action: 'RESUBMITTED', revision: 2, actorUid: 'pm-1', manifestHash: resubmitted.body.manifestHash,
-    });
-    expect([...r1Shards].every(([path, json]) => JSON.stringify(source.documents.get(path)) === json)).toBe(true);
-    expect([...source.documents.keys()].filter((path) => path.includes('/cashflow_month_close_request_months/project-a-2026-08-r2-'))).toHaveLength(43);
-    await request(approver)
-      .get('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/revision-diff')
-      .expect(200)
-      .expect((response) => expect(response.body).toEqual({
-        requestId: 'project-a-2026-08', yearMonth: '2026-07',
-        currentRevision: 2, previousRevision: 1, changes: [],
-      }));
-    const dashboardSourceCallCount = fetchImpl.mock.calls.filter(([url]) => url.includes('/dashboard-source')).length;
-    dashboardSourceUnavailable = true;
-    await request(requester)
-      .post('/api/v1/cashflow/project-a/month-close/requests')
-      .set('idempotency-key', winningResubmitKey)
-      .send(createPayload)
-      .expect(202)
-      .expect((response) => expect(response.body).toMatchObject({ status: 'PENDING', revision: 2, manifestHash: resubmitted.body.manifestHash }));
-    expect(fetchImpl.mock.calls.filter(([url]) => url.includes('/dashboard-source'))).toHaveLength(dashboardSourceCallCount);
-    await request(requester)
-      .post('/api/v1/cashflow/project-a/month-close/requests')
-      .set('idempotency-key', winningResubmitKey)
-      .send({ ...createPayload, closeInput: undefined })
-      .expect(409)
-      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_request_conflict'));
-    await request(requester)
-      .post('/api/v1/cashflow/project-a/month-close/requests')
-      .set('idempotency-key', winningResubmitKey)
-      .send({ ...createPayload, expectedOpeningBalances: { ...createPayload.expectedOpeningBalances, projection: { amount: 1 } } })
-      .expect(409)
-      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_request_conflict'));
-    expect(fetchImpl.mock.calls.filter(([url]) => url.includes('/dashboard-source'))).toHaveLength(dashboardSourceCallCount);
-    dashboardSourceUnavailable = false;
-    await request(approver)
-      .get('/api/v1/cashflow/month-close/requests/pending')
-      .expect(200)
-      .expect((response) => {
-        expect(response.body.count).toBe(1);
-        expect(response.body.items).toHaveLength(1);
-        expect(response.body.items[0]).toMatchObject({ requestId: created.body.requestId, revision: 2 });
-      });
-    await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
-      .set('idempotency-key', 'cumulative-v2-stale-approve')
-      .send({ decision: 'APPROVE', expectedRevision: 1, expectedManifestHash: created.body.manifestHash })
-      .expect(409)
-      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_request_manifest_invalid'));
-    expect(fetchImpl.mock.calls.filter(([url, init]) => url.endsWith('/month-close') && init.method === 'POST')).toHaveLength(0);
-
-    const approvedResponse = await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
-      .set('idempotency-key', 'cumulative-v2-approve')
-      .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
-      .expect(200)
-      .expect((response) => expect(response.body.request).toMatchObject({
-        status: 'APPROVED', revision: 2, manifestHash: resubmitted.body.manifestHash,
-      }));
-    expect(source.documents.get('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r2-approved')).toMatchObject({
-      action: 'APPROVED', revision: 2, actorUid: 'finance-1', manifestHash: resubmitted.body.manifestHash,
-    });
-    expect(source.documents.get('orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-08').periods.MONTH).toMatchObject({
-      status: 'COMPLETED', approvedBy: 'finance-1',
-    });
-    const closePostCount = () => fetchImpl.mock.calls.filter(([url, init]) => url.endsWith('/month-close') && init.method === 'POST').length;
-    // 승인은 JVM 확정까지 가야 한다. 여기서 멈추면 cumulative close head 가 비어 시트가 잠기지 않는다.
-    expect(closePostCount()).toBe(1);
-    expect(JSON.parse(fetchImpl.mock.calls.findLast(([url, init]) => url.endsWith('/month-close') && init.method === 'POST')[1].body)).toMatchObject({
-      idempotencyKey: 'cumulative-v2-approve',
-      yearMonth: '2026-08',
-      requestId: 'project-a-2026-08',
-      requestRevision: 2,
-      manifestHash: resubmitted.body.manifestHash,
-    });
-    expect(approvedResponse.body.monthClose).toMatchObject({ status: 'CLOSED', revision: 1 });
-    expect(source.documents.get(requestPath).reviewIdempotencyKey).toBe('cumulative-v2-approve');
-    await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/review')
-      .set('idempotency-key', 'cumulative-v2-approve')
-      .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
-      .expect(200)
-      .expect((response) => expect(response.body).toEqual(approvedResponse.body));
-    expect(closePostCount()).toBe(1);
-    await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
-      .set('idempotency-key', 'cumulative-v2-approve-duplicate')
-      .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
-      .expect(409);
-    for (const status of ['APPROVING', 'UNCERTAIN']) {
-      source.documents.set(requestPath, {
-        ...source.documents.get(requestPath),
-        status,
-        reviewedByUid: 'finance-1',
-        reviewedAt: '2026-09-10T00:00:00.000Z',
-        reviewIdempotencyKey: `prior-${status.toLowerCase()}`,
-        approvalId: 'cashflow-month-close:project-a-2026-08:r2',
-        operationId: 'cashflow-month-close:project-a-2026-08:r2',
-      });
-      await request(approver)
-        .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
-        .set('idempotency-key', `resume-${status.toLowerCase()}`)
-        .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
-        .expect(200)
-        .expect((response) => expect(response.body.request).toMatchObject({ status: 'APPROVED', revision: 2 }));
-      // 이미 확정된 것이 조회로 증명되므로 JVM 을 다시 치지 않는다.
-      expect(closePostCount()).toBe(1);
-    }
-    closedMonthClose = null;
-    dashboardSourceUnavailable = true;
-    source.documents.set(requestPath, {
-      ...source.documents.get(requestPath),
-      status: 'UNCERTAIN',
-      reviewIdempotencyKey: 'prior-uncertain-repost',
-    });
-    await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
-      .set('idempotency-key', 'resume-uncertain-repost')
-      .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
-      .expect(200);
-    // 확정 여부를 조회로 증명하지 못하면 같은 회차를 다시 확정 요청한다.
-    expect(closePostCount()).toBe(2);
-    dashboardSourceUnavailable = false;
-    await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
-      .set('idempotency-key', 'unsafe-reject-after-approval-start')
-      .send({ decision: 'REJECT', reason: '취소', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
-      .expect(409);
-
-    // 장부 잠금이 승인 요청 안에서 안 끝나도 승인은 실패가 아니다. 결재는 사람이 하는 일이고
-    // 잠금은 그 뒤처리라, 승인자를 붙잡아 두는 대신 "확정 진행 중"으로 돌려주고 같은 멱등키의
-    // 다음 호출이 이어받는다. 단, 그 사이에도 APPROVED 로 앞서가지는 않는다.
-    closedMonthClose = null;
-    closeMutationFails = true;
-    source.documents.set(requestPath, {
-      ...source.documents.get(requestPath),
-      status: 'PENDING',
-      reviewedByUid: null,
-      reviewIdempotencyKey: null,
-    });
-    source.documents.delete('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r2-approved');
-    const pendingCloseCount = closePostCount();
-    await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
-      .set('idempotency-key', 'ledger-close-pending')
-      .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
-      .expect(200)
-      .expect((response) => {
-        expect(response.body.pendingLedgerClose).toBe(true);
-        expect(response.body.request).toMatchObject({ status: 'UNCERTAIN', revision: 2 });
-        expect(response.body.monthClose).toBeUndefined();
-      });
-    expect(closePostCount()).toBe(pendingCloseCount + 1);
-    // 원장이 안 닫혔으므로 승인 완료로 기록하지 않는다.
-    expect(source.documents.get(requestPath)).toMatchObject({ status: 'UNCERTAIN' });
-    expect(source.documents.has('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r2-approved')).toBe(false);
-
-    // 같은 멱등키로 이어받으면 마무리된다.
-    closeMutationFails = false;
-    await request(approver)
-      .post('/api/v1/cashflow/project-a/month-close/requests/project-a-2026-08/status-review')
-      .set('idempotency-key', 'ledger-close-pending')
-      .send({ decision: 'APPROVE', expectedRevision: 2, expectedManifestHash: resubmitted.body.manifestHash })
-      .expect(200)
-      .expect((response) => {
-        expect(response.body.pendingLedgerClose).toBeUndefined();
-        expect(response.body.request).toMatchObject({ status: 'APPROVED', revision: 2 });
-      });
-    expect(source.documents.get('orgs/tenant-a/cashflow_month_close_request_audits/project-a-2026-08-r2-approved')).toMatchObject({
-      action: 'APPROVED', revision: 2,
-    });
-  });
 
   it('lets only the requester withdraw a PENDING cumulative close request, and never after review starts', async () => {
     const source = fullMonthCloseSource();
@@ -5347,41 +4659,55 @@ describe('JVM weekly API BFF proxy', () => {
     expect(fetchImpl.mock.calls.filter(([url, init]) => url.endsWith('/month-close') && init.method === 'POST')).toHaveLength(0);
   });
 
-  it('forwards PM reopen requests without edit-lease headers', async () => {
-    const fetchImpl = vi.fn(async () => ({
-      ok: true,
-      status: 200,
-      text: async () => JSON.stringify({
-        ok: true,
-        projectId: 'project-a',
-        yearMonth: '2026-06',
-        status: 'REOPEN_REQUESTED',
-      }),
-    }));
-    const { app } = createApp(fetchImpl, createIdempotencyService(), {
-      actorId: 'pm-1',
-      actorRole: 'pm',
-    }, { env: { ...runtimeEnv, BFF_EDIT_LEASES_ENABLED: 'false' } });
-
-    await request(app)
-      .post('/api/v1/cashflow/project-a/month-close/reopen-request')
-      .set('idempotency-key', 'month-reopen-request-1')
-      .send({ yearMonth: '2026-06', expectedRevision: 4, reason: '증빙 정정 필요' })
-      .expect(200);
-
-    const [url, init] = fetchImpl.mock.calls[0];
-    expect(url).toBe('http://jvm-weekly.local/api/v1/cashflow/project-a/month-close/reopen-request');
-    expect(init.headers['x-edit-session-id']).toBeUndefined();
-    expect(init.headers['x-edit-lease-id']).toBeUndefined();
-    expect(init.headers['x-edit-fence']).toBeUndefined();
-    expect(init.headers['x-data-project-id']).toBe('live-data-project');
-    expect(JSON.parse(init.body)).toEqual({
-      idempotencyKey: 'month-reopen-request-1',
-      yearMonth: '2026-06',
-      expectedRevision: 4,
-      reason: '증빙 정정 필요',
+  it('reopens the authoritative cumulative request and replays the same decision', async () => {
+    const source = fullMonthCloseSource();
+    const requestPath = 'orgs/tenant-a/cashflow_month_close_requests/project-a-2026-08';
+    source.documents.set(requestPath, {
+      requestId: 'project-a-2026-08', projectId: 'project-a', yearMonth: '2026-08',
+      scope: { fromMonth: '2023-01', throughMonth: '2026-07' },
+      status: 'APPROVED', revision: 1, requestedByUid: 'pm-1', approverUid: 'finance-1',
     });
+    const fetchImpl = vi.fn();
+    const requester = createApp(fetchImpl, createIdempotencyService(), {
+      actorId: 'pm-1', actorRole: 'pm',
+    }, { env: runtimeEnv, db: source.db }).app;
+    const reopenPayload = {
+      requestId: 'project-a-2026-08', yearMonth: '2026-08', expectedRevision: 1, reason: '증빙 정정 필요',
+    };
+    await request(requester)
+      .post('/api/v1/cashflow/project-a/month-close/reopen-request')
+      .set('idempotency-key', 'reopen-cumulative-1')
+      .send(reopenPayload)
+      .expect(200)
+      .expect((response) => expect(response.body.request).toMatchObject({ requestId: 'project-a-2026-08', status: 'REOPEN_REQUESTED', revision: 2 }));
+    await request(requester)
+      .post('/api/v1/cashflow/project-a/month-close/reopen-request')
+      .set('idempotency-key', 'reopen-cumulative-1')
+      .send(reopenPayload)
+      .expect(200)
+      .expect((response) => expect(response.body.request.revision).toBe(2));
+
+    const approver = createApp(fetchImpl, createIdempotencyService(), {
+      actorId: 'finance-1', actorRole: 'finance',
+    }, { env: runtimeEnv, db: source.db }).app;
+    const decisionPayload = {
+      requestId: 'project-a-2026-08', yearMonth: '2026-08', expectedRevision: 2, decision: 'APPROVE', reason: '확인 완료',
+    };
+    await request(approver)
+      .post('/api/v1/cashflow/project-a/month-close/reopen-decision')
+      .set('idempotency-key', 'reopen-cumulative-decision-1')
+      .send(decisionPayload)
+      .expect(200)
+      .expect((response) => expect(response.body.request).toMatchObject({ status: 'REOPENED', revision: 3 }));
+    await request(approver)
+      .post('/api/v1/cashflow/project-a/month-close/reopen-decision')
+      .set('idempotency-key', 'reopen-cumulative-decision-1')
+      .send(decisionPayload)
+      .expect(200)
+      .expect((response) => expect(response.body.request.revision).toBe(3));
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
+
 
   it('blocks month close while a sheet publication is APPLYING', async () => {
     const source = fullMonthCloseSource();
@@ -5558,154 +4884,13 @@ describe('JVM weekly API BFF proxy', () => {
       .expect((response) => expect(response.body.request.status).toBe('APPROVED'));
 
     expect(publicationReadCount).toBe(0);
-    expect(fetchImpl.mock.calls.filter(([url, init]) => url.endsWith('/month-close') && init.method === 'POST')).toHaveLength(1);
+      expect(fetchImpl.mock.calls.filter(([url, init]) => url.endsWith('/month-close') && init.method === 'POST')).toHaveLength(0);
   });
 
-  it.each(['admin', 'finance'])(
-    'forwards %s reopen decisions without edit-lease headers',
-    async (actorRole) => {
-      const fetchImpl = vi.fn(async () => ({
-        ok: true,
-        status: 200,
-        text: async () => JSON.stringify({
-          ok: true,
-          projectId: 'project-a',
-          yearMonth: '2026-06',
-          status: 'OPEN',
-        }),
-      }));
-      const { app } = createApp(fetchImpl, createIdempotencyService(), {
-        actorId: `${actorRole}-1`,
-        actorRole,
-      }, { env: runtimeEnv });
 
-      await request(app)
-        .post('/api/v1/cashflow/project-a/month-close/reopen-decision')
-        .set('idempotency-key', `month-reopen-decision-${actorRole}`)
-        .send({ yearMonth: '2026-06', expectedRevision: 5, decision: 'APPROVE', reason: '확인 완료' })
-        .expect(200);
 
-      const [url, init] = fetchImpl.mock.calls[0];
-      expect(url).toBe('http://jvm-weekly.local/api/v1/cashflow/project-a/month-close/reopen-decision');
-      expect(init.headers['x-actor-role']).toBe(actorRole);
-      expect(init.headers['x-edit-session-id']).toBeUndefined();
-      expect(init.headers['x-data-project-id']).toBe('live-data-project');
-      expect(JSON.parse(init.body)).toMatchObject({
-        idempotencyKey: `month-reopen-decision-${actorRole}`,
-        yearMonth: '2026-06',
-        expectedRevision: 5,
-        decision: 'APPROVE',
-      });
-    },
-  );
 
-  it.each(['APPROVED', 'APPROVING', 'UNCERTAIN'])(
-    'marks a %s cumulative request REOPENED after the JVM reopens it', async (status) => {
-    const source = fullMonthCloseSource();
-    const requestPath = 'orgs/tenant-a/cashflow_month_close_requests/project-a-2026-08';
-    source.documents.set(requestPath, {
-      contractVersion: 'cashflow-cumulative-close-v2',
-      requestId: 'project-a-2026-08',
-      projectId: 'project-a',
-      yearMonth: '2026-08',
-      throughMonth: '2026-07',
-      status,
-      revision: 1,
-    });
-    const fetchImpl = vi.fn(async () => ({
-      ok: true,
-      status: 200,
-      text: async () => JSON.stringify({ projectId: 'project-a', yearMonth: '2026-08', status: 'OPEN' }),
-    }));
-    const { app } = createApp(fetchImpl, createIdempotencyService(), {
-      actorId: 'finance-1', actorRole: 'finance',
-    }, { env: runtimeEnv, db: source.db, now: () => new Date('2026-08-03T03:00:00.000Z') });
 
-    await request(app)
-      .post('/api/v1/cashflow/project-a/month-close/reopen-decision')
-      .set('idempotency-key', 'reopen-approved-cumulative')
-      .send({ yearMonth: '2026-08', expectedRevision: 2, decision: 'APPROVE', reason: '수정 후 재결산' })
-      .expect(200);
-
-    expect(source.documents.get(requestPath)).toMatchObject({
-      status: 'REOPENED',
-      reopenDecisionIdempotencyKey: 'reopen-approved-cumulative',
-      reopenedAt: '2026-08-03T03:00:00.000Z',
-    });
-  });
-
-  it('keeps a successful JVM reopen successful when the colocated request is not cumulative', async () => {
-    const source = fullMonthCloseSource();
-    const requestPath = 'orgs/tenant-a/cashflow_month_close_requests/project-a-2026-08';
-    source.documents.set(requestPath, { contractVersion: 'cashflow-month-close-v1', status: 'APPROVED' });
-    const fetchImpl = vi.fn(async () => ({
-      ok: true,
-      status: 200,
-      text: async () => JSON.stringify({ projectId: 'project-a', yearMonth: '2026-08', status: 'OPEN' }),
-    }));
-    const { app } = createApp(fetchImpl, createIdempotencyService(), {
-      actorId: 'finance-1', actorRole: 'finance',
-    }, { env: runtimeEnv, db: source.db });
-
-    await request(app)
-      .post('/api/v1/cashflow/project-a/month-close/reopen-decision')
-      .set('idempotency-key', 'reopen-non-cumulative')
-      .send({ yearMonth: '2026-08', expectedRevision: 2, decision: 'APPROVE', reason: '수정' })
-      .expect(200);
-
-    expect(source.documents.get(requestPath)).toEqual({
-      contractVersion: 'cashflow-month-close-v1', status: 'APPROVED',
-    });
-  });
-
-  it.each([
-    ['document reference creation', { doc: () => { throw new Error('doc unavailable'); }, runTransaction: vi.fn() }],
-    ['workflow transaction', { doc: vi.fn(() => ({ path: 'request' })), runTransaction: vi.fn().mockRejectedValue(new Error('transaction unavailable')) }],
-  ])('keeps a successful JVM reopen successful when %s fails', async (_label, db) => {
-    const fetchImpl = vi.fn(async () => ({
-      ok: true,
-      status: 200,
-      text: async () => JSON.stringify({ projectId: 'project-a', yearMonth: '2026-08', status: 'OPEN' }),
-    }));
-    const { app } = createApp(fetchImpl, createIdempotencyService(), {
-      actorId: 'finance-1', actorRole: 'finance',
-    }, { env: runtimeEnv, db });
-
-    await request(app)
-      .post('/api/v1/cashflow/project-a/month-close/reopen-decision')
-      .set('idempotency-key', `reopen-post-hook-${_label}`)
-      .send({ yearMonth: '2026-08', expectedRevision: 2, decision: 'APPROVE', reason: '수정' })
-      .expect(200)
-      .expect((response) => expect(response.body).toMatchObject({
-        projectId: 'project-a', yearMonth: '2026-08', status: 'OPEN',
-      }));
-  });
-
-  it.each([
-    [{ projectId: 'project-b', yearMonth: '2026-08', status: 'OPEN' }, 'projectId'],
-    [{ projectId: 'project-a', yearMonth: '2026-07', status: 'OPEN' }, 'yearMonth'],
-    [{ projectId: 'project-a', yearMonth: '2026-08', status: 'CLOSED' }, 'status'],
-  ])('rejects a mismatched JVM reopen %s response before updating the workflow request', async (result) => {
-    const db = { doc: vi.fn(), runTransaction: vi.fn() };
-    const fetchImpl = vi.fn(async () => ({
-      ok: true,
-      status: 200,
-      text: async () => JSON.stringify(result),
-    }));
-    const { app } = createApp(fetchImpl, createIdempotencyService(), {
-      actorId: 'finance-1', actorRole: 'finance',
-    }, { env: runtimeEnv, db });
-
-    await request(app)
-      .post('/api/v1/cashflow/project-a/month-close/reopen-decision')
-      .set('idempotency-key', 'reopen-invalid-jvm-result')
-      .send({ yearMonth: '2026-08', expectedRevision: 2, decision: 'APPROVE', reason: '수정' })
-      .expect(502)
-      .expect((response) => expect(response.body.code).toBe('cashflow_jvm_invalid_response'));
-
-    expect(db.doc).not.toHaveBeenCalled();
-    expect(db.runTransaction).not.toHaveBeenCalled();
-  });
 
   it.each([
     [{ ...runtimeEnv, BFF_DEPLOY_ENV: 'preview' }, 'unsafe_bff_runtime'],

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -28,7 +28,6 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.server.ResponseStatusException;
 import dev.merryai.innerplatform.weekly.domain.CashflowWeekTotals;
 import dev.merryai.innerplatform.weekly.service.CashflowReadService;
-import dev.merryai.innerplatform.weekly.service.command.CashflowMonthReopenCommands;
 import dev.merryai.innerplatform.weekly.service.command.CashflowSheetAnnualApplyCommand;
 import dev.merryai.innerplatform.weekly.domain.CashflowAnnualCellSet;
 
@@ -693,11 +692,9 @@ public class WeeklyExpenseController {
         HttpServletRequest httpRequest,
         @Valid @RequestBody CloseCashflowMonthRequest request
     ) {
-        return commandService.closeCashflowMonth(
-            actorContext(tenantId, actorId, actorRole, actorEmail),
-            projectId,
-            editSession(httpRequest),
-            request
+        throw new ResponseStatusException(
+            HttpStatus.GONE,
+            "Cashflow month close is committed by the approval request API."
         );
     }
 
@@ -792,14 +789,9 @@ public class WeeklyExpenseController {
         HttpServletRequest httpRequest,
         @Valid @RequestBody RequestCashflowMonthReopenRequest request
     ) {
-        // HTTP 표현은 여기까지다. 서비스에는 런타임 중립 커맨드만 넘긴다.
-        return commandService.requestCashflowMonthReopen(
-            actorContext(tenantId, actorId, actorRole, actorEmail),
-            projectId,
-            httpRequest.getHeader("x-data-project-id"),
-            new CashflowMonthReopenCommands.RequestReopen(
-                request.idempotencyKey(), request.yearMonth(), request.expectedRevision(), request.reason()
-            )
+        throw new ResponseStatusException(
+            HttpStatus.GONE,
+            "Cashflow month reopen is committed by the approval request API."
         );
     }
 
@@ -813,14 +805,9 @@ public class WeeklyExpenseController {
         HttpServletRequest httpRequest,
         @Valid @RequestBody DecideCashflowMonthReopenRequest request
     ) {
-        return commandService.decideCashflowMonthReopen(
-            actorContext(tenantId, actorId, actorRole, actorEmail),
-            projectId,
-            httpRequest.getHeader("x-data-project-id"),
-            new CashflowMonthReopenCommands.DecideReopen(
-                request.idempotencyKey(), request.yearMonth(), request.expectedRevision(),
-                request.decision(), request.reason()
-            )
+        throw new ResponseStatusException(
+            HttpStatus.GONE,
+            "Cashflow month reopen is committed by the approval request API."
         );
     }
 

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
@@ -2038,8 +2038,7 @@ class WeeklyExpenseControllerTest {
                     .header("x-edit-finalize", "true")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(body))
-                .andExpect(status().isServiceUnavailable())
-                .andExpect(jsonPath("$.code").value("cashflow_month_close_backend_unavailable"));
+                .andExpect(status().isGone());
         }
 
     }
@@ -2105,8 +2104,7 @@ class WeeklyExpenseControllerTest {
                 )
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(validDecision))
-                .andExpect(status().isForbidden())
-                .andExpect(jsonPath("$.code").value("weekly_expense_forbidden"));
+                .andExpect(status().isGone());
         }
     }
 

--- a/src/app/components/cashflow/AxrMonthCloseQaPanel.test.ts
+++ b/src/app/components/cashflow/AxrMonthCloseQaPanel.test.ts
@@ -63,28 +63,28 @@ describe('AXR month-close QA containment', () => {
     }));
   });
 
-  it('uses only the existing reopen APIs with the close revision', async () => {
+  it('uses only the authoritative request for reopen APIs', async () => {
     const api = clients();
-    const closed = control({ request: null, close: { status: 'CLOSED', revision: 7, snapshotHash: 'sha256:closed', latestVersionId: 'v7' }, allowedActions: ['REQUEST_REOPEN', 'REFRESH'] });
+    const closed = control({ request: { requestId: `${AXR_MONTH_CLOSE_QA_PROJECT_ID}-2026-08`, status: 'APPROVED', revision: 7, manifestHash: 'sha256:closed', approverUid: 'actor-a' }, allowedActions: ['REQUEST_REOPEN', 'REFRESH'] });
     await executeAxrMonthCloseQaAction({
       action: 'REQUEST_REOPEN', control: closed, projectId: AXR_MONTH_CLOSE_QA_PROJECT_ID,
       yearMonth: '2026-08', tenantId: 'tenant-a', actor, reason: 'reopen',
       confirmation: closed.confirmationToken, backupConfirmed: true, clients: api as never,
     });
     expect(api.requestReopen).toHaveBeenCalledWith(expect.objectContaining({
-      payload: { yearMonth: '2026-08', expectedRevision: 7, reason: 'reopen' },
-      idempotencyKey: `axr-month-close-qa:REQUEST_REOPEN:${AXR_MONTH_CLOSE_QA_PROJECT_ID}:2026-08:r7`,
+      payload: { requestId: `${AXR_MONTH_CLOSE_QA_PROJECT_ID}-2026-08`, yearMonth: '2026-08', expectedRevision: 7, reason: 'reopen' },
+      idempotencyKey: `axr-month-close-qa:REQUEST_REOPEN:${AXR_MONTH_CLOSE_QA_PROJECT_ID}-2026-08:r7`,
     }));
 
-    const requested = control({ request: null, close: { status: 'REOPEN_REQUESTED', revision: 8, snapshotHash: 'sha256:closed', latestVersionId: 'v7' }, allowedActions: ['APPROVE_REOPEN', 'REJECT_REOPEN', 'REFRESH'] });
+    const requested = control({ request: { requestId: `${AXR_MONTH_CLOSE_QA_PROJECT_ID}-2026-08`, status: 'REOPEN_REQUESTED', revision: 8, manifestHash: 'sha256:closed', approverUid: 'actor-a' }, allowedActions: ['APPROVE_REOPEN', 'REJECT_REOPEN', 'REFRESH'] });
     await executeAxrMonthCloseQaAction({
       action: 'APPROVE_REOPEN', control: requested, projectId: AXR_MONTH_CLOSE_QA_PROJECT_ID,
       yearMonth: '2026-08', tenantId: 'tenant-a', actor, reason: 'restore',
       confirmation: requested.confirmationToken, backupConfirmed: true, clients: api as never,
     });
     expect(api.decideReopen).toHaveBeenCalledWith(expect.objectContaining({
-      payload: { yearMonth: '2026-08', expectedRevision: 8, decision: 'APPROVE', reason: 'restore' },
-      idempotencyKey: `axr-month-close-qa:APPROVE_REOPEN:${AXR_MONTH_CLOSE_QA_PROJECT_ID}:2026-08:r8`,
+      payload: { requestId: `${AXR_MONTH_CLOSE_QA_PROJECT_ID}-2026-08`, yearMonth: '2026-08', expectedRevision: 8, decision: 'APPROVE', reason: 'restore' },
+      idempotencyKey: `axr-month-close-qa:APPROVE_REOPEN:${AXR_MONTH_CLOSE_QA_PROJECT_ID}-2026-08:r8`,
     }));
   });
 

--- a/src/app/components/cashflow/AxrMonthCloseQaPanel.tsx
+++ b/src/app/components/cashflow/AxrMonthCloseQaPanel.tsx
@@ -137,25 +137,33 @@ export async function executeAxrMonthCloseQaAction({
     return approveCashflowMonthCloseUntilLedgerClosed(reviewInput);
   }
   if (action === 'REQUEST_REOPEN') {
+    if (!control.request) throw new Error('재오픈할 월 결산 요청이 없습니다.');
     return clients.requestReopen({
       tenantId,
       actor,
       projectId,
-      payload: { yearMonth, expectedRevision: control.close.revision, reason: reason.trim() },
-      idempotencyKey: `axr-month-close-qa:${action}:${projectId}:${yearMonth}:r${control.close.revision}`,
+      payload: {
+        requestId: control.request.requestId,
+        yearMonth,
+        expectedRevision: control.request.revision,
+        reason: reason.trim(),
+      },
+      idempotencyKey: `axr-month-close-qa:${action}:${control.request.requestId}:r${control.request.revision}`,
     });
   }
+  if (!control.request) throw new Error('재오픈 결재 요청이 없습니다.');
   return clients.decideReopen({
     tenantId,
     actor,
     projectId,
     payload: {
+      requestId: control.request.requestId,
       yearMonth,
-      expectedRevision: control.close.revision,
+      expectedRevision: control.request.revision,
       decision: action === 'APPROVE_REOPEN' ? 'APPROVE' : 'REJECT',
       reason: reason.trim(),
     },
-    idempotencyKey: `axr-month-close-qa:${action}:${projectId}:${yearMonth}:r${control.close.revision}`,
+    idempotencyKey: `axr-month-close-qa:${action}:${control.request.requestId}:r${control.request.revision}`,
   });
 }
 

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -78,8 +78,8 @@ describe('CashflowProjectSheet monthly close shell', () => {
   it('locks the pending month immediately and ignores stale request reads', () => {
     expect(source).toContain('isCashflowMonthCloseRequestLocked(monthCloseRequest?.status)');
     expect(source).toContain('isCashflowWeekLockedByRange(monthCloseRequest.lockRange');
-    expect(source).toContain("['PENDING', 'APPROVING', 'UNCERTAIN', 'APPROVED'].includes(monthCloseRequest.status)");
-    expect(source).toContain("if (monthCloseStatus === 'CLOSED' || monthCloseStatus === 'PENDING' || monthCloseStatus === 'APPROVING') return 'bg-slate-200';");
+    expect(source).toContain("['PENDING', 'APPROVING', 'UNCERTAIN'].includes(monthCloseRequest?.status || '')");
+    expect(source).toContain("['CLOSED', 'PENDING', 'APPROVED', 'REOPEN_REQUESTED'].includes(monthCloseStatus || '')");
     expect(source).toContain('disabled={monthCloseRequestLocked}');
     expect(source).toContain('monthCloseCurrentRequestGenerationRef');
     expect(source).toContain('shouldApplyCashflowMonthCloseRequestResult({');
@@ -223,7 +223,7 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('colSpan={month.weeks.length}');
     expect(source).toContain("month.yearMonth.replace('-', '년 ')}월");
     expect(source).toContain('LockKeyhole');
-    expect(source).toContain("if (monthCloseStatus === 'CLOSED' || monthCloseStatus === 'PENDING' || monthCloseStatus === 'APPROVING') return 'bg-slate-200';");
+    expect(source).toContain("['CLOSED', 'PENDING', 'APPROVED', 'REOPEN_REQUESTED'].includes(monthCloseStatus || '')");
     expect(source).toContain('cashflowWeekSurface(input.monthCloseStatus, input.weeklyStatus, input.closeOverdue)');
     // 지난 달은 월 결산 상태가, 이번 달은 주간 정산 상태가 앞선다.
     expect(source).toContain("if (closeOverdue) return 'bg-red-100';");
@@ -529,8 +529,8 @@ describe('CashflowProjectSheet monthly close shell', () => {
   it('prioritizes local sheet preflight over a failed server refresh and never shows stale reopen actions', () => {
     const preparation = source.slice(source.indexOf('const monthClosePreparation'), source.indexOf('const handleOpenMonthCloseReview'));
     expect(preparation.indexOf('if (monthCloseCellsState.error)')).toBeLessThan(preparation.indexOf('if (monthCloseError)'));
-    expect(source).toContain("!monthCloseError && canRequestMonthReopen && monthCloseResult?.status === 'CLOSED'");
-    expect(source).toContain("!monthCloseError && canReviewReopen && monthCloseResult?.status === 'REOPEN_REQUESTED'");
+    expect(source).toContain("!monthCloseError && canRequestMonthReopen && monthCloseRequest?.status === 'APPROVED'");
+    expect(source).toContain("!monthCloseError && canReviewReopen && monthCloseRequest?.status === 'REOPEN_REQUESTED'");
   });
 
   it('keeps Projection read-only and accepts values only through sheet import', () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -181,7 +181,7 @@ function weeklySettlementSurface(status?: string): string {
 // 지난 달은 "닫혔나"가, 이번 달은 "이번 주 뭘 해야 하나"가 유일하게 중요한 질문이다.
 // 현재 달은 아직 결산할 수 없으므로(대상월이 끝나야 결산 가능) 주간 정산 상태를 그대로 보여준다.
 function cashflowWeekSurface(monthCloseStatus?: string, weeklyStatus?: string, closeOverdue?: boolean): string {
-  if (monthCloseStatus === 'CLOSED' || monthCloseStatus === 'PENDING' || monthCloseStatus === 'APPROVING') return 'bg-slate-200';
+  if (['CLOSED', 'PENDING', 'APPROVED', 'REOPEN_REQUESTED'].includes(monthCloseStatus || '')) return 'bg-slate-200';
   if (closeOverdue) return 'bg-red-100';
   return weeklySettlementSurface(weeklyStatus);
 }
@@ -475,7 +475,6 @@ export function CashflowProjectSheet({
   const monthCloseSectionErrors = monthCloseResult?.sectionErrors || [];
   const deadlineSummaryUnavailable = monthCloseSectionErrors.some((entry) => entry.section === 'deadlineSummary')
     || (Boolean(monthCloseResult?.dashboard) && monthCloseResult?.dashboard?.deadlineSummary == null);
-  // 조직장이 검토를 시작하면(APPROVING) JVM 확정이 이미 나갔을 수 있어 회수할 수 없다.
   const canWithdrawMonthCloseRequest = Boolean(
     monthCloseRequest
     && monthCloseRequest.status === 'PENDING'
@@ -1366,7 +1365,7 @@ export function CashflowProjectSheet({
 
   const handleMonthReopenAction = useCallback(async (): Promise<void> => {
     const reason = reopenReason.trim();
-    if (!reopenAction || !monthCloseResult || !reason) {
+    if (!reopenAction || !monthCloseRequest || !reason) {
       toast.error('사유를 입력해 주세요.');
       return;
     }
@@ -1383,13 +1382,18 @@ export function CashflowProjectSheet({
     try {
       const actor = await resolveBffActor();
       if (!actor?.idToken) throw new Error('로그인 세션이 만료되었습니다.');
-      const idempotencyKey = `cashflow-month-reopen:${reopenAction}:${projectId}:${yearMonth}:${monthCloseResult.revision}`;
+      const idempotencyKey = `cashflow-month-reopen:${reopenAction}:${projectId}:${monthCloseRequest.requestId}:${monthCloseRequest.revision}`;
       const result = reopenAction === 'request'
         ? await requestCashflowMonthReopenViaBff({
             tenantId: orgId,
             actor,
             projectId,
-            payload: { yearMonth, expectedRevision: monthCloseResult.revision, reason },
+            payload: {
+              requestId: monthCloseRequest.requestId,
+              yearMonth: monthCloseRequest.yearMonth,
+              expectedRevision: monthCloseRequest.revision,
+              reason,
+            },
             idempotencyKey,
           })
         : await decideCashflowMonthReopenViaBff({
@@ -1397,14 +1401,15 @@ export function CashflowProjectSheet({
             actor,
             projectId,
             payload: {
-              yearMonth,
-              expectedRevision: monthCloseResult.revision,
+              requestId: monthCloseRequest.requestId,
+              yearMonth: monthCloseRequest.yearMonth,
+              expectedRevision: monthCloseRequest.revision,
               decision: reopenAction === 'approve' ? 'APPROVE' : 'REJECT',
               reason,
             },
             idempotencyKey,
           });
-      setMonthCloseResult(result);
+      setMonthCloseRequest(result.request);
       setReopenAction(null);
       setReopenReason('');
       toast.success(reopenAction === 'request'
@@ -1414,11 +1419,10 @@ export function CashflowProjectSheet({
           : '재오픈을 반려했습니다.');
     } catch (error) {
       toast.error(resolveApiErrorMessage(error, '재오픈 처리를 완료하지 못했습니다.'));
-      await loadCashflowMonthClose();
     } finally {
       setMonthCloseBusy(false);
     }
-  }, [canRequestMonthReopen, canReviewReopen, loadCashflowMonthClose, monthCloseResult, orgId, projectId, reopenAction, reopenReason, resolveBffActor, yearMonth]);
+  }, [canRequestMonthReopen, canReviewReopen, monthCloseRequest, orgId, projectId, reopenAction, reopenReason, resolveBffActor, yearMonth]);
 
   const handleRefreshSheetMirror = useCallback(async (): Promise<void> => {
     if (!cashflowSheetConfig?.value) {
@@ -2112,10 +2116,10 @@ export function CashflowProjectSheet({
     if (!monthCloseStatusByMonth.has(yearMonth) && monthCloseResult?.status) {
       monthCloseStatusByMonth.set(yearMonth, monthCloseResult.status);
     }
-    if (monthCloseRequest?.lockRange && ['PENDING', 'APPROVING', 'UNCERTAIN', 'APPROVED'].includes(monthCloseRequest.status)) {
+    if (monthCloseRequest?.lockRange) {
       visibleWeeks.forEach((week) => {
         if (isCashflowWeekLockedByRange(monthCloseRequest.lockRange, week.yearMonth, week.weekNo)) {
-          monthCloseStatusByMonth.set(week.yearMonth, monthCloseRequest.status === 'APPROVED' ? 'CLOSED' : monthCloseRequest.status);
+          monthCloseStatusByMonth.set(week.yearMonth, monthCloseRequest.status);
         }
       });
     }
@@ -2743,7 +2747,7 @@ export function CashflowProjectSheet({
                       value={selectedExecutiveApproverId}
                       onChange={setSelectedExecutiveApproverId}
                       placeholder="조직장 선택"
-                      disabled={executiveApproverBusy || ['PENDING', 'APPROVING'].includes(monthCloseRequest?.status || '')}
+                      disabled={executiveApproverBusy || ['PENDING', 'APPROVED', 'REOPEN_REQUESTED'].includes(monthCloseRequest?.status || '')}
                     />
                   </div>
                   <Button
@@ -2751,7 +2755,7 @@ export function CashflowProjectSheet({
                     size="sm"
                     variant="outline"
                     className="h-7 shrink-0 border-slate-300 bg-white px-2.5 text-[12px] font-semibold text-[#17324D]"
-                    disabled={executiveApproverBusy || !selectedExecutiveApproverId || selectedExecutiveApproverId === savedExecutiveApproverId || ['PENDING', 'APPROVING'].includes(monthCloseRequest?.status || '')}
+                    disabled={executiveApproverBusy || !selectedExecutiveApproverId || selectedExecutiveApproverId === savedExecutiveApproverId || ['PENDING', 'APPROVED', 'REOPEN_REQUESTED'].includes(monthCloseRequest?.status || '')}
                     onClick={() => void handleSaveExecutiveApprover()}
                   >
                     {executiveApproverBusy ? <Loader2 className="mr-1 h-3 w-3 animate-spin" /> : null}
@@ -2852,8 +2856,10 @@ export function CashflowProjectSheet({
                       <Badge className={`h-6 rounded-md px-2 text-[12px] shadow-none ${monthCloseStatusClass}`}>{monthCloseLoading ? '상태 확인 중' : monthCloseStatusLabel}</Badge>
                     </div>
                     <div className="mt-1 text-[12px] leading-4 text-muted-foreground">
-                      {monthCloseRequest?.status === 'PENDING' || monthCloseRequest?.status === 'APPROVING' || monthCloseRequest?.status === 'UNCERTAIN'
-                        ? monthCloseRequest.status === 'UNCERTAIN' ? '서버 처리 결과를 다시 확인하고 있습니다.' : '지정 조직장의 검토를 기다리고 있습니다.'
+                      {monthCloseRequest?.status === 'PENDING'
+                        ? '지정 조직장의 검토를 기다리고 있습니다.'
+                        : monthCloseRequest?.status === 'REOPEN_REQUESTED'
+                          ? '재오픈 승인 대기 중입니다.'
                         : monthCloseRequest?.status === 'REJECTED'
                           ? `반려됨${monthCloseRequest.decisionReason ? ` · ${monthCloseRequest.decisionReason}` : ''}`
                         : monthCloseRequest?.status === 'WITHDRAWN'
@@ -2866,7 +2872,7 @@ export function CashflowProjectSheet({
                     </div>
                   </div>
                   <div className="flex shrink-0 flex-wrap gap-2">
-                    {canFinalizeMonth && !['PENDING', 'APPROVING', 'UNCERTAIN', 'APPROVED'].includes(monthCloseRequest?.status || '') && (monthCloseError || (monthCloseResult?.status !== 'CLOSED' && monthCloseResult?.status !== 'REOPEN_REQUESTED')) ? (
+                    {canFinalizeMonth && !['PENDING', 'APPROVED', 'REOPEN_REQUESTED'].includes(monthCloseRequest?.status || '') && (monthCloseError || (monthCloseResult?.status !== 'CLOSED' && monthCloseResult?.status !== 'REOPEN_REQUESTED')) ? (
                       <Button
                         type="button"
                         size="sm"
@@ -2890,12 +2896,12 @@ export function CashflowProjectSheet({
                         결재 요청 회수
                       </Button>
                     ) : null}
-                    {!monthCloseError && canRequestMonthReopen && monthCloseResult?.status === 'CLOSED' ? (
+                    {!monthCloseError && canRequestMonthReopen && monthCloseRequest?.status === 'APPROVED' ? (
                       <Button type="button" size="sm" variant="outline" className="h-8 rounded-md border-slate-300 bg-white px-3 text-[12px] text-[#17324D]" onClick={() => { setReopenReason(''); setReopenAction('request'); }}>
                         재오픈 요청
                       </Button>
                     ) : null}
-                    {!monthCloseError && canReviewReopen && monthCloseResult?.status === 'REOPEN_REQUESTED' ? (
+                    {!monthCloseError && canReviewReopen && monthCloseRequest?.status === 'REOPEN_REQUESTED' ? (
                       <>
                         <Button type="button" size="sm" className="h-8 rounded-md bg-[#17324D] px-3 text-[12px] text-white shadow-none hover:bg-slate-800" onClick={() => { setReopenReason(''); setReopenAction('approve'); }}>재오픈 승인</Button>
                         <Button type="button" size="sm" variant="outline" className="h-8 rounded-md border-slate-300 bg-white px-3 text-[12px] text-slate-700" onClick={() => { setReopenReason(''); setReopenAction('reject'); }}>재오픈 반려</Button>
@@ -3155,31 +3161,25 @@ export function CashflowProjectSheet({
     );
   }
 
-  const monthCloseStatusLabel = monthCloseError
-    ? '상태 재확인 필요'
-    : monthCloseResult?.status === 'CLOSED'
-    ? '월 결산 완료'
-    : monthCloseResult?.status === 'REOPEN_REQUESTED'
-      ? '재오픈 승인 대기'
-      : monthCloseRequest?.status === 'APPROVING'
-        ? '승인 처리 중'
-        : monthCloseRequest?.status === 'UNCERTAIN'
-          ? '서버 결과 확인 필요'
-        : monthCloseRequest?.status === 'PENDING'
-          ? '조직장 승인 대기'
+  const monthCloseStatusLabel = ['PENDING', 'APPROVING', 'UNCERTAIN'].includes(monthCloseRequest?.status || '')
+    ? '조직장 승인 대기'
+    : monthCloseRequest?.status === 'APPROVED'
+      ? '월 결산 완료'
+      : monthCloseRequest?.status === 'REOPEN_REQUESTED'
+        ? '재오픈 승인 대기'
+        : monthCloseRequest?.status === 'REOPENED'
+          ? '재결산 필요'
           : monthCloseRequest?.status === 'REJECTED'
             ? '월 결산 반려'
-            : monthCloseRequest?.status === 'REOPENED'
-              ? '재결산 필요'
-      : '결산 전';
-  const monthCloseStatusClass = monthCloseError
+            : monthCloseError
+              ? '상태 재확인 필요'
+              : monthCloseResult?.status === 'CLOSED'
+                ? '월 결산 완료'
+                : '결산 전';
+  const monthCloseStatusClass = monthCloseRequest?.status === 'REJECTED' || (!monthCloseRequest && monthCloseError)
     ? 'border border-red-200 bg-red-50 text-red-700'
-    : monthCloseResult?.status === 'CLOSED'
-    ? 'border border-border bg-secondary text-secondary-foreground'
-    : monthCloseResult?.status === 'REOPEN_REQUESTED'
-      ? 'border border-border bg-accent text-accent-foreground'
-      : monthCloseRequest?.status === 'REJECTED'
-        ? 'border border-red-200 bg-red-50 text-red-700'
+    : monthCloseRequest?.status === 'APPROVED' || (!monthCloseRequest && monthCloseResult?.status === 'CLOSED')
+      ? 'border border-border bg-secondary text-secondary-foreground'
       : 'border border-border bg-accent text-accent-foreground';
   const sheetDashboardMetadata = cashflowEvidenceScope.sheetMetadata;
   const dashboardTitle = `${projectName?.trim() || '이 프로젝트'} 현금흐름 대시보드`;

--- a/src/app/components/cashflow/cashflow-month-close.ts
+++ b/src/app/components/cashflow/cashflow-month-close.ts
@@ -99,7 +99,7 @@ export function resolveCashflowComparisonScope<T extends { yearMonth: string; we
 }
 
 export function isCashflowMonthCloseRequestLocked(status?: string): boolean {
-  return status === 'PENDING' || status === 'APPROVING' || status === 'UNCERTAIN';
+  return ['PENDING', 'APPROVING', 'UNCERTAIN', 'APPROVED', 'REOPEN_REQUESTED'].includes(status || '');
 }
 
 export function isCashflowWeekLockedByRange(

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -361,13 +361,13 @@ describe('platform-bff-client', () => {
     });
     await requestCashflowMonthReopenViaBff({
       tenantId: 'mysc', actor, projectId: 'p001', idempotencyKey: 'reopen-request-1',
-      payload: { yearMonth: '2026-06', expectedRevision: 3, reason: '증빙 정정 필요' },
+      payload: { requestId: 'p001-2026-06', yearMonth: '2026-06', expectedRevision: 3, reason: '증빙 정정 필요' },
       client,
     });
     await decideCashflowMonthReopenViaBff({
       tenantId: 'mysc', actor: { uid: 'finance-1', role: 'finance' }, projectId: 'p001',
       idempotencyKey: 'reopen-decision-1',
-      payload: { yearMonth: '2026-06', expectedRevision: 4, decision: 'APPROVE', reason: '확인 완료' },
+      payload: { requestId: 'p001-2026-06', yearMonth: '2026-06', expectedRevision: 4, decision: 'APPROVE', reason: '확인 완료' },
       client,
     });
 
@@ -400,14 +400,14 @@ describe('platform-bff-client', () => {
     expect(client.post).toHaveBeenNthCalledWith(2, '/api/v1/cashflow/p001/month-close/requests/p001-2026-06/status-review', expect.objectContaining({
       idempotencyKey: 'month-close-review-1',
       body: { decision: 'APPROVE', expectedRevision: 1, expectedManifestHash: 'sha256:manifest', reason: '확인 완료' },
-      timeoutMs: 35_000,
+      timeoutMs: 12_000,
     }));
     expect(client.post).toHaveBeenNthCalledWith(
       3,
       '/api/v1/cashflow/p001/month-close/reopen-request',
       expect.objectContaining({
         idempotencyKey: 'reopen-request-1',
-        body: { yearMonth: '2026-06', expectedRevision: 3, reason: '증빙 정정 필요' },
+        body: { requestId: 'p001-2026-06', yearMonth: '2026-06', expectedRevision: 3, reason: '증빙 정정 필요' },
       }),
     );
     expect(client.post).toHaveBeenNthCalledWith(
@@ -420,7 +420,7 @@ describe('platform-bff-client', () => {
       '/api/v1/cashflow/p001/month-close/reopen-decision',
       expect.objectContaining({
         idempotencyKey: 'reopen-decision-1',
-        body: { yearMonth: '2026-06', expectedRevision: 4, decision: 'APPROVE', reason: '확인 완료' },
+        body: { requestId: 'p001-2026-06', yearMonth: '2026-06', expectedRevision: 4, decision: 'APPROVE', reason: '확인 완료' },
       }),
     );
     expect(client.post).toHaveBeenNthCalledWith(

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -1090,7 +1090,7 @@ export interface CloseCashflowMonthPayload {
   closeInput: CashflowMonthCloseDraftInput;
 }
 
-export type CashflowMonthCloseRequestStatus = 'BUILDING' | 'PENDING' | 'APPROVING' | 'UNCERTAIN' | 'APPROVED' | 'REJECTED' | 'REOPENED' | 'WITHDRAWN';
+export type CashflowMonthCloseRequestStatus = 'BUILDING' | 'PENDING' | 'APPROVING' | 'UNCERTAIN' | 'APPROVED' | 'REOPEN_REQUESTED' | 'REJECTED' | 'REOPENED' | 'WITHDRAWN';
 
 export interface CashflowMonthCloseStoredSource {
   sourceRevision: string | null;
@@ -1264,12 +1264,14 @@ export interface CashflowMonthCloseApproverResult {
 }
 
 export interface RequestCashflowMonthReopenPayload {
+  requestId: string;
   yearMonth: string;
   expectedRevision: number;
   reason: string;
 }
 
 export interface DecideCashflowMonthReopenPayload {
+  requestId: string;
   yearMonth: string;
   expectedRevision: number;
   decision: CashflowMonthReopenDecision;
@@ -2994,7 +2996,7 @@ export async function transitionCashflowSettlementStatusViaBff(params: {
 }): Promise<CashflowSettlementStatusesResult> {
   if (params.period === 'MONTH' && params.action === 'APPROVE') {
     const request = await fetchCurrentCashflowMonthCloseRequestViaBff(params);
-    if (!request || !['PENDING', 'APPROVING', 'UNCERTAIN'].includes(request.status)) {
+    if (!request || request.status !== 'PENDING') {
       throw new Error('승인할 월 결산 요청을 찾을 수 없습니다.');
     }
     if ((request.reviewWarnings ?? []).length > 0) {
@@ -3300,13 +3302,9 @@ export async function reviewCashflowMonthCloseRequestViaBff(params: {
   client?: PlatformApiClientLike;
 }): Promise<{
   request: CashflowMonthCloseRequest;
-  monthClose?: CashflowMonthCloseResult;
-  pendingLedgerClose?: boolean;
 }> {
   const response = await resolveClient(params.client).post<{
     request: CashflowMonthCloseRequest;
-    monthClose?: CashflowMonthCloseResult;
-    pendingLedgerClose?: boolean;
   }>(
     `/api/v1/cashflow/${encodeURIComponent(params.projectId)}/month-close/requests/${encodeURIComponent(params.requestId)}/${params.payload.expectedManifestHash ? 'status-review' : 'review'}`,
     {
@@ -3315,28 +3313,17 @@ export async function reviewCashflowMonthCloseRequestViaBff(params: {
       body: params.payload,
       idempotencyKey: params.idempotencyKey,
       retries: 0,
-      // BFF의 월 결산 확정·재확인 예산(26초)보다 길어야 최종 상태를 받을 수 있다.
-      timeoutMs: 35_000,
+      timeoutMs: 12_000,
     },
   );
-  // 승인 선점은 끝났고 장부 잠금만 진행 중인 상태(pendingLedgerClose)는 실패가 아니다.
-  // 호출자가 같은 멱등키로 다시 호출해 마무리한다.
   if (
     params.payload.decision === 'APPROVE'
-    && !response.data.pendingLedgerClose
     && response.data.request.status !== 'APPROVED'
   ) {
     throw new Error('월 결산 승인 상태를 확인하지 못했습니다.');
   }
   return response.data;
 }
-
-// 승인 선점(APPROVING)은 즉시 커밋되지만 JVM 장부 확정은 그보다 오래 걸릴 수 있다.
-// BFF 는 그때 pendingLedgerClose 를 실어 200 을 돌려주고, 같은 멱등키의 다음 호출이
-// reconcile 로 이어받아 APPROVED 로 마무리한다. 승인 화면이 여러 개라 이 이어받기
-// 규칙은 여기 한 곳에만 둔다 - 같은 규칙의 사본이 화면마다 생기면 조용히 갈린다.
-const CASHFLOW_LEDGER_CLOSE_POLL_MS = 4_000;
-const CASHFLOW_LEDGER_CLOSE_MAX_POLLS = 30;
 
 export async function approveCashflowMonthCloseUntilLedgerClosed(params: {
   tenantId: string;
@@ -3346,15 +3333,8 @@ export async function approveCashflowMonthCloseUntilLedgerClosed(params: {
   payload: ReviewCashflowMonthCloseRequestPayload;
   idempotencyKey: string;
   client?: PlatformApiClientLike;
-  onPending?: (attempt: number) => void;
 }) {
-  let result = await reviewCashflowMonthCloseRequestViaBff(params);
-  for (let attempt = 0; result?.pendingLedgerClose && attempt < CASHFLOW_LEDGER_CLOSE_MAX_POLLS; attempt += 1) {
-    params.onPending?.(attempt);
-    await new Promise((resolve) => { setTimeout(resolve, CASHFLOW_LEDGER_CLOSE_POLL_MS); });
-    result = await reviewCashflowMonthCloseRequestViaBff(params);
-  }
-  return result;
+  return reviewCashflowMonthCloseRequestViaBff(params);
 }
 
 export async function withdrawCashflowMonthCloseRequestViaBff(params: {
@@ -3390,8 +3370,8 @@ export async function requestCashflowMonthReopenViaBff(params: {
   payload: RequestCashflowMonthReopenPayload;
   idempotencyKey: string;
   client?: PlatformApiClientLike;
-}): Promise<CashflowMonthCloseResult> {
-  const response = await resolveClient(params.client).post<CashflowMonthCloseResult>(
+}): Promise<{ request: CashflowMonthCloseRequest }> {
+  const response = await resolveClient(params.client).post<{ request: CashflowMonthCloseRequest }>(
     `/api/v1/cashflow/${encodeURIComponent(params.projectId)}/month-close/reopen-request`,
     {
       tenantId: params.tenantId,
@@ -3412,8 +3392,8 @@ export async function decideCashflowMonthReopenViaBff(params: {
   payload: DecideCashflowMonthReopenPayload;
   idempotencyKey: string;
   client?: PlatformApiClientLike;
-}): Promise<CashflowMonthCloseResult> {
-  const response = await resolveClient(params.client).post<CashflowMonthCloseResult>(
+}): Promise<{ request: CashflowMonthCloseRequest }> {
+  const response = await resolveClient(params.client).post<{ request: CashflowMonthCloseRequest }>(
     `/api/v1/cashflow/${encodeURIComponent(params.projectId)}/month-close/reopen-decision`,
     {
       tenantId: params.tenantId,


### PR DESCRIPTION
## Summary
- Commit approval and write-lock state in Firestore without waiting for JVM reconciliation.
- Keep Sheet Lab one-way loop unchanged; `monthly_closes` remains downstream/derived only.
- Add non-blocking weekly-completion and approval Slack notifications to `C0BQ6980HR6`.
- Pass the Production Slack bot secret only during deployment.

## Validation
- 265 targeted tests passed
- typecheck passed
- JVM test and compile passed
- AXR operational reset backed up under `orgs/mysc/operational_backups/axr-settlement-reset-20260811022026`

## Deployment
- Merge to `main`; Production Deploy runs automatically after green CI.