### PR TITLE
fix(cashflow): make month-close Slack alerts actionable

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -2302,9 +2302,43 @@ export function mountJvmWeeklyApiRoutes(app, {
     ? Math.min(Number(cashflowMonthCloseRouteTimeoutMs), CASHFLOW_MONTH_CLOSE_ROUTE_TIMEOUT_MS)
     : CASHFLOW_MONTH_CLOSE_ROUTE_TIMEOUT_MS;
 
-  function notifyCashflowSlack(text) {
+  function notifyCashflowSlack(payload) {
     if (!cashflowSlackService?.enabled || typeof cashflowSlackService.notifyMessage !== 'function') return;
-    void Promise.resolve().then(() => cashflowSlackService.notifyMessage({ text })).catch(() => {});
+    const message = typeof payload === 'string' ? { text: payload } : payload;
+    void Promise.resolve().then(() => cashflowSlackService.notifyMessage(message)).catch(() => {});
+  }
+
+  function notifyCashflowMonthCloseSlack({ tenantId, record, event }) {
+    void Promise.resolve().then(async () => {
+      const [projectSnapshot, parties] = await Promise.all([
+        db.doc(`orgs/${tenantId}/projects/${record.projectId}`).get(),
+        readCashflowRequestPartyNames({ db, tenantId, record }),
+      ]);
+      const project = projectSnapshot.exists ? projectSnapshot.data() || {} : {};
+      const projectName = readOptionalText(project.name)
+        || readOptionalText(project.officialContractName)
+        || readOptionalText(project.projectCode)
+        || record.projectId;
+      const person = event === 'APPROVED' ? parties.reviewedByName : parties.requestedByName;
+      const personLabel = event === 'APPROVED' ? '승인자' : '요청자';
+      const title = event === 'APPROVED' ? '월 결산 승인 완료' : '월 결산 요청';
+      const actionLabel = event === 'APPROVED' ? '결재 결과 보기' : '결재 확인하기';
+      const url = `https://myscube.myscguard.app/portal/cashflow/${encodeURIComponent(record.projectId)}?month=${encodeURIComponent(record.yearMonth)}`;
+      const lines = [
+        `*[MYSCube] ${title}*`,
+        `프로젝트명: ${projectName}`,
+        `대상 월: ${record.yearMonth}`,
+        `${personLabel}: ${person || record[event === 'APPROVED' ? 'reviewedByUid' : 'requestedByUid']}`,
+        event === 'APPROVED' ? '월 잠금: 활성화' : '조직장 승인 대기',
+      ];
+      notifyCashflowSlack({
+        text: `[MYSCube] ${title}: ${projectName} · ${record.yearMonth}`,
+        blocks: [
+          { type: 'section', text: { type: 'mrkdwn', text: lines.join('\n') } },
+          { type: 'actions', elements: [{ type: 'button', text: { type: 'plain_text', text: actionLabel }, url, action_id: 'cashflow_month_close_open' }] },
+        ],
+      });
+    }).catch(() => {});
   }
 
   async function readWeeklyCompliance(context, projectId, { limit = 100, cursor = '' } = {}) {
@@ -3888,7 +3922,7 @@ export function mountJvmWeeklyApiRoutes(app, {
       const stored = await persistCumulativeMonthCloseRequest({
         req, prepared, approverUid, expectedApproverUid, expectedProjectVersion,
       });
-      notifyCashflowSlack(`*[MYSCube] 월 결산 요청*\n프로젝트: ${prepared.rawProjectId}\n대상 월: ${stored.yearMonth}\n요청자: ${req.context.actorId}\n조직장 승인 대기`);
+      notifyCashflowMonthCloseSlack({ tenantId: req.context.tenantId, record: stored, event: 'REQUESTED' });
       res.status(202).json(cashflowMonthCloseRequestView(stored));
       return;
     }
@@ -4045,7 +4079,7 @@ export function mountJvmWeeklyApiRoutes(app, {
         },
       );
     });
-    notifyCashflowSlack(`*[MYSCube] 월 결산 요청*\n프로젝트: ${prepared.rawProjectId}\n대상 월: ${storedRecord.yearMonth}\n요청자: ${req.context.actorId}\n조직장 승인 대기`);
+    notifyCashflowMonthCloseSlack({ tenantId: req.context.tenantId, record: storedRecord, event: 'REQUESTED' });
     res.status(202).json(cashflowMonthCloseRequestView(storedRecord));
   }));
 
@@ -4267,7 +4301,7 @@ export function mountJvmWeeklyApiRoutes(app, {
       );
     });
     if (terminalStatus === 'APPROVED') {
-      notifyCashflowSlack(`*[MYSCube] 월 결산 승인 완료*\n프로젝트: ${projectId}\n대상 월: ${reviewed.yearMonth}\n승인자: ${req.context.actorId}\n월 잠금: 활성화`);
+      notifyCashflowMonthCloseSlack({ tenantId: req.context.tenantId, record: reviewed, event: 'APPROVED' });
     }
     res.status(200).json({ request: cashflowMonthCloseRequestView(reviewed) });
     return;

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -4509,6 +4509,7 @@ describe('JVM weekly API BFF proxy', () => {
 
   it('lets only the requester withdraw a PENDING cumulative close request, and never after review starts', async () => {
     const source = fullMonthCloseSource();
+    source.documents.get('orgs/tenant-a/projects/project-a').name = '테스트 사업';
     source.closeInput.yearMonth = '2026-08';
     const mirror = source.documents.get('orgs/tenant-a/cashflow_sheet_mirrors/project-a');
     mirror.yearMonths = ['2026-08'];
@@ -4551,9 +4552,24 @@ describe('JVM weekly API BFF proxy', () => {
       .set('idempotency-key', 'withdraw-create')
       .send(createPayload)
       .expect(202);
-    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(cashflowSlackService.notifyMessage).toHaveBeenCalledWith(expect.objectContaining({
-      text: expect.stringContaining('월 결산 요청'),
+      text: '[MYSCube] 월 결산 요청: 테스트 사업 · 2026-08',
+      blocks: expect.arrayContaining([
+        expect.objectContaining({
+          type: 'section',
+          text: expect.objectContaining({ text: expect.stringContaining('요청자: Project Manager') }),
+        }),
+        expect.objectContaining({
+          type: 'actions',
+          elements: expect.arrayContaining([
+            expect.objectContaining({
+              text: { type: 'plain_text', text: '결재 확인하기' },
+              url: 'https://myscube.myscguard.app/portal/cashflow/project-a?month=2026-08',
+            }),
+          ]),
+        }),
+      ]),
     }));
     const settlementPath = 'orgs/tenant-a/cashflow_settlement_statuses/project-a-2026-08';
     expect(source.documents.get(settlementPath).periods.MONTH).toMatchObject({ status: 'PENDING_APPROVAL' });


### PR DESCRIPTION
## 변경
- 월결산 요청·승인 Slack 알림에 Firestore 프로젝트명과 구성원 이름을 표시합니다.
- 프로젝트·월별 캐시플로 결재 화면으로 이동하는 Slack 버튼을 추가합니다.

## 범위
- Sheet Lab one-way 루프 미변경
- 알림 조회/전송 실패는 기존처럼 월결산 성공을 막지 않습니다.

## 검증
- 실제 누적 월결산 요청 경로에서 프로젝트명·요청자명·결재 버튼 URL을 검증했습니다.