### PR TITLE
fix(cashflow): label ON_TIME weekly settlements as 기한 내 완료

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -327,10 +327,13 @@ function cashflowSectionErrorsForResponse(sectionErrors) {
   }));
 }
 
-function cashflowWeeklyStatusLabel(status, available) {
+// JVM 이 내는 주간 준수 상태는 ON_TIME · COMPLETED_LATE · MISSED · PENDING 넷이다
+// (FirestoreInheritedWeeklyExpensePersistence). 예전 이 표는 존재하지 않는 COMPLETED 를
+// 기다리고 ON_TIME 을 몰라서, 기한 내 완료한 주차를 "확인 필요" 로 그렸다.
+export function cashflowWeeklyStatusLabel(status, available) {
   if (!available) return '주간 정산 상태 확인 필요';
   if (!status) return '';
-  if (status === 'COMPLETED') return '기한 내 완료';
+  if (status === 'ON_TIME') return '기한 내 완료';
   if (status === 'COMPLETED_LATE') return '기한 후 완료';
   if (status === 'MISSED') return '기한 지남';
   if (status === 'PENDING') return '완료 대기';

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -31,6 +31,24 @@ describe('cashflow section error presentation', () => {
   it('does not expose an unknown raw section identifier as its label', () => {
     expect(jvmWeeklyApiModule.cashflowSectionErrorLabel?.('vendorRawSection')).toBe('일부 정보');
   });
+
+  // PARITY TABLE — JVM FirestoreInheritedWeeklyExpensePersistence 가 내는 주간 준수 상태와 같은 표다.
+  // BFF 가 존재하지 않는 COMPLETED 를 기다리고 ON_TIME 을 몰라서, 기한 내 완료한 주차가
+  // 라이브에서 "주간 정산 상태 확인 필요" 로 그려졌다. 한쪽 어휘를 바꾸면 여기서 깨진다.
+  it.each([
+    ['ON_TIME', '기한 내 완료'],
+    ['COMPLETED_LATE', '기한 후 완료'],
+    ['MISSED', '기한 지남'],
+    ['PENDING', '완료 대기'],
+  ])('labels JVM weekly status %s as %s', (status, label) => {
+    expect(jvmWeeklyApiModule.cashflowWeeklyStatusLabel(status, true)).toBe(label);
+  });
+
+  it('never labels a known JVM weekly status as 확인 필요', () => {
+    for (const status of ['ON_TIME', 'COMPLETED_LATE', 'MISSED', 'PENDING']) {
+      expect(jvmWeeklyApiModule.cashflowWeeklyStatusLabel(status, true)).not.toBe('주간 정산 상태 확인 필요');
+    }
+  });
 });
 
 describe('cashflow month-close revision diff', () => {


### PR DESCRIPTION
## 무엇

전남글로벌 `26-8-4 · 주간 정산 상태 확인 필요` — 주 정산은 **정상 완료**된 건인데 라벨이 틀렸음.

## 원인

JVM 은 `ON_TIME` 을 내는데 BFF 라벨 함수는 존재하지 않는 `COMPLETED` 를 기다리고 `ON_TIME` 을 몰랐다. 같은 화면의 "기한 내 완료 1회" 집계와 하단 이력표는 맞게 읽고, 헤더 라벨만 틀린 것 — 같은 데이터를 세 곳이 다르게 읽고 한 곳만 어휘가 어긋남.

## 수정

`COMPLETED` → `ON_TIME`. JVM 어휘 4개(`ON_TIME`·`COMPLETED_LATE`·`MISSED`·`PENDING`)를 짝 테이블로 고정, 알려진 값이 "확인 필요"로 떨어지면 깨지는 케이스 추가. 사보타주(COMPLETED 로 되돌림) → 2건 실패 확인.

jvm-weekly-api 263/263 · typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)