### PR TITLE
perf(cashflow): report sheet refresh phases in a Server-Timing header

### DIFF
--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -4145,13 +4145,16 @@ export function mountCashflowSheetLabRoutes(app, {
     });
   }));
 
-  const executeCashflowSheetMirrorRefresh = async (req) => {
+  // traceRef 는 라우트가 구간 기록을 응답 헤더로 내보내기 위한 통로다. 내부 호출(비교 관측)은
+  // 넘기지 않으므로 헤더도 붙지 않는다.
+  const executeCashflowSheetMirrorRefresh = async (req, traceRef) => {
     const trace = createCashflowPerformanceTrace({
       requestId: req.context?.requestId || req.requestId,
       operation: 'cashflow.sheet_mirror.refresh',
       ...(performanceLogger ? { logger: performanceLogger } : {}),
       ...(performanceNow ? { now: performanceNow } : {}),
     });
+    if (traceRef) traceRef.trace = trace;
     const { tenantId } = req.context;
     const { projectId } = req.params;
     const parsed = parseWithSchema(
@@ -4395,7 +4398,11 @@ export function mountCashflowSheetLabRoutes(app, {
 
   app.post('/api/v1/projects/:projectId/cashflow-sheet-lab/mirror/refresh', asyncHandler(async (req, res) => {
     assertCashflowSheetLabAccess(req, workspaceEmailDomain);
-    res.status(200).json(await executeCashflowSheetMirrorRefresh(req));
+    const traceRef = {};
+    const mirror = await executeCashflowSheetMirrorRefresh(req, traceRef);
+    // 불러오기가 20초씩 걸릴 때 구글 왕복인지 파싱인지 Firestore 쓰기인지 브라우저에서 바로 갈린다.
+    if (traceRef.trace) res.set('Server-Timing', traceRef.trace.serverTiming());
+    res.status(200).json(mirror);
   }));
 
   const compareCashflowSheetProject = async ({ tenantId, projectId, runId, context } = {}) => {

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -914,6 +914,11 @@ describe('cashflow sheet lab route', () => {
     expect(first.body.status).toBe('FRESH');
     expect(first.body.unchanged).toBeUndefined();
     expect(previewSpreadsheet).toHaveBeenCalledTimes(1);
+    // 불러오기가 느릴 때 어느 구간인지 브라우저에서 바로 갈리도록 구간 기록을 헤더로 낸다.
+    expect(first.headers['server-timing']).toMatch(/google_sheet_fetch;dur=\d+/);
+    expect(first.headers['server-timing']).toMatch(/sheet_parse_validate;dur=\d+/);
+    expect(first.headers['server-timing']).toMatch(/mirror_publish;dur=\d+/);
+    expect(first.headers['server-timing']).toMatch(/total;dur=\d+/);
     expect(db.__getDocument('orgs/tenant-a/cashflow_sheet_mirrors/project-a').sourceFileModifiedTime)
       .toBe(modifiedTime);
 
@@ -924,6 +929,9 @@ describe('cashflow sheet lab route', () => {
       .expect(200);
     expect(second.body.unchanged).toBe(true);
     expect(second.body.sourceRevision).toBe(first.body.sourceRevision);
+    // 변경 없음 경로도 헤더가 나온다 - freshness 확인에만 시간이 갔다는 것이 보여야 한다.
+    expect(second.headers['server-timing']).toMatch(/freshness_probe;dur=\d+/);
+    expect(second.headers['server-timing']).not.toMatch(/google_sheet_fetch/);
     expect(previewSpreadsheet).toHaveBeenCalledTimes(1);
     expect(getSpreadsheetFreshness).toHaveBeenCalledTimes(2);
 


### PR DESCRIPTION
## 왜
시트 불러오기가 느릴 때 **어디서 느린지 알 방법이 없었어요.** `mirror/refresh` 는 이미 9개 구간을 재고 있는데(`project_read`·`mirror_read`·`freshness_probe`·`google_sheet_fetch`·`sheet_parse_validate`·`target_snapshot_read`·`mirror_build`·`mirror_publish`), 그 값을 아무도 안 봐요 — `performanceLogger` 는 주입되지 않고 응답 헤더도 없었습니다.

## 무엇
month-close 와 같은 방식으로 기록된 구간을 응답 헤더로 내보냅니다. 내부 호출(비교 관측)은 trace ref 를 안 넘겨서 헤더도 안 붙어요. 로직 변경 없음.

## 확인
짝 테스트(`cashflow-sheet-lab.test.mjs`)에 두 가지 추가 — 풀 리드 경로는 `google_sheet_fetch`·`sheet_parse_validate`·`mirror_publish` 가 보이고, 변경 없음 경로는 `freshness_probe` 만 있고 `google_sheet_fetch` 는 없어야 함. 116개 통과(2회).

## 배경 (2026-08-19 측정)
리전 이동 뒤 `mirror/refresh` 20,807 → 7,889ms, 원클릭 30,684 → 12,292ms. 남은 7.9초의 내역은 이 헤더가 붙어야 말할 수 있어요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)