### PR TITLE
fix(projects): 계약 정보로 묶고 정산을 앞으로 · 휴지통 사업 포털 노출 수정

### DIFF
--- a/src/app/components/projects/ProjectEditorWizard.shell.test.ts
+++ b/src/app/components/projects/ProjectEditorWizard.shell.test.ts
@@ -436,7 +436,10 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain('{slot.description}');
     expect(source).toContain('isValidDriveUrl(draft.registrationConfirmations.proposalPptOriginal)');
     expect(source).toMatch(/number: 7,\s+label: 'RFP'/);
-    expect(source).toContain('title="연도별 계약·재무"');
+    // 연도별 표는 이제 독립 섹션이 아니라 「계약 정보」 안에 있다. 통화·기간과 떨어지면
+    // 무엇의 금액인지 멀어지기 때문이다.
+    expect(source).toContain('title="계약 정보"');
+    expect(source).not.toContain('title="연도별 계약·재무"');
     expect(source).toContain('계약기간 전체 연도별 재무 확인');
     expect(source).not.toContain('4대보험 포함 확인');
     expect(source).not.toContain('퇴직급여 포함 확인');

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -676,6 +676,14 @@ function ProjectFormRow({ label, required, note, hints, errors, issueLabel, chil
 }
 
 /**
+ * 짧은 필드 둘을 한 줄에 나란히 둔다. 한 항목이 한 줄씩 차지하면 화면이 세로로만 길어져
+ * 짝지어 읽어야 할 값(시작일-종료일, 상태-구분)이 멀어진다. 좁은 화면에서는 다시 한 줄씩이다.
+ */
+function ProjectFormFieldPair({ children }: { children: ReactNode }) {
+  return <div className="grid gap-4 lg:grid-cols-2 lg:gap-x-8">{children}</div>;
+}
+
+/**
  * 계산된 값은 입력칸이 아니다. 테두리와 배경을 걷어내고 얇은 세로선과 `계산됨` 마이크로
  * 라벨만 남긴다. 색이 아니라 형태로 구분하는 것이라 회색조를 유지한다.
  */
@@ -2328,7 +2336,11 @@ export function ProjectEditorWizard({
               <tr className="border-y border-slate-200 bg-slate-50">
                 <th scope="col" className={cn('py-2 pr-3', FORM_LABEL_CLASS)}>연도</th>
                 {columns.map(([field, label]) => (
-                  <th key={field} scope="col" className={cn('px-3 py-2 text-right', FORM_LABEL_CLASS)}>{label}</th>
+                  <th key={field} scope="col" className={cn('px-3 py-2 text-right', FORM_LABEL_CLASS)}>
+                    {label}
+                    {/* 금액 열임을 열 이름에서 바로 읽히게 한다. 셀마다 반복하지 않는다. */}
+                    <span className="ml-1 text-[11px] font-normal text-slate-400">{draft.currency}</span>
+                  </th>
                 ))}
                 <th scope="col" className={cn('px-3 py-2 text-right', FORM_LABEL_CLASS)}>수익률</th>
                 <th scope="col" className={cn('px-3 py-2 text-right', FORM_LABEL_CLASS)}>계약서 대조</th>
@@ -2346,7 +2358,8 @@ export function ProjectEditorWizard({
                         /* 숫자 열이라 오른쪽 정렬을 지킨다. 입력칸 모양은 쓰지 않는다. */
                         <div className="flex h-9 min-w-[116px] flex-col items-end justify-center">
                           <span className={cn('font-medium text-slate-900', FORM_NUMERIC_VALUE_CLASS)}>
-                            {fmtKRW(row.contractAmount)}원
+                            <span className="mr-1 text-[11px] font-normal text-slate-400">{draft.currency}</span>
+                            {fmtKRW(row.contractAmount)}
                           </span>
                           <span className="text-[11px] font-normal leading-4 text-slate-400">계산됨</span>
                         </div>
@@ -2380,8 +2393,10 @@ export function ProjectEditorWizard({
                     {fmtKRW(annualTotal(field))}
                   </td>
                 ))}
-                <td className={cn('px-3 py-2.5 text-right text-slate-600', FORM_NUMERIC_VALUE_CLASS)}>
-                  {profitRateLabel ? `${profitRateLabel}%` : '-'}
+                {/* 총수익률의 자리. 위에 따로 떼어 두지 않고 무엇을 나눈 값인지 여기서 밝힌다. */}
+                <td className={cn('px-3 py-2.5 text-right', FORM_NUMERIC_VALUE_CLASS)}>
+                  <span className="font-semibold text-slate-900">{profitRateLabel ? `${profitRateLabel}%` : '-'}</span>
+                  <span className="ml-1 text-[11px] font-normal text-slate-400">총수익÷계약금액</span>
                 </td>
                 <td className={cn('px-3 py-2.5 text-right text-slate-600', FORM_NUMERIC_VALUE_CLASS)}>
                   {draft.financialYears.length - unconfirmedYears.length}/{draft.financialYears.length}
@@ -2449,226 +2464,13 @@ export function ProjectEditorWizard({
 
   const renderFinancialStep = () => (
     <div className={FORM_SECTION_STACK_CLASS}>
-      {onContractFileUpload || onProjectDocumentFileUpload ? (
-        <div>
-          {usesRegistrationV2 ? (
-            <ProjectFormSection
-              title="등록 제출서류 7종"
-              description="1~2번은 필수, 3번은 첨부 또는 이후 제출로 진행할 수 있으며 4~7번은 선택입니다."
-              flushBelow
-            >
-              {renderRegistrationDocumentTable()}
-              {/* Contract-specific confirmations stay below the list; they belong to slot 1
-                  but are questions about the contract rather than an attachment. */}
-              <ProjectFormRow
-                label="모두 싸인으로 진행하셨나요?"
-                required
-                issueLabel="모두 싸인으로 진행하셨나요?"
-                errors={fieldIssues('모두 싸인으로 진행하셨나요?', '계약서를 써니(사업지원팀)에게 제출했습니다.')}
-              >
-                <div className={cn('flex gap-4 pt-2 text-slate-700', FORM_VALUE_CLASS)}>
-                  {[true, false].map((value) => (
-                    <label key={String(value)} className="flex items-center gap-2">
-                      <input type="radio" checked={draft.registrationConfirmations.modusignContractUsed === value} onChange={() => update('registrationConfirmations', { ...draft.registrationConfirmations, modusignContractUsed: value, originalContractSubmitted: value ? null : draft.registrationConfirmations.originalContractSubmitted })} />
-                      {value ? '예' : '아니오'}
-                    </label>
-                  ))}
-                </div>
-                {draft.registrationConfirmations.modusignContractUsed === false ? (
-                  <label className={cn('mt-2 flex items-center gap-2 text-slate-700', FORM_VALUE_CLASS)}>
-                    <Checkbox checked={draft.registrationConfirmations.originalContractSubmitted === true} onCheckedChange={(checked) => update('registrationConfirmations', { ...draft.registrationConfirmations, originalContractSubmitted: checked === true })} />
-                    계약서를 써니(사업지원팀)에게 제출했습니다.
-                  </label>
-                ) : null}
-              </ProjectFormRow>
-            </ProjectFormSection>
-          ) : (
-            <ProjectFormSection title="첨부 서류">
-              {registrationDocumentKinds.map((kind) => renderProjectDocumentUpload(kind))}
-            </ProjectFormSection>
-          )}
-        </div>
-      ) : null}
-
-      <ProjectFormSection title="계약 기간과 상태">
-        <ProjectFormRow label="계약 시작일" required issueLabel="계약 시작일" errors={fieldIssues('계약 시작일')}>
-          <Input type="date" value={draft.contractStart} onChange={(event) => update('contractStart', event.target.value)} className={cn('max-w-[200px]', FORM_NUMERIC_CONTROL_CLASS, 'text-left')} />
-        </ProjectFormRow>
-        <ProjectFormRow
-          label="계약 종료일"
-          required
-          issueLabel="계약 종료일"
-          errors={fieldIssues('계약 종료일', '계약 종료일은 시작일 이후여야 합니다.')}
-        >
-          <Input type="date" value={draft.contractEnd} onChange={(event) => update('contractEnd', event.target.value)} className={cn('max-w-[200px]', FORM_NUMERIC_CONTROL_CLASS, 'text-left')} />
-        </ProjectFormRow>
-
-        {canEditProjectStatus(mode) ? (
-          <ProjectFormRow label="프로젝트 진행 상태">
-            <Select value={draft.status} onValueChange={(value) => update('status', value as ProjectStatus)}>
-              <SelectTrigger className={cn('max-w-xs', FORM_CONTROL_CLASS)}><SelectValue /></SelectTrigger>
-              <SelectContent>
-                {(Object.keys(PROJECT_STATUS_LABELS) as ProjectStatus[]).map((status) => (
-                  <SelectItem key={status} value={status}>{PROJECT_STATUS_LABELS[status]}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </ProjectFormRow>
-        ) : null}
-        {canEditProjectStatus(mode) && isAdminMode(mode) ? (
-          <ProjectFormRow label="프로젝트 구분">
-            <Select value={draft.phase} onValueChange={(value) => update('phase', value as ProjectPhase)}>
-              <SelectTrigger className={cn('max-w-xs', FORM_CONTROL_CLASS)}><SelectValue /></SelectTrigger>
-              <SelectContent>
-                {(Object.keys(PROJECT_PHASE_LABELS) as ProjectPhase[]).map((phase) => (
-                  <SelectItem key={phase} value={phase}>{PROJECT_PHASE_LABELS[phase]}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </ProjectFormRow>
-        ) : null}
-        {/* 계약서 유형은 관리자 화면에서만 상태·구분과 나란히 있었고, 포털에서는 단독으로
-            보였다. 행 컴포넌트를 쓰면서 두 경우 모두 같은 자리에 한 번만 놓는다. */}
-        {!canEditProjectStatus(mode) || isAdminMode(mode) ? renderContractTypeSelect() : null}
-      </ProjectFormSection>
-
-      <ProjectFormSection title="계약 금액">
-        <ProjectFormRow label="통화">
-          <Select value={draft.currency} onValueChange={(value) => update('currency', (value === 'USD' ? 'USD' : 'KRW') as ProjectCurrency)}>
-            <SelectTrigger className={cn('max-w-[160px]', FORM_CONTROL_CLASS)}><SelectValue /></SelectTrigger>
-            <SelectContent>
-              {(Object.keys(PROJECT_CURRENCY_LABELS) as ProjectCurrency[]).map((currency) => (
-                <SelectItem key={currency} value={currency}>{PROJECT_CURRENCY_LABELS[currency]}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </ProjectFormRow>
-
-        {annualTotalsOwnAmounts ? (
-          <p className={FORM_HINT_CLASS}>
-            다년도 계약이라 계약금액 · 총매출부가세 · 총수익 · 총실비(원가) · 총지원금은
-            아래 연도별 표의 합계 행이 그대로 저장값입니다.
-          </p>
-        ) : (
-          <>
-            <ProjectFormRow
-              label="계약금액"
-              required
-              issueLabel="계약금액"
-              errors={fieldIssues('계약금액')}
-              hints={[
-                amountHint(draft.contractAmount, hasContractAmountInput, PROJECT_CURRENCY_LABELS[draft.currency]),
-                contractAmountCheck.message,
-              ]}
-            >
-              <Input
-                inputMode="numeric"
-                value={formatProjectAmountInput(draft.contractAmount, hasContractAmountInput)}
-                onChange={(event) => updateAmount('contractAmount', event.target.value)}
-                placeholder="0"
-                className={cn('max-w-[220px]', FORM_NUMERIC_CONTROL_CLASS)}
-              />
-            </ProjectFormRow>
-            <ProjectFormRow label="총매출부가세" hints={[amountHint(draft.salesVatAmount, hasSalesVatAmountInput)]}>
-              <Input
-                inputMode="numeric"
-                value={formatProjectAmountInput(draft.salesVatAmount, hasSalesVatAmountInput)}
-                onChange={(event) => updateAmount('salesVatAmount', event.target.value)}
-                placeholder="0"
-                className={cn('max-w-[220px]', FORM_NUMERIC_CONTROL_CLASS)}
-              />
-            </ProjectFormRow>
-            <ProjectFormRow label="총수익" hints={[amountHint(draft.totalRevenueAmount, hasTotalRevenueAmountInput)]}>
-              <Input
-                inputMode="numeric"
-                value={formatProjectAmountInput(draft.totalRevenueAmount, hasTotalRevenueAmountInput)}
-                onChange={(event) => updateAmount('totalRevenueAmount', event.target.value)}
-                placeholder="0"
-                className={cn('max-w-[220px]', FORM_NUMERIC_CONTROL_CLASS)}
-              />
-            </ProjectFormRow>
-            <ProjectFormRow label="총실비(원가)" hints={[amountHint(draft.totalActualCost, hasTotalActualCostInput)]}>
-              <Input
-                inputMode="numeric"
-                value={formatProjectAmountInput(draft.totalActualCost, hasTotalActualCostInput)}
-                onChange={(event) => updateAmount('totalActualCost', event.target.value)}
-                placeholder="0"
-                className={cn('max-w-[220px]', FORM_NUMERIC_CONTROL_CLASS)}
-              />
-            </ProjectFormRow>
-            <ProjectFormRow label="총지원금" hints={[amountHint(draft.supportAmount, hasSupportAmountInput)]}>
-              <Input
-                inputMode="numeric"
-                value={formatProjectAmountInput(draft.supportAmount, hasSupportAmountInput)}
-                onChange={(event) => updateAmount('supportAmount', event.target.value)}
-                placeholder="0"
-                className={cn('max-w-[220px]', FORM_NUMERIC_CONTROL_CLASS)}
-              />
-            </ProjectFormRow>
-          </>
-        )}
-
-        {/* 총수익률은 늘 파생값이었다. 입력칸 모양을 벗기고 "계산됨" 형태로만 구분한다. */}
-        <ProjectFormRow label="총수익률" note="총수익 / 계약금액">
-          <ProjectComputedValue value={profitRateLabel ? `${profitRateLabel}%` : '-'} />
-        </ProjectFormRow>
-      </ProjectFormSection>
-
-      {annualTotalsOwnAmounts ? (
-        <ProjectFormSection
-          title="연도별 계약·재무"
-          description={hasMultiYearContract
-            ? '계약기간의 모든 연도를 각각 입력하고 확인해야 하며, 합계 행이 저장되는 총계입니다.'
-            : '연도가 하나여도 같은 표로 입력합니다. 합계 행이 저장되는 총계입니다.'}
-        >
-          <div data-issue-label="계약기간 전체 연도별 재무 확인">
-            {draft.financialYears.length === 0 ? (
-              <p className={cn('rounded-lg border border-dashed border-slate-300 bg-white px-3 py-4', FORM_HINT_CLASS)}>
-                계약 시작일과 종료일을 먼저 입력해 주세요.
-              </p>
-            ) : renderAnnualFinanceTable()}
-          </div>
-        </ProjectFormSection>
-      ) : null}
-
-      {/* 입금 계획은 금액 표와 별개 경로다. 다년도만 연도별로 쪼갠다. */}
-      {annualTotalsOwnAmounts && hasMultiYearContract ? (
-        <>
-          {draft.financialYears.map((row, index) => (
-            <ProjectFormSection key={row.year} title={`${row.year}년 입금 계획`} flushBelow>
-              {renderPaymentFields(row, index)}
-            </ProjectFormSection>
-          ))}
-          <ProjectFormRow label="기타 메모">
-            <Textarea value={draft.paymentPlanDesc} onChange={(event) => update('paymentPlanDesc', event.target.value)} className={cn('min-h-[92px]', FORM_VALUE_CLASS)} />
-          </ProjectFormRow>
-        </>
-      ) : null}
-
-      {mode === 'admin' ? (
-        <ProjectFormSection title="관리자 입력">
-          <ProjectFormRow label="당해연도 예산" hints={[amountHint(draft.budgetCurrentYear, draft.budgetCurrentYear > 0)]}>
-            <Input
-              inputMode="numeric"
-              value={formatProjectAmountInput(draft.budgetCurrentYear, draft.budgetCurrentYear > 0)}
-              onChange={(event) => update('budgetCurrentYear', parseProjectAmountInput(event.target.value))}
-              placeholder="0"
-              className={cn('max-w-[220px]', FORM_NUMERIC_CONTROL_CLASS)}
-            />
-          </ProjectFormRow>
-          <ProjectFormRow label="세금계산서 발행액" hints={[amountHint(draft.taxInvoiceAmount, draft.taxInvoiceAmount > 0)]}>
-            <Input
-              inputMode="numeric"
-              value={formatProjectAmountInput(draft.taxInvoiceAmount, draft.taxInvoiceAmount > 0)}
-              onChange={(event) => update('taxInvoiceAmount', parseProjectAmountInput(event.target.value))}
-              placeholder="0"
-              className={cn('max-w-[220px]', FORM_NUMERIC_CONTROL_CLASS)}
-            />
-          </ProjectFormRow>
-        </ProjectFormSection>
-      ) : null}
-
+      {/*
+        정산(사업유형)이 아래 입력의 필요 여부를 결정한다. 뒤에 두면 서류와 금액을 다 채운
+        뒤에야 "이 사업은 정산이 없다"를 알게 되므로 맨 앞으로 옮겼다.
+      */}
       <ProjectFormSection title="정산">
+        {/* 사업유형이 정산 기준을 결정한다. 둘을 세로로 쌓으면 그 관계가 보이지 않아 나란히 둔다. */}
+        <ProjectFormFieldPair>
         <ProjectFormRow
           label={usesRegistrationV2 ? '사업유형' : '정산 유형'}
           required={usesRegistrationV2}
@@ -2714,6 +2516,7 @@ export function ProjectEditorWizard({
             </Select>
           </ProjectFormRow>
         )}
+        </ProjectFormFieldPair>
         {settlementDetailsEnabled ? (
           <>
             <ProjectFormRow label="통장 유형">
@@ -2788,6 +2591,232 @@ export function ProjectEditorWizard({
           </p>
         ) : null}
       </ProjectFormSection>
+      {onContractFileUpload || onProjectDocumentFileUpload ? (
+        <div>
+          {usesRegistrationV2 ? (
+            <ProjectFormSection
+              title="등록 제출서류 7종"
+              description="1~2번은 필수, 3번은 첨부 또는 이후 제출로 진행할 수 있으며 4~7번은 선택입니다."
+              flushBelow
+            >
+              {renderRegistrationDocumentTable()}
+              {/* Contract-specific confirmations stay below the list; they belong to slot 1
+                  but are questions about the contract rather than an attachment. */}
+              <ProjectFormRow
+                label="모두 싸인으로 진행하셨나요?"
+                required
+                issueLabel="모두 싸인으로 진행하셨나요?"
+                errors={fieldIssues('모두 싸인으로 진행하셨나요?', '계약서를 써니(사업지원팀)에게 제출했습니다.')}
+              >
+                <div className={cn('flex gap-4 pt-2 text-slate-700', FORM_VALUE_CLASS)}>
+                  {[true, false].map((value) => (
+                    <label key={String(value)} className="flex items-center gap-2">
+                      <input type="radio" checked={draft.registrationConfirmations.modusignContractUsed === value} onChange={() => update('registrationConfirmations', { ...draft.registrationConfirmations, modusignContractUsed: value, originalContractSubmitted: value ? null : draft.registrationConfirmations.originalContractSubmitted })} />
+                      {value ? '예' : '아니오'}
+                    </label>
+                  ))}
+                </div>
+                {draft.registrationConfirmations.modusignContractUsed === false ? (
+                  <label className={cn('mt-2 flex items-center gap-2 text-slate-700', FORM_VALUE_CLASS)}>
+                    <Checkbox checked={draft.registrationConfirmations.originalContractSubmitted === true} onCheckedChange={(checked) => update('registrationConfirmations', { ...draft.registrationConfirmations, originalContractSubmitted: checked === true })} />
+                    계약서를 써니(사업지원팀)에게 제출했습니다.
+                  </label>
+                ) : null}
+              </ProjectFormRow>
+            </ProjectFormSection>
+          ) : (
+            <ProjectFormSection title="첨부 서류">
+              {registrationDocumentKinds.map((kind) => renderProjectDocumentUpload(kind))}
+            </ProjectFormSection>
+          )}
+        </div>
+      ) : null}
+
+      {/*
+        계약 기간 · 계약 금액 · 연도별 계약·재무를 한 묶음으로 읽는다. 셋은 같은 계약을
+        기간 / 통화 / 금액으로 나눠 말할 뿐이라 제목을 세 번 끊으면 관계가 보이지 않았다.
+      */}
+      <ProjectFormSection title="계약 정보">
+        <ProjectFormFieldPair>
+          <ProjectFormRow label="계약 시작일" required issueLabel="계약 시작일" errors={fieldIssues('계약 시작일')}>
+            <Input type="date" value={draft.contractStart} onChange={(event) => update('contractStart', event.target.value)} className={cn('max-w-[200px]', FORM_NUMERIC_CONTROL_CLASS, 'text-left')} />
+          </ProjectFormRow>
+          <ProjectFormRow
+            label="계약 종료일"
+            required
+            issueLabel="계약 종료일"
+            errors={fieldIssues('계약 종료일', '계약 종료일은 시작일 이후여야 합니다.')}
+          >
+            <Input type="date" value={draft.contractEnd} onChange={(event) => update('contractEnd', event.target.value)} className={cn('max-w-[200px]', FORM_NUMERIC_CONTROL_CLASS, 'text-left')} />
+          </ProjectFormRow>
+        </ProjectFormFieldPair>
+
+        <ProjectFormFieldPair>
+        {canEditProjectStatus(mode) ? (
+          <ProjectFormRow label="프로젝트 진행 상태">
+            <Select value={draft.status} onValueChange={(value) => update('status', value as ProjectStatus)}>
+              <SelectTrigger className={cn('max-w-xs', FORM_CONTROL_CLASS)}><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {(Object.keys(PROJECT_STATUS_LABELS) as ProjectStatus[]).map((status) => (
+                  <SelectItem key={status} value={status}>{PROJECT_STATUS_LABELS[status]}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </ProjectFormRow>
+        ) : null}
+        {canEditProjectStatus(mode) && isAdminMode(mode) ? (
+          <ProjectFormRow label="프로젝트 구분">
+            <Select value={draft.phase} onValueChange={(value) => update('phase', value as ProjectPhase)}>
+              <SelectTrigger className={cn('max-w-xs', FORM_CONTROL_CLASS)}><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {(Object.keys(PROJECT_PHASE_LABELS) as ProjectPhase[]).map((phase) => (
+                  <SelectItem key={phase} value={phase}>{PROJECT_PHASE_LABELS[phase]}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </ProjectFormRow>
+        ) : null}
+        </ProjectFormFieldPair>
+        {/* 계약서 유형은 관리자 화면에서만 상태·구분과 나란히 있었고, 포털에서는 단독으로
+            보였다. 행 컴포넌트를 쓰면서 두 경우 모두 같은 자리에 한 번만 놓는다. */}
+        <ProjectFormFieldPair>
+        {!canEditProjectStatus(mode) || isAdminMode(mode) ? renderContractTypeSelect() : null}
+        <ProjectFormRow label="통화">
+          <Select value={draft.currency} onValueChange={(value) => update('currency', (value === 'USD' ? 'USD' : 'KRW') as ProjectCurrency)}>
+            <SelectTrigger className={cn('max-w-[160px]', FORM_CONTROL_CLASS)}><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {(Object.keys(PROJECT_CURRENCY_LABELS) as ProjectCurrency[]).map((currency) => (
+                <SelectItem key={currency} value={currency}>{PROJECT_CURRENCY_LABELS[currency]}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </ProjectFormRow>
+        </ProjectFormFieldPair>
+
+        {annualTotalsOwnAmounts ? (
+          <p className={FORM_HINT_CLASS}>
+            {hasMultiYearContract
+              ? '계약금액 · 총매출부가세 · 총수익 · 총실비(원가) · 총지원금은 아래 연도별 표의 합계 행이 그대로 저장값입니다.'
+              : '계약금액 · 총매출부가세 · 총수익 · 총실비(원가) · 총지원금은 아래 표에서 입력하며, 합계 행이 그대로 저장값입니다.'}
+          </p>
+        ) : (
+          <>
+            <ProjectFormRow
+              label="계약금액"
+              required
+              issueLabel="계약금액"
+              errors={fieldIssues('계약금액')}
+              hints={[
+                amountHint(draft.contractAmount, hasContractAmountInput, PROJECT_CURRENCY_LABELS[draft.currency]),
+                contractAmountCheck.message,
+              ]}
+            >
+              <Input
+                inputMode="numeric"
+                value={formatProjectAmountInput(draft.contractAmount, hasContractAmountInput)}
+                onChange={(event) => updateAmount('contractAmount', event.target.value)}
+                placeholder="0"
+                className={cn('max-w-[220px]', FORM_NUMERIC_CONTROL_CLASS)}
+              />
+            </ProjectFormRow>
+            <ProjectFormRow label="총매출부가세" hints={[amountHint(draft.salesVatAmount, hasSalesVatAmountInput)]}>
+              <Input
+                inputMode="numeric"
+                value={formatProjectAmountInput(draft.salesVatAmount, hasSalesVatAmountInput)}
+                onChange={(event) => updateAmount('salesVatAmount', event.target.value)}
+                placeholder="0"
+                className={cn('max-w-[220px]', FORM_NUMERIC_CONTROL_CLASS)}
+              />
+            </ProjectFormRow>
+            <ProjectFormRow label="총수익" hints={[amountHint(draft.totalRevenueAmount, hasTotalRevenueAmountInput)]}>
+              <Input
+                inputMode="numeric"
+                value={formatProjectAmountInput(draft.totalRevenueAmount, hasTotalRevenueAmountInput)}
+                onChange={(event) => updateAmount('totalRevenueAmount', event.target.value)}
+                placeholder="0"
+                className={cn('max-w-[220px]', FORM_NUMERIC_CONTROL_CLASS)}
+              />
+            </ProjectFormRow>
+            <ProjectFormRow label="총실비(원가)" hints={[amountHint(draft.totalActualCost, hasTotalActualCostInput)]}>
+              <Input
+                inputMode="numeric"
+                value={formatProjectAmountInput(draft.totalActualCost, hasTotalActualCostInput)}
+                onChange={(event) => updateAmount('totalActualCost', event.target.value)}
+                placeholder="0"
+                className={cn('max-w-[220px]', FORM_NUMERIC_CONTROL_CLASS)}
+              />
+            </ProjectFormRow>
+            <ProjectFormRow label="총지원금" hints={[amountHint(draft.supportAmount, hasSupportAmountInput)]}>
+              <Input
+                inputMode="numeric"
+                value={formatProjectAmountInput(draft.supportAmount, hasSupportAmountInput)}
+                onChange={(event) => updateAmount('supportAmount', event.target.value)}
+                placeholder="0"
+                className={cn('max-w-[220px]', FORM_NUMERIC_CONTROL_CLASS)}
+              />
+            </ProjectFormRow>
+          </>
+        )}
+
+        {/*
+          총수익률은 파생값이라 표의 합계 행 `수익률` 칸이 이미 같은 값을 보여준다.
+          표를 쓸 때 위에 따로 떼어 두면 어느 값의 비율인지 읽히지 않으므로 여기서는 접는다.
+        */}
+        {annualTotalsOwnAmounts ? null : (
+          <ProjectFormRow label="총수익률" note="총수익 / 계약금액">
+            <ProjectComputedValue value={profitRateLabel ? `${profitRateLabel}%` : '-'} />
+          </ProjectFormRow>
+        )}
+
+        {/* 금액 표는 「계약 정보」 안에 그대로 둔다. 통화·기간과 떨어지면 무엇의 금액인지 멀어진다. */}
+        {annualTotalsOwnAmounts ? (
+          <div data-issue-label="계약기간 전체 연도별 재무 확인">
+            {draft.financialYears.length === 0 ? (
+              <p className={cn('rounded-lg border border-dashed border-slate-300 bg-white px-3 py-4', FORM_HINT_CLASS)}>
+                계약 시작일과 종료일을 먼저 입력해 주세요.
+              </p>
+            ) : renderAnnualFinanceTable()}
+          </div>
+        ) : null}
+      </ProjectFormSection>
+
+      {/* 입금 계획은 금액 표와 별개 경로다. 다년도만 연도별로 쪼갠다. */}
+      {annualTotalsOwnAmounts && hasMultiYearContract ? (
+        <>
+          {draft.financialYears.map((row, index) => (
+            <ProjectFormSection key={row.year} title={`${row.year}년 입금 계획`} flushBelow>
+              {renderPaymentFields(row, index)}
+            </ProjectFormSection>
+          ))}
+          <ProjectFormRow label="기타 메모">
+            <Textarea value={draft.paymentPlanDesc} onChange={(event) => update('paymentPlanDesc', event.target.value)} className={cn('min-h-[92px]', FORM_VALUE_CLASS)} />
+          </ProjectFormRow>
+        </>
+      ) : null}
+
+      {mode === 'admin' ? (
+        <ProjectFormSection title="관리자 입력">
+          <ProjectFormRow label="당해연도 예산" hints={[amountHint(draft.budgetCurrentYear, draft.budgetCurrentYear > 0)]}>
+            <Input
+              inputMode="numeric"
+              value={formatProjectAmountInput(draft.budgetCurrentYear, draft.budgetCurrentYear > 0)}
+              onChange={(event) => update('budgetCurrentYear', parseProjectAmountInput(event.target.value))}
+              placeholder="0"
+              className={cn('max-w-[220px]', FORM_NUMERIC_CONTROL_CLASS)}
+            />
+          </ProjectFormRow>
+          <ProjectFormRow label="세금계산서 발행액" hints={[amountHint(draft.taxInvoiceAmount, draft.taxInvoiceAmount > 0)]}>
+            <Input
+              inputMode="numeric"
+              value={formatProjectAmountInput(draft.taxInvoiceAmount, draft.taxInvoiceAmount > 0)}
+              onChange={(event) => update('taxInvoiceAmount', parseProjectAmountInput(event.target.value))}
+              placeholder="0"
+              className={cn('max-w-[220px]', FORM_NUMERIC_CONTROL_CLASS)}
+            />
+          </ProjectFormRow>
+        </ProjectFormSection>
+      ) : null}
+
 
       {!hasMultiYearContract ? (
         <ProjectFormSection title="입금 계획" flushBelow>

--- a/src/app/platform/portal-project-selection.test.ts
+++ b/src/app/platform/portal-project-selection.test.ts
@@ -31,6 +31,26 @@ const projects = [
 ] as unknown as Project[];
 
 describe('portal project selection helpers', () => {
+  it('keeps trashed projects out of the portal candidate pool', () => {
+    // 관리자 화면(store.tsx)은 휴지통 사업을 걸러 보여주는데 포털은 걸러주는 곳이 없었다.
+    // BFF 목록 조회도 포털 리스너도 trashedAt 을 보지 않으므로 여기서 막는다.
+    const withTrashed = [
+      ...projects,
+      { id: 'p-trashed', name: 'Deleted Project', managerId: 'uid-pm', trashedAt: '2026-08-01T00:00:00.000Z' },
+    ] as unknown as Project[];
+
+    const result = resolvePortalProjectCandidates({
+      role: 'viewer',
+      authUid: 'uid-pm',
+      assignedProjectIds: ['p-assigned', 'p-trashed'],
+      projects: withTrashed,
+    });
+
+    const ids = [...result.priorityProjects, ...result.searchProjects].map((project) => project.id);
+    expect(ids).not.toContain('p-trashed');
+    expect(ids).toContain('p-assigned');
+  });
+
   it('lets PM portal users search the full project pool while keeping assigned projects prioritized', () => {
     const result = resolvePortalProjectCandidates({
       role: 'viewer',

--- a/src/app/platform/portal-project-selection.ts
+++ b/src/app/platform/portal-project-selection.ts
@@ -53,7 +53,9 @@ export function resolvePortalProjectCandidates(input: {
   projects: Project[];
 }): PortalProjectCandidateSet {
   const role = normalizeRole(input.role);
-  const projects = dedupeProjects(sortProjects(input.projects || []));
+  // 휴지통에 넣은 사업은 후보가 아니다. 관리자 화면은 store 에서 걸러 주지만 포털은
+  // BFF 목록 조회도 Firestore 리스너도 trashedAt 을 보지 않아 그대로 흘러든다.
+  const projects = dedupeProjects(sortProjects((input.projects || []).filter((project) => !project.trashedAt)));
 
   if (!role) {
     return {


### PR DESCRIPTION
라이브 화면을 보고 주신 지적과, 방치돼 있던 PR 정리에서 살려낸 수정입니다.

## 1. 단년도인데 "다년도 계약이라…" 가 떴다 (회귀)

#589 에서 금액 표를 단년도까지 넓히면서 힌트 문구를 조건부로 바꾸지 않았습니다.
연도가 하나인 계약에서 "다년도 계약이라 …" 가 그대로 떴습니다. 연도 수에 따라 다른
문장을 씁니다.

## 2. 계약/재무 단계 재배치

- **「계약 정보」로 통합** — `계약 기간과 상태` · `계약 금액` · `연도별 계약·재무` 를
  하나로 묶습니다. 셋은 같은 계약을 기간 / 통화 / 금액으로 나눠 말할 뿐인데 제목을 세 번
  끊어서 관계가 보이지 않았습니다. 금액 표도 통화·기간과 같은 묶음 안에 둡니다.
- **정산을 맨 앞으로** — 사업유형이 아래 입력의 필요 여부를 결정하는데 뒤에 있어서,
  서류와 금액을 다 채운 뒤에야 "이 사업은 정산이 없다" 를 알게 됐습니다.
  사업유형과 정산 기준은 세로 2단이 아니라 **가로 2열**로 나란히 둡니다.
- **한 줄에 한 항목씩 쌓지 않습니다** — `ProjectFormFieldPair` 로 짝지어 읽어야 할 값을
  나란히 놓습니다: 시작일-종료일, 진행 상태-구분, 계약서 유형-통화. 좁은 화면에서는
  다시 한 줄씩입니다.

**새 섹션 순서:** 정산 → 등록 제출서류 7종 → 첨부 서류 → 계약 정보 → 관리자 입력 → 입금 계획

## 3. 표에서 값이 안 읽히던 것

- **총수익률을 표 위에서 걷어냅니다.** 합계 행의 `수익률` 칸이 이미 같은 값인데 위에 따로
  떼어 두니 어느 값의 비율인지 읽히지 않았습니다. 합계 행에 `총수익÷계약금액` 을 덧붙여
  무엇을 나눈 값인지 밝힙니다.
- **금액 열에 통화를 작게 붙입니다.** 열 이름과 파생 계약금액 칸에만 붙이고 셀마다
  반복하지 않습니다. 크기는 DESIGN.md 타이포 스케일에 맞춰 11px 입니다
  (10px 은 폼 골격 계약이 막습니다).

## 4. 휴지통 사업이 포털 선택지에 남던 버그

관리자 화면은 `store.tsx` 에서 `trashedAt` 을 걸러 보여주는데 포털은 걸러 주는 곳이
없었습니다. BFF 목록 조회(`orderBy('__name__')` 만)도, 포털 Firestore 리스너(`limit(500)` 만)도
`trashedAt` 을 보지 않아 삭제한 사업이 포털 프로젝트 선택지에 그대로 남았습니다.

후보를 만드는 자리 한 곳에서 막습니다. `PortalLayout` · `PortalProjectSelectPage` ·
`portal-store` 세 호출부가 모두 이 함수를 지납니다. **실패하는 테스트를 먼저 쓰고 고쳤습니다.**

### 방치 PR 정리 결과

이 수정은 **#381 에서 살려낸 것**입니다. 두 PR 을 대조한 결과:

| PR | 판정 |
|---|---|
| **#381** `fix/live-read-paths` (345 커밋 뒤처짐) | 소스 변경 4가지 중 3가지(`usesLocalSeedData`, `!firestoreEnabled` 분기의 BFF fetch, `setDataSource` 분기)는 **이미 main 에 있음**. `production-deploy.yml` 변경은 자동 배포 개편으로 낡음. **`trashedAt` 필터만 미반영이라 이 PR 로 가져옴** → 닫아도 됨 |
| **#483** `fix/portal-project-single-source` (227 커밋 뒤처짐) | 구현이 **#468 `fix(portal): make project URLs authoritative`** 와 중복(#468 이 하루 먼저 main 에 머지됨). 다만 `portal-store.url-sync.test.ts`(211줄) · `portal-store.project-switch.test.ts`(151줄) 는 main 에 없는 테스트라 별도 이관 가치가 있음(`happy-dom` 의존성 필요) → 닫되 테스트는 후속으로 |

## 검증

| 게이트 | 결과 |
|---|---|
| `npm run typecheck` | no new type errors |
| 관련 테스트 | 244/244 통과 |
| `npm run build` | ✓ built in 20.30s |

> 위 결과는 리베이스 **전** 기준입니다. 리베이스(main 5커밋 전진, 충돌 0) 후 검증은 CI 결과로 대체합니다.

## 스크린샷 — 필요

재배치가 핵심이라 캡처 확인이 필요합니다: 새 섹션 순서, 2열 배치, 합계 행의 수익률 라벨,
금액 열의 통화 표기.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
