### PR TITLE
fix: restore session cashflow entry

### DIFF
--- a/src/app/components/portal/PortalCashflowPage.tsx
+++ b/src/app/components/portal/PortalCashflowPage.tsx
@@ -8,6 +8,7 @@ import {
 export function PortalCashflowPage() {
   const { projectId: routeProjectId } = useParams<{ projectId: string }>();
   const {
+    activeProjectId,
     members,
     portalUser,
     projects,
@@ -15,7 +16,8 @@ export function PortalCashflowPage() {
     upsertWeeklySubmissionStatus,
   } = usePortalStore();
 
-  const projectId = resolvePortalProjectResourceId(routeProjectId);
+  // `/portal/cashflow` is the session-entry URL; an explicit route ID always wins.
+  const projectId = resolvePortalProjectResourceId(routeProjectId, activeProjectId);
   const project = projects.find((candidate) => candidate.id === projectId);
 
   if (!projectId) {

--- a/src/app/routes.portal-canonical.shell.test.ts
+++ b/src/app/routes.portal-canonical.shell.test.ts
@@ -25,11 +25,11 @@ describe('portal canonical edit resource routes', () => {
     expect(source).toContain("{ path: 'cashflow/sheets-lab', element: <S C={CashflowSheetLabPage} /> }");
   });
 
-  it('lets the route project win and sends ID-less cashflow URLs to project selection', () => {
+  it('lets the route project win and uses the session project for ID-less cashflow URLs', () => {
     expect(cashflowSource).toContain('useParams');
-    expect(cashflowSource).toContain('resolvePortalProjectResourceId(routeProjectId);');
+    expect(cashflowSource).toContain('activeProjectId');
+    expect(cashflowSource).toContain('resolvePortalProjectResourceId(routeProjectId, activeProjectId);');
     expect(cashflowSource).toContain('<Navigate to="/portal/project-select" replace />');
-    expect(cashflowSource).not.toContain('activeProjectId');
     expect(cashflowSource).not.toContain('myProject');
     expect(sheetLabSource).toContain('useParams');
     expect(sheetLabSource).toContain('routeProjectId');


### PR DESCRIPTION
## Hotfix\n\nRestore /portal/cashflow as the session-project entry point. Explicit /portal/cashflow/:projectId remains authoritative.\n\n## Verified\n\n- npx vitest run src/app/routes.portal-canonical.shell.test.ts src/app/platform/portal-project-selection.test.ts --reporter=dot\n- npm run typecheck -- --pretty false\n- git diff --check