### PR TITLE
fix: render cashflow sheet formula values

### DIFF
--- a/server/bff/cashflow-sheet-snapshot.mjs
+++ b/server/bff/cashflow-sheet-snapshot.mjs
@@ -559,6 +559,14 @@ export function extractCashflowSheetFacts({
   const projectionControls = modeControls('projection');
   const actualControls = modeControls('actual');
   const weeklyCalculationChecks = buildWeeklyCalculationChecks({ template, matrix });
+  // 표준 관리시트의 Projection–Actual 차이 행(A11:BS11)은 별도 수식 결과다.
+  // 화면에서 Projection과 Actual을 다시 빼지 않고 이 고정값을 그대로 사용한다.
+  const projectionActualDifferences = weekColumns.map((week) => ({
+    yearMonth: week.yearMonth,
+    weekNo: week.weekNo,
+    amount: readComputedWholeWon(matrix, 10, week.columnIndex),
+    sourceCell: toA1(10, week.columnIndex),
+  }));
 
   return {
     metadata: {
@@ -573,6 +581,7 @@ export function extractCashflowSheetFacts({
       ? buildAnnualCashflowTotals({ cells, annualCells, annualDerivedCells, weeklyYear })
       : [],
     ...(weeklyCalculationChecks.length > 0 ? { weeklyCalculationChecks } : {}),
+    ...(projectionActualDifferences.some((value) => value.amount !== null) ? { projectionActualDifferences } : {}),
     cashflowGrandTotals: {
       projection: buildCashflowSheetTotal(totalCells, 'projection'),
       actual: buildCashflowSheetTotal(totalCells, 'actual'),

--- a/server/bff/cashflow-sheet-snapshot.test.mjs
+++ b/server/bff/cashflow-sheet-snapshot.test.mjs
@@ -232,6 +232,24 @@ describe('cashflow sheet pinned snapshot', () => {
       });
   });
 
+  it('pins the Sheet Projection–Actual formula row without recalculating it', () => {
+    const matrix = Array.from({ length: 12 }, () => Array.from({ length: 5 }, () => ''));
+    matrix[10][3] = '-4,796,728'; // D11: the sheet formula result, not Projection - Actual in application code.
+    const facts = extractCashflowSheetFacts({
+      matrix,
+      template: {
+        sections: [{
+          mode: 'projection',
+          weekColumns: [{ yearMonth: '2026-01', weekNo: 1, columnIndex: 3 }],
+        }],
+      },
+    });
+
+    expect(facts.projectionActualDifferences).toEqual([{
+      yearMonth: '2026-01', weekNo: 1, amount: -4_796_728, sourceCell: 'D11',
+    }]);
+  });
+
   it('pins normalized cells and keeps source and target revisions separate', () => {
     const mappings = [
       {

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -1884,6 +1884,21 @@ async function composeCashflowMonthDashboard({
     }, comparisonBoundary).months[0] || null
     : null;
   const sourceRows = sourceDepositRows(sheetFacts, yearMonth);
+  const sheetCalculationChecks = amendedCurrent
+    ? [
+      ...(Array.isArray(sheetFacts?.weeklyCalculationChecks) ? sheetFacts.weeklyCalculationChecks : [])
+        .filter((check) => readOptionalText(check?.yearMonth) !== yearMonth),
+      ...(Array.isArray(amendmentEvidence.calculationChecks) ? amendmentEvidence.calculationChecks : []),
+    ]
+    : (Array.isArray(sheetFacts?.weeklyCalculationChecks) ? sheetFacts.weeklyCalculationChecks : []);
+  const sheetFormulaValues = {
+    weekly: sheetCalculationChecks.filter((check) => Number(String(check?.yearMonth || '').slice(0, 4)) === selectedYear),
+    annual: Array.isArray(sheetFacts?.annualCashflowTotals) ? sheetFacts.annualCashflowTotals : [],
+    grandTotals: objectValue(sheetFacts?.cashflowGrandTotals) || {},
+    projectionActualDifferences: (Array.isArray(sheetFacts?.projectionActualDifferences)
+      ? sheetFacts.projectionActualDifferences
+      : []).filter((value) => Number(String(value?.yearMonth || '').slice(0, 4)) === selectedYear),
+  };
   const authoritativeOpeningBalances = openingBalanceCandidate
     ? requireJvmOpeningBalances({ openingBalances: openingBalanceCandidate }, yearMonth)
     : null;
@@ -2060,11 +2075,8 @@ async function composeCashflowMonthDashboard({
     project,
     projectMetadata: projectMetadata(project),
     sheetMetadata: sheetFacts?.metadata || {},
-    sheetCalculationChecks: amendedCurrent
-      ? (Array.isArray(amendmentEvidence.calculationChecks) ? amendmentEvidence.calculationChecks : [])
-      : (Array.isArray(sheetFacts?.weeklyCalculationChecks)
-        ? sheetFacts.weeklyCalculationChecks.filter((check) => readOptionalText(check?.yearMonth) === yearMonth)
-        : []),
+    sheetCalculationChecks: sheetFormulaValues.weekly,
+    sheetFormulaValues,
     sheetControlTotals: {
       deposit: objectValue(sheetFacts?.controlTotals?.deposit) || null,
       unpaid: objectValue(sheetFacts?.controlTotals?.unpaid) || null,

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -2955,6 +2955,8 @@ describe('JVM weekly API BFF proxy', () => {
           cell.mode === 'projection' && cell.weekNo === 1 && cell.cashflowLine === 'BANK_INTEREST_IN'
         ))).toMatchObject({ cellState: 'ZERO', amount: 0 });
         expect(response.body.dashboard.sheetCalculationChecks[0].reported.depositTotal).toBe(999);
+        expect(response.body.dashboard.sheetFormulaValues.weekly[0].reported.depositTotal).toBe(999);
+        expect(response.body.dashboard.sheetFormulaValues.projectionActualDifferences).toEqual([]);
         expect(response.body.dashboard.source).toMatchObject({
           sourceRevision: `sha256:${'1'.repeat(64)}`,
           targetRevision: `sha256:${'3'.repeat(64)}`,

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -109,9 +109,9 @@ describe('CashflowProjectSheet monthly close shell', () => {
   });
 
   it('consumes composed dashboard totals, comparison, summary, sheet metadata, and validation', () => {
-    expect(source).toContain('monthCloseResult?.dashboard?.totals?.[mode]?.weeks?.find');
+    expect(source).toContain('sheetFormulaValues?.weekly.find');
     expect(source).toContain('const canonicalReadModel = monthCloseResult?.dashboard?.canonical');
-    expect(source).toContain('canonicalReadModel?.range?.[mode]');
+    expect(source).toContain('sheetFormulaValues?.grandTotals?.[mode]');
     expect(source).not.toContain('fetchCashflowSnapshotViaBff');
     expect(source).not.toContain('loadCashflowComparison');
     expect(source).not.toContain('cashflowSnapshot');
@@ -134,28 +134,20 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain('monthSummaries.reduce');
   });
 
-  it('applies the server opening balance without recreating month-close reads during hydration', () => {
+  it('renders the pinned Sheet formula values without recreating balance calculations', () => {
     expect(source).toContain('monthCloseRequestGenerationRef');
     expect(source).toContain('requestGeneration === monthCloseRequestGenerationRef.current');
-    expect(source).toContain('monthCloseResult?.dashboard?.openingBalances?.selectedYear === selectedYear');
-    expect(source).toContain('const canonicalReadModel = monthCloseResult?.dashboard?.canonical');
-    expect(source).toContain('const reviewedOpeningBalances = monthCloseResult?.dashboard?.openingBalances');
-    expect(source).toContain('carryForwardCashflowRunningBalances({');
-    expect(source).toContain('priorWeeklyNet: Number(priorServerWeek?.net || 0)');
-    expect(source).toContain('annualOpeningBalance: openingBalance');
-    expect(source).toContain('serverRunningNets: serverWeeks.map');
-    expect(source).toContain('weekTotals.at(-1)?.net ?? openingBalance');
+    expect(source).toContain('const sheetFormulaValues = monthCloseResult?.dashboard?.sheetFormulaValues');
+    expect(source).toContain('const sheetDerivedAmount');
+    expect(source).toContain('reported?.balance ?? null');
+    expect(source).not.toContain('carryForwardCashflowRunningBalances({');
     expect(source).toMatch(/\}, \[orgId, projectId, resolveBffActor, selectedYear, user\?\.uid, yearMonth\]\);/);
   });
 
-  it('renders JVM canonical formula results instead of the pinned Sheet formulas', () => {
-    expect(source).toContain('function getCanonicalDerivedAmount');
-    expect(source).toContain("monthCloseResult?.dashboard?.canonical?.months");
-    expect(source).toContain('check?.totalIn');
-    expect(source).toContain('check?.totalOut');
-    expect(source).toContain('check?.net');
-    expect(source).toContain('getCanonicalDerivedAmount(mode, week.yearMonth, week.weekNo, kind)');
-    expect(source).not.toContain('function getPinnedDerivedAmount');
+  it('renders Sheet formula results instead of recomputing them from canonical cells', () => {
+    expect(source).toContain('sheetFormulaValues?.weekly.find');
+    expect(source).toContain('sheetFormulaValues?.grandTotals?.[mode]');
+    expect(source).not.toContain('function getCanonicalDerivedAmount');
   });
 
   it('drops the inbox card but keeps the issue count badge', () => {
@@ -184,7 +176,7 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source.indexOf('data-cashflow-block="projection"')).toBeLessThan(source.indexOf('data-cashflow-block="actual"'));
     expect(source).toMatch(/renderModeLineRows\(mode, CASHFLOW_IN_LINES[\s\S]*renderSummaryRow\(mode, 'totalIn'\)[\s\S]*renderModeLineRows\(mode, CASHFLOW_OUT_LINES[\s\S]*renderSummaryRow\(mode, 'totalOut'\)[\s\S]*renderSummaryRow\(mode, 'net'\)/);
     expect(source).toContain('Projection - Actual 차이');
-    expect(source).toContain('차이 항목만');
+    expect(source).toContain('시트 수식값');
     expect(source).not.toContain('setDifferenceViewMode');
     expect(source).toContain("'bg-[#EAF0F5] text-[#17324D]'");
     expect(source).toContain("rowIndex % 2 === 0 ? 'bg-white' : 'bg-slate-50'");
@@ -369,8 +361,8 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('캐시플로우 시트 연동 시작하기');
     expect(source).toContain('나중에 하기');
     expect(source).toContain('설정 후에도 자동으로 값을 가져오지 않습니다.');
-    expect(source).toContain('monthCloseResult?.dashboard?.canonical?.range?.[mode]');
-    expect(source).toContain('getServerReadCell({ targetYearMonth: week.yearMonth');
+    expect(source).toContain('sheetFormulaValues?.weekly.find');
+    expect(source).toContain('sheetFormulaValues?.grandTotals?.[mode]');
   });
 
   it('shows the server service account immediately in project sheet setup', () => {
@@ -591,7 +583,7 @@ describe('CashflowProjectSheet monthly close shell', () => {
   });
 
   it('does not globally truncate exact General Activity rows', () => {
-    const mergeSource = source.slice(source.indexOf('function mergeCashflowEvents'), source.indexOf('function diffColorExplanation'));
+    const mergeSource = source.slice(source.indexOf('function mergeCashflowEvents'), source.indexOf('function HoverExplain'));
     expect(mergeSource).not.toContain('.slice(');
   });
 
@@ -621,8 +613,8 @@ describe('CashflowProjectSheet monthly close shell', () => {
   it('uses the server KST comparison week and totals only the visible comparison scope', () => {
     expect(source).toContain('monthCloseResult?.dashboard?.summary?.comparisonAsOfWeek');
     expect(source).toContain('resolveCashflowComparisonScope({');
-    expect(source).toContain('comparisonWeeks.reduce');
-    expect(source).toContain('comparisonAnnualYears.reduce');
+    expect(source).not.toContain('comparisonWeeks.reduce');
+    expect(source).not.toContain('comparisonAnnualYears.reduce');
     expect(source).toContain('const cashflowTotalPeriodLabel = comparisonScope.periodLabel');
     expect(source).not.toContain("const totalProjection = projectLineTotalFor('projection', lineId)");
     expect(source).not.toContain("const totalActual = projectLineTotalFor('actual', lineId)");
@@ -637,19 +629,17 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('const weeklyYear = canonicalReadModel?.weeklyYear');
     expect(source).toContain('annualYearsFor(weeklyYear)');
     expect(source).not.toContain('CASHFLOW_STANDARD_ANNUAL_YEARS');
-    expect(source).toContain('canonicalCashflowAnnualTotalFor(canonicalAnnualTotals, year, mode)');
-    expect(source).toContain('canonicalReadModel?.annualTotals || []');
+    expect(source).toContain('sheetFormulaValues?.annual.find');
     expect(source).not.toContain('dashboard?.canonical as');
     expect(source).not.toContain('summarizeCanonicalCashflowYear');
     expect(source).toContain('const previousAnnualYears = annualYears.filter((year) => year < Number(weeklyYear))');
     expect(source).toContain('const followingAnnualYears = annualYears.filter((year) => year > Number(weeklyYear))');
     expect(source).toContain('const renderAnnualSummaryCell');
-    expect(source).not.toContain('cashflowSheetMirror?.sheetFacts?.annualCashflowTotals');
-    expect(source).toContain('annualYears.some((year) => !annualTotalFor(year, mode)?.lineStates?.[lineId])');
+    expect(source).toContain('sheetFormulaValues?.grandTotals?.[mode]');
     expect(source).toContain('Total');
     expect(source).toContain('const visibleWeeks = annualWeeks');
-    expect(source).toContain('openingBalances?.selectedYear === selectedYear');
-    expect(source).toContain('annualOpeningBalance: openingBalance');
+    expect(source).toContain('annualSummaryValue(year, mode, kind)');
+    expect(source).toContain('sheetDerivedAmount(mode, week.yearMonth, week.weekNo, kind)');
     expect(source).not.toContain("'서버 값'");
     expect(source).not.toContain("'값 없음'");
     expect(source).toContain('>미입력</');
@@ -661,26 +651,21 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('현금흐름 데이터를 불러오지 못했습니다.');
   });
 
-  it('aligns the Projection - Actual table to the same annual, weekly, and Total contract as the cashflow board', () => {
+  it('renders the Projection - Actual row from the pinned Sheet formula range', () => {
     expect(source).toContain('resolveCashflowComparisonScope');
     expect(source).toContain('monthCloseResult?.dashboard?.summary?.comparisonAsOfWeek');
     expect(source).toContain('visibleComparisonWeeks');
-    expect(source).toContain('visibleComparisonAnnualYears');
-    expect(source).toContain('comparisonWeeks.reduce');
+    expect(source).toContain('sheetFormulaValues?.projectionActualDifferences.find');
+    expect(source).not.toContain('comparisonWeeks.reduce');
     expect(source).not.toContain('const cashflowTotalPeriodLabel = `${previousAnnualYears[0] || selectedYear}년 ~ ${followingAnnualYears.at(-1) || selectedYear}년`');
     expect(source).not.toContain('const mirroredAnnualTotals = useMemo');
     expect(source).toContain('const annualTotalFor = (year: number');
     expect(source).not.toContain("const totalProjection = projectLineTotalFor('projection', lineId)");
     expect(source).not.toContain("const totalActual = projectLineTotalFor('actual', lineId)");
-    expect(source).toContain('{previousComparisonAnnualYears.map((year) => (');
-    expect(source).toContain('{followingComparisonAnnualYears.map((year) => (');
-    expect(source).toContain('previousComparisonAnnualYears.includes(cell.year)');
-    expect(source).toContain('followingComparisonAnnualYears.includes(cell.year)');
-    expect(source).toContain('row.totalCell.difference');
-    expect(source).toContain('difference: hasValue ? projection - actual : null');
-    expect(source).not.toContain("pinned.state === 'VALUE' || pinned.state === 'ZERO'");
-    expect(source).toContain('monthCloseResult?.dashboard?.canonical?.months?.find');
-    expect(source).toContain('const columnCount = visibleComparisonAnnualYears.length + visibleComparisonWeeks.length + 1');
+    expect(source).toContain("label: 'Projection - Actual 차이'");
+    expect(source).toContain('현금흐름 관리시트 A11:BS11 기준');
+    expect(source).toContain('const columnCount = visibleComparisonWeeks.length');
+    expect(source).not.toContain('difference: hasValue ? projection - actual : null');
   });
 
   it('keeps the last good month result during a same-month retry and lists every management finding', () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -78,7 +78,6 @@ import {
 } from '../../lib/sheets-cashflow-readonly-client';
 import {
   buildCashflowMonthCloseDraftInput,
-  carryForwardCashflowRunningBalances,
   createEmptyCashflowMonthCloseDepositRows,
   isCashflowMonthCloseRequestLocked,
   isCashflowWeekLockedByRange,
@@ -88,8 +87,6 @@ import {
   shouldApplyCashflowMonthCloseRequestResult,
   shouldHideCashflowValuesAfterLoadError,
   annualYearsFor,
-  annualSummaryAmountFor,
-  canonicalCashflowAnnualTotalFor,
   type CashflowMonthCloseDepositReviewRow,
 } from './cashflow-month-close';
 import { CashflowSheetSyncOverlay } from './CashflowSheetSyncOverlay';
@@ -222,14 +219,6 @@ function mergeCashflowEvents(current: CashflowEvent[], incoming: CashflowActivit
   incoming.forEach((event) => events.set(event.id, event));
   return [...events.values()]
     .sort((left, right) => String(right.createdAt).localeCompare(String(left.createdAt)));
-}
-
-function diffColorExplanation(section: '입금' | '출금', diff: number): string {
-  if (diff === 0) return '차이가 없습니다.';
-  const target = section === '입금' ? '입금' : '출금';
-  return diff > 0
-    ? `${target} Projection이 Actual보다 큽니다.`
-    : `${target} Projection이 Actual보다 작습니다.`;
 }
 
 function HoverExplain({
@@ -1884,79 +1873,42 @@ export function CashflowProjectSheet({
   const visibleComparisonAnnualYears = comparisonScope.annualYears;
   const previousComparisonAnnualYears = visibleComparisonAnnualYears.filter((year) => year < Number(weeklyYear));
   const followingComparisonAnnualYears = visibleComparisonAnnualYears.filter((year) => year > Number(weeklyYear));
-  const canonicalAnnualTotals = canonicalReadModel?.annualTotals || [];
+  const sheetFormulaValues = monthCloseResult?.dashboard?.sheetFormulaValues;
   const annualTotalFor = (year: number, mode: 'projection' | 'actual') => (
-    canonicalCashflowAnnualTotalFor(canonicalAnnualTotals, year, mode)
+    sheetFormulaValues?.annual.find((total) => total.year === year)?.[mode] ?? null
   );
+  const annualSummaryValue = (
+    year: number,
+    mode: 'projection' | 'actual',
+    kind: 'totalIn' | 'totalOut' | 'net',
+  ) => annualTotalFor(year, mode)?.[kind] ?? null;
   const projectLineTotalFor = (mode: 'projection' | 'actual', lineId: CashflowSheetLineId) => {
-    const rangeTotals = monthCloseResult?.dashboard?.canonical?.range?.[mode] as {
-      rowTotals?: Record<CashflowSheetLineId, number>;
-      lineAmounts?: Record<CashflowSheetLineId, number>;
-    } | null | undefined;
-    const selectedYearTotal = rangeTotals?.rowTotals?.[lineId] ?? rangeTotals?.lineAmounts?.[lineId] ?? 0;
-    if (annualYears.some((year) => !annualTotalFor(year, mode)?.lineStates?.[lineId])) return null;
-    return annualYears.reduce(
-      (sum, year) => sum + Number(annualTotalFor(year, mode)?.lineAmounts?.[lineId] || 0),
-      Number(selectedYearTotal),
-    );
+    const total = sheetFormulaValues?.grandTotals?.[mode];
+    const state = total?.lineStates?.[lineId];
+    return state === 'VALUE' || state === 'ZERO' ? Number(total?.lineAmounts?.[lineId] || 0) : null;
   };
 
   const projectionActualComparison = useMemo(() => {
-    const lineDefs = [
-      ...CASHFLOW_IN_LINES.map((lineId) => ({ section: '입금' as const, lineId })),
-      ...CASHFLOW_OUT_LINES.map((lineId) => ({ section: '출금' as const, lineId })),
-    ];
-    const rows = lineDefs.map(({ section, lineId }) => {
-      const comparisonWeeks = visibleComparisonWeeks.map((week) => {
-        const projectionCell = getServerReadCell({ targetYearMonth: week.yearMonth, mode: 'projection', weekNo: week.weekNo, lineId });
-        const actualCell = getServerReadCell({ targetYearMonth: week.yearMonth, mode: 'actual', weekNo: week.weekNo, lineId });
-        const hasValue = projectionCell.hasValue || actualCell.hasValue;
-        return {
-          yearMonth: week.yearMonth,
-          weekNo: week.weekNo,
-          weekLabel: week.label,
-          weekRange: week.weekStart && week.weekEnd ? `${week.weekStart} ~ ${week.weekEnd}` : '',
-          projection: projectionCell.amount,
-          actual: actualCell.amount,
-          difference: hasValue ? projectionCell.amount - actualCell.amount : null,
-        };
-      });
-      const comparisonAnnualYears = visibleComparisonAnnualYears.map((year) => {
-        const projectionTotal = annualTotalFor(year, 'projection');
-        const actualTotal = annualTotalFor(year, 'actual');
-        const projectionState = projectionTotal?.lineStates?.[lineId];
-        const actualState = actualTotal?.lineStates?.[lineId];
-        const hasValue = projectionState === 'VALUE' || projectionState === 'ZERO'
-          || actualState === 'VALUE' || actualState === 'ZERO';
-        const projection = Number(projectionTotal?.lineAmounts?.[lineId] || 0);
-        const actual = Number(actualTotal?.lineAmounts?.[lineId] || 0);
-        return { year, projection, actual, difference: hasValue ? projection - actual : null };
-      });
-      const totalProjection = comparisonWeeks.reduce((sum, cell) => sum + cell.projection, 0)
-        + comparisonAnnualYears.reduce((sum, cell) => sum + cell.projection, 0);
-      const totalActual = comparisonWeeks.reduce((sum, cell) => sum + cell.actual, 0)
-        + comparisonAnnualYears.reduce((sum, cell) => sum + cell.actual, 0);
-      const totalHasValue = [...comparisonAnnualYears, ...comparisonWeeks].some((cell) => cell.difference !== null);
-      return {
-        section,
-        lineId,
-        label: getCashflowModeLineLabel(lineId, 'projection'),
-        cells: comparisonWeeks,
-        annualCells: comparisonAnnualYears,
-        totalCell: {
-          projection: totalProjection,
-          actual: totalActual,
-          difference: totalHasValue ? totalProjection - totalActual : null,
-        },
-        changed: [...comparisonWeeks, ...comparisonAnnualYears, { difference: totalHasValue ? totalProjection - totalActual : null }]
-          .some((cell) => cell.difference !== null && cell.difference !== 0),
-      };
-    });
-    return {
-      rows,
-      changedRows: rows.filter((row) => row.changed),
+    const cells = visibleComparisonWeeks.map((week) => ({
+      yearMonth: week.yearMonth,
+      weekNo: week.weekNo,
+      weekLabel: week.label,
+      weekRange: week.weekStart && week.weekEnd ? `${week.weekStart} ~ ${week.weekEnd}` : '',
+      difference: sheetFormulaValues?.projectionActualDifferences.find((value) => (
+        value.yearMonth === week.yearMonth && value.weekNo === week.weekNo
+      ))?.amount ?? null,
+    }));
+    const row = {
+      section: '입금' as const,
+      lineId: 'sheet-projection-actual-difference',
+      label: 'Projection - Actual 차이',
+      cells,
+      annualCells: [],
+      totalCell: { difference: null },
+      changed: cells.some((cell) => cell.difference !== null && cell.difference !== 0),
     };
-  }, [monthCloseResult, selectedYear, visibleComparisonAnnualYears, visibleComparisonWeeks, yearMonth]);
+    return { rows: [row], changedRows: [row] };
+  }, [sheetFormulaValues, visibleComparisonWeeks]);
 
   const cashflowTotalPeriodLabel = comparisonScope.periodLabel;
   const sheetRangeLabel = cashflowSheetConfig
@@ -2049,23 +2001,6 @@ export function CashflowProjectSheet({
     lineId: CashflowSheetLineId;
   }): number {
     return getServerReadCell(params).amount;
-  }
-
-  function getCanonicalDerivedAmount(
-    mode: 'projection' | 'actual',
-    targetYearMonth: string,
-    weekNo: number,
-    kind: 'totalIn' | 'totalOut' | 'net',
-  ): number | null {
-    const check = monthCloseResult?.dashboard?.canonical?.months
-      ?.find((month) => month.yearMonth === targetYearMonth)?.[mode]?.weeks
-      ?.find((week) => week.weekNo === weekNo);
-    const value = kind === 'totalIn'
-      ? check?.totalIn
-      : kind === 'totalOut'
-        ? check?.totalOut
-        : check?.net;
-    return typeof value === 'number' && Number.isSafeInteger(value) ? value : null;
   }
 
   function renderProjectionCell(input: {
@@ -2205,64 +2140,24 @@ export function CashflowProjectSheet({
       return groups;
     }, []);
     const boardColumnCount = previousAnnualYears.length + visibleWeeks.length + followingAnnualYears.length + 2;
-    const readServerSummary = (mode: 'projection' | 'actual') => {
-      const openingBalance = monthCloseResult?.dashboard?.openingBalances?.selectedYear === selectedYear
-        ? Number(monthCloseResult.dashboard.openingBalances[mode]?.amount || 0)
-        : 0;
-      const priorServerWeek = (canonicalReadModel?.months || [])
-        .filter((month) => month.yearMonth < `${selectedYear}-01`)
-        .flatMap((month) => (month[mode]?.weeks || []).map((week) => ({ ...week, yearMonth: month.yearMonth })))
-        .sort((left, right) => left.yearMonth.localeCompare(right.yearMonth) || left.weekNo - right.weekNo)
-        .at(-1);
-      const serverWeeks = visibleWeeks.map((week) => {
-        const dashboardWeek = week.yearMonth === yearMonth
-          ? monthCloseResult?.dashboard?.totals?.[mode]?.weeks?.find((candidate) => candidate.weekNo === week.weekNo)
-          : null;
-        const canonicalWeek = canonicalReadModel?.months
-          ?.find((month) => month.yearMonth === week.yearMonth)
-          ?.[mode]?.weeks?.find((candidate) => candidate.weekNo === week.weekNo);
-        return canonicalWeek || dashboardWeek || null;
-      });
-      const displayedRunningBalances = carryForwardCashflowRunningBalances({
-        priorWeeklyNet: Number(priorServerWeek?.net || 0),
-        annualOpeningBalance: openingBalance,
-        serverRunningNets: serverWeeks.map((week) => week == null ? null : Number(week.net || 0)),
-      });
-      const weekTotals = serverWeeks.map((serverWeek, index) => {
-        const visibleWeek = visibleWeeks[index];
-        return {
-          ...(serverWeek || { weekNo: visibleWeek.weekNo, amounts: {}, totalIn: 0, totalOut: 0, weekIn: 0, weekOut: 0 }),
-          net: displayedRunningBalances[index],
-        };
-      });
-      const rangeTotals = canonicalReadModel?.range?.[mode];
-      const endingBalance = Number(weekTotals.at(-1)?.net ?? openingBalance);
-      return {
-        rowTotals: ((rangeTotals as { rowTotals?: Record<CashflowSheetLineId, number>; lineAmounts?: Record<CashflowSheetLineId, number> } | null)?.rowTotals
-          || (rangeTotals as { lineAmounts?: Record<CashflowSheetLineId, number> } | null)?.lineAmounts
-          || {}) as Record<CashflowSheetLineId, number>,
-        weekTotals,
-        monthTotals: {
-          totalIn: rangeTotals?.totalIn || 0,
-          totalOut: rangeTotals?.totalOut || 0,
-          net: endingBalance,
-        },
-      };
-    };
-    const derived = {
-      projection: readServerSummary('projection'),
-      actual: readServerSummary('actual'),
+    const sheetDerivedAmount = (
+      mode: 'projection' | 'actual',
+      targetYearMonth: string,
+      weekNo: number,
+      kind: 'totalIn' | 'totalOut' | 'net',
+    ) => {
+      const reported = sheetFormulaValues?.weekly.find((check) => (
+        check.mode === mode && check.yearMonth === targetYearMonth && check.weekNo === weekNo
+      ))?.reported;
+      return kind === 'totalIn'
+        ? reported?.depositTotal ?? null
+        : kind === 'totalOut'
+          ? reported?.withdrawalTotal ?? null
+          : reported?.balance ?? null;
     };
     const projectTotalsFor = (mode: 'projection' | 'actual') => {
-      // 연간 열 하나라도 합계를 구할 수 없으면(라인까지 전부 미기입) Total 열도 없는 값으로 둔다.
-      const annualIn = annualYears.map((year) => annualSummaryAmountFor(annualTotalFor(year, mode), 'totalIn'));
-      const annualOut = annualYears.map((year) => annualSummaryAmountFor(annualTotalFor(year, mode), 'totalOut'));
-      if (annualYears.some((year) => !annualTotalFor(year, mode))) {
-        return { totalIn: null, totalOut: null, net: null };
-      }
-      const totalIn = annualIn.reduce<number>((sum, value) => sum + Number(value ?? 0), Number(derived[mode].monthTotals.totalIn || 0));
-      const totalOut = annualOut.reduce<number>((sum, value) => sum + Number(value ?? 0), Number(derived[mode].monthTotals.totalOut || 0));
-      return { totalIn, totalOut, net: totalIn - totalOut };
+      const total = sheetFormulaValues?.grandTotals?.[mode];
+      return { totalIn: total?.totalIn ?? null, totalOut: total?.totalOut ?? null, net: total?.net ?? null };
     };
     const scrollBoard = (direction: -1 | 1) => {
       const container = cashflowBoardScrollRef.current;
@@ -2298,7 +2193,7 @@ export function CashflowProjectSheet({
       rowTone?: 'income' | 'expense',
     ) => renderSummaryCell({
       keyName: `${mode}-${kind}-${year}-annual`,
-      value: annualSummaryAmountFor(annualTotalFor(year, mode), kind),
+      value: annualSummaryValue(year, mode, kind),
       mode,
       emphasis,
       rowTone,
@@ -2351,9 +2246,9 @@ export function CashflowProjectSheet({
             {label}
           </td>
           {previousAnnualYears.map((year) => renderAnnualSummaryCell(mode, kind, year, emphasis, rowTone))}
-          {visibleWeeks.map((week, index) => renderSummaryCell({
+          {visibleWeeks.map((week) => renderSummaryCell({
             keyName: `${mode}-${kind}-${week.yearMonth}-${week.weekNo}`,
-            value: getCanonicalDerivedAmount(mode, week.yearMonth, week.weekNo, kind) ?? (derived[mode].weekTotals[index]?.[kind] || 0),
+            value: sheetDerivedAmount(mode, week.yearMonth, week.weekNo, kind),
             mode,
             isThisWeek: todayYearMonth === week.yearMonth && todayIso >= week.weekStart && todayIso <= week.weekEnd,
             monthCloseStatus: monthCloseStatusByMonth.get(week.yearMonth),
@@ -2525,7 +2420,7 @@ export function CashflowProjectSheet({
 
   function renderProjectionActualDiffTable() {
     const rows = projectionActualComparison.changedRows;
-    const columnCount = visibleComparisonAnnualYears.length + visibleComparisonWeeks.length + 1;
+    const columnCount = visibleComparisonWeeks.length;
     if (monthCloseResult?.dashboard?.snapshotCompatibility?.status === 'LEGACY_EVIDENCE_ONLY') {
       return (
         <div className="rounded-md border border-slate-300 bg-slate-50 px-3 py-5 text-[12px] leading-5 text-[#17324D]">
@@ -2561,33 +2456,26 @@ export function CashflowProjectSheet({
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div>
               <div className="text-[12px] font-semibold text-slate-950">
-                <HoverExplain message="아래 현금흐름 관리시트와 동일한 반영값으로 Projection에서 Actual을 뺍니다.">
+                <HoverExplain message="현금흐름 관리시트의 Projection–Actual 차이 수식 결과를 그대로 표시합니다.">
                   Projection - Actual 차이
                 </HoverExplain>
               </div>
               <div className="text-[12px] text-slate-500">
-                현금흐름 관리시트 기준 · 차이 = Projection - Actual
+                현금흐름 관리시트 A11:BS11 기준
               </div>
             </div>
-            <Badge className="rounded-md border border-[#C7D3DF] bg-[#EAF0F5] px-2.5 py-1 text-[12px] text-[#17324D]">차이 항목만</Badge>
+            <Badge className="rounded-md border border-[#C7D3DF] bg-[#EAF0F5] px-2.5 py-1 text-[12px] text-[#17324D]">시트 수식값</Badge>
           </div>
           <div className="overflow-x-auto rounded-md border border-slate-200 bg-white p-2">
             <table className="border-separate border-spacing-0 text-[12px]" style={{ minWidth: `${220 + columnCount * 96}px` }}>
               <thead className="bg-white text-slate-500">
                 <tr>
                   <th className="sticky left-0 z-20 w-[220px] min-w-[220px] border-r-[6px] border-r-white bg-white px-3 py-2 text-left font-medium">항목</th>
-                  {previousComparisonAnnualYears.map((year) => (
-                    <th key={`comparison-${year}-before`} className="min-w-[96px] border-l-[6px] border-l-white bg-slate-100 px-2 py-2 text-right font-medium">{year}년</th>
-                  ))}
                   {visibleComparisonWeeks.map((week) => (
                     <th key={`${week.yearMonth}-${week.weekNo}`} className="min-w-[96px] border-l-[6px] border-l-white bg-slate-50/80 px-2 py-2 text-right font-medium">
                       <div>{week.label}</div>
                     </th>
                   ))}
-                  {followingComparisonAnnualYears.map((year) => (
-                    <th key={`comparison-${year}-after`} className="min-w-[96px] border-l-[6px] border-l-white bg-slate-100 px-2 py-2 text-right font-medium">{year}년</th>
-                  ))}
-                  <th className="sticky right-0 z-20 min-w-[96px] border-l-[6px] border-l-white bg-white px-2 py-2 text-right font-medium shadow-[-12px_0_24px_rgba(15,23,42,0.08)]">Total</th>
                 </tr>
               </thead>
               <tbody>
@@ -2602,17 +2490,6 @@ export function CashflowProjectSheet({
                     <td className={`sticky left-0 z-10 w-[220px] min-w-[220px] border-r-[6px] border-r-white px-3 py-2 ${rowIndex % 2 === 0 ? 'bg-white' : 'bg-slate-50'}`}>
                       <div className={`truncate ${row.section === '입금' ? 'text-emerald-700' : 'text-red-700'}`}>{row.label}</div>
                     </td>
-                    {row.annualCells.filter((cell) => previousComparisonAnnualYears.includes(cell.year)).map((cell) => {
-                      const rowSurface = rowIndex % 2 === 0 ? 'bg-white' : 'bg-slate-50';
-                      const differenceClass = cell.difference === null || cell.difference === 0
-                        ? `${rowSurface} text-slate-300`
-                        : 'bg-[#EAF0F5] text-sky-700';
-                      return (
-                        <td key={`${row.lineId}-${cell.year}`} className={`min-w-[96px] border-l-[6px] border-l-white px-2 py-2 text-right font-semibold tabular-nums ${differenceClass}`} title={cell.difference === null ? `${cell.year}년\n미입력` : `${cell.year}년\nProjection ${fmt(cell.projection)} / Actual ${fmt(cell.actual)} / 차이 ${fmtSigned(cell.difference)}`}>
-                          {cell.difference === null ? '미입력' : fmtSigned(cell.difference)}
-                        </td>
-                      );
-                    })}
                     {row.cells.map((cell) => {
                       const rowSurface = rowIndex % 2 === 0 ? 'bg-white' : 'bg-slate-50';
                       const differenceClass = cell.difference === null || cell.difference === 0
@@ -2622,26 +2499,12 @@ export function CashflowProjectSheet({
                         <td
                           key={`${row.lineId}-${cell.yearMonth}-${cell.weekNo}`}
                           className={`min-w-[96px] border-l-[6px] border-l-white px-2 py-2 text-right font-semibold tabular-nums ${differenceClass}`}
-                          title={cell.difference === null ? `${cell.weekRange}\nBFF 비교 대상 기간 아님` : `${cell.weekRange}\nProjection ${fmt(cell.projection)} / Actual ${fmt(cell.actual)} / 차이 ${fmtSigned(cell.difference)}\n${diffColorExplanation(row.section, cell.difference)}`}
+                          title={cell.difference === null ? `${cell.weekRange}\n시트 수식값 없음` : `${cell.weekRange}\n시트 차이 ${fmtSigned(cell.difference)}`}
                         >
                           {cell.difference === null ? '미입력' : fmtSigned(cell.difference)}
                         </td>
                       );
                     })}
-                    {row.annualCells.filter((cell) => followingComparisonAnnualYears.includes(cell.year)).map((cell) => {
-                      const rowSurface = rowIndex % 2 === 0 ? 'bg-white' : 'bg-slate-50';
-                      const differenceClass = cell.difference === null || cell.difference === 0
-                        ? `${rowSurface} text-slate-300`
-                        : 'bg-[#EAF0F5] text-sky-700';
-                      return (
-                        <td key={`${row.lineId}-${cell.year}`} className={`min-w-[96px] border-l-[6px] border-l-white px-2 py-2 text-right font-semibold tabular-nums ${differenceClass}`} title={cell.difference === null ? `${cell.year}년\n미입력` : `${cell.year}년\nProjection ${fmt(cell.projection)} / Actual ${fmt(cell.actual)} / 차이 ${fmtSigned(cell.difference)}`}>
-                          {cell.difference === null ? '미입력' : fmtSigned(cell.difference)}
-                        </td>
-                      );
-                    })}
-                    <td className={`sticky right-0 z-10 min-w-[96px] border-l-[6px] border-l-white px-2 py-2 text-right font-semibold tabular-nums shadow-[-12px_0_24px_rgba(15,23,42,0.08)] ${row.totalCell.difference === null || row.totalCell.difference === 0 ? (rowIndex % 2 === 0 ? 'bg-white text-slate-300' : 'bg-slate-50 text-slate-300') : 'bg-[#EAF0F5] text-sky-700'}`} title={row.totalCell.difference === null ? 'Total\n미입력' : `Total\nProjection ${fmt(row.totalCell.projection)} / Actual ${fmt(row.totalCell.actual)} / 차이 ${fmtSigned(row.totalCell.difference)}`}>
-                      {row.totalCell.difference === null ? '미입력' : fmtSigned(row.totalCell.difference)}
-                    </td>
                   </tr>
                 ))}
               </tbody>

--- a/src/app/components/cashflow/cashflow-action-tooltips.shell.test.ts
+++ b/src/app/components/cashflow/cashflow-action-tooltips.shell.test.ts
@@ -15,13 +15,12 @@ const importEditorSource = readFileSync(
 describe('cashflow action chrome', () => {
   it('removes secondary cashflow toolbar actions and explanatory chrome', () => {
     expect(cashflowProjectSheetSource).toContain('Projection - Actual 차이');
-    expect(cashflowProjectSheetSource).toContain('차이 = Projection - Actual');
+    expect(cashflowProjectSheetSource).toContain('현금흐름 관리시트 A11:BS11 기준');
     expect(cashflowProjectSheetSource).not.toContain('Actual - Projection');
     expect(cashflowProjectSheetSource).not.toContain('Actual에서 Projection을 뺀 값');
     expect(cashflowProjectSheetSource).not.toContain('actual - projection');
-    expect(cashflowProjectSheetSource).toContain('diffColorExplanation');
-    expect(cashflowProjectSheetSource).toContain('차이 항목만');
-    expect(cashflowProjectSheetSource).toContain('현금흐름 관리시트 기준');
+    expect(cashflowProjectSheetSource).not.toContain('diffColorExplanation');
+    expect(cashflowProjectSheetSource).toContain('시트 수식값');
     expect(cashflowProjectSheetSource).not.toContain('엑셀 다운로드');
     expect(cashflowProjectSheetSource).not.toContain('Actual 불러오기');
     expect(cashflowProjectSheetSource).not.toContain('Actual 저장');

--- a/src/app/components/cashflow/cashflow-month-close.test.ts
+++ b/src/app/components/cashflow/cashflow-month-close.test.ts
@@ -2,13 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { CASHFLOW_ALL_LINES } from '../../platform/cashflow-sheet';
 import type { CashflowSheetLabMirrorResult } from '../../lib/sheets-cashflow-readonly-client';
 import type { CashflowDeadlineSummary, CashflowManagementCheck } from '../../lib/platform-bff-client';
-import type { CanonicalCashflowAnnualModeTotal } from '../../lib/platform-bff-client';
 import {
-  annualSummaryAmountFor,
   buildCashflowMonthCloseDraftInput,
   annualYearsFor,
-  canonicalCashflowAnnualTotalFor,
-  carryForwardCashflowRunningBalances,
   createEmptyCashflowMonthCloseDepositRows,
   isCashflowMonthCloseRequestLocked,
   isCashflowComparisonWeekVisible,
@@ -62,32 +58,6 @@ describe('cashflow month close contract', () => {
     expect(annualYearsFor(2026)).toEqual([2024, 2025, 2027, 2028, 2029, 2030, 2031, 2032]);
     expect(annualYearsFor(2027)).toEqual([2025, 2026, 2028, 2029, 2030, 2031, 2032, 2033]);
     expect(annualYearsFor(undefined)).toEqual([]);
-  });
-
-  it('returns the server annual-column value and cell states unchanged', () => {
-    const actual = {
-      lineAmounts: { SALES_IN: 317_449_417, SALES_VAT_IN: 0, TEAM_SUPPORT_IN: 0 },
-      lineStates: { SALES_IN: 'VALUE', SALES_VAT_IN: 'ZERO', TEAM_SUPPORT_IN: 'EMPTY' } as const,
-      totalIn: null,
-      totalOut: 0,
-      net: null,
-    };
-    const annualTotals = [{
-      year: 2025,
-      projection: { ...actual, lineAmounts: { SALES_IN: 7_582_243 } },
-      actual,
-    }];
-    const result = canonicalCashflowAnnualTotalFor(annualTotals, 2025, 'actual');
-
-    expect(result).toBe(actual);
-    expect(result).toEqual({
-      lineAmounts: { SALES_IN: 317_449_417, SALES_VAT_IN: 0, TEAM_SUPPORT_IN: 0 },
-      lineStates: { SALES_IN: 'VALUE', SALES_VAT_IN: 'ZERO', TEAM_SUPPORT_IN: 'EMPTY' },
-      totalIn: null,
-      totalOut: 0,
-      net: null,
-    });
-    expect(canonicalCashflowAnnualTotalFor(annualTotals, 2032, 'actual')).toBeNull();
   });
 
   it('hides values only when canonical loading failed without a retained model', () => {
@@ -253,14 +223,6 @@ describe('cashflow month close contract', () => {
     expect(scope.yearView).toBeNull();
     expect(scope.sheetMetadata).toBeUndefined();
   });
-  it('carries prior weekly net and annual-only opening through empty weeks', () => {
-    expect(carryForwardCashflowRunningBalances({
-      priorWeeklyNet: 3_000_000,
-      annualOpeningBalance: 2_000_000,
-      serverRunningNets: [null, 3_500_000, null, 2_750_000],
-    })).toEqual([5_000_000, 5_500_000, 5_500_000, 4_750_000]);
-  });
-
   it('normalizes exactly 160 pinned cells in Projection then Actual order', () => {
     const cells = normalizeCashflowMonthCloseCells(mirror(), '2026-07');
     expect(cells).toHaveLength(160);
@@ -353,47 +315,5 @@ describe('cashflow month close contract', () => {
     const source = mirror();
     source.cells = source.cells?.slice(0, -1);
     expect(() => normalizeCashflowMonthCloseCells(source, '2026-07')).toThrow('159/160');
-  });
-});
-
-describe('annual summary display fallback', () => {
-  const base: CanonicalCashflowAnnualModeTotal = {
-    lineStates: { SALES_IN: 'VALUE', SALES_VAT_IN: 'ZERO', TEAM_SUPPORT_IN: 'EMPTY', DIRECT_COST_OUT: 'VALUE' },
-    lineAmounts: { SALES_IN: 7_582_243, SALES_VAT_IN: 0, DIRECT_COST_OUT: 1_000_000 },
-    totalIn: null,
-    totalOut: null,
-    net: null,
-  };
-
-  it('falls back to the entered-line sum when the sheet totals row is not stored yet', () => {
-    expect(annualSummaryAmountFor(base, 'totalIn')).toBe(7_582_243);
-    expect(annualSummaryAmountFor(base, 'totalOut')).toBe(1_000_000);
-    expect(annualSummaryAmountFor(base, 'net')).toBe(6_582_243);
-  });
-
-  it('prefers the stored sheet totals over the line sum', () => {
-    const declared: CanonicalCashflowAnnualModeTotal = { ...base, totalIn: 8_340_487 };
-    expect(annualSummaryAmountFor(declared, 'totalIn')).toBe(8_340_487);
-  });
-
-  it('keeps the summary empty only when every line is empty', () => {
-    const empty: CanonicalCashflowAnnualModeTotal = {
-      lineStates: { SALES_IN: 'EMPTY', DIRECT_COST_OUT: 'EMPTY' },
-      lineAmounts: {},
-      totalIn: null, totalOut: null, net: null,
-    };
-    expect(annualSummaryAmountFor(empty, 'totalIn')).toBeNull();
-    expect(annualSummaryAmountFor(empty, 'net')).toBeNull();
-    expect(annualSummaryAmountFor(null, 'totalIn')).toBeNull();
-  });
-
-  it('treats all-zero lines as an entered zero, not as missing', () => {
-    const zero: CanonicalCashflowAnnualModeTotal = {
-      lineStates: { SALES_IN: 'ZERO', DIRECT_COST_OUT: 'ZERO' },
-      lineAmounts: { SALES_IN: 0, DIRECT_COST_OUT: 0 },
-      totalIn: null, totalOut: null, net: null,
-    };
-    expect(annualSummaryAmountFor(zero, 'totalIn')).toBe(0);
-    expect(annualSummaryAmountFor(zero, 'net')).toBe(0);
   });
 });

--- a/src/app/components/cashflow/cashflow-month-close.ts
+++ b/src/app/components/cashflow/cashflow-month-close.ts
@@ -1,5 +1,4 @@
-import { CASHFLOW_ALL_LINES, CASHFLOW_IN_LINES, CASHFLOW_OUT_LINES } from '../../platform/cashflow-sheet';
-import type { CashflowSheetLineId } from '../../data/types';
+import { CASHFLOW_ALL_LINES } from '../../platform/cashflow-sheet';
 import type {
   CashflowMonthCloseCell,
   CashflowMonthCloseConfirmation,
@@ -9,8 +8,6 @@ import type {
   CashflowManagementCheck,
   CashflowManagementConfirmation,
   CashflowDeadlineSummary,
-  CanonicalCashflowAnnualModeTotal,
-  CanonicalCashflowAnnualTotal,
 } from '../../lib/platform-bff-client';
 import type {
   CashflowSheetLabMirrorResult,
@@ -30,37 +27,6 @@ export function annualYearsFor(weeklyYear: number | undefined): number[] {
   if (!Number.isSafeInteger(weeklyYear)) return [];
   const year = Number(weeklyYear);
   return [year - 2, year - 1, ...Array.from({ length: 6 }, (_, index) => year + index + 1)];
-}
-
-export function canonicalCashflowAnnualTotalFor(
-  annualTotals: CanonicalCashflowAnnualTotal[],
-  year: number,
-  mode: 'projection' | 'actual',
-): CanonicalCashflowAnnualModeTotal | null {
-  return annualTotals.find((total) => total.year === year)?.[mode] ?? null;
-}
-
-// 연간 열의 합계 표시값. 시트 합계 행에서 읽은 저장값이 우선이고, 아직 저장되지 않은
-// 문서는 기입된 라인의 합으로 보완한다 — Total 열의 buildCashflowSheetTotal 과 같은
-// 순서다. 라인이 전부 미기입일 때만 합계도 없는 값으로 남는다. 표시 전용이며 계약대비
-// Projection 합계 같은 판정 연산에는 쓰지 않는다.
-export function annualSummaryAmountFor(
-  total: CanonicalCashflowAnnualModeTotal | null,
-  kind: 'totalIn' | 'totalOut' | 'net',
-): number | null {
-  if (!total) return null;
-  if (typeof total[kind] === 'number') return total[kind];
-  const entered = (lineId: CashflowSheetLineId) => (
-    total.lineStates?.[lineId] === 'VALUE' || total.lineStates?.[lineId] === 'ZERO'
-  );
-  const sumOf = (lineIds: readonly CashflowSheetLineId[]) => (lineIds.some(entered)
-    ? lineIds.reduce((sum, lineId) => sum + (entered(lineId) ? Number(total.lineAmounts?.[lineId] || 0) : 0), 0)
-    : null);
-  if (kind === 'totalIn') return sumOf(CASHFLOW_IN_LINES);
-  if (kind === 'totalOut') return sumOf(CASHFLOW_OUT_LINES);
-  const totalIn = sumOf(CASHFLOW_IN_LINES);
-  const totalOut = sumOf(CASHFLOW_OUT_LINES);
-  return totalIn === null && totalOut === null ? null : (totalIn ?? 0) - (totalOut ?? 0);
 }
 
 export function shouldHideCashflowValuesAfterLoadError(error: string | null, hasCanonical: boolean): boolean {
@@ -166,18 +132,6 @@ export function resolveCashflowEvidenceScope(input: {
         ? input.liveSheetMetadata
         : undefined,
   };
-}
-
-export function carryForwardCashflowRunningBalances(input: {
-  priorWeeklyNet: number;
-  annualOpeningBalance: number;
-  serverRunningNets: Array<number | null>;
-}): number[] {
-  let carriedWeeklyNet = input.priorWeeklyNet;
-  return input.serverRunningNets.map((serverNet) => {
-    if (serverNet != null) carriedWeeklyNet = serverNet;
-    return carriedWeeklyNet + input.annualOpeningBalance;
-  });
 }
 
 export function cashflowMonthCloseConfirmationKey(input: {

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -1,6 +1,7 @@
 import { featureFlags, parseFeatureFlag } from '../config/feature-flags';
 import type {
   AccountType,
+  CashflowSheetLineId,
   Project,
   ProjectRequest,
   ProjectExecutiveReviewStatus,
@@ -966,6 +967,24 @@ export interface CashflowMonthCloseDashboard {
       balance: number | null;
     };
   }>;
+  sheetFormulaValues: {
+    weekly: CashflowMonthCloseDashboard['sheetCalculationChecks'];
+    annual: Array<{
+      year: number;
+      projection: CashflowSheetFormulaModeTotal;
+      actual: CashflowSheetFormulaModeTotal;
+    }>;
+    grandTotals: {
+      projection?: CashflowSheetFormulaModeTotal;
+      actual?: CashflowSheetFormulaModeTotal;
+    };
+    projectionActualDifferences: Array<{
+      yearMonth: string;
+      weekNo: number;
+      amount: number | null;
+      sourceCell: string;
+    }>;
+  };
   sheetControlTotals: {
     deposit: {
       sourceCell: string;
@@ -1078,6 +1097,14 @@ export interface CashflowMonthCloseDashboard {
     warnings: Array<{ code: string; message: string; details?: unknown }>;
   };
   canonical: CashflowSnapshotResult['readModel'] | null;
+}
+
+export interface CashflowSheetFormulaModeTotal {
+  lineAmounts: Partial<Record<CashflowSheetLineId, number>>;
+  lineStates: Partial<Record<CashflowSheetLineId, 'VALUE' | 'ZERO' | 'EMPTY' | 'INVALID'>>;
+  totalIn: number | null;
+  totalOut: number | null;
+  net: number | null;
 }
 
 export interface CloseCashflowMonthPayload {


### PR DESCRIPTION
## What changed\n- pass frozen Sheet formula rows through the cashflow dashboard\n- render weekly, annual, total, balance, and Projection–Actual values without frontend arithmetic\n- pin Projection–Actual from A11:BS11\n\n## Verification\n- targeted cashflow tests (119 passed)\n- targeted BFF contract test\n- typecheck\n