### PR TITLE
fix(cashflow): colour ON_TIME weeks green, same table as the label

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -386,11 +386,11 @@ function cashflowMonthPresentation(entry, available) {
   };
 }
 
-function cashflowWeekSurfaceTone({ month, weeklyStatus, weeklyAvailable, isCurrent }) {
+export function cashflowWeekSurfaceTone({ month, weeklyStatus, weeklyAvailable, isCurrent }) {
   if (month.tone === 'unavailable') return 'unavailable';
   if (month.tone !== 'default') return month.tone;
   if (!weeklyAvailable) return 'unavailable';
-  if (weeklyStatus === 'COMPLETED' || weeklyStatus === 'COMPLETED_LATE') return 'success';
+  if (weeklyStatus === 'ON_TIME' || weeklyStatus === 'COMPLETED_LATE') return 'success';
   if (weeklyStatus === 'MISSED') return 'danger';
   if (weeklyStatus === 'PENDING') return 'warning';
   if (weeklyStatus) return 'unavailable';

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -44,6 +44,18 @@ describe('cashflow section error presentation', () => {
     expect(jvmWeeklyApiModule.cashflowWeeklyStatusLabel(status, true)).toBe(label);
   });
 
+  // 색도 같은 표를 따른다. 라벨만 고치고 색을 빠뜨려 기한 내 완료가 회색으로 남았었다.
+  it.each([
+    ['ON_TIME', 'success'],
+    ['COMPLETED_LATE', 'success'],
+    ['MISSED', 'danger'],
+    ['PENDING', 'warning'],
+  ])('colours JVM weekly status %s as %s', (weeklyStatus, tone) => {
+    expect(jvmWeeklyApiModule.cashflowWeekSurfaceTone({
+      month: { tone: 'default' }, weeklyStatus, weeklyAvailable: true, isCurrent: false,
+    })).toBe(tone);
+  });
+
   it('never labels a known JVM weekly status as 확인 필요', () => {
     for (const status of ['ON_TIME', 'COMPLETED_LATE', 'MISSED', 'PENDING']) {
       expect(jvmWeeklyApiModule.cashflowWeeklyStatusLabel(status, true)).not.toBe('주간 정산 상태 확인 필요');


### PR DESCRIPTION
#580 은 라벨만 고쳤고 색 함수(`cashflowWeekSurfaceTone`)는 여전히 `COMPLETED` 를 기다려 기한 내 완료 주차가 회색으로 남았음. 같은 표로 고정, 라벨·색 둘 다 짝 테이블에.

전남글로벌 7월 빨강은 주간이 아니라 **월 결산 기한 초과**(7월 미결산, 기한 8/10 경과). 재결산하면 사라짐. 동작 정상.

jvm-weekly-api 267/267.

🤖 Generated with [Claude Code](https://claude.com/claude-code)