### PR TITLE
feat(people): 명부 목록에서 근로형태를 가리고 인턴을 별도 표로 뗀다

### DIFF
--- a/src/app/components/people/PeopleDirectoryPage.shell.test.ts
+++ b/src/app/components/people/PeopleDirectoryPage.shell.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(import.meta.dirname, 'PeopleDirectoryPage.tsx'), 'utf8');
+
+/**
+ * 근로형태는 이름 옆에 붙으면 신분 표시가 된다. 명부 목록에서는 가리고, 계약을 바꾸는
+ * 자리에서만 보여준다. 인턴은 같은 표에 섞지 않는다 - 근로형태 열을 지워도 한 표에
+ * 두면 순서와 빈칸으로 드러난다.
+ */
+describe('PeopleDirectoryPage 근로형태 노출 계약', () => {
+  it('목록 표에 근로형태 열이 없다', () => {
+    const table = source.slice(source.indexOf('function PeopleTable'), source.indexOf('export function PeopleDirectoryPage'));
+    expect(table).not.toContain('근로형태');
+    expect(table).not.toContain('TYPE_TONE');
+    expect(table).not.toContain('EMPLOYMENT_TYPE_LABELS');
+  });
+
+  it('근로형태별 필터 버튼이 없다 — 누르는 것만으로 누가 어느 형태인지 드러난다', () => {
+    expect(source).not.toContain("['FULL_TIME', `정규직");
+    expect(source).not.toContain("['INTERN', `인턴");
+    expect(source).not.toContain("['PARTNER', `파트너");
+    expect(source).not.toContain("['PLACEHOLDER', `미채용");
+  });
+
+  it('인턴은 별도 표로 뗀다', () => {
+    expect(source).toContain("row.current?.type !== 'INTERN'");
+    expect(source).toContain("row.current?.type === 'INTERN'");
+    expect(source).toContain('const mainRows');
+    expect(source).toContain('const internRows');
+    // 두 표가 같은 컴포넌트를 쓴다 - 한쪽만 조용히 달라지지 않게.
+    expect(source.match(/<PeopleTable/g)).toHaveLength(2);
+  });
+
+  it('계약 관리에서는 근로형태를 그대로 보여준다 — 바꾸려면 보여야 한다', () => {
+    const dialog = source.slice(source.indexOf('계약 이력'));
+    expect(dialog).toContain('EMPLOYMENT_TYPE_LABELS');
+  });
+
+  it('목록에는 이름·재직상태·소속·직급·입사일·근속만 둔다', () => {
+    const table = source.slice(source.indexOf('function PeopleTable'), source.indexOf('export function PeopleDirectoryPage'));
+    ['이름', '재직상태', '소속', '직급', '입사일', '근속'].forEach((column) => {
+      expect(table).toContain(`>${column}</TableHead>`);
+    });
+  });
+});

--- a/src/app/components/people/PeopleDirectoryPage.tsx
+++ b/src/app/components/people/PeopleDirectoryPage.tsx
@@ -171,6 +171,80 @@ function EmploymentForm({
   );
 }
 
