### PR TITLE
fix: hide actor UID in weekly cashflow Slack alerts

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -3170,7 +3170,14 @@ export function mountJvmWeeklyApiRoutes(app, {
       },
       { cashflowWrite: true },
     );
-    notifyCashflowSlack(`*[MYSCube] 주정산 완료*\n프로젝트: ${projectId}\n대상: ${hasExplicitScope ? requestedYearMonth : boundary.asOfWeek.yearMonth} ${hasExplicitScope ? requestedWeekNo : boundary.asOfWeek.weekNo}주차\n처리자: ${req.context.actorId}`);
+    void Promise.resolve().then(async () => {
+      const { requestedByName } = await readCashflowRequestPartyNames({
+        db,
+        tenantId: req.context.tenantId,
+        record: { requestedByUid: req.context.actorId },
+      });
+      notifyCashflowSlack(`*[MYSCube] 주정산 완료*\n프로젝트: ${projectId}\n대상: ${hasExplicitScope ? requestedYearMonth : boundary.asOfWeek.yearMonth} ${hasExplicitScope ? requestedWeekNo : boundary.asOfWeek.weekNo}주차\n처리자: ${requestedByName || '미확인'}`);
+    }).catch(() => {});
     res.status(200).json(result);
   }));
 

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -1558,8 +1558,9 @@ describe('JVM weekly API BFF proxy', () => {
         nextCursor: '', onTimeCount: completion ? 1 : 0, missedCount: 0,
       };
     };
+    const cashflowSlackService = { enabled: true, notifyMessage: vi.fn().mockResolvedValue(undefined) };
     const { app } = createApp(fetchImpl, createIdempotencyService(), { actorRole: 'viewer' }, {
-      env: runtimeEnv, db: source.db, weeklyComplianceResponse,
+      env: runtimeEnv, db: source.db, weeklyComplianceResponse, cashflowSlackService,
       now: () => new Date('2026-07-16T09:00:00.000Z'),
     });
 
@@ -1570,6 +1571,14 @@ describe('JVM weekly API BFF proxy', () => {
       .expect((response) => expect(response.body).toMatchObject({
         projectId: 'project-a', yearMonth: '2026-07', weekNo: 3, alreadyCompleted: false,
       }));
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(cashflowSlackService.notifyMessage).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('처리자: Project Manager'),
+    }));
+    expect(cashflowSlackService.notifyMessage).not.toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('처리자: pm-1'),
+    }));
 
     const saved = source.documents.get('orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w3');
     expect(saved).toMatchObject({ projectId: 'project-a', yearMonth: '2026-07', weekNo: 3 });


### PR DESCRIPTION
## Summary
- resolve the weekly settlement actor through the active member profile
- show the member name or 미확인, never the raw UID
- preserve non-blocking Slack delivery behavior

## Verification
- npx vitest run server/bff/routes/jvm-weekly-api.test.mjs --reporter=dot
- git diff --check