### PR TITLE
feat(cashflow): 주정산 완료 요청 → 회수 → 확정 (월결산과 정렬)

### DIFF
--- a/policies/jvm-command-roles.json
+++ b/policies/jvm-command-roles.json
@@ -152,6 +152,16 @@
         "viewer"
       ]
     },
+    "CONFIRM_CASHFLOW_WEEKLY_UPDATE_COMMAND": {
+      "command": "cashflowWeeklyUpdate.confirm",
+      "roles": [
+        "admin",
+        "finance",
+        "pm",
+        "tenant_admin",
+        "viewer"
+      ]
+    },
     "DECIDE_CASHFLOW_MONTH_REOPEN_COMMAND": {
       "command": "cashflowMonth.decideReopen",
       "roles": [

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -164,16 +164,33 @@ function buildCashflowMonthCloseActions({
           ? '현재 주간 정산 대상을 서버에서 확인하지 못했습니다.'
           : '이미 완료된 주간 정산입니다.',
     ),
-    // 주정산 회수: 완료된 주가 있으면 즉시. 결재 없음, 사유 없음.
+    // 주정산 회수: 완료 요청(SUBMITTED) 상태에서만, 즉시, 사유 없음. 확정(LOCKED) 뒤엔 사유 있는 재오픈만.
     reopenWeekly: cashflowAction(
-      weeklyRoleAllowed && Boolean(currentDeadline) && Boolean(readOptionalText(currentDeadline?.completedAt)),
+      weeklyRoleAllowed && Boolean(currentDeadline) && readOptionalText(currentDeadline?.lockState) === 'SUBMITTED',
       !actionAllowed
         ? accessGuide
         : !weeklyRoleAllowed
         ? '현금흐름 주간 정산 회수 권한이 없습니다.'
         : !currentDeadline
           ? '현재 주간 정산 대상을 서버에서 확인하지 못했습니다.'
-          : '아직 완료되지 않은 주간 정산입니다.',
+          : readOptionalText(currentDeadline?.lockState) === 'LOCKED'
+            ? '조직장이 확정한 주간 정산은 회수할 수 없습니다. 사유와 함께 재오픈해야 합니다.'
+            : '아직 완료 요청되지 않은 주간 정산입니다.',
+    ),
+    // 주정산 확정: 완료 요청된 주를 프로젝트 조직장이 잠금으로 확정.
+    confirmWeekly: cashflowAction(
+      weeklyRoleAllowed
+        && Boolean(currentDeadline)
+        && readOptionalText(currentDeadline?.lockState) === 'SUBMITTED'
+        && Boolean(readOptionalText(req.context?.actorId))
+        && readOptionalText(dashboard?.project?.executiveApproverId) === readOptionalText(req.context?.actorId),
+      !actionAllowed
+        ? accessGuide
+        : !currentDeadline
+          ? '현재 주간 정산 대상을 서버에서 확인하지 못했습니다.'
+          : readOptionalText(currentDeadline?.lockState) !== 'SUBMITTED'
+            ? '완료 요청된 주간 정산만 확정할 수 있습니다.'
+            : '프로젝트 조직장만 주간 정산을 확정할 수 있습니다.',
     ),
     changeExecutiveApprover: cashflowAction(
       requestAvailable
@@ -341,8 +358,10 @@ function cashflowSectionErrorsForResponse(sectionErrors) {
 // JVM 이 내는 주간 준수 상태는 ON_TIME · COMPLETED_LATE · MISSED · PENDING 넷이다
 // (FirestoreInheritedWeeklyExpensePersistence). 예전 이 표는 존재하지 않는 COMPLETED 를
 // 기다리고 ON_TIME 을 몰라서, 기한 내 완료한 주차를 "확인 필요" 로 그렸다.
-export function cashflowWeeklyStatusLabel(status, available) {
+// lockState: SUBMITTED = 완료 요청됨(조직장 확정 대기). LOCKED/없음 = 준수 상태 그대로.
+export function cashflowWeeklyStatusLabel(status, available, lockState = '') {
   if (!available) return '주간 정산 상태 확인 필요';
+  if (lockState === 'SUBMITTED') return '확정 대기';
   if (!status) return '';
   if (status === 'ON_TIME') return '기한 내 완료';
   if (status === 'COMPLETED_LATE') return '기한 후 완료';
@@ -397,12 +416,14 @@ function cashflowMonthPresentation(entry, available) {
   };
 }
 
-export function cashflowWeekSurfaceTone({ month, weeklyStatus, weeklyAvailable, isCurrent }) {
+export function cashflowWeekSurfaceTone({ month, weeklyStatus, weeklyAvailable, isCurrent, weeklyLockState = '' }) {
   if (month.tone === 'unavailable') return 'unavailable';
   // 월 결산 기한 초과는 배경이 아니라 테두리로 그린다 (week.overdue). 배경 빨강은 주간 놓침만.
   // 같은 빨강 하나로 둘을 그리니 무엇이 늦었는지 화면에서 구분이 안 됐다.
   if (month.tone !== 'default' && month.tone !== 'danger') return month.tone;
   if (!weeklyAvailable) return 'unavailable';
+  // 완료 요청만 되고 확정 전이면 노랑. 초록은 조직장이 확정한 뒤.
+  if (weeklyLockState === 'SUBMITTED') return 'warning';
   if (weeklyStatus === 'ON_TIME' || weeklyStatus === 'COMPLETED_LATE') return 'success';
   if (weeklyStatus === 'MISSED') return 'danger';
   if (weeklyStatus === 'PENDING') return 'warning';
@@ -477,7 +498,8 @@ function buildCashflowMonthClosePresentation({
     const weeklyStatus = weeklyStatusesAvailable && weeklyEntry
       ? readOptionalText(weeklyEntry.status) || null
       : null;
-    const weeklyStatusLabel = cashflowWeeklyStatusLabel(weeklyStatus, weeklyStatusesAvailable);
+    const weeklyLockState = weeklyStatusesAvailable && weeklyEntry ? readOptionalText(weeklyEntry.lockState) : '';
+    const weeklyStatusLabel = cashflowWeeklyStatusLabel(weeklyStatus, weeklyStatusesAvailable, weeklyLockState);
     const isCurrent = week.yearMonth === effectiveAsOfWeek?.yearMonth
       && week.weekNo === effectiveAsOfWeek?.weekNo;
     const statusLabel = month.tone === 'unavailable'
@@ -497,9 +519,10 @@ function buildCashflowMonthClosePresentation({
       monthStatusLabel: month.statusLabel,
       overdue: month.overdue,
       weeklyStatus,
+      weeklyLockState: weeklyLockState || null,
       weeklyStatusLabel,
       statusLabel,
-      surfaceTone: cashflowWeekSurfaceTone({ month, weeklyStatus, weeklyAvailable: weeklyStatusesAvailable, isCurrent }),
+      surfaceTone: cashflowWeekSurfaceTone({ month, weeklyStatus, weeklyAvailable: weeklyStatusesAvailable, isCurrent, weeklyLockState }),
     };
   });
   const asOfYear = Number(readOptionalText(effectiveAsOfWeek?.yearMonth).slice(0, 4));
@@ -2717,6 +2740,7 @@ function deadlineSummaryFromCompliance(compliance, comparisonBoundary, weeklyYea
       yearMonth: item.yearMonth,
       weekNo: item.weekNo,
       status: item.status,
+      lockState: readOptionalText(item.lockState) || null,
       deadline: item.deadline,
       updateResult: item.updateResult,
       operationId: item.operationId,
@@ -3421,7 +3445,7 @@ export function mountJvmWeeklyApiRoutes(app, {
       ...result,
       items: result.items.map((item) => ({
         ...item,
-        statusLabel: cashflowWeeklyStatusLabel(readOptionalText(item?.status), true),
+        statusLabel: cashflowWeeklyStatusLabel(readOptionalText(item?.status), true, readOptionalText(item?.lockState)),
       })),
     };
   }
@@ -4277,22 +4301,52 @@ export function mountJvmWeeklyApiRoutes(app, {
         'cashflow_weekly_reopen_request_invalid',
       );
     }
-    // 회수는 사유 없이 즉시. 화면은 revision 을 모르므로 BFF 가 현재 잠금 기록에서 읽어 JVM 낙관적 잠금에 넘긴다.
-    let expectedRevision = Number(requested.expectedRevision);
-    if (!Number.isSafeInteger(expectedRevision) || expectedRevision < 1) {
-      const completion = await readDocument(
-        db,
-        `orgs/${req.context.tenantId}/cashflow_weekly_update_completions/${projectId}-${yearMonth}-w${weekNo}`,
-      );
-      if (readOptionalText(completion?.status) !== 'LOCKED' || !Number.isSafeInteger(Number(completion?.revision))) {
-        throw createHttpError(409, '완료된 주간 정산만 회수할 수 있습니다.', 'cashflow_weekly_reopen_not_locked');
-      }
-      expectedRevision = Number(completion.revision);
+    // 화면은 revision 을 모른다. BFF 가 현재 완료 기록에서 읽어 JVM 낙관적 잠금에 넘긴다.
+    // 완료 요청(SUBMITTED) 은 사유 없이 회수. 확정(LOCKED) 은 사유가 있어야 재오픈 (조직장·관리자만, JVM 이 검사).
+    const completion = await readDocument(
+      db,
+      `orgs/${req.context.tenantId}/cashflow_weekly_update_completions/${projectId}-${yearMonth}-w${weekNo}`,
+    );
+    const completionStatus = readOptionalText(completion?.status);
+    if (!['SUBMITTED', 'LOCKED'].includes(completionStatus) || !Number.isSafeInteger(Number(completion?.revision))) {
+      throw createHttpError(409, '완료 요청되거나 확정된 주간 정산만 되돌릴 수 있습니다.', 'cashflow_weekly_reopen_not_locked');
     }
+    if (completionStatus === 'LOCKED' && !reason) {
+      throw createHttpError(400, '조직장이 확정한 주간 정산을 되돌리려면 사유가 필요합니다.', 'cashflow_weekly_reopen_reason_required');
+    }
+    const expectedRevision = Number.isSafeInteger(Number(requested.expectedRevision)) && Number(requested.expectedRevision) >= 1
+      ? Number(requested.expectedRevision)
+      : Number(completion.revision);
     const result = await proxyMutation(
       req,
       `/api/v1/cashflow/${encodeURIComponent(projectId)}/weekly-update-complete/reopen`,
       { ...requested, yearMonth, weekNo, expectedRevision, ...(reason ? { reason } : {}) },
+      { cashflowWrite: true },
+    );
+    res.status(200).json(result);
+  }));
+
+  // 주정산 확정: 완료 요청된 주를 프로젝트 조직장이 잠금으로 확정한다. revision 은 BFF 가 읽어 넘긴다.
+  app.post('/api/v1/cashflow/:projectId/weekly-update-complete/confirm', asyncHandler(async (req, res) => {
+    assertWeeklyWorkspaceOrRoleAllowed(req, ['admin', 'finance', 'pm', 'viewer', 'tenant_admin'], 'confirm weekly cashflow update', authMode, workspaceEmailDomain);
+    const projectId = readOptionalText(req.params.projectId);
+    const requested = commandBody(req);
+    const yearMonth = readOptionalText(requested.yearMonth);
+    const weekNo = Number(requested.weekNo);
+    if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(yearMonth) || !Number.isSafeInteger(weekNo) || weekNo < 1 || weekNo > 5) {
+      throw createHttpError(400, '주간 정산 확정에는 대상 연월과 주차가 필요합니다.', 'cashflow_weekly_confirm_request_invalid');
+    }
+    const completion = await readDocument(
+      db,
+      `orgs/${req.context.tenantId}/cashflow_weekly_update_completions/${projectId}-${yearMonth}-w${weekNo}`,
+    );
+    if (readOptionalText(completion?.status) !== 'SUBMITTED' || !Number.isSafeInteger(Number(completion?.revision))) {
+      throw createHttpError(409, '완료 요청된 주간 정산만 확정할 수 있습니다.', 'cashflow_weekly_confirm_not_submitted');
+    }
+    const result = await proxyMutation(
+      req,
+      `/api/v1/cashflow/${encodeURIComponent(projectId)}/weekly-update-complete/confirm`,
+      { ...requested, yearMonth, weekNo, expectedRevision: Number(completion.revision) },
       { cashflowWrite: true },
     );
     res.status(200).json(result);

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -2000,7 +2000,8 @@ describe('JVM weekly API BFF proxy', () => {
         expect(response.body.actions).toMatchObject({
           completeWeekly: { enabled: true },
           // 완료 전이면 회수할 게 없다. 완료·회수는 서로 배타.
-          reopenWeekly: { enabled: false, guide: '아직 완료되지 않은 주간 정산입니다.' },
+          reopenWeekly: { enabled: false, guide: '아직 완료 요청되지 않은 주간 정산입니다.' },
+          confirmWeekly: { enabled: false, guide: '완료 요청된 주간 정산만 확정할 수 있습니다.' },
           changeExecutiveApprover: { enabled: true },
           requestMonthClose: { enabled: true, label: '월 결산 요청' },
           withdrawMonthClose: { enabled: false },
@@ -3225,6 +3226,16 @@ describe('JVM weekly API BFF proxy', () => {
           }),
         };
       }
+      if (url.endsWith('/api/v1/cashflow/project-a/weekly-update-complete/confirm')) {
+        return {
+          ok: true,
+          status: 200,
+          text: async () => JSON.stringify({
+            ok: true, projectId: 'project-a', yearMonth: body.yearMonth, weekNo: body.weekNo,
+            status: 'LOCKED', revision: body.expectedRevision + 1,
+          }),
+        };
+      }
       return {
         ok: true,
         status: 200,
@@ -3251,6 +3262,9 @@ describe('JVM weekly API BFF proxy', () => {
         yearMonth: '2026-06', weekNo: 2, status: 'LOCKED', revision: 1,
       }));
 
+    source.documents.set('orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-06-w2', {
+      projectId: 'project-a', yearMonth: '2026-06', weekNo: 2, status: 'LOCKED', revision: 1,
+    });
     await request(app)
       .post('/api/v1/cashflow/project-a/weekly-update-complete/reopen')
       .send({ yearMonth: '2026-06', weekNo: 2, expectedRevision: 1, reason: '긴급 정정' })
@@ -3267,9 +3281,9 @@ describe('JVM weekly API BFF proxy', () => {
       yearMonth: '2026-06', weekNo: 2, expectedRevision: 1, reason: '긴급 정정',
     });
 
-    // 회수(사유 없음): 화면은 revision 을 모른다. BFF 가 잠금 기록에서 읽어 JVM 낙관적 잠금에 넘긴다.
+    // 회수(사유 없음): 완료 요청(SUBMITTED) 상태. 화면은 revision 을 모른다. BFF 가 완료 기록에서 읽어 JVM 낙관적 잠금에 넘긴다.
     source.documents.set('orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-06-w3', {
-      projectId: 'project-a', yearMonth: '2026-06', weekNo: 3, status: 'LOCKED', revision: 4,
+      projectId: 'project-a', yearMonth: '2026-06', weekNo: 3, status: 'SUBMITTED', revision: 4,
     });
     await request(app)
       .post('/api/v1/cashflow/project-a/weekly-update-complete/reopen')
@@ -3280,12 +3294,36 @@ describe('JVM weekly API BFF proxy', () => {
     const withdrawBody = JSON.parse(withdrawCall[1].body);
     expect(withdrawBody).toMatchObject({ yearMonth: '2026-06', weekNo: 3, expectedRevision: 4 });
     expect(withdrawBody).not.toHaveProperty('reason');
-    // 완료된 적 없는 주는 회수할 수 없다.
+    // 확정(LOCKED) 된 주는 사유 없이 못 되돌린다.
+    source.documents.set('orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-06-w5', {
+      projectId: 'project-a', yearMonth: '2026-06', weekNo: 5, status: 'LOCKED', revision: 2,
+    });
+    await request(app)
+      .post('/api/v1/cashflow/project-a/weekly-update-complete/reopen')
+      .send({ yearMonth: '2026-06', weekNo: 5 })
+      .expect(400)
+      .expect((response) => expect(response.body.code).toBe('cashflow_weekly_reopen_reason_required'));
+    // 완료 요청된 적 없는 주는 되돌릴 수 없다.
     await request(app)
       .post('/api/v1/cashflow/project-a/weekly-update-complete/reopen')
       .send({ yearMonth: '2026-06', weekNo: 4 })
       .expect(409)
       .expect((response) => expect(response.body.code).toBe('cashflow_weekly_reopen_not_locked'));
+    // 확정: 완료 요청된 주만, revision 은 BFF 가 읽어 넘긴다.
+    await request(app)
+      .post('/api/v1/cashflow/project-a/weekly-update-complete/confirm')
+      .send({ yearMonth: '2026-06', weekNo: 5 })
+      .expect(409)
+      .expect((response) => expect(response.body.code).toBe('cashflow_weekly_confirm_not_submitted'));
+    source.documents.set('orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-06-w3', {
+      projectId: 'project-a', yearMonth: '2026-06', weekNo: 3, status: 'SUBMITTED', revision: 4,
+    });
+    await request(app)
+      .post('/api/v1/cashflow/project-a/weekly-update-complete/confirm')
+      .send({ yearMonth: '2026-06', weekNo: 3 })
+      .expect(200);
+    const confirmCall = fetchImpl.mock.calls.find(([url]) => url.endsWith('/weekly-update-complete/confirm'));
+    expect(JSON.parse(confirmCall[1].body)).toMatchObject({ yearMonth: '2026-06', weekNo: 3, expectedRevision: 4 });
   });
 
   it('does not count a reopened weekly completion as settled', async () => {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowWeeklyComplianceHistoryResponse.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowWeeklyComplianceHistoryResponse.java
@@ -17,6 +17,7 @@ public record CashflowWeeklyComplianceHistoryResponse(
         String completedBy,
         String operationId,
         String auditId,
-        String updateResult
+        String updateResult,
+        String lockState
     ) {}
 }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/ConfirmCashflowWeeklyUpdateRequest.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/ConfirmCashflowWeeklyUpdateRequest.java
@@ -1,0 +1,16 @@
+package dev.merryai.innerplatform.weekly.api;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+// 주정산 확정: 완료 요청(SUBMITTED) 된 주를 프로젝트 조직장이 잠금(LOCKED) 으로 확정한다.
+public record ConfirmCashflowWeeklyUpdateRequest(
+    @NotBlank @Size(max = WeeklyExpenseRequestLimits.MAX_IDEMPOTENCY_KEY_LENGTH) String idempotencyKey,
+    @NotBlank @Pattern(regexp = "20\\d{2}-(0[1-9]|1[0-2])") String yearMonth,
+    @Min(1) @Max(CashflowSheetLabApplyRequest.FINANCE_WEEK_COUNT) int weekNo,
+    @Min(1) long expectedRevision
+) {
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -738,6 +738,22 @@ public class WeeklyExpenseController {
         );
     }
 
+    @PostMapping("/cashflow/{projectId}/weekly-update-complete/confirm")
+    public CashflowWeeklyUpdateCompletionResponse confirmCashflowWeeklyUpdate(
+        @PathVariable String projectId,
+        @RequestHeader("x-tenant-id") String tenantId,
+        @RequestHeader("x-actor-id") String actorId,
+        @RequestHeader("x-actor-role") String actorRole,
+        @RequestHeader(value = "x-actor-email", required = false) String actorEmail,
+        @Valid @RequestBody ConfirmCashflowWeeklyUpdateRequest request
+    ) {
+        return commandService.confirmCashflowWeeklyUpdate(
+            actorContext(tenantId, actorId, actorRole, actorEmail),
+            projectId,
+            request
+        );
+    }
+
     @PostMapping("/cashflow/{projectId}/weekly-update-complete/reopen")
     public CashflowWeeklyUpdateCompletionResponse reopenCashflowWeeklyUpdate(
         @PathVariable String projectId,

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseAuthorizationService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseAuthorizationService.java
@@ -44,6 +44,7 @@ public class WeeklyExpenseAuthorizationService {
         WeeklyExpenseCommandService.CLOSE_CASHFLOW_MONTH_COMMAND,
         WeeklyExpenseCommandService.COMPLETE_CASHFLOW_WEEKLY_UPDATE_COMMAND,
         WeeklyExpenseCommandService.REOPEN_CASHFLOW_WEEKLY_UPDATE_COMMAND,
+        WeeklyExpenseCommandService.CONFIRM_CASHFLOW_WEEKLY_UPDATE_COMMAND,
         WeeklyExpenseCommandService.REQUEST_CASHFLOW_MONTH_REOPEN_COMMAND,
         WeeklyExpenseCommandService.DECIDE_CASHFLOW_MONTH_REOPEN_COMMAND,
         WeeklyExpenseCommandService.AUDIT_EXPORT_CREATE_COMMAND
@@ -71,6 +72,7 @@ public class WeeklyExpenseAuthorizationService {
         Map.entry(WeeklyExpenseCommandService.CLOSE_CASHFLOW_MONTH_COMMAND, Set.of("admin", "finance", "pm", "viewer", "tenant_admin")),
         Map.entry(WeeklyExpenseCommandService.COMPLETE_CASHFLOW_WEEKLY_UPDATE_COMMAND, Set.of("admin", "finance", "pm", "viewer", "tenant_admin")),
         Map.entry(WeeklyExpenseCommandService.REOPEN_CASHFLOW_WEEKLY_UPDATE_COMMAND, Set.of("admin", "finance", "pm", "viewer", "tenant_admin")),
+        Map.entry(WeeklyExpenseCommandService.CONFIRM_CASHFLOW_WEEKLY_UPDATE_COMMAND, Set.of("admin", "finance", "pm", "viewer", "tenant_admin")),
         Map.entry(WeeklyExpenseCommandService.REQUEST_CASHFLOW_MONTH_REOPEN_COMMAND, Set.of("admin", "finance", "pm", "viewer", "tenant_admin")),
         Map.entry(WeeklyExpenseCommandService.DECIDE_CASHFLOW_MONTH_REOPEN_COMMAND, Set.of(
             "admin", "finance", "pm", "viewer", "tenant_admin", "auditor", "support", "security"

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -56,6 +56,7 @@ import dev.merryai.innerplatform.weekly.api.PasteCellsRequest;
 import dev.merryai.innerplatform.weekly.api.RowCommandResponse;
 import dev.merryai.innerplatform.weekly.api.RowDeleteRequest;
 import dev.merryai.innerplatform.weekly.api.RowInsertRequest;
+import dev.merryai.innerplatform.weekly.api.ConfirmCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.ReopenCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.SaveDraftRequest;
 import dev.merryai.innerplatform.weekly.api.SaveDraftResponse;
@@ -149,6 +150,7 @@ public class WeeklyExpenseCommandService {
     public static final String READ_CASHFLOW_WEEKLY_UPDATE_COMMAND = "cashflowWeeklyUpdate.read";
     public static final String COMPLETE_CASHFLOW_WEEKLY_UPDATE_COMMAND = "cashflowWeeklyUpdate.complete";
     public static final String REOPEN_CASHFLOW_WEEKLY_UPDATE_COMMAND = "cashflowWeeklyUpdate.reopen";
+    public static final String CONFIRM_CASHFLOW_WEEKLY_UPDATE_COMMAND = "cashflowWeeklyUpdate.confirm";
     public static final String REQUEST_CASHFLOW_MONTH_REOPEN_COMMAND = "cashflowMonth.requestReopen";
     public static final String DECIDE_CASHFLOW_MONTH_REOPEN_COMMAND = "cashflowMonth.decideReopen";
     public static final String READ_CASHFLOW_MONTH_REOPEN_AUTHORITY_COMMAND = "cashflowMonth.readReopenAuthority";
@@ -1301,7 +1303,7 @@ public class WeeklyExpenseCommandService {
         return new CashflowWeeklyComplianceHistoryResponse(
             page.items().stream().map(item -> new CashflowWeeklyComplianceHistoryResponse.Item(
                 item.yearMonth(), item.weekNo(), item.deadline(), item.status(), item.completedAt(),
-                item.completedBy(), item.operationId(), item.auditId(), item.updateResult()
+                item.completedBy(), item.operationId(), item.auditId(), item.updateResult(), item.lockState()
             )).toList(),
             page.nextCursor(),
             page.onTimeCount(),
@@ -1489,6 +1491,63 @@ public class WeeklyExpenseCommandService {
     }
 
     private record AppliedCellChangeCandidate(CashflowAppliedCellChangesResponse.Item item, int ordinal) {
+    }
+
+    // 주정산 확정: 완료 요청된 주를 프로젝트 조직장이 잠금으로 확정한다. 조직장 검사는 저장소에서 프로젝트 문서로.
+    public CashflowWeeklyUpdateCompletionResponse confirmCashflowWeeklyUpdate(
+        TrustedActorContext actor,
+        String projectId,
+        ConfirmCashflowWeeklyUpdateRequest request
+    ) {
+        TrustedActorContext writer = requireCashflowMonthClosePermission(
+            CONFIRM_CASHFLOW_WEEKLY_UPDATE_COMMAND,
+            actor,
+            projectId
+        );
+        String requestHash = hashJson(request);
+        Optional<CashflowWeeklyUpdateCompletionResponse> replay = readIdempotentResponse(
+            writer.tenantId(),
+            projectId,
+            CONFIRM_CASHFLOW_WEEKLY_UPDATE_COMMAND,
+            request.idempotencyKey(),
+            requestHash,
+            CashflowWeeklyUpdateCompletionResponse.class
+        );
+        if (replay.isPresent()) return replay.get();
+
+        WeeklyExpensePersistence.CashflowWeeklyUpdateCompletionRecord saved = persistence.confirmCashflowWeeklyUpdate(
+            writer,
+            projectId,
+            request
+        );
+        persistence.saveAuditEvent(new WeeklyExpenseAuditEventEntity(
+            writer.tenantId(),
+            projectId,
+            projectId + "-" + saved.yearMonth() + "-w" + saved.weekNo(),
+            CONFIRM_CASHFLOW_WEEKLY_UPDATE_COMMAND,
+            writer.id(),
+            normalizeRole(writer.role()),
+            request.idempotencyKey(),
+            writeJson(Map.of(
+                "yearMonth", saved.yearMonth(),
+                "weekNo", saved.weekNo(),
+                "revision", saved.revision(),
+                "snapshotHash", saved.snapshotHash()
+            ))
+        ));
+        CashflowWeeklyUpdateCompletionResponse response = weeklyCompletionResponse(
+            CONFIRM_CASHFLOW_WEEKLY_UPDATE_COMMAND,
+            saved
+        );
+        persistence.saveIdempotency(new WeeklyExpenseIdempotencyEntity(
+            writer.tenantId(),
+            projectId,
+            request.idempotencyKey(),
+            CONFIRM_CASHFLOW_WEEKLY_UPDATE_COMMAND,
+            requestHash,
+            writeJson(response)
+        ));
+        return response;
     }
 
     public CashflowWeeklyUpdateCompletionResponse reopenCashflowWeeklyUpdate(

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -32,6 +32,7 @@ import dev.merryai.innerplatform.weekly.api.CashflowSheetLabApplyRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowPendingApprovalAffectedMonth;
 import dev.merryai.innerplatform.weekly.api.CloseCashflowMonthRequest;
 import dev.merryai.innerplatform.weekly.api.CompleteCashflowWeeklyUpdateRequest;
+import dev.merryai.innerplatform.weekly.api.ConfirmCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.ReopenCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.TrustedActorContext;
 import dev.merryai.innerplatform.weekly.api.WeeklyExpenseConflictException;
@@ -1060,7 +1061,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                 DocumentSnapshot snapshot = get(ref);
                 return snapshot.exists() ? data(snapshot) : Map.of();
             });
-            if ("LOCKED".equals(text(document.get("status"), ""))) {
+            if (isSettledWeeklyStatus(text(document.get("status"), ""))) {
                 locked.add(new CashflowSettledWeekChangeConfirmation.Week(
                     scope.yearMonth(),
                     scope.weekNo(),
@@ -1094,7 +1095,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                 DocumentSnapshot snapshot = get(ref);
                 return snapshot.exists() ? data(snapshot) : Map.of();
             });
-            if ("LOCKED".equals(text(document.get("status"), ""))) {
+            if (isSettledWeeklyStatus(text(document.get("status"), ""))) {
                 locked.add(Map.entry(scope, document));
             }
         }
@@ -1541,7 +1542,9 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                 text(value.get("completedBy"), text(value.get("completedByUid"), "")),
                 text(value.get("operationId"), ""),
                 text(value.get("auditId"), ""),
-                text(value.get("updateResult"), "")
+                text(value.get("updateResult"), ""),
+                // lockState 도입 전 버전(확정 개념 없던 완료) 은 확정으로 본다.
+                text(value.get("lockState"), "LOCKED")
             ));
         }
         // 현재 완료 문서가 OPEN(회수됨) 이면 버전 이력과 무관하게 그 주는 완료가 아니다.
@@ -1595,7 +1598,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                     all.add(new CashflowWeeklyComplianceRecord(
                         weekKey, scope.yearMonth(), scope.weekNo(), deadline.toString(),
                         clock.instant().isAfter(deadline) ? "MISSED" : "PENDING",
-                        "", "", "", "", ""
+                        "", "", "", "", "", ""
                     ));
                 }
                 scope = nextFinanceWeek(scope);
@@ -1713,7 +1716,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                 || request.weekNo() != intValue(existing.get("weekNo"), 0)) {
                 throw new WeeklyExpenseConflictException("Stored weekly cashflow completion scope is invalid.");
             }
-            if ("LOCKED".equals(text(existing.get("status"), ""))) {
+            if (isSettledWeeklyStatus(text(existing.get("status"), ""))) {
                 requireWeeklyCompletionIntegrity(existing);
                 lockedCompletion = existing;
             }
@@ -1840,7 +1843,8 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         completion.put("projectId", projectId);
         completion.put("yearMonth", request.yearMonth());
         completion.put("weekNo", request.weekNo());
-        completion.put("status", "LOCKED");
+        // 완료 요청. 확정(LOCKED) 은 조직장이 별도로 한다. 준수(기한 내/후) 는 이 요청 시각으로 판정한다.
+        completion.put("status", "SUBMITTED");
         completion.put("revision", revision);
         completion.put("reopenCount", reopenCount);
         completion.put("snapshot", lockedSnapshot);
@@ -1877,6 +1881,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
         version.put("completedBy", completedBy);
         version.put("deadline", deadline.toString());
         version.put("complianceStatus", weeklyComplianceStatus(request.yearMonth(), request.weekNo(), completedAt, deadline));
+        version.put("lockState", "SUBMITTED");
         version.put("operationId", request.idempotencyKey());
         version.put("auditId", weeklyComplianceAuditId(actor.tenantId(), projectId, request.idempotencyKey()));
         if (!complianceHeadSnapshot.exists()) {
@@ -2081,12 +2086,26 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             || request.weekNo() != intValue(current.get("weekNo"), 0)) {
             throw new WeeklyExpenseConflictException("Stored weekly cashflow completion scope is invalid.");
         }
-        if (!"LOCKED".equals(text(current.get("status"), ""))) {
-            throw new WeeklyExpenseConflictException("Only a locked cashflow week can be reopened.");
+        String currentStatus = text(current.get("status"), "");
+        if (!isSettledWeeklyStatus(currentStatus)) {
+            throw new WeeklyExpenseConflictException("Only a submitted or locked cashflow week can be reopened.");
         }
         long currentRevision = longValue(current.get("revision"), 0);
         if (currentRevision != request.expectedRevision()) {
             throw new WeeklyExpenseConflictException("Cashflow weekly lock revision changed. Reload before reopening.");
+        }
+        if ("LOCKED".equals(currentStatus)) {
+            // 확정된 주를 되돌리는 것은 재오픈: 사유가 있어야 하고 프로젝트 조직장이나 관리자만.
+            if (request.reason() == null || request.reason().isBlank()) {
+                throw new WeeklyExpenseConflictException("A reason is required to reopen a confirmed cashflow week.");
+            }
+            DocumentSnapshot projectSnapshot = get(db.document("orgs/" + actor.tenantId() + "/projects/" + projectId));
+            Map<String, Object> project = projectSnapshot.exists() ? data(projectSnapshot) : Map.of();
+            String role = text(actor.role(), "").trim().toLowerCase(java.util.Locale.ROOT);
+            boolean approver = actor.id().equals(text(project.get("executiveApproverId"), ""));
+            if (!approver && !"admin".equals(role) && !"finance".equals(role) && !"tenant_admin".equals(role)) {
+                throw leaseError(403, "cashflow_weekly_reopen_forbidden", "Only the project approver or an admin can reopen a confirmed cashflow week.");
+            }
         }
         Instant reopenedAt = clock.instant();
         Map<String, Object> patch = new LinkedHashMap<>();
@@ -2130,6 +2149,77 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             merge(current, patch),
             false
         );
+    }
+
+    @Override
+    public CashflowWeeklyUpdateCompletionRecord confirmCashflowWeeklyUpdate(
+        TrustedActorContext actor,
+        String projectId,
+        ConfirmCashflowWeeklyUpdateRequest request
+    ) {
+        requireValidatedCashflowWriteScope(actor.tenantId(), projectId);
+        requireYearMonth(request.yearMonth());
+        requireCashflowMonthsOpen(actor.tenantId(), projectId, List.of(request.yearMonth()));
+        DocumentSnapshot projectSnapshot = get(db.document("orgs/" + actor.tenantId() + "/projects/" + projectId));
+        Map<String, Object> project = projectSnapshot.exists() ? data(projectSnapshot) : Map.of();
+        if (!actor.id().equals(text(project.get("executiveApproverId"), ""))) {
+            throw leaseError(403, "cashflow_weekly_confirm_forbidden", "Only the project approver can confirm a cashflow week.");
+        }
+        String documentId = projectId + "-" + request.yearMonth() + "-w" + request.weekNo();
+        DocumentReference ref = db.document(cashflowWeeklyUpdateCompletionPath(actor.tenantId(), documentId));
+        DocumentSnapshot snapshot = get(ref);
+        if (!snapshot.exists()) {
+            throw new WeeklyExpenseConflictException("Only a submitted cashflow week can be confirmed.");
+        }
+        Map<String, Object> current = data(snapshot);
+        if (!projectId.equals(text(current.get("projectId"), ""))
+            || !request.yearMonth().equals(text(current.get("yearMonth"), ""))
+            || request.weekNo() != intValue(current.get("weekNo"), 0)) {
+            throw new WeeklyExpenseConflictException("Stored weekly cashflow completion scope is invalid.");
+        }
+        if (!"SUBMITTED".equals(text(current.get("status"), ""))) {
+            throw new WeeklyExpenseConflictException("Only a submitted cashflow week can be confirmed.");
+        }
+        long currentRevision = longValue(current.get("revision"), 0);
+        if (currentRevision != request.expectedRevision()) {
+            throw new WeeklyExpenseConflictException("Cashflow weekly lock revision changed. Reload before confirming.");
+        }
+        Instant confirmedAt = clock.instant();
+        long nextRevision = Math.addExact(currentRevision, 1);
+        Map<String, Object> patch = new LinkedHashMap<>();
+        patch.put("status", "LOCKED");
+        patch.put("revision", nextRevision);
+        patch.put("confirmedAt", confirmedAt.toString());
+        patch.put("confirmedByUid", actor.id());
+        patch.put("confirmedByName", actor.name());
+        patch.put("updatedAt", confirmedAt.toString());
+        set(ref, patch);
+        // 준수 이력 버전: 준수 판정(요청 시각 기준) 은 그대로, 잠금 상태만 LOCKED 로.
+        String versionId = documentId + "-r" + nextRevision;
+        DocumentReference versionRef = db.document(cashflowWeeklyUpdateCompletionVersionPath(actor.tenantId(), versionId));
+        if (get(versionRef).exists()) {
+            throw new WeeklyExpenseConflictException("Weekly compliance history version already exists and is immutable.");
+        }
+        Map<String, Object> version = new LinkedHashMap<>();
+        version.put("id", versionId);
+        version.put("tenantId", actor.tenantId());
+        version.put("projectId", projectId);
+        version.put("yearMonth", request.yearMonth());
+        version.put("weekNo", request.weekNo());
+        version.put("revision", nextRevision);
+        version.put("complianceStatus", text(current.get("complianceStatus"), ""));
+        version.put("lockState", "LOCKED");
+        version.put("deadline", text(current.get("deadline"), ""));
+        version.put("completedAt", text(current.get("completedAt"), ""));
+        version.put("completedBy", text(current.get("completedByName"), text(current.get("completedByUid"), "")));
+        version.put("operationId", text(current.get("operationId"), ""));
+        version.put("auditId", text(current.get("auditId"), ""));
+        version.put("updateResult", text(current.get("updateResult"), ""));
+        version.put("confirmedAt", confirmedAt.toString());
+        version.put("confirmedByUid", actor.id());
+        version.put("createdAt", confirmedAt.toString());
+        set(versionRef, version);
+        return toWeeklyCompletionRecord(projectId, request.yearMonth(), request.weekNo(), merge(current, patch), false);
     }
 
     @Override
@@ -2247,7 +2337,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                     || weekNo > CashflowSheetLabApplyRequest.FINANCE_WEEK_COUNT) {
                     throw new WeeklyExpenseConflictException("Stored weekly cashflow completion scope is invalid.");
                 }
-                if (!"LOCKED".equals(text(completion.get("status"), ""))) continue;
+                if (!isSettledWeeklyStatus(text(completion.get("status"), ""))) continue;
                 Map<String, Object> weeklyPatch = new LinkedHashMap<>();
                 weeklyPatch.put("status", "OPEN");
                 weeklyPatch.put("revision", Math.addExact(longValue(completion.get("revision"), 0), 1));
@@ -3221,6 +3311,11 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
 
     private String monthlyClosePath(String tenantId, String projectId, String yearMonth) {
         return "orgs/" + tenantId + "/monthly_closes/" + projectId + "-" + yearMonth;
+    }
+
+    // 완료 요청(SUBMITTED) 부터 그 주는 잠긴다. 확정(LOCKED) 은 조직장이 한다. 둘 다 "정산된 주" 로 본다.
+    private static boolean isSettledWeeklyStatus(String status) {
+        return "SUBMITTED".equals(status) || "LOCKED".equals(status);
     }
 
     private String cashflowWeeklyUpdateCompletionPath(String tenantId, String documentId) {
@@ -4320,7 +4415,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     }
 
     private void requireWeeklyCompletionIntegrity(Map<String, Object> completion) {
-        if (!"LOCKED".equals(text(completion.get("status"), ""))) return;
+        if (!isSettledWeeklyStatus(text(completion.get("status"), ""))) return;
         Map<String, Object> lockedSnapshot = nestedMap(completion.get("snapshot"));
         String snapshotHash = text(completion.get("snapshotHash"), "");
         if (lockedSnapshot.isEmpty() || snapshotHash.isBlank() || !snapshotHash.equals(hashCanonicalJson(lockedSnapshot))) {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/WeeklyExpensePersistence.java
@@ -14,6 +14,7 @@ import dev.merryai.innerplatform.weekly.api.CashflowEditSession;
 import dev.merryai.innerplatform.weekly.api.CashflowVarianceRequest;
 import dev.merryai.innerplatform.weekly.api.CloseCashflowMonthRequest;
 import dev.merryai.innerplatform.weekly.api.CompleteCashflowWeeklyUpdateRequest;
+import dev.merryai.innerplatform.weekly.api.ConfirmCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.ReopenCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetLabApplyRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowSheetBatchApplyRequest;
@@ -224,6 +225,7 @@ public interface WeeklyExpensePersistence extends CashflowMonthReopenPort, Cashf
         }
     }
 
+    // lockState: SUBMITTED(완료 요청, 확정 대기) | LOCKED(확정) | ""(완료 아님)
     record CashflowWeeklyComplianceRecord(
         String id,
         String yearMonth,
@@ -234,7 +236,8 @@ public interface WeeklyExpensePersistence extends CashflowMonthReopenPort, Cashf
         String completedBy,
         String operationId,
         String auditId,
-        String updateResult
+        String updateResult,
+        String lockState
     ) {}
 
     record CashflowWeeklyCompliancePage(
@@ -467,6 +470,18 @@ public interface WeeklyExpensePersistence extends CashflowMonthReopenPort, Cashf
 
     default CashflowCumulativeCloseHead findCashflowCumulativeCloseHead(String tenantId, String projectId) {
         return null;
+    }
+
+    default CashflowWeeklyUpdateCompletionRecord confirmCashflowWeeklyUpdate(
+        TrustedActorContext actor,
+        String projectId,
+        ConfirmCashflowWeeklyUpdateRequest request
+    ) {
+        throw new WeeklyExpenseEditLeaseException(
+            503,
+            "cashflow_weekly_confirm_backend_unavailable",
+            "Cashflow weekly confirm requires the Firestore transaction backend."
+        );
     }
 
     default CashflowWeeklyUpdateCompletionRecord reopenCashflowWeeklyUpdate(

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -35,6 +35,7 @@ import dev.merryai.innerplatform.weekly.api.CompleteCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowWeeklyUpdateCompletionResponse;
 import dev.merryai.innerplatform.weekly.api.CashflowWeeklyComplianceHistoryResponse;
 import dev.merryai.innerplatform.weekly.api.CloseWeekRequest;
+import dev.merryai.innerplatform.weekly.api.ConfirmCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.ReopenCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.SaveDraftResponse;
 import dev.merryai.innerplatform.weekly.api.SaveDraftRequest;
@@ -2717,7 +2718,7 @@ class FirestoreCashflowLeaseGuardTest {
         assertThat(first.alreadyCompleted()).isFalse();
         assertThat(second.alreadyCompleted()).isTrue();
         assertThat(second.completedAt()).isEqualTo(first.completedAt());
-        assertThat(read.status()).isEqualTo("LOCKED");
+        assertThat(read.status()).isEqualTo("SUBMITTED");
         assertThat(read.snapshotHash()).isEqualTo(first.snapshotHash());
         assertThat(fixture.documents.get(
             "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w3"
@@ -2725,7 +2726,7 @@ class FirestoreCashflowLeaseGuardTest {
             .containsEntry("projectId", "project-a")
             .containsEntry("yearMonth", "2026-07")
             .containsEntry("weekNo", 3)
-            .containsEntry("status", "LOCKED")
+            .containsEntry("status", "SUBMITTED")
             .containsEntry("revision", 1L)
             .containsEntry("sourceRevision", SOURCE_REVISION)
             .containsEntry("completedAt", "2026-07-16T09:00:00Z")
@@ -2822,7 +2823,7 @@ class FirestoreCashflowLeaseGuardTest {
             )
         );
 
-        assertThat(response.status()).isEqualTo("LOCKED");
+        assertThat(response.status()).isEqualTo("SUBMITTED");
         Map<?, ?> completion = fixture.documents.get(
             "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w3"
         );
@@ -2902,7 +2903,7 @@ class FirestoreCashflowLeaseGuardTest {
                 )
             );
 
-            assertThat(response.status()).isEqualTo("LOCKED");
+            assertThat(response.status()).isEqualTo("SUBMITTED");
             Map<?, ?> completion = fixture.documents.get(
                 "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w3"
             );
@@ -3144,7 +3145,7 @@ class FirestoreCashflowLeaseGuardTest {
             )
         );
 
-        assertThat(read.status()).isEqualTo("LOCKED");
+        assertThat(read.status()).isEqualTo("SUBMITTED");
         assertThat(replay.alreadyCompleted()).isTrue();
         assertThat(replay.revision()).isEqualTo(1L);
 
@@ -3201,7 +3202,7 @@ class FirestoreCashflowLeaseGuardTest {
                 .containsEntry("SALES_IN", 200L));
         assertThat(fixture.documents.get(
             "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w3"
-        )).containsEntry("status", "LOCKED");
+        )).containsEntry("status", "SUBMITTED");
     }
 
     @Test
@@ -3531,7 +3532,7 @@ class FirestoreCashflowLeaseGuardTest {
             )
         ));
 
-        assertThat(response.status()).isEqualTo("LOCKED");
+        assertThat(response.status()).isEqualTo("SUBMITTED");
         assertThat(response.completedBy()).isEqualTo("pm@example.com");
     }
 
@@ -3561,7 +3562,7 @@ class FirestoreCashflowLeaseGuardTest {
         ));
 
         assertThat(upgraded.alreadyCompleted()).isFalse();
-        assertThat(upgraded.status()).isEqualTo("LOCKED");
+        assertThat(upgraded.status()).isEqualTo("SUBMITTED");
         assertThat(upgraded.revision()).isEqualTo(1L);
         assertThat(fixture.documents).containsKey(
             "orgs/tenant-a/cashflow_weekly_update_completion_versions/project-a-2026-07-w3-r1"
@@ -3681,7 +3682,7 @@ class FirestoreCashflowLeaseGuardTest {
         CashflowWeeklyUpdateCompletionResponse completed = fixture.persistence.runCommandTransaction(() -> commandService(
             fixture.persistence
         ).completeCashflowWeeklyUpdate(ACTOR, "project-a", override));
-        assertThat(completed.status()).isEqualTo("LOCKED");
+        assertThat(completed.status()).isEqualTo("SUBMITTED");
         assertThat(completed.updateResult()).isEqualTo("NO_CHANGES");
         assertThat(completed.complianceStatus()).isEqualTo("ON_TIME");
         assertThat(fixture.documents.get(
@@ -3818,13 +3819,19 @@ class FirestoreCashflowLeaseGuardTest {
         );
     }
 
+    private static Map<String, Object> submittedWeeklyCompletion(String yearMonth, int weekNo, long revision) {
+        Map<String, Object> value = lockedWeeklyCompletion(yearMonth, weekNo, revision);
+        value.put("status", "SUBMITTED");
+        return value;
+    }
+
     @Test
     void weeklyReopenNeedsNoReasonAndReopensALockedWeek() {
-        // 주정산 회수는 결재가 없는 가벼운 되돌림이라 사유 없이도 된다. 있으면 기록만 한다.
+        // 완료 요청(SUBMITTED) 상태의 회수는 결재 없는 가벼운 되돌림이라 사유 없이도 된다. 있으면 기록만 한다.
         Fixture fixture = fixture(activeMember(), Map.of());
         fixture.documents.put(
             "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w3",
-            lockedWeeklyCompletion("2026-07", 3, 1)
+            submittedWeeklyCompletion("2026-07", 3, 1)
         );
         var response = fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
             .reopenCashflowWeeklyUpdate(
@@ -3849,13 +3856,63 @@ class FirestoreCashflowLeaseGuardTest {
     }
 
     @Test
+    void weeklyConfirmMovesASubmittedWeekToLockedForTheProjectApproverOnly() {
+        // 확정은 프로젝트 조직장만. SUBMITTED → LOCKED, revision +1, 준수 판정은 요청 시각 그대로.
+        Fixture fixture = fixture(activeMember(), Map.of());
+        fixture.documents.put("orgs/tenant-a/projects/project-a", Map.of(
+            "id", "project-a", "tenantId", "tenant-a", "executiveApproverId", "manager-1"
+        ));
+        Map<String, Object> submitted = submittedWeeklyCompletion("2026-07", 3, 1);
+        submitted.put("complianceStatus", "ON_TIME");
+        submitted.put("deadline", "2026-07-16T14:59:59Z");
+        fixture.documents.put("orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w3", submitted);
+        fixture.documents.put("orgs/tenant-a/members/manager-1", member(Map.of("uid", "manager-1", "role", "pm", "projectIds", List.of("project-a"))));
+        fixture.documents.put("orgs/tenant-a/persons/person-manager-1", Map.of("uid", "manager-1"));
+        TrustedActorContext manager = new TrustedActorContext("tenant-a", "manager-1", "manager@example.com", "pm", "Manager");
+
+        assertThatThrownBy(() -> fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
+            .confirmCashflowWeeklyUpdate(ACTOR, "project-a",
+                new ConfirmCashflowWeeklyUpdateRequest("confirm-by-pm", "2026-07", 3, 1))))
+            .isInstanceOfSatisfying(WeeklyExpenseEditLeaseException.class, error ->
+                assertThat(error.code()).isEqualTo("cashflow_weekly_confirm_forbidden"));
+
+        var response = fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
+            .confirmCashflowWeeklyUpdate(manager, "project-a",
+                new ConfirmCashflowWeeklyUpdateRequest("confirm-by-manager", "2026-07", 3, 1)));
+        assertThat(response.status()).isEqualTo("LOCKED");
+        assertThat(response.revision()).isEqualTo(2L);
+        assertThat(fixture.documents.get(
+            "orgs/tenant-a/cashflow_weekly_update_completion_versions/project-a-2026-07-w3-r2"
+        ))
+            .containsEntry("lockState", "LOCKED")
+            .containsEntry("complianceStatus", "ON_TIME");
+
+        // 확정된 주는 사유 없이 못 되돌리고, 사유가 있어도 조직장/관리자만 되돌린다.
+        assertThatThrownBy(() -> fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
+            .reopenCashflowWeeklyUpdate(manager, "project-a",
+                new ReopenCashflowWeeklyUpdateRequest("reopen-locked-no-reason", "2026-07", 3, 2, null))))
+            .isInstanceOf(WeeklyExpenseConflictException.class)
+            .hasMessageContaining("reason");
+        assertThatThrownBy(() -> fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
+            .reopenCashflowWeeklyUpdate(ACTOR, "project-a",
+                new ReopenCashflowWeeklyUpdateRequest("reopen-locked-by-pm", "2026-07", 3, 2, "정정"))))
+            .isInstanceOfSatisfying(WeeklyExpenseEditLeaseException.class, error ->
+                assertThat(error.code()).isEqualTo("cashflow_weekly_reopen_forbidden"));
+        var reopened = fixture.persistence.runCommandTransaction(() -> commandService(fixture.persistence)
+            .reopenCashflowWeeklyUpdate(manager, "project-a",
+                new ReopenCashflowWeeklyUpdateRequest("reopen-locked-by-manager", "2026-07", 3, 2, "정정")));
+        assertThat(reopened.status()).isEqualTo("OPEN");
+        assertThat(reopened.revision()).isEqualTo(3L);
+    }
+
+    @Test
     void weeklyComplianceHistoryTreatsAReopenedWeekAsNotCompleted() {
-        // 완료(r1 ON_TIME) 뒤 회수(r2 REOPENED): 이력은 그 주를 완료 아님(PENDING/MISSED) 으로 되돌리고 완료 수에서 뺀다.
+        // 완료 요청(r1 ON_TIME, SUBMITTED) 뒤 회수(r2 REOPENED): 이력은 그 주를 완료 아님(PENDING/MISSED) 으로 되돌리고 완료 수에서 뺀다.
         // 그래야 대시보드의 현재 주가 "완료 대기" 로 바뀌고 회수 버튼이 다시 뜨지 않는다.
         Fixture fixture = fixture(activeMember(), Map.of());
         fixture.documents.put(
             "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-07-w2",
-            lockedWeeklyCompletion("2026-07", 2, 1)
+            submittedWeeklyCompletion("2026-07", 2, 1)
         );
         fixture.documents.put(
             "orgs/tenant-a/cashflow_weekly_update_completion_versions/project-a-2026-07-w2-r1",
@@ -3877,6 +3934,8 @@ class FirestoreCashflowLeaseGuardTest {
         assertThat(before.items()).anySatisfy(item -> {
             assertThat(item.id()).isEqualTo("2026-07-w2");
             assertThat(item.status()).isEqualTo("ON_TIME");
+            // lockState 없는 옛 버전은 확정으로 본다
+            assertThat(item.lockState()).isEqualTo("LOCKED");
         });
         assertThat(before.onTimeCount()).isEqualTo(1L);
 
@@ -5431,7 +5490,7 @@ class FirestoreCashflowLeaseGuardTest {
             )
         );
 
-        assertThat(august.status()).isEqualTo("LOCKED");
+        assertThat(august.status()).isEqualTo("SUBMITTED");
         assertThat(fixture.documents).containsKey(
             "orgs/tenant-a/cashflow_weekly_update_completions/project-a-2026-08-w3"
         );

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -44,6 +44,7 @@ import {
   withdrawCashflowMonthCloseRequestViaBff,
   saveCashflowMonthCloseApproverViaBff,
   completeCashflowWeeklyUpdateViaBff,
+  confirmCashflowWeeklyUpdateViaBff,
   reopenCashflowWeeklyUpdateViaBff,
   decideCashflowMonthReopenViaBff,
   fetchCashflowMonthCloseViaBff,
@@ -393,6 +394,7 @@ export function CashflowProjectSheet({
   const [weeklyCompletionError, setWeeklyCompletionError] = useState('');
   const [weeklyWithdrawBusy, setWeeklyWithdrawBusy] = useState(false);
   const [weeklyWithdrawError, setWeeklyWithdrawError] = useState('');
+  const [weeklyConfirmBusy, setWeeklyConfirmBusy] = useState(false);
   const [weeklyProjectionWarning, setWeeklyProjectionWarning] = useState<WeeklyProjectionValidation | null>(null);
   const [weeklyHistoryOpen, setWeeklyHistoryOpen] = useState(false);
   const [weeklyComplianceHistory, setWeeklyComplianceHistory] = useState<CashflowWeeklyComplianceItem[]>([]);
@@ -961,6 +963,51 @@ export function CashflowProjectSheet({
       setWeeklyWithdrawBusy(false);
     }
   }, [loadCashflowMonthClose, monthCloseActions?.reopenWeekly, monthCloseResult?.dashboard?.deadlineSummary?.current, orgId, projectId, resolveBffActor, yearMonth]);
+
+  // 주정산 확정: 완료 요청된 주를 프로젝트 조직장이 잠근다. 서버(actions.confirmWeekly) 가 조직장인지 판정한다.
+  const handleConfirmWeeklyUpdate = useCallback(async (): Promise<void> => {
+    if (monthCloseActions?.confirmWeekly.enabled !== true) return;
+    const currentDeadline = monthCloseResult?.dashboard?.deadlineSummary?.current;
+    if (!currentDeadline) return;
+    if (selectedProjectIdRef.current !== projectId || selectedYearMonthRef.current !== yearMonth) return;
+    setWeeklyConfirmBusy(true);
+    setWeeklyWithdrawError('');
+    const startedAt = Date.now();
+    try {
+      const actor = await resolveBffActor();
+      if (!actor?.idToken) throw new Error('로그인 세션이 만료되었습니다.');
+      const result = await confirmCashflowWeeklyUpdateViaBff({
+        tenantId: orgId,
+        actor,
+        projectId,
+        yearMonth: currentDeadline.yearMonth,
+        weekNo: currentDeadline.weekNo,
+      });
+      await loadCashflowMonthClose();
+      logCashflowSettlement({
+        phase: 'success',
+        operation: 'cashflow.weekly_settlement.confirm',
+        projectId,
+        yearMonth: result.yearMonth,
+        weekNo: result.weekNo,
+        durationMs: Date.now() - startedAt,
+        summary: { revision: result.revision },
+      });
+    } catch (error) {
+      logCashflowSettlement({
+        phase: 'error',
+        operation: 'cashflow.weekly_settlement.confirm',
+        projectId,
+        yearMonth: currentDeadline.yearMonth,
+        weekNo: currentDeadline.weekNo,
+        durationMs: Date.now() - startedAt,
+        error,
+      });
+      setWeeklyWithdrawError(resolveApiErrorMessage(error, '주간 정산을 확정하지 못했습니다. 화면을 다시 불러온 뒤 시도해 주세요.'));
+    } finally {
+      setWeeklyConfirmBusy(false);
+    }
+  }, [loadCashflowMonthClose, monthCloseActions?.confirmWeekly, monthCloseResult?.dashboard?.deadlineSummary?.current, orgId, projectId, resolveBffActor, yearMonth]);
 
   const loadWeeklyComplianceHistory = useCallback(async (): Promise<void> => {
     setWeeklyComplianceHistoryLoading(true);
@@ -2679,7 +2726,7 @@ export function CashflowProjectSheet({
                       }}
                     >
                       {weeklyCompletionBusy ? <Loader2 className="mr-1 h-3 w-3 animate-spin" /> : <ClipboardCheck className="mr-1 h-3 w-3" />}
-                      주간 정산 완료
+                      주간 정산 완료 요청
                     </Button>
                   ) : null}
                   {monthCloseActions?.reopenWeekly.enabled ? (
@@ -2692,7 +2739,19 @@ export function CashflowProjectSheet({
                       onClick={() => void handleWithdrawWeeklyUpdate()}
                     >
                       {weeklyWithdrawBusy ? <Loader2 className="mr-1 h-3 w-3 animate-spin" /> : <Undo2 className="mr-1 h-3 w-3" />}
-                      주간 정산 회수
+                      요청 회수
+                    </Button>
+                  ) : null}
+                  {monthCloseActions?.confirmWeekly.enabled ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      className="h-8 shrink-0 rounded-md bg-[#17324D] px-3 text-[12px] font-semibold text-white hover:bg-slate-800"
+                      disabled={weeklyConfirmBusy || monthCloseLoading}
+                      onClick={() => void handleConfirmWeeklyUpdate()}
+                    >
+                      {weeklyConfirmBusy ? <Loader2 className="mr-1 h-3 w-3 animate-spin" /> : <CheckCircle2 className="mr-1 h-3 w-3" />}
+                      주간 정산 확정
                     </Button>
                   ) : null}
                 </div>
@@ -3085,7 +3144,7 @@ export function CashflowProjectSheet({
       }}>
         <AlertDialogContent className="sm:max-w-[620px]">
           <AlertDialogHeader>
-            <AlertDialogTitle>주간 정산 완료</AlertDialogTitle>
+            <AlertDialogTitle>주간 정산 완료 요청</AlertDialogTitle>
             <AlertDialogDescription>대상 주차와 그 이후 15개 재무주차(총 16주·256칸)의 JVM 저장 Projection 값을 확인합니다.</AlertDialogDescription>
           </AlertDialogHeader>
           {weeklyCompletionError ? <div role="alert" className="rounded-md border border-red-200 bg-red-50 p-3 text-[12px] leading-5 text-red-800">{weeklyCompletionError}</div> : null}

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -277,6 +277,7 @@ describe('platform-bff-client', () => {
     const actions = {
       completeWeekly: { enabled: false, guide: '주간 가이드' },
       reopenWeekly: { enabled: false, guide: '주간 회수 가이드' },
+      confirmWeekly: { enabled: false, guide: '주간 확정 가이드' },
       changeExecutiveApprover: { enabled: false, guide: '조직장 가이드' },
       requestMonthClose: { enabled: false, guide: '서버 가이드', label: '월 결산 요청' },
       withdrawMonthClose: { enabled: false, guide: '회수 가이드' },

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -997,6 +997,7 @@ export interface CashflowDeadlineSummary {
     yearMonth: string;
     weekNo: number;
     status: 'ON_TIME' | 'COMPLETED_LATE' | 'MISSED' | 'PENDING';
+    lockState?: 'SUBMITTED' | 'LOCKED' | null;
     deadline?: string | null;
     completedAt?: string | null;
     completedBy?: string | null;
@@ -1009,6 +1010,8 @@ export interface CashflowDeadlineSummary {
     completedAt: string | null;
     completedBy?: string | null;
     status: 'ON_TIME' | 'COMPLETED_LATE' | 'MISSED' | 'PENDING';
+    // SUBMITTED = 완료 요청됨(조직장 확정 대기), LOCKED = 확정, 없음 = 완료 요청 전
+    lockState?: 'SUBMITTED' | 'LOCKED' | null;
   } | null;
 }
 
@@ -1404,6 +1407,7 @@ export interface CashflowMonthCloseActionDecision {
 export interface CashflowMonthCloseActions {
   completeWeekly: CashflowMonthCloseActionDecision;
   reopenWeekly: CashflowMonthCloseActionDecision;
+  confirmWeekly: CashflowMonthCloseActionDecision;
   changeExecutiveApprover: CashflowMonthCloseActionDecision;
   requestMonthClose: CashflowMonthCloseActionDecision & { label: string };
   withdrawMonthClose: CashflowMonthCloseActionDecision;
@@ -1447,6 +1451,7 @@ export interface CashflowMonthClosePresentationWeek {
   monthStatus: 'OPEN' | 'CLOSED' | 'REOPEN_REQUESTED' | null;
   monthStatusLabel: string;
   weeklyStatus: 'ON_TIME' | 'COMPLETED_LATE' | 'MISSED' | 'PENDING' | null;
+  weeklyLockState?: 'SUBMITTED' | 'LOCKED' | null;
   weeklyStatusLabel: string;
   statusLabel: string;
   surfaceTone: 'unavailable' | 'closed' | 'danger' | 'warning' | 'success' | 'current' | 'default';
@@ -1543,7 +1548,7 @@ export interface CashflowWeeklyUpdateCompletionResult {
   completedAt: string;
   completedBy: string | null;
   alreadyCompleted: boolean;
-  status: 'LOCKED' | 'OPEN';
+  status: 'SUBMITTED' | 'LOCKED' | 'OPEN';
   revision: number;
   reopenCount: number;
   snapshotHash: string;
@@ -1564,6 +1569,7 @@ export interface CashflowWeeklyComplianceItem {
   weekNo: number;
   deadline: string;
   status: 'PENDING' | 'MISSED' | 'ON_TIME' | 'COMPLETED_LATE';
+  lockState?: 'SUBMITTED' | 'LOCKED' | '' | null;
   statusLabel: string;
   completedAt: string | null;
   completedBy: string | null;
@@ -3505,7 +3511,29 @@ export async function fetchCashflowWeeklyOverviewViaBff(params: {
   return result;
 }
 
-// 주정산 회수: 사유 없이 즉시. 현재 revision 은 BFF 가 잠금 기록에서 읽는다.
+// 주정산 확정: 완료 요청된 주를 프로젝트 조직장이 잠금으로 확정. revision 은 BFF 가 읽는다.
+export async function confirmCashflowWeeklyUpdateViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectId: string;
+  yearMonth: string;
+  weekNo: number;
+  client?: PlatformApiClientLike;
+}): Promise<CashflowWeeklyUpdateCompletionResult> {
+  const response = await resolveClient(params.client).post<CashflowWeeklyUpdateCompletionResult>(
+    `/api/v1/cashflow/${encodeURIComponent(params.projectId)}/weekly-update-complete/confirm`,
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      body: { yearMonth: params.yearMonth, weekNo: params.weekNo },
+      retries: 0,
+      timeoutMs: 12000,
+    },
+  );
+  return response.data;
+}
+
+// 주정산 회수: 완료 요청 상태에서 사유 없이 즉시. 현재 revision 은 BFF 가 완료 기록에서 읽는다.
 export async function reopenCashflowWeeklyUpdateViaBff(params: {
   tenantId: string;
   actor: ActorLike;

--- a/src/app/platform/api-error-messages.ts
+++ b/src/app/platform/api-error-messages.ts
@@ -104,6 +104,26 @@ const presentations = new Map<string, ApiErrorPresentation>([
     guide: '승인 결과를 확인하고 있어요. 잠시 후 월 결산 상태를 확인해 주세요.',
     resolution: 'wait',
   }],
+  ['cashflow_weekly_reopen_not_locked', {
+    guide: '완료 요청되거나 확정된 주간 정산만 되돌릴 수 있어요. 화면을 다시 불러온 뒤 상태를 확인해 주세요.',
+    resolution: 'retry',
+  }],
+  ['cashflow_weekly_reopen_reason_required', {
+    guide: '조직장이 확정한 주간 정산은 사유와 함께 재오픈해야 해요.',
+    resolution: 'contact',
+  }],
+  ['cashflow_weekly_reopen_forbidden', {
+    guide: '확정된 주간 정산은 프로젝트 조직장이나 관리자만 되돌릴 수 있어요.',
+    resolution: 'contact',
+  }],
+  ['cashflow_weekly_confirm_not_submitted', {
+    guide: '완료 요청된 주간 정산만 확정할 수 있어요. 화면을 다시 불러온 뒤 상태를 확인해 주세요.',
+    resolution: 'retry',
+  }],
+  ['cashflow_weekly_confirm_forbidden', {
+    guide: '주간 정산 확정은 프로젝트 조직장만 할 수 있어요.',
+    resolution: 'contact',
+  }],
   ['cashflow_month_closed', {
     guide: '이미 누적 결산이 끝난 월이에요. 수정이 필요하면 관리자에게 월 재오픈을 요청해 주세요.',
     resolution: 'contact',


### PR DESCRIPTION
결정(2026-08-19): 확정 주체=프로젝트 조직장 · 준수 기준=완료 요청 시각 · 요청부터 잠금 · 확정 뒤엔 사유 있는 재오픈만.

**상태 전이** OPEN → SUBMITTED(완료 요청, PM) → LOCKED(확정, 조직장). SUBMITTED → OPEN 은 요청 회수(사유 없음). LOCKED → OPEN 은 사유+조직장/관리자. 기존 LOCKED 42건 = 확정, 이행 없음.

**JVM** 새 커맨드 `cashflowWeeklyUpdate.confirm`; SUBMITTED 도 잠금으로 취급(정산주 변경 감지·월 재오픈 해제·무결성·재요청 멱등); 준수 버전에 lockState, 이력에 lockState 반환; 권한표 재생성. 424/424.
**BFF** `/weekly-update-complete/confirm`; reopen 이 SUBMITTED(사유 없음)/LOCKED(사유 필수 400) 처리; 라벨 `확정 대기`(노랑) → 확정 후 초록; `actions.reopenWeekly/confirmWeekly`.
**화면** 주간 정산 완료 요청 / 요청 회수 / 주간 정산 확정.

jvm-weekly-api 267 · cashflow 컴포넌트 · client · policy:verify · typecheck · build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)