### PR TITLE
feat(jvm): dashboard read loop developer log (reads, phases, instance)

### DIFF
--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/observability/CashflowReadMetrics.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/observability/CashflowReadMetrics.java
@@ -1,0 +1,190 @@
+package dev.merryai.innerplatform.weekly.observability;
+
+import java.lang.management.ManagementFactory;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+/**
+ * 8초 문제(C 단계) 측정용 개발자 로그. 로직에는 손대지 않고, 요청 하나가
+ *  - Firestore 를 몇 번/얼마나 읽었는지 (문서 get / getAll / query 별 횟수·소요·문서 수)
+ *  - 어떤 인스턴스에서 (Cloud Run 서비스·리비전·인스턴스 id, vCPU, 힙, 스레드, 동시 처리 수, 기동 후 경과)
+ *  - 어느 단계에서 얼마나 걸렸는지
+ * 를 한 줄로 남긴다. 병렬 읽기(CompletableFuture) 스레드에도 같은 컨텍스트를 물려준다.
+ */
+public final class CashflowReadMetrics {
+    private static final System.Logger LOGGER = System.getLogger(CashflowReadMetrics.class.getName());
+    private static final ThreadLocal<CashflowReadMetrics> CURRENT = new ThreadLocal<>();
+    private static final AtomicInteger IN_FLIGHT = new AtomicInteger();
+    private static final long STARTED_AT_MS = System.currentTimeMillis();
+    private static volatile String instanceId = "";
+    private static volatile boolean instanceIdResolved = false;
+
+    private final String operation;
+    private final String requestId;
+    private final String projectId;
+    private final long startedAtNanos = System.nanoTime();
+    private final AtomicLong docGets = new AtomicLong();
+    private final AtomicLong docGetNanos = new AtomicLong();
+    private final AtomicLong getAlls = new AtomicLong();
+    private final AtomicLong getAllNanos = new AtomicLong();
+    private final AtomicLong getAllDocs = new AtomicLong();
+    private final AtomicLong queries = new AtomicLong();
+    private final AtomicLong queryNanos = new AtomicLong();
+    private final AtomicLong queryDocs = new AtomicLong();
+    private final Map<String, Long> phases = new ConcurrentHashMap<>();
+    private final int inFlightAtStart;
+
+    private CashflowReadMetrics(String operation, String requestId, String projectId) {
+        this.operation = operation;
+        this.requestId = requestId == null ? "" : requestId;
+        this.projectId = projectId == null ? "" : projectId;
+        this.inFlightAtStart = IN_FLIGHT.incrementAndGet();
+    }
+
+    /** 요청 하나의 측정을 시작한다. try-with-resources 로 닫히면 요약 한 줄을 남긴다. */
+    public static Scope begin(String operation, String requestId, String projectId) {
+        CashflowReadMetrics metrics = new CashflowReadMetrics(operation, requestId, projectId);
+        CashflowReadMetrics previous = CURRENT.get();
+        CURRENT.set(metrics);
+        return new Scope(metrics, previous);
+    }
+
+    public static CashflowReadMetrics current() {
+        return CURRENT.get();
+    }
+
+    /** 병렬 읽기 스레드에 현재 컨텍스트를 물려준다. */
+    public static <T> Supplier<T> propagate(Supplier<T> task) {
+        CashflowReadMetrics captured = CURRENT.get();
+        if (captured == null) return task;
+        return () -> {
+            CashflowReadMetrics previous = CURRENT.get();
+            CURRENT.set(captured);
+            try {
+                return task.get();
+            } finally {
+                if (previous == null) CURRENT.remove(); else CURRENT.set(previous);
+            }
+        };
+    }
+
+    public static void recordDocGet(long nanos) {
+        CashflowReadMetrics m = CURRENT.get();
+        if (m == null) return;
+        m.docGets.incrementAndGet();
+        m.docGetNanos.addAndGet(nanos);
+    }
+
+    public static void recordGetAll(long nanos, int docs) {
+        CashflowReadMetrics m = CURRENT.get();
+        if (m == null) return;
+        m.getAlls.incrementAndGet();
+        m.getAllNanos.addAndGet(nanos);
+        m.getAllDocs.addAndGet(docs);
+    }
+
+    public static void recordQuery(long nanos, int docs) {
+        CashflowReadMetrics m = CURRENT.get();
+        if (m == null) return;
+        m.queries.incrementAndGet();
+        m.queryNanos.addAndGet(nanos);
+        m.queryDocs.addAndGet(docs);
+    }
+
+    public static void recordPhase(String phase, long durationMs) {
+        CashflowReadMetrics m = CURRENT.get();
+        if (m == null) return;
+        m.phases.merge(phase, durationMs, Long::sum);
+    }
+
+    public static final class Scope implements AutoCloseable {
+        private final CashflowReadMetrics metrics;
+        private final CashflowReadMetrics previous;
+        private String outcome = "ok";
+
+        private Scope(CashflowReadMetrics metrics, CashflowReadMetrics previous) {
+            this.metrics = metrics;
+            this.previous = previous;
+        }
+
+        public void failed(Throwable error) {
+            outcome = error == null ? "error" : error.getClass().getSimpleName();
+        }
+
+        @Override
+        public void close() {
+            IN_FLIGHT.decrementAndGet();
+            if (previous == null) CURRENT.remove(); else CURRENT.set(previous);
+            metrics.log(outcome);
+        }
+    }
+
+    private void log(String outcome) {
+        Runtime runtime = Runtime.getRuntime();
+        long totalMs = (System.nanoTime() - startedAtNanos) / 1_000_000L;
+        double processCpu = -1;
+        try {
+            java.lang.management.OperatingSystemMXBean os = ManagementFactory.getOperatingSystemMXBean();
+            if (os instanceof com.sun.management.OperatingSystemMXBean sun) processCpu = sun.getProcessCpuLoad();
+        } catch (Throwable ignored) {
+            // 측정은 요청을 절대 깨뜨리지 않는다.
+        }
+        Map<String, Object> line = new LinkedHashMap<>();
+        line.put("message", "cashflow.read.summary");
+        line.put("operation", operation);
+        line.put("requestId", requestId);
+        line.put("projectId", projectId);
+        line.put("outcome", outcome);
+        line.put("totalMs", totalMs);
+        line.put("reads", Map.of(
+            "docGet", docGets.get(), "docGetMs", docGetNanos.get() / 1_000_000L,
+            "getAll", getAlls.get(), "getAllMs", getAllNanos.get() / 1_000_000L, "getAllDocs", getAllDocs.get(),
+            "query", queries.get(), "queryMs", queryNanos.get() / 1_000_000L, "queryDocs", queryDocs.get()
+        ));
+        line.put("phasesMs", new java.util.TreeMap<>(phases));
+        Map<String, Object> instance = new LinkedHashMap<>();
+        instance.put("service", System.getenv().getOrDefault("K_SERVICE", ""));
+        instance.put("revision", System.getenv().getOrDefault("K_REVISION", ""));
+        instance.put("instanceId", resolveInstanceId());
+        instance.put("cpus", runtime.availableProcessors());
+        instance.put("commonPoolParallelism", ForkJoinPool.getCommonPoolParallelism());
+        instance.put("heapUsedMb", (runtime.totalMemory() - runtime.freeMemory()) / (1024 * 1024));
+        instance.put("heapMaxMb", runtime.maxMemory() / (1024 * 1024));
+        instance.put("threads", Thread.activeCount());
+        instance.put("inFlightAtStart", inFlightAtStart);
+        instance.put("uptimeMs", System.currentTimeMillis() - STARTED_AT_MS);
+        instance.put("processCpuLoad", processCpu);
+        line.put("instance", instance);
+        LOGGER.log(System.Logger.Level.INFO, line.toString());
+    }
+
+    // Cloud Run 인스턴스 id: 메타데이터 서버에서 한 번만, 최대 300ms. 로컬·테스트에선 빈 값.
+    private static String resolveInstanceId() {
+        if (instanceIdResolved) return instanceId;
+        instanceIdResolved = true;
+        if (System.getenv("K_SERVICE") == null) return "";
+        try {
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofMillis(300)).build();
+            HttpRequest request = HttpRequest.newBuilder(URI.create("http://metadata.google.internal/computeMetadata/v1/instance/id"))
+                .header("Metadata-Flavor", "Google")
+                .timeout(Duration.ofMillis(300))
+                .GET()
+                .build();
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() == 200) instanceId = response.body().trim();
+        } catch (Throwable ignored) {
+            instanceId = "";
+        }
+        return instanceId;
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -58,6 +58,7 @@ import dev.merryai.innerplatform.weekly.api.RowDeleteRequest;
 import dev.merryai.innerplatform.weekly.api.RowInsertRequest;
 import dev.merryai.innerplatform.weekly.api.ConfirmCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.ReopenCashflowWeeklyUpdateRequest;
