### PR TITLE
chore(cashflow): delete the unused /years read path; parallelize dashboard reads

### DIFF
--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -170,25 +170,6 @@ function readSelectedYear(value) {
   return year;
 }
 
-function cashflowAvailableYears(mirror, project, selectedYear) {
-  const registeredYears = projectCashflowYears(project);
-  return [...new Set([
-    ...(registeredYears.length > 0 ? registeredYears : [selectedYear - 1, selectedYear, selectedYear + 1]),
-    ...(Array.isArray(project?.financialYears) ? project.financialYears.map((row) => Number(row?.year)) : []),
-    ...(Array.isArray(mirror?.years) ? mirror.years.map(Number) : []),
-    ...(Array.isArray(mirror?.appliedAnnualYears) ? mirror.appliedAnnualYears.map(Number) : []),
-    ...(Array.isArray(mirror?.appliedWeeklyYears) ? mirror.appliedWeeklyYears.map(Number) : []),
-    ...(mirror?.sheetFacts?.annualCashflowTotals || []).map((row) => Number(row?.year)),
-  ].filter(Number.isSafeInteger))].sort((left, right) => left - right);
-}
-
-function cashflowNavigationYears(availableYears, selectedYear) {
-  if (availableYears.length <= 3) return availableYears;
-  const selectedIndex = Math.max(0, availableYears.indexOf(selectedYear));
-  const start = Math.min(Math.max(0, selectedIndex - 1), availableYears.length - 3);
-  return availableYears.slice(start, start + 3);
-}
-
 async function readCanonicalAnnualTotal(db, tenantId, projectId, year) {
   const snap = await db.doc(cashflowAnnualTotalDocPath(tenantId, projectId, year)).get();
   if (!snap.exists) return null;
@@ -202,110 +183,6 @@ async function readCanonicalAnnualTotal(db, tenantId, projectId, year) {
     updatedAt: readOptionalText(value.updatedAt),
     projection: summarizeCashflowAnnualMode(value, 'projection'),
     actual: summarizeCashflowAnnualMode(value, 'actual'),
-  };
-}
-
-function cashflowReadModelHash(value) {
-  const canonicalize = (item) => {
-    if (Array.isArray(item)) return item.map(canonicalize);
-    if (!item || typeof item !== 'object') return item;
-    return Object.fromEntries(Object.keys(item)
-      .sort()
-      .map((key) => [key, canonicalize(item[key])]));
-  };
-  return stableHash(canonicalize(value));
-}
-
-async function readCashflowSheetYearView({ db, tenantId, projectId, project, selectedYear }) {
-  const mirror = await readCashflowSheetMirror(db, tenantId, projectId);
-  const availableYears = cashflowAvailableYears(mirror, project, selectedYear);
-  const navigationYears = cashflowNavigationYears(availableYears, selectedYear);
-  // The ledger renders every project year around the selected year's weekly columns.
-  // Keep the compact navigation separately, but load all annual totals in one read model.
-  const ledgerYears = availableYears;
-  const canonicalAnnualDocs = await Promise.all(ledgerYears.map((year) => (
-    readCanonicalAnnualTotal(db, tenantId, projectId, year)
-  )));
-  const hasAppliedSourceMarkers = Array.isArray(mirror?.appliedAnnualYears) || Array.isArray(mirror?.appliedWeeklyYears);
-  const activeAnnualYears = new Set((mirror?.appliedAnnualYears || []).map(Number));
-  const canonicalAnnualYears = canonicalAnnualDocs
-    .filter(Boolean)
-    .filter((row) => !hasAppliedSourceMarkers || activeAnnualYears.has(row.year));
-  if (!mirror?.sourceRevision) {
-    return {
-      projectId,
-      status: canonicalAnnualYears.length > 0 ? 'FRESH' : 'EMPTY',
-      selectedYear,
-      availableYears,
-      navigationYears,
-      years: [],
-      canonicalAnnualYears,
-      readModelStatus: canonicalAnnualYears.length > 0 ? 'CURRENT' : 'EMPTY',
-      fallbackYears: [],
-      mismatchYears: [],
-    };
-  }
-
-  const snapshotId = readOptionalText(mirror.snapshotId);
-  const mirrorTotals = new Map((mirror.sheetFacts?.annualCashflowTotals || [])
-    .filter((row) => Number.isSafeInteger(row?.year))
-    .map((row) => [row.year, row]));
-  const snapshotEnabled = /^cfsnap_[a-f0-9]{32}$/.test(snapshotId);
-  const snapshotDocs = snapshotEnabled
-    ? await Promise.all(ledgerYears.map(async (year) => {
-      const snap = await db.doc(cashflowSheetSnapshotYearDocPath(tenantId, snapshotId, year)).get();
-      return [year, snap.exists ? snap.data() || {} : null];
-    }))
-    : [];
-  const snapshotTotals = new Map(snapshotDocs);
-  const fallbackYears = [];
-  const mismatchYears = [];
-  const years = ledgerYears.flatMap((year) => {
-    const mirrorTotal = mirrorTotals.get(year);
-    const snapshotTotal = snapshotTotals.get(year);
-    const snapshotCurrent = snapshotTotal
-      && readOptionalText(snapshotTotal.snapshotId) === snapshotId
-      && readOptionalText(snapshotTotal.projectId) === projectId
-      && readOptionalText(snapshotTotal.sourceRevision) === readOptionalText(mirror.sourceRevision)
-      && Number(snapshotTotal.year) === year;
-    if (snapshotCurrent) {
-      if (mirrorTotal && cashflowReadModelHash({ projection: snapshotTotal.projection, actual: snapshotTotal.actual })
-        !== cashflowReadModelHash({ projection: mirrorTotal.projection, actual: mirrorTotal.actual })) {
-        mismatchYears.push(year);
-      }
-      return [{
-        year,
-        projection: snapshotTotal.projection,
-        actual: snapshotTotal.actual,
-        sourceRevision: snapshotTotal.sourceRevision,
-        capturedAt: snapshotTotal.capturedAt,
-        storage: 'SNAPSHOT',
-      }];
-    }
-    if (!mirrorTotal) return [];
-    fallbackYears.push(year);
-    return [{
-      ...mirrorTotal,
-      sourceRevision: mirror.sourceRevision,
-      capturedAt: mirror.capturedAt,
-      storage: 'MIRROR_FALLBACK',
-    }];
-  });
-
-  return {
-    projectId,
-    status: readOptionalText(mirror.status) || 'FRESH',
-    selectedYear,
-    availableYears,
-    navigationYears,
-    snapshotId: snapshotEnabled ? snapshotId : undefined,
-    sourceRevision: mirror.sourceRevision,
-    capturedAt: mirror.capturedAt,
-    years,
-    canonicalAnnualYears,
-    readModelStatus: mismatchYears.length > 0 ? 'MISMATCH' : fallbackYears.length > 0 ? 'FALLBACK' : 'CURRENT',
-    fallbackYears,
-    mismatchYears,
   };
 }
 
