### PR TITLE
fix(cashflow): stage only changed cells; widen the after-close dialog

### DIFF
--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -1815,7 +1815,7 @@ function sortMonthDifferenceChanges(changes) {
   ));
 }
 
-function buildPinnedSheetChangeCandidates({ tenantId, projectId, runId, mirror, cashflowSnapshot, closedMonths = new Set(), context, now, forceFullReplacement = false }) {
+function buildPinnedSheetChangeCandidates({ tenantId, projectId, runId, mirror, cashflowSnapshot, closedMonths = new Set(), context, now }) {
   const amountIndex = buildSnapshotAmountIndex(cashflowSnapshot);
   const weekIndex = new Map((cashflowSnapshot?.weeks || []).map((week) => [`${week.yearMonth}:${week.weekNo}`, week]));
   const blockedMonths = new Set((mirror?.cells || [])
@@ -1896,7 +1896,10 @@ function buildPinnedSheetChangeCandidates({ tenantId, projectId, runId, mirror, 
       const beforeAmount = beforeHadValue ? normalizeAppliedAmount(readIndexedSnapshotAmount(amountIndex, mapping)) : null;
       const proposedHadValue = ['VALUE', 'ZERO'].includes(cell.state);
       const proposedAmount = proposedHadValue ? normalizeAppliedAmount(cell.amount) : null;
-      if (!forceFullReplacement && beforeHadValue === proposedHadValue && (!proposedHadValue || beforeAmount === proposedAmount)) return null;
+      // 값이 같으면 후보가 아니다. 전체 교체 모드여도 마찬가지다 - 바뀌지 않은 셀을
+      // JVM 에 쓰면 잠긴 달에서 사유를 요구받고, 그 사유는 조직에 경고로 기록된다.
+      // 바뀐 것이 없는데 경고가 남으면 담당자가 하지 않은 일을 한 것으로 남는다.
+      if (beforeHadValue === proposedHadValue && (!proposedHadValue || beforeAmount === proposedAmount)) return null;
 
       const week = weekIndex.get(`${cell.yearMonth}:${cell.weekNo}`);
       const riskFlags = closedMonths.has(readOptionalText(cell.yearMonth)) ? ['closed_month_change'] : [];
@@ -1977,7 +1980,6 @@ async function buildPinnedAnnualChangeCandidates({
   mirror,
   context,
   now,
-  forceFullReplacement = false,
 }) {
   const weeklyYear = Number(mirror?.sheetContract?.weeklyYear ?? mirror?.weeklyYear);
   const contractAnnualYears = Array.isArray(mirror?.sheetContract?.annualYears)
@@ -2010,7 +2012,8 @@ async function buildPinnedAnnualChangeCandidates({
         : null;
       const proposedHadValue = ['VALUE', 'ZERO'].includes(cell.cellState);
       const proposedAmount = proposedHadValue ? normalizeAppliedAmount(cell.amount) : null;
-      if (!forceFullReplacement && beforeState === cell.cellState && (!proposedHadValue || beforeAmount === proposedAmount)) {
+      // 위와 같다. 연간 셀도 값이 같으면 후보가 아니다.
+      if (beforeState === cell.cellState && (!proposedHadValue || beforeAmount === proposedAmount)) {
         return null;
       }
       return {
@@ -3887,7 +3890,6 @@ async function stagePinnedCashflowSheetLab({
     closedMonths,
     context,
     now,
-    forceFullReplacement: Boolean(parsed.replaceAllActualSources),
   });
   const annual = parsed.yearMonth ? { candidates: [], documents: [], stagedYears: [] } : await buildPinnedAnnualChangeCandidates({
     db,
@@ -3897,7 +3899,6 @@ async function stagePinnedCashflowSheetLab({
     mirror,
     context,
     now,
-    forceFullReplacement: Boolean(parsed.replaceAllActualSources),
   });
   const candidates = [...weekly.candidates, ...annual.candidates];
   const pendingApproval = parsed.replaceAllActualSources

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -4361,6 +4361,113 @@ describe('cashflow sheet lab route', () => {
     }));
   });
 
+  it('stages no candidates when closed-month cells already equal the sheet, even in full-replacement mode', async () => {
+    // 라이브 AXR 재현. 1~7월이 결산돼 있고 시트 값이 DB 와 같을 때 "전체 교체" 로 반영하면
+    // 값이 같은 잠긴 셀 1,120개가 후보로 들어가 JVM 이 사유를 요구했고, 에러 표는 0원→0원 으로
+    // 채워졌으며, 화면 manifest 와 서버 manifest 가 어긋나 반영이 막혔다.
+    // 바뀐 것이 없으면 후보가 아니어야 한다. 그 사유는 조직에 경고로 남기 때문이다.
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        cashflowSheetLab: {
+          value: 'saved-spreadsheet-a',
+          sheetName: 'cashflow(사용내역 연동)',
+          startWeek: '26-1-1',
+          endWeek: '26-1-5',
+        },
+      },
+      initialDocuments: {
+        'orgs/tenant-a/monthly_closes/project-a-2026-01': {
+          contractVersion: 'cashflow-month-close-v1',
+          tenantId: 'tenant-a',
+          projectId: 'project-a',
+          yearMonth: '2026-01',
+          status: 'CLOSED',
+        },
+      },
+    });
+    const previewSpreadsheet = vi.fn(async () => ({
+      spreadsheetId: 'spreadsheet-a',
+      selectedSheetName: 'cashflow(사용내역 연동)',
+      availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
+      matrix: buildMatrixWithWeekLabels(JANUARY_FINANCE_WEEKS),
+    }));
+    const applyCashflowSheetBatch = vi.fn(async (input) => javaBatchApplyResponse(input, `sha256:${'5'.repeat(64)}`));
+    const app = createApp({
+      db,
+      googleSheetsService: { previewSpreadsheet },
+      routeOptions: { editLeasesEnabled: true, javaWeeklyClient: { applyCashflowSheetBatch } },
+    });
+
+    const mirror = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'refresh-same-values' })
+      .expect(200);
+
+    // DB 를 시트와 완전히 같게 만든다 - 첫 미러의 셀을 그대로 cashflow_weeks 로 옮겨
+    // 같은 결산 상태의 두 번째 앱을 세운다.
+    const weeksByKey = new Map();
+    for (const cell of mirror.body.cells) {
+      if (!['VALUE', 'ZERO'].includes(cell.state)) continue;
+      const key = `${cell.yearMonth}-w${cell.weekNo}`;
+      const week = weeksByKey.get(key) || {
+        id: `project-a-${key}`, projectId: 'project-a', tenantId: 'tenant-a',
+        yearMonth: cell.yearMonth, weekNo: cell.weekNo,
+        projection: {}, weeklyExpenseActualBySheet: { 'cashflow-sheet-lab': {} },
+      };
+      if (cell.mode === 'projection') week.projection[cell.lineId] = Number(cell.amount);
+      else week.weeklyExpenseActualBySheet['cashflow-sheet-lab'][cell.lineId] = Number(cell.amount);
+      weeksByKey.set(key, week);
+    }
+    const sameDb = createDb({
+      project: {
+        id: 'project-a',
+        cashflowSheetLab: {
+          value: 'saved-spreadsheet-a',
+          sheetName: 'cashflow(사용내역 연동)',
+          startWeek: '26-1-1',
+          endWeek: '26-1-5',
+        },
+      },
+      weeks: [...weeksByKey.values()],
+      initialDocuments: {
+        'orgs/tenant-a/monthly_closes/project-a-2026-01': {
+          contractVersion: 'cashflow-month-close-v1',
+          tenantId: 'tenant-a',
+          projectId: 'project-a',
+          yearMonth: '2026-01',
+          status: 'CLOSED',
+        },
+      },
+    });
+    const sameApp = createApp({
+      db: sameDb,
+      googleSheetsService: { previewSpreadsheet },
+      routeOptions: { editLeasesEnabled: true, javaWeeklyClient: { applyCashflowSheetBatch } },
+    });
+    const refreshed = await request(sameApp)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'refresh-same-values-2' })
+      .expect(200);
+
+    const stage = await request(sameApp)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+      .send({
+        expectedMirrorRevision: refreshed.body.sourceRevision,
+        replaceAllActualSources: true,
+        idempotencyKey: 'stage-same-values',
+      })
+      .expect(200);
+
+    // 전체 교체 모드여도 값이 같으면 후보가 아니다.
+    expect(stage.body.status).toBe('NO_CHANGES');
+    expect(stage.body.stagedLineCount).toBe(0);
+    expect(stage.body.closedMonthDifferenceCount).toBe(0);
+    expect(stage.body.closedMonthDifferences).toEqual([]);
+    // JVM 은 호출조차 되지 않는다 - 사유를 요구할 기회가 없다.
+    expect(applyCashflowSheetBatch).not.toHaveBeenCalled();
+  });
+
   it('retries the same staged run with a reason after the JVM rejects a late closed-month change', async () => {
     const twoFullMonths = [
       ...JANUARY_FINANCE_WEEKS,

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -2957,7 +2957,7 @@ export function CashflowProjectSheet({
           </div>
           <div className="mb-2 grid gap-2 sm:grid-cols-3">
             <Input aria-label="실제 반영 기록 검색" value={cashflowEventQuery} onChange={(event) => setCashflowEventQuery(event.target.value)} placeholder="항목·담당자 검색" />
-            <select aria-label="실제 반영 mode 필터" className="h-9 rounded-md border border-slate-300 bg-white px-2 text-[12px]" value={cashflowEventMode} onChange={(event) => setCashflowEventMode(event.target.value)}><option value="ALL">전체 mode</option><option value="projection">Projection</option><option value="actual">Actual</option></select>
+            <select aria-label="실제 반영 구분 필터" className="h-9 rounded-md border border-slate-300 bg-white px-2 text-[12px]" value={cashflowEventMode} onChange={(event) => setCashflowEventMode(event.target.value)}><option value="ALL">전체 구분</option><option value="projection">Projection</option><option value="actual">Actual</option></select>
             <select aria-label="실제 반영 월 필터" className="h-9 rounded-md border border-slate-300 bg-white px-2 text-[12px]" value={cashflowEventMonth} onChange={(event) => setCashflowEventMonth(event.target.value)}><option value="ALL">전체 월</option>{[...new Set(cashflowEvents.map((event) => event.yearMonth).filter(Boolean))].sort((left, right) => left.localeCompare(right)).map((month) => <option key={month} value={month}>{month}</option>)}</select>
           </div>
           {cashflowEventErrors.map((failure) => (
@@ -3442,7 +3442,7 @@ export function CashflowProjectSheet({
           }
         }}
       >
-        <AlertDialogContent className="w-[calc(100vw-2rem)] max-w-[560px]">
+        <AlertDialogContent className="w-[calc(100vw-2rem)] max-w-[960px]">
           <AlertDialogHeader>
             <AlertDialogTitle>{sheetApplyResumeRequired ? '시트 반영 이어서 완료' : '마감 후 시트값 변경'}</AlertDialogTitle>
             <AlertDialogDescription>
@@ -3456,22 +3456,25 @@ export function CashflowProjectSheet({
               {!sheetApplyResumeRequired && (
                 <>
                   <div className={`rounded-md border px-3 py-2 text-[12px] ${lateSheetDiffComplete ? 'border-slate-300 bg-slate-50 text-slate-700' : 'border-red-300 bg-red-50 text-red-800'}`} role={lateSheetDiffComplete ? 'status' : 'alert'}>
-                    {lateSheetDiffComplete ? `검토본 manifest와 일치하는 전체 ${lateSheetDiffRows.length.toLocaleString()}건입니다.` : '변경 목록의 manifest 또는 건수가 일치하지 않아 반영할 수 없습니다. 다시 비교해 주세요.'}
-                    <span className="ml-2 break-all text-[12px]">{lateSheetApply.closedMonthDifferenceManifestHash || 'manifest 없음'}</span>
+                    {lateSheetDiffComplete ? `검토본과 일치하는 변경 ${lateSheetDiffRows.length.toLocaleString()}건입니다.` : '변경 목록이 검토본과 일치하지 않아 반영할 수 없습니다. 시트 값을 다시 불러온 뒤 비교해 주세요.'}
                   </div>
                   <div className="grid gap-2 sm:grid-cols-4">
                     <Input aria-label="변경 이력 검색" placeholder="월·주·항목 검색" value={lateSheetDiffQuery} onChange={(event) => setLateSheetDiffQuery(event.target.value)} />
-                    <select aria-label="Projection Actual 필터" className="h-9 rounded-md border border-slate-300 bg-white px-2 text-[12px]" value={lateSheetDiffMode} onChange={(event) => setLateSheetDiffMode(event.target.value)}><option value="ALL">전체 mode</option><option value="projection">Projection</option><option value="actual">Actual</option></select>
+                    <select aria-label="Projection Actual 필터" className="h-9 rounded-md border border-slate-300 bg-white px-2 text-[12px]" value={lateSheetDiffMode} onChange={(event) => setLateSheetDiffMode(event.target.value)}><option value="ALL">전체 구분</option><option value="projection">Projection</option><option value="actual">Actual</option></select>
                     <select aria-label="월 필터" className="h-9 rounded-md border border-slate-300 bg-white px-2 text-[12px]" value={lateSheetDiffMonth} onChange={(event) => setLateSheetDiffMonth(event.target.value)}><option value="ALL">전체 월</option>{[...new Set(lateSheetDiffRows.map((row) => row.yearMonth))].map((month) => <option key={month} value={month}>{month}</option>)}</select>
                     <select aria-label="주차 필터" className="h-9 rounded-md border border-slate-300 bg-white px-2 text-[12px]" value={lateSheetDiffWeek} onChange={(event) => setLateSheetDiffWeek(event.target.value)}><option value="ALL">전체 주차</option>{[1, 2, 3, 4, 5].map((weekNo) => <option key={weekNo} value={weekNo}>{weekNo}주차</option>)}</select>
                   </div>
-                  <div className="max-h-[300px] overflow-auto rounded-md border border-slate-200 bg-slate-50" role="region" aria-label="마감 후 변경 후보 전체 목록" tabIndex={0}>
+                  <div className="max-h-[min(60dvh,720px)] overflow-auto rounded-md border border-slate-200 bg-slate-50" role="region" aria-label="마감 후 변경 후보 전체 목록" tabIndex={0}>
                     <table className="w-full min-w-[620px] border-collapse text-[12px] leading-4 text-slate-700">
-                      <caption className="sr-only">월, 주차, mode, 항목별 이전값과 변경값</caption>
-                      <thead className="sticky top-0 bg-slate-100"><tr><th className="px-2 py-2 text-left">월·주차</th><th className="px-2 py-2 text-left">mode</th><th className="px-2 py-2 text-left">항목</th><th className="px-2 py-2 text-right">이전값 → 변경값</th></tr></thead>
-                      <tbody>{filteredLateSheetDiffRows.map((change) => <tr key={`${change.yearMonth}:${change.mode}:${change.weekNo}:${change.lineId}`} className="border-t border-slate-200"><th className="px-2 py-1.5 text-left">{change.yearMonth} {change.weekNo}주차</th><td className="px-2 py-1.5">{change.mode === 'projection' ? 'Projection' : 'Actual'}</td><td className="px-2 py-1.5">{CASHFLOW_SHEET_LINE_LABELS[change.lineId as CashflowSheetLineId] || change.lineId}</td><td className="px-2 py-1.5 text-right tabular-nums"><span className={change.beforeHadValue ? 'text-slate-500' : 'text-slate-400'}>{change.beforeHadValue ? formatCashflowAmount(change.beforeAmount) : 'EMPTY'}</span><span className="px-1 text-slate-400">→</span><strong>{change.afterHadValue ? formatCashflowAmount(change.afterAmount) : 'EMPTY'}</strong></td></tr>)}</tbody>
+                      <caption className="sr-only">월, 주차, 구분, 항목별 이전값과 변경값</caption>
+                      <thead className="sticky top-0 bg-slate-100"><tr><th className="px-2 py-2 text-left">월·주차</th><th className="px-2 py-2 text-left">구분</th><th className="px-2 py-2 text-left">항목</th><th className="px-2 py-2 text-right">이전값 → 변경값</th></tr></thead>
+                      <tbody>{filteredLateSheetDiffRows.map((change) => <tr key={`${change.yearMonth}:${change.mode}:${change.weekNo}:${change.lineId}`} className="border-t border-slate-200"><th className="px-2 py-1.5 text-left">{change.yearMonth} {change.weekNo}주차</th><td className="px-2 py-1.5">{change.mode === 'projection' ? 'Projection' : 'Actual'}</td><td className="px-2 py-1.5">{CASHFLOW_SHEET_LINE_LABELS[change.lineId as CashflowSheetLineId] || change.lineId}</td><td className="px-2 py-1.5 text-right tabular-nums"><span className={change.beforeHadValue ? 'text-slate-500' : 'text-slate-400'}>{change.beforeHadValue ? formatCashflowAmount(change.beforeAmount) : '빈칸'}</span><span className="px-1 text-slate-400">→</span><strong>{change.afterHadValue ? formatCashflowAmount(change.afterAmount) : '빈칸'}</strong></td></tr>)}</tbody>
                     </table>
-                    {filteredLateSheetDiffRows.length === 0 ? <p className="p-5 text-center text-[12px] text-slate-500">필터와 일치하는 변경 후보가 없습니다.</p> : null}
+                    {filteredLateSheetDiffRows.length === 0
+                      ? <p className="p-5 text-center text-[12px] text-slate-500">필터와 일치하는 변경 후보가 없습니다.</p>
+                      : filteredLateSheetDiffRows.length !== lateSheetDiffRows.length
+                        ? <p className="px-3 py-2 text-right text-[12px] text-slate-500">전체 {lateSheetDiffRows.length.toLocaleString()}건 중 {filteredLateSheetDiffRows.length.toLocaleString()}건 표시</p>
+                        : null}
                   </div>
                   <label className="block text-[12px] font-semibold text-slate-800" htmlFor="late-sheet-change-reason">
                     변경 사유


### PR DESCRIPTION
## 무엇

라이브 AXR QA 에서 발견된 증상을 고칩니다.

> 마감 후 시트값 변경 — 1~7월 1,120건, 전부 `0원→0원`
> 변경 목록의 manifest 또는 건수가 일치하지 않아 반영할 수 없습니다.

## 원인

프론트가 **항상** `replaceAllActualSources=true` (전체 교체) 로 반영합니다. 그 모드에서 후보 선정이 **값이 같아도 전부** 후보에 넣었습니다.

```
잠긴 1~7월의 값 같은 셀 1,120개 → JVM 에 씀
→ JVM: 잠긴 달 쓰기 → 사유 요구
→ BFF 에러 경로: "쓰려던 것" 전부로 표 생성 → 0원→0원 1,120건
→ 사용자 사유 입력 → 재시도
→ 서버가 센 진짜 변경은 0건 → 화면 1,120건과 불일치 → 차단
```

**데이터는 멀쩡했고 반영은 차단됐습니다.** 8월 오잠금 수정(#572)이 표 맨 위에 있던 8월 진짜 변경 11건을 걷어내면서 이 증상이 드러났습니다.

## 왜 민감한가

여기서 요구되는 사유는 **조직에 경고로 기록**됩니다. 바뀐 게 없는데 사유를 요구하면 담당자가 하지 않은 변경에 대해 경고를 지게 됩니다.

## 변경

| | 내용 |
|---|---|
| 후보 선정 | 전체 교체 예외 제거. **값이 다른 셀만 후보.** `forceFullReplacement` 파라미터 삭제. one-way 반영 의미론(`replaceAllActualSources` 의 revision 검사 생략 등)은 그대로 |
| 다이얼로그 | 560→960px, 표 300px→화면 비례. `mode`→구분, `EMPTY`→빈칸. 필터 시 표시 건수. **manifest 해시 64자 노출 제거** |

## 검증

- **재현 테스트**: 결산된 달 + DB=시트 + 전체 교체 stage → `NO_CHANGES`, 후보 0, **JVM 호출 0**
- **사보타주**: 옛 필터 복원 → `READY` 로 깨짐
- sheet-lab 118/118 · 셸 69/69 · 유닛 3,229 · policy · build

## 라이브 영향

- 데이터 쓰기 없음. 후보가 **줄기만** 합니다.
- 진짜 변경은 그대로 잡힙니다 — 값이 다른 셀은 필터를 통과합니다.

## 배포 후 QA

`docs/architecture/contracts/2026-08-18-cashflow-close-authority-live-qa.md` A-1 부터 다시 — 이번엔 반영이 끝까지 가야 합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)