### PR TITLE
feat(projects): 종료사업 최종 결과보고서(원본)를 받는다

### DIFF
--- a/server/bff/project-document-validation.mjs
+++ b/server/bff/project-document-validation.mjs
@@ -29,6 +29,7 @@ export const PROJECT_INFO_DOCUMENT_KINDS = Object.freeze([
   'performance_certificate',
   'tax_invoice',
   'final_settlement_report',
+  'final_report',
 ]);
 
 const PDF_ONLY_KINDS = new Set([
@@ -39,6 +40,7 @@ const PDF_ONLY_KINDS = new Set([
   'performance_certificate',
   'tax_invoice',
   'final_settlement_report',
+  'final_report',
 ]);
 const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
 const PPTX_MIME = 'application/vnd.openxmlformats-officedocument.presentationml.presentation';

--- a/src/app/components/portal/PortalProjectCheckout.tsx
+++ b/src/app/components/portal/PortalProjectCheckout.tsx
@@ -39,6 +39,11 @@ function readUploads(project: Project): UploadItem[] {
   const checkout = project.checkout;
   return [
     {
+      label: '최종 결과보고서 (원본)',
+      attached: Boolean(project.finalReportDocument?.path),
+      note: '종료사업은 결과보고서 원본을 제출합니다.',
+    },
+    {
       label: '사업 관련 발행 세금계산서 PDF',
       attached: Boolean(project.taxInvoiceDocument?.path),
       note: checkout?.taxInvoiceEvidenceConfirmed ? '해당 사업으로 표시됨' : '해당 시에만 제출합니다.',

--- a/src/app/components/portal/PortalProjectEdit.tsx
+++ b/src/app/components/portal/PortalProjectEdit.tsx
@@ -100,6 +100,7 @@ const PROJECT_INFO_PREVIEW_FIELDS: Array<{
   { documentKind: 'performance_certificate', field: 'performanceCertificateDocument' },
   { documentKind: 'tax_invoice', field: 'taxInvoiceDocument' },
   { documentKind: 'final_settlement_report', field: 'finalSettlementReportDocument' },
+  { documentKind: 'final_report', field: 'finalReportDocument' },
 ];
 
 function resolveExecutiveBanner(project: Project) {
@@ -202,6 +203,9 @@ function editorDraftFromPrivate(record: ProjectInfoDraft): ProjectEditorDraft {
       ? { performanceCertificateDocument: documents.performance_certificate }
       : {}),
     ...(documents.tax_invoice ? { taxInvoiceDocument: documents.tax_invoice } : {}),
+    ...(documents.final_report
+      ? { finalReportDocument: documents.final_report }
+      : {}),
     ...(documents.final_settlement_report
       ? { finalSettlementReportDocument: documents.final_settlement_report }
       : {}),

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -230,6 +230,7 @@ const PROJECT_DOCUMENT_LABELS: Record<ProjectRequestDocumentKind, string> = {
   performance_certificate: '수행확인서 PDF',
   tax_invoice: '세금계산서 PDF',
   final_settlement_report: '최종 정산보고서 PDF',
+  final_report: '최종 결과보고서',
 };
 const PROJECT_DOCUMENT_BUTTON_LABELS: Record<ProjectRequestDocumentKind, string> = {
   contract: '계약서',
@@ -243,6 +244,7 @@ const PROJECT_DOCUMENT_BUTTON_LABELS: Record<ProjectRequestDocumentKind, string>
   performance_certificate: '수행확인서',
   tax_invoice: '세금계산서',
   final_settlement_report: '최종 정산보고서',
+  final_report: '최종 결과보고서',
 };
 const PROJECT_DOCUMENT_FIELD: Record<ProjectRequestDocumentKind, keyof ProjectEditorDraft> = {
   contract: 'contractDocument',
@@ -256,6 +258,7 @@ const PROJECT_DOCUMENT_FIELD: Record<ProjectRequestDocumentKind, keyof ProjectEd
   performance_certificate: 'performanceCertificateDocument',
   tax_invoice: 'taxInvoiceDocument',
   final_settlement_report: 'finalSettlementReportDocument',
+  final_report: 'finalReportDocument',
 };
 const OPTIONAL_REGISTRATION_DOCUMENT_NOTE_FIELD = {
   proposal_word_original: 'proposalWordOriginal',
@@ -856,6 +859,7 @@ export function ProjectEditorWizard({
     performance_certificate: 'idle',
     tax_invoice: 'idle',
     final_settlement_report: 'idle',
+    final_report: 'idle',
   });
   const [documentUploadError, setDocumentUploadError] = useState<Record<ProjectRequestDocumentKind, string>>({
     contract: '',
@@ -869,6 +873,7 @@ export function ProjectEditorWizard({
     performance_certificate: '',
     tax_invoice: '',
     final_settlement_report: '',
+    final_report: '',
   });
   const [restoreCandidate, setRestoreCandidate] = useState<StoredProjectEditorDraft | null>(null);
   const [autosaveState, setAutosaveState] = useState<AutosaveState>('idle');
@@ -889,6 +894,7 @@ export function ProjectEditorWizard({
   const performanceCertificateUploadInputRef = useRef<HTMLInputElement | null>(null);
   const taxInvoiceUploadInputRef = useRef<HTMLInputElement | null>(null);
   const finalSettlementReportUploadInputRef = useRef<HTMLInputElement | null>(null);
+  const finalReportUploadInputRef = useRef<HTMLInputElement | null>(null);
   const retryDocumentFileRef = useRef<Partial<Record<ProjectRequestDocumentKind, File>>>({});
   /**
    * Bumped when an upload is cancelled. The request itself cannot be recalled, so a run
@@ -975,6 +981,7 @@ export function ProjectEditorWizard({
       performance_certificate: 'idle',
       tax_invoice: 'idle',
       final_settlement_report: 'idle',
+      final_report: 'idle',
     });
     setDocumentUploadError({
       contract: '',
@@ -988,6 +995,7 @@ export function ProjectEditorWizard({
       performance_certificate: '',
       tax_invoice: '',
       final_settlement_report: '',
+      final_report: '',
     });
     setAutosaveState('idle');
     setLastAutosavedAt('');
@@ -1418,6 +1426,7 @@ export function ProjectEditorWizard({
     performance_certificate: performanceCertificateUploadInputRef,
     tax_invoice: taxInvoiceUploadInputRef,
     final_settlement_report: finalSettlementReportUploadInputRef,
+    final_report: finalReportUploadInputRef,
   }[kind]);
 
   const uploadProjectDocument = async (kind: ProjectRequestDocumentKind, file: File) => {
@@ -3524,6 +3533,21 @@ export function ProjectEditorWizard({
               onLoadPreview={onLoadDocumentPreview ? () => onLoadDocumentPreview('final_settlement_report') : undefined}
               title="최종 정산보고서 원문"
               description="종료사업 최종 정산보고서 증빙입니다."
+            />
+          </div>
+        ) : null}
+        {showProjectCheckout && draft.finalReportDocument ? (
+          <div className="lg:col-span-2">
+            <ContractDocumentPreview
+              document={{
+                ...draft.finalReportDocument,
+                downloadURL: documentPreviewUrls?.final_report || draft.finalReportDocument.downloadURL,
+              }}
+              privateDraftAttachment={Boolean(documentPreviewStates?.final_report) && !(documentPreviewUrls?.final_report || draft.finalReportDocument.downloadURL)}
+              previewState={documentPreviewStates?.final_report}
+              onLoadPreview={onLoadDocumentPreview ? () => onLoadDocumentPreview('final_report') : undefined}
+              title="최종 결과보고서 원문"
+              description="종료사업 최종 결과보고서(원본) 증빙입니다."
             />
           </div>
         ) : null}

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -750,6 +750,7 @@ export interface Project {
   performanceCertificateDocument?: FileAttachment | null;
   taxInvoiceDocument?: FileAttachment | null;
   finalSettlementReportDocument?: FileAttachment | null;
+  finalReportDocument?: FileAttachment | null;
   contractAnalysis?: ProjectRequestContractAnalysis | null;
   // 팀/담당자
   department: string;            // 담당조직
@@ -969,6 +970,7 @@ export interface ProjectRequestPayload {
   performanceCertificateDocument?: FileAttachment | null;
   taxInvoiceDocument?: FileAttachment | null;
   finalSettlementReportDocument?: FileAttachment | null;
+  finalReportDocument?: FileAttachment | null;
   contractAnalysis?: ProjectRequestContractAnalysis | null;
 }
 

--- a/src/app/lib/project-info-draft-client.ts
+++ b/src/app/lib/project-info-draft-client.ts
@@ -19,7 +19,8 @@ export type ProjectInfoDocumentKind =
   | 'rfp_request_evidence'
   | 'performance_certificate'
   | 'tax_invoice'
-  | 'final_settlement_report';
+  | 'final_settlement_report'
+  | 'final_report';
 
 export interface ProjectInfoAttachment {
   attachmentId?: string;

--- a/src/app/platform/project-contract-upload.ts
+++ b/src/app/platform/project-contract-upload.ts
@@ -14,7 +14,8 @@ export type ProjectRequestDocumentKind =
   | 'rfp_request_evidence'
   | 'performance_certificate'
   | 'tax_invoice'
-  | 'final_settlement_report';
+  | 'final_settlement_report'
+  | 'final_report';
 
 export const PROJECT_REQUEST_DOCUMENT_UPLOAD_MAX_SIZE_BYTES = 1024 * 1024 * 1024;
 export const PROJECT_REQUEST_DOCUMENT_UPLOAD_MAX_SIZE_LABEL = '1GB';
@@ -25,7 +26,7 @@ const DOCX_MIME = 'application/vnd.openxmlformats-officedocument.wordprocessingm
 const PPTX_MIME = 'application/vnd.openxmlformats-officedocument.presentationml.presentation';
 const PDF_ONLY_KINDS = new Set<ProjectRequestDocumentKind>([
   'contract', 'customer_business_registration', 'quote', 'proposal',
-  'performance_certificate', 'tax_invoice', 'final_settlement_report',
+  'performance_certificate', 'tax_invoice', 'final_settlement_report', 'final_report',
 ]);
 
 export function getProjectDocumentUploadAccept(kind: ProjectRequestDocumentKind): string {

--- a/src/app/platform/project-editor.ts
+++ b/src/app/platform/project-editor.ts
@@ -151,6 +151,7 @@ export interface ProjectEditorDraft {
   performanceCertificateDocument: FileAttachment | null;
   taxInvoiceDocument: FileAttachment | null;
   finalSettlementReportDocument: FileAttachment | null;
+  finalReportDocument: FileAttachment | null;
   contractAnalysis: ProjectRequestContractAnalysis | null;
 }
 
@@ -257,6 +258,7 @@ const DEFAULT_DRAFT: ProjectEditorDraft = {
   performanceCertificateDocument: null,
   taxInvoiceDocument: null,
   finalSettlementReportDocument: null,
+  finalReportDocument: null,
   contractAnalysis: null,
 };
 
@@ -528,6 +530,7 @@ const REVIEW_CHANGE_FIELDS: Array<{
   { key: 'performanceCertificateDocument', label: '수행확인서 PDF', before: (project) => normalizeChangeValue(project.performanceCertificateDocument?.name), after: (draft) => normalizeChangeValue(draft.performanceCertificateDocument?.name) },
   { key: 'taxInvoiceDocument', label: '세금계산서 PDF', before: (project) => normalizeChangeValue(project.taxInvoiceDocument?.name), after: (draft) => normalizeChangeValue(draft.taxInvoiceDocument?.name) },
   { key: 'finalSettlementReportDocument', label: '최종 정산보고서 PDF', before: (project) => normalizeChangeValue(project.finalSettlementReportDocument?.name), after: (draft) => normalizeChangeValue(draft.finalSettlementReportDocument?.name) },
+  { key: 'finalReportDocument', label: '최종 결과보고서 PDF', before: (project) => normalizeChangeValue(project.finalReportDocument?.name), after: (draft) => normalizeChangeValue(draft.finalReportDocument?.name) },
 ];
 
 export function createProjectEditorDraft(overrides: Partial<ProjectEditorDraft> = {}): ProjectEditorDraft {
@@ -646,6 +649,9 @@ export function buildProjectEditorDraftFromProject(
     ?? payload?.performanceCertificateDocument
     ?? null;
   const taxInvoiceDocument = normalizedProject.taxInvoiceDocument ?? payload?.taxInvoiceDocument ?? null;
+  const finalReportDocument = normalizedProject.finalReportDocument
+    ?? payload?.finalReportDocument
+    ?? null;
   const finalSettlementReportDocument = normalizedProject.finalSettlementReportDocument
     ?? payload?.finalSettlementReportDocument
     ?? null;
@@ -757,6 +763,7 @@ export function buildProjectEditorDraftFromProject(
     performanceCertificateDocument,
     taxInvoiceDocument,
     finalSettlementReportDocument,
+    finalReportDocument,
     contractAnalysis: normalizedProject.contractAnalysis ?? payload?.contractAnalysis ?? null,
   });
 }


### PR DESCRIPTION
## 왜

종료사업 체크아웃 스펙에서 **유일하게 필드가 없던 항목**입니다. 나머지 체크 5종과 증빙 3종(실적증명서·세금계산서·최종 정산리포트)은 이미 있었고, 이것만 받을 자리가 없어 화면에서 빼 두었습니다.

## 무엇을

기존 증빙 3종과 **같은 배선을 그대로** 따릅니다. 새 패턴을 만들지 않았습니다.

| 지점 | 변경 |
|---|---|
| 문서 종류 | `final_report` 를 프론트(`project-contract-upload.ts`) · BFF(`project-document-validation.mjs`) 양쪽 목록에 추가. PDF 전용 |
| 데이터 | `Project` · 초안 payload · 편집기 초안에 `finalReportDocument` |
| 변경 이력 | `최종 결과보고서 PDF` 로 표시 |
| 포털 수정 | 문서 매핑 + 초안 클라이언트 종류 연결 |
| 편집기 | 종료 단계 사업에서 원문 미리보기 |
| 체크아웃 화면 | 업로드 목록 **맨 앞**(스펙 순서) |

## 잡은 함정 하나

업로드 `input` ref 를 **전용으로** 만들었습니다. 처음에 정산리포트 ref 를 재사용하도록 매핑됐는데, 그러면 두 업로드가 같은 input 을 공유해 **서로의 파일 선택을 덮어씁니다.**

## 검증

| 게이트 | 결과 |
|---|---|
| `npm test` 전체 | 3,250 통과 |
| `npm run typecheck` | no new type errors |
| `npm run build` | ✓ 성공 |

> `cashflow-sheet-lab.test.mjs` 1건이 전체 실행에서 실패했으나 **단독 116/116 통과**로 flake 확인. 이 PR 이 바꾼 파일과 겹치지 않습니다.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)