### PR TITLE
fix(cashflow): unblock close on unused date rows; surface section failure causes; fix dialog widths

### DIFF
--- a/server/bff/cashflow-sheet-snapshot.mjs
+++ b/server/bff/cashflow-sheet-snapshot.mjs
@@ -445,14 +445,12 @@ export function extractCashflowSheetFacts({
   const depositControlColumnIndex = 70; // BS
   const unpaidControlColumnIndex = 71; // BT
   const depositScheduleRows = weekColumns.map((week) => {
+    // 6·7행(세금계산서 발행일·예정입금일)은 좌표 계약 밖이다. 누적 결산은 이 값을 쓰지 않는데
+    // (JVM: cumulative 면 depositScheduleRows = List.of()), 날짜 형식이 어긋났다고 issue 를 내면
+    // 그 issue 가 SHEET_VALUE_INVALID blocker 가 되어 쓰지도 않을 값 때문에 결산이 막힌다.
+    // 라이브 2026전남글로벌이 그 상태였다. 읽히면 쓰고, 안 읽히면 빈 값이다 - 거부하지 않는다.
     const taxInvoiceIssuedDate = normalizeDateCell(matrix?.[6]?.[week.columnIndex]);
     const expectedDepositDate = normalizeDateCell(matrix?.[7]?.[week.columnIndex]);
-    if (taxInvoiceIssuedDate === null) {
-      issues.push({ code: 'sheet_date_invalid', field: 'taxInvoiceIssuedDate', sourceCell: toA1(6, week.columnIndex) });
-    }
-    if (expectedDepositDate === null) {
-      issues.push({ code: 'sheet_date_invalid', field: 'expectedDepositDate', sourceCell: toA1(7, week.columnIndex) });
-    }
     return {
       yearMonth: week.yearMonth,
       weekNo: week.weekNo,

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -312,6 +312,14 @@ export function cashflowSectionErrorLabel(section) {
   return CASHFLOW_SECTION_ERROR_LABELS.get(readOptionalText(section)) || '일부 정보';
 }
 
+// 조회 부가 기능이 실패하면 그 section 만 비우고 나머지는 그린다 (계약). 다만 왜 실패했는지는
+// 남겨야 한다 - 화면에 "확인 필요" 만 뜨고 이유가 없으면 진단하려고 소스와 Firestore 를 뒤져야 했다.
+// 실는 것은 안정된 error code 뿐이다. 예외 메시지는 사용자 화면에 나가면 안 된다 (계약).
+function sectionUnavailable(section, code, error) {
+  const cause = readOptionalText(error?.code);
+  return cause ? { section, code, cause } : { section, code };
+}
+
 function cashflowSectionErrorsForResponse(sectionErrors) {
   return (Array.isArray(sectionErrors) ? sectionErrors : []).map((entry) => ({
     ...entry,
@@ -3673,8 +3681,8 @@ export function mountJvmWeeklyApiRoutes(app, {
               tenantId: req.context.tenantId,
               projectId: rawProjectId,
               nowMs: currentNow.getTime(),
-            }).catch(() => {
-              sectionErrors.push({ section: 'sheetPublication', code: 'sheet_publication_state_unavailable' });
+            }).catch((error) => {
+              sectionErrors.push(sectionUnavailable('sheetPublication', 'sheet_publication_state_unavailable', error));
               return { blocked: false, fingerprint: null, unavailable: true };
             }),
             { attempt: traceAttempt },
@@ -3693,8 +3701,8 @@ export function mountJvmWeeklyApiRoutes(app, {
           ),
           trace.measure(
             'jvm_compliance',
-            () => readWeeklyCompliance(req.context, rawProjectId).catch(() => {
-              sectionErrors.push({ section: 'deadlineSummary', code: 'weekly_compliance_unavailable' });
+            () => readWeeklyCompliance(req.context, rawProjectId).catch((error) => {
+              sectionErrors.push(sectionUnavailable('deadlineSummary', 'weekly_compliance_unavailable', error));
               return null;
             }),
             { attempt: traceAttempt },
@@ -3704,29 +3712,23 @@ export function mountJvmWeeklyApiRoutes(app, {
             tenantId: req.context.tenantId,
             projectId: rawProjectId,
             yearMonth,
-          }).then((record) => ({ available: true, record })).catch(() => {
-            sectionErrors.push({
-              section: 'monthCloseRequest', code: 'cashflow_month_close_request_unavailable',
-            });
+          }).then((record) => ({ available: true, record })).catch((error) => {
+            sectionErrors.push(sectionUnavailable('monthCloseRequest', 'cashflow_month_close_request_unavailable', error));
             return { available: false, record: null };
           }),
           readCashflowProjectApproverLock({
             db,
             tenantId: req.context.tenantId,
             projectId: rawProjectId,
-          }).then((locked) => ({ available: true, locked })).catch(() => {
-            sectionErrors.push({
-              section: 'monthCloseApproverLock', code: 'cashflow_month_close_approver_lock_unavailable',
-            });
+          }).then((locked) => ({ available: true, locked })).catch((error) => {
+            sectionErrors.push(sectionUnavailable('monthCloseApproverLock', 'cashflow_month_close_approver_lock_unavailable', error));
             return { available: false, locked: true };
           }),
           assertCashflowMonthActionAccess({
             db, req, projectId: rawProjectId, authMode, workspaceEmailDomain,
           }).then(() => ({ available: true, allowed: true })).catch((error) => {
             if (!['cashflow_month_close_member_inactive', 'cashflow_project_forbidden'].includes(readOptionalText(error?.code))) {
-              sectionErrors.push({
-                section: 'monthCloseActionAccess', code: 'cashflow_month_close_action_access_unavailable',
-              });
+              sectionErrors.push(sectionUnavailable('monthCloseActionAccess', 'cashflow_month_close_action_access_unavailable', error));
               return { available: false, allowed: false };
             }
             return { available: true, allowed: false };

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -1263,11 +1263,11 @@ describe('JVM weekly API BFF proxy', () => {
         // 판정 불능을 "지각 0회" 로 그리지 않도록 요약 자체를 비운다.
         expect(response.body.dashboard.deadlineSummary).toBeNull();
         expect(response.body.sectionErrors).toEqual(expect.arrayContaining([
-          {
+          expect.objectContaining({
             section: 'deadlineSummary',
             code: 'weekly_compliance_unavailable',
             label: '주간 정산 이력',
-          },
+          }),
         ]));
       });
   });
@@ -1306,11 +1306,11 @@ describe('JVM weekly API BFF proxy', () => {
         expect(response.body.pendingApply).toBeNull();
         expect(response.body.publicationChangedDuringRead).toBe(false);
         expect(response.body.sectionErrors).toEqual(expect.arrayContaining([
-          {
+          expect.objectContaining({
             section: 'sheetPublication',
             code: 'sheet_publication_state_unavailable',
             label: '시트 반영 상태',
-          },
+          }),
         ]));
       });
     // 확인 재읽기(publication_after)까지 실패해도 요청당 한 번만 알린다.
@@ -1348,11 +1348,11 @@ describe('JVM weekly API BFF proxy', () => {
           code: 'PROJECT_SOURCE_UNAVAILABLE',
           message: '프로젝트 등록 정보를 불러오지 못했습니다. 잠시 후 다시 불러와 주세요.',
         });
-        expect(response.body.sectionErrors).toContainEqual({
+        expect(response.body.sectionErrors).toContainEqual(expect.objectContaining({
           section: 'projectMetadata',
           code: 'cashflow_project_metadata_unavailable',
           label: '프로젝트 등록 정보',
-        });
+        }));
       });
   });
 
@@ -1395,11 +1395,11 @@ describe('JVM weekly API BFF proxy', () => {
           code: 'SHEET_SOURCE_UNAVAILABLE',
           message: '시트 기준값을 불러오지 못했습니다. 잠시 후 다시 불러와 주세요.',
         });
-        expect(response.body.sectionErrors).toContainEqual({
+        expect(response.body.sectionErrors).toContainEqual(expect.objectContaining({
           section: 'sheetMirror',
           code: 'cashflow_sheet_mirror_unavailable',
           label: '시트 기준값',
-        });
+        }));
       });
   });
 
@@ -1561,11 +1561,11 @@ describe('JVM weekly API BFF proxy', () => {
           code: 'CASHFLOW_SOURCE_UNAVAILABLE',
           message: '현금흐름 원장을 불러오지 못했습니다. 잠시 후 다시 불러와 주세요.',
         });
-        expect(response.body.sectionErrors).toContainEqual({
+        expect(response.body.sectionErrors).toContainEqual(expect.objectContaining({
           section: 'cashflow',
           code: 'cashflow_ledger_source_unavailable',
           label: '현금흐름 원장',
-        });
+        }));
         expect(JSON.stringify(response.body)).not.toContain('raw datastore');
       });
   });
@@ -1811,11 +1811,11 @@ describe('JVM weekly API BFF proxy', () => {
         expect(response.body.dashboard.validation.blockers).toContainEqual(expect.objectContaining({
           code: 'CUMULATIVE_CLOSE_MIGRATION_REQUIRED',
         }));
-        expect(response.body.sectionErrors).toContainEqual({
+        expect(response.body.sectionErrors).toContainEqual(expect.objectContaining({
           section: 'monthCloseStatuses',
           code: 'cashflow_month_close_migration_required',
           label: '월 결산 상태',
-        });
+        }));
       });
   });
 
