### PR TITLE
fix(cashflow): link Slack alerts to weekly overview

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -2323,7 +2323,7 @@ export function mountJvmWeeklyApiRoutes(app, {
       const personLabel = event === 'APPROVED' ? '승인자' : '요청자';
       const title = event === 'APPROVED' ? '월 결산 승인 완료' : '월 결산 요청';
       const actionLabel = event === 'APPROVED' ? '결재 결과 보기' : '결재 확인하기';
-      const url = `https://myscube.myscguard.app/portal/cashflow/${encodeURIComponent(record.projectId)}?month=${encodeURIComponent(record.yearMonth)}`;
+      const url = 'https://myscube.myscguard.app/cashflow/weekly';
       const lines = [
         `*[MYSCube] ${title}*`,
         `프로젝트명: ${projectName}`,

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -4565,7 +4565,7 @@ describe('JVM weekly API BFF proxy', () => {
           elements: expect.arrayContaining([
             expect.objectContaining({
               text: { type: 'plain_text', text: '결재 확인하기' },
-              url: 'https://myscube.myscguard.app/portal/cashflow/project-a?month=2026-08',
+              url: 'https://myscube.myscguard.app/cashflow/weekly',
             }),
           ]),
         }),


### PR DESCRIPTION
## 변경
- 월결산 요청·승인 Slack 버튼을 전사 캐시플로우 결재 화면으로 변경합니다.

## 검증
- 누적 월결산 요청 Slack 버튼 URL 테스트 통과.
- Sheet Lab one-way 루프 미변경.