### PR TITLE
fix(projects): 통화를 계약금액 옆 열로 · 진행 상태를 기한에서 유도 · 대조 체크 제거

### DIFF
--- a/src/app/components/portal/PortalMinimalSweep.layout.test.ts
+++ b/src/app/components/portal/PortalMinimalSweep.layout.test.ts
@@ -78,10 +78,13 @@ describe('portal minimal sweep', () => {
     expect(projectEditSource).not.toContain('현재 프로젝트:');
   });
 
-  it('allows PM project edit to change the project status through the shared editor', () => {
+  it('derives the project status from the contract period instead of letting anyone pick it', () => {
+    // 예전에는 PM 이 공유 편집기에서 진행 상태를 직접 골랐다. 손으로 고르게 두니 계약이
+    // 끝난 사업이 "진행 중" 으로 남아, 기한에서 따라 나오게 바꿨다.
     expect(projectEditorWizardSource).toContain("mode === 'admin' || mode === 'portal-edit'");
-    expect(projectEditorWizardSource).toContain('프로젝트 진행 상태');
-    expect(projectEditorWizardSource).toContain("update('status', value as ProjectStatus)");
+    expect(projectEditorWizardSource).not.toContain("update('status', value as ProjectStatus)");
+    expect(projectEditorWizardSource).toContain('deriveProjectStatusFromContractPeriod');
+    expect(projectEditorWizardSource).toContain('updateContractPeriod');
   });
 
   it('removes dash placeholders and review coaching from project register summaries', () => {

--- a/src/app/components/projects/ProjectEditorWizard.shell.test.ts
+++ b/src/app/components/projects/ProjectEditorWizard.shell.test.ts
@@ -161,7 +161,9 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain("{ id: 'team', label: '팀/인력', icon: Users }");
     expect(source).not.toContain('<Label className="text-xs">팀원 구성</Label>');
     // 라벨은 이제 ProjectFormRow 의 라벨 열이 그린다. 개별 <Label className="text-xs"> 는 사라졌다.
-    expect(source).toContain('<ProjectFormRow label="통화">');
+    // 통화는 별도 폼 행이 아니라 계약금액 옆 열의 드롭다운이다. 금액과 떨어지면 단위가 멀어진다.
+    expect(source).not.toContain('<ProjectFormRow label="통화">');
+    expect(source).toContain('aria-label="통화"');
     expect(source).toContain('PROJECT_CURRENCY_LABELS[draft.currency]');
   });
 
@@ -660,7 +662,12 @@ describe('ProjectEditorWizard form skeleton contract', () => {
     expect(source).toContain("'px-3 py-2.5 text-right font-semibold text-[#0176D3]'");
     // 총계 입력칸 5개는 v1 등록에만 남는다.
     expect(source).toContain('formatProjectAmountInput(draft.contractAmount, hasContractAmountInput)');
-    expect(source).toContain('금액을 계약서와 대조하여 확인했습니다.');
+    // 계약서 대조 체크는 걷어냈다. 체크박스를 지우면서 그것을 요구하던 제출 검증도 함께 지웠다.
+    expect(source).not.toContain('금액을 계약서와 대조하여 확인했습니다.');
+    expect(source).not.toContain('row.year === year && row.confirmed');
+    // 진행 상태는 사람이 고르지 않고 계약 기간에서 나온다.
+    expect(source).not.toContain('<ProjectFormRow label="프로젝트 진행 상태">');
+    expect(source).toContain('deriveProjectStatusFromContractPeriod');
     // 입금 계획은 금액 표와 다른 경로다. 연도별로 쪼개는 것은 다년도뿐이다.
     expect(source).toContain('{annualTotalsOwnAmounts && hasMultiYearContract ? (');
   });

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -17,7 +17,7 @@ import {
   Users,
   Wallet,
 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type ReactNode } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type ReactNode } from 'react';
 import { toast } from 'sonner';
 import { useBlocker } from 'react-router';
 import {
@@ -72,6 +72,7 @@ import {
   type ContractAmountItemField,
 } from '../../platform/project-contract-amount';
 import { buildContractDocumentEditPolicy } from '../../platform/project-contract-document-policy';
+import { deriveProjectStatusFromContractPeriod } from '../../platform/project-status-from-period';
 import {
   PROJECT_REQUEST_DOCUMENT_UPLOAD_MAX_SIZE_BYTES,
   PROJECT_REQUEST_DOCUMENT_UPLOAD_MAX_SIZE_LABEL,
@@ -1323,6 +1324,25 @@ export function ProjectEditorWizard({
     }));
   };
 
+  /**
+   * 계약 기간을 고치면 진행 상태가 따라온다. 사람이 고르는 값이 아니라 날짜에서 나오는 값이다.
+   * 불러오기만으로 저장된 상태를 바꾸지는 않는다 - 사람이 기간을 손댈 때만 다시 계산한다.
+   */
+  const updateContractPeriod = (key: 'contractStart' | 'contractEnd', value: string) => {
+    setDraft((prev) => {
+      const next = { ...prev, [key]: value };
+      return createProjectEditorWizardDraft({
+        ...next,
+        status: deriveProjectStatusFromContractPeriod({
+          contractStart: next.contractStart,
+          contractEnd: next.contractEnd,
+          currentStatus: next.status,
+          today: new Date().toISOString().slice(0, 10),
+        }),
+      });
+    });
+  };
+
   const updateFinancialYear = (
     index: number,
     key: 'contractAmount' | 'salesVatAmount' | 'totalRevenueAmount' | 'totalActualCost' | 'supportAmount' | 'paymentPlan' | 'paymentExpectedMonths' | 'advanceInterimBelow70Reason' | 'isSettled' | 'confirmed',
@@ -1573,7 +1593,7 @@ export function ProjectEditorWizard({
         : [];
       const financialYearsComplete = expectedYears.length > 0
         && draft.financialYears.length === expectedYears.length
-        && expectedYears.every((year) => draft.financialYears.some((row) => row.year === year && row.confirmed));
+        && expectedYears.every((year) => draft.financialYears.some((row) => row.year === year));
       const annualTotal = (field: 'contractAmount' | 'salesVatAmount' | 'totalRevenueAmount' | 'totalActualCost' | 'supportAmount') => (
         draft.financialYears.reduce((sum, row) => sum + row[field], 0)
       );
@@ -2321,7 +2341,6 @@ export function ProjectEditorWizard({
       ['totalActualCost', '실비(원가)'],
       ['supportAmount', '지원금'],
     ] as const;
-    const unconfirmedYears = draft.financialYears.filter((row) => !row.confirmed).map((row) => `${row.year}년`);
     const emptyContractYears = draft.financialYears.filter((row) => row.contractAmount <= 0).map((row) => `${row.year}년`);
     // 저장된 총계와 연도 합계가 어긋나면 이미 submitIssues 가 잡는다. 여기서는 같은 사실을
     // 표 밑에서 보여주기만 하고 판정은 하지 않는다.
@@ -2336,14 +2355,15 @@ export function ProjectEditorWizard({
               <tr className="border-y border-slate-200 bg-slate-50">
                 <th scope="col" className={cn('py-2 pr-3', FORM_LABEL_CLASS)}>연도</th>
                 {columns.map(([field, label]) => (
-                  <th key={field} scope="col" className={cn('px-3 py-2 text-right', FORM_LABEL_CLASS)}>
-                    {label}
-                    {/* 금액 열임을 열 이름에서 바로 읽히게 한다. 셀마다 반복하지 않는다. */}
-                    <span className="ml-1 text-[11px] font-normal text-slate-400">{draft.currency}</span>
-                  </th>
+                  <Fragment key={field}>
+                    <th scope="col" className={cn('px-3 py-2 text-right', FORM_LABEL_CLASS)}>{label}</th>
+                    {/* 통화는 계약금액 바로 옆에서 고른다. 금액과 떨어지면 무슨 단위인지 멀어진다. */}
+                    {field === 'contractAmount' ? (
+                      <th scope="col" className={cn('px-3 py-2 text-left', FORM_LABEL_CLASS)}>통화</th>
+                    ) : null}
+                  </Fragment>
                 ))}
                 <th scope="col" className={cn('px-3 py-2 text-right', FORM_LABEL_CLASS)}>수익률</th>
-                <th scope="col" className={cn('px-3 py-2 text-right', FORM_LABEL_CLASS)}>계약서 대조</th>
               </tr>
             </thead>
             <tbody>
@@ -2353,12 +2373,12 @@ export function ProjectEditorWizard({
                     {row.year}년
                   </th>
                   {columns.map(([field, label]) => (
-                    <td key={field} className="px-3 py-2">
+                    <Fragment key={field}>
+                    <td className="px-3 py-2">
                       {field === 'contractAmount' && contractAmountIsDerived ? (
                         /* 숫자 열이라 오른쪽 정렬을 지킨다. 입력칸 모양은 쓰지 않는다. */
                         <div className="flex h-9 min-w-[116px] flex-col items-end justify-center">
                           <span className={cn('font-medium text-slate-900', FORM_NUMERIC_VALUE_CLASS)}>
-                            <span className="mr-1 text-[11px] font-normal text-slate-400">{draft.currency}</span>
                             {fmtKRW(row.contractAmount)}
                           </span>
                           <span className="text-[11px] font-normal leading-4 text-slate-400">계산됨</span>
@@ -2373,33 +2393,38 @@ export function ProjectEditorWizard({
                         />
                       )}
                     </td>
+                    {/* 통화는 사업 단위로 하나다. 합계 행에서 한 번만 고른다. */}
+                    {field === 'contractAmount' ? <td className="px-3 py-2" /> : null}
+                    </Fragment>
                   ))}
                   <td className={cn('px-3 py-2 text-right text-slate-600', FORM_NUMERIC_VALUE_CLASS)}>
                     {`${(row.profitRate * 100).toFixed(2)}%`}
-                  </td>
-                  <td className="px-3 py-2 text-right">
-                    <Checkbox
-                      aria-label={`${row.year}년 금액을 계약서와 대조하여 확인했습니다.`}
-                      checked={row.confirmed}
-                      onCheckedChange={(checked) => updateFinancialYear(index, 'confirmed', checked === true)}
-                    />
                   </td>
                 </tr>
               ))}
               <tr className="bg-slate-100">
                 <th scope="row" className={cn('py-2.5 pr-3 text-slate-900', FORM_LABEL_CLASS)}>합계</th>
                 {columns.map(([field]) => (
-                  <td key={field} className={cn('px-3 py-2.5 text-right font-semibold text-[#0176D3]', FORM_NUMERIC_VALUE_CLASS)}>
-                    {fmtKRW(annualTotal(field))}
-                  </td>
+                  <Fragment key={field}>
+                    <td className={cn('px-3 py-2.5 text-right font-semibold text-[#0176D3]', FORM_NUMERIC_VALUE_CLASS)}>
+                      {fmtKRW(annualTotal(field))}
+                    </td>
+                    {field === 'contractAmount' ? (
+                      <td className="px-3 py-2.5">
+                        <Select value={draft.currency} onValueChange={(value) => update('currency', (value === 'USD' ? 'USD' : 'KRW') as ProjectCurrency)}>
+                          <SelectTrigger className={cn('h-8 min-w-[92px]', FORM_CONTROL_CLASS)} aria-label="통화"><SelectValue /></SelectTrigger>
+                          <SelectContent>
+                            {(Object.keys(PROJECT_CURRENCY_LABELS) as ProjectCurrency[]).map((currency) => (
+                              <SelectItem key={currency} value={currency}>{PROJECT_CURRENCY_LABELS[currency]}</SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </td>
+                    ) : null}
+                  </Fragment>
                 ))}
-                {/* 총수익률의 자리. 위에 따로 떼어 두지 않고 무엇을 나눈 값인지 여기서 밝힌다. */}
-                <td className={cn('px-3 py-2.5 text-right', FORM_NUMERIC_VALUE_CLASS)}>
-                  <span className="font-semibold text-slate-900">{profitRateLabel ? `${profitRateLabel}%` : '-'}</span>
-                  <span className="ml-1 text-[11px] font-normal text-slate-400">총수익÷계약금액</span>
-                </td>
-                <td className={cn('px-3 py-2.5 text-right text-slate-600', FORM_NUMERIC_VALUE_CLASS)}>
-                  {draft.financialYears.length - unconfirmedYears.length}/{draft.financialYears.length}
+                <td className={cn('px-3 py-2.5 text-right font-semibold text-slate-900', FORM_NUMERIC_VALUE_CLASS)}>
+                  {profitRateLabel ? `${profitRateLabel}%` : '-'}
                 </td>
               </tr>
             </tbody>
@@ -2436,18 +2461,12 @@ export function ProjectEditorWizard({
             금액을 한 번 고쳐 넣으면 항목 합계로 바뀌어 저장되니, 어느 쪽이 맞는지 먼저 확인해 주세요.
           </p>
         ) : null}
-        {emptyContractYears.length > 0 || unconfirmedYears.length > 0 || totalsDrifted ? (
+        {emptyContractYears.length > 0 || totalsDrifted ? (
           <ul className={cn('space-y-1', FORM_ERROR_CLASS)}>
             {emptyContractYears.length > 0 ? (
               <li className="flex gap-1.5">
                 <span aria-hidden>·</span>
                 <span>{emptyContractYears.join(', ')} 계약금액이 아직 비어 있습니다.</span>
-              </li>
-            ) : null}
-            {unconfirmedYears.length > 0 ? (
-              <li className="flex gap-1.5">
-                <span aria-hidden>·</span>
-                <span>{unconfirmedYears.join(', ')} 금액을 계약서와 대조하여 확인해 주세요.</span>
               </li>
             ) : null}
             {totalsDrifted ? (
@@ -2639,7 +2658,7 @@ export function ProjectEditorWizard({
       <ProjectFormSection title="계약 정보">
         <ProjectFormFieldPair>
           <ProjectFormRow label="계약 시작일" required issueLabel="계약 시작일" errors={fieldIssues('계약 시작일')}>
-            <Input type="date" value={draft.contractStart} onChange={(event) => update('contractStart', event.target.value)} className={cn('max-w-[200px]', FORM_NUMERIC_CONTROL_CLASS, 'text-left')} />
+            <Input type="date" value={draft.contractStart} onChange={(event) => updateContractPeriod('contractStart', event.target.value)} className={cn('max-w-[200px]', FORM_NUMERIC_CONTROL_CLASS, 'text-left')} />
           </ProjectFormRow>
           <ProjectFormRow
             label="계약 종료일"
@@ -2647,23 +2666,11 @@ export function ProjectEditorWizard({
             issueLabel="계약 종료일"
             errors={fieldIssues('계약 종료일', '계약 종료일은 시작일 이후여야 합니다.')}
           >
-            <Input type="date" value={draft.contractEnd} onChange={(event) => update('contractEnd', event.target.value)} className={cn('max-w-[200px]', FORM_NUMERIC_CONTROL_CLASS, 'text-left')} />
+            <Input type="date" value={draft.contractEnd} onChange={(event) => updateContractPeriod('contractEnd', event.target.value)} className={cn('max-w-[200px]', FORM_NUMERIC_CONTROL_CLASS, 'text-left')} />
           </ProjectFormRow>
         </ProjectFormFieldPair>
 
         <ProjectFormFieldPair>
-        {canEditProjectStatus(mode) ? (
-          <ProjectFormRow label="프로젝트 진행 상태">
-            <Select value={draft.status} onValueChange={(value) => update('status', value as ProjectStatus)}>
-              <SelectTrigger className={cn('max-w-xs', FORM_CONTROL_CLASS)}><SelectValue /></SelectTrigger>
-              <SelectContent>
-                {(Object.keys(PROJECT_STATUS_LABELS) as ProjectStatus[]).map((status) => (
-                  <SelectItem key={status} value={status}>{PROJECT_STATUS_LABELS[status]}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </ProjectFormRow>
-        ) : null}
         {canEditProjectStatus(mode) && isAdminMode(mode) ? (
           <ProjectFormRow label="프로젝트 구분">
             <Select value={draft.phase} onValueChange={(value) => update('phase', value as ProjectPhase)}>
@@ -2681,16 +2688,6 @@ export function ProjectEditorWizard({
             보였다. 행 컴포넌트를 쓰면서 두 경우 모두 같은 자리에 한 번만 놓는다. */}
         <ProjectFormFieldPair>
         {!canEditProjectStatus(mode) || isAdminMode(mode) ? renderContractTypeSelect() : null}
-        <ProjectFormRow label="통화">
-          <Select value={draft.currency} onValueChange={(value) => update('currency', (value === 'USD' ? 'USD' : 'KRW') as ProjectCurrency)}>
-            <SelectTrigger className={cn('max-w-[160px]', FORM_CONTROL_CLASS)}><SelectValue /></SelectTrigger>
-            <SelectContent>
-              {(Object.keys(PROJECT_CURRENCY_LABELS) as ProjectCurrency[]).map((currency) => (
-                <SelectItem key={currency} value={currency}>{PROJECT_CURRENCY_LABELS[currency]}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </ProjectFormRow>
         </ProjectFormFieldPair>
 
         {annualTotalsOwnAmounts ? (

--- a/src/app/platform/project-status-from-period.test.ts
+++ b/src/app/platform/project-status-from-period.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { deriveProjectStatusFromContractPeriod } from './project-status-from-period';
+
+const base = { contractStart: '2026-03-01', contractEnd: '2026-12-31', currentStatus: 'IN_PROGRESS' as const };
+
+describe('deriveProjectStatusFromContractPeriod', () => {
+  it('reads the status off the contract period', () => {
+    expect(deriveProjectStatusFromContractPeriod({ ...base, today: '2026-02-28' })).toBe('CONTRACT_PENDING');
+    expect(deriveProjectStatusFromContractPeriod({ ...base, today: '2026-03-01' })).toBe('IN_PROGRESS');
+    expect(deriveProjectStatusFromContractPeriod({ ...base, today: '2026-12-31' })).toBe('IN_PROGRESS');
+    expect(deriveProjectStatusFromContractPeriod({ ...base, today: '2027-01-01' })).toBe('COMPLETED');
+  });
+
+  it('never overwrites 완료(잔금 대기) — 날짜가 아니라 입금 여부의 문제다', () => {
+    expect(deriveProjectStatusFromContractPeriod({
+      ...base,
+      currentStatus: 'COMPLETED_PENDING_PAYMENT',
+      today: '2027-06-01',
+    })).toBe('COMPLETED_PENDING_PAYMENT');
+  });
+
+  it('leaves the stored status alone until both dates are real', () => {
+    expect(deriveProjectStatusFromContractPeriod({ ...base, contractStart: '', today: '2026-06-01' })).toBe('IN_PROGRESS');
+    expect(deriveProjectStatusFromContractPeriod({ ...base, contractEnd: '2026', today: '2026-06-01' })).toBe('IN_PROGRESS');
+    // 종료일이 시작일보다 앞서면 기간이 아니다. 판정하지 않는다.
+    expect(deriveProjectStatusFromContractPeriod({
+      ...base, contractStart: '2026-12-31', contractEnd: '2026-03-01',
+      currentStatus: 'CONTRACT_PENDING', today: '2026-06-01',
+    })).toBe('CONTRACT_PENDING');
+  });
+});

--- a/src/app/platform/project-status-from-period.ts
+++ b/src/app/platform/project-status-from-period.ts
@@ -1,0 +1,30 @@
+import type { ProjectStatus } from '../data/types';
+
+/**
+ * 계약 기간으로 프로젝트 진행 상태를 정한다.
+ *
+ * 진행 상태는 사람이 고를 것이 아니라 날짜에서 따라 나오는 값이다. 손으로 고르게 두면
+ * 계약이 끝난 사업이 몇 달째 "진행 중"으로 남는다.
+ *
+ * 다만 **완료(잔금 대기)는 날짜로 알 수 없다.** 기간이 끝났는지가 아니라 돈이 들어왔는지의
+ * 문제라, 이미 그 상태인 사업은 그대로 둔다. 날짜가 아직 안 채워진 경우도 건드리지 않는다.
+ */
+export function deriveProjectStatusFromContractPeriod(input: {
+  contractStart: string;
+  contractEnd: string;
+  currentStatus: ProjectStatus;
+  today: string;
+}): ProjectStatus {
+  if (input.currentStatus === 'COMPLETED_PENDING_PAYMENT') return input.currentStatus;
+
+  const isDate = (value: string) => /^\d{4}-\d{2}-\d{2}$/.test(value);
+  const start = String(input.contractStart || '').slice(0, 10);
+  const end = String(input.contractEnd || '').slice(0, 10);
+  const today = String(input.today || '').slice(0, 10);
+  if (!isDate(start) || !isDate(end) || !isDate(today)) return input.currentStatus;
+  if (start > end) return input.currentStatus;
+
+  if (today < start) return 'CONTRACT_PENDING';
+  if (today > end) return 'COMPLETED';
+  return 'IN_PROGRESS';
+}


### PR DESCRIPTION
라이브 화면 피드백 5건입니다.

| 요청 | 반영 |
|---|---|
| 통화를 계약금액 옆 열에 드롭다운으로 | 표 안 `통화` 열 추가, 별도 폼 행 제거 |
| 불필요한 `KRW` 표기 제외 | 열 이름·파생 칸의 통화 라벨 제거 |
| 프로젝트 진행 상태 제외, 기한으로 자동 계산 | 선택 제거 + `deriveProjectStatusFromContractPeriod` |
| `총수익÷계약금액` 삭제 (UI 깨짐) | 합계 행 라벨 제거 |
| 계약서 대조 체크 삭제 | 열·검증·안내 함께 제거 |

## 통화

계약금액 바로 옆 열에서 고릅니다. **통화는 사업 단위로 하나라 합계 행에서 한 번만** 고르게
했습니다(연도마다 다른 통화를 쓰지 않으므로 행마다 드롭다운을 반복하지 않습니다).
표 안으로 들어왔으니 열 이름에 붙였던 `KRW` 는 같은 말이 되어 걷었습니다.

## 계약서 대조 체크 — 함께 지운 것이 있습니다

체크박스만 지우면 **제출이 영구히 막힙니다.** 직전 배포에서 "표가 미확인 연도를 빨갛게
알려주는데 제출은 통과하면 그 빨간 글씨가 뜻이 없다"는 이유로 `row.confirmed` 를 요구하는
제출 검증을 넣어 뒀기 때문입니다. 그래서 함께 지웠습니다.

- `financialYearsComplete` 의 `&& row.confirmed` 조건
- 미확인 연도 안내 문구와 합계 행의 `0/1` 칸

저장 필드 `confirmed` 자체는 변경 이력 요약이 참조하므로 남겼습니다.

## 진행 상태 — 기한에서 유도

`오늘 < 시작일` → 계약 전 · `종료일 < 오늘` → 완료 · 그 사이 → 진행 중.

지킨 두 가지가 있습니다.

1. **완료(잔금 대기)는 덮어쓰지 않습니다.** 기간이 끝났는지가 아니라 돈이 들어왔는지의
   문제라 날짜로 알 수 없습니다. 이미 그 상태면 그대로 둡니다.
2. **불러오기만으로 저장된 상태를 바꾸지 않습니다.** 사람이 계약 기간을 손댈 때만 다시
   계산합니다. 열기만 해도 값이 바뀌면 그것대로 사고입니다.

### ⚠️ 이 변경으로 사라지는 것 — 확인 필요

`PortalMinimalSweep.layout.test.ts` 에 **"PM 이 공유 편집기에서 진행 상태를 바꿀 수 있어야
한다"** 는 계약이 있었습니다(`17d49d1d Fix project status edit`). 이번 변경이 그 계약을
대체하므로 테스트를 새 규칙으로 고쳤습니다.

그 결과 **`완료(잔금 대기)` 를 새로 지정할 수 있는 화면이 없어집니다.** 지금 이 값을 넣는
경로는 ETL 이관(`DataMigrationTab.tsx:1251`, 텍스트에 "잔금" 이 있으면 매핑)뿐입니다.
기존 값은 보존되지만 새로 만들 수는 없습니다.

괜찮은지 확인 부탁드립니다. 필요하면 (a) 잔금 대기만 고를 수 있는 최소 선택을 남기거나,
(b) 입금 계획의 잔금 입금 여부에서 유도하는 방향이 있습니다.

## 검증

| 게이트 | 결과 |
|---|---|
| `npm run typecheck` | no new type errors |
| 관련 테스트 | 191/191 통과 |
| `npm run build` | ✓ 성공 |

신규 헬퍼 `project-status-from-period.ts` 는 경계값(시작일 당일·종료일 당일·역전된 기간·
빈 날짜·잔금 대기 보존)을 테스트로 덮었습니다.

## 스크린샷 — 필요

표 레이아웃이 바뀌므로 확인이 필요합니다: 통화 드롭다운 위치, 대조 열이 사라진 뒤 열 정렬,
합계 행 수익률.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