@@ -1857,11 +1857,11 @@ describe('JVM weekly API BFF proxy', () => {
         expect(statuses.get('2026-06')).toMatchObject({ status: 'OPEN', sheetCalculationChecks: null });
         expect(response.body.dashboard.validation.blockers.map((blocker) => blocker.code))
           .not.toContain('CUMULATIVE_CLOSE_AUTHORITY_UNAVAILABLE');
-        expect(response.body.sectionErrors).toContainEqual({
+        expect(response.body.sectionErrors).toContainEqual(expect.objectContaining({
           section: 'monthCloseHistory',
           code: 'cashflow_month_close_history_unavailable',
           label: '월 결산 이력',
-        });
+        }));
       });
   });
 
@@ -2179,11 +2179,11 @@ describe('JVM weekly API BFF proxy', () => {
           enabled: false,
           guide: expect.stringContaining('다시 불러온 뒤'),
         });
-        expect(response.body.sectionErrors).toContainEqual({
+        expect(response.body.sectionErrors).toContainEqual(expect.objectContaining({
           section: 'monthCloseReopenCapability',
           code: 'cashflow_month_reopen_capability_unavailable',
           label: '월 결산 재오픈 가능 여부',
-        });
+        }));
       });
   });
 
@@ -2212,11 +2212,11 @@ describe('JVM weekly API BFF proxy', () => {
       .expect(200)
       .expect((response) => {
         expect(response.body.dashboard.cells).toHaveLength(160);
-        expect(response.body.sectionErrors).toContainEqual({
+        expect(response.body.sectionErrors).toContainEqual(expect.objectContaining({
           section: 'monthCloseRequest',
           code: 'cashflow_month_close_request_unavailable',
           label: '월 결산 승인 요청',
-        });
+        }));
         for (const action of ['changeExecutiveApprover', 'requestMonthClose', 'withdrawMonthClose', 'requestMonthReopen']) {
           expect(response.body.actions[action]).toMatchObject({
             enabled: false,
@@ -4072,11 +4072,11 @@ describe('JVM weekly API BFF proxy', () => {
           code: 'SHEET_SOURCE_REQUIRED',
           message: '시트에서 주별 관리 연도를 확인하지 못했습니다. 표준 양식으로 다시 불러와 주세요.',
         });
-        expect(response.body.sectionErrors).toContainEqual({
+        expect(response.body.sectionErrors).toContainEqual(expect.objectContaining({
           section: 'monthCloseStatuses',
           code: 'cashflow_month_close_period_contract_unavailable',
           label: '월 결산 상태',
-        });
+        }));
       });
   });
 

--- a/src/app/components/cashflow/CashflowFormulaMismatchDialog.tsx
+++ b/src/app/components/cashflow/CashflowFormulaMismatchDialog.tsx
@@ -70,7 +70,7 @@ export function CashflowFormulaMismatchDialog({
   const first = issues[0];
   return (
     <AlertDialog open={issues.length > 0}>
-      <AlertDialogContent className="w-[calc(100vw-2rem)] max-w-[520px]">
+      <AlertDialogContent className="sm:max-w-[520px]">
         <AlertDialogHeader>
           <AlertDialogTitle>시트 계산값을 확인해 주세요</AlertDialogTitle>
           <AlertDialogDescription className="leading-5">

--- a/src/app/components/cashflow/CashflowLateSheetChangeDialog.tsx
+++ b/src/app/components/cashflow/CashflowLateSheetChangeDialog.tsx
@@ -61,7 +61,7 @@ export function CashflowLateSheetChangeDialog({
       open={Boolean(stage)}
       onOpenChange={(open) => { if (!open) onCancel(); }}
     >
-      <AlertDialogContent className="w-[calc(100vw-2rem)] max-w-[960px]">
+      <AlertDialogContent className="sm:max-w-[960px]">
         <AlertDialogHeader>
           <AlertDialogTitle>{resumeRequired ? '시트 반영 이어서 완료' : '마감 후 시트값 변경'}</AlertDialogTitle>
           <AlertDialogDescription>

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -9,7 +9,7 @@ const source = readFileSync(resolve(import.meta.dirname, 'CashflowProjectSheet.t
 
 describe('CashflowProjectSheet monthly close shell', () => {
   it('uses the server month-close guide instead of rebuilding a target-month deadline label', () => {
-    expect(source).toContain('monthCloseActions?.requestMonthClose.guide || cashflowPresentation?.monthClose.statusLabel');
+    expect(source).toContain('monthCloseActions?.requestMonthClose.guide ? (');
     expect(source).not.toContain('monthCloseResult.dashboard.summary.targetYearMonth}월 결산');
   });
 
@@ -138,7 +138,7 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('monthCloseActions.requestMonthClose.guide');
     expect(source).not.toContain('dashboard?.validation?.canClose');
     expect(source).not.toContain('dashboard?.validation?.blockers?.[0]?.message');
-    expect(source).toContain('monthCloseSectionErrors.map((entry) => entry.label)');
+    expect(source).toContain('monthCloseSectionErrors.map((entry) => entry.cause ? `${entry.label}: ${entry.cause}` : entry.label)');
     expect(source).not.toContain("entry.section === 'monthCloseStatuses'");
   });
 
@@ -150,7 +150,7 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('cashflowPresentation?.comparison.cells || []');
     expect(source).toContain('cashflowPresentation?.comparison.periodLabel || \'확인 불가\'');
     expect(source).toContain('cashflowPresentation?.monthClose.statusLabel || \'확인 불가\'');
-    expect(source).toContain('monthCloseSectionErrors.map((entry) => entry.label)');
+    expect(source).toContain('monthCloseSectionErrors.map((entry) => entry.cause ? `${entry.label}: ${entry.cause}` : entry.label)');
 
     expect(source).not.toContain('getSeoulTodayIso');
     expect(source).not.toContain('getMonthMondayWeeks');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -2665,7 +2665,7 @@ export function CashflowProjectSheet({
                   <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
                   <span>
                     일부 정보를 불러오지 못했습니다
-                    {` (${monthCloseSectionErrors.map((entry) => entry.label).join(', ')})`}
+                    {` (${monthCloseSectionErrors.map((entry) => entry.cause ? `${entry.label}: ${entry.cause}` : entry.label).join(', ')})`}
                     . 불러오지 못한 항목은 표시하지 않으며, 다시 조회하기 전까지 관련 판정은 차단됩니다.
                   </span>
                   <button
@@ -2685,9 +2685,11 @@ export function CashflowProjectSheet({
                       <div className="text-[13px] font-bold text-card-foreground">월 결산</div>
                       <Badge className={`h-6 rounded-md px-2 text-[12px] shadow-none ${monthCloseStatusClass}`}>{monthCloseLoading ? '상태 확인 중' : monthCloseStatusLabel}</Badge>
                     </div>
-                    <div className="mt-1 text-[12px] leading-4 text-muted-foreground">
-                      {cashflowPresentation?.monthClose.statusLabel || '확인 불가'}
-                    </div>
+                    {monthCloseActions?.requestMonthClose.guide ? (
+                      <div className="mt-1 text-[12px] leading-4 text-muted-foreground">
+                        {monthCloseActions.requestMonthClose.guide}
+                      </div>
+                    ) : null}
                     {monthCloseRequestError ? (
                       <div role="alert" className="mt-2 flex flex-wrap items-center gap-2 text-[12px] text-red-700">
                         <span>{monthCloseRequestError}</span>
@@ -2738,9 +2740,6 @@ export function CashflowProjectSheet({
                       </>
                     ) : null}
                   </div>
-                </div>
-                <div className="mt-3 flex flex-wrap items-center gap-2 text-[12px] text-muted-foreground">
-                  <span>{monthCloseActions?.requestMonthClose.guide || cashflowPresentation?.monthClose.statusLabel || '확인 불가'}</span>
                 </div>
               </div>
           </section>
@@ -3041,7 +3040,7 @@ export function CashflowProjectSheet({
           if (!open) setWeeklyProjectionWarning(null);
         }
       }}>
-        <AlertDialogContent className="w-[calc(100vw-2rem)] max-w-[620px]">
+        <AlertDialogContent className="sm:max-w-[620px]">
           <AlertDialogHeader>
             <AlertDialogTitle>주간 정산 완료</AlertDialogTitle>
             <AlertDialogDescription>대상 주차와 그 이후 15개 재무주차(총 16주·256칸)의 JVM 저장 Projection 값을 확인합니다.</AlertDialogDescription>
@@ -3077,7 +3076,7 @@ export function CashflowProjectSheet({
       </AlertDialog>
 
       <AlertDialog open={weeklyHistoryOpen} onOpenChange={setWeeklyHistoryOpen}>
-        <AlertDialogContent className="w-[calc(100vw-2rem)] max-w-[860px]">
+        <AlertDialogContent className="sm:max-w-[860px]">
           <AlertDialogHeader>
             <AlertDialogTitle>주간 정산 준수 이력</AlertDialogTitle>
             <AlertDialogDescription>JVM 프로젝트 원장의 연월·주차별 전체 준수 이력입니다.</AlertDialogDescription>
@@ -3102,7 +3101,7 @@ export function CashflowProjectSheet({
           if (!monthCloseBusy) setMonthCloseReviewOpen(open);
         }}
       >
-        <AlertDialogContent className="w-[calc(100vw-2rem)] max-w-[620px]">
+        <AlertDialogContent className="sm:max-w-[620px]">
           <AlertDialogHeader>
             <AlertDialogTitle>{yearMonth} 누적 월결산 승인 요청</AlertDialogTitle>
             <AlertDialogDescription>
@@ -3304,7 +3303,7 @@ export function CashflowProjectSheet({
         open={sheetReviewDialogOpen}
         onOpenChange={(open) => setSheetReviewDialogOpen(open)}
       >
-        <AlertDialogContent className="max-w-[760px]">
+        <AlertDialogContent className="sm:max-w-[760px]">
           <AlertDialogHeader>
             <AlertDialogTitle>{cashflowSheetConfig ? '시트 업데이트 반영' : '캐시플로우 시트 연동 시작하기'}</AlertDialogTitle>
             <AlertDialogDescription>

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -1528,7 +1528,7 @@ export interface CashflowMonthCloseResult {
   blockers?: Array<{ code: string; message: string; details?: unknown }>;
   // 본체(dashboard-source)는 성공했지만 부가 조회가 실패해 일부 섹션이 비었을 때.
   // 화면은 그대로 그리되 이 목록으로 사용자에게 알리고 재시도 경로를 준다.
-  sectionErrors?: Array<{ section: 'sheetPublication' | 'deadlineSummary' | string; code: string; label: string }>;
+  sectionErrors?: Array<{ section: 'sheetPublication' | 'deadlineSummary' | string; code: string; label: string; cause?: string }>;
 }
 
 export interface CashflowWeeklyUpdateCompletionResult {


### PR DESCRIPTION
## 무엇 — 2026전남글로벌 라이브 QA

| 증상 | 원인 | 수정 |
|---|---|---|
| "재결산 필요"인데 버튼 없음 | 시트 6·7행(예정입금일) 날짜 형식 → `sheet_date_invalid` → blocker. **누적 결산은 그 값을 안 씀** (JVM `List.of()`), 좌표 계약 밖 | issue 안 냄. 읽히면 쓰고 안 읽히면 빈 값 |
| "주간 정산 상태 확인 필요" — 이유 없음 | 5개 side read 의 `.catch(() => {...})` 가 원인 삼킴 | error **code** 를 `cause` 로 실어 배너에 표시. 메시지는 안 실음(계약) |
| "재결산 필요 / 재결산 필요" 두 번 | 배지 + 아래 줄 중복, guide 는 따로 | 배지 → 바로 아래 guide |
| 다이얼로그 512px 에 갇힘 (표 튀어나옴) | `max-w-[Npx]` 에 `sm:` 없음 → 기본 `sm:max-w-lg` 가 이김 | 6개 전부 `sm:max-w-[Npx]` |

## 라이브 영향

- 전남글로벌: issue 가 `sheet_date_invalid` **하나뿐** → 배포 후 불러오기 하면 blocker 해제, 재결산 버튼 활성
- JLIN: `sheet_value_invalid`(금액 칸) 있음 → 정당한 차단, 그대로
- 데이터 쓰기 없음

## 검증

jvm-weekly-api 258 · sheet-lab 116 · snapshot 32 · 셸 69 · typecheck · build. `sectionErrors` 단언은 `objectContaining` 으로 (진단 필드가 실릴 수 있게).

🤖 Generated with [Claude Code](https://claude.com/claude-code)