### PR TITLE
fix(cashflow): notify Slack on month-close requests

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -3888,6 +3888,7 @@ export function mountJvmWeeklyApiRoutes(app, {
       const stored = await persistCumulativeMonthCloseRequest({
         req, prepared, approverUid, expectedApproverUid, expectedProjectVersion,
       });
+      notifyCashflowSlack(`*[MYSCube] 월 결산 요청*\n프로젝트: ${prepared.rawProjectId}\n대상 월: ${stored.yearMonth}\n요청자: ${req.context.actorId}\n조직장 승인 대기`);
       res.status(202).json(cashflowMonthCloseRequestView(stored));
       return;
     }
@@ -4044,6 +4045,7 @@ export function mountJvmWeeklyApiRoutes(app, {
         },
       );
     });
+    notifyCashflowSlack(`*[MYSCube] 월 결산 요청*\n프로젝트: ${prepared.rawProjectId}\n대상 월: ${storedRecord.yearMonth}\n요청자: ${req.context.actorId}\n조직장 승인 대기`);
     res.status(202).json(cashflowMonthCloseRequestView(storedRecord));
   }));
 

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -4533,7 +4533,8 @@ describe('JVM weekly API BFF proxy', () => {
       }
       return { ok: true, status: 200, text: async () => JSON.stringify(cashflow) };
     });
-    const appOptions = { env: runtimeEnv, db: source.db, now: () => new Date('2026-09-10T00:00:00.000Z') };
+    const cashflowSlackService = { enabled: true, notifyMessage: vi.fn().mockResolvedValue(undefined) };
+    const appOptions = { env: runtimeEnv, db: source.db, cashflowSlackService, now: () => new Date('2026-09-10T00:00:00.000Z') };
     const requester = createApp(fetchImpl, createIdempotencyService(), { actorId: 'pm-1', actorRole: 'pm' }, appOptions).app;
     const approver = createApp(fetchImpl, createIdempotencyService(), { actorId: 'finance-1', actorRole: 'finance' }, appOptions).app;
 
@@ -4550,6 +4551,10 @@ describe('JVM weekly API BFF proxy', () => {
       .set('idempotency-key', 'withdraw-create')
       .send(createPayload)
       .expect(202);
+    await Promise.resolve();
+    expect(cashflowSlackService.notifyMessage).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('월 결산 요청'),
+    }));
     const settlementPath = 'orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-08';
     expect(source.documents.get(settlementPath).periods.MONTH).toMatchObject({ status: 'PENDING_APPROVAL' });
     const withdrawPayload = {


### PR DESCRIPTION
## 변경
- 실무자가 월결산 요청을 성공적으로 제출하면 기존 Slack 알림 채널에 비차단 알림을 보냅니다.
- 실제 누적 월결산 요청 경로를 테스트했습니다.

## 범위
- Sheet Lab 연동/one-way 루프 미변경
- 승인 완료 알림은 기존 동작 유지

## 검증
- `npm test -- server/bff/routes/jvm-weekly-api.test.mjs --maxWorkers=1 -t "lets only the requester withdraw a PENDING cumulative close request"` 통과
- 전체 동일 파일 테스트는 변경과 무관한 `applied-cell-changes` 권한 기대값 1건이 실패했습니다. 해당 테스트는 수정하거나 skip하지 않았습니다.