### PR TITLE
fix: route cashflow sheet actions through lab

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -252,6 +252,13 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain('변경 내용 검토');
   });
 
+  it('uses Sheet Lab as the only manual sheet refresh and overwrite entry', () => {
+    expect(source).toContain("onClick={() => navigate(`/portal/cashflow/${encodeURIComponent(projectId)}/sheets-lab`)}");
+    expect(source).toContain('시트 값 가져오기');
+    expect(source).toContain('data-cashflow-sheet-last-apply');
+    expect(source).toContain('최근 시트 반영');
+  });
+
   it('keeps the dashboard information order from the PPT before the comparison table', () => {
     const metadata = source.indexOf('sheetDashboardMetadata');
     const summary = source.indexOf('{dashboardSummary}');
@@ -311,8 +318,9 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain('checkCashflowSheetChangesViaBff');
     expect(source).not.toContain('const sheetChangeCount = [');
     expect(source).not.toContain('변경 ${sheetChangeCount.toLocaleString()}건');
-    // 버튼 통일: '변경 N건' 별도 버튼 제거, 단일 '시트 불러오기' 가 배지를 겸한다.
-    expect(source).toContain('시트 변경됨 · 불러오기');
+    // 메인은 변경 여부를 판단하거나 자체 반영하지 않고, 동결된 Sheet Lab 진입만 제공한다.
+    expect(source).toContain('시트 값 가져오기');
+    expect(source).toContain('data-cashflow-sheet-last-apply');
     expect(source).not.toContain('onClick={handleOpenSheetReviewDialog}');
     expect(source).toContain('시트 이동');
     expect(source).toContain('href={configuredSheetUrl}');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -2698,9 +2698,7 @@ export function CashflowProjectSheet({
                 size="sm"
                 variant="outline"
                 className="h-7 shrink-0 rounded-md border-slate-300 bg-white px-2.5 text-[12px] font-semibold text-[#17324D]"
-                onClick={() => cashflowSheetConfig
-                  ? navigate(`/portal/cashflow/${encodeURIComponent(projectId)}/sheets-lab`)
-                  : handleOpenSheetOnboarding()}
+                onClick={() => navigate(`/portal/cashflow/${encodeURIComponent(projectId)}/sheets-lab`)}
               >
                 {cashflowSheetConfig ? '시트 설정' : '시트 연결'}
               </Button>
@@ -2716,23 +2714,23 @@ export function CashflowProjectSheet({
                 </a>
               ) : null}
               {cashflowSheetConfig ? (
-                // 단일 진입점: 평소엔 '시트 불러오기', 변경이 감지되면 상태 배지를 겸한다.
-                // 진입 시 풀 리드를 하지 않으므로 이 버튼을 눌러야 실제 diff·반영이 시작된다.
                 <Button
                   type="button"
                   size="sm"
                   variant="outline"
-                  className={`h-7 shrink-0 rounded-md px-2.5 text-[12px] font-semibold ${
-                    sheetChangedSinceMirror
-                      ? 'border-yellow-300 bg-yellow-50 text-yellow-900 hover:bg-yellow-100'
-                      : 'border-slate-300 bg-white text-[#17324D] hover:bg-accent'
-                  }`}
-                  disabled={sheetRefreshLoading}
-                  onClick={() => void handleRefreshSheetMirror()}
+                  className="h-7 shrink-0 rounded-md border-slate-300 bg-white px-2.5 text-[12px] font-semibold text-[#17324D] hover:bg-accent"
+                  onClick={() => navigate(`/portal/cashflow/${encodeURIComponent(projectId)}/sheets-lab`)}
                 >
-                  {sheetRefreshLoading ? <Loader2 className="mr-1 h-3 w-3 animate-spin" /> : <RefreshCw className="mr-1 h-3 w-3" />}
-                  {sheetChangedSinceMirror ? '시트 변경됨 · 불러오기' : '시트 불러오기'}
+                  <RefreshCw className="mr-1 h-3 w-3" />
+                  시트 값 가져오기
                 </Button>
+              ) : null}
+              {cashflowSheetConfig?.lastAppliedAt ? (
+                <span data-cashflow-sheet-last-apply className="shrink-0 text-[12px] text-slate-500">
+                  최근 시트 반영 · {cashflowSheetConfig.lastAppliedLineCount?.toLocaleString() || 0}건
+                  {' · '}Projection {cashflowSheetConfig.lastProjectionLineCount?.toLocaleString() || 0}건
+                  {' · '}Actual {cashflowSheetConfig.lastActualLineCount?.toLocaleString() || 0}건
+                </span>
               ) : null}
               {project && members ? (
                 <div

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts
@@ -20,6 +20,12 @@ const portalCashflowSource = readFileSync(
 );
 
 describe('CashflowSheetLabPage shell', () => {
+  it('renders the persisted apply result until a newly fetched sheet is ready to apply', () => {
+    expect(pageSource).toContain('const displayedReflectResult = reflectResult || (!hasCurrentFreshMirror && savedConfig?.lastAppliedAt');
+    expect(pageSource).toContain('appliedLineCount: savedConfig.lastAppliedLineCount || 0');
+    expect(pageSource).toContain('displayedReflectResult.appliedLineCount');
+  });
+
   it('keeps sheet lab as an explicit route, not auto-mounted inside portal cashflow', () => {
     expect(routesSource).toContain("path: '/portal'");
     expect(routesSource).toContain("path: 'cashflow/sheets-lab'");

--- a/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
+++ b/src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.tsx
@@ -939,6 +939,12 @@ export function CashflowSheetLabPage() {
   const canRefresh = Boolean(projectId && spreadsheetId && isCurrentSheetConfigSaved && !loading);
   const canSaveConfig = Boolean(projectId && spreadsheetId && !loading);
   const hasCurrentFreshMirror = Boolean(mirror?.status === 'FRESH' && mirror.sourceRevision && reviewedSourceKey === sourceKey);
+  const displayedReflectResult = reflectResult || (!hasCurrentFreshMirror && savedConfig?.lastAppliedAt ? {
+    appliedLineCount: savedConfig.lastAppliedLineCount || 0,
+    projectionLineCount: savedConfig.lastProjectionLineCount || 0,
+    actualLineCount: savedConfig.lastActualLineCount || 0,
+    lastAppliedAt: savedConfig.lastAppliedAt,
+  } : null);
   const canOverwrite = Boolean(
     projectId
     && spreadsheetId
@@ -1090,14 +1096,14 @@ export function CashflowSheetLabPage() {
                 <h2 className="text-[19px] font-bold text-slate-950">시트 값으로 덮어쓰기</h2>
                 <HelpMemo>고정한 시트의 Projection과 Actual로 MYSCube 값을 덮어씁니다. 별도 운영자 검토는 없으며, 월 결산된 기간만 보호됩니다.</HelpMemo>
               </div>
-              {reflectResult ? (
+              {displayedReflectResult ? (
                 <div className="space-y-3">
                   <div className="border border-emerald-200 bg-emerald-50 px-3 py-2 text-[12px] text-emerald-900">
-                    {reflectResult.appliedLineCount > 0 ? (
+                    {displayedReflectResult.appliedLineCount > 0 ? (
                       <>
-                        덮어쓰기 완료 · {reflectResult.appliedLineCount.toLocaleString()}건
-                        {' · '}Projection {reflectResult.projectionLineCount.toLocaleString()}건
-                        {' · '}Actual {reflectResult.actualLineCount.toLocaleString()}건
+                        덮어쓰기 완료 · {displayedReflectResult.appliedLineCount.toLocaleString()}건
+                        {' · '}Projection {displayedReflectResult.projectionLineCount.toLocaleString()}건
+                        {' · '}Actual {displayedReflectResult.actualLineCount.toLocaleString()}건
                       </>
                     ) : '이미 시트 최신값과 같습니다.'}
                   </div>


### PR DESCRIPTION
## 변경\n- 메인 현금흐름의 시트 연결·값 가져오기 버튼을 동결된 Sheet Lab 진입으로 통일\n- Sheet Lab에 서버 저장된 마지막 반영 결과 표시\n\n## 변경하지 않음\n- BFF/JVM API\n- mirror/refresh → stage → apply 계약\n- Sheet Lab one-way 로직\n\n## 검증\n- npm test -- --run src/app/components/cashflow/CashflowProjectSheet.shell.test.ts src/app/features/cashflow-sheet-compare/CashflowSheetLabPage.shell.test.ts (74 passed)\n- npm run build\n- git diff --check