### PR TITLE
perf(bff): run the BFF function next to Firestore (iad1)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -12,7 +12,7 @@
     "api/bff.js": {
       "maxDuration": 300,
       "regions": [
-        "icn1"
+        "iad1"
       ]
     }
   },


### PR DESCRIPTION
## 왜
Firestore `(default)` 는 `nam5`(미국) 인데 BFF 함수는 `icn1`(서울) → Firestore 읽기 1회 = 태평양 왕복 ≈200ms. 08-19 측정: 사소한 GET 1.0~1.5s, month-close 8s 중 BFF 자체 읽기·compose ≈ 4s.

## 무엇
`vercel.json` `api/bff.js` regions `icn1` → `iad1`. 로직 변경 없음. 되돌리기 = 이 한 줄 revert.

## 기대
BFF 안의 Firestore 읽기·쓰기 200ms → ~10ms. 브라우저는 요청당 태평양 1회만.

## 확인
배포 뒤 김제 화면 열어 `month-close` 콘솔 소요시간·`Server-Timing` 비교(측정 기록: 세션 스크래치 c-stage-measurement-20260819.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)