### PR TITLE
fix(cashflow): align monthly approvals with prior month

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -3041,33 +3041,51 @@ export function mountJvmWeeklyApiRoutes(app, {
       }
       return { projectIds, yearMonth };
     });
-    const result = await trace.measure('java_overview', () => proxyJavaWeeklyRequest({
-      context: req.context,
-      method: 'POST',
-      path: '/api/v1/cashflow/weekly-overview',
-      command: 'read_cashflow_weekly_overview',
-      body: { projectIds, yearMonth },
-      mutation: false,
-    }), { projectCount: projectIds.length });
-    const sheetSummary = await trace.measure('sheet_formula_summary', () => readSheetFormulaProjectionActualSummaries({
-      db,
-      req,
-      projectIds,
-      yearMonth,
-      comparisonBoundary: resolveCashflowComparisonAsOf('', now()),
-      authMode,
-      workspaceEmailDomain,
-    }), { projectCount: projectIds.length });
-    const summaryByProjectId = new Map(sheetSummary.items.map((item) => [item.projectId, item]));
-    const resultErrors = Array.isArray(result?.errors) ? result.errors.filter((error) => error?.code !== 'SUMMARY_UNAVAILABLE') : [];
+    const monthCloseTargetYearMonth = previousYearMonth(yearMonth);
+    const [weeklyResult, monthStatusResult] = await trace.measure('java_overview', () => Promise.all([
+      proxyJavaWeeklyRequest({
+        context: req.context,
+        method: 'POST',
+        path: '/api/v1/cashflow/weekly-overview',
+        command: 'read_cashflow_weekly_overview',
+        body: { projectIds, yearMonth },
+        mutation: false,
+      }),
+      proxyJavaWeeklyRequest({
+        context: req.context,
+        method: 'POST',
+        path: '/api/v1/cashflow/settlement-statuses/batch',
+        command: 'read_cashflow_settlement_statuses_batch',
+        body: { projectIds, yearMonth: monthCloseTargetYearMonth },
+        mutation: false,
+      }),
+    ]), { projectCount: projectIds.length });
+    const alignedMonthStatusResult = await alignMonthSettlementStatus(db, req.context.tenantId, monthStatusResult);
+    const monthStatuses = new Map((Array.isArray(alignedMonthStatusResult?.items) ? alignedMonthStatusResult.items : []).map((item) => [
+      item?.projectId,
+      Array.isArray(item?.items)
+        ? item.items.find((status) => status?.period === 'MONTH') || null
+        : null,
+    ]));
     const combined = {
-      ...result,
-      version: '2',
-      items: (Array.isArray(result?.items) ? result.items : []).map((item) => ({
+      ...weeklyResult,
+      version: '3',
+      yearMonth,
+      monthCloseTargetYearMonth,
+      items: (Array.isArray(weeklyResult?.items) ? weeklyResult.items : []).map((item) => ({
         ...item,
-        projectionActualSummary: summaryByProjectId.get(item?.projectId) || null,
+        settlementStatuses: item?.settlementStatuses ? {
+          ...item.settlementStatuses,
+          items: item.settlementStatuses.items.map((status) => status?.period === 'MONTH'
+            ? (monthStatuses.get(item.projectId) || status)
+            : status),
+        } : null,
+        projectionActualSummary: null,
       })),
-      errors: [...resultErrors, ...sheetSummary.errors],
+      errors: [
+        ...(Array.isArray(weeklyResult?.errors) ? weeklyResult.errors : []),
+        ...(Array.isArray(alignedMonthStatusResult?.errors) ? alignedMonthStatusResult.errors : []),
+      ],
     };
     trace.emit('response', {
       outcome: 'ok',

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -603,7 +603,7 @@ describe('JVM weekly API BFF proxy', () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
-  it('reads a 61-project weekly overview with one JVM status request and sheet summary errors', async () => {
+  it('reads a 61-project weekly overview and exposes the previous month as the monthly-close target', async () => {
     const projectIds = Array.from({ length: 61 }, (_, index) => `project-${index + 1}`);
     const canonical = {
       version: '1',
@@ -621,13 +621,17 @@ describe('JVM weekly API BFF proxy', () => {
       .send({ projectIds, yearMonth: '2026-08' })
       .expect(200);
 
-    expect(response.body).toMatchObject({ version: '2', yearMonth: '2026-08', items: canonical.items });
-    expect(response.body.errors).toHaveLength(62);
+    expect(response.body).toMatchObject({ version: '3', yearMonth: '2026-08', monthCloseTargetYearMonth: '2026-07', items: canonical.items });
+    expect(response.body.errors).toHaveLength(2);
 
-    expect(fetchImpl).toHaveBeenCalledOnce();
-    expect(fetchImpl).toHaveBeenCalledWith(
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(fetchImpl).toHaveBeenNthCalledWith(1,
       'http://jvm-weekly.local/api/v1/cashflow/weekly-overview',
       expect.objectContaining({ method: 'POST', body: JSON.stringify({ projectIds, yearMonth: '2026-08' }) }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(2,
+      'http://jvm-weekly.local/api/v1/cashflow/settlement-statuses/batch',
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ projectIds, yearMonth: '2026-07' }) }),
     );
   });
 

--- a/src/app/components/approval/AdminApprovalPage.tsx
+++ b/src/app/components/approval/AdminApprovalPage.tsx
@@ -21,7 +21,7 @@ export function AdminApprovalPage() {
       <PageHeader
         icon={CheckCircle2}
         iconGradient="linear-gradient(135deg, #0f766e, #14b8a6)"
-        title="승인 대기열"
+        title="프로젝트 등록/승인"
         description="프로젝트 등록 요청을 최종 결재자 (사업총괄)가 확인하고 승인하거나 반려합니다"
         badge={`대기 ${totalPending}건`}
       />

--- a/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
+++ b/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
@@ -10,9 +10,9 @@ import {
 const source = readFileSync(resolve(import.meta.dirname, 'CashflowWeeklyPage.tsx'), 'utf8');
 
 describe('CashflowWeeklyPage settlement status surface', () => {
-  it('shows the requested month and weekly status columns without the old summary', () => {
+  it('shows the prior-month close and weekly status columns without cashflow amounts', () => {
     expect(source).toContain('title="전사 현금흐름 현황"');
-    expect(source).toContain('>월 결산</th>');
+    expect(source).toContain("monthCloseTargetYearMonth || '직전 월'");
     expect(source).toContain('>현금흐름(링크)</th>');
     expect(source).toContain('<div>{week.label}</div>');
     expect(source).not.toContain('>요약<');
@@ -22,6 +22,10 @@ describe('CashflowWeeklyPage settlement status surface', () => {
     expect(source).not.toContain("['P - A'");
     expect(source).not.toContain('금액 조회 오류');
     expect(source).not.toContain('>조회 오류</span>');
+    expect(source).toContain('monthCloseTargetYearMonth');
+    expect(source).toContain('실무자 결재:');
+    expect(source).toContain('조직장 승인:');
+    expect(source).not.toContain('PeriodAmounts');
   });
 
   it('uses one overview snapshot and refreshes it after a status transition', () => {
@@ -29,7 +33,7 @@ describe('CashflowWeeklyPage settlement status surface', () => {
     expect(source).toContain('sticky left-0');
     expect(source).toContain('fetchCashflowWeeklyOverviewViaBff');
     expect(source).toContain('transitionCashflowSettlementStatusViaBff');
-    expect(source).toContain("onAction={(action) => void transition(project.id, 'MONTH', action)}");
+    expect(source).toContain("onAction={(action) => void transition(project.id, 'MONTH', action, overview?.monthCloseTargetYearMonth || yearMonth)}");
     expect(source).toContain('주정산 이전');
     expect(source).toContain('결산 전');
     expect(source).toContain('조직장 승인 필요');

--- a/src/app/components/cashflow/CashflowWeeklyPage.tsx
+++ b/src/app/components/cashflow/CashflowWeeklyPage.tsx
@@ -14,7 +14,6 @@ import { useFirebase } from '../../lib/firebase-context';
 import {
   fetchCashflowWeeklyOverviewViaBff,
   transitionCashflowSettlementStatusViaBff,
-  type CashflowProjectionActualSummary,
   type CashflowSettlementPeriod,
   type CashflowSettlementStatus,
   type CashflowSettlementStatusItem,
@@ -126,25 +125,25 @@ function SettlementStatusFilterSelect({
   );
 }
 
-function PeriodAmounts({
-  summary,
-  period,
-  loading,
-  error,
-}: {
-  summary: CashflowProjectionActualSummary | undefined;
-  period: CashflowSettlementPeriod;
-  loading?: boolean;
-  error?: boolean;
-}) {
-  if (error) return <div className="mt-1 text-[9px] text-amber-700">금액 확인 필요</div>;
-  if (loading) return <div className="mt-1 text-[9px] text-slate-400">금액 확인 중…</div>;
-  const amounts = summary?.periods.find((item) => item.period === period);
-  if (!amounts) return null;
-  if (amounts.differenceAmount === null) return <div className="mt-1 text-[9px] text-slate-400">시트값 없음</div>;
+function formatSettlementAt(value: string) {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Asia/Seoul', day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: false,
+  }).formatToParts(date);
+  const part = (type: Intl.DateTimeFormatPartTypes) => parts.find((item) => item.type === type)?.value || '';
+  return `${part('day')}일 ${part('hour')}:${part('minute')}`;
+}
+
+function SettlementApprovalTimes({ item }: { item?: CashflowSettlementStatusItem }) {
+  const submittedAt = formatSettlementAt(item?.submittedAt || '');
+  const approvedAt = formatSettlementAt(item?.approvedAt || '');
+  if (!submittedAt && !approvedAt) return null;
   return (
-    <div className="mt-1 text-[9px] leading-tight text-slate-500 tabular-nums">
-      <div className="font-semibold text-slate-700">P-A {amounts.differenceAmount.toLocaleString('ko-KR')}원</div>
+    <div className="mt-1.5 space-y-0.5 text-left text-[9px] leading-tight text-slate-500">
+      {submittedAt ? <div>실무자 결재: {submittedAt}</div> : null}
+      {approvedAt ? <div>조직장 승인: {approvedAt}</div> : null}
     </div>
   );
 }
@@ -185,15 +184,6 @@ export function CashflowWeeklyPage() {
     return Object.fromEntries((overview?.errors || [])
       .filter((error) => error.code === 'STATUS_UNAVAILABLE')
       .map((error) => [error.projectId, '결산 상태를 불러오지 못했습니다. 다시 불러와 주세요.']));
-  }, [overview, overviewError, overviewProjectIds]);
-  const summaries = useMemo<Record<string, CashflowProjectionActualSummary>>(() => Object.fromEntries(
-    (overview?.items || []).flatMap((item) => item.projectionActualSummary ? [[item.projectId, item.projectionActualSummary]] : []),
-  ), [overview]);
-  const summaryErrors = useMemo<Record<string, boolean>>(() => {
-    if (overviewError) return Object.fromEntries(overviewProjectIds.map((projectId) => [projectId, true]));
-    return Object.fromEntries((overview?.errors || [])
-      .filter((error) => error.code === 'SUMMARY_UNAVAILABLE')
-      .map((error) => [error.projectId, true]));
   }, [overview, overviewError, overviewProjectIds]);
   const filteredProjects = useMemo(() => filterCashflowProjectsBySettlementStatus(
     projects,
@@ -265,12 +255,12 @@ export function CashflowWeeklyPage() {
     return () => { active = false; window.clearTimeout(requestTimer); };
   }, [orgId, overviewActor, overviewProjectIdsKey, refreshSequence, yearMonth]);
 
-  async function transition(projectId: string, period: CashflowSettlementPeriod, action: 'SUBMIT' | 'APPROVE') {
+  async function transition(projectId: string, period: CashflowSettlementPeriod, action: 'SUBMIT' | 'APPROVE', targetYearMonth = yearMonth) {
     if (!user?.idToken) return;
     const key = `${projectId}:${period}`;
     setActionKey(key);
     try {
-      await transitionCashflowSettlementStatusViaBff({ tenantId: orgId, actor: user, projectId, yearMonth, period, action });
+      await transitionCashflowSettlementStatusViaBff({ tenantId: orgId, actor: user, projectId, yearMonth: targetYearMonth, period, action });
       setRefreshSequence((current) => current + 1);
       toast.success(action === 'APPROVE' ? '정산을 승인했습니다.' : '조직장 승인 대기로 변경했습니다.');
     } catch (error) {
@@ -331,7 +321,7 @@ export function CashflowWeeklyPage() {
                 <tr className="bg-muted/30">
                   <th className="sticky left-0 top-0 z-40 min-w-[220px] border-b bg-slate-50 px-4 py-2 text-left font-bold">프로젝트</th>
                   <th className="sticky left-[220px] top-0 z-40 min-w-[120px] border-b bg-slate-50 px-3 py-2 text-left font-bold">담당자</th>
-                  <th className="sticky top-0 z-30 min-w-[150px] border-b bg-slate-50 px-3 py-2 text-center font-bold">월 결산</th>
+                  <th className="sticky top-0 z-30 min-w-[170px] border-b bg-slate-50 px-3 py-2 text-center font-bold">{overview?.monthCloseTargetYearMonth || '직전 월'} 결산</th>
                   <th className="sticky top-0 z-30 min-w-[140px] border-b bg-slate-50 px-3 py-2 text-center font-bold">현금흐름(링크)</th>
                   {monthWeeks.map((week) => (
                     <th key={week.weekNo} className="sticky top-0 z-30 min-w-[170px] border-b bg-slate-50 px-3 py-2 text-center font-bold">
@@ -359,10 +349,10 @@ export function CashflowWeeklyPage() {
                             period="MONTH"
                             loading={actionKey === `${project.id}:MONTH`}
                             canApprove={canApprove}
-                            onAction={(action) => void transition(project.id, 'MONTH', action)}
+                            onAction={(action) => void transition(project.id, 'MONTH', action, overview?.monthCloseTargetYearMonth || yearMonth)}
                           />
                         )}
-                        <PeriodAmounts summary={summaries[project.id]} period="MONTH" loading={overviewLoading && !summaries[project.id]} error={summaryErrors[project.id]} />
+                        <SettlementApprovalTimes item={statusItem(projectStatuses, 'MONTH')} />
                       </td>
                       <td className="px-3 py-3 text-center">
                         <Button size="sm" variant="outline" className="h-8 gap-1.5 text-[11px]" onClick={() => openProject(project.id)}>
@@ -382,7 +372,7 @@ export function CashflowWeeklyPage() {
                                 onAction={(action) => void transition(project.id, period, action)}
                               />
                             )}
-                            <PeriodAmounts summary={summaries[project.id]} period={period} loading={overviewLoading && !summaries[project.id]} error={summaryErrors[project.id]} />
+                            <SettlementApprovalTimes item={statusItem(projectStatuses, period)} />
                           </td>
                         );
                       })}

--- a/src/app/components/layout/QuickActionFab.tsx
+++ b/src/app/components/layout/QuickActionFab.tsx
@@ -11,7 +11,7 @@ import { shouldShowShellRoute, useShellLabEnabled } from '../../platform/shell-l
 const ACTIONS = [
   { icon: BarChart3, label: '캐시플로 모니터링', path: '/cashflow', color: '#0d9488' },
   { icon: FileCheck, label: '증빙/정산', path: '/evidence', color: '#f59e0b' },
-  { icon: Shield, label: '승인 대기열', path: '/approvals', color: '#0891b2' },
+  { icon: Shield, label: '프로젝트 등록/승인', path: '/approvals', color: '#0891b2' },
 ];
 
 export function QuickActionFab() {

--- a/src/app/components/portal/PortalSubmissionsPage.lease.shell.test.ts
+++ b/src/app/components/portal/PortalSubmissionsPage.lease.shell.test.ts
@@ -6,8 +6,8 @@ const source = readFileSync(resolve(import.meta.dirname, 'PortalSubmissionsPage.
 
 describe('PortalSubmissionsPage weekly history', () => {
   it('keeps weekly status as read-only history and delegates final authority to monthly close', () => {
-    expect(source).toContain('주간 입력 기록 (조회용)');
-    expect(source).toContain('주차별 입력 이력은 조회만 가능하며, 최종 확정과 수정 잠금은 프로젝트별 월 결산에서 처리합니다.');
+    expect(source).toContain('현금흐름 승인');
+    expect(source).toContain('주차별 입력 현황은 조회만 가능하며, 최종 확정과 수정 잠금은 프로젝트별 월 결산에서 처리합니다.');
     expect(source).toContain('기존 제출 이력');
     expect(source).toContain('기존 결산 이력');
     expect(source).not.toContain('useCashflowEditLease');

--- a/src/app/components/portal/PortalSubmissionsPage.tsx
+++ b/src/app/components/portal/PortalSubmissionsPage.tsx
@@ -213,7 +213,7 @@ export function PortalSubmissionsPage() {
           <div className="flex items-center justify-between gap-3">
             <CardTitle className="flex items-center gap-1.5 text-[13px] font-semibold text-slate-950">
               <BarChart3 className="w-4 h-4 text-[#1f4a7d]" />
-              주간 입력 기록 (조회용)
+              현금흐름 승인
             </CardTitle>
             <div className="flex items-center gap-1.5">
               <Button variant="outline" size="sm" className={outlineActionButtonClassName} onClick={goPrevMonth}>
@@ -227,7 +227,7 @@ export function PortalSubmissionsPage() {
         </CardHeader>
         <CardContent className="space-y-4 pt-4">
           <div className="rounded-xl border border-slate-200/80 bg-slate-50/80 px-3 py-2 text-[11px] text-slate-600">
-            주차별 입력 이력은 조회만 가능하며, 최종 확정과 수정 잠금은 프로젝트별 월 결산에서 처리합니다.
+            주차별 입력 현황은 조회만 가능하며, 최종 확정과 수정 잠금은 프로젝트별 월 결산에서 처리합니다.
           </div>
           <div className="flex flex-wrap items-center gap-2 rounded-xl border border-slate-200/80 bg-slate-50/80 px-3 py-3">
             <span className="text-[11px] font-semibold text-slate-600">{yearMonth}</span>

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -1493,6 +1493,7 @@ export interface CashflowProjectionActualSummaryBatch {
 export interface CashflowWeeklyOverviewResult {
   version: string;
   yearMonth: string;
+  monthCloseTargetYearMonth: string;
   items: Array<{
     projectId: string;
     settlementStatuses: CashflowSettlementStatusesResult | null;

--- a/src/app/platform/nav-config.ts
+++ b/src/app/platform/nav-config.ts
@@ -19,18 +19,18 @@ export interface NavGroup {
 
 export const NAV_GROUPS: NavGroup[] = [
   {
-    label: '인사이트',
+    label: 'CEO',
     items: [
-      { to: '/dashboard', icon: LayoutDashboard, label: '대시보드' },
+      { to: '/dashboard', icon: LayoutDashboard, label: '통합 대시보드' },
     ],
   },
   {
-    label: '프로젝트 관리',
+    label: '관리자',
     items: [
-      { to: '/projects', icon: FolderKanban, label: '통합 관리' },
+      { to: '/projects', icon: FolderKanban, label: '통합 대시보드' },
       { to: '/projects/migration-audit', icon: ArrowLeftRight, label: '프로젝트 등록/승인' },
       { to: '/cashflow', icon: BarChart3, label: '현금흐름 승인' },
-      { to: '/participation', icon: Shield, label: '참여율 대시보드' },
+      { to: '/participation', icon: Shield, label: '참여율 관리' },
     ],
   },
   {
@@ -42,7 +42,7 @@ export const NAV_GROUPS: NavGroup[] = [
     ],
   },
   {
-    label: '시스템 관리',
+    label: 'AXR',
     items: [
       { to: '/users', icon: UserCog, label: '권한 관리' },
       { to: '/settings?tab=members', icon: UserCog, label: '멤버DB' },


### PR DESCRIPTION
## 변경\n- 관리자 라우터 명칭을 정리합니다.\n- 선택 월의 직전 월을 월결산 대상으로 서버에서 조회합니다.\n- P/A 금액 대신 실무자·조직장 승인 시각을 표시합니다.\n\n## 검증\n- 관련 Vitest 195개 통과\n- npm run typecheck 통과\n- git diff --check 통과