### PR TITLE
fix(portal): 체크아웃 저장이 409 로 튕기던 것을 고친다

### DIFF
--- a/src/app/data/portal-store.checkout-save.shell.test.ts
+++ b/src/app/data/portal-store.checkout-save.shell.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(import.meta.dirname, 'portal-store.tsx'), 'utf8');
+
+describe('종료사업 체크아웃 저장', () => {
+  it('저장을 한 줄로 세운다', () => {
+    // 라이브 사고: 체크박스를 연달아 누르니 요청이 동시에 나가 각자 자기가 읽은 version 을
+    // 보냈고, 뒤엣것이 409 version_conflict 로 전부 튕겼다.
+    expect(source).toContain('const checkoutSaveChainRef = useRef<Promise<unknown>>(Promise.resolve())');
+    expect(source).toContain('checkoutSaveChainRef.current = queued');
+    expect(source).toContain('.then(() => runCheckoutSave(projectId, patch))');
+  });
+
+  it('서버가 올린 version 을 로컬에 되쓴다', () => {
+    // 되쓰지 않으면 다음 체크가 다시 낡은 version 을 보낸다. 줄을 세워도 409 가 난다.
+    expect(source).toContain('const saved = await upsertProjectViaBff(');
+    expect(source).toContain('if (typeof saved?.version === \'number\')');
+    expect(source).toContain('project.id === targetProjectId ? { ...project, version: saved.version } : project');
+  });
+
+  it('저장 직전에 최신 프로젝트를 다시 읽는다', () => {
+    // 큐에서 기다리는 동안 앞 저장이 version 을 올렸을 수 있다.
+    expect(source).toContain('const latest = projectsRef.current.find((project) => project.id === targetProjectId) || existingProject');
+    expect(source).toContain('expectedVersion: latest.version ?? 1');
+  });
+});

--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -3426,7 +3426,14 @@ export function PortalProvider({ children }: { children: ReactNode }) {
    * 종료사업 체크아웃 항목을 저장한다. 상태 저장과 같은 경로를 쓰되 `checkout` 만 덮어쓴다.
    * 종료 확인은 편집기 초안을 열 만큼 큰 일이 아니라 체크 하나가 곧 저장이다.
    */
-  const updateProjectCheckout = useCallback(async (
+  /**
+   * 체크아웃 저장은 한 줄로 세운다. 체크박스를 연달아 누르면 요청이 동시에 나가고, 각자
+   * 자기가 읽은 version 을 보내 뒤엣것이 409 로 튕긴다. 앞 요청이 끝나야 다음이 시작한다.
+   */
+  const checkoutSaveChainRef = useRef<Promise<unknown>>(Promise.resolve());
+
+
+  const runCheckoutSave = useCallback(async (
     projectId: string,
     patch: Partial<ProjectCheckout>,
   ): Promise<boolean> => {
@@ -3456,7 +3463,9 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     try {
       if (isPlatformApiEnabled()) {
         const idToken = authUser?.idToken || await getAuthInstance()?.currentUser?.getIdToken() || undefined;
-        await upsertProjectViaBff({
+        // 앞 저장이 끝난 뒤의 최신 버전을 읽는다. 이 함수가 처음 읽은 값은 이미 낡았을 수 있다.
+        const latest = projectsRef.current.find((project) => project.id === targetProjectId) || existingProject;
+        const saved = await upsertProjectViaBff({
           tenantId: orgId,
           actor: {
             uid: authUser?.uid || portalUser?.id || 'portal-user',
@@ -3465,11 +3474,19 @@ export function PortalProvider({ children }: { children: ReactNode }) {
             idToken,
           },
           project: {
-            ...existingProject,
+            ...latest,
             ...projectPatch,
-            expectedVersion: existingProject.version ?? 1,
+            expectedVersion: latest.version ?? 1,
           } as UpsertProjectPayload,
         });
+        // 서버가 올린 version 을 되쓰지 않으면 다음 체크가 다시 낡은 값을 보낸다.
+        if (typeof saved?.version === 'number') {
+          const versioned = projectsRef.current.map((project) => (
+            project.id === targetProjectId ? { ...project, version: saved.version } : project
+          ));
+          projectsRef.current = versioned;
+          setProjects(versioned);
+        }
       } else {
         await setDoc(
           doc(db, getOrgDocumentPath(orgId, 'projects', targetProjectId)),
@@ -3499,6 +3516,23 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     portalUser?.role,
     scopedProjectIds,
   ]);
+
+  /**
+   * 밖에서 부르는 입구. 실제 저장은 위 구현이 하고, 여기서는 줄을 세우기만 한다.
+   * 체크박스를 연달아 누르면 요청이 동시에 나가 각자 자기가 읽은 version 을 보내고
+   * 뒤엣것이 409 로 튕긴다 (라이브에서 실제로 났다).
+   */
+  const updateProjectCheckout = useCallback((
+    projectId: string,
+    patch: Partial<ProjectCheckout>,
+  ): Promise<boolean> => {
+    const queued = checkoutSaveChainRef.current
+      .catch(() => undefined)
+      .then(() => runCheckoutSave(projectId, patch));
+    checkoutSaveChainRef.current = queued;
+    return queued;
+  }, [runCheckoutSave]);
+
 
   const logout = useCallback(() => {
     setActiveProjectIdState('');


### PR DESCRIPTION
## 라이브 버그

방금 배포한 종료사업 체크아웃에서 **체크박스를 연달아 누르면 전부 실패**했습니다.

```
POST /api/v1/projects → 409
{ code: 'version_conflict', message: 'Version mismatch: expected 7, actual 8' }
```

## 원인 둘

1. **요청이 동시에 나갔습니다.** 체크박스마다 저장을 부르는데 앞 요청이 끝나기 전에 다음이 출발해, 둘 다 자기가 읽은 같은 `version` 을 보내고 뒤엣것이 튕겼습니다.
2. **서버가 올린 `version` 을 로컬에 되쓰지 않았습니다.** upsert 는 새 version 을 돌려주는데 버리고 있었습니다. 그래서 첫 저장이 성공한 뒤부터는 계속 낡은 version 만 보냈습니다.

`updateProjectStatus` 를 본떠 만들면서 놓쳤습니다. 상태는 한 번 바뀌고 값이 같으면 조기 반환하지만, **체크아웃은 다섯 개를 연달아 누르는 화면**이라 같은 코드가 다르게 동작합니다.

## 고친 것

- 저장을 promise 체인으로 **한 줄로 세웁니다.** 실패해도 줄이 끊기지 않도록 `catch` 로 이어 붙였습니다.
- 저장 직전에 `projectsRef` 에서 **최신 프로젝트를 다시 읽습니다.** 큐에서 기다리는 동안 앞 저장이 version 을 올렸을 수 있습니다.
- 성공하면 **서버가 준 version 을 로컬 목록에 되씁니다.**

세 가지 모두 회귀 테스트로 고정했습니다.

## 검증

전체 3,253 통과 · typecheck clean · build 성공

> `project-registration-drafts` 1건 실패는 단독 71/71 통과로 flake 확인. 변경 파일(`portal-store.tsx`)과 무관합니다.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)