@@ -4273,21 +4150,6 @@ export function mountCashflowSheetLabRoutes(app, {
       stagedRunId: result.stagedRunId || '',
       releasedAt: result.releasedAt || '',
     });
-  }));
-
-  app.get('/api/v1/projects/:projectId/cashflow-sheet-lab/years', asyncHandler(async (req, res) => {
-    assertCashflowSheetLabAccess(req, workspaceEmailDomain);
-    const { tenantId } = req.context;
-    const { projectId } = req.params;
-    const selectedYear = readSelectedYear(req.query.selectedYear);
-    const project = await readProjectDocument(db, tenantId, projectId);
-    res.status(200).json(await readCashflowSheetYearView({
-      db,
-      tenantId,
-      projectId,
-      project,
-      selectedYear,
-    }));
   }));
 
   const executeCashflowSheetMirrorRefresh = async (req) => {

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -1111,24 +1111,6 @@ describe('cashflow sheet lab route', () => {
       Object.entries(reordered.data.projection.lineAmounts).reverse(),
     );
     await db.doc(reordered.path).set(reordered.data);
-
-    const yearView = await request(app)
-      .get('/api/v1/projects/project-a/cashflow-sheet-lab/years?selectedYear=2026')
-      .expect(200);
-
-    expect(yearView.body).toMatchObject({
-      selectedYear: 2026,
-      availableYears: [2024, 2025, 2026, 2027, 2028, 2029, 2030, 2031, 2032],
-      navigationYears: [2025, 2026, 2027],
-      readModelStatus: 'CURRENT',
-      fallbackYears: [],
-      mismatchYears: [],
-    });
-    // availableYears 는 내비게이션이라 주차 연도를 포함하지만, 연간 항목 목록에는 없다.
-    expect(yearView.body.years.map((row) => row.year)).toEqual([
-      2024, 2025, 2027, 2028, 2029, 2030, 2031, 2032,
-    ]);
-    expect(yearView.body.years.every((row) => row.storage === 'SNAPSHOT')).toBe(true);
   });
 
   it('applies annual totals and weekly values together without inventing annual weeks', async () => {
@@ -1254,19 +1236,6 @@ describe('cashflow sheet lab route', () => {
       stagedRunId: stage.body.runId,
       appliedTargetRevision: applied.body.resultingTargetRevision,
     });
-
-    const yearView = await request(app)
-      .get('/api/v1/projects/project-a/cashflow-sheet-lab/years?selectedYear=2025')
-      .expect(200);
-    expect(yearView.body.canonicalAnnualYears).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        year: 2025,
-        source: 'ANNUAL',
-        revision: 1,
-        projection: expect.objectContaining({ source: 'ANNUAL', totalIn: 600, totalOut: 900, net: -300 }),
-        actual: expect.objectContaining({ source: 'ANNUAL', totalIn: 350, totalOut: 450, net: -100 }),
-      }),
-    ]));
 
   });
 
