### PR TITLE
fix(cashflow): rebuild stale-schema mirrors on refresh; say when nothing changed

### DIFF
--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -58,6 +58,12 @@ const CASHFLOW_SHEET_STAGE_MONTHS_COLLECTION_ID = 'cashflow_sheet_stage_months';
 const CASHFLOW_SHEET_STAGE_YEARS_COLLECTION_ID = 'cashflow_sheet_stage_years';
 const CASHFLOW_MODES = ['projection', 'actual'];
 const CASHFLOW_SHEET_SOURCE_KEY = 'cashflow-sheet-lab';
+// 미러 본체(sheetFacts 포함)의 형태 버전. 형태를 바꾸는 코드 변경마다 올린다.
+// refresh 는 시트 modifiedTime 이 같으면 저장된 미러를 그대로 돌려주는데, 그 최적화는
+// "시트가 같으면 결과도 같다" 를 전제한다. 코드가 바뀌면 전제가 깨지므로 버전이 다른
+// 미러는 시트가 안 바뀌었어도 한 번 다시 읽는다. 다시 만들어지면 최적화가 다시 돈다.
+//   2 → 3: annualCashflowTotals 가 항목별 lineStates 를 담고 주차 연도 항목을 만들지 않는다.
+const CASHFLOW_SHEET_MIRROR_SCHEMA_VERSION = 3;
 const CASHFLOW_SHEET_APPLY_COMMAND = 'weeklyExpense.cashflowSheetLab.apply';
 const CASHFLOW_ACTIVE_CLOSE_REQUEST_STATUSES = new Set(['PENDING', 'APPROVING', 'UNCERTAIN']);
 const CASHFLOW_LINE_ORDER = new Map(CASHFLOW_ALL_LINES.map((lineId, index) => [lineId, index]));
