### PR TITLE
fix(cashflow): period-policy screen in business terms; NO_CHANGES records applied target

### DIFF
--- a/server/bff/cashflow-period-policy-service.mjs
+++ b/server/bff/cashflow-period-policy-service.mjs
@@ -25,7 +25,7 @@ const POLICY_STORE_ISSUES = Object.freeze({
   closes: ['MONTHLY_CLOSE_STORE_UNAVAILABLE', 'MONTHLY_CLOSE_STORE_TRUNCATED', '월 결산 확정 저장소 조회 불가'],
   runs: ['MONTHLY_CLOSE_VERSION_STORE_UNAVAILABLE', 'MONTHLY_CLOSE_VERSION_STORE_TRUNCATED', '월 결산 실행 이력 저장소 조회 불가'],
   requests: ['MONTH_CLOSE_REQUEST_STORE_UNAVAILABLE', 'MONTH_CLOSE_REQUEST_STORE_TRUNCATED', '월 결산 요청 저장소 조회 불가'],
-  mirrors: ['SHEET_MIRROR_STORE_UNAVAILABLE', 'SHEET_MIRROR_STORE_TRUNCATED', 'Sheet mirror 저장소 조회 불가'],
+  mirrors: ['SHEET_MIRROR_STORE_UNAVAILABLE', 'SHEET_MIRROR_STORE_TRUNCATED', '시트 원본 저장소 조회 불가'],
   completions: ['WEEKLY_COMPLETION_STORE_UNAVAILABLE', 'WEEKLY_COMPLETION_STORE_TRUNCATED', '주간 완료 이력 저장소 조회 불가'],
   amendments: ['CASHFLOW_MONTH_AMENDMENT_STORE_UNAVAILABLE', 'CASHFLOW_MONTH_AMENDMENT_STORE_TRUNCATED', '닫힌 월 수정 이력 저장소 조회 불가'],
   people: ['PEOPLE_STORE_UNAVAILABLE', 'PEOPLE_STORE_TRUNCATED', 'People 저장소 조회 불가'],
@@ -332,10 +332,10 @@ function resolvePeopleIdentity(uid, peopleIndex, peopleAvailable, memberIndex, m
   if (!peopleAvailable || !membersAvailable) {
     return {
       status: 'UNAVAILABLE',
-      statusLabel: 'People 연결 확인 불가',
+      statusLabel: '인력 명부 연결 확인 불가',
       uid: normalizedUid,
       personId: null,
-      displayName: 'People UID 확인 불가',
+      displayName: '인력 명부 확인 불가',
       person: null,
     };
   }
@@ -343,20 +343,20 @@ function resolvePeopleIdentity(uid, peopleIndex, peopleAvailable, memberIndex, m
   if (matches.length === 0) {
     return {
       status: 'UNLINKED',
-      statusLabel: 'People UID 연결 필요',
+      statusLabel: '인력 명부 연결 필요',
       uid: normalizedUid,
       personId: null,
-      displayName: `People UID 연결 필요 (${normalizedUid})`,
+      displayName: `인력 명부 연결 필요 (${normalizedUid})`,
       person: null,
     };
   }
   if (matches.length > 1) {
     return {
       status: 'AMBIGUOUS',
-      statusLabel: 'People UID 중복',
+      statusLabel: '인력 명부에 같은 계정이 둘 이상',
       uid: normalizedUid,
       personId: null,
-      displayName: `People UID 중복 (${normalizedUid})`,
+      displayName: `인력 명부에 같은 계정이 둘 이상 (${normalizedUid})`,
       person: null,
     };
   }
@@ -374,7 +374,7 @@ function resolvePeopleIdentity(uid, peopleIndex, peopleAvailable, memberIndex, m
   }
   return {
     status: 'LINKED',
-    statusLabel: 'People UID 연결됨',
+    statusLabel: '인력 명부 연결됨',
     uid: normalizedUid,
     personId: person.personId,
     displayName: personDisplayName(person),
@@ -389,6 +389,8 @@ function buildAuthority(head, storeAvailable, { tenantId, projectId }) {
       statusLabel: '누적 마감 권한 조회 불가',
       closedThrough: null,
       closedThroughLabel: '조회 불가',
+      settlementMonth: null,
+      settlementMonthLabel: '조회 불가',
       revision: null,
       revisionLabel: '조회 불가',
       rootHash: null,
@@ -403,6 +405,8 @@ function buildAuthority(head, storeAvailable, { tenantId, projectId }) {
       statusLabel: '누적 마감 없음',
       closedThrough: null,
       closedThroughLabel: '누적 마감 없음',
+      settlementMonth: null,
+      settlementMonthLabel: '결산 회차 없음',
       revision: null,
       revisionLabel: '리비전 없음',
       rootHash: null,
@@ -422,6 +426,8 @@ function buildAuthority(head, storeAvailable, { tenantId, projectId }) {
       statusLabel: '누적 마감 권한 오류',
       closedThrough: null,
       closedThroughLabel: '계약 오류',
+      settlementMonth: null,
+      settlementMonthLabel: '계약 오류',
       revision: null,
       revisionLabel: '계약 오류',
       rootHash: null,
@@ -431,6 +437,7 @@ function buildAuthority(head, storeAvailable, { tenantId, projectId }) {
     };
   }
   const { status, closedThrough, revision, rootHash } = authority;
+  const settlementMonth = authority.settlementMonth || null;
   const closedAt = timestampIso(head.closedAt);
   return {
     status,
@@ -438,7 +445,12 @@ function buildAuthority(head, storeAvailable, { tenantId, projectId }) {
     closedThrough,
     closedThroughLabel: closedThrough
       ? formatYearMonthLabel(closedThrough, '까지 마감')
-      : 'closedThrough 미기록',
+      : '마감 범위 없음',
+    // 잠금은 결산 회차 연도 안에서 closedThrough 이하 월만 (cashflowCumulativeMonthLocked). 회차가 없으면 잠금도 없다.
+    settlementMonth,
+    settlementMonthLabel: settlementMonth
+      ? formatYearMonthLabel(settlementMonth, ' 회차')
+      : '결산 회차 없음',
     revision,
     revisionLabel: formatRevisionLabel(revision),
     rootHash,
@@ -493,11 +505,11 @@ function buildResetToReclose(resetRow, evidenceAvailable) {
       selectionAllowed: false,
       expectedEvidence: resetRow.expectedEvidence,
       warning: preserveMutableHeader
-        ? '손상된 누적 authority만 제거하는 되돌리기 어려운 작업입니다. 정상 OPEN/재오픈 진행 header는 보존되고 변경 전 authority는 append-only 감사 사본에 남습니다.'
-        : '현재 누적 authority와 선택한 월결산 header를 제거하는 되돌리기 어려운 작업입니다. 변경 전 전체 값은 append-only 감사 사본에 보존됩니다.',
+        ? '손상된 잠금 권한만 걷어내는 되돌리기 어려운 작업입니다. 진행 중인 결산·재오픈 기록은 그대로 두고, 걷어낸 값은 append-only 감사 사본에 남습니다.'
+        : '현재 잠금 권한과 선택한 회차의 결산 기록을 걷어내는 되돌리기 어려운 작업입니다. 변경 전 전체 값은 append-only 감사 사본에 보존됩니다.',
       guide: preserveMutableHeader
-        ? `${formatYearMonthLabel(resetRow.yearMonth, ' 회차')}의 정상 mutable header는 유지하고 손상 authority만 감사 격리합니다.`
-        : `${formatYearMonthLabel(resetRow.yearMonth, ' 회차')}를 감사 격리한 뒤 시트 검증본 검토와 정상 월결산을 다시 진행합니다. immutable version·request·Sheet 값은 변경하지 않습니다.`,
+        ? `${formatYearMonthLabel(resetRow.yearMonth, ' 회차')}의 결산 기록은 유지하고 손상된 잠금 권한만 감사 사본으로 옮깁니다.`
+        : `${formatYearMonthLabel(resetRow.yearMonth, ' 회차')}를 감사 사본으로 옮긴 뒤 시트 검증본을 검토하고 월 결산을 다시 진행합니다. 확정된 결산 이력·요청·시트 값은 건드리지 않습니다.`,
       cycleCandidates: [],
     };
   }
@@ -509,7 +521,7 @@ function buildResetToReclose(resetRow, evidenceAvailable) {
       selectionAllowed: false,
       expectedEvidence: null,
       warning: null,
-      guide: '누적 authority와 mutable 월결산 header가 이미 없어 추가 격리가 필요하지 않습니다. 시트 검증본을 확인한 뒤 정상 월결산을 진행해 주세요.',
+      guide: '잠금 권한과 진행 중인 결산 기록이 이미 없어 따로 정리할 것이 없습니다. 시트 검증본을 확인한 뒤 평소처럼 월 결산을 진행해 주세요.',
       cycleCandidates: [],
     };
   }
@@ -521,7 +533,7 @@ function buildResetToReclose(resetRow, evidenceAvailable) {
       selectionAllowed: false,
       expectedEvidence: null,
       warning: null,
-      guide: '유효한 누적 마감 권한은 격리하지 않고 정상 재오픈 절차를 사용합니다.',
+      guide: '잠금 권한이 정상이라 여기서 손대지 않습니다. 결산을 되돌리려면 프로젝트 화면의 재오픈 절차를 사용해 주세요.',
       cycleCandidates: [],
     };
   }
@@ -533,7 +545,7 @@ function buildResetToReclose(resetRow, evidenceAvailable) {
       selectionAllowed: false,
       expectedEvidence: null,
       warning: null,
-      guide: 'immutable evidence가 완전하므로 authority 정확 복구를 먼저 사용합니다.',
+      guide: '원본 기록이 온전해서 그대로 되살릴 수 있습니다. 위의 권한 복구를 먼저 실행해 주세요.',
       cycleCandidates: [],
     };
   }
@@ -544,8 +556,8 @@ function buildResetToReclose(resetRow, evidenceAvailable) {
       actionAllowed: false,
       selectionAllowed: true,
       expectedEvidence: null,
-      warning: '선택한 회차의 현재 mutable header와 손상 authority만 감사 격리합니다. immutable version·request·Sheet 값은 변경하지 않습니다.',
-      guide: '서버가 확인한 회차 중 실제로 다시 결산할 회차를 선택해 주세요. 선택한 근거는 실행 직전 transaction에서 다시 검증합니다.',
+      warning: '선택한 회차의 진행 중 결산 기록과 손상된 잠금 권한만 감사 사본으로 옮깁니다. 확정된 결산 이력·요청·시트 값은 건드리지 않습니다.',
+      guide: '다시 결산할 회차를 선택해 주세요. 실행 직전에 서버가 선택한 회차의 상태를 한 번 더 확인합니다.',
       cycleCandidates,
     };
   }
@@ -556,7 +568,7 @@ function buildResetToReclose(resetRow, evidenceAvailable) {
     selectionAllowed: false,
     expectedEvidence: null,
     warning: null,
-    guide: '격리할 exact 월결산 회차를 확인할 수 없습니다. 최신 정책 상태를 다시 불러와 주세요.',
+    guide: '재결산할 회차를 특정할 수 없습니다. 화면을 다시 불러와 주세요.',
     cycleCandidates: [],
   };
 }
@@ -596,7 +608,7 @@ function buildRecovery(planRow, resetRow, evidenceAvailable, projectId) {
       actionAllowed: true,
       expectedEvidence: planRow.expectedEvidence,
       reasons: planRow.reasons || [],
-      warning: '되돌리기 어려운 권한 복구입니다. 현재 head와 복구 후 head의 전체 값은 append-only 감사 사본으로 보존됩니다.',
+      warning: '되돌리기 어려운 권한 복구입니다. 복구 전·후 잠금 권한 전체 값은 append-only 감사 사본으로 보존됩니다.',
       guide: planRow.status === 'READY'
         ? '서버가 확정 월결산·버전·요청 증거를 다시 검증한 뒤 누락된 권한만 생성합니다.'
         : '서버가 손상 head를 제외하고 확정 월결산·버전·요청 증거로 canonical head를 다시 계산합니다.',
@@ -612,8 +624,8 @@ function buildRecovery(planRow, resetRow, evidenceAvailable, projectId) {
     reasons: planRow?.reasons?.length ? planRow.reasons : ['IMMUTABLE_CLOSE_EVIDENCE_MISSING'],
     warning: null,
     guide: resetToReclose.actionAllowed
-      ? '권한 값을 추측해 만들 수 없습니다. 현재 authority와 월결산 header를 감사 격리한 뒤 시트 검증본을 검토하고 정상 월결산으로 immutable close evidence를 다시 생성해 주세요.'
-      : '권한 값을 추측해 만들 수 없습니다. 프로젝트의 최신 시트 검증본을 다시 검토·반영한 뒤 정상 월결산으로 immutable close evidence를 다시 생성해 주세요.',
+      ? '남은 기록으로는 잠금 권한을 되살릴 수 없습니다. 아래 재결산 준비로 현재 기록을 감사 사본으로 옮긴 뒤, 시트 검증본을 검토하고 월 결산을 다시 실행해 주세요.'
+      : '남은 기록으로는 잠금 권한을 되살릴 수 없습니다. 프로젝트의 최신 시트 검증본을 다시 검토·반영한 뒤 월 결산을 다시 실행해 주세요.',
     nextAction: resetToReclose.actionAllowed ? null : recoveryNextAction(projectId),
     resetToReclose,
   };
@@ -797,25 +809,25 @@ function buildLatestRun(run, storeAvailable, peopleIndex, peopleAvailable, membe
 function buildSheet(mirror, storeAvailable) {
   if (!storeAvailable) {
     return {
-      status: 'UNAVAILABLE', statusLabel: 'Sheet mirror 조회 불가',
+      status: 'UNAVAILABLE', statusLabel: '시트 원본 조회 불가',
       weeklyYear: null, weeklyYearLabel: '조회 불가', annualYears: [], annualYearsLabel: '조회 불가',
       sourceRevision: null, sourceRevisionLabel: '조회 불가',
       appliedSourceRevision: null, appliedSourceRevisionLabel: '조회 불가',
       targetRevisionAtFetch: null, targetRevisionAtFetchLabel: '조회 불가',
       appliedTargetRevision: null, appliedTargetRevisionLabel: '조회 불가',
-      revisionStatus: 'UNAVAILABLE', revisionStatusLabel: '리비전 조회 불가',
+      revisionStatus: 'UNAVAILABLE', revisionStatusLabel: '조회 불가',
       capturedAt: null, capturedAtLabel: '조회 불가',
     };
   }
   if (!mirror) {
     return {
-      status: 'MISSING', statusLabel: 'Sheet mirror 없음',
-      weeklyYear: null, weeklyYearLabel: '주차형 계약 없음', annualYears: [], annualYearsLabel: '연간형 계약 없음',
-      sourceRevision: null, sourceRevisionLabel: '원본 리비전 없음',
-      appliedSourceRevision: null, appliedSourceRevisionLabel: '반영 리비전 없음',
-      targetRevisionAtFetch: null, targetRevisionAtFetchLabel: '대상 리비전 없음',
-      appliedTargetRevision: null, appliedTargetRevisionLabel: '반영 대상 리비전 없음',
-      revisionStatus: 'MISSING', revisionStatusLabel: '리비전 없음',
+      status: 'MISSING', statusLabel: '시트를 아직 불러오지 않음',
+      weeklyYear: null, weeklyYearLabel: '주차 결산 연도 없음', annualYears: [], annualYearsLabel: '연간 결산 연도 없음',
+      sourceRevision: null, sourceRevisionLabel: '불러온 값 없음',
+      appliedSourceRevision: null, appliedSourceRevisionLabel: '반영 기록 없음',
+      targetRevisionAtFetch: null, targetRevisionAtFetchLabel: '기록 없음',
+      appliedTargetRevision: null, appliedTargetRevisionLabel: '기록 없음',
+      revisionStatus: 'MISSING', revisionStatusLabel: '반영 기록 없음',
       capturedAt: null, capturedAtLabel: '수집 기록 없음',
     };
   }
@@ -832,44 +844,44 @@ function buildSheet(mirror, storeAvailable) {
   const targetRevisionAtFetch = readOptionalText(mirror.targetRevisionAtFetch) || null;
   const appliedTargetRevision = readOptionalText(mirror.appliedTargetRevision) || null;
   let revisionStatus = 'ALIGNED';
-  let revisionStatusLabel = 'Source/target 리비전 일치';
+  let revisionStatusLabel = '불러온 값이 결산에 반영됨';
   if (!sourceRevision) {
     revisionStatus = 'SOURCE_MISSING';
-    revisionStatusLabel = '원본 리비전 없음';
+    revisionStatusLabel = '불러온 값 없음';
   } else if (!appliedSourceRevision) {
     revisionStatus = 'SOURCE_NOT_APPLIED';
-    revisionStatusLabel = '원본 미반영';
+    revisionStatusLabel = '불러온 값을 아직 반영하지 않음';
   } else if (sourceRevision !== appliedSourceRevision) {
     revisionStatus = 'SOURCE_DRIFT';
-    revisionStatusLabel = '원본·반영 리비전 불일치';
+    revisionStatusLabel = '시트가 바뀐 뒤 아직 반영하지 않음';
   } else if (!targetRevisionAtFetch) {
     revisionStatus = 'TARGET_MISSING';
-    revisionStatusLabel = '대상 리비전 없음';
+    revisionStatusLabel = '불러올 때 결산 상태 기록 없음';
   } else if (!appliedTargetRevision) {
     revisionStatus = 'TARGET_NOT_APPLIED';
-    revisionStatusLabel = '대상 리비전 미반영';
+    revisionStatusLabel = '반영 후 결산 상태 기록 없음';
   } else if (targetRevisionAtFetch !== appliedTargetRevision) {
     revisionStatus = 'TARGET_DRIFT';
-    revisionStatusLabel = '대상·반영 대상 리비전 불일치';
+    revisionStatusLabel = '마지막 반영 뒤 결산이 바뀜, 다시 불러오기 필요';
   }
   const capturedAt = timestampIso(mirror.capturedAt);
   return {
     status,
-    statusLabel: status === 'FRESH' ? '최신 mirror' : status === 'STALE' ? '갱신 필요' : `Mirror 상태 ${status}`,
+    statusLabel: status === 'FRESH' ? '최신 값 불러옴' : status === 'STALE' ? '다시 불러오기 필요' : status === 'EMPTY' ? '불러온 값 없음' : `상태 ${status}`,
     weeklyYear,
-    weeklyYearLabel: weeklyYear ? `${weeklyYear}년 주차형` : '주차형 계약 없음',
+    weeklyYearLabel: weeklyYear ? `${weeklyYear}년 주차 결산` : '주차 결산 연도 없음',
     annualYears,
     annualYearsLabel: annualYears.length > 0
-      ? `${annualYears.map((year) => `${year}년`).join(', ')} 연간형`
-      : '연간형 계약 없음',
+      ? `${annualYears.map((year) => `${year}년`).join(', ')} 연간 결산`
+      : '연간 결산 연도 없음',
     sourceRevision,
-    sourceRevisionLabel: sourceRevision || '원본 리비전 없음',
+    sourceRevisionLabel: sourceRevision || '불러온 값 없음',
     appliedSourceRevision,
-    appliedSourceRevisionLabel: appliedSourceRevision || '반영 리비전 없음',
+    appliedSourceRevisionLabel: appliedSourceRevision || '반영 기록 없음',
     targetRevisionAtFetch,
-    targetRevisionAtFetchLabel: targetRevisionAtFetch || '대상 리비전 없음',
+    targetRevisionAtFetchLabel: targetRevisionAtFetch || '기록 없음',
     appliedTargetRevision,
-    appliedTargetRevisionLabel: appliedTargetRevision || '반영 대상 리비전 없음',
+    appliedTargetRevisionLabel: appliedTargetRevision || '기록 없음',
     revisionStatus,
     revisionStatusLabel,
     capturedAt,
@@ -881,33 +893,33 @@ function buildSheetRevisionIssue(projectId, revisionStatus) {
   const issues = {
     SOURCE_MISSING: [
       'SHEET_SOURCE_REVISION_MISSING',
-      'Sheet 원본 리비전 없음',
-      `${projectId}의 sourceRevision이 없습니다.`,
+      '시트 불러온 값 없음',
+      `${projectId} 시트를 아직 불러오지 않았습니다. 프로젝트 시트 화면에서 시트 값 불러오기를 실행해 주세요.`,
     ],
     SOURCE_NOT_APPLIED: [
       'SHEET_SOURCE_REVISION_NOT_APPLIED',
-      'Sheet 원본 미반영',
-      `${projectId}의 appliedSourceRevision이 없습니다.`,
+      '시트 값 미반영',
+      `${projectId} 시트 값을 불러왔지만 결산에 반영한 기록이 없습니다.`,
     ],
     SOURCE_DRIFT: [
       'SHEET_SOURCE_REVISION_DRIFT',
-      'Sheet 원본·반영 리비전 불일치',
-      `${projectId}의 sourceRevision과 appliedSourceRevision이 다릅니다.`,
+      '시트 변경 후 미반영',
+      `${projectId} 시트가 마지막 반영 이후 바뀌었습니다. 변경 내용을 확인하고 반영해 주세요.`,
     ],
     TARGET_MISSING: [
       'SHEET_TARGET_REVISION_MISSING',
-      'Sheet 대상 리비전 없음',
-      `${projectId}의 targetRevisionAtFetch가 없습니다.`,
+      '불러올 때 결산 상태 기록 없음',
+      `${projectId} 시트를 불러올 때의 결산 상태가 기록되지 않았습니다. 다시 불러와 주세요.`,
     ],
     TARGET_NOT_APPLIED: [
       'SHEET_TARGET_REVISION_NOT_APPLIED',
-      'Sheet 대상 리비전 미반영',
-      `${projectId}의 appliedTargetRevision이 없습니다.`,
+      '반영 후 결산 상태 기록 없음',
+      `${projectId} 반영 후 결산 상태가 기록되지 않았습니다. 다시 불러와 주세요.`,
     ],
     TARGET_DRIFT: [
       'SHEET_TARGET_REVISION_DRIFT',
-      'Sheet 대상·반영 대상 리비전 불일치',
-      `${projectId}의 targetRevisionAtFetch와 appliedTargetRevision이 다릅니다.`,
+      '마지막 반영 뒤 결산이 바뀜',
+      `${projectId} 결산이 마지막 시트 반영 이후 바뀌었습니다. 시트 값을 다시 불러오면 정리됩니다.`,
     ],
   };
   const values = issues[revisionStatus];
@@ -936,7 +948,7 @@ function buildIdentityIssue(projectId, identity) {
   if (identity.status === 'UNLINKED') {
     return issue(
       'EXECUTIVE_APPROVER_PEOPLE_UID_UNLINKED',
-      '조직장 People UID 연결 필요',
+      '조직장 인력 명부 연결 필요',
       `${projectId}의 executiveApproverId가 People 명부와 연결되지 않았습니다.`,
       'ERROR',
     );
@@ -944,7 +956,7 @@ function buildIdentityIssue(projectId, identity) {
   if (identity.status === 'AMBIGUOUS') {
     return issue(
       'EXECUTIVE_APPROVER_PEOPLE_UID_AMBIGUOUS',
-      '조직장 People UID 중복',
+      '조직장 계정이 인력 명부에 둘 이상',
       `${projectId}의 executiveApproverId에 둘 이상의 People 레코드가 연결되어 있습니다.`,
       'ERROR',
     );
@@ -984,7 +996,7 @@ function buildRuntimeSuperadmins(memberIndex, membersAvailable, peopleIndex, peo
   if (!membersAvailable || !peopleAvailable) {
     return {
       status: 'UNAVAILABLE',
-      statusLabel: 'Runtime superadmin 조회 불가',
+      statusLabel: '관리자 목록 조회 불가',
       items: [],
     };
   }
@@ -1005,9 +1017,9 @@ function buildRuntimeSuperadmins(memberIndex, membersAvailable, peopleIndex, peo
         return {
           uid: member.uid,
           personId: null,
-          displayName: matches.length > 1 ? 'People UID 중복' : 'People UID 연결 필요',
+          displayName: matches.length > 1 ? '인력 명부에 같은 계정이 둘 이상' : '인력 명부 연결 필요',
           identityStatus: matches.length > 1 ? 'AMBIGUOUS' : 'UNLINKED',
-          identityStatusLabel: matches.length > 1 ? 'People UID 중복' : 'People UID 연결 필요',
+          identityStatusLabel: matches.length > 1 ? '인력 명부에 같은 계정이 둘 이상' : '인력 명부 연결 필요',
         };
       }
       return {
@@ -1015,11 +1027,11 @@ function buildRuntimeSuperadmins(memberIndex, membersAvailable, peopleIndex, peo
         personId: matches[0].personId,
         displayName: personDisplayName(matches[0]),
         identityStatus: 'LINKED',
-        identityStatusLabel: 'People UID 연결됨',
+        identityStatusLabel: '인력 명부 연결됨',
       };
     })
     .sort((left, right) => left.displayName.localeCompare(right.displayName, 'ko'));
-  return { status: 'AVAILABLE', statusLabel: 'Runtime member.role=admin 기준', items };
+  return { status: 'AVAILABLE', statusLabel: '활성 관리자 멤버', items };
 }
 
 function buildExecutiveApproverCandidates(peopleIndex, peopleAvailable, memberIndex, membersAvailable) {
@@ -1037,7 +1049,7 @@ function buildExecutiveApproverCandidates(peopleIndex, peopleAvailable, memberIn
     items.push({ uid, personId: matches[0].personId, displayName: personDisplayName(matches[0]) });
   }
   items.sort((left, right) => left.displayName.localeCompare(right.displayName, 'ko'));
-  return { status: 'AVAILABLE', statusLabel: 'People UID 연결 활성 멤버', items };
+  return { status: 'AVAILABLE', statusLabel: '조직장 후보 조회 완료', items };
 }
 
 export function createCashflowPeriodPolicyService({
@@ -1368,7 +1380,7 @@ export function createCashflowPeriodPolicyService({
 
       const identity = {
         status: 'LINKED',
-        statusLabel: 'People UID 연결됨',
+        statusLabel: '인력 명부 연결됨',
         uid: approverUid,
         personId: result.person.personId,
         displayName: personDisplayName(result.person),
@@ -1412,7 +1424,7 @@ export function createCashflowPeriodPolicyService({
             recoveryAction: 'VERIFIED',
             changed: false,
             replayed: true,
-            guide: '같은 원본 근거로 canonical 누적 마감 권한이 이미 복구되어 있습니다. 이후 변경이 필요하면 프로젝트의 정상 재오픈 절차를 사용해 주세요.',
+            guide: '같은 근거로 잠금 권한이 이미 복구되어 있습니다. 이후 변경이 필요하면 프로젝트의 재오픈 절차를 사용해 주세요.',
           };
         }
         throw applicationError(
@@ -1531,7 +1543,7 @@ export function createCashflowPeriodPolicyService({
       if (current?.status === 'EXACT_REPAIR_REQUIRED') {
         throw applicationError(
           'cashflow_close_reset_to_reclose_exact_recovery_required',
-          'immutable evidence가 완전하므로 누적 마감 권한 정확 복구를 먼저 실행해 주세요.',
+          '원본 기록이 온전해서 그대로 되살릴 수 있습니다. 누적 마감 권한 복구를 먼저 실행해 주세요.',
         );
       }
       if (!current || !['RESET_TO_RECLOSE_READY', 'RECLOSE_READY'].includes(current.status)) {
@@ -1584,7 +1596,7 @@ export function createCashflowPeriodPolicyService({
         ) {
           throw applicationError(
             'cashflow_close_reset_to_reclose_exact_recovery_required',
-            'immutable evidence가 완전하므로 누적 마감 권한 정확 복구를 먼저 실행해 주세요.',
+            '원본 기록이 온전해서 그대로 되살릴 수 있습니다. 누적 마감 권한 복구를 먼저 실행해 주세요.',
           );
         }
         if (
@@ -1616,8 +1628,8 @@ export function createCashflowPeriodPolicyService({
         ...result,
         statusLabel: replayed ? '재결산 준비 상태 확인' : '재결산 준비 완료',
         guide: replayed
-          ? '누적 authority와 mutable 월결산 header가 이미 격리된 상태를 확인했습니다. 추가 변경 없이 시트 검증본 확인과 정상 월결산을 계속 진행해 주세요.'
-          : '손상 authority와 현재 mutable 월결산 header의 감사 사본을 남기고 격리했습니다. 시트 검증본을 확인한 뒤 정상 월결산을 다시 진행해 주세요.',
+          ? '이미 정리된 상태입니다. 추가 변경 없이 시트 검증본을 확인하고 월 결산을 계속 진행해 주세요.'
+          : '손상된 잠금 권한과 진행 중 결산 기록을 감사 사본으로 옮겼습니다. 시트 검증본을 확인한 뒤 월 결산을 다시 진행해 주세요.',
         nextAction: recoveryNextAction(projectId),
       };
     },

--- a/server/bff/routes/cashflow-period-policy.test.mjs
+++ b/server/bff/routes/cashflow-period-policy.test.mjs
@@ -458,9 +458,9 @@ describe('AXR 현금흐름 기간·마감 정책 BFF', () => {
           revision: 2, closedByUid: 'head-uid', closedByLabel: '고인효(베리)',
         },
         sheet: {
-          status: 'FRESH', weeklyYear: 2026, weeklyYearLabel: '2026년 주차형',
-          annualYears: [2024, 2025], annualYearsLabel: '2024년, 2025년 연간형',
-          revisionStatus: 'ALIGNED', revisionStatusLabel: 'Source/target 리비전 일치', revisionTone: 'positive',
+          status: 'FRESH', weeklyYear: 2026, weeklyYearLabel: '2026년 주차 결산',
+          annualYears: [2024, 2025], annualYearsLabel: '2024년, 2025년 연간 결산',
+          revisionStatus: 'ALIGNED', revisionStatusLabel: '불러온 값이 결산에 반영됨', revisionTone: 'positive',
         },
         executiveApprover: {
           status: 'LINKED', uid: 'head-uid', personId: 'person-head', displayName: '고인효(베리)',
@@ -587,7 +587,7 @@ describe('AXR 현금흐름 기간·마감 정책 BFF', () => {
     expect(driftResponse.status).toBe(200);
     expect(driftResponse.body.items[0].sheet).toMatchObject({
       revisionStatus: 'TARGET_DRIFT',
-      revisionStatusLabel: '대상·반영 대상 리비전 불일치',
+      revisionStatusLabel: '마지막 반영 뒤 결산이 바뀜, 다시 불러오기 필요',
     });
     expect(driftResponse.body.items[0].issues.map((entry) => entry.code))
       .toContain('SHEET_TARGET_REVISION_DRIFT');
@@ -605,7 +605,7 @@ describe('AXR 현금흐름 기간·마감 정책 BFF', () => {
     expect(missingResponse.status).toBe(200);
     expect(missingResponse.body.items[0].sheet).toMatchObject({
       revisionStatus: 'TARGET_MISSING',
-      revisionStatusLabel: '대상 리비전 없음',
+      revisionStatusLabel: '불러올 때 결산 상태 기록 없음',
     });
     expect(missingResponse.body.items[0].issues.map((entry) => entry.code))
       .toContain('SHEET_TARGET_REVISION_MISSING');
@@ -968,8 +968,8 @@ describe('AXR 현금흐름 기간·마감 정책 BFF', () => {
         },
       },
     });
-    expect(recovery.guide).toContain('격리');
-    expect(recovery.guide).toContain('정상 월결산');
+    expect(recovery.guide).toContain('재결산 준비');
+    expect(recovery.guide).toContain('월 결산을 다시 실행');
   });
 
   it('authority/header/immutable evidence가 모두 없는 프로젝트는 추가 reset 없이 정상 재결산 가능 상태로 표시한다', async () => {

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -3953,8 +3953,11 @@ async function stagePinnedCashflowSheetLab({
           appliedAt: now,
           response,
         }), { merge: true });
+        // 바뀐 것이 없다 = 이 시점의 시트와 결산이 같다. source 만 올리고 target 을 안 올리면
+        // 월결산·주정산 뒤 첫 불러오기부터 영원히 리비전 불일치로 남는다.
         transaction.set(mirrorRef, {
           appliedSourceRevision: mirror.sourceRevision,
+          appliedTargetRevision: mirror.targetRevisionAtFetch,
           lastAppliedAt: now,
           lastAppliedBy: response.lastStagedBy,
         }, { merge: true });

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -3310,8 +3310,10 @@ describe('cashflow sheet lab route', () => {
       sourceRevision: mirror.body.sourceRevision,
       targetRevisionAtFetch: mirror.body.targetRevisionAtFetch,
       appliedSourceRevision: mirror.body.sourceRevision,
+      // 바뀐 것 없음 = 이 시점의 시트와 결산이 같다. target 을 같이 기록해야 다음 결산 뒤 불러오기가
+      // 영원한 리비전 불일치(편차·수정 스냅샷 UNAVAILABLE, 정책 화면 확인 필요)로 남지 않는다.
+      appliedTargetRevision: mirror.body.targetRevisionAtFetch,
     });
-    expect(db.__getDocument('orgs/tenant-a/cashflow_sheet_mirrors/project-a')).not.toHaveProperty('appliedTargetRevision');
     expect(db.__getDocument(`orgs/tenant-a/cashflow_sheet_stage_runs/${stage.body.runId}`)).toMatchObject({
       status: 'APPLIED',
       response: stage.body,
@@ -3399,6 +3401,8 @@ describe('cashflow sheet lab route', () => {
       });
       expect(db.__getDocument('orgs/tenant-a/cashflow_sheet_mirrors/project-a')).toMatchObject({
         appliedSourceRevision: mirror.body.sourceRevision,
+        // 바뀐 것 없음도 반영이다. target 이 안 올라가면 다음 결산 뒤 영원히 리비전 불일치.
+        appliedTargetRevision: mirror.body.targetRevisionAtFetch,
         lastAppliedBy: { uid: 'current-worker' },
       });
     } finally {

--- a/src/app/components/cashflow/CashflowPeriodPolicyPage.test.ts
+++ b/src/app/components/cashflow/CashflowPeriodPolicyPage.test.ts
@@ -65,6 +65,7 @@ const snapshot: CashflowPeriodPolicyResponse = {
     project: { id: 'project-a', name: 'AXR 프로젝트', status: 'ACTIVE', statusLabel: '운영 중', tone: 'positive' },
     authority: {
       status: 'CLOSED', statusLabel: '누적 마감', tone: 'positive', closedThrough: '2026-07', closedThroughLabel: '2026년 7월까지',
+      settlementMonth: '2026-08', settlementMonthLabel: '2026년 8월 결산 회차',
       revision: 4, revisionLabel: 'rev.4', rootHash: 'sha256:authority-a', rootHashLabel: 'sha256:authority-a',
       closedAt: '2026-08-10T00:00:00.000Z', closedAtLabel: '2026.08.10 09:00',
     },
@@ -96,7 +97,7 @@ const snapshot: CashflowPeriodPolicyResponse = {
     },
     sheet: {
       status: 'PARTIAL', statusLabel: '시트 QA 확인 필요', tone: 'caution', weeklyYear: 2026, weeklyYearLabel: '2026년 주차 결산',
-      annualYears: [2024, 2025], annualYearsLabel: '2024년, 2025년 연간형',
+      annualYears: [2024, 2025], annualYearsLabel: '2024년, 2025년 연간 결산',
       sourceRevision: 'sheet-source-a', sourceRevisionLabel: '원본 sheet-source-a',
       appliedSourceRevision: 'sheet-source-b', appliedSourceRevisionLabel: '반영 sheet-source-b',
       targetRevisionAtFetch: 'target-a', targetRevisionAtFetchLabel: '조회 target-a',
@@ -148,10 +149,10 @@ describe('CashflowPeriodPolicyView', () => {
     const html = render({ kind: 'ready', snapshot });
 
     for (const text of [
-      '현금흐름 기간·마감 정책', '정책 / 권한', '월결산 authority', '월결산 run / error',
-      'Sheet grain / source revision QA', 'Projection ↔ Actual 편차', 'Issues / UNAVAILABLE', 'Audit',
-      '2026년 7월까지', 'sha256:authority-a', '2026년 8월 회차', '2026년 주차 결산', '2024년, 2025년 연간형', '2024', '2025',
-      '원본 sheet-source-a', '반영 sheet-source-b', '전사 편차 부분 비교', '전사 비교 가능 1/1주차 · 부분 합계',
+      '현금흐름 기간·마감 정책', '정책 / 권한', '월 결산 잠금 범위', '마지막 결산 실행',
+      '시트 원본 상태', 'Projection ↔ Actual 편차', '확인 필요 항목', '닫힌 월 수정 이력',
+      '2026년 7월까지', 'sha256:authority-a', '2026년 8월 회차', '2026년 주차 결산', '2024년, 2025년 연간 결산', '2024', '2025',
+      '2026년 8월 결산 회차', 'sheet-source-a', 'sheet-source-b', '전사 편차 부분 비교', '전사 비교 가능 1/1주차 · 부분 합계',
       '2026년 8월 2주차', '기초 잔액', '1,000원', '900원', '100원', '90원', '10원',
       'People UID 연결됨', '조직장 후보 조회 완료', '김조직장', '권한 관리', 'version 7', '일부 원본을 읽지 못했습니다.',
       '닫힌 월 수정 이력 1건', '7월 결산 후 직접사업비 정정', 'uid-superadmin',
@@ -209,7 +210,6 @@ describe('CashflowPeriodPolicyView', () => {
     });
 
     expect(html).toContain('닫힌 월 수정 이력 조회 불가');
-    expect(html).toContain('UNAVAILABLE');
     expect(html).not.toContain('7월 결산 후 직접사업비 정정');
     expect(html).not.toContain('정책 스냅샷 생성');
   });
@@ -356,9 +356,9 @@ describe('CashflowPeriodPolicyView', () => {
     const pageSource = readFileSync(resolve(import.meta.dirname, 'CashflowPeriodPolicyPage.tsx'), 'utf8');
 
     expect(pageSource).not.toContain("resolveApiErrorMessage(error, '기간·마감 정책을 불러오지 못했습니다.')");
-    expect(pageSource).not.toContain("resolveApiErrorMessage(error, '조직장 People UID를 연결하지 못했습니다.')");
+    expect(pageSource).not.toContain("resolveApiErrorMessage(error, '조직장을 연결하지 못했습니다.')");
     expect(pageSource).toContain('기간·마감 정책을 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.');
-    expect(pageSource).toContain('조직장 People UID를 연결하지 못했습니다. 화면을 다시 불러온 뒤 다시 시도해 주세요.');
+    expect(pageSource).toContain('조직장을 연결하지 못했습니다. 화면을 다시 불러온 뒤 다시 시도해 주세요.');
   });
 });
 

--- a/src/app/components/cashflow/CashflowPeriodPolicyPage.tsx
+++ b/src/app/components/cashflow/CashflowPeriodPolicyPage.tsx
@@ -55,7 +55,7 @@ export function resolveCashflowPeriodPolicyRecoveryError(error: unknown): string
     return '복구 요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요. 계속되면 AXR팀에 프로젝트 ID와 함께 알려 주세요.';
   }
   if (error.status === 403) {
-    return 'People UID가 연결된 ACTIVE runtime admin 권한을 확인해 주세요.';
+    return '인력 명부와 연결된 활성 관리자만 실행할 수 있습니다. 권한 관리에서 연결 상태를 확인해 주세요.';
   }
   if (error.code === 'cashflow_close_head_recovery_normal_reopen_required'
     || error.code === 'cashflow_close_reset_to_reclose_normal_reopen_required') {
@@ -76,7 +76,7 @@ function Header({ snapshot, onRetry }: { snapshot?: CashflowPeriodPolicyResponse
       icon={CalendarRange}
       iconGradient="linear-gradient(135deg, #0f766e, #2dd4bf)"
       title="현금흐름 기간·마감 정책"
-      description="서버 authority 기준으로 기간 grain, 월결산 실행, 권한, source revision을 분리해 확인합니다."
+      description="프로젝트별로 월 결산이 어디까지 잠겼는지, 마지막 결산 실행, 시트 원본 상태, 조직장 승인 권한을 확인하고 필요하면 복구합니다."
       badge={snapshot?.statusLabel}
       actions={snapshot ? (
         <Button type="button" variant="outline" size="sm" className="gap-2" onClick={onRetry}>
@@ -152,7 +152,7 @@ export function CashflowPeriodPolicyView({
           <CardContent className="py-12 text-center">
             <CalendarRange className="mx-auto h-9 w-9 text-muted-foreground" />
             <h2 className="mt-3 text-sm font-semibold">표시할 현금흐름 기간·마감 정책이 없습니다</h2>
-            <p className="mt-1 text-xs text-muted-foreground">서버 스냅샷 생성 시각: {state.snapshot.generatedAtLabel}</p>
+            <p className="mt-1 text-xs text-muted-foreground">기준 시각: {state.snapshot.generatedAtLabel}</p>
           </CardContent>
         </Card>
         <CashflowPeriodPolicySections
@@ -174,7 +174,7 @@ export function CashflowPeriodPolicyView({
       <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border bg-card px-4 py-3 shadow-sm">
         <StatusBadge status={state.snapshot.status} label={state.snapshot.statusLabel} tone={state.snapshot.tone} />
         <p className="text-xs text-muted-foreground">
-          서버 스냅샷 {state.snapshot.generatedAtLabel}
+          기준 시각 {state.snapshot.generatedAtLabel}
           <span className="sr-only">{state.snapshot.generatedAt}</span>
         </p>
       </div>
@@ -250,13 +250,13 @@ export function CashflowPeriodPolicyPage() {
         reason,
         idempotencyKey: `cashflow-period-policy-${crypto.randomUUID()}`,
       });
-      toast.success(`${item.project.name} 조직장 People UID를 연결했습니다.`);
+      toast.success(`${item.project.name} 조직장을 연결했습니다.`);
       retry();
     } catch (error: unknown) {
       if (error instanceof PlatformApiError && error.status === 403) {
         setState({ kind: 'forbidden' });
       } else {
-        toast.error('조직장 People UID를 연결하지 못했습니다. 화면을 다시 불러온 뒤 다시 시도해 주세요.');
+        toast.error('조직장을 연결하지 못했습니다. 화면을 다시 불러온 뒤 다시 시도해 주세요.');
       }
     } finally {
       setSavingProjectId('');

--- a/src/app/components/cashflow/CashflowPeriodPolicySections.tsx
+++ b/src/app/components/cashflow/CashflowPeriodPolicySections.tsx
@@ -35,8 +35,19 @@ export function StatusBadge({ status, label, tone }: {
     <Badge variant="outline" className={`gap-1.5 ${STATUS_CLASS[tone]}`}>
       <span aria-hidden="true" className={`h-1.5 w-1.5 rounded-full ${STATUS_DOT[tone]}`} />
       <span>{label}</span>
-      <span className="font-mono text-[9px] opacity-70">{status}</span>
+      <span className="sr-only">{status}</span>
     </Badge>
+  );
+}
+
+// 해시는 앞 12자만 보인다. 전체 값은 title 과 sr-only 로 남긴다.
+function ShortHash({ value, label }: { value: string | null | undefined; label: string }) {
+  if (!value) return <span>{label}</span>;
+  const body = value.replace(/^sha256:/, '');
+  return (
+    <span className="font-mono text-[11px]" title={value}>
+      {body.slice(0, 12)}…<span className="sr-only">{value}</span>
+    </span>
   );
 }
 
@@ -100,7 +111,7 @@ function ExecutiveApproverEditor({
         void onUpdate(item, uid, reason);
       }}
     >
-      <label htmlFor={inputId} className="block text-xs font-medium">조직장 People UID</label>
+      <label htmlFor={inputId} className="block text-xs font-medium">조직장 (인력 명부에서 선택)</label>
       <div className="flex gap-2">
         <select
           id={inputId}
@@ -151,7 +162,7 @@ function PolicyPermissionsSection({
   onUpdateExecutiveApprover: (item: CashflowPeriodPolicyProjectItem, uid: string, reason: string) => Promise<void>;
 }) {
   return (
-    <SectionCard title="정책 / 권한" description="슈퍼관리자와 프로젝트별 조직장 People UID 연결을 서버 권한 기준으로 표시합니다." icon={ShieldCheck}>
+    <SectionCard title="정책 / 권한" description="월 결산을 승인할 수 있는 관리자와 프로젝트별 조직장 연결 상태입니다." icon={ShieldCheck}>
       <div className="space-y-3 border-b border-border p-4">
         <div className="flex flex-wrap items-center justify-between gap-2">
           <div className="flex flex-wrap items-center gap-2">
@@ -172,7 +183,7 @@ function PolicyPermissionsSection({
         </div>
       </div>
       <Table className="min-w-[980px]">
-        <TableHeader><TableRow><TableHead>프로젝트</TableHead><TableHead>조직장 연결 상태</TableHead><TableHead>현재 연결</TableHead><TableHead>field-only 변경</TableHead></TableRow></TableHeader>
+        <TableHeader><TableRow><TableHead>프로젝트</TableHead><TableHead>조직장 연결 상태</TableHead><TableHead>현재 조직장</TableHead><TableHead>조직장 변경</TableHead></TableRow></TableHeader>
         <TableBody>{snapshot.items.map((item) => (
           <TableRow key={`permission:${item.project.id}`}>
             <TableCell><div className="font-medium">{item.project.name}</div><div className="font-mono text-[10px] text-muted-foreground">{item.project.id}</div></TableCell>
@@ -288,7 +299,7 @@ function RecoveryEditor({
               disabled={recovering}
               className="mt-0.5 h-4 w-4 rounded border-input"
             />
-            <span>되돌리기 어려운 복구이며 변경 전·후 전체 값이 append-only 감사 사본으로 보존됨을 확인했습니다.</span>
+            <span>되돌리기 어려운 권한 복구입니다. 변경 전·후 전체 값이 append-only 감사 사본으로 보존됨을 확인했습니다.</span>
           </label>
           <Button
             type="submit"
@@ -313,7 +324,7 @@ function RecoveryEditor({
         ) : null}
         {item.recovery.resetToReclose.selectionAllowed ? (
           <fieldset className="space-y-1.5 rounded-md border border-border bg-background p-2">
-            <legend className="px-1 text-xs font-medium">서버 확인 재결산 회차</legend>
+            <legend className="px-1 text-xs font-medium">재결산할 회차</legend>
             {item.recovery.resetToReclose.cycleCandidates.map((candidate) => (
               <label key={`${item.project.id}:reset:${candidate.yearMonth}`} className="flex items-center gap-2 text-xs">
                 <input
@@ -358,7 +369,7 @@ function RecoveryEditor({
                 disabled={resetting || recovering}
                 className="mt-0.5 h-4 w-4 rounded border-input"
               />
-              <span>되돌리기 어려운 격리 작업이며 전체 before 값이 append-only 감사 사본으로 보존됨을 확인했습니다.</span>
+              <span>되돌리기 어려운 작업입니다. 지금 값 전체가 append-only 감사 사본으로 보존됨을 확인했습니다.</span>
             </label>
             <Button
               type="submit"
@@ -393,9 +404,9 @@ function AuthoritySectionWithRecovery({
   ) => Promise<void>;
 }) {
   return (
-    <SectionCard title="월결산 authority" description="누적 마감 경계는 authority head가 제공한 값을 그대로 표시합니다." icon={CheckCircle2}>
-      <Table className="min-w-[1320px]"><TableHeader><TableRow><TableHead>프로젝트</TableHead><TableHead>상태</TableHead><TableHead>닫힌 범위</TableHead><TableHead>Revision</TableHead><TableHead>Root hash</TableHead><TableHead>마감 시각</TableHead><TableHead>ERP 복구</TableHead></TableRow></TableHeader>
-        <TableBody>{snapshot.items.map((item) => <TableRow key={`authority:${item.project.id}`}><TableCell>{item.project.name}</TableCell><TableCell><StatusBadge status={item.authority.status} label={item.authority.statusLabel} tone={item.authority.tone} /></TableCell><TableCell>{item.authority.closedThroughLabel}<span className="sr-only">{item.authority.closedThrough}</span></TableCell><TableCell>{item.authority.revisionLabel}</TableCell><TableCell className="max-w-[220px] break-all font-mono text-xs">{item.authority.rootHashLabel}<span className="sr-only">{item.authority.rootHash}</span></TableCell><TableCell>{item.authority.closedAtLabel}<span className="sr-only">{item.authority.closedAt}</span></TableCell><TableCell><RecoveryEditor item={item} recovering={recoveringProjectId === item.project.id} resetting={resettingProjectId === item.project.id} onRecover={onRecoverCumulativeCloseHead} onReset={onResetCumulativeCloseToReclose} /></TableCell></TableRow>)}</TableBody>
+    <SectionCard title="월 결산 잠금 범위" description="어느 달까지 결산이 확정되어 잠겼는지 프로젝트별로 표시합니다. 잠금은 결산 회차와 같은 연도의 마감 범위 이하 월에만 적용되고, 지난 연도는 연간 결산으로만 다룹니다." icon={CheckCircle2}>
+      <Table className="min-w-[1320px]"><TableHeader><TableRow><TableHead>프로젝트</TableHead><TableHead>상태</TableHead><TableHead>마감 범위</TableHead><TableHead>결산 회차</TableHead><TableHead>결산 차수</TableHead><TableHead>확정 해시</TableHead><TableHead>마감 시각</TableHead><TableHead>복구</TableHead></TableRow></TableHeader>
+        <TableBody>{snapshot.items.map((item) => <TableRow key={`authority:${item.project.id}`}><TableCell>{item.project.name}</TableCell><TableCell><StatusBadge status={item.authority.status} label={item.authority.statusLabel} tone={item.authority.tone} /></TableCell><TableCell>{item.authority.closedThroughLabel}<span className="sr-only">{item.authority.closedThrough}</span></TableCell><TableCell>{item.authority.settlementMonthLabel}<span className="sr-only">{item.authority.settlementMonth}</span></TableCell><TableCell>{item.authority.revisionLabel}</TableCell><TableCell><ShortHash value={item.authority.rootHash} label={item.authority.rootHashLabel} /></TableCell><TableCell>{item.authority.closedAtLabel}<span className="sr-only">{item.authority.closedAt}</span></TableCell><TableCell><RecoveryEditor item={item} recovering={recoveringProjectId === item.project.id} resetting={resettingProjectId === item.project.id} onRecover={onRecoverCumulativeCloseHead} onReset={onResetCumulativeCloseToReclose} /></TableCell></TableRow>)}</TableBody>
       </Table>
     </SectionCard>
   );
@@ -403,8 +414,8 @@ function AuthoritySectionWithRecovery({
 
 function RunSection({ snapshot }: { snapshot: CashflowPeriodPolicyResponse }) {
   return (
-    <SectionCard title="월결산 run / error" description="회차 실행 기록은 authority 상태와 분리해 표시합니다." icon={Clock3}>
-      <Table className="min-w-[900px]"><TableHeader><TableRow><TableHead>프로젝트</TableHead><TableHead>실행 상태</TableHead><TableHead>회차</TableHead><TableHead>Revision</TableHead><TableHead>처리자</TableHead><TableHead>처리 시각</TableHead></TableRow></TableHeader>
+    <SectionCard title="마지막 결산 실행" description="가장 최근에 실행된 월 결산 회차와 처리자입니다. 위의 잠금 범위와 별개로, 실행이 실패했거나 진행 중이면 여기서 보입니다." icon={Clock3}>
+      <Table className="min-w-[900px]"><TableHeader><TableRow><TableHead>프로젝트</TableHead><TableHead>실행 상태</TableHead><TableHead>회차</TableHead><TableHead>결산 차수</TableHead><TableHead>처리자</TableHead><TableHead>처리 시각</TableHead></TableRow></TableHeader>
         <TableBody>{snapshot.items.map((item) => <TableRow key={`run:${item.project.id}`}><TableCell>{item.project.name}</TableCell><TableCell><StatusBadge status={item.latestRun.status} label={item.latestRun.statusLabel} tone={item.latestRun.tone} /></TableCell><TableCell>{item.latestRun.yearMonthLabel}<span className="sr-only">{item.latestRun.yearMonth}</span></TableCell><TableCell>{item.latestRun.revisionLabel}</TableCell><TableCell>{item.latestRun.closedByLabel}<div className="font-mono text-[10px] text-muted-foreground">{item.latestRun.closedByUid}</div></TableCell><TableCell>{item.latestRun.closedAtLabel}<span className="sr-only">{item.latestRun.closedAt}</span></TableCell></TableRow>)}</TableBody>
       </Table>
     </SectionCard>
@@ -413,22 +424,25 @@ function RunSection({ snapshot }: { snapshot: CashflowPeriodPolicyResponse }) {
 
 function SheetSection({ snapshot }: { snapshot: CashflowPeriodPolicyResponse }) {
   return (
-    <SectionCard title="Sheet grain / source revision QA" description="연 결산과 주차 결산 grain, source/target revision을 서버 QA 결과 그대로 나눠 표시합니다." icon={Database}>
+    <SectionCard title="시트 원본 상태" description="프로젝트 시트에서 마지막으로 불러온 값의 상태입니다. 주차 결산 연도 1개와 연간 결산 연도가 시트 양식대로 잡혔는지, 불러온 값이 결산에 반영됐는지 표시합니다." icon={Database}>
       <div className="divide-y divide-border">{snapshot.items.map((item) => (
         <article key={`sheet:${item.project.id}`} className="space-y-4 p-4">
           <div className="flex flex-wrap items-center justify-between gap-2"><h3 className="text-sm font-semibold">{item.project.name}</h3><StatusBadge status={item.sheet.status} label={item.sheet.statusLabel} tone={item.sheet.tone} /></div>
           <dl className="grid gap-3 text-xs md:grid-cols-2 xl:grid-cols-4">
-            <div><dt className="text-muted-foreground">주차 grain</dt><dd className="mt-1 font-medium">{item.sheet.weeklyYearLabel}</dd></div>
-            <div><dt className="text-muted-foreground">연 grain</dt><dd className="mt-1 font-medium">{item.sheet.annualYearsLabel}</dd></div>
-            <div><dt className="text-muted-foreground">Revision QA</dt><dd className="mt-1"><StatusBadge status={item.sheet.revisionStatus} label={item.sheet.revisionStatusLabel} tone={item.sheet.revisionTone} /></dd></div>
-            <div><dt className="text-muted-foreground">캡처 시각</dt><dd className="mt-1 font-medium">{item.sheet.capturedAtLabel}</dd><dd className="sr-only">{item.sheet.capturedAt}</dd></div>
+            <div><dt className="text-muted-foreground">주차 결산 연도</dt><dd className="mt-1 font-medium">{item.sheet.weeklyYearLabel}</dd></div>
+            <div><dt className="text-muted-foreground">연간 결산 연도</dt><dd className="mt-1 font-medium">{item.sheet.annualYearsLabel}</dd></div>
+            <div><dt className="text-muted-foreground">불러온 값 반영</dt><dd className="mt-1"><StatusBadge status={item.sheet.revisionStatus} label={item.sheet.revisionStatusLabel} tone={item.sheet.revisionTone} /></dd></div>
+            <div><dt className="text-muted-foreground">마지막 불러오기</dt><dd className="mt-1 font-medium">{item.sheet.capturedAtLabel}</dd><dd className="sr-only">{item.sheet.capturedAt}</dd></div>
           </dl>
-          <dl className="grid gap-3 rounded-md border border-border bg-muted/20 p-3 text-xs md:grid-cols-2">
-            <div><dt className="text-muted-foreground">Source revision</dt><dd className="mt-1 break-all font-mono">{item.sheet.sourceRevisionLabel}</dd><dd className="sr-only">{item.sheet.sourceRevision}</dd></div>
-            <div><dt className="text-muted-foreground">Applied source revision</dt><dd className="mt-1 break-all font-mono">{item.sheet.appliedSourceRevisionLabel}</dd><dd className="sr-only">{item.sheet.appliedSourceRevision}</dd></div>
-            <div><dt className="text-muted-foreground">Target revision at fetch</dt><dd className="mt-1 break-all font-mono">{item.sheet.targetRevisionAtFetchLabel}</dd><dd className="sr-only">{item.sheet.targetRevisionAtFetch}</dd></div>
-            <div><dt className="text-muted-foreground">Applied target revision</dt><dd className="mt-1 break-all font-mono">{item.sheet.appliedTargetRevisionLabel}</dd><dd className="sr-only">{item.sheet.appliedTargetRevision}</dd></div>
-          </dl>
+          <details className="rounded-md border border-border bg-muted/20 text-xs">
+            <summary className="cursor-pointer px-3 py-2 text-muted-foreground">불러온 값·반영 값 식별자 (AXR 확인용)</summary>
+            <dl className="grid gap-3 border-t border-border p-3 md:grid-cols-2">
+              <div><dt className="text-muted-foreground">시트에서 불러온 값</dt><dd className="mt-1"><ShortHash value={item.sheet.sourceRevision} label={item.sheet.sourceRevisionLabel} /></dd></div>
+              <div><dt className="text-muted-foreground">결산에 반영된 값</dt><dd className="mt-1"><ShortHash value={item.sheet.appliedSourceRevision} label={item.sheet.appliedSourceRevisionLabel} /></dd></div>
+              <div><dt className="text-muted-foreground">불러올 때의 결산 상태</dt><dd className="mt-1"><ShortHash value={item.sheet.targetRevisionAtFetch} label={item.sheet.targetRevisionAtFetchLabel} /></dd></div>
+              <div><dt className="text-muted-foreground">반영 후 결산 상태</dt><dd className="mt-1"><ShortHash value={item.sheet.appliedTargetRevision} label={item.sheet.appliedTargetRevisionLabel} /></dd></div>
+            </dl>
+          </details>
         </article>
       ))}</div>
     </SectionCard>
@@ -437,7 +451,7 @@ function SheetSection({ snapshot }: { snapshot: CashflowPeriodPolicyResponse }) 
 
 function VarianceSection({ snapshot }: { snapshot: CashflowPeriodPolicyResponse }) {
   return (
-    <SectionCard title="Projection ↔ Actual 편차" description="편차와 coverage는 서버 제공값만 표시하며 화면에서 합산하지 않습니다." icon={History}>
+    <SectionCard title="Projection ↔ Actual 편차" description="주 정산이 잠긴 주차의 예상(Projection)과 실제(Actual) 차이입니다. 비교할 수 없는 주차는 이유와 함께 그대로 표시합니다." icon={History}>
       <div className="space-y-3 border-b border-border p-4">
         <div className="flex flex-wrap items-center gap-2">
           <h3 className="text-xs font-semibold">전사 편차 요약</h3>
@@ -486,25 +500,25 @@ function VarianceSection({ snapshot }: { snapshot: CashflowPeriodPolicyResponse 
 }
 
 function IssueRows({ issues, prefix }: { issues: CashflowPeriodPolicyIssue[]; prefix: string }) {
-  if (issues.length === 0) return <p className="text-xs text-muted-foreground">등록된 issue가 없습니다.</p>;
+  if (issues.length === 0) return <p className="text-xs text-muted-foreground">확인할 항목이 없습니다.</p>;
   return <ul className="space-y-2">{issues.map((issue) => <li key={`${prefix}:${issue.code}`} className="rounded-md border border-border bg-background p-3 text-xs"><div className="flex flex-wrap items-center gap-2"><StatusBadge status={issue.severity} label={issue.severity} tone={issue.severityTone} /><span className="font-semibold">{issue.label}</span><code className="text-[10px] text-muted-foreground">{issue.code}</code></div><p className="mt-2 text-muted-foreground">{issue.detail}</p></li>)}</ul>;
 }
 
 function IssuesSection({ snapshot }: { snapshot: CashflowPeriodPolicyResponse }) {
   return (
-    <SectionCard title="Issues / UNAVAILABLE" description="누락과 조회 실패를 숨기지 않고 서버 issue 및 UNAVAILABLE 상태 그대로 표시합니다." icon={AlertTriangle}>
-      <div className="space-y-4 p-4"><div><h3 className="mb-2 text-xs font-semibold">전사 issue</h3><IssueRows issues={snapshot.issues} prefix="global" /></div>{snapshot.items.map((item) => <div key={`issues:${item.project.id}`}><h3 className="mb-2 text-xs font-semibold">{item.project.name}</h3><IssueRows issues={item.issues} prefix={item.project.id} /></div>)}</div>
+    <SectionCard title="확인 필요 항목" description="빠졌거나 읽지 못한 것을 숨기지 않고 그대로 보여줍니다. 여기가 비어 있으면 위 상태가 정상입니다." icon={AlertTriangle}>
+      <div className="space-y-4 p-4"><div><h3 className="mb-2 text-xs font-semibold">전사 공통</h3><IssueRows issues={snapshot.issues} prefix="global" /></div>{snapshot.items.map((item) => <div key={`issues:${item.project.id}`}><h3 className="mb-2 text-xs font-semibold">{item.project.name}</h3><IssueRows issues={item.issues} prefix={item.project.id} /></div>)}</div>
     </SectionCard>
   );
 }
 
 function AuditSection({ snapshot }: { snapshot: CashflowPeriodPolicyResponse }) {
   return (
-    <SectionCard title="Audit" description="JVM이 append-only로 기록한 닫힌 월 수정 증거만 읽기 전용으로 표시합니다." icon={History}>
+    <SectionCard title="닫힌 월 수정 이력" description="결산이 끝난 달의 값을 사유와 함께 고친 기록입니다. 서버가 추가만 하고 지우지 않는 기록이라 화면에서는 읽기만 합니다." icon={History}>
       <div className="border-b border-border p-4">
         <StatusBadge status={snapshot.amendments.status} label={snapshot.amendments.statusLabel} tone={snapshot.amendments.tone} />
       </div>
-      <Table className="min-w-[1180px]"><TableHeader><TableRow><TableHead>프로젝트</TableHead><TableHead>대상 월</TableHead><TableHead>수정 사유</TableHead><TableHead>Close revision</TableHead><TableHead>Sheet revision</TableHead><TableHead>처리자</TableHead><TableHead>생성 시각</TableHead></TableRow></TableHeader>
+      <Table className="min-w-[1180px]"><TableHeader><TableRow><TableHead>프로젝트</TableHead><TableHead>대상 월</TableHead><TableHead>수정 사유</TableHead><TableHead>결산 차수</TableHead><TableHead>시트 값 식별자</TableHead><TableHead>처리자</TableHead><TableHead>기록 시각</TableHead></TableRow></TableHeader>
         <TableBody>{snapshot.amendments.rows.length === 0 ? (
           <TableRow><TableCell colSpan={7}><StatusBadge status={snapshot.amendments.status} label={snapshot.amendments.statusLabel} tone={snapshot.amendments.tone} /></TableCell></TableRow>
         ) : snapshot.amendments.rows.map((row) => (
@@ -512,8 +526,8 @@ function AuditSection({ snapshot }: { snapshot: CashflowPeriodPolicyResponse }) 
             <TableCell><div className="font-medium">{row.projectName}</div><div className="font-mono text-[10px] text-muted-foreground">{row.projectId}</div></TableCell>
             <TableCell>{row.yearMonthLabel}<div className="font-mono text-[10px] text-muted-foreground">{row.yearMonth}</div></TableCell>
             <TableCell className="max-w-[260px] whitespace-normal">{row.reasonLabel}</TableCell>
-            <TableCell><div>{row.closeRevisionLabel} → {row.resultingCloseRevisionLabel}</div><div className="mt-1 max-w-[220px] break-all font-mono text-[10px] text-muted-foreground">{row.closeSnapshotHashLabel}</div></TableCell>
-            <TableCell className="space-y-1 font-mono text-[10px]"><div>source {row.sourceRevisionLabel}</div><div>target {row.targetRevisionLabel}</div><div>result {row.resultingTargetRevisionLabel}</div></TableCell>
+            <TableCell><div>{row.closeRevisionLabel} → {row.resultingCloseRevisionLabel}</div><div className="mt-1 text-muted-foreground"><ShortHash value={row.closeSnapshotHash} label={row.closeSnapshotHashLabel} /></div></TableCell>
+            <TableCell className="space-y-1 text-[11px]"><div>불러온 값 <ShortHash value={row.sourceRevision} label={row.sourceRevisionLabel} /></div><div>수정 전 <ShortHash value={row.targetRevision} label={row.targetRevisionLabel} /></div><div>수정 후 <ShortHash value={row.resultingTargetRevision} label={row.resultingTargetRevisionLabel} /></div></TableCell>
             <TableCell><div>{row.actorLabel}</div><div className="font-mono text-[10px] text-muted-foreground">{row.actorUid}</div></TableCell>
             <TableCell><div>{row.createdAtLabel}</div><div className="font-mono text-[10px] text-muted-foreground">{row.createdAt}</div></TableCell>
           </TableRow>

--- a/src/app/lib/cashflow-period-policy-client.ts
+++ b/src/app/lib/cashflow-period-policy-client.ts
@@ -40,6 +40,8 @@ export interface CashflowPeriodPolicyStatusBlock {
 export interface CashflowPeriodPolicyAuthority extends CashflowPeriodPolicyStatusBlock {
   closedThrough: string | null;
   closedThroughLabel: string;
+  settlementMonth: string | null;
+  settlementMonthLabel: string;
   revision: number | null;
   revisionLabel: string;
   rootHash: string | null;


### PR DESCRIPTION
AXR 기간·마감 정책 화면 정리 + sync 버그 1건.

**정리** — 섹션·열·안내문 전부 업무 용어로. 해시는 12자 축약(전체값은 title/sr-only), 시트 식별자 4개는 접힘, 배지의 원시 상태 코드 제거. 서버 라벨도 같은 어휘로 (코드는 그대로).

**sync 버그** — diff-only(#573) 이후 NO_CHANGES 가 기본 경로가 됐는데 거기서 `appliedTargetRevision` 을 안 올렸음. 월결산·주정산 한 번 뒤엔 불러올 때마다 target 불일치가 영구히 남아 이 화면 확인 필요 / 편차 MIRROR_REVISION_MISMATCH / 수정 스냅샷 UNAVAILABLE. NO_CHANGES = 그 시점 시트=결산이므로 target 도 기록.

**추가** — 잠금 규칙이 결산 회차 연도에 의존하므로 authority 표에 결산 회차 열.

policy 61 · sheet-lab 116 · variance · recovery · typecheck · build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)