### PR TITLE
fix(jvm): withdrawn week no longer reported as completed

### DIFF
--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -1526,6 +1526,11 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             long revision = longValue(value.get("revision"), 0);
             if (revision <= evidenceRevisions.getOrDefault(weekKey, -1L)) continue;
             evidenceRevisions.put(weekKey, revision);
+            if ("REOPENED".equals(status)) {
+                // 회수가 최신이면 그 주는 아직 완료 안 된 주다. 근거를 비워 PENDING/MISSED 합성으로 보낸다.
+                evidenceByWeek.remove(weekKey);
+                continue;
+            }
             evidenceByWeek.put(weekKey, new CashflowWeeklyComplianceRecord(
                 weekKey,
                 yearMonth,
@@ -1538,6 +1543,20 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                 text(value.get("auditId"), ""),
                 text(value.get("updateResult"), "")
             ));
+        }
+        // 현재 완료 문서가 OPEN(회수됨) 이면 버전 이력과 무관하게 그 주는 완료가 아니다.
+        // 버전 없이 회수된 기록(REOPENED 버전 도입 이전)도 이걸로 정직하게 보인다.
+        QuerySnapshot completionSnapshot = query(
+            db.collection("orgs/" + tenantId + "/cashflow_weekly_update_completions")
+                .whereEqualTo("projectId", projectId)
+        );
+        for (DocumentSnapshot document : completionSnapshot.getDocuments()) {
+            Map<String, Object> value = data(document);
+            if (!"OPEN".equals(text(value.get("status"), ""))) continue;
+            String yearMonth = text(value.get("yearMonth"), "");
+            int weekNo = intValue(value.get("weekNo"), 0);
+            if (!yearMonth.matches("20\\d{2}-(0[1-9]|1[0-2])") || weekNo < 1 || weekNo > 5) continue;
+            evidenceByWeek.remove(yearMonth + "-w" + weekNo);
         }
         java.time.ZonedDateTime now = clock.instant().atZone(java.time.ZoneId.of("Asia/Seoul"));
         CashflowWeekScope currentScope = financeWeekScope(now.toLocalDate());
@@ -2080,6 +2099,30 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         patch.put("reopenReason", request.reason() == null ? "" : request.reason().trim());
         patch.put("updatedAt", reopenedAt.toString());
         set(ref, patch);