@@ -774,7 +780,7 @@ function mergeCashflowSourceMirror(previous, next, sourceYear) {
 
   return stripUndefinedDeep({
     ...next,
-    schemaVersion: 2,
+    schemaVersion: CASHFLOW_SHEET_MIRROR_SCHEMA_VERSION,
     sourceYear,
     sources,
     sourceRevision,
@@ -4335,6 +4341,7 @@ export function mountCashflowSheetLabRoutes(app, {
     let freshness = null;
     if (
       previousMirror?.status === 'FRESH'
+      && Number(previousMirror?.schemaVersion) === CASHFLOW_SHEET_MIRROR_SCHEMA_VERSION
       && readOptionalText(previousMirror?.sourceFileModifiedTime)
       && readOptionalText(previousMirror?.lastRefreshRequestHash) === refreshRequestHash
     ) {

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -3789,6 +3789,75 @@ describe('cashflow sheet lab route', () => {
     expect(editLeaseService.release).not.toHaveBeenCalled();
   });
 
+  it('rebuilds a mirror written by an older schema even when the sheet has not changed', async () => {
+    // 라이브 AXR 재현. 연간 열의 항목별 상태를 담도록 코드를 고쳐 배포했는데, refresh 는
+    // 시트 modifiedTime 이 같다는 이유로 옛 미러를 그대로 돌려줬다. 시트를 안 건드린 47개
+    // 프로젝트가 영원히 옛 형태로 남는다. "시트가 같으면 결과도 같다" 는 코드가 같을 때만 참이다.
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        contractStart: '2024-01-01',
+        contractEnd: '2028-12-31',
+        cashflowSheetLab: {
+          value: 'https://docs.google.com/spreadsheets/d/spreadsheet-a/edit',
+          sheetName: 'cashflow(사용내역 연동)',
+          startWeek: '26-1-1',
+          endWeek: '26-1-1',
+        },
+      },
+    });
+    const modifiedTime = '2026-08-09T10:00:00.000Z';
+    const previewSpreadsheet = vi.fn(async () => ({
+      spreadsheetId: 'spreadsheet-a',
+      spreadsheetTitle: 'Cashflow workbook',
+      selectedSheetName: 'cashflow(사용내역 연동)',
+      availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
+      matrix: buildMatrix(),
+    }));
+    const getSpreadsheetFreshness = vi.fn(async () => ({
+      spreadsheetId: 'spreadsheet-a', modifiedTime, version: '7',
+    }));
+    const app = createApp({ db, googleSheetsService: { previewSpreadsheet, getSpreadsheetFreshness } });
+
+    const first = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'schema-001' })
+      .expect(200);
+    expect(previewSpreadsheet).toHaveBeenCalledTimes(1);
+    const mirrorPath = 'orgs/tenant-a/cashflow_sheet_mirrors/project-a';
+    const currentSchema = db.__getDocument(mirrorPath).schemaVersion;
+    expect(currentSchema).toBeGreaterThanOrEqual(3);
+
+    // 같은 시트, 같은 코드 → 건너뜀 (기존 fast-path 유지)
+    const second = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'schema-002' })
+      .expect(200);
+    expect(second.body.unchanged).toBe(true);
+    expect(previewSpreadsheet).toHaveBeenCalledTimes(1);
+
+    // 배포 전 코드가 남긴 미러로 되돌린다: 형태 버전만 낮춘다.
+    const stored = db.__getDocument(mirrorPath);
+    db.__setDocument?.(mirrorPath, { ...stored, schemaVersion: currentSchema - 1 })
+      ?? Object.assign(stored, { schemaVersion: currentSchema - 1 });
+
+    // 시트는 그대로인데 형태가 옛것 → 다시 읽어서 새 형태로 만든다.
+    const third = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'schema-003' })
+      .expect(200);
+    expect(third.body.unchanged).toBeUndefined();
+    expect(previewSpreadsheet).toHaveBeenCalledTimes(2);
+    expect(db.__getDocument(mirrorPath).schemaVersion).toBe(currentSchema);
+    // 새로 읽었으니 다시 형태 버전이 맞고, 그 다음 refresh 는 다시 fast-path 를 탄다.
+    const fourth = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'schema-004' })
+      .expect(200);
+    expect(fourth.body.unchanged).toBe(true);
+    expect(previewSpreadsheet).toHaveBeenCalledTimes(2);
+  });
+
   it('includes unchanged bridge months for explicit month replacement without applying them', async () => {
     const lineAmounts = Object.fromEntries(CASHFLOW_LINE_IDS.map((lineId) => [lineId, 999]));
     const db = createDb({

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1802,6 +1802,8 @@ export function CashflowProjectSheet({
         return;
       }
       if (result.stagedLineCount <= 0) {
+        // 없으면 없다고 말한다. 조용히 끝나면 반영이 중간에 멈춘 것처럼 보인다.
+        toast.success('시트 값을 확인했습니다. 반영할 변경이 없습니다.');
         return;
       }
       if (result.pendingApprovalDifferences?.length) {


### PR DESCRIPTION
## 무엇

배포 후 AXR QA 에서 "시트 값 불러오기" 를 두 번 했는데도 2024·2025 열이 계속 **확인 불가**로 남는 원인을 고칩니다.

## 원인

refresh 에 fast-path 가 있습니다 — Drive `modifiedTime` 이 저장된 미러와 같으면 시트를 안 읽고 미러를 그대로 돌려줍니다. 시트가 유일한 입력일 땐 맞는 최적화인데, **코드가 바뀌면 전제가 깨집니다.** #572 가 미러 형태를 바꿨는데(항목별 `lineStates`, 주차 연도 항목 제거), 8월 14일 이후 안 건드린 AXR 시트는 새벽 1:39 미러를 계속 반환했습니다.

라이브 확인: refresh 200 두 번 → 미러 `capturedAt` 01:39 그대로, `lineStates` 0개, 2026 항목 남아 있음.

**시트를 안 건드린 47개 프로젝트가 영원히 옛 형태로 남는 상태**였습니다.

## 변경

| | |
|---|---|
| fast-path 조건 | 저장된 미러의 `schemaVersion` 이 현재와 같을 때만. 옛 버전이면 시트가 안 바뀌었어도 **한 번** 다시 읽음 → 새 형태로 저장 → 이후 fast-path 복귀 |
| 스키마 | 2 → 3 (#572 형태 변경) |
| 마이그레이션 | **없음** — 각 프로젝트가 다음 불러오기 때 스스로 따라옴 |
| 프론트 | stage 결과 후보 0 이면 조용히 끝나던 것 → "반영할 변경이 없습니다" 토스트 |

## 검증

- 재현 테스트: 시트 동일 + 미러 옛 버전 → 다시 읽음 → 새 버전 → 그 다음은 fast-path
- 사보타주: 버전 조건 제거 → 옛 미러를 `unchanged` 로 반환 → 실패
- sheet-lab 119/119 · 셸 69/69 · 유닛 3,231 · typecheck · build

## 배포 후

AXR·JLIN·전남글로벌에서 **불러오기 1회** → 2024·2025 열이 값/미입력/0 으로 바뀌어야 함. 그리고 시트를 안 바꿨으면 "반영할 변경이 없습니다" 가 떠야 함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)