### PR TITLE
fix(cashflow): timed-out month-close request reconciles before saying success or failure

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -37,6 +37,7 @@ import {
   resolveCashflowWeeklyCompletionErrorMessage,
 } from '../../platform/api-error-message';
 import { PlatformApiError } from '../../platform/api-client';
+import { isRequestTimeoutError, reconcileMonthCloseRequestAfterTimeout } from '../../data/cashflow-month-close-request-reconcile';
 import { resolveApiErrorPresentation, type ApiErrorPresentation } from '../../platform/api-error-messages';
 import { recordDevtoolsLog, toDevtoolsError } from '../../platform/devtools-transaction-log';
 import {
@@ -1273,21 +1274,41 @@ export function CashflowProjectSheet({
             || '서버에서 월 결산 가능 상태를 확인하지 못했습니다.',
         );
       }
-      const request = await requestCashflowMonthCloseViaBff({
-        tenantId: orgId,
-        actor,
-        projectId,
-        payload: {
-          contractVersion: 'cashflow-cumulative-close-v2',
-          yearMonth,
-          expectedRevision: prepared.revision,
-          expectedApproverUid: savedExecutiveApproverId,
-          expectedProjectVersion: project?.version ?? 0,
-          expectedOpeningBalances: reviewedOpeningBalances,
-          closeInput: monthCloseInput,
-        },
-        idempotencyKey: `cashflow-month-close-request:${projectId}:${yearMonth}:${prepared.revision}:r${monthCloseRequest?.revision ?? -1}`,
-      });
+      const requestStartedAtIso = new Date().toISOString();
+      let request: CashflowMonthCloseRequest;
+      try {
+        request = await requestCashflowMonthCloseViaBff({
+          tenantId: orgId,
+          actor,
+          projectId,
+          payload: {
+            contractVersion: 'cashflow-cumulative-close-v2',
+            yearMonth,
+            expectedRevision: prepared.revision,
+            expectedApproverUid: savedExecutiveApproverId,
+            expectedProjectVersion: project?.version ?? 0,
+            expectedOpeningBalances: reviewedOpeningBalances,
+            closeInput: monthCloseInput,
+          },
+          idempotencyKey: `cashflow-month-close-request:${projectId}:${yearMonth}:${prepared.revision}:r${monthCloseRequest?.revision ?? -1}`,
+        });
+      } catch (error) {
+        // 브라우저가 27초에 끊어도 서버는 저장까지 갈 수 있다(첫 누적 요청은 43개월 shard).
+        // 타임아웃은 실패가 아니라 모름이다. 서버에 이번 요청이 남았는지 확인하고 둘 중 하나만 말한다.
+        if (!isRequestTimeoutError(error) || !isCurrentMonthCloseMutation(mutationScope)) throw error;
+        setMonthCloseError('요청 결과를 확인하고 있어요. 잠시만 기다려 주세요.');
+        const reconciled = await reconcileMonthCloseRequestAfterTimeout({
+          fetchCurrent: () => fetchCurrentCashflowMonthCloseRequestViaBff({ tenantId: orgId, actor, projectId, yearMonth }),
+          actorUid: actor.uid,
+          startedAtIso: requestStartedAtIso,
+        });
+        if (!isCurrentMonthCloseMutation(mutationScope)) return;
+        setMonthCloseError(null);
+        if (!reconciled) {
+          throw new Error('월 결산 요청이 접수되지 않았어요. 잠시 후 다시 시도해 주세요.');
+        }
+        request = reconciled;
+      }
       if (!isCurrentMonthCloseMutation(mutationScope, request)) return;
       if (request.status !== 'PENDING') throw new Error('월결산 결재 요청 상태를 확인하지 못했습니다.');
       monthCloseCurrentRequestGenerationRef.current += 1;

--- a/src/app/data/cashflow-month-close-request-reconcile.test.ts
+++ b/src/app/data/cashflow-month-close-request-reconcile.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { CashflowMonthCloseRequest } from '../lib/platform-bff-client';
+import {
+  isRequestFromThisAttempt,
+  isRequestTimeoutError,
+  reconcileMonthCloseRequestAfterTimeout,
+} from './cashflow-month-close-request-reconcile';
+
+const base = {
+  documentType: 'MONTHLY_CLOSE',
+  requestId: 'p1-2026-08',
+  projectId: 'p1',
+  yearMonth: '2026-08',
+  status: 'PENDING',
+  canDecideReopen: false,
+  revision: 1,
+  requestedByUid: 'me',
+  requestedAt: '2026-08-19T00:46:23.282Z',
+} as unknown as CashflowMonthCloseRequest;
+
+describe('month close request reconcile after client timeout', () => {
+  it('recognises the client timeout error only', () => {
+    const timeout = new Error('서버 응답이 늦어 요청을 중단했습니다.');
+    timeout.name = 'TimeoutError';
+    expect(isRequestTimeoutError(timeout)).toBe(true);
+    expect(isRequestTimeoutError(new Error('409'))).toBe(false);
+    expect(isRequestTimeoutError(null)).toBe(false);
+  });
+
+  it('accepts only a live request made by this actor after this attempt started', () => {
+    const startedAtIso = '2026-08-19T00:46:00.000Z';
+    expect(isRequestFromThisAttempt(base, { actorUid: 'me', startedAtIso })).toBe(true);
+    expect(isRequestFromThisAttempt({ ...base, requestedByUid: 'someone' }, { actorUid: 'me', startedAtIso })).toBe(false);
+    expect(isRequestFromThisAttempt({ ...base, requestedAt: '2026-08-19T00:45:59.000Z' }, { actorUid: 'me', startedAtIso })).toBe(false);
+    expect(isRequestFromThisAttempt({ ...base, status: 'REJECTED' } as CashflowMonthCloseRequest, { actorUid: 'me', startedAtIso })).toBe(false);
+    expect(isRequestFromThisAttempt(null, { actorUid: 'me', startedAtIso })).toBe(false);
+  });
+
+  it('returns the request once the server shows it PENDING, waiting through BUILDING and read failures', async () => {
+    const fetchCurrent = vi.fn()
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce({ ...base, status: 'BUILDING' })
+      .mockResolvedValueOnce(base);
+    const sleep = vi.fn(async () => {});
+    const result = await reconcileMonthCloseRequestAfterTimeout({
+      fetchCurrent, actorUid: 'me', startedAtIso: '2026-08-19T00:46:00.000Z', attempts: 5, sleep,
+    });
+    expect(result).toEqual(base);
+    expect(fetchCurrent).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up with null when the request never appears — that is the only time "failed" is true', async () => {
+    const fetchCurrent = vi.fn(async () => null);
+    const sleep = vi.fn(async () => {});
+    const result = await reconcileMonthCloseRequestAfterTimeout({
+      fetchCurrent, actorUid: 'me', startedAtIso: '2026-08-19T00:46:00.000Z', attempts: 3, sleep,
+    });
+    expect(result).toBeNull();
+    expect(fetchCurrent).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not adopt an older request left by someone else', async () => {
+    const fetchCurrent = vi.fn(async () => ({ ...base, requestedByUid: 'other' }));
+    const result = await reconcileMonthCloseRequestAfterTimeout({
+      fetchCurrent, actorUid: 'me', startedAtIso: '2026-08-19T00:46:00.000Z', attempts: 2, sleep: async () => {},
+    });
+    expect(result).toBeNull();
+  });
+});

--- a/src/app/data/cashflow-month-close-request-reconcile.ts
+++ b/src/app/data/cashflow-month-close-request-reconcile.ts
@@ -1,0 +1,48 @@
+import type { CashflowMonthCloseRequest } from '../lib/platform-bff-client';
+
+// 브라우저는 요청 POST 를 27초에 끊지만 서버(Vercel, 300초)는 계속 돌아 저장까지 간다.
+// 첫 누적 요청은 2023-01 부터 43개월 shard 를 한 트랜잭션에 쓰므로 그 창이 실제로 열린다.
+// 그래서 타임아웃은 "실패" 가 아니라 "모름" 이다. 서버의 현재 요청을 몇 번 다시 읽어서
+// 이번 시도가 남긴 요청이 보이면 성공, 끝까지 안 보이면 그때 실패라고 말한다. 둘 중 하나만.
+
+export function isRequestTimeoutError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'TimeoutError';
+}
+
+// 이번 시도가 만든 요청인가: 같은 사람이, 시도 시작 이후에, 아직 살아 있는 상태로.
+export function isRequestFromThisAttempt(
+  request: CashflowMonthCloseRequest | null,
+  input: { actorUid: string; startedAtIso: string },
+): boolean {
+  if (!request) return false;
+  if (request.requestedByUid !== input.actorUid) return false;
+  if (!request.requestedAt || request.requestedAt < input.startedAtIso) return false;
+  return request.status === 'PENDING' || request.status === 'BUILDING';
+}
+
+export async function reconcileMonthCloseRequestAfterTimeout(input: {
+  fetchCurrent: () => Promise<CashflowMonthCloseRequest | null>;
+  actorUid: string;
+  startedAtIso: string;
+  attempts?: number;
+  waitMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+}): Promise<CashflowMonthCloseRequest | null> {
+  const attempts = input.attempts ?? 10;
+  const waitMs = input.waitMs ?? 3_000;
+  const sleep = input.sleep ?? ((ms: number) => new Promise<void>((resolve) => { setTimeout(resolve, ms); }));
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    let current: CashflowMonthCloseRequest | null = null;
+    try {
+      current = await input.fetchCurrent();
+    } catch {
+      current = null; // 조회 실패는 "아직 모름" 이지 "없음" 이 아니다. 다음 회차에 다시 본다.
+    }
+    if (isRequestFromThisAttempt(current, input)) {
+      if (current?.status === 'PENDING') return current;
+      // BUILDING 은 서버가 아직 쓰는 중. 기다린다.
+    }
+    if (attempt < attempts - 1) await sleep(waitMs);
+  }
+  return null;
+}


### PR DESCRIPTION
김제청년로컬랩2기: 에러 토스트 + 결재 요청 둘 다 발생. 데이터: 요청 1건·감사 1건·PENDING·43개월 shard 단일 트랜잭션. 브라우저 27초 타임아웃 vs Vercel 300초 커밋의 경합.

타임아웃 = 모름. 서버의 현재 요청을 최대 ~30초 재조회해서 이번 시도(같은 actor, 시작 이후, PENDING)가 보이면 정상 성공 흐름(토스트 없음), 끝까지 안 보이면 그때만 "접수되지 않았어요". 둘 중 하나만.

순수 헬퍼 `src/app/data/cashflow-month-close-request-reconcile.ts` + 테스트 5건. cashflow 컴포넌트 161 · typecheck · build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)