### PR TITLE
fix(cashflow): restore management download entry

### DIFF
--- a/src/app/components/cashflow/CashflowAnalyticsPage.tsx
+++ b/src/app/components/cashflow/CashflowAnalyticsPage.tsx
@@ -138,9 +138,9 @@ function FilterLabel({ label, disabled = false }: { label: string; disabled?: bo
   );
 }
 
-export function CashflowAnalyticsPage({ managementPlanningOnly = false }: { managementPlanningOnly?: boolean }) {
+export function CashflowAnalyticsPage() {
   const { transactions, projects } = useAppStore();
-  const [activeView, setActiveView] = useState<'analytics' | 'projectApproval'>(managementPlanningOnly ? 'projectApproval' : 'analytics');
+  const [activeView, setActiveView] = useState<'analytics' | 'projectApproval'>('analytics');
   const [projectFilter, setProjectFilter] = useState('ALL');
   const [typeFilter, setTypeFilter] = useState('ALL');
   const [departmentFilter, setDepartmentFilter] = useState('ALL');
@@ -278,7 +278,7 @@ export function CashflowAnalyticsPage({ managementPlanningOnly = false }: { mana
               <h1 className="text-[28px] leading-tight text-zinc-950" style={{ fontWeight: 900 }}>프로젝트 등록·승인</h1>
               <p className="mt-2 text-[12px] text-[#6f7478]">등록 문서를 열어 프로젝트 코드를 부여하고 승인 또는 반려 사유를 처리합니다.</p>
             </div>
-            {!managementPlanningOnly && <Button variant="outline" className="rounded-none border-[#c7c7c7]" onClick={() => setActiveView('analytics')}>통합 현황으로</Button>}
+            <Button variant="outline" className="rounded-none border-[#c7c7c7]" onClick={() => setActiveView('analytics')}>통합 현황으로</Button>
           </div>
         </section>
         <ProjectMigrationAuditPage embedded reviewStage="managementPlanning" />
@@ -710,8 +710,4 @@ export function CashflowAnalyticsPage({ managementPlanningOnly = false }: { mana
       </Card>
     </div>
   );
-}
-
-export function CashflowManagementPlanningPage() {
-  return <CashflowAnalyticsPage managementPlanningOnly />;
 }

--- a/src/app/components/cashflow/CashflowExportPage.tsx
+++ b/src/app/components/cashflow/CashflowExportPage.tsx
@@ -225,7 +225,7 @@ export function CashflowExportPage() {
       <PageHeader
         icon={BarChart3}
         iconGradient="linear-gradient(135deg, #fafaf9 0%, #f5f5f4 100%)"
-        title="현금흐름 내보내기"
+        title="경영기획실 통합 관리"
         description="프로젝트와 기간을 선택해 서버 기준 현금흐름 엑셀을 다운로드합니다."
         badge={scope === 'selected' ? '선택 사업 추출' : '전체 추출'}
         badgeVariant="outline"

--- a/src/app/components/cashflow/CashflowPage.shell.test.ts
+++ b/src/app/components/cashflow/CashflowPage.shell.test.ts
@@ -4,11 +4,14 @@ import { describe, expect, it } from 'vitest';
 
 const pageSource = readFileSync(resolve(import.meta.dirname, 'CashflowPage.tsx'), 'utf8');
 const routesSource = readFileSync(resolve(import.meta.dirname, '../../routes.tsx'), 'utf8');
+const exportSource = readFileSync(resolve(import.meta.dirname, 'CashflowExportPage.tsx'), 'utf8');
 
 describe('Cashflow entry routes', () => {
-  it('opens weekly history and replaces the old export page with management planning', () => {
+  it('opens weekly history and keeps cashflow download under management planning', () => {
     expect(pageSource).toContain('<CashflowWeeklyPage />');
     expect(pageSource).not.toContain('CashflowMonitorPage');
-    expect(routesSource).toContain("{ path: 'cashflow/export', element: <S C={CashflowManagementPlanningPage} /> }");
+    expect(routesSource).toContain("{ path: 'cashflow/export', element: <S C={CashflowExportPage} /> }");
+    expect(exportSource).toContain('title="경영기획실 통합 관리"');
+    expect(exportSource).toContain('현금흐름 엑셀을 다운로드합니다.');
   });
 });

--- a/src/app/platform/admin-foundation.shell.test.ts
+++ b/src/app/platform/admin-foundation.shell.test.ts
@@ -41,13 +41,13 @@ describe('admin navigation shell contract', () => {
     expect(destinations).toEqual([...new Set(destinations)]);
   });
 
-  it('registers the management-planning route under the admin shell', () => {
+  it('registers the cashflow download route under the admin shell', () => {
     expect(routesSource).toContain("const FeatureSearchPage");
     expect(routesSource).toContain("function MobileAwareAdminHome()");
     expect(routesSource).toContain(": <S C={FeatureSearchPage} />;");
     expect(routesSource).toContain("{ index: true, element: <MobileAwareAdminHome /> }");
     expect(routesSource).toContain("{ path: 'dashboard', element: <S C={DashboardPage} /> }");
-    expect(routesSource).toContain("{ path: 'cashflow/export', element: <S C={CashflowManagementPlanningPage} /> }");
+    expect(routesSource).toContain("{ path: 'cashflow/export', element: <S C={CashflowExportPage} /> }");
     expect(routesSource).toContain("{ path: 'cashflow/weekly', element: <S C={CashflowWeeklyPage} /> }");
     expect(routesSource).toContain("{ path: 'cashflow/analytics', element: <S C={CashflowAnalyticsPage} /> }");
     expect(routesSource).toContain("{ path: 'management-planning/project-codes', element: <S C={ProjectCodeIssuancePage} /> }");

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -56,7 +56,7 @@ const LedgerDetailPage = lazyRoute(() => import('./components/ledgers/LedgerDeta
 const CashflowPage = lazyRoute(() => import('./components/cashflow/CashflowPage'), 'CashflowPage');
 const CashflowWeeklyPage = lazyRoute(() => import('./components/cashflow/CashflowWeeklyPage'), 'CashflowWeeklyPage');
 const CashflowAnalyticsPage = lazyRoute(() => import('./components/cashflow/CashflowAnalyticsPage'), 'CashflowAnalyticsPage');
-const CashflowManagementPlanningPage = lazyRoute(() => import('./components/cashflow/CashflowAnalyticsPage'), 'CashflowManagementPlanningPage');
+const CashflowExportPage = lazyRoute(() => import('./components/cashflow/CashflowExportPage'), 'CashflowExportPage');
 const ProjectCashflowSheetPage = lazyRoute(() => import('./components/cashflow/ProjectCashflowSheetPage'), 'ProjectCashflowSheetPage');
 const EvidenceQueuePage = lazyRoute(() => import('./components/evidence/EvidenceQueuePage'), 'EvidenceQueuePage');
 const AuditLogPage = lazyRoute(() => import('./components/audit/AuditLogPage'), 'AuditLogPage');
@@ -155,7 +155,7 @@ export const router = createBrowserRouter([
       { path: 'cashflow', element: <S C={CashflowPage} /> },
       { path: 'cashflow/weekly', element: <S C={CashflowWeeklyPage} /> },
       { path: 'cashflow/analytics', element: <S C={CashflowAnalyticsPage} /> },
-      { path: 'cashflow/export', element: <S C={CashflowManagementPlanningPage} /> },
+      { path: 'cashflow/export', element: <S C={CashflowExportPage} /> },
       { path: 'cashflow/projects', element: <S C={CashflowPage} /> },
       { path: 'cashflow/projects/:projectId', element: <S C={ProjectCashflowSheetPage} /> },
       { path: 'evidence', element: <S C={EvidenceQueuePage} /> },


### PR DESCRIPTION
## Summary\n- restore the original cashflow download surface for Management Planning > Integrated Management\n- remove the accidental project registration/approval route substitution\n\n## Verification\n- npm test -- --run src/app/components/cashflow/CashflowPage.shell.test.ts src/app/platform/admin-foundation.shell.test.ts src/app/components/cashflow/CashflowAnalyticsPage.copy.test.ts