### PR TITLE
feat(projects): notify Slack when project code is assigned

### DIFF
--- a/server/bff/routes/management-planning-review.test.mjs
+++ b/server/bff/routes/management-planning-review.test.mjs
@@ -55,7 +55,7 @@ function createDb(seed = {}) {
   };
 }
 
-function createRouteApp({ actorRole = 'finance', memberStatus = 'ACTIVE', seed = {} } = {}) {
+function createRouteApp({ actorRole = 'finance', memberStatus = 'ACTIVE', seed = {}, projectRegistrationSlackService } = {}) {
   const db = createDb({
     'orgs/tenant-a/members/finance-a': {
       uid: 'finance-a', role: actorRole, status: memberStatus,
@@ -83,6 +83,7 @@ function createRouteApp({ actorRole = 'finance', memberStatus = 'ACTIVE', seed =
       complete: vi.fn(async () => undefined),
       fail: vi.fn(async () => undefined),
     },
+    projectRegistrationSlackService,
   });
   app.use((error, _req, res, _next) => {
     res.status(error.statusCode || 500).json({ error: error.code || 'internal_error', message: error.message });
@@ -138,7 +139,8 @@ function reviewSeed(project = approvedProject(), projectRequest = approvedReques
 
 describe('management planning project review route', () => {
   it('agrees after executive approval, normalizes and atomically claims the project code', async () => {
-    const { app, db } = createRouteApp({ seed: reviewSeed() });
+    const projectRegistrationSlackService = { enabled: true, notifyMessage: vi.fn(async () => {}) };
+    const { app, db } = createRouteApp({ seed: reviewSeed(), projectRegistrationSlackService });
 
     const response = await request(app)
       .post('/api/v1/projects/project-a/management-planning-review')
@@ -158,6 +160,7 @@ describe('management planning project review route', () => {
       requestId: 'request-a',
       reviewStatus: 'AGREED',
       projectCode: 'AXR-2026-001',
+      slackDelivered: true,
     });
     expect(db.documents.get('orgs/tenant-a/projects/project-a')).toMatchObject({
       executiveReviewStatus: 'APPROVED',
@@ -184,6 +187,9 @@ describe('management planning project review route', () => {
       projectCode: 'AXR-2026-001',
       projectCodeKey: 'AXR-2026-001',
     });
+    expect(projectRegistrationSlackService.notifyMessage).toHaveBeenCalledWith(expect.objectContaining({
+      text: expect.stringContaining('프로젝트 코드 등록 완료: AXR-2026-001'),
+    }));
   });
 
   it('closes a resubmitted management-planning change request when it agrees', async () => {

--- a/server/bff/routes/projects.mjs
+++ b/server/bff/routes/projects.mjs
@@ -265,6 +265,39 @@ function buildProjectExecutiveReviewSlackPayload({ project, projectRequest, revi
   };
 }
 
+function buildProjectCodeRegisteredSlackPayload({ project, projectRequest, projectCode, reviewerName }) {
+  const payload = project && typeof project === 'object' ? project : {};
+  const requestPayload = projectRequest?.payload && typeof projectRequest.payload === 'object'
+    ? projectRequest.payload
+    : {};
+  const projectName = trimSlackText(payload.name || requestPayload.name, 120);
+  const officialContractName = trimSlackText(payload.officialContractName || requestPayload.officialContractName, 220);
+  const clientOrg = trimSlackText(payload.clientOrg || requestPayload.clientOrg, 160);
+  const department = trimSlackText(payload.department || requestPayload.department, 120);
+  const requester = trimSlackText(projectRequest?.requestedByName, 120);
+  const requestId = trimSlackText(projectRequest?.id, 120);
+  const projectId = trimSlackText(payload.id, 120);
+  const code = trimSlackText(projectCode || payload.projectCode, 120);
+  const reviewer = trimSlackText(reviewerName, 120);
+  const lines = [
+    '*[InnerPlatform] 프로젝트 코드 등록 완료*',
+    `프로젝트명: \`${projectName}\``,
+    `프로젝트 코드: ${code}`,
+    `공식 계약명: ${officialContractName}`,
+    `계약 대상: ${clientOrg}`,
+    `담당조직(CIC): ${department}`,
+    `처리자: ${reviewer}`,
+    `요청자: ${requester}`,
+    `requestId: \`${requestId}\``,
+    `projectId: \`${projectId}\``,
+  ];
+
+  return {
+    text: `[InnerPlatform] 프로젝트 코드 등록 완료: ${code} · ${projectName}`,
+    blocks: [{ type: 'section', text: { type: 'mrkdwn', text: lines.join('\n') } }],
+  };
+}
+
 function assertProjectRequestMatchesProject(request, projectId) {
   const normalizedProjectId = readOptionalText(projectId);
   const requestProjectIds = [request?.approvedProjectId, request?.targetProjectId]
@@ -3522,7 +3555,7 @@ export function mountProjectRoutes(app, {
       && isProjectChangeRequest(request)
       && readOptionalText(request?.status) === 'PENDING';
 
-    await mergeProjectAndRequestDocs({
+    const projectResult = await mergeProjectAndRequestDocs({
       db,
       projectPath,
       buildProjectPatch: async (currentProject, currentRequest, _nextVersion, tx) => {
@@ -3656,6 +3689,27 @@ export function mountProjectRoutes(app, {
       notFoundMessage: `Project not found: ${projectId}`,
     });
 
+    let slackDelivered = false;
+    let slackReason = null;
+    if (parsed.reviewStatus === 'AGREED') {
+      if (!projectRegistrationSlackService?.enabled || typeof projectRegistrationSlackService.notifyMessage !== 'function') {
+        slackReason = 'slack_not_configured';
+      } else {
+        try {
+          await projectRegistrationSlackService.notifyMessage(buildProjectCodeRegisteredSlackPayload({
+            project: projectResult.data,
+            projectRequest: projectResult.request || request,
+            projectCode,
+            reviewerName,
+          }));
+          slackDelivered = true;
+        } catch (error) {
+          console.error('[BFF] project code Slack notification failed:', error);
+          slackReason = error instanceof Error ? error.message : 'slack_delivery_failed';
+        }
+      }
+    }
+
     return {
       status: 200,
       body: {
@@ -3665,6 +3719,8 @@ export function mountProjectRoutes(app, {
         reviewStatus: parsed.reviewStatus,
         projectCode,
         reviewedAt: now,
+        slackDelivered,
+        slackReason,
       },
     };
   }));


### PR DESCRIPTION
## Summary\n- notify the shared axr-qa channel after finance assigns a project code\n- reuse the existing project registration Slack delivery service\n- keep Slack delivery non-blocking for the state transition\n\n## Verification\n- npx vitest run server/bff/app.test.ts server/bff/app.integration.test.ts server/bff/routes/management-planning-review.test.mjs --reporter=dot\n- git diff --check