+import dev.merryai.innerplatform.weekly.observability.CashflowReadMetrics;
 import dev.merryai.innerplatform.weekly.api.SaveDraftRequest;
 import dev.merryai.innerplatform.weekly.api.SaveDraftResponse;
 import dev.merryai.innerplatform.weekly.api.SubmitWeekRequest;
@@ -1297,9 +1298,16 @@ public class WeeklyExpenseCommandService {
         String cursor
     ) {
         authorizationService.requireProjectAllowed(READ_CASHFLOW_WEEKLY_UPDATE_COMMAND, actor, projectId);
-        WeeklyExpensePersistence.CashflowWeeklyCompliancePage page = persistence.findCashflowWeeklyComplianceHistory(
-            actor.tenantId(), projectId, limit, cursor
-        );
+        // C 단계 측정: 대시보드가 부르는 두 번째 JVM 읽기. 읽기 수·소요를 같은 형식으로.
+        WeeklyExpensePersistence.CashflowWeeklyCompliancePage page;
+        try (CashflowReadMetrics.Scope scope = CashflowReadMetrics.begin("cashflow.weekly_compliance", "", projectId)) {
+            try {
+                page = persistence.findCashflowWeeklyComplianceHistory(actor.tenantId(), projectId, limit, cursor);
+            } catch (RuntimeException error) {
+                scope.failed(error);
+                throw error;
+            }
+        }
         return new CashflowWeeklyComplianceHistoryResponse(
             page.items().stream().map(item -> new CashflowWeeklyComplianceHistoryResponse.Item(
                 item.yearMonth(), item.weekNo(), item.deadline(), item.status(), item.completedAt(),

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/query/CashflowMonthDashboardQueryService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/query/CashflowMonthDashboardQueryService.java
@@ -1,5 +1,6 @@
 package dev.merryai.innerplatform.weekly.service.query;
 
+import dev.merryai.innerplatform.weekly.observability.CashflowReadMetrics;
 import dev.merryai.innerplatform.weekly.domain.CashflowCumulativeCloseHead;
 import dev.merryai.innerplatform.weekly.domain.CashflowLedgerSource;
 import dev.merryai.innerplatform.weekly.domain.CashflowMonthCloseState;
@@ -50,11 +51,20 @@ public class CashflowMonthDashboardQueryService {
 
     public Result read(String tenantId, String projectId, String yearMonth, String requestId) {
         YearMonth.parse(yearMonth);
-        for (int attempt = 1; attempt <= 2; attempt += 1) {
-            Result result = readAttempt(tenantId, projectId, yearMonth, requestId, attempt);
-            if (result != null) return result;
+        // Stage-C measurement: one summary line per request (Firestore reads, phases, instance). No logic change.
+        try (CashflowReadMetrics.Scope scope = CashflowReadMetrics.begin("cashflow.dashboard_source", requestId, projectId)) {
+            try {
+                for (int attempt = 1; attempt <= 2; attempt += 1) {
+                    CashflowReadMetrics.recordPhase("attempts", 1);
+                    Result result = readAttempt(tenantId, projectId, yearMonth, requestId, attempt);
+                    if (result != null) return result;
+                }
+                throw new UnstableRead();
+            } catch (RuntimeException error) {
+                scope.failed(error);
+                throw error;
+            }
         }
-        throw new UnstableRead();
     }
 
     private Result readAttempt(
@@ -355,7 +365,7 @@ public class CashflowMonthDashboardQueryService {
         Supplier<T> operation
     ) {
         return CompletableFuture.supplyAsync(
-            () -> measuredRead(requestId, projectId, attempt, phase, operation)
+            CashflowReadMetrics.propagate(() -> measuredRead(requestId, projectId, attempt, phase, operation))
         );
     }
 
@@ -402,6 +412,7 @@ public class CashflowMonthDashboardQueryService {
     }
 
     private void log(String requestId, String projectId, int attempt, String phase, long durationMs) {
+        CashflowReadMetrics.recordPhase(phase, durationMs);
         LOGGER.log(
             System.Logger.Level.INFO,
             "cashflow_dashboard_source requestId={0} projectId={1} attempt={2} phase={3} durationMs={4}",

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -34,6 +34,7 @@ import dev.merryai.innerplatform.weekly.api.CloseCashflowMonthRequest;
 import dev.merryai.innerplatform.weekly.api.CompleteCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.ConfirmCashflowWeeklyUpdateRequest;
 import dev.merryai.innerplatform.weekly.api.ReopenCashflowWeeklyUpdateRequest;
+import dev.merryai.innerplatform.weekly.observability.CashflowReadMetrics;
 import dev.merryai.innerplatform.weekly.api.TrustedActorContext;
 import dev.merryai.innerplatform.weekly.api.WeeklyExpenseConflictException;
 import dev.merryai.innerplatform.weekly.api.CashflowSettledWeekChangeConfirmation;
@@ -5281,10 +5282,12 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     }
 
     private DocumentSnapshot get(DocumentReference ref) {
+        long startedAt = System.nanoTime();
         try {
             Transaction tx = currentTransaction.get();
             DocumentSnapshot snap = tx == null ? ref.get().get() : tx.get(ref).get();
             cacheDocument(ref, snap.exists() ? data(snap) : Map.of());
+            CashflowReadMetrics.recordDocGet(System.nanoTime() - startedAt);
             return snap;
         } catch (Exception error) {
             throw new IllegalStateException("Could not read Firestore document: " + ref.getPath(), error);
@@ -5300,12 +5303,14 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     }
 
     private List<DocumentSnapshot> getAll(DocumentReference... refs) {
+        long startedAt = System.nanoTime();
         try {
             Transaction tx = currentTransaction.get();
             List<DocumentSnapshot> snapshots = tx == null ? db.getAll(refs).get() : tx.getAll(refs).get();
             for (DocumentSnapshot snap : snapshots) {
                 cacheDocument(snap.getReference(), snap.exists() ? data(snap) : Map.of());
             }
+            CashflowReadMetrics.recordGetAll(System.nanoTime() - startedAt, snapshots.size());
             return snapshots;
         } catch (Exception error) {
             throw new IllegalStateException("Could not read Firestore documents.", error);
@@ -5313,12 +5318,14 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     }
 
     private QuerySnapshot query(Query query) {
+        long startedAt = System.nanoTime();
         try {
             Transaction tx = currentTransaction.get();
             QuerySnapshot snap = tx == null ? query.get().get() : tx.get(query).get();
             for (DocumentSnapshot doc : snap.getDocuments()) {
                 cacheDocument(doc.getReference(), data(doc));
             }
+            CashflowReadMetrics.recordQuery(System.nanoTime() - startedAt, snap.size());
             return snap;
         } catch (Exception error) {
             throw new IllegalStateException("Could not query Firestore.", error);

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/observability/CashflowReadMetricsTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/observability/CashflowReadMetricsTest.java
@@ -1,0 +1,33 @@
+package dev.merryai.innerplatform.weekly.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+
+class CashflowReadMetricsTest {
+
+    @Test
+    void recordsReadsFromParallelThreadsIntoTheRequestScopeAndNeverThrows() {
+        assertThat(CashflowReadMetrics.current()).isNull();
+        assertThatCode(() -> {
+            try (CashflowReadMetrics.Scope scope = CashflowReadMetrics.begin("test.op", "req-1", "project-a")) {
+                CashflowReadMetrics.recordDocGet(1_000_000L);
+                CashflowReadMetrics.recordPhase("month_close", 12);
+                // 병렬 읽기 스레드도 같은 요청 컨텍스트에 기록한다.
+                CompletableFuture.supplyAsync(CashflowReadMetrics.propagate(() -> {
+                    CashflowReadMetrics.recordQuery(2_000_000L, 7);
+                    CashflowReadMetrics.recordPhase("weekly_ledger", 30);
+                    return CashflowReadMetrics.current() != null;
+                })).join();
+                assertThat(CashflowReadMetrics.current()).isNotNull();
+                scope.failed(new IllegalStateException("boom"));
+            }
+        }).doesNotThrowAnyException();
+        // 스코프가 닫히면 컨텍스트는 사라진다.
+        assertThat(CashflowReadMetrics.current()).isNull();
+        // 컨텍스트 밖의 기록은 무시된다 (요청을 절대 깨뜨리지 않는다).
+        assertThatCode(() -> CashflowReadMetrics.recordDocGet(1)).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
8초 문제 C 단계 측정 준비 — 로그만, 로직 불변.

dashboard-source·weekly-compliance 읽기마다 `cashflow.read.summary` 한 줄: totalMs / Firestore docGet·getAll·query 횟수·ms·문서수 / 단계별 ms(재시도 횟수 포함) / 인스턴스(K_SERVICE·K_REVISION·instanceId, vCPU, commonPool 병렬도, 힙 used/max, 스레드, 시작 시 동시 처리 수, 기동 후 경과=콜드 프록시, processCpuLoad). 병렬 섹션 읽기도 같은 요청 컨텍스트에 기록.

JVM 425/425 (아키텍처 규칙 포함).

🤖 Generated with [Claude Code](https://claude.com/claude-code)