### PR TITLE
feat(portal): 종료사업 체크아웃을 화면에서 바로 체크한다

### DIFF
--- a/src/app/components/portal/PortalProjectCheckout.tsx
+++ b/src/app/components/portal/PortalProjectCheckout.tsx
@@ -1,8 +1,9 @@
 import { useMemo } from 'react';
 import { Link } from 'react-router';
-import { CheckCircle2, Circle, FileText, AlertTriangle } from 'lucide-react';
+import { CheckCircle2, FileText, AlertTriangle } from 'lucide-react';
+import { Checkbox } from '../ui/checkbox';
 import { usePortalStore } from '../../data/portal-store';
-import type { Project } from '../../data/types';
+import type { Project, ProjectCheckout } from '../../data/types';
 
 /**
  * 종료사업 체크아웃.
@@ -12,15 +13,21 @@ import type { Project } from '../../data/types';
  * "무엇이 남았는지" 를 묻는 자리를 여기 하나로 둔다.
  */
 
-type CheckItem = { label: string; done: boolean; note?: string };
+type CheckField = keyof Pick<
+  ProjectCheckout,
+  'finalPaymentReceived' | 'bankBalanceZero' | 'performanceCertificateReceived'
+  | 'usbEvidenceSubmitted' | 'evidenceDeletedAfterUsb'
+>;
+type CheckItem = { field: CheckField; label: string; done: boolean; note?: string };
 type UploadItem = { label: string; attached: boolean; note?: string };
 
 function readChecklist(project: Project): CheckItem[] {
   const checkout = project.checkout;
   return [
-    { label: '잔금 입금 완료', done: checkout?.finalPaymentReceived === true },
-    { label: '사업비 통장 0원', done: checkout?.bankBalanceZero === true },
+    { field: 'finalPaymentReceived', label: '잔금 입금 완료', done: checkout?.finalPaymentReceived === true },
+    { field: 'bankBalanceZero', label: '사업비 통장 0원', done: checkout?.bankBalanceZero === true },
     {
+      field: 'performanceCertificateReceived',
       label: '용역수행실적증명서 원본 제출',
       done: checkout?.performanceCertificateReceived === true,
       note: '원본 수령 시 최소 5부. 전자플랫폼(e나라도움 · KOICA · 온드림 등)은 업로드로 마무리합니다.',
@@ -50,7 +57,7 @@ function readUploads(project: Project): UploadItem[] {
 }
 
 export function PortalProjectCheckout() {
-  const { activeProjectId, projects } = usePortalStore();
+  const { activeProjectId, projects, updateProjectCheckout } = usePortalStore();
   const project = useMemo(
     () => projects.find((candidate) => candidate.id === activeProjectId) || null,
     [activeProjectId, projects],
@@ -98,14 +105,20 @@ export function PortalProjectCheckout() {
         <h2 className="border-b border-slate-200 pb-2 text-[12px] font-semibold text-slate-700">체크리스트</h2>
         <ul className="space-y-2">
           {checklist.map((item) => (
-            <li key={item.label} className="flex items-start gap-2 text-[13px]">
-              {item.done
-                ? <CheckCircle2 aria-hidden className="mt-0.5 h-4 w-4 shrink-0 text-[#047857]" />
-                : <Circle aria-hidden className="mt-0.5 h-4 w-4 shrink-0 text-slate-300" />}
-              <span className="min-w-0">
-                <span className={item.done ? 'text-slate-900' : 'text-slate-600'}>{item.label}</span>
-                {item.note ? <span className="mt-0.5 block text-[12px] text-slate-500">{item.note}</span> : null}
-              </span>
+            <li key={item.field} className="text-[13px]">
+              <label className="flex cursor-pointer items-start gap-2">
+                <Checkbox
+                  className="mt-0.5"
+                  checked={item.done}
+                  onCheckedChange={(checked) => {
+                    void updateProjectCheckout(project.id, { [item.field]: checked === true });
+                  }}
+                />
+                <span className="min-w-0">
+                  <span className={item.done ? 'text-slate-900' : 'text-slate-600'}>{item.label}</span>
+                  {item.note ? <span className="mt-0.5 block text-[12px] text-slate-500">{item.note}</span> : null}
+                </span>
+              </label>
             </li>
           ))}
         </ul>
@@ -130,23 +143,28 @@ export function PortalProjectCheckout() {
       <section className="space-y-3">
         <h2 className="border-b border-slate-200 pb-2 text-[12px] font-semibold text-slate-700">정산사업 마감</h2>
         <ul className="space-y-2 text-[13px]">
-          <li className="flex items-start gap-2">
-            {settlementClosed
-              ? <CheckCircle2 aria-hidden className="mt-0.5 h-4 w-4 shrink-0 text-[#047857]" />
-              : <Circle aria-hidden className="mt-0.5 h-4 w-4 shrink-0 text-slate-300" />}
-            <span>정산 자료 USB 저장 후 재경팀 제출</span>
-          </li>
-          <li className="flex items-start gap-2">
-            {evidenceDeleted
-              ? <CheckCircle2 aria-hidden className="mt-0.5 h-4 w-4 shrink-0 text-[#047857]" />
-              : <Circle aria-hidden className="mt-0.5 h-4 w-4 shrink-0 text-slate-300" />}
-            <span>증빙자료 삭제 (사용내역은 그대로 유지)</span>
-          </li>
+          {([
+            ['usbEvidenceSubmitted', '정산 자료 USB 저장 후 재경팀 제출', settlementClosed],
+            ['evidenceDeletedAfterUsb', '증빙자료 삭제 (사용내역은 그대로 유지)', evidenceDeleted],
+          ] as Array<[CheckField, string, boolean]>).map(([field, label, done]) => (
+            <li key={field}>
+              <label className="flex cursor-pointer items-start gap-2">
+                <Checkbox
+                  className="mt-0.5"
+                  checked={done}
+                  onCheckedChange={(checked) => {
+                    void updateProjectCheckout(project.id, { [field]: checked === true });
+                  }}
+                />
+                <span className={done ? 'text-slate-900' : 'text-slate-600'}>{label}</span>
+              </label>
+            </li>
+          ))}
         </ul>
       </section>
 
       <p className="text-[13px] text-slate-600">
-        체크와 증빙은{' '}
+        체크는 이 화면에서 바로 저장됩니다. 증빙 업로드는{' '}
         <Link className="font-medium text-[#0176D3] underline underline-offset-2" to={`/portal/edit-project/${project.id}`}>
           프로젝트 수정
         </Link>

--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -27,6 +27,7 @@ import type {
   ProjectSheetSourceSnapshot,
   ProjectSheetSourceType,
   Project,
+  ProjectCheckout,
   ProjectStatus,
   OrgMember,
   ParticipationEntry,
@@ -520,6 +521,7 @@ interface PortalActions {
   setSessionActiveProject: (projectId: string) => Promise<boolean>;
   patchProjectSnapshot: (project: Project) => void;
   updateProjectStatus: (projectId: string, status: ProjectStatus) => Promise<boolean>;
+  updateProjectCheckout: (projectId: string, patch: Partial<ProjectCheckout>) => Promise<boolean>;
   logout: () => void;
   addExpenseSet: (set: ExpenseSet) => void;
   updateExpenseSet: (id: string, updates: Partial<ExpenseSet>) => void;
@@ -3420,6 +3422,84 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     scopedProjectIds,
   ]);
 
+  /**
+   * 종료사업 체크아웃 항목을 저장한다. 상태 저장과 같은 경로를 쓰되 `checkout` 만 덮어쓴다.
+   * 종료 확인은 편집기 초안을 열 만큼 큰 일이 아니라 체크 하나가 곧 저장이다.
+   */
+  const updateProjectCheckout = useCallback(async (
+    projectId: string,
+    patch: Partial<ProjectCheckout>,
+  ): Promise<boolean> => {
+    const targetProjectId = projectId.trim();
+    if (!targetProjectId || !includesProject(scopedProjectIds, targetProjectId)) {
+      toast.error('선택 가능한 사업이 아닙니다.');
+      return false;
+    }
+
+    const existingProject = projectsRef.current.find((project) => project.id === targetProjectId);
+    if (!existingProject) {
+      toast.error('사업 정보를 찾지 못했습니다.');
+      return false;
+    }
+
+    const nextCheckout = { ...(existingProject.checkout || {}), ...patch } as ProjectCheckout;
+    const projectPatch: Partial<Project> = { checkout: nextCheckout, updatedAt: new Date().toISOString() };
+    const previousProjects = projectsRef.current;
+    const nextProjects = previousProjects.map((project) => (
+      project.id === targetProjectId ? { ...project, ...projectPatch } : project
+    ));
+    projectsRef.current = nextProjects;
+    setProjects(nextProjects);
+
+    if (isDevHarnessUser || !firestoreEnabled || !db) return true;
+
+    try {
+      if (isPlatformApiEnabled()) {
+        const idToken = authUser?.idToken || await getAuthInstance()?.currentUser?.getIdToken() || undefined;
+        await upsertProjectViaBff({
+          tenantId: orgId,
+          actor: {
+            uid: authUser?.uid || portalUser?.id || 'portal-user',
+            email: authUser?.email || portalUser?.email || '',
+            role: authUser?.role || portalUser?.role || 'pm',
+            idToken,
+          },
+          project: {
+            ...existingProject,
+            ...projectPatch,
+            expectedVersion: existingProject.version ?? 1,
+          } as UpsertProjectPayload,
+        });
+      } else {
+        await setDoc(
+          doc(db, getOrgDocumentPath(orgId, 'projects', targetProjectId)),
+          withTenantScope(orgId, projectPatch),
+          { merge: true },
+        );
+      }
+      return true;
+    } catch (err) {
+      console.error('[PortalStore] updateProjectCheckout error:', err);
+      projectsRef.current = previousProjects;
+      setProjects(previousProjects);
+      toast.error('체크아웃 저장에 실패했습니다.');
+      return false;
+    }
+  }, [
+    authUser?.email,
+    authUser?.idToken,
+    authUser?.role,
+    authUser?.uid,
+    db,
+    firestoreEnabled,
+    isDevHarnessUser,
+    orgId,
+    portalUser?.email,
+    portalUser?.id,
+    portalUser?.role,
+    scopedProjectIds,
+  ]);
+
   const logout = useCallback(() => {
     setActiveProjectIdState('');
     setPortalUser(null);
@@ -3786,6 +3866,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     setSessionActiveProject,
     patchProjectSnapshot,
     updateProjectStatus,
+    updateProjectCheckout,
     logout,
     addExpenseSet,
     updateExpenseSet,


### PR DESCRIPTION
## 왜

배포한 화면이 **"객관식처럼 보인다"** 는 지적을 받았습니다. 아이콘으로 완료 여부만 그려 두니 읽는 표처럼 보였고, 실제로도 읽기 전용이라 입력은 `프로젝트 수정` 화면으로 보내고 있었습니다.

## 무엇을

체크 항목 5개를 **진짜 체크박스**로 바꾸고 여기서 바로 저장합니다.

- 체크리스트 3개 — 잔금 입금 · 사업비 통장 0원 · 실적증명서 원본 제출
- 정산사업 마감 2개 — USB 재경팀 제출 · 증빙자료 삭제

## 저장 경로

`updateProjectCheckout` 을 포털 스토어에 더했습니다. **`updateProjectStatus` 와 같은 경로**를 쓰되 `checkout` 만 덮어씁니다.

종료 확인은 편집기 초안과 30분 편집 리스를 열 만큼 큰 일이 아니라 **체크 하나가 곧 저장**입니다. 낙관적으로 먼저 반영하고, 실패하면 이전 목록으로 되돌리고 토스트로 알립니다.

항목을 `ProjectCheckout` 의 **필드 키와 함께** 들고 다니게 바꿔, 체크박스가 무엇을 저장하는지 코드에서 바로 보이게 했습니다.

## 범위 밖으로 남긴 것

**증빙 업로드는 그대로 `프로젝트 수정` 화면에 남깁니다.** 파일 업로드는 문서 종류·BFF 검증·리스가 얽혀 있어 체크 저장과 성격이 다릅니다. 화면 안내 문구도 "체크는 여기서, 업로드는 수정 화면에서" 로 바꿨습니다.

## 검증

포털 테스트 101/101 · typecheck clean · build 성공

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)