### PR TITLE
fix(cashflow): move the after-close dialog out of the board; drop informational toasts

### DIFF
--- a/src/app/components/cashflow/CashflowLateSheetChangeDialog.tsx
+++ b/src/app/components/cashflow/CashflowLateSheetChangeDialog.tsx
@@ -1,0 +1,144 @@
+import { useMemo, useState } from 'react';
+import { Loader2, Save } from 'lucide-react';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '../ui/alert-dialog';
+import { CASHFLOW_SHEET_LINE_LABELS, type CashflowSheetLineId } from '../../data/types';
+import type { CashflowSheetLabStageResult } from '../../lib/sheets-cashflow-readonly-client';
+
+// 마감 후 시트값 변경 확인. 사유·필터 입력은 이 컴포넌트 안에서만 산다.
+// 부모(CashflowProjectSheet, 3,500줄·보드 1,920셀)에 두면 글자 하나에 화면 전체가 다시 그려진다.
+export function CashflowLateSheetChangeDialog({
+  stage,
+  resumeRequired,
+  resumeReason = '',
+  submitting,
+  onCancel,
+  onSubmit,
+}: {
+  stage: CashflowSheetLabStageResult | null;
+  resumeRequired: boolean;
+  // 이어서 완료할 때는 이전 반영이 남긴 사유를 그대로 쓴다.
+  resumeReason?: string;
+  submitting: boolean;
+  onCancel: () => void;
+  onSubmit: (reason: string) => void;
+}) {
+  const [reason, setReason] = useState('');
+  const [query, setQuery] = useState('');
+  const [mode, setMode] = useState('ALL');
+  const [month, setMonth] = useState('ALL');
+  const [week, setWeek] = useState('ALL');
+
+  const rows = useMemo(() => (stage?.closedMonthDifferences || []).flatMap((entry) => (
+    (entry.changes || []).map((change) => ({ ...change, yearMonth: entry.yearMonth }))
+  )), [stage]);
+  const complete = Boolean(stage?.closedMonthDifferenceManifestHash)
+    && Number.isSafeInteger(stage?.closedMonthDifferenceCount)
+    && stage?.closedMonthDifferenceCount === rows.length
+    && (stage?.closedMonthDifferences || []).every((entry) => !entry.truncatedChangeCount);
+  const filtered = rows.filter((change) => {
+    const label = CASHFLOW_SHEET_LINE_LABELS[change.lineId as CashflowSheetLineId] || change.lineId;
+    const needle = query.trim().toLocaleLowerCase('ko-KR');
+    return (mode === 'ALL' || change.mode === mode)
+      && (month === 'ALL' || change.yearMonth === month)
+      && (week === 'ALL' || String(change.weekNo) === week)
+      && (!needle || `${change.yearMonth} ${change.weekNo}주차 ${label}`.toLocaleLowerCase('ko-KR').includes(needle));
+  });
+  const months = [...new Set(rows.map((row) => row.yearMonth))];
+  const won = (value: number | null | undefined) => `${Number(value ?? 0).toLocaleString('ko-KR')}원`;
+
+  return (
+    <AlertDialog
+      open={Boolean(stage)}
+      onOpenChange={(open) => { if (!open) onCancel(); }}
+    >
+      <AlertDialogContent className="w-[calc(100vw-2rem)] max-w-[960px]">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{resumeRequired ? '시트 반영 이어서 완료' : '마감 후 시트값 변경'}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {resumeRequired
+              ? '이전 반영의 응답을 확인하지 못했습니다. 같은 검토본으로 안전하게 이어서 완료해 주세요.'
+              : '이미 결산이 완료된 월의 값이 시트에서 변경되었습니다. 사유를 남기면 변경 이력과 경고 횟수에 함께 기록됩니다. 그래도 반영할까요?'}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {stage && !resumeRequired && (
+          <div className="min-w-0 space-y-3">
+            <div className={`rounded-md border px-3 py-2 text-[12px] ${complete ? 'border-slate-300 bg-slate-50 text-slate-700' : 'border-red-300 bg-red-50 text-red-800'}`} role={complete ? 'status' : 'alert'}>
+              {complete ? `검토본과 일치하는 변경 ${rows.length.toLocaleString()}건입니다.` : '변경 목록이 검토본과 일치하지 않아 반영할 수 없습니다. 시트 값을 다시 불러온 뒤 비교해 주세요.'}
+            </div>
+            <div className="grid gap-2 sm:grid-cols-4">
+              <Input aria-label="변경 이력 검색" placeholder="월·주·항목 검색" value={query} onChange={(event) => setQuery(event.target.value)} />
+              <select aria-label="Projection Actual 필터" className="h-9 rounded-md border border-slate-300 bg-white px-2 text-[12px]" value={mode} onChange={(event) => setMode(event.target.value)}>
+                <option value="ALL">전체 구분</option><option value="projection">Projection</option><option value="actual">Actual</option>
+              </select>
+              <select aria-label="월 필터" className="h-9 rounded-md border border-slate-300 bg-white px-2 text-[12px]" value={month} onChange={(event) => setMonth(event.target.value)}>
+                <option value="ALL">전체 월</option>{months.map((value) => <option key={value} value={value}>{value}</option>)}
+              </select>
+              <select aria-label="주차 필터" className="h-9 rounded-md border border-slate-300 bg-white px-2 text-[12px]" value={week} onChange={(event) => setWeek(event.target.value)}>
+                <option value="ALL">전체 주차</option>{[1, 2, 3, 4, 5].map((weekNo) => <option key={weekNo} value={weekNo}>{weekNo}주차</option>)}
+              </select>
+            </div>
+            <div className="max-h-[min(60dvh,720px)] overflow-auto rounded-md border border-slate-200 bg-slate-50" role="region" aria-label="마감 후 변경 후보 전체 목록" tabIndex={0}>
+              <table className="w-full border-collapse text-[12px] leading-4 text-slate-700">
+                <caption className="sr-only">월, 주차, 구분, 항목별 이전값과 변경값</caption>
+                <thead className="sticky top-0 bg-slate-100">
+                  <tr><th className="px-2 py-2 text-left">월·주차</th><th className="px-2 py-2 text-left">구분</th><th className="px-2 py-2 text-left">항목</th><th className="px-2 py-2 text-right">이전값 → 변경값</th></tr>
+                </thead>
+                <tbody>
+                  {filtered.map((change) => (
+                    <tr key={`${change.yearMonth}:${change.mode}:${change.weekNo}:${change.lineId}`} className="border-t border-slate-200">
+                      <th className="px-2 py-1.5 text-left">{change.yearMonth} {change.weekNo}주차</th>
+                      <td className="px-2 py-1.5">{change.mode === 'projection' ? 'Projection' : 'Actual'}</td>
+                      <td className="px-2 py-1.5">{CASHFLOW_SHEET_LINE_LABELS[change.lineId as CashflowSheetLineId] || change.lineId}</td>
+                      <td className="px-2 py-1.5 text-right tabular-nums">
+                        <span className={change.beforeHadValue ? 'text-slate-500' : 'text-slate-400'}>{change.beforeHadValue ? won(change.beforeAmount) : '빈칸'}</span>
+                        <span className="px-1 text-slate-400">→</span>
+                        <strong>{change.afterHadValue ? won(change.afterAmount) : '빈칸'}</strong>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {filtered.length === 0
+                ? <p className="p-5 text-center text-[12px] text-slate-500">필터와 일치하는 변경 후보가 없습니다.</p>
+                : filtered.length !== rows.length
+                  ? <p className="px-3 py-2 text-right text-[12px] text-slate-500">전체 {rows.length.toLocaleString()}건 중 {filtered.length.toLocaleString()}건 표시</p>
+                  : null}
+            </div>
+            <label className="block text-[12px] font-semibold text-slate-800" htmlFor="late-sheet-change-reason">변경 사유</label>
+            <textarea
+              id="late-sheet-change-reason"
+              value={reason}
+              onChange={(event) => setReason(event.target.value.slice(0, 1000))}
+              placeholder="예: 결산 후 확인된 실제 입금액을 시트 기준으로 정정"
+              className="min-h-[96px] w-full resize-y rounded-md border border-slate-300 bg-white px-3 py-2 text-[13px] leading-5 text-slate-900 outline-none focus:border-[#17324D] focus:ring-2 focus:ring-[#17324D]/10"
+              disabled={submitting}
+            />
+            <div className="text-right text-[12px] text-slate-400">{reason.length}/1000</div>
+          </div>
+        )}
+        <AlertDialogFooter>
+          {!resumeRequired && <AlertDialogCancel disabled={submitting}>취소</AlertDialogCancel>}
+          <Button
+            type="button"
+            className="bg-[#17324D] hover:bg-slate-800"
+            disabled={submitting || !stage || (!resumeRequired && (!reason.trim() || !complete))}
+            onClick={() => onSubmit((resumeRequired ? resumeReason : reason).trim())}
+          >
+            {submitting ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <Save className="mr-1.5 h-3.5 w-3.5" />}
+            {resumeRequired ? '같은 작업 이어서 완료' : '사유와 함께 반영'}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -2,7 +2,10 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
-const source = readFileSync(resolve(import.meta.dirname, 'CashflowProjectSheet.tsx'), 'utf8');
+// 마감 후 변경 다이얼로그는 별도 파일이다. 사유·필터 입력이 부모 state 였을 때 글자 하나에 3,500줄이
+// 다시 그려졌다. 셸 검사는 두 파일을 하나의 소스로 본다.
+const source = readFileSync(resolve(import.meta.dirname, 'CashflowProjectSheet.tsx'), 'utf8')
+  + readFileSync(resolve(import.meta.dirname, 'CashflowLateSheetChangeDialog.tsx'), 'utf8');
 
 describe('CashflowProjectSheet monthly close shell', () => {
   it('uses the server month-close guide instead of rebuilding a target-month deadline label', () => {
@@ -41,13 +44,16 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain('applyCashflowMonthCloseProjectionDrafts');
   });
 
-  it('shows submission success only after the BFF persists a pending request', () => {
+  it('treats a submission as done only after the BFF persists a pending request', () => {
+    // 성공 토스트는 없앴다. 요청 상태가 화면에 바로 반영되므로 따로 말할 필요가 없다.
+    // 대신 상태 갱신이 PENDING 검사 뒤에 온다는 순서는 유지한다.
     const pendingGuard = source.indexOf("if (request.status !== 'PENDING')");
-    const successToast = source.indexOf("toast.success('월결산 결재 요청을 제출했습니다.');");
+    const applied = source.indexOf('setMonthCloseRequest(request);', pendingGuard);
 
     expect(pendingGuard).toBeGreaterThan(-1);
-    expect(successToast).toBeGreaterThan(pendingGuard);
+    expect(applied).toBeGreaterThan(pendingGuard);
     expect(source).not.toContain('월 결산 승인을 요청했습니다.');
+    expect(source).not.toContain("toast.success('월결산 결재 요청을 제출했습니다.');");
   });
 
   it('drops delayed mutation responses after the selected project or month changes', () => {
@@ -409,7 +415,7 @@ describe('CashflowProjectSheet monthly close shell', () => {
 
   it('reuses the staged run when a closed-month change needs a reason', () => {
     expect(source).toContain("bffErrorCode(finalError) === 'cashflow_closed_month_reason_required'");
-    expect(source).toContain('lateSheetChangeReason.trim(),');
+    expect(source).toContain("onSubmit((resumeRequired ? resumeReason : reason).trim())");
     expect(source).toContain('lateSheetFormulaAccepted,');
     expect(source).toContain('closedMonthChangeReason');
     expect(source).toContain('마감 후 시트값 변경');
@@ -559,8 +565,9 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('setLateSheetApply(stage)');
     expect(source).toContain('setSheetApplyResumeRequired(true)');
     expect(source).toContain('같은 작업 이어서 완료');
-    expect(source).toContain('!sheetStageApplyLoading && !sheetApplyResumeRequired');
-    expect(source).toContain('!sheetApplyResumeRequired && (');
+    // 전송 중이거나 이어서 완료 중이면 닫기가 무시된다.
+    expect(source).toContain('if (sheetStageApplyLoading || sheetApplyResumeRequired) return;');
+    expect(source).toContain('!resumeRequired && (');
   });
 
   it('uses the sheets-lab one-way apply contract and does not turn post-apply reads into a failed save', () => {
@@ -590,10 +597,10 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(stageFlow.indexOf('setLateSheetApply(result)')).toBeLessThan(stageFlow.indexOf('handleApplyStagedSheetValues(result)'));
     expect(source).toContain('이미 결산이 완료된 월의 값이 시트에서 변경되었습니다. 사유를 남기면 변경 이력과 경고 횟수에 함께 기록됩니다. 그래도 반영할까요?');
     expect(source).not.toContain('결산 마감일이 지난 값');
-    expect(source).toContain('!lateSheetChangeReason.trim() || !lateSheetDiffComplete');
+    expect(source).toContain('!reason.trim() || !complete');
     expect(source).toContain('closedMonthDifferenceManifestHash');
     expect(source).toContain('closedMonthDifferenceCount');
-    expect(source).toContain('lateSheetChangeReason.trim(),');
+    expect(source).toContain("onSubmit((resumeRequired ? resumeReason : reason).trim())");
   });
 
   it('runs the same main-page sheet action in refresh, stage, then apply order', () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -18,6 +18,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '../ui/alert-dialog';
+import { CashflowLateSheetChangeDialog } from './CashflowLateSheetChangeDialog';
 import { useCashflowWeeks } from '../../data/cashflow-weeks-store';
 import {
   CASHFLOW_SHEET_LINE_LABELS,
@@ -409,12 +410,8 @@ export function CashflowProjectSheet({
   const [sheetReviewDialogOpen, setSheetReviewDialogOpen] = useState(false);
   const [lateSheetApply, setLateSheetApply] = useState<CashflowSheetLabStageResult | null>(null);
   const [sheetApplyResumeRequired, setSheetApplyResumeRequired] = useState(false);
-  const [lateSheetChangeReason, setLateSheetChangeReason] = useState('');
+  const [lateSheetResumeReason, setLateSheetResumeReason] = useState('');
   const [lateSheetFormulaAccepted, setLateSheetFormulaAccepted] = useState(false);
-  const [lateSheetDiffQuery, setLateSheetDiffQuery] = useState('');
-  const [lateSheetDiffMode, setLateSheetDiffMode] = useState('ALL');
-  const [lateSheetDiffMonth, setLateSheetDiffMonth] = useState('ALL');
-  const [lateSheetDiffWeek, setLateSheetDiffWeek] = useState('ALL');
   const [formulaMismatchPrompt, setFormulaMismatchPrompt] = useState<{
     stage: CashflowSheetLabStageResult;
     issues: CashflowFormulaMismatch[];
@@ -423,24 +420,10 @@ export function CashflowProjectSheet({
   } | null>(null);
   const [pendingApprovalStage, setPendingApprovalStage] = useState<CashflowSheetLabStageResult | null>(null);
   const [sheetStageApplyLoading, setSheetStageApplyLoading] = useState(false);
-  const lateSheetDiffRows = useMemo(() => (lateSheetApply?.closedMonthDifferences || []).flatMap((month) =>
-    (month.changes || []).map((change) => ({ ...change, yearMonth: month.yearMonth }))), [lateSheetApply]);
-  const lateSheetDiffComplete = Boolean(lateSheetApply?.closedMonthDifferenceManifestHash)
-    && Number.isSafeInteger(lateSheetApply?.closedMonthDifferenceCount)
-    && lateSheetApply?.closedMonthDifferenceCount === lateSheetDiffRows.length
-    && (lateSheetApply?.closedMonthDifferences || []).every((month) => !month.truncatedChangeCount);
   const pendingApprovalChangeRows = (pendingApprovalStage?.pendingApprovalDifferences || []).flatMap((month) => month.changes || []);
   const pendingApprovalManifestComplete = Boolean(pendingApprovalStage?.pendingApprovalDifferenceManifestHash)
     && pendingApprovalStage?.pendingApprovalDifferenceCount === pendingApprovalChangeRows.length
     && (pendingApprovalStage?.pendingApprovalDifferences || []).every((month) => !month.truncatedChangeCount);
-  const filteredLateSheetDiffRows = lateSheetDiffRows.filter((change) => {
-    const label = CASHFLOW_SHEET_LINE_LABELS[change.lineId as CashflowSheetLineId] || change.lineId;
-    const query = lateSheetDiffQuery.trim().toLocaleLowerCase('ko-KR');
-    return (lateSheetDiffMode === 'ALL' || change.mode === lateSheetDiffMode)
-      && (lateSheetDiffMonth === 'ALL' || change.yearMonth === lateSheetDiffMonth)
-      && (lateSheetDiffWeek === 'ALL' || String(change.weekNo) === lateSheetDiffWeek)
-      && (!query || `${change.yearMonth} ${change.weekNo} ${change.mode} ${label} ${change.lineId}`.toLocaleLowerCase('ko-KR').includes(query));
-  });
   // 조직장은 로그인해서 승인해야 하므로 계정이 필수지만, 명부에 없는 사람(퇴사 후 계정이
   // 남은 경우)은 후보에서 빠져야 한다. 명부는 문지기로만 쓴다.
   const approverRoster = usePersonRoster();
@@ -917,9 +900,6 @@ export function CashflowProjectSheet({
         durationMs: Date.now() - startedAt,
         summary: { alreadyCompleted: result.alreadyCompleted },
       });
-      toast.success(result.alreadyCompleted
-        ? `${result.yearMonth} ${result.weekNo}주차는 이미 정산 완료되었습니다.`
-        : `${result.yearMonth} ${result.weekNo}주차 정산을 완료했습니다.`);
     } catch (error) {
       logCashflowSettlement({
         phase: 'error',
@@ -1172,7 +1152,6 @@ export function CashflowProjectSheet({
       setSavedExecutiveApproverId(result.executiveApproverId);
       setExecutiveApproverAttention(false);
       onExecutiveApproverSaved?.(result);
-      toast.success(`${result.executiveApproverName || approver.name}님을 프로젝트 조직장으로 지정했습니다.`);
     } catch (error) {
       if (!isCurrentMonthCloseMutation(mutationScope)) return;
       toast.error(resolveApiErrorMessage(error, '조직장을 저장하지 못했습니다.'));
@@ -1313,7 +1292,6 @@ export function CashflowProjectSheet({
       setMonthCloseRequest(request);
       setMonthCloseReviewOpen(false);
       setMonthCloseReviewDirty(false);
-      toast.success('월결산 결재 요청을 제출했습니다.');
       if (!isCurrentMonthCloseMutation(mutationScope, request)) return;
       await Promise.all([
         loadCashflowMonthClose(),
@@ -1398,7 +1376,6 @@ export function CashflowProjectSheet({
       setMonthCloseRequest(request);
       setMonthCloseWithdrawOpen(false);
       setMonthCloseWithdrawReason('');
-      toast.success('월결산 결재 요청을 회수했습니다.');
       if (!isCurrentMonthCloseMutation(mutationScope, request)) return;
       await Promise.all([loadCashflowMonthClose(), loadMonthCloseRequest(), loadCashflowEvents()]);
       if (!isCurrentMonthCloseMutation(mutationScope, request)) return;
@@ -1496,11 +1473,6 @@ export function CashflowProjectSheet({
       void loadMonthCloseRequest();
       setReopenAction(null);
       setReopenReason('');
-      toast.success(reopenAction === 'request'
-        ? '재오픈 요청을 보냈습니다.'
-        : reopenAction === 'approve'
-          ? '재오픈을 승인했습니다.'
-          : '재오픈을 반려했습니다.');
     } catch (error) {
       if (!isCurrentMonthCloseMutation(mutationScope)) return;
       toast.error(resolveCashflowMonthReopenErrorMessage(
@@ -1550,10 +1522,8 @@ export function CashflowProjectSheet({
         : mirror);
       if (mirror.status === 'FRESH' && mirror.sourceRevision) {
         void loadCashflowEvents();
-        toast.success('시트값을 불러왔습니다. MYSCube 시트 반영 전 금액을 확인합니다.');
-      } else if (mirror.status === 'STALE') {
-        toast.warning('최신 시트 조회에 실패해 마지막 정상 고정값을 유지했습니다.');
-      } else {
+        } else if (mirror.status === 'STALE') {
+        } else {
         toast.error(mirror.lastRefreshError?.message || '시트 연동에 실패했습니다.');
       }
     };
@@ -1678,10 +1648,8 @@ export function CashflowProjectSheet({
       } : current);
       setLateSheetApply(null);
       setSheetApplyResumeRequired(false);
-      setLateSheetChangeReason('');
       setLateSheetFormulaAccepted(false);
       setFormulaMismatchPrompt(null);
-      toast.success(`시트 최신값 ${result.appliedLineCount.toLocaleString()}건을 MYSCube 시트에 반영했습니다.`);
     };
 
     setSheetStageApplyLoading(true);
@@ -1732,7 +1700,6 @@ export function CashflowProjectSheet({
             ? details.closedMonthDifferences
             : stage.closedMonthDifferences,
         });
-        setLateSheetChangeReason('');
         setLateSheetFormulaAccepted(acceptFormulaMismatches);
         setSheetApplyResumeRequired(false);
         return;
@@ -1761,7 +1728,7 @@ export function CashflowProjectSheet({
         const status = await getCashflowSheetLabApplyStatusViaBff({ tenantId: orgId, actor, projectId });
         if (cancelled || status.status !== 'APPLYING' || !status.stagedRun) return;
         setLateSheetApply(status.stagedRun);
-        setLateSheetChangeReason(status.applyInput?.closedMonthChangeReason || '');
+        setLateSheetResumeReason(status.applyInput?.closedMonthChangeReason || '');
         setLateSheetFormulaAccepted(status.applyInput?.acceptFormulaMismatches === true);
         setSheetApplyResumeRequired(true);
       } catch {
@@ -1803,7 +1770,6 @@ export function CashflowProjectSheet({
       }
       if (result.stagedLineCount <= 0) {
         // 없으면 없다고 말한다. 조용히 끝나면 반영이 중간에 멈춘 것처럼 보인다.
-        toast.success('시트 값을 확인했습니다. 반영할 변경이 없습니다.');
         return;
       }
       if (result.pendingApprovalDifferences?.length) {
@@ -1812,7 +1778,6 @@ export function CashflowProjectSheet({
       }
       if (result.closedMonthDifferences?.length) {
         setLateSheetApply(result);
-        setLateSheetChangeReason('');
         setLateSheetFormulaAccepted(false);
         setSheetApplyResumeRequired(false);
         return;
@@ -1913,7 +1878,6 @@ export function CashflowProjectSheet({
   }, [handleStagePinnedSheetValues]);
 
   const handleRevertCashflowRun = useCallback(async (_runId: string): Promise<void> => {
-    toast.info('되돌리기는 서버 검증 경로가 준비될 때까지 읽기 전용입니다.');
   }, []);
 
   function getWeekLabel(weekNo: number, targetYearMonth = yearMonth): string {
@@ -3433,87 +3397,19 @@ export function CashflowProjectSheet({
         </AlertDialogContent>
       </AlertDialog>
 
-      <AlertDialog
-        open={!!lateSheetApply}
-        onOpenChange={(open) => {
-          if (!open && !sheetStageApplyLoading && !sheetApplyResumeRequired) {
-            setLateSheetApply(null);
-            setSheetApplyResumeRequired(false);
-            setLateSheetChangeReason('');
-            setLateSheetFormulaAccepted(false);
-          }
+      <CashflowLateSheetChangeDialog
+        stage={lateSheetApply}
+        resumeRequired={sheetApplyResumeRequired}
+        resumeReason={lateSheetResumeReason}
+        submitting={sheetStageApplyLoading}
+        onCancel={() => {
+          if (sheetStageApplyLoading || sheetApplyResumeRequired) return;
+          setLateSheetApply(null);
+          setSheetApplyResumeRequired(false);
+          setLateSheetFormulaAccepted(false);
         }}
-      >
-        <AlertDialogContent className="w-[calc(100vw-2rem)] max-w-[960px]">
-          <AlertDialogHeader>
-            <AlertDialogTitle>{sheetApplyResumeRequired ? '시트 반영 이어서 완료' : '마감 후 시트값 변경'}</AlertDialogTitle>
-            <AlertDialogDescription>
-              {sheetApplyResumeRequired
-                ? '이전 반영의 응답을 확인하지 못했습니다. 같은 검토본으로 안전하게 이어서 완료해 주세요.'
-                : '이미 결산이 완료된 월의 값이 시트에서 변경되었습니다. 사유를 남기면 변경 이력과 경고 횟수에 함께 기록됩니다. 그래도 반영할까요?'}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          {lateSheetApply && (
-            <div className="space-y-3">
-              {!sheetApplyResumeRequired && (
-                <>
-                  <div className={`rounded-md border px-3 py-2 text-[12px] ${lateSheetDiffComplete ? 'border-slate-300 bg-slate-50 text-slate-700' : 'border-red-300 bg-red-50 text-red-800'}`} role={lateSheetDiffComplete ? 'status' : 'alert'}>
-                    {lateSheetDiffComplete ? `검토본과 일치하는 변경 ${lateSheetDiffRows.length.toLocaleString()}건입니다.` : '변경 목록이 검토본과 일치하지 않아 반영할 수 없습니다. 시트 값을 다시 불러온 뒤 비교해 주세요.'}
-                  </div>
-                  <div className="grid gap-2 sm:grid-cols-4">
-                    <Input aria-label="변경 이력 검색" placeholder="월·주·항목 검색" value={lateSheetDiffQuery} onChange={(event) => setLateSheetDiffQuery(event.target.value)} />
-                    <select aria-label="Projection Actual 필터" className="h-9 rounded-md border border-slate-300 bg-white px-2 text-[12px]" value={lateSheetDiffMode} onChange={(event) => setLateSheetDiffMode(event.target.value)}><option value="ALL">전체 구분</option><option value="projection">Projection</option><option value="actual">Actual</option></select>
-                    <select aria-label="월 필터" className="h-9 rounded-md border border-slate-300 bg-white px-2 text-[12px]" value={lateSheetDiffMonth} onChange={(event) => setLateSheetDiffMonth(event.target.value)}><option value="ALL">전체 월</option>{[...new Set(lateSheetDiffRows.map((row) => row.yearMonth))].map((month) => <option key={month} value={month}>{month}</option>)}</select>
-                    <select aria-label="주차 필터" className="h-9 rounded-md border border-slate-300 bg-white px-2 text-[12px]" value={lateSheetDiffWeek} onChange={(event) => setLateSheetDiffWeek(event.target.value)}><option value="ALL">전체 주차</option>{[1, 2, 3, 4, 5].map((weekNo) => <option key={weekNo} value={weekNo}>{weekNo}주차</option>)}</select>
-                  </div>
-                  <div className="max-h-[min(60dvh,720px)] overflow-auto rounded-md border border-slate-200 bg-slate-50" role="region" aria-label="마감 후 변경 후보 전체 목록" tabIndex={0}>
-                    <table className="w-full min-w-[620px] border-collapse text-[12px] leading-4 text-slate-700">
-                      <caption className="sr-only">월, 주차, 구분, 항목별 이전값과 변경값</caption>
-                      <thead className="sticky top-0 bg-slate-100"><tr><th className="px-2 py-2 text-left">월·주차</th><th className="px-2 py-2 text-left">구분</th><th className="px-2 py-2 text-left">항목</th><th className="px-2 py-2 text-right">이전값 → 변경값</th></tr></thead>
-                      <tbody>{filteredLateSheetDiffRows.map((change) => <tr key={`${change.yearMonth}:${change.mode}:${change.weekNo}:${change.lineId}`} className="border-t border-slate-200"><th className="px-2 py-1.5 text-left">{change.yearMonth} {change.weekNo}주차</th><td className="px-2 py-1.5">{change.mode === 'projection' ? 'Projection' : 'Actual'}</td><td className="px-2 py-1.5">{CASHFLOW_SHEET_LINE_LABELS[change.lineId as CashflowSheetLineId] || change.lineId}</td><td className="px-2 py-1.5 text-right tabular-nums"><span className={change.beforeHadValue ? 'text-slate-500' : 'text-slate-400'}>{change.beforeHadValue ? formatCashflowAmount(change.beforeAmount) : '빈칸'}</span><span className="px-1 text-slate-400">→</span><strong>{change.afterHadValue ? formatCashflowAmount(change.afterAmount) : '빈칸'}</strong></td></tr>)}</tbody>
-                    </table>
-                    {filteredLateSheetDiffRows.length === 0
-                      ? <p className="p-5 text-center text-[12px] text-slate-500">필터와 일치하는 변경 후보가 없습니다.</p>
-                      : filteredLateSheetDiffRows.length !== lateSheetDiffRows.length
-                        ? <p className="px-3 py-2 text-right text-[12px] text-slate-500">전체 {lateSheetDiffRows.length.toLocaleString()}건 중 {filteredLateSheetDiffRows.length.toLocaleString()}건 표시</p>
-                        : null}
-                  </div>
-                  <label className="block text-[12px] font-semibold text-slate-800" htmlFor="late-sheet-change-reason">
-                    변경 사유
-                  </label>
-                  <textarea
-                    id="late-sheet-change-reason"
-                    value={lateSheetChangeReason}
-                    onChange={(event) => setLateSheetChangeReason(event.target.value.slice(0, 1000))}
-                    placeholder="예: 결산 후 확인된 실제 입금액을 시트 기준으로 정정"
-                    className="min-h-[96px] w-full resize-y rounded-md border border-slate-300 bg-white px-3 py-2 text-[13px] leading-5 text-slate-900 outline-none focus:border-[#17324D] focus:ring-2 focus:ring-[#17324D]/10"
-                    disabled={sheetStageApplyLoading}
-                  />
-                  <div className="text-right text-[12px] text-slate-400">{lateSheetChangeReason.length}/1000</div>
-                </>
-              )}
-            </div>
-          )}
-          <AlertDialogFooter>
-            {!sheetApplyResumeRequired && (
-              <AlertDialogCancel disabled={sheetStageApplyLoading}>취소</AlertDialogCancel>
-            )}
-            <Button
-              type="button"
-              className="bg-[#17324D] hover:bg-slate-800"
-              disabled={sheetStageApplyLoading || !lateSheetApply || (!sheetApplyResumeRequired && (!lateSheetChangeReason.trim() || !lateSheetDiffComplete))}
-              onClick={() => lateSheetApply && void handleApplyStagedSheetValues(
-                lateSheetApply,
-                lateSheetChangeReason.trim(),
-                lateSheetFormulaAccepted,
-              )}
-            >
-              {sheetStageApplyLoading ? <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" /> : <Save className="mr-1.5 h-3.5 w-3.5" />}
-              {sheetApplyResumeRequired ? '같은 작업 이어서 완료' : '사유와 함께 반영'}
-            </Button>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+        onSubmit={(reason) => lateSheetApply && void handleApplyStagedSheetValues(lateSheetApply, reason, lateSheetFormulaAccepted)}
+      />
 
 
       <AlertDialog


### PR DESCRIPTION
## 무엇

라이브 QA 에서 나온 셋.

| 증상 | 원인 | 수정 |
|---|---|---|
| 사유 입력 렉 | 사유·검색·필터 3개가 3,500줄 부모 state → 글자마다 보드 1,920셀 리렌더 | 다이얼로그를 별도 컴포넌트로. state 는 안에서만 |
| UI 박살 (표가 튀어나옴) | 표 `min-w-[620px]` | 제거 |
| 우측 하단 토스트 | 화면 상태로 이미 보이는 걸 다시 말함 | 성공·정보 10개 삭제. **에러는 유지** (실패 보고의 유일한 경로) |

## 남긴 토스트

- 에러 34개 — 인라인화는 별도 Task
- `BLOCKED` 사유 경고 1개 — 왜 막혔는지 알려주는 것이라 정보성이 아님

## 검증

cashflow 컴포넌트 테스트 156/156 · typecheck · build. 셸 테스트는 부모+다이얼로그 두 파일을 한 소스로 읽음.

## 라이브 확인 (QA 에서 이미)

- 8월 셀 반영 → 팝업 없음 ✅ (#572)
- 7월 셀 반영 → 팝업에 **1건만** ✅ (#573, 어제 1,120건이던 것)
- 연간 열 확인 불가 → 값 ✅ (#574, 불러오기 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)