### PR TITLE
fix(projects): 팀원 후보가 비지 않도록 인력 명부를 안전망으로 되살린다

### DIFF
--- a/src/app/components/portal/PortalProjectEdit.tsx
+++ b/src/app/components/portal/PortalProjectEdit.tsx
@@ -14,6 +14,7 @@ import {
 import { toast } from 'sonner';
 import { useAuth } from '../../data/auth-store';
 import { useProjectDepartmentSettings } from '../../data/project-department-settings';
+import { usePersonRoster } from '../../data/use-person-roster';
 import { usePortalStore } from '../../data/portal-store';
 import type { FileAttachment, Project, ProjectRequest } from '../../data/types';
 import { getAuthInstance } from '../../lib/firebase';
@@ -235,6 +236,7 @@ function ProjectInfoEditor({
   departmentOptions,
   draftClient,
   members,
+  roster,
   project,
   requestDoc,
   settlementSystemOptions,
@@ -245,6 +247,7 @@ function ProjectInfoEditor({
   departmentOptions: string[];
   draftClient: DraftClient;
   members: ReturnType<typeof usePortalStore>['members'];
+  roster: ReturnType<typeof usePersonRoster>;
   project: Project;
   requestDoc: ProjectRequest | null;
   settlementSystemOptions: string[];
@@ -652,6 +655,7 @@ function ProjectInfoEditor({
         initialDraft={initialDraft}
         draftKey={autosaveKey}
         members={members}
+        roster={roster}
         departmentOptions={departmentOptions}
         settlementSystemOptions={settlementSystemOptions}
         topSlot={topSlot}
@@ -756,6 +760,7 @@ export function PortalProjectEdit() {
   const { user } = useAuth();
   const { orgId } = useFirebase();
   const { activeProjectId, isLoading: portalLoading, members, myProject: sessionProject, projects } = usePortalStore();
+  const roster = usePersonRoster();
   const { options: departmentOptions } = useProjectDepartmentSettings();
   const routeProject = routeProjectId ? projects.find((project) => project.id === routeProjectId) || null : null;
   const fallbackProject = projects.find((project) => project.id === activeProjectId) || sessionProject;
@@ -881,6 +886,7 @@ export function PortalProjectEdit() {
       departmentOptions={departmentOptions}
       draftClient={bootstrap.draftClient}
       members={members}
+      roster={roster}
       project={project}
       requestDoc={requestDoc}
       settlementSystemOptions={projects.flatMap((item) => item.settlementSystem === 'OTHER' && item.settlementSystemOther && !item.trashedAt ? [item.settlementSystemOther] : [])}

--- a/src/app/components/portal/PortalProjectRegister.tsx
+++ b/src/app/components/portal/PortalProjectRegister.tsx
@@ -4,6 +4,7 @@ import { CheckCircle2, Clock3, LockKeyhole, Pencil, Send } from 'lucide-react';
 import { toast } from 'sonner';
 import { useAuth } from '../../data/auth-store';
 import { useProjectDepartmentSettings } from '../../data/project-department-settings';
+import { usePersonRoster } from '../../data/use-person-roster';
 import { usePortalStore } from '../../data/portal-store';
 import type { FileAttachment } from '../../data/types';
 import { getAuthInstance } from '../../lib/firebase';
@@ -79,6 +80,7 @@ function RegistrationEditor({
   const navigate = useNavigate();
   const { orgId } = useFirebase();
   const { members, projects } = usePortalStore();
+  const roster = usePersonRoster();
   const { options: departmentOptions } = useProjectDepartmentSettings();
   const [record, setRecord] = useState(initialRecord);
   const [busyActionId, setBusyActionId] = useState<string | null>(null);
@@ -282,6 +284,7 @@ function RegistrationEditor({
         initialDraft={editorDraft}
         draftKey={`portal-register-${record.draftId}`}
         members={members}
+        roster={roster}
         departmentOptions={departmentOptions}
         settlementSystemOptions={projects.flatMap((project) => project.settlementSystem === 'OTHER' && project.settlementSystemOther && !project.trashedAt ? [project.settlementSystemOther] : [])}
         topSlot={topSlot}

--- a/src/app/components/projects/ProjectEditorWizard.shell.test.ts
+++ b/src/app/components/projects/ProjectEditorWizard.shell.test.ts
@@ -127,7 +127,9 @@ describe('ProjectEditorWizard dropdown contract', () => {
   it('uses a searchable team member picker for registration and edit flows', () => {
     expect(source).toContain('function TeamMemberSearchCombobox');
     expect(source).toContain('<CommandInput placeholder="이름/닉네임으로 검색" />');
-    expect(source).toContain('buildProjectTeamMemberOptions(members)');
+    // 후보의 출처는 계정 원장(members)이고, roster 는 계정 목록이 비었을 때의 안전망이다.
+    // 포털 등록 화면은 members 가 [] 로 시작하므로 roster 가 빠지면 팀원을 아예 못 고른다.
+    expect(source).toContain('buildProjectTeamMemberOptions(members, roster)');
     expect(source).toContain('options.length}명 중 검색');
     expect(source).toContain('options={availableTeamMemberOptions}');
     expect(source).toContain('<TeamMemberSearchCombobox');

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -55,6 +55,7 @@ import {
   type SettlementSystemCode,
 } from '../../data/types';
 import { PROJECT_DEPARTMENT_OPTIONS, dedupeProjectDepartmentLabels } from '../../data/project-department-options';
+import type { DirectoryPerson } from '../../platform/person-directory';
 import {
   buildProjectTeamMemberOptions,
   type ProjectTeamMemberOption,
@@ -158,6 +159,8 @@ interface ProjectEditorWizardProps {
   description?: string;
   embeddedInShell?: boolean;
   members?: OrgMember[];
+  /** 인력 명부. 계정 목록을 못 받았을 때 팀원 후보의 안전망이 된다. */
+  roster?: DirectoryPerson[];
   departmentOptions?: string[];
   settlementSystemOptions?: string[];
   topSlot?: ReactNode;
@@ -606,6 +609,7 @@ export function ProjectEditorWizard({
   description,
   embeddedInShell = false,
   members = [],
+  roster = [],
   departmentOptions,
   settlementSystemOptions = [],
   topSlot,
@@ -1003,9 +1007,12 @@ export function ProjectEditorWizard({
   const teamMembersSummary = formatProjectTeamMembersSummary(draft.teamMembersDetailed, '', '\n');
   const projectTypeOptions = getProjectTypeSelectableOptions(draft.type);
   const contractTypeOptions = getProjectContractTypeSelectableOptions(draft.contractType);
-  // 후보 목록의 출처는 계정 원장(members) 이다 - 지금 동작 그대로다.
-  // 인력 명부(persons) 기반 디렉터리는 안정화 후 2단계에서 연결한다.
-  const teamMemberOptions = useMemo(() => buildProjectTeamMemberOptions(members), [members]);
+  // 후보 목록의 출처는 계정 원장(members) 이다. roster 는 계정 목록이 아직/영영 안 왔을 때만
+  // 쓰이는 안전망이고, 별명이 빈 계정 문서의 표시 이름을 채우는 데도 쓴다.
+  const teamMemberOptions = useMemo(
+    () => buildProjectTeamMemberOptions(members, roster),
+    [members, roster],
+  );
   const teamMemberOptionMap = useMemo(() => Object.fromEntries(
     teamMemberOptions.map((option) => [option.value, option]),
   ) as Record<string, ProjectTeamMemberOption>, [teamMemberOptions]);

--- a/src/app/components/projects/ProjectWizard.tsx
+++ b/src/app/components/projects/ProjectWizard.tsx
@@ -99,7 +99,7 @@ function createProjectFromDraft(
 
 export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: ProjectWizardProps) {
   const navigate = useNavigate();
-  const { addProject, updateProject, upsertMember, members, projects, currentUser } = useAppStore();
+  const { addProject, updateProject, upsertMember, members, projects, currentUser, persons } = useAppStore();
   const { orgId } = useFirebase();
   const { options: departmentOptions } = useProjectDepartmentSettings();
   const [busyActionId, setBusyActionId] = useState<string | null>(null);
@@ -217,6 +217,7 @@ export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: Projec
       initialDraft={initialDraft}
       draftKey={`admin-${editProject?.id || 'new'}-${editProject?.updatedAt || initialPhase}`}
       members={members}
+      roster={persons}
       departmentOptions={departmentOptions}
       settlementSystemOptions={projects.flatMap((project) => project.settlementSystem === 'OTHER' && project.settlementSystemOther && !project.trashedAt ? [project.settlementSystemOther] : [])}
       actions={editProject ? [

--- a/src/app/data/project-team-member-options.test.ts
+++ b/src/app/data/project-team-member-options.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'vitest';
-import { buildPersonDirectory } from '../platform/person-directory';
 import {
   buildProjectTeamMemberOptions,
   buildTeamMemberDirectory,
@@ -12,11 +11,11 @@ import {
  * 어떻게 동작하는가"와 "명부가 없어도 사람을 고를 수 있는가"를 지킨다.
  */
 
-const directory = buildPersonDirectory([
+const roster = [
   { personId: 'psn-mwbyun1220', name: '변민욱', nickname: '보람' },
   { personId: 'psn-jypark', name: '박지연', nickname: '느티' },
   { personId: 'psn-sykim', name: '김소영', nickname: '소이' },
-]);
+];
 
 describe('project-team-member-options', () => {
   it('후보 목록의 출처는 계정 원장이고, 비활성 계정은 뺀다', () => {
@@ -24,7 +23,7 @@ describe('project-team-member-options', () => {
       { uid: 'u-boram', name: '변민욱', email: 'boram@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
       { uid: 'u-new', name: '신규구성원(새별)', email: 'new@mysc.co.kr', role: 'viewer', status: 'ACTIVE' },
       { uid: 'u-left', name: '퇴사자', email: 'left@mysc.co.kr', role: 'viewer', status: 'INACTIVE' },
-    ], directory);
+    ], roster);
 
     expect(options).toEqual([
       expect.objectContaining({ name: '변민욱', nickname: '보람', label: '변민욱(보람)' }),
@@ -36,21 +35,21 @@ describe('project-team-member-options', () => {
   it('명부에만 있고 계정이 없는 사람은 후보에 넣지 않는다 — 고르면 배정이 계정과 어긋난다', () => {
     const options = buildProjectTeamMemberOptions([
       { uid: 'u-boram', name: '변민욱', email: 'boram@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
-    ], directory);
+    ], roster);
     expect(options.map((option) => option.name)).not.toContain('박지연');
   });
 
   it('계정 문서에 별명이 없으면 명부에서 채운다', () => {
     const options = buildProjectTeamMemberOptions([
       { uid: 'u-boram', name: '변민욱', email: 'boram@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
-    ], directory);
+    ], roster);
     expect(options[0]).toMatchObject({ nickname: '보람', label: '변민욱(보람)' });
   });
 
   it('계정 문서의 별명이 명부보다 우선한다 — 본인이 고친 값이 이긴다', () => {
     const options = buildProjectTeamMemberOptions([
       { uid: 'u-boram', name: '변민욱', nickname: '민욱', email: 'boram@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
-    ], directory);
+    ], roster);
     expect(options[0]).toMatchObject({ nickname: '민욱', label: '변민욱(민욱)' });
   });
 
@@ -63,13 +62,34 @@ describe('project-team-member-options', () => {
     expect(options[0].nickname).toBe('');
   });
 
-  it('계정이 하나도 없으면 빈 목록이다 — 코드에 박힌 명단으로 되돌아가지 않는다', () => {
-    expect(buildProjectTeamMemberOptions([], directory)).toEqual([]);
+  it('계정 목록을 못 받으면 인력 명부로 후보를 만든다 — 빈 목록이면 팀원을 아예 못 고른다', () => {
+    const options = buildProjectTeamMemberOptions([], roster);
+    expect(options.map((option) => option.label)).toEqual(['김소영(소이)', '박지연(느티)', '변민욱(보람)']);
+  });
+
+  it('계정이 전부 비활성이어도 같은 안전망을 쓴다', () => {
+    const options = buildProjectTeamMemberOptions([
+      { uid: 'u-left', name: '퇴사자', email: 'left@mysc.co.kr', role: 'viewer', status: 'INACTIVE' },
+    ], roster);
+    expect(options.length).toBe(3);
+  });
+
+  it('명부도 계정도 없으면 빈 목록이다 — 코드에 박힌 명단으로 되돌아가지 않는다', () => {
+    expect(buildProjectTeamMemberOptions([], [])).toEqual([]);
+  });
+
+  it('후보 라벨은 항상 이름(별명) 으로 정규화된다', () => {
+    const options = buildProjectTeamMemberOptions([
+      { uid: 'a', name: '변민욱', email: 'a@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
+      { uid: 'b', name: '김소영(소이)', email: 'b@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
+      { uid: 'c', name: '박지연', nickname: '느티', email: 'c@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
+    ], roster);
+    expect(options.map((option) => option.label)).toEqual(['김소영(소이)', '박지연(느티)', '변민욱(보람)']);
   });
 
   it('실명·별명·표시 라벨 어느 쪽으로 물어도 같은 사람을 찾는다', () => {
-    expect(findProjectTeamMemberOption('박지연', directory)?.nickname).toBe('느티');
-    expect(findProjectTeamMemberOption('김소영(소이)', directory)?.name).toBe('김소영');
+    expect(findProjectTeamMemberOption('박지연', buildTeamMemberDirectory(roster))?.nickname).toBe('느티');
+    expect(findProjectTeamMemberOption('김소영(소이)', buildTeamMemberDirectory(roster))?.name).toBe('김소영');
   });
 
   it('명부 없이 물으면 표시 라벨에 들어있는 별명만 쓴다', () => {

--- a/src/app/data/project-team-member-options.ts
+++ b/src/app/data/project-team-member-options.ts
@@ -1,4 +1,9 @@
-import { buildPersonDirectory, EMPTY_PERSON_DIRECTORY, type PersonDirectory } from '../platform/person-directory';
+import {
+  buildPersonDirectory,
+  EMPTY_PERSON_DIRECTORY,
+  type DirectoryPerson,
+  type PersonDirectory,
+} from '../platform/person-directory';
 import type { OrgMember, Project } from './types';
 
 function memberLabel(name: string, nickname: string): string {
@@ -44,11 +49,33 @@ export function splitMemberDisplayName(value: string): { name: string; nickname:
   return { name: match[1].trim(), nickname: match[2].trim() };
 }
 
+/** 인력 명부 레코드를 그대로 후보로 만든다. 배정에는 이름·별명만 저장되므로 계정이 없어도 고를 수 있다. */
+function rosterOptions(roster: DirectoryPerson[]): ProjectTeamMemberOption[] {
+  const options = new Map<string, ProjectTeamMemberOption>();
+  roster.forEach((person) => {
+    const name = String(person?.name || '').trim();
+    if (!name) return;
+    const nickname = String(person?.nickname || '').trim();
+    const key = name.toLowerCase();
+    if (options.has(key)) return;
+    options.set(key, { value: name, name, nickname, label: memberLabel(name, nickname) });
+  });
+  return [...options.values()].sort((left, right) => left.label.localeCompare(right.label, 'ko'));
+}
+
+/**
+ * 팀원 후보 목록.
+ *
+ * 출처는 계정 원장(members)이다. 다만 계정 목록이 아직 안 왔거나 못 읽었을 때 빈 목록을
+ * 돌려주면 사람이 팀원을 아예 못 고른다 - 포털 등록 화면은 members 가 [] 로 시작한다.
+ * 그럴 때는 인력 명부(roster)로 후보를 만든다. 화면이 멈추는 것보다 낫다.
+ */
 export function buildProjectTeamMemberOptions(
   members: OrgMember[],
-  directory: PersonDirectory = EMPTY_PERSON_DIRECTORY,
+  roster: DirectoryPerson[] = [],
 ): ProjectTeamMemberOption[] {
-  if (!members.length) return [];
+  const directory = roster.length ? buildPersonDirectory(roster) : EMPTY_PERSON_DIRECTORY;
+  if (!members.length) return rosterOptions(roster);
 
   const options = new Map<string, ProjectTeamMemberOption>();
   members.forEach((member) => {
@@ -69,8 +96,10 @@ export function buildProjectTeamMemberOptions(
     });
   });
 
-  return [...options.values()]
+  const liveOptions = [...options.values()]
     .sort((left, right) => left.label.localeCompare(right.label, 'ko'));
+  // 계정이 전부 비활성이거나 uid 가 없어 한 명도 안 남는 경우도 같은 안전망을 쓴다.
+  return liveOptions.length ? liveOptions : rosterOptions(roster);
 }
 
 /** 인력 명부 레코드로 디렉터리를 만든다. 호출부가 person-directory 를 직접 몰라도 되게. */

--- a/src/app/data/use-person-roster.ts
+++ b/src/app/data/use-person-roster.ts
@@ -1,0 +1,67 @@
+import { useEffect, useState } from 'react';
+import { featureFlags } from '../config/feature-flags';
+import { useFirebase } from '../lib/firebase-context';
+import { fetchPersonsViaBff, type PersonRecord } from '../lib/platform-bff-client';
+import type { DirectoryPerson } from '../platform/person-directory';
+import { useAuth } from './auth-store';
+
+/**
+ * 인력 명부를 읽는다. 팀원 후보 목록의 안전망으로 쓴다.
+ *
+ * 포털 스토어의 members 는 [] 로 시작해서, 계정 목록이 오기 전까지 팀원 드롭다운이 빈다.
+ * 그 사이를 명부로 메운다. 실패해도 던지지 않고 빈 배열을 돌려준다 - 명부를 못 읽었다고
+ * 등록 화면이 막히면 안 된다.
+ *
+ * 한 번 읽은 결과는 모듈에 담아 둔다. 등록·수정 화면이 여러 번 열려도 다시 부르지 않는다.
+ */
+
+let cache: DirectoryPerson[] | null = null;
+let inflight: Promise<DirectoryPerson[]> | null = null;
+
+function toDirectoryPeople(items: PersonRecord[]): DirectoryPerson[] {
+  return items.map((person) => ({
+    personId: person.personId,
+    name: person.name,
+    nickname: person.nickname || '',
+  }));
+}
+
+/** 명부가 바뀌었을 때 다음 조회가 서버를 다시 보게 한다. */
+export function resetPersonRosterCache(): void {
+  cache = null;
+  inflight = null;
+}
+
+export function usePersonRoster(): DirectoryPerson[] {
+  const { user: authUser } = useAuth();
+  const { orgId } = useFirebase();
+  const [roster, setRoster] = useState<DirectoryPerson[]>(() => cache || []);
+
+  useEffect(() => {
+    if (cache) {
+      setRoster(cache);
+      return undefined;
+    }
+    if (!featureFlags.platformApiEnabled || !authUser?.idToken) return undefined;
+
+    let cancelled = false;
+    if (!inflight) {
+      inflight = fetchPersonsViaBff({ tenantId: orgId, actor: authUser })
+        .then((response) => {
+          cache = toDirectoryPeople(response.items || []);
+          return cache;
+        })
+        .catch(() => {
+          inflight = null;
+          return [];
+        });
+    }
+    void inflight.then((people) => {
+      if (!cancelled) setRoster(people);
+    });
+
+    return () => { cancelled = true; };
+  }, [orgId, authUser?.uid, authUser?.idToken]);
+
+  return roster;
+}


### PR DESCRIPTION
## 제가 낸 회귀입니다

#548 에서 직원 명부 하드코딩을 걷어내면서 `buildProjectTeamMemberOptions` 의 **폴백까지 같이 없앴습니다.**

```diff
- if (!members.length) return PROJECT_TEAM_MEMBER_OPTIONS;   // 하드코딩 87명
+ if (!members.length) return [];                            // 빈 목록
```

포털 스토어의 `members` 는 `useState<OrgMember[]>([])` 로 시작하고 현재 사용자를 얹지도 않습니다. 그래서 `/portal/register-project` 와 `/portal/edit-project` 는 **계정 목록이 오기 전까지 — 못 받으면 영영 — 팀원을 아예 고를 수 없었습니다.**

관리자 스토어는 현재 사용자를 앞에 붙이기 때문에 이 경로를 타지 않습니다. 그래서 관리자 화면만 보면 정상으로 보입니다.

## 고침

폴백을 코드가 아니라 **DB 인력 명부**(`orgs/{org}/persons`)로 되살립니다.

- 배정에는 이름·별명만 저장되므로 계정이 없는 사람(인턴 등)도 후보가 될 수 있습니다
- 계정이 전부 비활성이라 한 명도 안 남는 경우에도 같은 안전망을 씁니다
- `usePersonRoster` 는 결과를 모듈에 캐시하고, **실패해도 던지지 않고 빈 배열**을 돌려줍니다

## 보여주는 라벨은 이름(별명) 으로 정규화

계정 문서에 별명이 없으면 명부에서 채웁니다. 본인이 계정에 적어둔 별명이 명부보다 우선합니다.

## 프로덕션 실측

| | |
|---|---|
| 정상 경로 후보 | **80명 · 라벨 변화 0건** (안전망은 이 경로에 영향 없음) |
| 안전망 후보 | **91명 · 전원 별명 보유** → 폴백 화면도 100% `이름(별명)` |
| 별명 없는 후보 | `(AX) AI` 서비스 계정 **1건뿐**, 이전부터 있던 항목 |

## 검증

- `project-team-member-options` 12개 통과 — 안전망·정규화·우선순위를 새로 잠금
- `src/app/data` · `components/projects` · `components/portal` · `platform` 직렬 1,468개 통과
- 빌드 통과 / 타입 에러 기준선(234줄) 동일

> `(AX) AI` 서비스 계정이 팀원 후보로 노출되는 건 이전부터 있던 문제라 이번엔 건드리지 않았습니다. 빼는 게 맞다면 별도로 처리하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)