### PR TITLE
fix(cashflow): mention approver in Slack close alerts

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -387,18 +387,23 @@ async function readActiveCashflowMember({ db, tenantId, actorId }) {
 }
 
 async function readCashflowRequestPartyNames({ db, tenantId, record }) {
-  const entries = await Promise.all([
-    ['requestedByName', record.requestedByUid],
-    ['approverName', record.approverUid],
-    ['reviewedByName', record.reviewedByUid],
-  ].map(async ([key, uid]) => {
+  const member = async (uid) => {
     const normalizedUid = readOptionalText(uid);
-    if (!normalizedUid || normalizedUid.includes('/')) return [key, ''];
+    if (!normalizedUid || normalizedUid.includes('/')) return {};
     const snapshot = await db.doc(`orgs/${tenantId}/members/${normalizedUid}`).get();
-    const member = snapshot.exists ? snapshot.data() || {} : {};
-    return [key, readOptionalText(member.status).toUpperCase() === 'ACTIVE' ? readOptionalText(member.name) : ''];
-  }));
-  return Object.fromEntries(entries);
+    const value = snapshot.exists ? snapshot.data() || {} : {};
+    return readOptionalText(value.status).toUpperCase() === 'ACTIVE' ? value : {};
+  };
+  const [requester, approver, reviewer] = await Promise.all([
+    member(record.requestedByUid), member(record.approverUid), member(record.reviewedByUid),
+  ]);
+  const slackUserId = readOptionalText(approver.slackUserId);
+  return {
+    requestedByName: readOptionalText(requester.name),
+    approverName: readOptionalText(approver.name),
+    approverSlackUserId: /^[UW][A-Z0-9]{8,}$/.test(slackUserId) ? slackUserId : '',
+    reviewedByName: readOptionalText(reviewer.name),
+  };
 }
 
 async function readCashflowMonthCloseRequest({ db, tenantId, projectId, yearMonth }) {
@@ -2323,13 +2328,17 @@ export function mountJvmWeeklyApiRoutes(app, {
       const personLabel = event === 'APPROVED' ? '승인자' : '요청자';
       const title = event === 'APPROVED' ? '월 결산 승인 완료' : '월 결산 요청';
       const actionLabel = event === 'APPROVED' ? '결재 결과 보기' : '결재 확인하기';
+      const approver = parties.approverSlackUserId
+        ? `<@${parties.approverSlackUserId}>`
+        : parties.approverName || '미지정';
       const url = 'https://myscube.myscguard.app/cashflow/weekly';
       const lines = [
         `*[MYSCube] ${title}*`,
         `프로젝트명: ${projectName}`,
         `대상 월: ${record.yearMonth}`,
-        `${personLabel}: ${person || record[event === 'APPROVED' ? 'reviewedByUid' : 'requestedByUid']}`,
-        event === 'APPROVED' ? '월 잠금: 활성화' : '조직장 승인 대기',
+        `${personLabel}: ${person || '미확인'}`,
+        `조직장: ${approver}`,
+        `상태: ${event === 'APPROVED' ? '승인 완료 · 월 잠금 활성화' : '조직장 승인 대기'}`,
       ];
       notifyCashflowSlack({
         text: `[MYSCube] ${title}: ${projectName} · ${record.yearMonth}`,

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -279,7 +279,7 @@ function fullMonthCloseSource({
       id: 'project-a', settlementType: 'TYPE1', basis: '공급가액', accountType: 'DEDICATED',
       fundInputMode: 'BANK_UPLOAD', contractAmount, executiveApproverId: 'finance-1',
     }],
-    ['orgs/tenant-a/members/finance-1', { uid: 'finance-1', name: 'Finance One', role: 'viewer', status: 'ACTIVE', projectIds: ['project-a'] }],
+    ['orgs/tenant-a/members/finance-1', { uid: 'finance-1', name: 'Finance One', slackUserId: 'U0123456789', role: 'viewer', status: 'ACTIVE', projectIds: ['project-a'] }],
     ['orgs/tenant-a/members/finance-2', { uid: 'finance-2', role: 'finance', status: 'ACTIVE', projectIds: ['project-a'] }],
     ['orgs/tenant-a/members/pm-1', { uid: 'pm-1', name: 'Project Manager', role: 'pm', status: 'ACTIVE', projectIds: ['project-a'] }],
     ['orgs/tenant-a/members/viewer-2', { uid: 'viewer-2', role: 'viewer', status: 'ACTIVE', projectIds: [] }],
@@ -4558,7 +4558,7 @@ describe('JVM weekly API BFF proxy', () => {
       blocks: expect.arrayContaining([
         expect.objectContaining({
           type: 'section',
-          text: expect.objectContaining({ text: expect.stringContaining('요청자: Project Manager') }),
+          text: expect.objectContaining({ text: expect.stringContaining('요청자: Project Manager\n조직장: <@U0123456789>\n상태: 조직장 승인 대기') }),
         }),
         expect.objectContaining({
           type: 'actions',


### PR DESCRIPTION
## Summary\n- include project, target month, requester, approver mention, and status in month-close Slack alerts\n- read only persisted member slackUserId; no runtime Slack directory lookup\n\n## Verification\n- npm test -- --run server/bff/routes/jvm-weekly-api.test.mjs