### PR TITLE
fix: remove cashflow sheet no-change toast

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -300,6 +300,8 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain('시트 연동하기');
     expect(source).not.toContain('최신값 다시 가져오기');
     expect(source).not.toContain('setInterval');
+    expect(source).not.toContain('MYSCube 시트와 다른 값이 없습니다.');
+    expect(source).not.toContain('시트 변경이 없어 기존 고정값을 그대로 사용합니다.');
   });
 
   it('probes sheet freshness on entry without a full read', () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1466,10 +1466,7 @@ export function CashflowProjectSheet({
             cells: mirror.cells || current.cells,
           }
         : mirror);
-      if (mirror.status === 'FRESH' && mirror.unchanged) {
-        // 시트 변경 없음 - 서버가 풀 리드를 건너뛰고 고정본을 그대로 돌려준 경우.
-        toast.success('시트 변경이 없어 기존 고정값을 그대로 사용합니다.');
-      } else if (mirror.status === 'FRESH' && mirror.sourceRevision) {
+      if (mirror.status === 'FRESH' && mirror.sourceRevision) {
         void loadCashflowEvents();
         toast.success('시트값을 불러왔습니다. MYSCube 시트 반영 전 금액을 확인합니다.');
       } else if (mirror.status === 'STALE') {
@@ -1754,7 +1751,6 @@ export function CashflowProjectSheet({
         return;
       }
       if (result.stagedLineCount <= 0) {
-        toast.info('MYSCube 시트와 다른 값이 없습니다.');
         return;
       }
       if (result.pendingApprovalDifferences?.length) {


### PR DESCRIPTION
## 변경\n- 현금흐름 시트 연동의 변경 없음/값 차이 없음 토스트 제거\n- refresh → stage → apply 및 데이터 처리 계약은 변경하지 않음\n\n## 검증\n- CashflowProjectSheet shell test: 62 passed\n- npm run build\n- git diff --check