+        // 준수 이력은 버전 문서(불변)에서 최고 revision 을 읽는다. 회수도 버전을 남겨야
+        // 이력이 "완료됨" 에 머물지 않는다 — 안 남기면 회수 뒤에도 대시보드가 완료로 보여 회수 버튼이 다시 뜬다.
+        String versionId = documentId + "-r" + Math.addExact(currentRevision, 1);
+        DocumentReference versionRef = db.document(cashflowWeeklyUpdateCompletionVersionPath(actor.tenantId(), versionId));
+        if (get(versionRef).exists()) {
+            throw new WeeklyExpenseConflictException("Weekly compliance history version already exists and is immutable.");
+        }
+        Map<String, Object> version = new LinkedHashMap<>();
+        version.put("id", versionId);
+        version.put("tenantId", actor.tenantId());
+        version.put("projectId", projectId);
+        version.put("yearMonth", request.yearMonth());
+        version.put("weekNo", request.weekNo());
+        version.put("revision", Math.addExact(currentRevision, 1));
+        version.put("complianceStatus", "REOPENED");
+        version.put("deadline", text(current.get("deadline"), ""));
+        version.put("completedAt", "");
+        version.put("reopenedAt", reopenedAt.toString());
+        version.put("reopenedByUid", actor.id());
+        version.put("reopenedByName", actor.name());
+        version.put("reopenReason", request.reason() == null ? "" : request.reason().trim());
+        version.put("previousSnapshotHash", text(current.get("snapshotHash"), ""));
+        version.put("createdAt", reopenedAt.toString());
+        set(versionRef, version);
         return toWeeklyCompletionRecord(
             projectId,
             request.yearMonth(),

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -3839,6 +3839,95 @@ class FirestoreCashflowLeaseGuardTest {
         );
         assertThat(stored.get("status")).isEqualTo("OPEN");
         assertThat(stored.get("reopenReason")).isEqualTo("");
+        // 회수도 불변 버전을 남긴다. 준수 이력은 최고 revision 을 읽으므로 이게 없으면 회수 뒤에도 "완료" 로 남는다.
+        assertThat(fixture.documents.get(
+            "orgs/tenant-a/cashflow_weekly_update_completion_versions/project-a-2026-07-w3-r2"
+        ))
+            .containsEntry("complianceStatus", "REOPENED")
+            .containsEntry("revision", 2L)
+            .containsEntry("completedAt", "");
+    }
+
+    @Test
+    void weeklyComplianceHistoryTreatsAReopenedWeekAsNotCompleted() {
+        // 완료(r1 ON_TIME) 뒤 회수(r2 REOPENED): 이력은 그 주를 완료 아님(PENDING/MISSED) 으로 되돌리고 완료 수에서 뺀다.
+        // 그래야 대시보드의 현재 주가 "완료 대기" 로 바뀌고 회수 버튼이 다시 뜨지 않는다.
+        Fixture fixture = fixture(activeMember(), Map.of());
+        fixture.documents.put(
+            "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w2",
+            lockedWeeklyCompletion("2026-07", 2, 1)
+        );
+        fixture.documents.put(
+            "orgs/tenant-a/cashflow_weekly_update_completion_versions/project-a-2026-07-w2-r1",
+            new LinkedHashMap<>(Map.ofEntries(
+                Map.entry("id", "project-a-2026-07-w2-r1"),
+                Map.entry("tenantId", "tenant-a"),
+                Map.entry("projectId", "project-a"),
+                Map.entry("yearMonth", "2026-07"),
+                Map.entry("weekNo", 2),
+                Map.entry("revision", 1L),
+                Map.entry("complianceStatus", "ON_TIME"),
+                Map.entry("deadline", "2026-07-09T14:59:59Z"),
+                Map.entry("completedAt", "2026-07-08T09:00:00Z"),
+                Map.entry("completedBy", "pm-1")
+            ))
+        );
+        WeeklyExpensePersistence.CashflowWeeklyCompliancePage before = fixture.persistence
+            .findCashflowWeeklyComplianceHistory("tenant-a", "project-a", 50, "");
+        assertThat(before.items()).anySatisfy(item -> {
+            assertThat(item.id()).isEqualTo("2026-07-w2");
+            assertThat(item.status()).isEqualTo("ON_TIME");
+        });
+        assertThat(before.onTimeCount()).isEqualTo(1L);
+
+        fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
+            .reopenCashflowWeeklyUpdate(
+                ACTOR,
+                "project-a",
+                new ReopenCashflowWeeklyUpdateRequest("reopen-w2", "2026-07", 2, 1, null)
+            ));
+
+        WeeklyExpensePersistence.CashflowWeeklyCompliancePage after = fixture.persistence
+            .findCashflowWeeklyComplianceHistory("tenant-a", "project-a", 50, "");
+        assertThat(after.items()).anySatisfy(item -> {
+            assertThat(item.id()).isEqualTo("2026-07-w2");
+            assertThat(item.status()).isIn("PENDING", "MISSED");
+            assertThat(item.completedAt()).isEmpty();
+        });
+        assertThat(after.onTimeCount()).isEqualTo(0L);
+    }
+
+    @Test
+    void weeklyComplianceHistoryTrustsAnOpenCompletionDocumentOverOldVersions() {
+        // REOPENED 버전 도입 이전에 회수된 주(완료 문서 OPEN, 버전은 r1 ON_TIME 뿐)도 완료 아님으로 보여야 한다.
+        Fixture fixture = fixture(activeMember(), Map.of());
+        Map<String, Object> reopened = lockedWeeklyCompletion("2026-07", 2, 2);
+        reopened.put("status", "OPEN");
+        reopened.put("reopenCount", 1L);
+        fixture.documents.put("orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w2", reopened);
+        fixture.documents.put(
+            "orgs/tenant-a/cashflow_weekly_update_completion_versions/project-a-2026-07-w2-r1",
+            new LinkedHashMap<>(Map.ofEntries(
+                Map.entry("id", "project-a-2026-07-w2-r1"),
+                Map.entry("tenantId", "tenant-a"),
+                Map.entry("projectId", "project-a"),
+                Map.entry("yearMonth", "2026-07"),
+                Map.entry("weekNo", 2),
+                Map.entry("revision", 1L),
+                Map.entry("complianceStatus", "ON_TIME"),
+                Map.entry("deadline", "2026-07-09T14:59:59Z"),
+                Map.entry("completedAt", "2026-07-08T09:00:00Z"),
+                Map.entry("completedBy", "pm-1")
+            ))
+        );
+        WeeklyExpensePersistence.CashflowWeeklyCompliancePage page = fixture.persistence
+            .findCashflowWeeklyComplianceHistory("tenant-a", "project-a", 50, "");
+        assertThat(page.items()).anySatisfy(item -> {
+            assertThat(item.id()).isEqualTo("2026-07-w2");
+            assertThat(item.status()).isIn("PENDING", "MISSED");
+            assertThat(item.completedAt()).isEmpty();
+        });
+        assertThat(page.onTimeCount()).isEqualTo(0L);
     }
 
     @Test


### PR DESCRIPTION
김제청년로컬랩2기 회수 409 의 진짜 원인: 회수는 성공(11:09:28)했는데 준수 이력이 버전 문서 최고 revision 만 읽고 회수는 버전을 안 남겨서 화면이 계속 완료 → 회수 버튼 재노출 → 두 번째 클릭 409.

- 회수가 불변 `REOPENED` 버전(r{n+1})을 남김
- 이력: 최신이 REOPENED 면 근거 없음 → PENDING/MISSED 합성 (완료 대기 노랑 / 기한 지남 빨강)
- 이력: 현재 완료 문서가 OPEN 이면 버전과 무관하게 근거 없음 — 데이터 손 안 대고 김제 4주차도 정상화

JVM 전체 423/423 (LeaseGuard 154, 신규 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)