### PR TITLE
fix(projects): 정산지원 담당자가 프로젝트 저장을 막지 않게 한다

### DIFF
--- a/src/app/components/projects/ProjectEditorWizard.shell.test.ts
+++ b/src/app/components/projects/ProjectEditorWizard.shell.test.ts
@@ -387,6 +387,13 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain('계약 종료일은 시작일 이후여야 합니다.');
     expect(source).not.toContain('인건비 투입 종료월은 시작월 이후여야 합니다.');
     expect(source).toContain('운영매니저 1인 이상');
+    // 정산지원 담당자는 저장을 막지 않는다. 예전에는 submitIssues 에 들어가 최종 저장을
+    // 막았고, 후보 드롭다운도 두 사람으로 좁혀 다른 사람을 아예 고를 수 없었다. 담당이
+    // 바뀌거나 그 두 분이 자리를 비우면 프로젝트 등록 자체가 멈춘다.
+    expect(source).not.toContain("issues.push({ step: 'team', label: '정산지원은 도담 또는 써니를 선택' })");
+    expect(source).not.toContain('hasInvalidProjectSettlementSupportMember');
+    expect(source).not.toContain('정산지원은 도담 또는 써니를 선택해 주세요.');
+    expect(source).toContain('const availableTeamMemberOptions = teamMemberOptions;');
     expect(source).toContain("const requiresSettlementConfirmations = usesRegistrationV2 ? draft.basis !== 'NONE' : draft.settlementType !== 'NONE'");
     expect(source).not.toContain('정산 기준이 정산없음인 사업은 인건비·고객사 정산 확인을 입력하지 않습니다.');
     expect(source).toContain('md:grid-cols-3');

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -98,7 +98,6 @@ import {
 } from '../ui/alert-dialog';
 import {
   formatProjectTeamMembersSummary,
-  hasInvalidProjectSettlementSupportMember,
   hasIncompleteProjectTeamMembers,
   hasProjectOperatingManager,
   isProjectSettlementSupportMember,
@@ -1423,9 +1422,8 @@ export function ProjectEditorWizard({
     if (usesRegistrationV2 && !hasProjectOperatingManager(draft.teamMembersDetailed)) {
       issues.push({ step: 'team', label: '운영매니저 1인 이상' });
     }
-    if (usesRegistrationV2 && hasInvalidProjectSettlementSupportMember(draft.teamMembersDetailed)) {
-      issues.push({ step: 'team', label: '정산지원은 도담 또는 써니를 선택' });
-    }
+    // 정산지원 담당자는 저장을 막지 않는다. 담당이 정해져 있다는 안내일 뿐이고,
+    // 담당자가 바뀌거나 자리를 비운 사이에 프로젝트 등록 자체가 막히면 안 된다.
     return issues;
   }, [departmentOptionSet, draft, hasContractAmountInput, hasMultiYearContract, onProjectDocumentFileUpload, requiresAdvanceInterimReason, requiresSettlementConfirmations, selectedExecutiveApprover, showProjectCheckout, usesRegistrationV2]);
 
@@ -2462,15 +2460,10 @@ export function ProjectEditorWizard({
                 .map((item, itemIndex) => (itemIndex === index ? '' : item.memberName))
                 .filter(Boolean),
             );
-            const availableTeamMemberOptions = member.role === '정산지원'
-              ? teamMemberOptions.filter((option) => isProjectSettlementSupportMember({
-                memberName: option.name,
-                memberNickname: option.nickname,
-              }))
-              : teamMemberOptions;
-            const availableTeamMemberOptionMap = member.role === '정산지원'
-              ? Object.fromEntries(availableTeamMemberOptions.map((option) => [option.value, option])) as Record<string, ProjectTeamMemberOption>
-              : teamMemberOptionMap;
+            // 정산지원이라고 후보를 두 사람으로 좁히지 않는다. 담당이 바뀌거나 그 두 분이
+            // 자리를 비우면 아무도 고를 수 없게 된다. 담당자 안내는 아래 문구로 남긴다.
+            const availableTeamMemberOptions = teamMemberOptions;
+            const availableTeamMemberOptionMap = teamMemberOptionMap;
             const currentTeamMemberOptionExists = !member.memberName
               || availableTeamMemberOptions.some((option) => option.value === member.memberName);
             return (
@@ -2538,7 +2531,9 @@ export function ProjectEditorWizard({
                       </SelectContent>
                     </Select>
                     {member.role === '정산지원' && !isProjectSettlementSupportMember(member) ? (
-                      <p className="mt-1 text-[10px] text-red-700">정산지원은 도담 또는 써니를 선택해 주세요.</p>
+                      <p className="mt-1 text-[10px] text-amber-700">
+                        정산지원은 보통 도담 또는 써니가 맡습니다. 다른 분으로 지정하려면 그대로 두셔도 됩니다.
+                      </p>
                     ) : null}
                   </div>
                 </div>

--- a/src/app/platform/project-team-members.test.ts
+++ b/src/app/platform/project-team-members.test.ts
@@ -3,7 +3,6 @@ import {
   formatProjectTeamMembersSummary,
   hasInvalidProjectTeamMemberLaborPeriod,
   hasIncompleteProjectTeamMembers,
-  hasInvalidProjectSettlementSupportMember,
   hasProjectOperatingManager,
   normalizeProjectTeamMemberDraftRows,
   normalizeProjectTeamMembers,
@@ -169,15 +168,6 @@ describe('project-team-members', () => {
     ]);
   });
 
-  it('allows only 도담 or 써니 as settlement support', () => {
-    expect(hasInvalidProjectSettlementSupportMember([
-      { memberName: '송성미', memberNickname: '도담', role: '정산지원', participationRate: 0, isDocumentOnly: false },
-      { memberName: '최지윤', memberNickname: '써니', role: '정산지원', participationRate: 0, isDocumentOnly: false },
-    ])).toBe(false);
-    expect(hasInvalidProjectSettlementSupportMember([
-      { memberName: '다른 구성원', memberNickname: '', role: '정산지원', participationRate: 0, isDocumentOnly: false },
-    ])).toBe(true);
-  });
 
   it('parses manual identity input in 이름(별명) format', () => {
     expect(parseProjectTeamMemberIdentityInput('박지연(느티)')).toEqual({

--- a/src/app/platform/project-team-members.ts
+++ b/src/app/platform/project-team-members.ts
@@ -127,15 +127,6 @@ export function isProjectSettlementSupportMember(
   return name === '송성미' || name === '최지윤' || nickname === '도담' || nickname === '써니';
 }
 
-export function hasInvalidProjectSettlementSupportMember(
-  members: ProjectTeamMemberAssignment[] | null | undefined,
-) {
-  return normalizeProjectTeamMembers(members).some((member) => (
-    member.role === '정산지원'
-    && !isProjectSettlementSupportMember(member)
-  ));
-}
-
 export function hasInvalidProjectTeamMemberLaborPeriod(
   members: ProjectTeamMemberAssignment[] | null | undefined,
 ) {


### PR DESCRIPTION
## 버그

정산지원 담당자 지정이 **두 곳에서** 사람을 막고 있었습니다.

**① 최종 저장이 안 됨** — `submitIssues` 에 들어가서 `canSubmit = false` 가 되고, 버튼은 `if (submitBlocked) return` 으로 아무 일도 하지 않습니다.

**② 다른 사람을 고를 수조차 없음** — 역할을 `정산지원` 으로 고르면 후보 드롭다운이 두 사람으로 좁혀집니다.

```ts
const availableTeamMemberOptions = member.role === '정산지원'
  ? teamMemberOptions.filter((option) => isProjectSettlementSupportMember({ ... }))
  : teamMemberOptions;
```

담당자가 바뀌거나 그 두 분이 자리를 비우면 **배포 없이는 프로젝트 등록 자체가 멈춥니다.** 담당이 정해져 있다는 사실은 안내로 충분하고, 저장을 막을 일이 아닙니다.

## 고침

- 저장 차단 조건에서 제거
- 후보 드롭다운을 좁히지 않음
- 붉은 오류 문구 → 안내 문구

> 정산지원은 보통 도담 또는 써니가 맡습니다. 다른 분으로 지정하려면 그대로 두셔도 됩니다.

`hasInvalidProjectSettlementSupportMember` 는 이 변경으로 소비자가 없어져 제거했습니다.

## 검증

- **347개 통과** / 타입 에러 기준선(234줄) 동일 / 빌드 통과
- **사보타주 2회 검출** — 저장 차단 되살리기, 드롭다운 다시 좁히기. 셸 테스트에 `not.toContain` 으로 잠가서 같은 버그가 조용히 돌아오지 못합니다.

> 담당자 이름 두 개가 코드에 박혀 있는 문제(`project-team-members.ts:127`)는 그대로 남아 있습니다. 목록을 조직 설정(`settings/projectRoles`)으로 옮기는 작업은 이어서 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)