### PR TITLE
feat(cashflow): 주간 정산 회수 — 즉시, 사유 없음

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -164,6 +164,17 @@ function buildCashflowMonthCloseActions({
           ? '현재 주간 정산 대상을 서버에서 확인하지 못했습니다.'
           : '이미 완료된 주간 정산입니다.',
     ),
+    // 주정산 회수: 완료된 주가 있으면 즉시. 결재 없음, 사유 없음.
+    reopenWeekly: cashflowAction(
+      weeklyRoleAllowed && Boolean(currentDeadline) && Boolean(readOptionalText(currentDeadline?.completedAt)),
+      !actionAllowed
+        ? accessGuide
+        : !weeklyRoleAllowed
+        ? '현금흐름 주간 정산 회수 권한이 없습니다.'
+        : !currentDeadline
+          ? '현재 주간 정산 대상을 서버에서 확인하지 못했습니다.'
+          : '아직 완료되지 않은 주간 정산입니다.',
+    ),
     changeExecutiveApprover: cashflowAction(
       requestAvailable
         && approverLockRead.available
@@ -4252,28 +4263,36 @@ export function mountJvmWeeklyApiRoutes(app, {
     const requested = commandBody(req);
     const yearMonth = readOptionalText(requested.yearMonth);
     const weekNo = Number(requested.weekNo);
-    const expectedRevision = Number(requested.expectedRevision);
     const reason = readOptionalText(requested.reason);
     if (
       !/^20\d{2}-(0[1-9]|1[0-2])$/.test(yearMonth)
       || !Number.isSafeInteger(weekNo)
       || weekNo < 1
       || weekNo > 5
-      || !Number.isSafeInteger(expectedRevision)
-      || expectedRevision < 1
-      || !reason
       || reason.length > 1_000
     ) {
       throw createHttpError(
         400,
-        '주간 정산 재오픈에는 대상 연월·주차·현재 revision·사유가 필요합니다.',
+        '주간 정산 회수에는 대상 연월과 주차가 필요합니다.',
         'cashflow_weekly_reopen_request_invalid',
       );
+    }
+    // 회수는 사유 없이 즉시. 화면은 revision 을 모르므로 BFF 가 현재 잠금 기록에서 읽어 JVM 낙관적 잠금에 넘긴다.
+    let expectedRevision = Number(requested.expectedRevision);
+    if (!Number.isSafeInteger(expectedRevision) || expectedRevision < 1) {
+      const completion = await readDocument(
+        db,
+        `orgs/${req.context.tenantId}/cashflow_weekly_update_completions/${projectId}-${yearMonth}-w${weekNo}`,
+      );
+      if (readOptionalText(completion?.status) !== 'LOCKED' || !Number.isSafeInteger(Number(completion?.revision))) {
+        throw createHttpError(409, '완료된 주간 정산만 회수할 수 있습니다.', 'cashflow_weekly_reopen_not_locked');
+      }
+      expectedRevision = Number(completion.revision);
     }
     const result = await proxyMutation(
       req,
       `/api/v1/cashflow/${encodeURIComponent(projectId)}/weekly-update-complete/reopen`,
-      { ...requested, yearMonth, weekNo, expectedRevision, reason },
+      { ...requested, yearMonth, weekNo, expectedRevision, ...(reason ? { reason } : {}) },
       { cashflowWrite: true },
     );
     res.status(200).json(result);

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -1999,6 +1999,8 @@ describe('JVM weekly API BFF proxy', () => {
       .expect((response) => {
         expect(response.body.actions).toMatchObject({
           completeWeekly: { enabled: true },
+          // 완료 전이면 회수할 게 없다. 완료·회수는 서로 배타.
+          reopenWeekly: { enabled: false, guide: '아직 완료되지 않은 주간 정산입니다.' },
           changeExecutiveApprover: { enabled: true },
           requestMonthClose: { enabled: true, label: '월 결산 요청' },
           withdrawMonthClose: { enabled: false },
@@ -3264,6 +3266,26 @@ describe('JVM weekly API BFF proxy', () => {
     expect(JSON.parse(reopenCall[1].body)).toMatchObject({
       yearMonth: '2026-06', weekNo: 2, expectedRevision: 1, reason: '긴급 정정',
     });
+
+    // 회수(사유 없음): 화면은 revision 을 모른다. BFF 가 잠금 기록에서 읽어 JVM 낙관적 잠금에 넘긴다.
+    source.documents.set('orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-06-w3', {
+      projectId: 'project-a', yearMonth: '2026-06', weekNo: 3, status: 'LOCKED', revision: 4,
+    });
+    await request(app)
+      .post('/api/v1/cashflow/project-a/weekly-update-complete/reopen')
+      .send({ yearMonth: '2026-06', weekNo: 3 })
+      .expect(200)
+      .expect((response) => expect(response.body).toMatchObject({ yearMonth: '2026-06', weekNo: 3, status: 'OPEN' }));
+    const withdrawCall = fetchImpl.mock.calls.filter(([url]) => url.endsWith('/weekly-update-complete/reopen')).at(-1);
+    const withdrawBody = JSON.parse(withdrawCall[1].body);
+    expect(withdrawBody).toMatchObject({ yearMonth: '2026-06', weekNo: 3, expectedRevision: 4 });
+    expect(withdrawBody).not.toHaveProperty('reason');
+    // 완료된 적 없는 주는 회수할 수 없다.
+    await request(app)
+      .post('/api/v1/cashflow/project-a/weekly-update-complete/reopen')
+      .send({ yearMonth: '2026-06', weekNo: 4 })
+      .expect(409)
+      .expect((response) => expect(response.body.code).toBe('cashflow_weekly_reopen_not_locked'));
   });
 
   it('does not count a reopened weekly completion as settled', async () => {
@@ -3370,7 +3392,7 @@ describe('JVM weekly API BFF proxy', () => {
       .expect((response) => expect(response.body.code).toBe('cashflow_weekly_update_scope_invalid'));
     await request(app)
       .post('/api/v1/cashflow/project-a/weekly-update-complete/reopen')
-      .send({ yearMonth: '2026-06', weekNo: 2, expectedRevision: 1, reason: '' })
+      .send({ yearMonth: '2026-06', weekNo: 9 })
       .expect(400)
       .expect((response) => expect(response.body.code).toBe('cashflow_weekly_reopen_request_invalid'));
     expect(fetchImpl).not.toHaveBeenCalled();

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/ReopenCashflowWeeklyUpdateRequest.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/ReopenCashflowWeeklyUpdateRequest.java
@@ -11,6 +11,7 @@ public record ReopenCashflowWeeklyUpdateRequest(
     @NotBlank @Pattern(regexp = "20\\d{2}-(0[1-9]|1[0-2])") String yearMonth,
     @Min(1) @Max(CashflowSheetLabApplyRequest.FINANCE_WEEK_COUNT) int weekNo,
     @Min(1) long expectedRevision,
-    @NotBlank @Size(max = 1_000) String reason
+    // 주정산 회수는 사유 없이도 된다 (월 결산 재오픈과 달리 결재가 없는 가벼운 되돌림). 있으면 기록만.
+    @Size(max = 1_000) String reason
 ) {
 }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -1496,9 +1496,6 @@ public class WeeklyExpenseCommandService {
         String projectId,
         ReopenCashflowWeeklyUpdateRequest request
     ) {
-        if (request.reason().isBlank()) {
-            throw new IllegalArgumentException("A reason is required to reopen a cashflow week.");
-        }
         TrustedActorContext writer = requireCashflowMonthClosePermission(
             REOPEN_CASHFLOW_WEEKLY_UPDATE_COMMAND,
             actor,
@@ -1534,7 +1531,7 @@ public class WeeklyExpenseCommandService {
                 "revision", saved.revision(),
                 "reopenedAt", saved.reopenedAt(),
                 "reopenedBy", saved.reopenedBy(),
-                "reason", saved.reopenReason(),
+                "reason", saved.reopenReason() == null ? "" : saved.reopenReason(),
                 "previousSnapshotHash", saved.snapshotHash()
             ))
         ));

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -2049,9 +2049,6 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     ) {
         requireValidatedCashflowWriteScope(actor.tenantId(), projectId);
         requireYearMonth(request.yearMonth());
-        if (request.reason() == null || request.reason().isBlank()) {
-            throw new IllegalArgumentException("A reason is required to reopen a cashflow week.");
-        }
         requireCashflowMonthsOpen(actor.tenantId(), projectId, List.of(request.yearMonth()));
         String documentId = projectId + "-" + request.yearMonth() + "-w" + request.weekNo();
         DocumentReference ref = db.document(cashflowWeeklyUpdateCompletionPath(actor.tenantId(), documentId));
@@ -2080,7 +2077,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         patch.put("reopenedAt", reopenedAt.toString());
         patch.put("reopenedByUid", actor.id());
         patch.put("reopenedByName", actor.name());
-        patch.put("reopenReason", request.reason().trim());
+        patch.put("reopenReason", request.reason() == null ? "" : request.reason().trim());
         patch.put("updatedAt", reopenedAt.toString());
         set(ref, patch);
         return toWeeklyCompletionRecord(

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -3819,6 +3819,29 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
+    void weeklyReopenNeedsNoReasonAndReopensALockedWeek() {
+        // 주정산 회수는 결재가 없는 가벼운 되돌림이라 사유 없이도 된다. 있으면 기록만 한다.
+        Fixture fixture = fixture(activeMember(), Map.of());
+        fixture.documents.put(
+            "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w3",
+            lockedWeeklyCompletion("2026-07", 3, 1)
+        );
+        var response = fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
+            .reopenCashflowWeeklyUpdate(
+                ACTOR,
+                "project-a",
+                new ReopenCashflowWeeklyUpdateRequest("reopen-no-reason", "2026-07", 3, 1, null)
+            ));
+        assertThat(response.status()).isEqualTo("OPEN");
+        assertThat(response.revision()).isEqualTo(2L);
+        Map<String, Object> stored = fixture.documents.get(
+            "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w3"
+        );
+        assertThat(stored.get("status")).isEqualTo("OPEN");
+        assertThat(stored.get("reopenReason")).isEqualTo("");
+    }
+
+    @Test
     void weeklyReopenRejectsRevisionDriftAndClosedMonth() {
         Fixture revisionFixture = fixture(activeMember(), Map.of());
         revisionFixture.documents.put(

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { AlertTriangle, ArrowDownToLine, CheckCircle2, ChevronLeft, ChevronRight, ClipboardCheck, ClipboardList, Columns2, FileSpreadsheet, Loader2, LockKeyhole, RefreshCw, Save } from 'lucide-react';
+import { AlertTriangle, ArrowDownToLine, CheckCircle2, ChevronLeft, ChevronRight, ClipboardCheck, ClipboardList, Columns2, FileSpreadsheet, Loader2, LockKeyhole, RefreshCw, Save, Undo2 } from 'lucide-react';
 import { useBlocker, useNavigate } from 'react-router';
 import { Button } from '../ui/button';
 import { Card, CardContent } from '../ui/card';
@@ -44,6 +44,7 @@ import {
   withdrawCashflowMonthCloseRequestViaBff,
   saveCashflowMonthCloseApproverViaBff,
   completeCashflowWeeklyUpdateViaBff,
+  reopenCashflowWeeklyUpdateViaBff,
   decideCashflowMonthReopenViaBff,
   fetchCashflowMonthCloseViaBff,
   fetchCurrentCashflowMonthCloseRequestViaBff,
@@ -390,6 +391,8 @@ export function CashflowProjectSheet({
   const [weeklyCompletionOpen, setWeeklyCompletionOpen] = useState(false);
   const [weeklyUpdateResult, setWeeklyUpdateResult] = useState<'CHANGED' | 'NO_CHANGES' | ''>('');
   const [weeklyCompletionError, setWeeklyCompletionError] = useState('');
+  const [weeklyWithdrawBusy, setWeeklyWithdrawBusy] = useState(false);
+  const [weeklyWithdrawError, setWeeklyWithdrawError] = useState('');
   const [weeklyProjectionWarning, setWeeklyProjectionWarning] = useState<WeeklyProjectionValidation | null>(null);
   const [weeklyHistoryOpen, setWeeklyHistoryOpen] = useState(false);
   const [weeklyComplianceHistory, setWeeklyComplianceHistory] = useState<CashflowWeeklyComplianceItem[]>([]);
@@ -917,6 +920,51 @@ export function CashflowProjectSheet({
       setWeeklyCompletionBusy(false);
     }
   }, [loadCashflowMonthClose, monthCloseActions?.completeWeekly, monthCloseResult?.dashboard?.deadlineSummary?.current, orgId, projectId, resolveBffActor, savedExecutiveApproverId, weeklyProjectionWarning, weeklyUpdateResult, yearMonth]);
+
+  // 주정산 회수: 사유·결재 없이 즉시. revision 은 BFF 가 잠금 기록에서 읽는다. 되돌리려면 다시 완료하면 된다.
+  const handleWithdrawWeeklyUpdate = useCallback(async (): Promise<void> => {
+    if (monthCloseActions?.reopenWeekly.enabled !== true) return;
+    const currentDeadline = monthCloseResult?.dashboard?.deadlineSummary?.current;
+    if (!currentDeadline) return;
+    if (selectedProjectIdRef.current !== projectId || selectedYearMonthRef.current !== yearMonth) return;
+    setWeeklyWithdrawBusy(true);
+    setWeeklyWithdrawError('');
+    const startedAt = Date.now();
+    try {
+      const actor = await resolveBffActor();
+      if (!actor?.idToken) throw new Error('로그인 세션이 만료되었습니다.');
+      const result = await reopenCashflowWeeklyUpdateViaBff({
+        tenantId: orgId,
+        actor,
+        projectId,
+        yearMonth: currentDeadline.yearMonth,
+        weekNo: currentDeadline.weekNo,
+      });
+      await loadCashflowMonthClose();
+      logCashflowSettlement({
+        phase: 'success',
+        operation: 'cashflow.weekly_settlement.withdraw',
+        projectId,
+        yearMonth: result.yearMonth,
+        weekNo: result.weekNo,
+        durationMs: Date.now() - startedAt,
+        summary: { revision: result.revision },
+      });
+    } catch (error) {
+      logCashflowSettlement({
+        phase: 'error',
+        operation: 'cashflow.weekly_settlement.withdraw',
+        projectId,
+        yearMonth: currentDeadline.yearMonth,
+        weekNo: currentDeadline.weekNo,
+        durationMs: Date.now() - startedAt,
+        error,
+      });
+      setWeeklyWithdrawError(resolveApiErrorMessage(error, '주간 정산을 회수하지 못했습니다. 화면을 다시 불러온 뒤 시도해 주세요.'));
+    } finally {
+      setWeeklyWithdrawBusy(false);
+    }
+  }, [loadCashflowMonthClose, monthCloseActions?.reopenWeekly, monthCloseResult?.dashboard?.deadlineSummary?.current, orgId, projectId, resolveBffActor, yearMonth]);
 
   const loadWeeklyComplianceHistory = useCallback(async (): Promise<void> => {
     setWeeklyComplianceHistoryLoading(true);
@@ -2638,7 +2686,21 @@ export function CashflowProjectSheet({
                       주간 정산 완료
                     </Button>
                   ) : null}
+                  {monthCloseActions?.reopenWeekly.enabled ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      className="h-8 shrink-0 rounded-md border-slate-300 bg-white px-3 text-[12px] font-semibold text-slate-700"
+                      disabled={weeklyWithdrawBusy || monthCloseLoading}
+                      onClick={() => void handleWithdrawWeeklyUpdate()}
+                    >
+                      {weeklyWithdrawBusy ? <Loader2 className="mr-1 h-3 w-3 animate-spin" /> : <Undo2 className="mr-1 h-3 w-3" />}
+                      주간 정산 회수
+                    </Button>
+                  ) : null}
                 </div>
+                {weeklyWithdrawError ? <div role="alert" className="mt-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] leading-5 text-red-800">{weeklyWithdrawError}</div> : null}
                 <div className="mt-3 flex items-center gap-4 text-[12px] text-muted-foreground">
                   <span>누적 미준수 <strong className="ml-1 text-red-700">{deadlineSummaryUnavailable ? '확인 불가' : formatCashflowCount(monthCloseResult?.dashboard?.deadlineSummary?.missedCount, '회')}</strong></span>
                   <span>기한 내 완료 <strong className="ml-1 text-primary">{deadlineSummaryUnavailable ? '확인 불가' : formatCashflowCount(monthCloseResult?.dashboard?.deadlineSummary?.completedCount, '회')}</strong></span>

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -276,6 +276,7 @@ describe('platform-bff-client', () => {
     } satisfies CashflowMonthClosePresentation;
     const actions = {
       completeWeekly: { enabled: false, guide: '주간 가이드' },
+      reopenWeekly: { enabled: false, guide: '주간 회수 가이드' },
       changeExecutiveApprover: { enabled: false, guide: '조직장 가이드' },
       requestMonthClose: { enabled: false, guide: '서버 가이드', label: '월 결산 요청' },
       withdrawMonthClose: { enabled: false, guide: '회수 가이드' },
@@ -572,8 +573,7 @@ describe('platform-bff-client', () => {
       tenantId: 'mysc', actor, projectId: 'p001', yearMonth: '2026-06', weekNo: 2, client,
     });
     await reopenCashflowWeeklyUpdateViaBff({
-      tenantId: 'mysc', actor, projectId: 'p001', yearMonth: '2026-06', weekNo: 2,
-      expectedRevision: 1, reason: '긴급 정정', client,
+      tenantId: 'mysc', actor, projectId: 'p001', yearMonth: '2026-06', weekNo: 2, client,
     });
 
     expect(client.post).toHaveBeenNthCalledWith(1, '/api/v1/cashflow/p001/weekly-update-complete', expect.objectContaining({
@@ -584,8 +584,9 @@ describe('platform-bff-client', () => {
       '/api/v1/cashflow/p001/weekly-update-complete?yearMonth=2026-06&weekNo=2',
       expect.objectContaining({ retries: 0 }),
     );
+    // 회수는 사유 없이, revision 도 화면이 아니라 BFF 가 잠금 기록에서 읽는다.
     expect(client.post).toHaveBeenNthCalledWith(2, '/api/v1/cashflow/p001/weekly-update-complete/reopen', expect.objectContaining({
-      body: { yearMonth: '2026-06', weekNo: 2, expectedRevision: 1, reason: '긴급 정정' },
+      body: { yearMonth: '2026-06', weekNo: 2 },
     }));
   });
 

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -1403,6 +1403,7 @@ export interface CashflowMonthCloseActionDecision {
 
 export interface CashflowMonthCloseActions {
   completeWeekly: CashflowMonthCloseActionDecision;
+  reopenWeekly: CashflowMonthCloseActionDecision;
   changeExecutiveApprover: CashflowMonthCloseActionDecision;
   requestMonthClose: CashflowMonthCloseActionDecision & { label: string };
   withdrawMonthClose: CashflowMonthCloseActionDecision;
@@ -3504,14 +3505,13 @@ export async function fetchCashflowWeeklyOverviewViaBff(params: {
   return result;
 }
 
+// 주정산 회수: 사유 없이 즉시. 현재 revision 은 BFF 가 잠금 기록에서 읽는다.
 export async function reopenCashflowWeeklyUpdateViaBff(params: {
   tenantId: string;
   actor: ActorLike;
   projectId: string;
   yearMonth: string;
   weekNo: number;
-  expectedRevision: number;
-  reason: string;
   client?: PlatformApiClientLike;
 }): Promise<CashflowWeeklyUpdateCompletionResult> {
   const response = await resolveClient(params.client).post<CashflowWeeklyUpdateCompletionResult>(
@@ -3522,8 +3522,6 @@ export async function reopenCashflowWeeklyUpdateViaBff(params: {
       body: {
         yearMonth: params.yearMonth,
         weekNo: params.weekNo,
-        expectedRevision: params.expectedRevision,
-        reason: params.reason,
       },
       retries: 0,
       timeoutMs: 12000,


### PR DESCRIPTION
주정산에 회수 추가 (월결산의 회수와 정렬). 라우트·JVM 커맨드는 7월부터 있었고 사유 필수·호출자 없음 상태였음.

- JVM: 사유 선택(레코드 @NotBlank 제거, 서비스·저장소 검사 제거, 있으면 기록). 테스트 1건 추가(사유 없이 LOCKED→OPEN).
- BFF: 사유 선택, `expectedRevision` 은 화면 대신 BFF 가 LOCKED 완료 기록에서 읽어 JVM 낙관적 잠금에 전달. 완료 안 된 주는 409 `cashflow_weekly_reopen_not_locked`. `actions.reopenWeekly` 추가.
- 프론트: 완료된 주에 `주간 정산 회수` 버튼, 즉시 실행, 인라인 에러.
- 역할표는 손대지 않음 — viewer 는 모든 현금흐름 워크플로 커맨드에 일관되게 들어 있고 프로덕션은 workspace 인증.

JVM FirestoreCashflowLeaseGuardTest 152 · jvm-weekly-api 267 · cashflow 컴포넌트 · client · policy:verify · typecheck · build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)