### PR TITLE
fix: rename cashflow approval navigation

### DIFF
--- a/src/app/platform/admin-foundation.shell.test.ts
+++ b/src/app/platform/admin-foundation.shell.test.ts
@@ -14,11 +14,11 @@ const routesSource = readFileSync(
 );
 
 describe('admin navigation shell contract', () => {
-  it('exposes the weekly history and management-planning entry paths', () => {
+  it('exposes the cashflow approval and management-planning entry paths', () => {
     expect(navConfigSource).not.toContain("label: '기능 검색'");
     expect(navConfigSource).toContain("to: '/dashboard'");
     expect(navConfigSource).toContain("to: '/cashflow'");
-    expect(navConfigSource).toContain("label: '주간 입력 이력'");
+    expect(navConfigSource).toContain("label: '현금흐름 승인'");
     expect(navConfigSource).toContain("to: '/cashflow/export'");
     expect(navConfigSource).toContain("label: '프로젝트 등록/승인'");
     expect(navConfigSource).toContain("to: '/management-planning/project-codes'");

--- a/src/app/platform/nav-config.ts
+++ b/src/app/platform/nav-config.ts
@@ -29,7 +29,7 @@ export const NAV_GROUPS: NavGroup[] = [
     items: [
       { to: '/projects', icon: FolderKanban, label: '통합 관리' },
       { to: '/projects/migration-audit', icon: ArrowLeftRight, label: '프로젝트 등록/승인' },
-      { to: '/cashflow', icon: BarChart3, label: '주간 입력 이력' },
+      { to: '/cashflow', icon: BarChart3, label: '현금흐름 승인' },
       { to: '/participation', icon: Shield, label: '참여율 대시보드' },
     ],
   },


### PR DESCRIPTION
## Summary
- rename the /cashflow navigation label to 현금흐름 승인
- preserve the existing /cashflow route and shared weekly overview data path

## Verification
- npx vitest run src/app/platform/admin-foundation.shell.test.ts src/app/components/cashflow/useCashflowProjectionActualSummaries.test.ts --reporter=dot
- npm run typecheck -- --pretty false
- git diff --check