### PR TITLE
fix(ci): run Sheet Lab freeze check on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,12 @@ jobs:
 
       - name: Keep the Sheet Lab one-way pipeline frozen
         run: |
-          changed="$(git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- server/bff/routes/cashflow-sheet-lab.mjs)"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="origin/${{ github.base_ref }}"
+          else
+            base="HEAD^"
+          fi
+          changed="$(git diff --name-only "${base}...HEAD" -- server/bff/routes/cashflow-sheet-lab.mjs)"
           test -z "$changed" || { echo "Frozen Sheet Lab pipeline changed:"; echo "$changed"; exit 1; }
 
   test-and-build:


### PR DESCRIPTION
Fixes the required freeze check so it compares against HEAD^ on main pushes; the Sheet Lab pipeline remains unchanged.