+interface PersonRow {
+  person: PersonRecord;
+  current: ReturnType<typeof resolveCurrentEmployment>;
+  separatedAt: string | null;
+  tenure: ReturnType<typeof deriveTenure>;
+}
+
+/**
+ * 인력 표. 근로형태 열은 두지 않는다 — 이름 옆에 붙는 신분 표시가 되기 때문이다.
+ * 계약 형태가 필요한 자리는 계약 관리 다이얼로그뿐이고, 거기서는 그대로 보인다.
+ */
+function PeopleTable({ rows, loading, onOpen }: {
+  rows: PersonRow[];
+  loading: boolean;
+  onOpen: (person: PersonRecord) => void;
+}) {
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow className="bg-muted/30">
+            <TableHead className="min-w-[130px]">이름</TableHead>
+            <TableHead className="min-w-[90px]">재직상태</TableHead>
+            <TableHead className="min-w-[150px]">소속</TableHead>
+            <TableHead className="min-w-[110px]">직급</TableHead>
+            <TableHead className="min-w-[100px]">입사일</TableHead>
+            <TableHead className="min-w-[100px]">근속</TableHead>
+            <TableHead className="w-24" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={7} className="py-10 text-center text-sm text-slate-500">
+                {loading ? '불러오는 중…' : '조건에 맞는 인력이 없습니다.'}
+              </TableCell>
+            </TableRow>
+          ) : rows.map(({ person, current, separatedAt, tenure }) => (
+            <TableRow
+              key={person.personId}
+              className="cursor-pointer hover:bg-accent/40"
+              onClick={() => onOpen(person)}
+            >
+              <TableCell>
+                <span className="text-xs font-semibold">{person.name}</span>
+                {person.nickname ? <span className="ml-1 text-[10px] text-muted-foreground">({person.nickname})</span> : null}
+              </TableCell>
+              <TableCell>
+                {current ? (
+                  <Badge variant="outline" className={`text-[10px] ${STATE_TONE[current.state as EmploymentState]}`}>
+                    {EMPLOYMENT_STATE_LABELS[current.state as EmploymentState]}
+                  </Badge>
+                ) : (
+                  <span className="text-[11px] text-slate-500">{separatedAt ? `${formatDate(separatedAt)} 종료` : '계약 종료'}</span>
+                )}
+              </TableCell>
+              <TableCell className="text-xs text-muted-foreground">
+                {person.departmentTop || '-'}
+                {person.departmentMid ? <span className="text-slate-400"> · {person.departmentMid}</span> : null}
+              </TableCell>
+              <TableCell className="text-xs">{person.grade || person.title || '-'}</TableCell>
+              <TableCell className="text-xs tabular-nums text-muted-foreground">{formatDate(person.joinedAt)}</TableCell>
+              <TableCell className="text-xs tabular-nums">{tenure?.label || '-'}</TableCell>
+              <TableCell>
+                <Button variant="ghost" size="sm" className="h-6 px-2 text-[11px]">계약 관리</Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
 export function PeopleDirectoryPage() {
   const { user: authUser } = useAuth();
   const { orgId } = useFirebase();
@@ -220,7 +294,6 @@ export function PeopleDirectoryPage() {
       })
       .filter((row) => {
         if (typeFilter === 'SEPARATED') return !row.current;
-        if (typeFilter !== 'ALL' && row.current?.type !== typeFilter) return false;
         if (!query) return true;
         return [row.person.name, row.person.nickname, row.person.departmentTop, row.person.grade]
           .some((value) => String(value || '').toLowerCase().includes(query));
@@ -228,12 +301,25 @@ export function PeopleDirectoryPage() {
       .sort((a, b) => a.person.name.localeCompare(b.person.name, 'ko'));
   }, [people, searchText, typeFilter, asOf]);
 
+  // 근로형태는 이름 옆에 붙는 신분 표시라 목록에서 보여주지 않는다. 인턴은 섞지 않고
+  // 아래 별도 표로 뗀다 - 한 표에 두면 근로형태를 가려도 순서와 빈칸으로 드러난다.
+  // 계약을 바꾸는 자리(계약 관리)에서는 그대로 보인다. 거기서는 필요한 정보다.
+  const mainRows = useMemo(
+    () => rows.filter((row) => row.current?.type !== 'INTERN'),
+    [rows],
+  );
+  const internRows = useMemo(
+    () => rows.filter((row) => row.current?.type === 'INTERN'),
+    [rows],
+  );
+
   const counts = useMemo(() => {
-    const base = { FULL_TIME: 0, INTERN: 0, PARTNER: 0, PLACEHOLDER: 0, SEPARATED: 0 };
+    const base = { MAIN: 0, INTERN: 0, SEPARATED: 0 };
     people.forEach((person) => {
       const current = resolveCurrentEmployment(person as unknown as Person, asOf);
       if (!current) base.SEPARATED += 1;
-      else base[current.type] += 1;
+      else if (current.type === 'INTERN') base.INTERN += 1;
+      else base.MAIN += 1;
     });
     return base;
   }, [people, asOf]);
@@ -341,12 +427,9 @@ export function PeopleDirectoryPage() {
             value={searchText} onChange={(event) => setSearchText(event.target.value)}
           />
         </div>
+        {/* 근로형태별 필터를 없앴다. 필터를 누르는 것만으로도 누가 어느 형태인지 드러난다. */}
         {([
-          ['ALL', `전체 ${people.length}`],
-          ['FULL_TIME', `정규직 ${counts.FULL_TIME}`],
-          ['INTERN', `인턴 ${counts.INTERN}`],
-          ['PARTNER', `파트너 ${counts.PARTNER}`],
-          ['PLACEHOLDER', `미채용 ${counts.PLACEHOLDER}`],
+          ['ALL', `전체 ${counts.MAIN + counts.INTERN}`],
           ['SEPARATED', `계약 종료 ${counts.SEPARATED}`],
         ] as const).map(([value, label]) => (
           <Button
@@ -412,70 +495,17 @@ export function PeopleDirectoryPage() {
         </Card>
       ) : null}
 
-      <div className="overflow-x-auto rounded-lg border">
-        <Table>
-          <TableHeader>
-            <TableRow className="bg-muted/30">
-              <TableHead className="min-w-[130px]">이름</TableHead>
-              <TableHead className="min-w-[110px]">근로형태</TableHead>
-              <TableHead className="min-w-[90px]">재직상태</TableHead>
-              <TableHead className="min-w-[150px]">소속</TableHead>
-              <TableHead className="min-w-[110px]">직급</TableHead>
-              <TableHead className="min-w-[100px]">입사일</TableHead>
-              <TableHead className="min-w-[100px]">근속</TableHead>
-              <TableHead className="w-24" />
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {rows.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={8} className="py-10 text-center text-sm text-slate-500">
-                  {loading ? '불러오는 중…' : '조건에 맞는 인력이 없습니다.'}
-                </TableCell>
-              </TableRow>
-            ) : rows.map(({ person, current, separatedAt, tenure }) => (
-              <TableRow
-                key={person.personId}
-                className="cursor-pointer hover:bg-accent/40"
-                onClick={() => openPerson(person)}
-              >
-                <TableCell>
-                  <span className="text-xs font-semibold">{person.name}</span>
-                  {person.nickname ? <span className="ml-1 text-[10px] text-muted-foreground">({person.nickname})</span> : null}
-                </TableCell>
-                <TableCell>
-                  {current ? (
-                    <Badge variant="outline" className={`text-[10px] ${TYPE_TONE[current.type as EmploymentType]}`}>
-                      {EMPLOYMENT_TYPE_LABELS[current.type as EmploymentType]}
-                    </Badge>
-                  ) : (
-                    <Badge variant="outline" className="border-slate-300 bg-slate-100 text-[10px] text-slate-500">계약 종료</Badge>
-                  )}
-                </TableCell>
-                <TableCell>
-                  {current ? (
-                    <Badge variant="outline" className={`text-[10px] ${STATE_TONE[current.state as EmploymentState]}`}>
-                      {EMPLOYMENT_STATE_LABELS[current.state as EmploymentState]}
-                    </Badge>
-                  ) : (
-                    <span className="text-[11px] text-slate-500">{separatedAt ? `${formatDate(separatedAt)} 종료` : '-'}</span>
-                  )}
-                </TableCell>
-                <TableCell className="text-xs text-muted-foreground">
-                  {person.departmentTop || '-'}
-                  {person.departmentMid ? <span className="text-slate-400"> · {person.departmentMid}</span> : null}
-                </TableCell>
-                <TableCell className="text-xs">{person.grade || person.title || '-'}</TableCell>
-                <TableCell className="text-xs tabular-nums text-muted-foreground">{formatDate(person.joinedAt)}</TableCell>
-                <TableCell className="text-xs tabular-nums">{tenure?.label || '-'}</TableCell>
-                <TableCell>
-                  <Button variant="ghost" size="sm" className="h-6 px-2 text-[11px]">계약 관리</Button>
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
+      <PeopleTable rows={mainRows} loading={loading} onOpen={openPerson} />
+
+      {internRows.length > 0 || counts.INTERN > 0 ? (
+        <section className="space-y-2">
+          <div className="flex items-baseline gap-2">
+            <h2 className="text-sm font-semibold text-slate-900">인턴</h2>
+            <span className="text-[11px] tabular-nums text-slate-500">{counts.INTERN}명</span>
+          </div>
+          <PeopleTable rows={internRows} loading={loading} onOpen={openPerson} />
+        </section>
+      ) : null}
 
       <p className="text-[11px] text-slate-500">
         근속은 입사일과 오늘({asOf}) 기준으로 매번 다시 계산합니다. 계약 이력은 지우지 않고 쌓습니다 —


### PR DESCRIPTION
## 왜

근로형태가 이름 옆 배지로 붙으면 **신분 표시**가 됩니다. `/people` 을 여는 사람 누구나 누가 인턴이고 누가 파트너인지 알게 됩니다.

## 무엇을

| | |
|---|---|
| **근로형태 열** | 목록에서 제거 |
| **근로형태별 필터 칩** | 제거 — 필터를 누르는 것만으로도 누가 어느 형태인지 드러납니다 |
| **인턴** | 아래 **별도 표**로 분리 |
| **계약 관리 다이얼로그** | **그대로 유지** — 계약을 바꾸려면 보여야 합니다 |

목록에 남는 것: 이름 · 재직상태 · 소속 · 직급 · 입사일 · 근속

**열만 지우고 한 표에 두면 순서와 빈칸으로 드러나서** 표를 뗐습니다. 두 표는 같은 컴포넌트(`PeopleTable`)를 씁니다 — 한쪽만 조용히 달라지지 않게.

## 검증

- 셸 테스트 5개로 잠금
- **사보타주 2회 검출** — 목록에 근로형태 열 되살리기, 인턴을 한 표로 합치기
- 타입 에러 기준선(234줄) 동일 / 빌드 통과

> `재직상태`(휴직·육아휴직)는 이번에 건드리지 않았습니다. 근로형태보다 민감할 수 있어 별도 판단이 필요해 보입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)