### PR TITLE
fix(cashflow): confirm weekly request, withdrawal and approval on screen

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -273,6 +273,14 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('프로젝트 조직장');
     expect(source).toContain('project-executive-approver');
     // 우측 하단 토스트는 전부 지웠다 (성공·안내는 #578, 에러는 2026-08-19). 화면 상태만 남는다.
+    // 대신 완료 요청·회수·확정은 카드 안에서 한 줄로 접수됐음을 알린다 - 상태 배지만으로는
+    // "내가 누른 것이 먹혔는지" 가 안 보인다.
+    expect(source).toContain('setWeeklyActionNotice');
+    expect(source).toContain('주간 정산 완료 요청을 보냈어요');
+    expect(source).toContain('완료 요청을 회수했어요');
+    expect(source).toContain('주간 정산을 확정했어요');
+    expect(source).toContain('weeklyActionNotice && !weeklyWithdrawError');
+    expect(source).toContain("setWeeklyActionNotice(''), 6000");
     expect(source).not.toContain('toast.');
     expect(source).not.toContain("from 'sonner'");
     expect(source).not.toContain('월 결산 승인 조직장을 선택하세요');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -395,6 +395,8 @@ export function CashflowProjectSheet({
   const [weeklyWithdrawBusy, setWeeklyWithdrawBusy] = useState(false);
   const [weeklyWithdrawError, setWeeklyWithdrawError] = useState('');
   const [weeklyConfirmBusy, setWeeklyConfirmBusy] = useState(false);
+  // 완료 요청·회수·확정이 실제로 접수됐다는 확인. 상태 배지만으로는 "내가 누른 것이 먹혔는지" 가 안 보인다.
+  const [weeklyActionNotice, setWeeklyActionNotice] = useState('');
   const [weeklyProjectionWarning, setWeeklyProjectionWarning] = useState<WeeklyProjectionValidation | null>(null);
   const [weeklyHistoryOpen, setWeeklyHistoryOpen] = useState(false);
   const [weeklyComplianceHistory, setWeeklyComplianceHistory] = useState<CashflowWeeklyComplianceItem[]>([]);
@@ -833,6 +835,12 @@ export function CashflowProjectSheet({
     void loadMonthCloseRequest();
   }, [loadMonthCloseRequest]);
 
+  useEffect(() => {
+    if (!weeklyActionNotice) return;
+    const timer = window.setTimeout(() => setWeeklyActionNotice(''), 6000);
+    return () => window.clearTimeout(timer);
+  }, [weeklyActionNotice]);
+
   const handleCompleteWeeklyUpdate = useCallback(async (): Promise<void> => {
     if (!weeklyUpdateResult) return;
     if (monthCloseActions?.completeWeekly.enabled !== true) {
@@ -846,6 +854,7 @@ export function CashflowProjectSheet({
       return;
     }
     setWeeklyCompletionBusy(true);
+    setWeeklyActionNotice('');
     const startedAt = Date.now();
     const currentDeadline = monthCloseResult?.dashboard?.deadlineSummary?.current;
     logCashflowSettlement({
@@ -887,6 +896,9 @@ export function CashflowProjectSheet({
       await loadCashflowMonthClose();
       setWeeklyCompletionOpen(false);
       setWeeklyCompletionError('');
+      setWeeklyActionNotice(result.alreadyCompleted
+        ? '이미 완료 요청된 주입니다. 현재 상태를 다시 불러왔어요.'
+        : '주간 정산 완료 요청을 보냈어요. 조직장 확정을 기다립니다.');
       setWeeklyProjectionWarning(null);
       setWeeklyUpdateResult('');
       logCashflowSettlement({
@@ -927,6 +939,7 @@ export function CashflowProjectSheet({
     if (selectedProjectIdRef.current !== projectId || selectedYearMonthRef.current !== yearMonth) return;
     setWeeklyWithdrawBusy(true);
     setWeeklyWithdrawError('');
+    setWeeklyActionNotice('');
     const startedAt = Date.now();
     try {
       const actor = await resolveBffActor();
@@ -939,6 +952,7 @@ export function CashflowProjectSheet({
         weekNo: currentDeadline.weekNo,
       });
       await loadCashflowMonthClose();
+      setWeeklyActionNotice('완료 요청을 회수했어요. 값을 고친 뒤 다시 요청할 수 있어요.');
       logCashflowSettlement({
         phase: 'success',
         operation: 'cashflow.weekly_settlement.withdraw',
@@ -972,6 +986,7 @@ export function CashflowProjectSheet({
     if (selectedProjectIdRef.current !== projectId || selectedYearMonthRef.current !== yearMonth) return;
     setWeeklyConfirmBusy(true);
     setWeeklyWithdrawError('');
+    setWeeklyActionNotice('');
     const startedAt = Date.now();
     try {
       const actor = await resolveBffActor();
@@ -984,6 +999,7 @@ export function CashflowProjectSheet({
         weekNo: currentDeadline.weekNo,
       });
       await loadCashflowMonthClose();
+      setWeeklyActionNotice('주간 정산을 확정했어요. 이제 이 주는 잠깁니다.');
       logCashflowSettlement({
         phase: 'success',
         operation: 'cashflow.weekly_settlement.confirm',
@@ -2756,6 +2772,7 @@ export function CashflowProjectSheet({
                   ) : null}
                 </div>
                 {weeklyWithdrawError ? <div role="alert" className="mt-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] leading-5 text-red-800">{weeklyWithdrawError}</div> : null}
+                {weeklyActionNotice && !weeklyWithdrawError ? <div role="status" className="mt-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-[12px] leading-5 text-emerald-900">{weeklyActionNotice}</div> : null}
                 <div className="mt-3 flex items-center gap-4 text-[12px] text-muted-foreground">
                   <span>누적 미준수 <strong className="ml-1 text-red-700">{deadlineSummaryUnavailable ? '확인 불가' : formatCashflowCount(monthCloseResult?.dashboard?.deadlineSummary?.missedCount, '회')}</strong></span>
                   <span>기한 내 완료 <strong className="ml-1 text-primary">{deadlineSummaryUnavailable ? '확인 불가' : formatCashflowCount(monthCloseResult?.dashboard?.deadlineSummary?.completedCount, '회')}</strong></span>


### PR DESCRIPTION
## 왜
우측 하단 토스트를 지운 뒤 주간 정산의 세 동작(완료 요청·요청 회수·확정)이 **아무 말도 안 하게** 됐어요. 상태 배지는 바뀌지만, 누른 사람 입장에서 "내 클릭이 접수됐는지" 가 안 보입니다.

## 무엇
주간 정산 카드 안에 한 줄로 알려요 (6초 뒤 사라짐, `role="status"`):
- 완료 요청 → `주간 정산 완료 요청을 보냈어요. 조직장 확정을 기다립니다.` (이미 완료된 주면 그렇게 말함)
- 요청 회수 → `완료 요청을 회수했어요. 값을 고친 뒤 다시 요청할 수 있어요.`
- 확정 → `주간 정산을 확정했어요. 이제 이 주는 잠깁니다.`

에러 줄은 그대로고, 둘 다 뜰 상황이면 **에러가 이깁니다**. 토스트는 계속 없습니다.

## 확인
`CashflowProjectSheet.shell.test.ts` 에 문구·조건·타이머 핀 추가 (69 통과). typecheck·build 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)