### PR TITLE
fix(cashflow): align month close with view month

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -162,8 +162,11 @@ async function alignMonthSettlementStatus(db, tenantId, result) {
   if (!db?.doc) return result;
   await Promise.all(projects.map(async (project) => {
     const projectId = readOptionalText(project?.projectId);
-    const yearMonth = readOptionalText(project?.yearMonth);
-    if (!projectId || !yearMonth || !Array.isArray(project.items)) return;
+    const yearMonth = readOptionalText(project?.yearMonth) || readOptionalText(result?.yearMonth);
+    const statusItems = Array.isArray(project?.items)
+      ? project.items
+      : project?.settlementStatuses?.items;
+    if (!projectId || !yearMonth || !Array.isArray(statusItems)) return;
     const snapshot = await db.doc(cashflowMonthCloseRequestPath(tenantId, `${projectId}-${yearMonth}`)).get();
     if (!snapshot.exists) return;
     const requestStatus = readOptionalText(snapshot.data()?.status);
@@ -172,7 +175,12 @@ async function alignMonthSettlementStatus(db, tenantId, result) {
       : ['PENDING', 'REOPEN_REQUESTED', 'APPROVING', 'UNCERTAIN'].includes(requestStatus)
         ? 'PENDING_APPROVAL'
         : 'WAITING_FOR_UPDATE';
-    project.items = project.items.map((item) => item.period === 'MONTH' ? { ...item, status } : item);
+    const alignedItems = statusItems.map((item) => item.period === 'MONTH' ? { ...item, status } : item);
+    if (Array.isArray(project?.items)) {
+      project.items = alignedItems;
+    } else {
+      project.settlementStatuses = { ...project.settlementStatuses, items: alignedItems };
+    }
   }));
   return result;
 }
@@ -3042,50 +3050,27 @@ export function mountJvmWeeklyApiRoutes(app, {
       return { projectIds, yearMonth };
     });
     const monthCloseTargetYearMonth = previousYearMonth(yearMonth);
-    const [weeklyResult, monthStatusResult] = await trace.measure('java_overview', () => Promise.all([
-      proxyJavaWeeklyRequest({
-        context: req.context,
-        method: 'POST',
-        path: '/api/v1/cashflow/weekly-overview',
-        command: 'read_cashflow_weekly_overview',
-        body: { projectIds, yearMonth },
-        mutation: false,
-      }),
-      proxyJavaWeeklyRequest({
-        context: req.context,
-        method: 'POST',
-        path: '/api/v1/cashflow/settlement-statuses/batch',
-        command: 'read_cashflow_settlement_statuses_batch',
-        body: { projectIds, yearMonth: monthCloseTargetYearMonth },
-        mutation: false,
-      }),
-    ]), { projectCount: projectIds.length });
-    const alignedMonthStatusResult = await alignMonthSettlementStatus(db, req.context.tenantId, monthStatusResult);
-    const monthStatuses = new Map((Array.isArray(alignedMonthStatusResult?.items) ? alignedMonthStatusResult.items : []).map((item) => [
-      item?.projectId,
-      Array.isArray(item?.items)
-        ? item.items.find((status) => status?.period === 'MONTH') || null
-        : null,
-    ]));
+    const weeklyResult = await trace.measure('java_overview', () => proxyJavaWeeklyRequest({
+      context: req.context,
+      method: 'POST',
+      path: '/api/v1/cashflow/weekly-overview',
+      command: 'read_cashflow_weekly_overview',
+      body: { projectIds, yearMonth },
+      mutation: false,
+    }), { projectCount: projectIds.length });
+    const alignedWeeklyResult = await alignMonthSettlementStatus(db, req.context.tenantId, weeklyResult);
     const combined = {
-      ...weeklyResult,
+      ...alignedWeeklyResult,
       version: '3',
       yearMonth,
       monthCloseTargetYearMonth,
       monthCloseTargetLabel: `${Number(monthCloseTargetYearMonth.slice(5, 7))}월`,
-      items: (Array.isArray(weeklyResult?.items) ? weeklyResult.items : []).map((item) => ({
+      items: (Array.isArray(alignedWeeklyResult?.items) ? alignedWeeklyResult.items : []).map((item) => ({
         ...item,
-        settlementStatuses: item?.settlementStatuses ? {
-          ...item.settlementStatuses,
-          items: item.settlementStatuses.items.map((status) => status?.period === 'MONTH'
-            ? (monthStatuses.get(item.projectId) || status)
-            : status),
-        } : null,
         projectionActualSummary: null,
       })),
       errors: [
-        ...(Array.isArray(weeklyResult?.errors) ? weeklyResult.errors : []),
-        ...(Array.isArray(alignedMonthStatusResult?.errors) ? alignedMonthStatusResult.errors : []),
+        ...(Array.isArray(alignedWeeklyResult?.errors) ? alignedWeeklyResult.errors : []),
       ],
     };
     trace.emit('response', {

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -603,35 +603,46 @@ describe('JVM weekly API BFF proxy', () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
-  it('reads a 61-project weekly overview and exposes the previous month as the monthly-close target', async () => {
+  it('reads one 61-project weekly overview and exposes its monthly status as the previous-month close', async () => {
     const projectIds = Array.from({ length: 61 }, (_, index) => `project-${index + 1}`);
+    const source = fullMonthCloseSource();
+    source.documents.set('orgs/tenant-a/cashflow_month_close_requests/project-1-2026-08', {
+      requestId: 'project-1-2026-08', projectId: 'project-1', yearMonth: '2026-08', status: 'PENDING',
+    });
     const canonical = {
       version: '1',
       yearMonth: '2026-08',
-      items: [{ projectId: 'project-1', settlementStatuses: null, projectionActualSummary: null }],
-      errors: [{ projectId: 'project-1', code: 'STATUS_UNAVAILABLE' }],
+      items: [{
+        projectId: 'project-1',
+        settlementStatuses: {
+          projectId: 'project-1', yearMonth: '2026-08',
+          items: [{ period: 'MONTH', status: 'COMPLETED' }, { period: 'WEEK_1', status: 'COMPLETED' }],
+        },
+        projectionActualSummary: null,
+      }],
+      errors: [],
     };
     const fetchImpl = vi.fn(async () => new Response(JSON.stringify(canonical), {
       status: 200, headers: { 'content-type': 'application/json' },
     }));
-    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { env: runtimeEnv });
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { env: runtimeEnv, db: source.db });
 
     const response = await request(app)
       .post('/api/v1/cashflow/weekly-overview')
       .send({ projectIds, yearMonth: '2026-08' })
       .expect(200);
 
-    expect(response.body).toMatchObject({ version: '3', yearMonth: '2026-08', monthCloseTargetYearMonth: '2026-07', monthCloseTargetLabel: '7월', items: canonical.items });
-    expect(response.body.errors).toHaveLength(2);
+    expect(response.body).toMatchObject({ version: '3', yearMonth: '2026-08', monthCloseTargetYearMonth: '2026-07', monthCloseTargetLabel: '7월' });
+    expect(response.body.items[0].settlementStatuses.items).toEqual([
+      { period: 'MONTH', status: 'PENDING_APPROVAL' },
+      { period: 'WEEK_1', status: 'COMPLETED' },
+    ]);
+    expect(response.body.errors).toEqual([]);
 
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
-    expect(fetchImpl).toHaveBeenNthCalledWith(1,
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledWith(
       'http://jvm-weekly.local/api/v1/cashflow/weekly-overview',
       expect.objectContaining({ method: 'POST', body: JSON.stringify({ projectIds, yearMonth: '2026-08' }) }),
-    );
-    expect(fetchImpl).toHaveBeenNthCalledWith(2,
-      'http://jvm-weekly.local/api/v1/cashflow/settlement-statuses/batch',
-      expect.objectContaining({ method: 'POST', body: JSON.stringify({ projectIds, yearMonth: '2026-07' }) }),
     );
   });
 

--- a/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
+++ b/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
@@ -26,7 +26,7 @@ describe('CashflowWeeklyPage settlement status surface', () => {
     expect(source).not.toContain("['P - A'");
     expect(source).not.toContain('금액 조회 오류');
     expect(source).not.toContain('>조회 오류</span>');
-    expect(source).toContain('monthCloseTargetYearMonth');
+    expect(source).toContain('monthCloseTargetLabel');
     expect(source).toContain('실무자 결재:');
     expect(source).toContain('조직장 승인:');
     expect(source).not.toContain('PeriodAmounts');
@@ -37,7 +37,7 @@ describe('CashflowWeeklyPage settlement status surface', () => {
     expect(source).toContain('sticky left-0');
     expect(source).toContain('fetchCashflowWeeklyOverviewViaBff');
     expect(source).toContain('transitionCashflowSettlementStatusViaBff');
-    expect(source).toContain("onAction={(action) => void transition(project.id, 'MONTH', action, overview?.monthCloseTargetYearMonth || yearMonth)}");
+    expect(source).toContain("onAction={(action) => void transition(project.id, 'MONTH', action, yearMonth)}");
     expect(source).toContain('주정산 이전');
     expect(source).toContain('결산 전');
     expect(source).toContain('조직장 승인 필요');
@@ -49,6 +49,7 @@ describe('CashflowWeeklyPage settlement status surface', () => {
     expect(source).not.toContain('window.setInterval');
     expect(source).not.toContain('window.location.reload');
     expect(source).not.toContain("onAction('SUBMIT')");
+    expect(source).not.toContain('{project.department} · {project.clientOrg}');
   });
 
   it('filters both visible rows and compliance requests by normalized department', () => {

--- a/src/app/components/cashflow/CashflowWeeklyPage.tsx
+++ b/src/app/components/cashflow/CashflowWeeklyPage.tsx
@@ -321,9 +321,9 @@ export function CashflowWeeklyPage() {
             <table className="w-full min-w-[1440px] border-separate border-spacing-0 text-[11px]">
               <thead>
                 <tr className="bg-muted/30">
-                  <th className="sticky left-0 top-0 z-40 min-w-[220px] border-b bg-slate-50 px-4 py-2 text-left font-bold">프로젝트</th>
-                  <th className="sticky left-[220px] top-0 z-40 min-w-[120px] border-b bg-slate-50 px-3 py-2 text-left font-bold">조직장</th>
-                  <th className="sticky left-[340px] top-0 z-40 min-w-[120px] border-b bg-slate-50 px-3 py-2 text-left font-bold">책임자</th>
+                  <th className="sticky left-0 top-0 z-40 min-w-[180px] border-b bg-slate-50 px-3 py-2 text-left font-bold">프로젝트</th>
+                  <th className="sticky left-[180px] top-0 z-40 min-w-[104px] border-b bg-slate-50 px-2 py-2 text-left font-bold">조직장</th>
+                  <th className="sticky left-[284px] top-0 z-40 min-w-[104px] border-b bg-slate-50 px-2 py-2 text-left font-bold">책임자</th>
                   <th className="sticky top-0 z-30 min-w-[170px] border-b bg-slate-50 px-3 py-2 text-center font-bold">{overview?.monthCloseTargetLabel || '직전 월'} 결산</th>
                   <th className="sticky top-0 z-30 min-w-[140px] border-b border-l-2 border-slate-300 bg-slate-50 px-3 py-2 text-center font-bold">현금흐름(링크)</th>
                   {monthWeeks.map((week) => (
@@ -340,12 +340,11 @@ export function CashflowWeeklyPage() {
                   const canApprove = user?.uid === project.executiveApproverId;
                   return (
                     <tr key={project.id} className="border-t border-border/30 transition-colors hover:bg-muted/20">
-                      <td className="sticky left-0 z-20 bg-white px-4 py-3">
+                      <td className="sticky left-0 z-20 bg-white px-3 py-2">
                         <p className="truncate font-semibold">{project.name}</p>
-                        <p className="truncate text-[10px] text-muted-foreground">{project.department} · {project.clientOrg}</p>
                       </td>
-                      <td className="sticky left-[220px] z-20 bg-white px-3 py-3 font-medium">{formatCashflowExecutiveApprover(project, members)}</td>
-                      <td className="sticky left-[340px] z-20 bg-white px-3 py-3 font-medium">{formatCashflowManager(project)}</td>
+                      <td className="sticky left-[180px] z-20 bg-white px-2 py-2 font-medium">{formatCashflowExecutiveApprover(project, members)}</td>
+                      <td className="sticky left-[284px] z-20 bg-white px-2 py-2 font-medium">{formatCashflowManager(project)}</td>
                       <td className="px-3 py-3 text-center">
                         {statusErrors[project.id] ? <span className="text-amber-700">정보 확인 필요</span> : (overviewLoading && !projectStatuses) ? <span className="text-muted-foreground">확인 중…</span> : (
                           <SettlementStatusButton
@@ -353,7 +352,7 @@ export function CashflowWeeklyPage() {
                             period="MONTH"
                             loading={actionKey === `${project.id}:MONTH`}
                             canApprove={canApprove}
-                            onAction={(action) => void transition(project.id, 'MONTH', action, overview?.monthCloseTargetYearMonth || yearMonth)}
+                            onAction={(action) => void transition(project.id, 'MONTH', action, yearMonth)}
                           />
                         )}
                         <SettlementApprovalTimes item={statusItem(projectStatuses, 'MONTH')} />


### PR DESCRIPTION
## 변경\n- 월결산 상태를 조회 월의 단일 weekly overview에서 사용\n- 이전 달 settlement-statuses 별도 조회 및 덮어쓰기 제거\n- 프로젝트 목록의 보조 문구와 여백 축소\n\n## 검증\n- npm run typecheck -- --pretty false\n- npx vitest run server/bff/routes/jvm-weekly-api.test.mjs -t "reads one 61-project weekly overview" --reporter=dot\n- npx vitest run src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts --reporter=dot