### PR TITLE
feat(people): 사람을 고르는 자리의 출처를 인력 명부로 일원화한다

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -94,6 +94,7 @@ import { CashflowFormulaMismatchDialog } from './CashflowFormulaMismatchDialog';
 import { CashflowCanonicalSummary } from './CashflowCanonicalSummary';
 import { MemberPicker } from '../ui/member-picker';
 import { buildOrgMemberPickerOptions } from '../../data/project-team-member-options';
+import { usePersonRoster } from '../../data/use-person-roster';
 import { loadCashflowActivitySourcesSequentially } from './cashflow-activity-loader';
 
 function previousYearMonth(yearMonth: string): string {
@@ -445,7 +446,13 @@ export function CashflowProjectSheet({
       && (lateSheetDiffWeek === 'ALL' || String(change.weekNo) === lateSheetDiffWeek)
       && (!query || `${change.yearMonth} ${change.weekNo} ${change.mode} ${label} ${change.lineId}`.toLocaleLowerCase('ko-KR').includes(query));
   });
-  const executiveApproverOptions = useMemo(() => buildOrgMemberPickerOptions(members || []), [members]);
+  // 조직장은 로그인해서 승인해야 하므로 계정이 필수지만, 명부에 없는 사람(퇴사 후 계정이
+  // 남은 경우)은 후보에서 빠져야 한다. 명부는 문지기로만 쓴다.
+  const approverRoster = usePersonRoster();
+  const executiveApproverOptions = useMemo(
+    () => buildOrgMemberPickerOptions(members || [], approverRoster),
+    [members, approverRoster],
+  );
 
   useEffect(() => {
     const approverId = project?.executiveApproverId || '';

--- a/src/app/components/projects/ProjectEditorWizard.shell.test.ts
+++ b/src/app/components/projects/ProjectEditorWizard.shell.test.ts
@@ -120,16 +120,19 @@ describe('ProjectEditorWizard dropdown contract', () => {
     );
     expect(optionsSource).toContain("if (status === 'INACTIVE' || status === 'DELETED') return;");
     expect(optionsSource).not.toContain("=== 'ACTIVE'");
-    expect(source).toContain('buildOrgMemberPickerOptions(members)');
+    expect(source).toContain('buildOrgMemberPickerOptions(members, roster)');
     expect(source).toContain('const executiveApproverOptions = useMemo');
   });
 
   it('uses a searchable team member picker for registration and edit flows', () => {
     expect(source).toContain('function TeamMemberSearchCombobox');
     expect(source).toContain('<CommandInput placeholder="이름/닉네임으로 검색" />');
-    // 후보의 출처는 계정 원장(members)이고, roster 는 계정 목록이 비었을 때의 안전망이다.
-    // 포털 등록 화면은 members 가 [] 로 시작하므로 roster 가 빠지면 팀원을 아예 못 고른다.
-    expect(source).toContain('buildProjectTeamMemberOptions(members, roster)');
+    // 후보의 출처는 인력 명부(roster) 하나다. 계정 원장을 출처로 쓰면 퇴사 후 계정이
+    // 남은 사람이 계속 뜨고, 명부에만 있는 사람은 안 뜬다. members 는 명부를 못 읽었을
+    // 때의 안전망으로만 남는다.
+    expect(source).toContain('buildProjectTeamMemberOptions(roster, members)');
+    // PM·조직장은 계정이 필수라 계정 원장이 출처지만, 명부가 문지기 역할을 한다.
+    expect(source).toContain('buildOrgMemberPickerOptions(members, roster)');
     expect(source).toContain('options.length}명 중 검색');
     expect(source).toContain('options={availableTeamMemberOptions}');
     expect(source).toContain('<TeamMemberSearchCombobox');

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -1007,11 +1007,11 @@ export function ProjectEditorWizard({
   const teamMembersSummary = formatProjectTeamMembersSummary(draft.teamMembersDetailed, '', '\n');
   const projectTypeOptions = getProjectTypeSelectableOptions(draft.type);
   const contractTypeOptions = getProjectContractTypeSelectableOptions(draft.contractType);
-  // 후보 목록의 출처는 계정 원장(members) 이다. roster 는 계정 목록이 아직/영영 안 왔을 때만
-  // 쓰이는 안전망이고, 별명이 빈 계정 문서의 표시 이름을 채우는 데도 쓴다.
+  // 팀원 후보의 출처는 인력 명부(roster) 하나다. 배정에는 이름·별명만 저장되므로 계정이
+  // 없어도 되고, 인턴은 근로형태로 걸러진다. members 는 명부를 못 읽었을 때의 안전망.
   const teamMemberOptions = useMemo(
-    () => buildProjectTeamMemberOptions(members, roster),
-    [members, roster],
+    () => buildProjectTeamMemberOptions(roster, members),
+    [roster, members],
   );
   const teamMemberOptionMap = useMemo(() => Object.fromEntries(
     teamMemberOptions.map((option) => [option.value, option]),
@@ -1019,7 +1019,12 @@ export function ProjectEditorWizard({
   // The ledger list decides whether a stored value is still linked, so the "not in the
   // member ledger" warning keeps working. The picker lists carry the stored value on top
   // of it so opening an old project never silently drops its owner or approver.
-  const ledgerMemberOptions = useMemo(() => buildOrgMemberPickerOptions(members), [members]);
+  // PM·최종 결재자는 로그인해서 승인해야 하므로 계정이 필수다. 명부는 문지기로만 쓴다 -
+  // 명부에 없는 사람(퇴사 후 계정이 남은 경우, 서비스 계정)은 후보에서 빠진다.
+  const ledgerMemberOptions = useMemo(
+    () => buildOrgMemberPickerOptions(members, roster),
+    [members, roster],
+  );
   const ownerOptions = useMemo(
     () => withSavedOrgMemberOption(ledgerMemberOptions, {
       uid: draft.registeredById,

--- a/src/app/components/projects/ProjectWizard.tsx
+++ b/src/app/components/projects/ProjectWizard.tsx
@@ -99,7 +99,7 @@ function createProjectFromDraft(
 
 export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: ProjectWizardProps) {
   const navigate = useNavigate();
-  const { addProject, updateProject, upsertMember, members, projects, currentUser, persons } = useAppStore();
+  const { addProject, updateProject, upsertMember, members, projects, currentUser, personRoster } = useAppStore();
   const { orgId } = useFirebase();
   const { options: departmentOptions } = useProjectDepartmentSettings();
   const [busyActionId, setBusyActionId] = useState<string | null>(null);
@@ -217,7 +217,7 @@ export function ProjectWizard({ editProject, initialPhase = 'PROSPECT' }: Projec
       initialDraft={initialDraft}
       draftKey={`admin-${editProject?.id || 'new'}-${editProject?.updatedAt || initialPhase}`}
       members={members}
-      roster={persons}
+      roster={personRoster}
       departmentOptions={departmentOptions}
       settlementSystemOptions={projects.flatMap((project) => project.settlementSystem === 'OTHER' && project.settlementSystemOther && !project.trashedAt ? [project.settlementSystemOther] : [])}
       actions={editProject ? [

--- a/src/app/data/project-team-member-options.structured-name.test.ts
+++ b/src/app/data/project-team-member-options.structured-name.test.ts
@@ -45,8 +45,10 @@ describe('display name comes from the roster fields', () => {
     expect(option.label).toBe('하송희(솔)');
   });
 
-  it('applies the same rule to the team member picker', () => {
-    const options = buildProjectTeamMemberOptions([
+  it('applies the same rule to the team member picker fallback', () => {
+    // 팀원 후보의 출처는 인력 명부지만, 명부를 못 읽었을 때 쓰는 계정 원장 경로에도
+    // 같은 이름 정규화가 적용되어야 한다.
+    const options = buildProjectTeamMemberOptions([], [
       member({ uid: 'u1', name: 'Inhyo Ko (베리)', nameKo: '고인효', nickname: '베리' }),
     ]);
     expect(options[0].label).toBe('고인효(베리)');
@@ -54,7 +56,7 @@ describe('display name comes from the roster fields', () => {
   });
 
   it('keeps one entry per person when both documents disagree on the combined string', () => {
-    const options = buildProjectTeamMemberOptions([
+    const options = buildProjectTeamMemberOptions([], [
       member({ uid: 'u1', name: 'Jeongtae KIM (Able)', nameKo: '김정태', nickname: '에이블' }),
       member({ uid: 'u2', name: '김정태(에이블)', nameKo: '김정태', nickname: '에이블' }),
     ]);

--- a/src/app/data/project-team-member-options.test.ts
+++ b/src/app/data/project-team-member-options.test.ts
@@ -1,95 +1,127 @@
 import { describe, expect, it } from 'vitest';
+import type { DirectoryPerson } from '../platform/person-directory';
+import type { OrgMember } from './types';
 import {
+  buildOrgMemberPickerOptions,
   buildProjectTeamMemberOptions,
   buildTeamMemberDirectory,
   findProjectTeamMemberOption,
 } from './project-team-member-options';
 
 /**
- * 예전에는 코드에 박힌 직원 명단(EMPLOYEES)이 후보 목록의 근거였고, 이 파일이 그 명단과의
- * 일치를 지켰다. 지금 근거는 DB 인력 명부(orgs/{org}/persons)라서, 여기서는 "명부를 받았을 때
- * 어떻게 동작하는가"와 "명부가 없어도 사람을 고를 수 있는가"를 지킨다.
+ * 사람을 고르는 자리의 출처는 인력 명부(orgs/{org}/persons) 하나다. HR 담당자가 /people
+ * 에서 관리한다. 예전에는 코드에 박힌 명단이, 그 다음에는 계정 원장이 출처였다.
+ *
+ * 여기서 지키는 것 셋:
+ *   - 팀원 후보는 명부에서 나오고 인턴은 빠진다
+ *   - PM·조직장은 계정이 필수지만 명부에 없으면 후보가 아니다
+ *   - 명부를 못 읽어도 사람을 고를 수는 있다
  */
 
-const roster = [
-  { personId: 'psn-mwbyun1220', name: '변민욱', nickname: '보람' },
-  { personId: 'psn-jypark', name: '박지연', nickname: '느티' },
-  { personId: 'psn-sykim', name: '김소영', nickname: '소이' },
+const roster: DirectoryPerson[] = [
+  { personId: 'psn-mwbyun1220', name: '변민욱', nickname: '보람', employmentType: 'FULL_TIME' },
+  { personId: 'psn-jypark', name: '박지연', nickname: '느티', employmentType: 'FULL_TIME' },
+  { personId: 'psn-sykim', name: '김소영', nickname: '소이', employmentType: 'PARTNER' },
+  { personId: 'psn-i-intern', name: '한승호', nickname: '숀', employmentType: 'INTERN' },
 ];
 
-describe('project-team-member-options', () => {
-  it('후보 목록의 출처는 계정 원장이고, 비활성 계정은 뺀다', () => {
-    const options = buildProjectTeamMemberOptions([
-      { uid: 'u-boram', name: '변민욱', email: 'boram@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
-      { uid: 'u-new', name: '신규구성원(새별)', email: 'new@mysc.co.kr', role: 'viewer', status: 'ACTIVE' },
-      { uid: 'u-left', name: '퇴사자', email: 'left@mysc.co.kr', role: 'viewer', status: 'INACTIVE' },
-    ], roster);
-
-    expect(options).toEqual([
-      expect.objectContaining({ name: '변민욱', nickname: '보람', label: '변민욱(보람)' }),
-      expect.objectContaining({ name: '신규구성원', nickname: '새별', label: '신규구성원(새별)' }),
-    ]);
-    expect(options.map((option) => option.name)).not.toContain('퇴사자');
-  });
-
-  it('명부에만 있고 계정이 없는 사람은 후보에 넣지 않는다 — 고르면 배정이 계정과 어긋난다', () => {
-    const options = buildProjectTeamMemberOptions([
-      { uid: 'u-boram', name: '변민욱', email: 'boram@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
-    ], roster);
-    expect(options.map((option) => option.name)).not.toContain('박지연');
-  });
-
-  it('계정 문서에 별명이 없으면 명부에서 채운다', () => {
-    const options = buildProjectTeamMemberOptions([
-      { uid: 'u-boram', name: '변민욱', email: 'boram@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
-    ], roster);
-    expect(options[0]).toMatchObject({ nickname: '보람', label: '변민욱(보람)' });
-  });
-
-  it('계정 문서의 별명이 명부보다 우선한다 — 본인이 고친 값이 이긴다', () => {
-    const options = buildProjectTeamMemberOptions([
-      { uid: 'u-boram', name: '변민욱', nickname: '민욱', email: 'boram@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
-    ], roster);
-    expect(options[0]).toMatchObject({ nickname: '민욱', label: '변민욱(민욱)' });
-  });
-
-  it('명부가 아직 안 왔어도 후보 목록은 나온다 — 별명만 비고 사람은 고를 수 있다', () => {
-    const options = buildProjectTeamMemberOptions([
-      { uid: 'u-boram', name: '변민욱', email: 'boram@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
-      { uid: 'u-new', name: '신규구성원(새별)', email: 'new@mysc.co.kr', role: 'viewer', status: 'ACTIVE' },
-    ]);
-    expect(options.map((option) => option.name)).toEqual(['변민욱', '신규구성원']);
-    expect(options[0].nickname).toBe('');
-  });
-
-  it('계정 목록을 못 받으면 인력 명부로 후보를 만든다 — 빈 목록이면 팀원을 아예 못 고른다', () => {
-    const options = buildProjectTeamMemberOptions([], roster);
+describe('팀원 후보', () => {
+  it('출처는 인력 명부다 — 계정이 없어도 고를 수 있다', () => {
+    const options = buildProjectTeamMemberOptions(roster);
     expect(options.map((option) => option.label)).toEqual(['김소영(소이)', '박지연(느티)', '변민욱(보람)']);
   });
 
-  it('계정이 전부 비활성이어도 같은 안전망을 쓴다', () => {
-    const options = buildProjectTeamMemberOptions([
+  it('인턴은 후보에서 빠진다 — 사람에게 붙는 표시가 아니라 근로형태로 가른다', () => {
+    expect(buildProjectTeamMemberOptions(roster).map((option) => option.name)).not.toContain('한승호');
+  });
+
+  it('파트너는 후보에 남는다 — 실제로 사업에 들어가 있다', () => {
+    expect(buildProjectTeamMemberOptions(roster).map((option) => option.name)).toContain('김소영');
+  });
+
+  it('라벨은 항상 이름(별명) 으로 정규화된다', () => {
+    const withBareName = buildProjectTeamMemberOptions([
+      { personId: 'p1', name: '노성진', nickname: '', employmentType: 'PARTNER' },
+      { personId: 'p2', name: '강에나', nickname: '하에나', employmentType: 'PARTNER' },
+    ]);
+    expect(withBareName.map((option) => option.label)).toEqual(['강에나(하에나)', '노성진']);
+  });
+
+  it('계정 원장은 이제 후보에 영향을 주지 않는다 — 퇴사 후 계정이 남아도 안 뜬다', () => {
+    const options = buildProjectTeamMemberOptions(roster, [
+      { uid: 'u-left', name: '김혜령(테일러)', email: 'hlkim@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
+    ]);
+    expect(options.map((option) => option.name)).not.toContain('김혜령');
+  });
+
+  it('명부를 못 읽으면 계정 원장으로 후보를 만든다 — 빈 목록이면 팀원을 아예 못 고른다', () => {
+    const options = buildProjectTeamMemberOptions([], [
+      { uid: 'u-boram', name: '변민욱(보람)', email: 'boram@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
       { uid: 'u-left', name: '퇴사자', email: 'left@mysc.co.kr', role: 'viewer', status: 'INACTIVE' },
-    ], roster);
-    expect(options.length).toBe(3);
+    ]);
+    expect(options.map((option) => option.label)).toEqual(['변민욱(보람)']);
   });
 
   it('명부도 계정도 없으면 빈 목록이다 — 코드에 박힌 명단으로 되돌아가지 않는다', () => {
     expect(buildProjectTeamMemberOptions([], [])).toEqual([]);
   });
 
-  it('후보 라벨은 항상 이름(별명) 으로 정규화된다', () => {
-    const options = buildProjectTeamMemberOptions([
-      { uid: 'a', name: '변민욱', email: 'a@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
-      { uid: 'b', name: '김소영(소이)', email: 'b@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
-      { uid: 'c', name: '박지연', nickname: '느티', email: 'c@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
-    ], roster);
-    expect(options.map((option) => option.label)).toEqual(['김소영(소이)', '박지연(느티)', '변민욱(보람)']);
+  it('근로형태를 모르는 명부도 거르지 않는다 — 형태 정보가 없다고 전원을 빼면 아무도 못 고른다', () => {
+    const options = buildProjectTeamMemberOptions([{ personId: 'p1', name: '홍길동', nickname: '길동' }]);
+    expect(options.map((option) => option.name)).toEqual(['홍길동']);
   });
 
+  it('계약이 끝난 사람은 후보가 아니다', () => {
+    const options = buildProjectTeamMemberOptions([
+      { personId: 'p1', name: '퇴사자', nickname: '', employmentType: 'NONE' },
+      { personId: 'p2', name: '재직자', nickname: '', employmentType: 'FULL_TIME' },
+    ]);
+    expect(options.map((option) => option.name)).toEqual(['재직자']);
+  });
+});
+
+describe('PM · 최종 결재자 · 월 결산 조직장 후보', () => {
+  const members: OrgMember[] = [
+    { uid: 'u-boram', name: '변민욱', nameKo: '변민욱', email: 'boram@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
+    { uid: 'u-left', name: '김혜령', nameKo: '김혜령', email: 'hlkim@mysc.co.kr', role: 'pm', status: 'ACTIVE' },
+    { uid: 'u-bot', name: '(AX) AI', nameKo: '(AX) AI', email: 'ai@mysc.co.kr', role: 'admin', status: 'ACTIVE' },
+  ] as OrgMember[];
+
+  it('계정이 있어야 후보다 — 로그인해서 승인해야 하기 때문', () => {
+    const options = buildOrgMemberPickerOptions(members, roster);
+    expect(options.every((option) => option.uid)).toBe(true);
+  });
+
+  it('명부에 없으면 계정이 살아 있어도 후보가 아니다 — 퇴사자와 서비스 계정이 여기서 걸러진다', () => {
+    const names = buildOrgMemberPickerOptions(members, roster).map((option) => option.name);
+    expect(names).toEqual(['변민욱']);
+    expect(names).not.toContain('김혜령');
+    expect(names).not.toContain('(AX) AI');
+  });
+
+  it('명부에 있어도 계정이 없으면 후보가 아니다 — 승인을 할 수 없다', () => {
+    const names = buildOrgMemberPickerOptions(members, roster).map((option) => option.name);
+    expect(names).not.toContain('박지연');
+  });
+
+  it('별명은 명부에서 채운다', () => {
+    expect(buildOrgMemberPickerOptions(members, roster)[0]).toMatchObject({
+      nickname: '보람', label: '변민욱(보람)',
+    });
+  });
+
+  it('명부를 못 읽으면 문지기 없이 계정 원장만 쓴다 — 조직장을 못 고르면 결산이 막힌다', () => {
+    const names = buildOrgMemberPickerOptions(members).map((option) => option.name);
+    expect(names).toContain('변민욱');
+    expect(names).toContain('김혜령');
+  });
+});
+
+describe('이름 조회', () => {
   it('실명·별명·표시 라벨 어느 쪽으로 물어도 같은 사람을 찾는다', () => {
-    expect(findProjectTeamMemberOption('박지연', buildTeamMemberDirectory(roster))?.nickname).toBe('느티');
-    expect(findProjectTeamMemberOption('김소영(소이)', buildTeamMemberDirectory(roster))?.name).toBe('김소영');
+    const directory = buildTeamMemberDirectory(roster);
+    expect(findProjectTeamMemberOption('박지연', directory)?.nickname).toBe('느티');
+    expect(findProjectTeamMemberOption('김소영(소이)', directory)?.name).toBe('김소영');
   });
 
   it('명부 없이 물으면 표시 라벨에 들어있는 별명만 쓴다', () => {
@@ -98,13 +130,8 @@ describe('project-team-member-options', () => {
   });
 
   it('buildTeamMemberDirectory 는 명부 레코드를 그대로 받는다', () => {
-    const built = buildTeamMemberDirectory([
-      { personId: 'psn-a', name: '노성진', nickname: '' },
-      { personId: 'psn-b', name: '강에나', nickname: '하에나' },
-    ]);
-    expect(built.resolveId('노성진')).toBe('psn-a');
-    expect(built.resolveId('강에나(하에나)')).toBe('psn-b');
-    expect(built.resolveId('하에나')).toBe('psn-b');
-    expect(built.resolveId('없는사람')).toBeNull();
+    const built = buildTeamMemberDirectory(roster);
+    expect(built.resolveId('변민욱')).toBe('psn-mwbyun1220');
+    expect(built.resolveId('하에나')).toBeNull();
   });
 });

--- a/src/app/data/project-team-member-options.ts
+++ b/src/app/data/project-team-member-options.ts
@@ -4,6 +4,7 @@ import {
   type DirectoryPerson,
   type PersonDirectory,
 } from '../platform/person-directory';
+import { isProjectAssignableType } from '../platform/person-employment';
 import type { OrgMember, Project } from './types';
 
 function memberLabel(name: string, nickname: string): string {
@@ -49,10 +50,11 @@ export function splitMemberDisplayName(value: string): { name: string; nickname:
   return { name: match[1].trim(), nickname: match[2].trim() };
 }
 
-/** 인력 명부 레코드를 그대로 후보로 만든다. 배정에는 이름·별명만 저장되므로 계정이 없어도 고를 수 있다. */
+/** 인력 명부 레코드를 후보로 만든다. 배정에는 이름·별명만 저장되므로 계정이 없어도 고를 수 있다. */
 function rosterOptions(roster: DirectoryPerson[]): ProjectTeamMemberOption[] {
   const options = new Map<string, ProjectTeamMemberOption>();
   roster.forEach((person) => {
+    if (!isProjectAssignableType(person?.employmentType)) return;
     const name = String(person?.name || '').trim();
     if (!name) return;
     const nickname = String(person?.nickname || '').trim();
@@ -63,20 +65,8 @@ function rosterOptions(roster: DirectoryPerson[]): ProjectTeamMemberOption[] {
   return [...options.values()].sort((left, right) => left.label.localeCompare(right.label, 'ko'));
 }
 
-/**
- * 팀원 후보 목록.
- *
- * 출처는 계정 원장(members)이다. 다만 계정 목록이 아직 안 왔거나 못 읽었을 때 빈 목록을
- * 돌려주면 사람이 팀원을 아예 못 고른다 - 포털 등록 화면은 members 가 [] 로 시작한다.
- * 그럴 때는 인력 명부(roster)로 후보를 만든다. 화면이 멈추는 것보다 낫다.
- */
-export function buildProjectTeamMemberOptions(
-  members: OrgMember[],
-  roster: DirectoryPerson[] = [],
-): ProjectTeamMemberOption[] {
-  const directory = roster.length ? buildPersonDirectory(roster) : EMPTY_PERSON_DIRECTORY;
-  if (!members.length) return rosterOptions(roster);
-
+/** 계정 원장으로 후보를 만든다. 인력 명부를 못 읽었을 때만 쓰는 안전망. */
+function memberFallbackOptions(members: OrgMember[]): ProjectTeamMemberOption[] {
   const options = new Map<string, ProjectTeamMemberOption>();
   members.forEach((member) => {
     const status = String(member.status || '').trim().toUpperCase();
@@ -84,8 +74,7 @@ export function buildProjectTeamMemberOptions(
     const parsed = splitMemberDisplayName(member.name || '');
     const displayName = String(member.nameKo || '').trim() || parsed.name;
     if (!String(member.uid || '').trim() || !displayName) return;
-    const canonical = findProjectTeamMemberOption(displayName, directory);
-    const nickname = String(member.nickname || '').trim() || parsed.nickname || canonical?.nickname || '';
+    const nickname = String(member.nickname || '').trim() || parsed.nickname || '';
     const key = displayName.toLowerCase();
     if (options.has(key)) return;
     options.set(key, {
@@ -95,11 +84,25 @@ export function buildProjectTeamMemberOptions(
       label: memberLabel(displayName, nickname),
     });
   });
+  return [...options.values()].sort((left, right) => left.label.localeCompare(right.label, 'ko'));
+}
 
-  const liveOptions = [...options.values()]
-    .sort((left, right) => left.label.localeCompare(right.label, 'ko'));
-  // 계정이 전부 비활성이거나 uid 가 없어 한 명도 안 남는 경우도 같은 안전망을 쓴다.
-  return liveOptions.length ? liveOptions : rosterOptions(roster);
+/**
+ * 팀원 후보 목록.
+ *
+ * 출처는 인력 명부(orgs/{org}/persons) 하나다. HR 담당자가 /people 에서 관리한다.
+ * 계정 원장을 출처로 쓰면 로그인한 적 없는 사람이 후보에서 빠지고, 퇴사해도 계정이
+ * 살아 있으면 계속 남는다. 배정에는 이름과 별명만 저장되므로 계정은 필요하지 않다.
+ *
+ * 명부를 아직/영영 못 읽었을 때만 계정 원장으로 후보를 만든다. 빈 목록을 돌려주면
+ * 사람이 팀원을 아예 못 고른다.
+ */
+export function buildProjectTeamMemberOptions(
+  roster: DirectoryPerson[],
+  members: OrgMember[] = [],
+): ProjectTeamMemberOption[] {
+  const fromRoster = rosterOptions(roster);
+  return fromRoster.length ? fromRoster : memberFallbackOptions(members);
 }
 
 /** 인력 명부 레코드로 디렉터리를 만든다. 호출부가 person-directory 를 직접 몰라도 되게. */
@@ -119,12 +122,23 @@ export interface OrgMemberPickerOption {
 }
 
 /**
- * Options for the pickers that choose a person (PM, 최종 결재자, 월 결산 조직장).
+ * PM · 최종 결재자 · 월 결산 조직장을 고르는 자리.
  *
- * Only an explicit INACTIVE or DELETED status removes someone. Requiring status to equal
- * ACTIVE hid the 15 members whose document carries no status field at all.
+ * 이 사람들은 실제로 로그인해서 승인해야 하므로 계정이 필수다. 그래서 후보는 계정
+ * 원장에서 나오지만, 인력 명부(roster)가 문지기 역할을 한다 - 명부에 없는 사람은
+ * 계정이 살아 있어도 후보가 아니다. 퇴사했는데 계정이 남아 있는 경우와 사람이 아닌
+ * 서비스 계정이 여기서 걸러진다.
+ *
+ * 명부를 못 읽었으면 문지기 없이 계정 원장만 쓴다. 조직장을 못 고르면 결산이 막힌다.
+ *
+ * 상태는 명시적 INACTIVE/DELETED 만 제외한다. ACTIVE 를 요구하면 status 필드가
+ * 아예 없는 구성원 15명이 사라진다.
  */
-export function buildOrgMemberPickerOptions(members: OrgMember[]): OrgMemberPickerOption[] {
+export function buildOrgMemberPickerOptions(
+  members: OrgMember[],
+  roster: DirectoryPerson[] = [],
+): OrgMemberPickerOption[] {
+  const directory = roster.length ? buildPersonDirectory(roster) : EMPTY_PERSON_DIRECTORY;
   const byUid = new Map<string, OrgMemberPickerOption>();
   members.forEach((member) => {
     const uid = String(member.uid || '').trim();
@@ -136,9 +150,10 @@ export function buildOrgMemberPickerOptions(members: OrgMember[]): OrgMemberPick
     // by sign-in paths, so it is only parsed when the structured fields are absent.
     const parsed = splitMemberDisplayName(member.name || '');
     const name = String(member.nameKo || '').trim() || parsed.name || email || uid;
+    if (directory.size > 0 && !directory.resolveId(name)) return;
     const nickname = String(member.nickname || '').trim()
       || parsed.nickname
-      || findProjectTeamMemberOption(name)?.nickname
+      || directory.resolveNickname(name)
       || '';
     byUid.set(uid, {
       uid,

--- a/src/app/data/store.tsx
+++ b/src/app/data/store.tsx
@@ -24,7 +24,8 @@ import {
   AUDIT_LOGS,
   LEDGER_TEMPLATES,
 } from './mock-data';
-import { buildPersonDirectory, type PersonDirectory } from '../platform/person-directory';
+import { buildPersonDirectory, type DirectoryPerson, type PersonDirectory } from '../platform/person-directory';
+import { resolveEmploymentTypeAt } from '../platform/person-employment';
 import { mergeProjectMutationResult } from './project-store-mutation';
 import { resolveAppWriteStrategy } from './store-write-strategy';
 import { useFirebase } from '../lib/firebase-context';
@@ -87,6 +88,8 @@ interface AppState {
   auditLogs: AuditLog[];
   participationEntries: ParticipationEntry[];
   persons: PersonRecord[];
+  /** 사람 고르는 자리들이 쓰는 형태. 근로형태가 오늘 기준으로 채워져 있다. */
+  personRoster: DirectoryPerson[];
   personDirectory: PersonDirectory;
   dataSource: 'local' | 'firestore';
 }
@@ -270,7 +273,16 @@ export function AppProvider({ children }: { children: ReactNode }) {
     return () => { cancelled = true; };
   }, [orgId, platformApiEnabled, bffActor]);
 
-  const personDirectory = useMemo(() => buildPersonDirectory(persons), [persons]);
+  // 명부를 사람 고르는 자리들이 쓰는 형태로 한 번만 변환한다. 근로형태는 오늘 기준으로
+  // 파생시킨다 - 문서에 저장하면 계약이 끝나도 값이 그대로 남는다.
+  const personRoster = useMemo<DirectoryPerson[]>(() => persons.map((person) => ({
+    personId: person.personId,
+    name: person.name,
+    nickname: person.nickname || '',
+    employmentType: resolveEmploymentTypeAt(person.employments, new Date().toISOString().slice(0, 10)),
+  })), [persons]);
+
+  const personDirectory = useMemo(() => buildPersonDirectory(personRoster), [personRoster]);
 
   const members = useMemo<OrgMember[]>(() => {
     const baseMembers = dataSource === 'firestore'
@@ -850,6 +862,7 @@ export function AppProvider({ children }: { children: ReactNode }) {
     auditLogs,
     participationEntries,
     persons,
+    personRoster,
     personDirectory,
     dataSource,
     upsertMember,

--- a/src/app/data/use-person-roster.ts
+++ b/src/app/data/use-person-roster.ts
@@ -3,6 +3,7 @@ import { featureFlags } from '../config/feature-flags';
 import { useFirebase } from '../lib/firebase-context';
 import { fetchPersonsViaBff, type PersonRecord } from '../lib/platform-bff-client';
 import type { DirectoryPerson } from '../platform/person-directory';
+import { resolveEmploymentTypeAt } from '../platform/person-employment';
 import { useAuth } from './auth-store';
 
 /**
@@ -23,7 +24,12 @@ function toDirectoryPeople(items: PersonRecord[]): DirectoryPerson[] {
     personId: person.personId,
     name: person.name,
     nickname: person.nickname || '',
+    employmentType: resolveEmploymentTypeAt(person.employments, today()),
   }));
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
 }
 
 /** 명부가 바뀌었을 때 다음 조회가 서버를 다시 보게 한다. */

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -11,6 +11,7 @@ import type {
   ProjectRequestContractAnalysis,
   TransactionState,
 } from '../data/types';
+import type { EmploymentState, EmploymentType } from '../platform/person-employment';
 import { PlatformApiClient } from '../platform/api-client';
 import { buildStandardHeaders, type RequestActor } from '../platform/request-context';
 import {
@@ -2292,10 +2293,12 @@ export async function createPersonViaBff(params: {
   return response.data;
 }
 
+// 근로형태·재직상태는 도메인 타입을 그대로 쓴다. 여기서 string 으로 느슨하게 두면
+// 서버가 새 값을 보내도 컴파일이 통과해 화면에서만 조용히 깨진다.
 export interface PersonEmploymentRecord {
   id: string;
-  type: string;
-  state: string;
+  type: EmploymentType;
+  state: EmploymentState;
   startDate: string;
   endDate: string | null;
   note: string;

--- a/src/app/platform/person-directory.ts
+++ b/src/app/platform/person-directory.ts
@@ -9,10 +9,17 @@
  * 막히면 안 된다 — 못 찾은 사람은 이름 기반 대체 키로 떨어지고, 화면은 계속 뜬다.
  */
 
+import type { DirectoryEmploymentType } from './person-employment';
+
 export interface DirectoryPerson {
   personId: string;
   name: string;
   nickname: string;
+  /**
+   * 조회 시점의 근로형태. 동일인 판정에는 쓰지 않고, 후보 목록을 거를 때만 본다.
+   * 인력 명부를 아직 못 읽었을 때를 위해 선택 항목으로 둔다.
+   */
+  employmentType?: DirectoryEmploymentType;
 }
 
 export interface PersonDirectory {

--- a/src/app/platform/person-employment.ts
+++ b/src/app/platform/person-employment.ts
@@ -352,3 +352,37 @@ export function addEmployment(
 export function selectableAt(people: Person[], isoDate: string): Person[] {
   return people.filter((person) => resolveEmploymentAt(person, isoDate) !== null);
 }
+
+/** 오늘 유효한 계약이 없는 상태. 퇴사했거나 아직 시작 전이다. */
+export const NO_CURRENT_EMPLOYMENT = 'NONE';
+
+export type DirectoryEmploymentType = EmploymentType | typeof NO_CURRENT_EMPLOYMENT;
+
+/** 조회 시점에 유효한 계약의 근로형태. 계약이 없으면 NONE. */
+export function resolveEmploymentTypeAt(
+  employments: Array<Pick<PersonEmployment, 'type' | 'startDate' | 'endDate'>> | null | undefined,
+  isoDate: string,
+): DirectoryEmploymentType {
+  const list = Array.isArray(employments) ? employments : [];
+  const matches = list.filter((item) => (
+    item.startDate <= isoDate && (item.endDate === null || item.endDate >= isoDate)
+  ));
+  if (matches.length === 0) return NO_CURRENT_EMPLOYMENT;
+  // 겹치면 늦게 시작한 쪽을 현재로 본다 - resolveEmploymentAt 과 같은 규칙.
+  return [...matches].sort((a, b) => a.startDate.localeCompare(b.startDate)).at(-1)!.type;
+}
+
+/**
+ * 프로젝트 팀에 배정할 수 있는 근로형태인가.
+ *
+ * 인턴은 사업에 배정하지 않는다. 사람에게 붙는 자격 표시가 아니라 근로형태로 가르는
+ * 것이라 명부에는 아무 표시도 남지 않고, 인턴이 정규직이 되면 그냥 따라온다.
+ * 파트너와 미채용 자리는 배정 대상이다 - 실제로 사업에 들어가 있다.
+ *
+ * undefined 는 "근로형태를 모른다"는 뜻이고 거르지 않는다. 명부를 못 읽어 형태 정보가
+ * 없는 상황에서 전원을 걸러버리면 아무도 고를 수 없게 된다.
+ */
+export function isProjectAssignableType(type: DirectoryEmploymentType | undefined): boolean {
+  if (type === undefined) return true;
+  return type !== 'INTERN' && type !== NO_CURRENT_EMPLOYMENT;
+}


### PR DESCRIPTION
## 왜

사람 후보가 **계정 원장(`members`)**에서 나오고 있었습니다. 계정은 로그인해야 생기므로 아직 로그인 안 한 사람은 후보에서 빠지고, **퇴사해도 계정이 살아 있으면 계속 남습니다.**

지금 실제로 이렇습니다:

```
김혜령 (테일러)   hlkim@mysc.co.kr   role=pm  status=ACTIVE   ← 명부에 없는 퇴사자
(AX) AI          ai@mysc.co.kr      role=admin               ← 사람 아님
```

둘 다 **최종 결재자·월 결산 조직장 후보로 뜹니다.**

출처를 `/people` 이 관리하는 인력 명부(`orgs/{org}/persons`) 하나로 모읍니다.

## 성격이 다른 두 자리를 다르게 다룹니다

| 자리 | 저장값 | 계정 | 출처 |
|---|---|---|---|
| **팀원 배정** | 이름·별명 문자열 | 불필요 | 명부가 곧 후보 |
| **PM · 최종 결재자 · 월 결산 조직장** | `uid` | **필수** (로그인해서 승인) | 계정 원장 + **명부가 문지기** |

명부에 없으면 계정이 살아 있어도 후보가 아닙니다.

## 인턴은 근로형태로 거릅니다

**사람에게 붙는 자격 표시를 만들지 않았습니다.** 명부에는 아무 표시도 남지 않고, 인턴이 정규직이 되면 그냥 따라옵니다. 파트너와 미채용 자리는 후보로 남습니다 — 실제로 사업에 들어가 있습니다.

## 프로덕션 실측 (2026-08-12)

| | |
|---|---|
| 팀원 후보 | **80명** (명부 91 − 인턴 11) |
| PM·조직장 후보 | **78명** (계정 ∩ 명부) |
| 라벨이 `이름(별명)` 이 아닌 후보 | **0건** |
| 팀원 후보에 인턴 | 없음 |
| 조직장 후보에 김혜령·`(AX) AI` | **없음** (지금은 뜸) |

## 멈추지 않습니다

명부를 못 읽으면 계정 원장으로 후보를 만듭니다. 근로형태를 모르는 명부도 거르지 않습니다 — 형태 정보가 없다고 전원을 빼면 아무도 고를 수 없게 됩니다.

## 곁가지로 고친 것

- `buildOrgMemberPickerOptions` 가 별명을 채우려고 부르던 `findProjectTeamMemberOption` 이 **디렉터리 없이 호출돼 항상 `undefined`** 를 돌려주고 있었습니다. 이제 명부에서 채웁니다.
- `PersonEmploymentRecord` 의 `type`/`state` 를 도메인 타입으로 좁혔습니다. `string` 이면 서버가 새 값을 보내도 컴파일이 통과해 화면에서만 조용히 깨집니다.

## 검증

- **228개 통과** / 타입 에러 기준선(234줄) 동일 / 빌드 통과
- **사보타주 3회 전부 검출**: 인턴 필터 제거(3개 실패), 명부 문지기 제거(2개), 출처를 계정 우선으로 뒤집기(1개)

> 인턴 11명은 Auth 계정이 2명만 있고, `members`(89) 와 Firebase Auth(78) 가 어긋나 있습니다. `/users` 권한 관리 영역이라 이번 PR 범위 밖입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)