### PR TITLE
fix: source cashflow variance from synced sheet formulas

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -1651,6 +1651,62 @@ async function readDocument(db, path) {
   return snapshot.exists ? snapshot.data() || {} : null;
 }
 
+function sheetFormulaProjectionActualSummary({ projectId, mirror, comparisonBoundary, yearMonth = '' }) {
+  if (readOptionalText(mirror?.status) !== 'FRESH'
+    || !readOptionalText(mirror?.sourceRevision)
+    || readOptionalText(mirror?.sourceRevision) !== readOptionalText(mirror?.appliedSourceRevision)) return null;
+  const rows = (Array.isArray(mirror?.sheetFacts?.projectionActualDifferences)
+    ? mirror.sheetFacts.projectionActualDifferences
+    : [])
+    .map((row) => ({
+      yearMonth: readOptionalText(row?.yearMonth),
+      weekNo: Number(row?.weekNo),
+      amount: Number(row?.amount),
+    }))
+    .filter((row) => /^20\d{2}-(0[1-9]|1[0-2])$/.test(row.yearMonth)
+      && Number.isInteger(row.weekNo) && row.weekNo >= 1 && row.weekNo <= 5
+      && Number.isSafeInteger(row.amount));
+  const asOf = comparisonBoundary?.asOfWeek;
+  const latest = rows
+    .filter((row) => row.yearMonth < asOf?.yearMonth
+      || (row.yearMonth === asOf?.yearMonth && row.weekNo <= asOf?.weekNo))
+    .sort((left, right) => left.yearMonth.localeCompare(right.yearMonth) || left.weekNo - right.weekNo)
+    .at(-1);
+  if (!latest) return null;
+  const requestedMonth = yearMonth || latest.yearMonth;
+  const periods = ['MONTH', 'WEEK_1', 'WEEK_2', 'WEEK_3', 'WEEK_4', 'WEEK_5'].map((period) => {
+    if (period === 'MONTH') return { period, differenceAmount: latest.amount };
+    const weekNo = Number(period.slice(-1));
+    const value = rows.find((row) => row.yearMonth === requestedMonth && row.weekNo === weekNo);
+    return { period, differenceAmount: value?.amount ?? null };
+  });
+  return {
+    projectId,
+    source: 'SHEET_FORMULA',
+    sourceRevision: readOptionalText(mirror.sourceRevision),
+    fromMonth: `${readWeeklyYear(mirror.weeklyYear) ?? Number(latest.yearMonth.slice(0, 4))}-01`,
+    comparisonAsOfWeek: { yearMonth: latest.yearMonth, weekNo: latest.weekNo },
+    differenceAmount: latest.amount,
+    settlementDifferenceAmount: latest.amount,
+    settlementMatches: latest.amount === 0,
+    periods,
+  };
+}
+
+async function readSheetFormulaProjectionActualSummaries({ db, req, projectIds, comparisonBoundary, yearMonth, authMode, workspaceEmailDomain }) {
+  const tenantId = readOptionalText(req.context?.tenantId);
+  const results = await Promise.all(projectIds.map(async (projectId) => {
+    await assertCashflowProjectInScope({ db, req, projectId, authMode, workspaceEmailDomain });
+    const mirror = await readDocument(db, `orgs/${tenantId}/cashflow_sheet_mirrors/${projectId}`);
+    return sheetFormulaProjectionActualSummary({ projectId, mirror, comparisonBoundary, yearMonth });
+  }));
+  return {
+    version: '2',
+    items: results.filter(Boolean),
+    errors: projectIds.filter((_projectId, index) => !results[index]).map((projectId) => ({ projectId, code: 'SUMMARY_UNAVAILABLE' })),
+  };
+}
+
 function annualModeFromStoredDocument(document, mode) {
   const lineAmounts = objectValue(document?.[mode]);
   const lineStates = objectValue(document?.[`${mode}States`]);
@@ -1936,6 +1992,18 @@ async function composeCashflowMonthDashboard({
       ? formulaSheetFacts.projectionActualDifferences
       : []).filter((value) => Number(String(value?.yearMonth || '').slice(0, 4)) === selectedYear),
   };
+  const directProjectionActualSummary = sheetFormulaProjectionActualSummary({
+    projectId,
+    mirror: {
+      status: closedSnapshot ? 'FRESH' : mirror?.status,
+      sourceRevision: closedSnapshot ? (formulaSnapshot.sourceRevision || 'snapshot') : mirror?.sourceRevision,
+      appliedSourceRevision: closedSnapshot ? (formulaSnapshot.sourceRevision || 'snapshot') : mirror?.appliedSourceRevision,
+      weeklyYear,
+      sheetFacts: formulaSheetFacts,
+    },
+    comparisonBoundary,
+    yearMonth,
+  });
   const authoritativeOpeningBalances = openingBalanceCandidate
     ? requireJvmOpeningBalances({ openingBalances: openingBalanceCandidate }, yearMonth)
     : null;
@@ -2127,7 +2195,7 @@ async function composeCashflowMonthDashboard({
     openingBalances: authoritativeOpeningBalances,
     snapshotCompatibility,
     deadlineSummary,
-    projectionActualSummary,
+    projectionActualSummary: directProjectionActualSummary,
     monthCloseStatuses,
     postCloseAdjustment: closedSnapshot ? postCloseAdjustment(close, closedSnapshot) : null,
     draftRevision: null,
@@ -2144,8 +2212,8 @@ async function composeCashflowMonthDashboard({
       actualProgressPercent: actualWrittenProgressPercent(cells, yearMonth, comparisonBoundary),
       confirmationProgressPercent,
       settlementProgressPercent: settlement.percent,
-      settlementDifferenceAmount: projectionActualSummary.settlementDifferenceAmount,
-      settlementMatches: projectionActualSummary.settlementMatches,
+      settlementDifferenceAmount: directProjectionActualSummary?.settlementDifferenceAmount ?? null,
+      settlementMatches: directProjectionActualSummary?.settlementMatches ?? null,
       settlementCompletedWeekCount: settlement.completed,
       settlementTargetWeekCount: settlement.total,
       settlementIncompleteWeeks: settlement.incompleteWeeks,
@@ -2742,17 +2810,6 @@ export function mountJvmWeeklyApiRoutes(app, {
         if (cashflow && readOptionalText(cashflow?.projectId) !== rawProjectId) {
           throw createHttpError(502, '다른 프로젝트의 자료가 도착했습니다. 화면을 새로고침해 주세요.', 'jvm_weekly_project_mismatch');
         }
-        const projectionActualSummary = objectValue(source?.projectionActualSummary);
-        if (readOptionalText(projectionActualSummary?.projectId) !== rawProjectId
-          || !/^20\d{2}-(0[1-9]|1[0-2])$/.test(readOptionalText(projectionActualSummary?.fromMonth))
-          || !/^20\d{2}-(0[1-9]|1[0-2])$/.test(readOptionalText(projectionActualSummary?.comparisonAsOfWeek?.yearMonth))
-          || !Number.isSafeInteger(Number(projectionActualSummary?.comparisonAsOfWeek?.weekNo))
-          || Number(projectionActualSummary?.comparisonAsOfWeek?.weekNo) < 1
-          || Number(projectionActualSummary?.comparisonAsOfWeek?.weekNo) > 5
-          || !Number.isFinite(Number(projectionActualSummary?.settlementDifferenceAmount))
-          || typeof projectionActualSummary?.settlementMatches !== 'boolean') {
-          throw createHttpError(502, 'JVM 누적 Projection-Actual 요약을 확인할 수 없습니다.', 'jvm_weekly_response_invalid');
-        }
         const cycleBusinessDate = readOptionalText(result?.evaluatedBusinessDate) || comparisonBoundary.asOfDate;
         const cumulativeCycle = cashflowCumulativeCloseCycle(yearMonth, cycleBusinessDate);
         if (!cumulativeCycle) {
@@ -2782,7 +2839,7 @@ export function mountJvmWeeklyApiRoutes(app, {
             openingBalances,
             comparisonBoundary,
             weeklyCompliance,
-            projectionActualSummary,
+            projectionActualSummary: null,
             weeklyComplianceBoundary,
           }),
           { attempt: traceAttempt },
@@ -2948,15 +3005,15 @@ export function mountJvmWeeklyApiRoutes(app, {
       || (yearMonth && !/^20\d{2}-(0[1-9]|1[0-2])$/.test(yearMonth))) {
       throw createHttpError(400, '현금흐름 요약 조회 범위가 올바르지 않습니다.', 'cashflow_projection_actual_summary_request_invalid');
     }
-    const result = await proxyJavaWeeklyRequest({
-      context: req.context,
-      method: 'POST',
-      path: '/api/v1/cashflow/projection-actual-summary/batch',
-      command: 'read_cashflow_projection_actual_summaries',
-      body: { projectIds, ...(yearMonth ? { yearMonth } : {}) },
-      mutation: false,
-    });
-    res.status(200).json(result);
+    res.status(200).json(await readSheetFormulaProjectionActualSummaries({
+      db,
+      req,
+      projectIds,
+      yearMonth,
+      comparisonBoundary: resolveCashflowComparisonAsOf('', now()),
+      authMode,
+      workspaceEmailDomain,
+    }));
   }));
 
   async function readWeeklyOverview(req) {
@@ -2992,13 +3049,33 @@ export function mountJvmWeeklyApiRoutes(app, {
       body: { projectIds, yearMonth },
       mutation: false,
     }), { projectCount: projectIds.length });
+    const sheetSummary = await trace.measure('sheet_formula_summary', () => readSheetFormulaProjectionActualSummaries({
+      db,
+      req,
+      projectIds,
+      yearMonth,
+      comparisonBoundary: resolveCashflowComparisonAsOf('', now()),
+      authMode,
+      workspaceEmailDomain,
+    }), { projectCount: projectIds.length });
+    const summaryByProjectId = new Map(sheetSummary.items.map((item) => [item.projectId, item]));
+    const resultErrors = Array.isArray(result?.errors) ? result.errors.filter((error) => error?.code !== 'SUMMARY_UNAVAILABLE') : [];
+    const combined = {
+      ...result,
+      version: '2',
+      items: (Array.isArray(result?.items) ? result.items : []).map((item) => ({
+        ...item,
+        projectionActualSummary: summaryByProjectId.get(item?.projectId) || null,
+      })),
+      errors: [...resultErrors, ...sheetSummary.errors],
+    };
     trace.emit('response', {
       outcome: 'ok',
       projectCount: projectIds.length,
-      itemCount: Array.isArray(result?.items) ? result.items.length : 0,
-      issueCount: Array.isArray(result?.errors) ? result.errors.length : 0,
+      itemCount: Array.isArray(combined.items) ? combined.items.length : 0,
+      issueCount: combined.errors.length,
     });
-    return result;
+    return combined;
   }
 
   app.post('/api/v1/cashflow/weekly-overview', asyncHandler(async (req, res) => {

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -270,6 +270,9 @@ function fullMonthCloseSource({
         ? { depositTotal: false, withdrawalTotal: true, balance: true }
         : { depositTotal: true, withdrawalTotal: true, balance: true },
     })),
+    projectionActualDifferences: Array.from({ length: 5 }, (_, index) => ({
+      yearMonth: '2026-06', weekNo: index + 1, amount: index === 4 ? -43_962_826 : 0, sourceCell: `A${11 + index}`,
+    })),
     issues: [],
   };
   const draftId = `v1_${Buffer.from(JSON.stringify(['cashflow', 'project-a', 'pm-1']), 'utf8').toString('base64url')}`;
@@ -576,39 +579,31 @@ describe('JVM weekly API BFF proxy', () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
-  it('forwards the canonical projection-actual batch summary unchanged', async () => {
-    const canonical = {
-      version: '1',
-      items: [{
-        projectId: 'project-a',
-        fromMonth: '2023-01',
-        comparisonAsOfWeek: { yearMonth: '2026-08', weekNo: 4 },
-        settlementDifferenceAmount: 18_371_453,
-        settlementMatches: false,
-      }],
-      errors: [{ projectId: 'project-b', code: 'SUMMARY_UNAVAILABLE' }],
-    };
-    const fetchImpl = vi.fn(async (_url, init) => new Response(JSON.stringify(canonical), {
-      status: 200,
-      headers: { 'content-type': 'application/json' },
-    }));
-    const { app } = createApp(fetchImpl);
+  it('reads the latest synced sheet formula values without calling the JVM summary endpoint', async () => {
+    const { db } = fullMonthCloseSource();
+    const fetchImpl = vi.fn();
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, {
+      env: runtimeEnv, db, now: () => new Date('2026-06-30T00:00:00.000Z'),
+    });
 
     const response = await request(app)
       .post('/api/v1/cashflow/projection-actual-summary/batch')
-      .send({ projectIds: ['project-a', 'project-b'], yearMonth: '2026-11' })
+      .send({ projectIds: ['project-a'], yearMonth: '2026-06' })
       .expect(200);
 
-    expect(response.body).toEqual(canonical);
-    expect(fetchImpl).toHaveBeenCalledOnce();
-    const [url, init] = fetchImpl.mock.calls[0];
-    expect(String(url)).toBe('http://jvm-weekly.local/api/v1/cashflow/projection-actual-summary/batch');
-    expect(init.method).toBe('POST');
-    expect(JSON.parse(init.body)).toEqual({ projectIds: ['project-a', 'project-b'], yearMonth: '2026-11' });
-    expect(new Headers(init.headers).get('x-tenant-id')).toBe('tenant-a');
+    expect(response.body).toMatchObject({
+      version: '2', errors: [], items: [{
+        projectId: 'project-a', source: 'SHEET_FORMULA', differenceAmount: -43_962_826,
+        comparisonAsOfWeek: { yearMonth: '2026-06', weekNo: 5 },
+      }],
+    });
+    expect(response.body.items[0].periods.find((period) => period.period === 'WEEK_5')).toEqual({
+      period: 'WEEK_5', differenceAmount: -43_962_826,
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
-  it('reads a 61-project weekly overview with one JVM request and no BFF status rewrite', async () => {
+  it('reads a 61-project weekly overview with one JVM status request and sheet summary errors', async () => {
     const projectIds = Array.from({ length: 61 }, (_, index) => `project-${index + 1}`);
     const canonical = {
       version: '1',
@@ -621,10 +616,13 @@ describe('JVM weekly API BFF proxy', () => {
     }));
     const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { env: runtimeEnv });
 
-    await request(app)
+    const response = await request(app)
       .post('/api/v1/cashflow/weekly-overview')
       .send({ projectIds, yearMonth: '2026-08' })
-      .expect(200, canonical);
+      .expect(200);
+
+    expect(response.body).toMatchObject({ version: '2', yearMonth: '2026-08', items: canonical.items });
+    expect(response.body.errors).toHaveLength(62);
 
     expect(fetchImpl).toHaveBeenCalledOnce();
     expect(fetchImpl).toHaveBeenCalledWith(
@@ -673,21 +671,6 @@ describe('JVM weekly API BFF proxy', () => {
         expect(response.body.code).toBe('cashflow_projection_actual_summary_request_invalid');
       });
     expect(fetchImpl).not.toHaveBeenCalled();
-  });
-
-  it('keeps canonical batch transport failures bounded', async () => {
-    const fetchImpl = vi.fn(async (_url, init) => new Promise((_resolve, reject) => {
-      init.signal.addEventListener('abort', () => reject(Object.assign(new Error('aborted'), { name: 'AbortError' })));
-    }));
-    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { jvmWeeklyApiTimeoutMs: 5 });
-
-    await request(app)
-      .post('/api/v1/cashflow/projection-actual-summary/batch')
-      .send({ projectIds: ['project-a'] })
-      .expect(503)
-      .expect((response) => {
-        expect(response.body.code).toBe('jvm_weekly_api_unreachable');
-      });
   });
 
   it('rejects only weekly-expense writers before the JVM when their edit lease is missing', async () => {
@@ -1314,13 +1297,6 @@ describe('JVM weekly API BFF proxy', () => {
 
   it('composes the open-month dashboard from the pinned sheet, project, and JVM state without a private draft', async () => {
     const { db, sourceRevision, targetRevision } = fullMonthCloseSource();
-    const projectionActualSummary = {
-      projectId: 'project-a',
-      fromMonth: '2023-01',
-      comparisonAsOfWeek: { yearMonth: '2026-07', weekNo: 2 },
-      settlementDifferenceAmount: 18_371_453,
-      settlementMatches: false,
-    };
     const fetchImpl = vi.fn(async () => ({
       ok: true,
       status: 200,
@@ -1329,7 +1305,6 @@ describe('JVM weekly API BFF proxy', () => {
           ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0,
           reopenCount: 0, projectWarningCount: 0, snapshot: {},
         }),
-        projectionActualSummary,
       }),
     }));
     const { app } = createApp(fetchImpl, createIdempotencyService(), {}, {
@@ -1364,13 +1339,16 @@ describe('JVM weekly API BFF proxy', () => {
             actualProgressPercent: 100,
             confirmationProgressPercent: 0,
             settlementProgressPercent: 0,
-            settlementDifferenceAmount: 18_371_453,
+            settlementDifferenceAmount: -43_962_826,
             settlementMatches: false,
             settlementCompletedWeekCount: 0,
             settlementTargetWeekCount: 5,
           },
           validation: { canClose: true, blockers: [] },
-          projectionActualSummary,
+          projectionActualSummary: {
+            projectId: 'project-a', source: 'SHEET_FORMULA', differenceAmount: -43_962_826,
+            settlementDifferenceAmount: -43_962_826, settlementMatches: false,
+          },
         });
         expect(response.body.dashboard.cells).toHaveLength(160);
         expect(response.body.dashboard.depositScheduleRows).toHaveLength(5);
@@ -1379,24 +1357,21 @@ describe('JVM weekly API BFF proxy', () => {
     expect(fetchImpl).toHaveBeenCalledTimes(1);
   });
 
-  it.each([
-    undefined,
-    { projectId: 'other-project', fromMonth: '2023-01', comparisonAsOfWeek: { yearMonth: '2026-07', weekNo: 2 }, settlementDifferenceAmount: 18_371_453, settlementMatches: false },
-  ])('fails closed when the JVM dashboard canonical projection-actual summary is unavailable or mismatched', async (projectionActualSummary) => {
+  it('does not use an unavailable JVM projection-actual summary for the month dashboard', async () => {
     const { db } = fullMonthCloseSource();
     const source = monthDashboardSource({
       ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0,
       reopenCount: 0, projectWarningCount: 0, snapshot: {},
     });
-    source.projectionActualSummary = projectionActualSummary;
+    source.projectionActualSummary = undefined;
     const { app } = createApp(vi.fn(async () => ({
       ok: true, status: 200, text: async () => JSON.stringify(source),
     })), createIdempotencyService(), {}, { env: runtimeEnv, db });
 
     await request(app)
       .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
-      .expect(502)
-      .expect((response) => expect(response.body.code).toBe('jvm_weekly_response_invalid'));
+      .expect(200)
+      .expect((response) => expect(response.body.dashboard.projectionActualSummary).toMatchObject({ source: 'SHEET_FORMULA' }));
   });
 
   it.each([

--- a/src/app/components/cashflow/CashflowWeeklyPage.tsx
+++ b/src/app/components/cashflow/CashflowWeeklyPage.tsx
@@ -141,10 +141,10 @@ function PeriodAmounts({
   if (loading) return <div className="mt-1 text-[9px] text-slate-400">금액 확인 중…</div>;
   const amounts = summary?.periods.find((item) => item.period === period);
   if (!amounts) return null;
+  if (amounts.differenceAmount === null) return <div className="mt-1 text-[9px] text-slate-400">시트값 없음</div>;
   return (
-    <div className="mt-1 space-y-0.5 text-[9px] leading-tight text-slate-500 tabular-nums">
-      <div>P {amounts.projectionAmount.toLocaleString('ko-KR')}원 · A {amounts.actualAmount.toLocaleString('ko-KR')}원</div>
-      <div className="font-semibold text-slate-700">P-A {amounts.projectionActualDifferenceAmount.toLocaleString('ko-KR')}원</div>
+    <div className="mt-1 text-[9px] leading-tight text-slate-500 tabular-nums">
+      <div className="font-semibold text-slate-700">P-A {amounts.differenceAmount.toLocaleString('ko-KR')}원</div>
     </div>
   );
 }

--- a/src/app/components/cashflow/useCashflowProjectionActualSummaries.test.ts
+++ b/src/app/components/cashflow/useCashflowProjectionActualSummaries.test.ts
@@ -3,11 +3,11 @@ import { mergeCashflowProjectionActualSummaryBatch } from './useCashflowProjecti
 
 const summary = (projectId: string, amount = 18_371_453) => ({
   projectId,
+  source: 'SHEET_FORMULA' as const,
+  sourceRevision: 'source-revision',
   fromMonth: '2023-01',
   comparisonAsOfWeek: { yearMonth: '2026-08', weekNo: 4 },
-  projectionAmount: amount,
-  actualAmount: 0,
-  projectionActualDifferenceAmount: amount,
+  differenceAmount: amount,
   settlementDifferenceAmount: amount,
   settlementMatches: amount === 0,
   periods: [],
@@ -19,7 +19,7 @@ describe('mergeCashflowProjectionActualSummaryBatch', () => {
     const result = mergeCashflowProjectionActualSummaryBatch(
       { summaries: {}, errors: {} },
       ids,
-      { version: '1', items: ids.slice(0, 9).map((id) => summary(id)), errors: [{ projectId: 'p10', code: 'SUMMARY_UNAVAILABLE' }] },
+      { version: '2', items: ids.slice(0, 9).map((id) => summary(id)), errors: [{ projectId: 'p10', code: 'SUMMARY_UNAVAILABLE' }] },
     );
     expect(Object.keys(result.summaries)).toHaveLength(9);
     expect(result.errors).toMatchObject({ p1: false, p9: false, p10: true });
@@ -30,7 +30,7 @@ describe('mergeCashflowProjectionActualSummaryBatch', () => {
     const result = mergeCashflowProjectionActualSummaryBatch(
       { summaries: { p1: retained }, errors: { p1: false } },
       ['p1'],
-      { version: '1', items: [], errors: [{ projectId: 'p1', code: 'SUMMARY_UNAVAILABLE' }] },
+      { version: '2', items: [], errors: [{ projectId: 'p1', code: 'SUMMARY_UNAVAILABLE' }] },
     );
     expect(result.summaries.p1).toBe(retained);
     expect(result.errors.p1).toBe(true);
@@ -41,7 +41,7 @@ describe('mergeCashflowProjectionActualSummaryBatch', () => {
     const result = mergeCashflowProjectionActualSummaryBatch(
       { summaries: { p0: retained }, errors: {} },
       ['p1', 'p2'],
-      { version: '1', items: [summary('p1')], errors: [] },
+      { version: '2', items: [summary('p1')], errors: [] },
     );
     expect(result.summaries).toMatchObject({ p0: retained, p1: summary('p1') });
     expect(result.errors).toMatchObject({ p1: false, p2: true });

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -140,16 +140,16 @@ describe('platform-bff-client', () => {
     expect(result).toEqual(data);
   });
 
-  it('posts project IDs and the selected month to the canonical JVM projection-actual summary adapter unchanged', async () => {
+  it('posts project IDs and the selected month to the sheet-formula projection-actual summary adapter', async () => {
     const data = {
-      version: '1',
+      version: '2',
       items: Array.from({ length: 9 }, (_, index) => ({
         projectId: `p00${index + 1}`, fromMonth: '2023-01',
         comparisonAsOfWeek: { yearMonth: '2026-08', weekNo: 4 },
-        projectionAmount: 30_000_000 + index, actualAmount: 20_000_000 + index,
-        projectionActualDifferenceAmount: 10_000_000,
+        source: 'SHEET_FORMULA' as const, sourceRevision: `source-${index}`,
+        differenceAmount: 10_000_000,
         settlementDifferenceAmount: 18_371_453 + index, settlementMatches: false,
-        periods: [{ period: 'MONTH' as const, projectionAmount: 30_000_000 + index, actualAmount: 20_000_000 + index, projectionActualDifferenceAmount: 10_000_000 }],
+        periods: [{ period: 'MONTH' as const, differenceAmount: 10_000_000 }],
       })),
       errors: [{ projectId: 'p010', code: 'SUMMARY_UNAVAILABLE' as const }],
     };

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -1418,18 +1418,16 @@ export interface CashflowSettlementStatusesBatchResult {
 
 export interface CashflowProjectionActualSummary {
   projectId: string;
+  source: 'SHEET_FORMULA';
+  sourceRevision: string;
   fromMonth: string;
   comparisonAsOfWeek: { yearMonth: string; weekNo: number };
-  projectionAmount: number;
-  actualAmount: number;
-  projectionActualDifferenceAmount: number;
+  differenceAmount: number;
   settlementDifferenceAmount: number;
   settlementMatches: boolean;
   periods: Array<{
     period: CashflowSettlementPeriod;
-    projectionAmount: number;
-    actualAmount: number;
-    projectionActualDifferenceAmount: number;
+    differenceAmount: number | null;
   }>;
 }
 
@@ -3079,19 +3077,19 @@ export async function fetchCashflowProjectionActualSummariesViaBff(params: {
   const requestedIds = new Set(params.projectIds);
   const itemIds = Array.isArray(result?.items) ? result.items.map((item) => item?.projectId) : [];
   const errorIds = Array.isArray(result?.errors) ? result.errors.map((error) => error?.projectId) : [];
-  if (typeof result?.version !== 'string'
+  if (result?.version !== '2'
     || !Array.isArray(result?.items)
     || result.items.length > params.projectIds.length
     || itemIds.some((projectId) => !requestedIds.has(projectId))
     || new Set(itemIds).size !== itemIds.length
-    || result.items.some((item) => !Number.isFinite(item?.projectionAmount)
-      || !Number.isFinite(item?.actualAmount)
-      || !Number.isFinite(item?.projectionActualDifferenceAmount)
+    || result.items.some((item) => item?.source !== 'SHEET_FORMULA'
+      || typeof item?.sourceRevision !== 'string'
+      || !Number.isFinite(item?.differenceAmount)
+      || !Number.isFinite(item?.settlementDifferenceAmount)
+      || typeof item?.settlementMatches !== 'boolean'
       || !Array.isArray(item?.periods)
       || item.periods.some((period) => !['MONTH', 'WEEK_1', 'WEEK_2', 'WEEK_3', 'WEEK_4', 'WEEK_5'].includes(period?.period)
-        || !Number.isFinite(period?.projectionAmount)
-        || !Number.isFinite(period?.actualAmount)
-        || !Number.isFinite(period?.projectionActualDifferenceAmount)))
+        || (period?.differenceAmount !== null && !Number.isFinite(period?.differenceAmount))))
     || !Array.isArray(result?.errors)
     || result.errors.length > params.projectIds.length
     || result.errors.some((error) => error?.code !== 'SUMMARY_UNAVAILABLE' || !requestedIds.has(error?.projectId))


### PR DESCRIPTION
## Summary\n- read cumulative and weekly P-A values directly from the synced cashflow sheet formula mirror\n- remove JVM ledger-derived P/A values from the company dashboard response\n- render only the direct P-A formula value in the company weekly table\n\n## Verification\n- npx vitest run server/bff/routes/jvm-weekly-api.test.mjs src/app/lib/platform-bff-client.test.ts --reporter=dot\n- npm run typecheck -- --pretty false\n- git diff --check