@@ -1478,92 +1447,6 @@ describe('cashflow sheet lab route', () => {
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
       .send({ expectedMirrorRevision: mirror.body.sourceRevision, idempotencyKey: 'conflicting-year-stage' })
       .expect(200);
-  });
-
-  it('keeps legacy mirrors readable until the next explicit sheet refresh rebuilds year snapshots', async () => {
-    const db = createDb({
-      initialDocuments: {
-        'orgs/tenant-a/cashflow_sheet_mirrors/project-a': {
-          projectId: 'project-a',
-          status: 'FRESH',
-          sourceRevision: 'sha256:legacy',
-          years: [2025],
-          sheetFacts: {
-            annualCashflowTotals: [{
-              year: 2025,
-              projection: { source: 'ANNUAL', totalIn: 100, totalOut: 20, net: 80, lineAmounts: {} },
-              actual: { source: 'ANNUAL', totalIn: 90, totalOut: 10, net: 80, lineAmounts: {} },
-            }],
-          },
-        },
-      },
-    });
-
-    const response = await request(createApp({ db }))
-      .get('/api/v1/projects/project-a/cashflow-sheet-lab/years?selectedYear=2026')
-      .expect(200);
-
-    expect(response.body).toMatchObject({
-      availableYears: [2025, 2026, 2027],
-      navigationYears: [2025, 2026, 2027],
-      readModelStatus: 'FALLBACK',
-      fallbackYears: [2025],
-      years: [{ year: 2025, storage: 'MIRROR_FALLBACK' }],
-    });
-  });
-
-  it('keeps imported annual years visible when registration still has a single-year period', async () => {
-    const db = createDb({
-      project: {
-        id: 'project-a',
-        contractStart: '2026-01-01',
-        contractEnd: '2026-12-31',
-      },
-      initialDocuments: {
-        'orgs/tenant-a/cashflow_sheet_mirrors/project-a': {
-          projectId: 'project-a',
-          status: 'FRESH',
-          sourceRevision: 'sha256:multi-year-source',
-          years: [2024, 2025, 2026, 2027, 2028],
-          sheetFacts: {
-            annualCashflowTotals: [2024, 2025, 2026, 2027, 2028].map((year) => ({
-              year,
-              projection: { source: year === 2026 ? 'WEEKLY' : 'ANNUAL', totalIn: year, totalOut: 0, net: year, lineAmounts: {} },
-              actual: { source: year === 2026 ? 'WEEKLY' : 'ANNUAL', totalIn: year, totalOut: 0, net: year, lineAmounts: {} },
-            })),
-          },
-        },
-      },
-    });
-
-    const response = await request(createApp({ db }))
-      .get('/api/v1/projects/project-a/cashflow-sheet-lab/years?selectedYear=2026')
-      .expect(200);
-
-    expect(response.body.availableYears).toEqual([2024, 2025, 2026, 2027, 2028]);
-    expect(response.body.navigationYears).toEqual([2025, 2026, 2027]);
-    expect(response.body.years.map((row) => row.year)).toEqual([2024, 2025, 2026, 2027, 2028]);
-  });
-
-  it('does not invent adjacent years for an unlinked single-year project', async () => {
-    const db = createDb({
-      project: {
-        id: 'project-a',
-        contractStart: '2026-01-01',
-        contractEnd: '2026-12-31',
-      },
-    });
-
-    const response = await request(createApp({ db }))
-      .get('/api/v1/projects/project-a/cashflow-sheet-lab/years?selectedYear=2026')
-      .expect(200);
-
-    expect(response.body).toMatchObject({
-      availableYears: [2026],
-      navigationYears: [2026],
-      years: [],
-      canonicalAnnualYears: [],
-    });
   });
 
   it('compares a pinned multi-year sheet total with registered financial years', async () => {

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -2718,6 +2718,8 @@ async function composeCashflowMonthDashboard({
   const tenantId = readOptionalText(req.context?.tenantId);
   const businessDate = readOptionalText(close?.evaluatedBusinessDate);
   const selectedYear = Number(yearMonth.slice(0, 4));
+  // 읽기는 두 라운드다. 1: 프로젝트·미러 (서로 독립). 2: 월 상태·연간 문서 (weeklyYear 가
+  // 미러에서 나오므로 미러 뒤, 둘은 서로 독립이라 함께). 예전엔 넷을 순차 네 라운드로 읽었다.
   const [projectRead, mirrorRead] = await Promise.all([
     closedSnapshot
       ? Promise.resolve({ available: true, value: null })
@@ -2741,9 +2743,12 @@ async function composeCashflowMonthDashboard({
   const weeklyYear = closedSnapshot
     ? readWeeklyYear(closedSnapshot.weeklyYear) ?? readWeeklyYear(selectedYear)
     : readWeeklyYear(mirror?.weeklyYear);
-  const monthCloseStatusRead = await readCashflowMonthCloseStatuses({
-    db, tenantId, projectId, selectedYear, weeklyYear, cumulativeAuthority, businessDate,
-  });
+  const [monthCloseStatusRead, annualTotals] = await Promise.all([
+    readCashflowMonthCloseStatuses({
+      db, tenantId, projectId, selectedYear, weeklyYear, cumulativeAuthority, businessDate,
+    }),
+    readAnnualTotals({ db, tenantId, projectId, weeklyYear }),
+  ]);
   monthCloseStatusRead.sectionErrors.forEach((entry) => {
     if (!sectionErrors.some((current) => current.section === entry.section && current.code === entry.code)) {
       sectionErrors.push(entry);
@@ -2794,12 +2799,6 @@ async function composeCashflowMonthDashboard({
     canonicalSource,
     weeklyYear,
   );
-  const annualTotals = await readAnnualTotals({
-    db,
-    tenantId,
-    projectId,
-    weeklyYear,
-  });
   const monthCellsAvailable = Boolean(closedSnapshot || mirror);
   const projectionMode = monthCellsAvailable ? buildMonthModeReadModel(cells, 'projection') : null;
   const actualMode = monthCellsAvailable ? buildMonthModeReadModel(cells, 'actual') : null;

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -452,7 +452,6 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain('fetchCashflowSnapshotViaBff');
     expect(source).not.toContain('resolveCashflowEvidenceScope({');
     expect(source).toContain("cashflowPresentation?.evidenceSource === 'DASHBOARD'");
-    expect(source).not.toContain('getCashflowSheetLabYearViewViaBff');
     expect(source).not.toContain('data-cashflow-block="multi-year-view"');
     expect(source).not.toContain('data-cashflow-year-view');
     expect(source).toContain('monthCloseResult?.dashboard?.sheetMetadata as CashflowSheetDashboardMetadata');
@@ -650,7 +649,6 @@ describe('CashflowProjectSheet monthly close shell', () => {
   });
 
   it('keeps the selected-year board self-contained', () => {
-    expect(source).not.toContain('getCashflowSheetLabYearViewViaBff');
     expect(source).not.toContain('cashflowYearView');
     expect(source).not.toContain('data-cashflow-block="multi-year-view"');
     expect(source).not.toContain('data-cashflow-year-view');

--- a/src/app/lib/sheets-cashflow-readonly-client.test.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.test.ts
@@ -6,7 +6,6 @@ import {
   extractSpreadsheetIdFromSheetInput,
   getCashflowSheetLabMirrorViaBff,
   getCashflowSheetLabShareAccountViaBff,
-  getCashflowSheetLabYearViewViaBff,
   isCashflowSheetApplyResultUncertain,
   refreshCashflowSheetLabMirrorViaBff,
   saveCashflowSheetLabConfigViaBff,
@@ -236,38 +235,6 @@ describe('sheets cashflow readonly client', () => {
   it('does not expose the retired full sheet change-count check', () => {
     expect(clientSource).not.toContain('checkCashflowSheetChangesViaBff');
     expect(clientSource).not.toContain('/cashflow-sheet-lab/changes/check');
-  });
-
-  it('reads the server-owned annual view for the selected year', async () => {
-    const client = asMockClient({
-      get: vi.fn(async () => ({
-        data: {
-          projectId: 'p001',
-          status: 'FRESH',
-          selectedYear: 2026,
-          availableYears: [2025, 2026, 2027],
-          navigationYears: [2025, 2026, 2027],
-          years: [],
-          readModelStatus: 'CURRENT',
-          fallbackYears: [],
-          mismatchYears: [],
-        },
-      })),
-    });
-
-    const result = await getCashflowSheetLabYearViewViaBff({
-      tenantId: 'mysc',
-      actor: { uid: 'user-1', role: 'workspace_user', email: 'user@mysc.co.kr' },
-      projectId: 'p001',
-      selectedYear: 2026,
-      client,
-    });
-
-    expect(result.navigationYears).toEqual([2025, 2026, 2027]);
-    expect(client.get).toHaveBeenCalledWith(
-      '/api/v1/projects/p001/cashflow-sheet-lab/years?selectedYear=2026',
-      expect.objectContaining({ tenantId: 'mysc' }),
-    );
   });
 
   it('refreshes the mirror only on an explicit request and retains a stale last-good snapshot', async () => {

--- a/src/app/lib/sheets-cashflow-readonly-client.ts
+++ b/src/app/lib/sheets-cashflow-readonly-client.ts
@@ -468,37 +468,6 @@ export interface CashflowSheetLabGrandTotal {
   net: number;
 }
 
-export interface CashflowSheetLabYearViewResult {
-  projectId: string;
-  status: 'EMPTY' | 'FRESH' | 'STALE';
-  selectedYear: number;
-  availableYears: number[];
-  navigationYears: number[];
-  snapshotId?: string;
-  sourceRevision?: string;
-  capturedAt?: string;
-  years: Array<{
-    year: number;
-    projection: CashflowSheetLabAnnualModeTotal;
-    actual: CashflowSheetLabAnnualModeTotal;
-    sourceRevision: string;
-    capturedAt?: string;
-    storage: 'SNAPSHOT' | 'MIRROR_FALLBACK';
-  }>;
-  canonicalAnnualYears: Array<{
-    year: number;
-    source: 'ANNUAL';
-    revision: number;
-    sourceRevision: string;
-    updatedAt?: string;
-    projection: CashflowSheetLabAnnualModeTotal;
-    actual: CashflowSheetLabAnnualModeTotal;
-  }>;
-  readModelStatus: 'EMPTY' | 'CURRENT' | 'FALLBACK' | 'MISMATCH';
-  fallbackYears: number[];
-  mismatchYears: number[];
-}
-
 export interface CashflowSheetLabStageResult {
   ok: boolean;
   commandName: 'cashflowSheetLab.stage.firebase';
@@ -811,26 +780,6 @@ export async function getCashflowSheetLabMirrorViaBff(params: {
   const apiClient = params.client || createSameOriginBffClient();
   const response = await apiClient.get<CashflowSheetLabMirrorResult>(
     `/api/v1/projects/${encodeURIComponent(params.projectId)}/cashflow-sheet-lab/mirror`,
-    {
-      tenantId: params.tenantId,
-      actor: toRequestActor(params.actor),
-      timeoutMs: 15000,
-      retries: 0,
-    },
-  );
-  return response.data;
-}
-
-export async function getCashflowSheetLabYearViewViaBff(params: {
-  tenantId: string;
-  actor: ActorLike;
-  projectId: string;
-  selectedYear: number;
-  client?: PlatformApiClientLike;
-}): Promise<CashflowSheetLabYearViewResult> {
-  const apiClient = params.client || createSameOriginBffClient();
-  const response = await apiClient.get<CashflowSheetLabYearViewResult>(
-    `/api/v1/projects/${encodeURIComponent(params.projectId)}/cashflow-sheet-lab/years?selectedYear=${params.selectedYear}`,
     {
       tenantId: params.tenantId,
       actor: toRequestActor(params.actor),


### PR DESCRIPTION
## 무엇

읽기 경로 계약(`2026-08-18-cashflow-read-path-contract.md`)의 첫 삽. 둘 다 **런타임 동작 무변경**.

| | 내용 | 규모 |
|---|---|---|
| 삭제 | `GET /cashflow-sheet-lab/years` 라우트, 전용 헬퍼 4개, 프론트 클라이언트 함수·타입, 그 테스트 5개. 셸 테스트가 "화면에서 쓰지 마라"고 못 박은 죽은 경로 | **−341** |
| 병렬화 | `composeCashflowMonthDashboard` 안 순차 읽기 3라운드 → 2라운드. 월 상태 12개와 연간 8개는 서로 독립 | +8 / −9 |

## 정직한 규모

병렬화는 수백 ms 급입니다. AXR 대시보드 8.6초의 덩어리는 **JVM 왕복 2개**(`jvm_dashboard`, `jvm_compliance`)이고, 그건 계약 순서대로 별도 진행 — JVM 응답 6필드가 전부 BFF 가 이미 읽는 Firestore 문서라 뗄 수 있지만, 480줄을 옮겨 짓는 일이라 한 PR 로 안 갑니다.

## 검증

- sheet-lab 116/116 · jvm-weekly-api 258 · 셸 69 · 유닛 3,226 (단일 워커) · typecheck · policy · build
- 삭제된 헬퍼 잔여 참조 0. `readCanonicalAnnualTotal` 은 살아 있는 연간 후보 경로가 써서 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)