### PR TITLE
fix(cashflow): say what blocks the month close, and where

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -96,6 +96,7 @@ import { MemberPicker } from '../ui/member-picker';
 import { buildOrgMemberPickerOptions } from '../../data/project-team-member-options';
 import { usePersonRoster } from '../../data/use-person-roster';
 import { loadCashflowActivitySourcesSequentially } from './cashflow-activity-loader';
+import { describeCashflowMonthCloseIssue } from './cashflow-month-close-blocker-helpers';
 
 type CashflowOpsTone = 'neutral' | 'info' | 'warning' | 'danger' | 'success';
 
@@ -1174,6 +1175,25 @@ export function CashflowProjectSheet({
       };
     }
   }, [monthClosePinnedSource, yearMonth]);
+
+  // 막는 사유는 서버 판정 그대로 쓰고, 어느 칸인지만 펴서 보여준다. 화면이 다시 판정하지 않는다.
+  const monthCloseBlockers = useMemo(() => (
+    (monthCloseResult?.dashboard?.validation?.blockers || []).map((blocker) => ({
+      code: blocker.code,
+      message: blocker.message,
+      lines: describeCashflowMonthCloseIssue(blocker),
+    }))
+  ), [monthCloseResult?.dashboard?.validation?.blockers]);
+
+  // 버튼을 숨기면 "기능이 없다"로 읽힌다. 서버가 왜 못 하는지 이미 문구로 주므로 그대로 보여준다.
+  // 지금 화면에서 의미가 있는 것만 - 진행 중 요청의 회수, 승인 완료 회차의 재오픈.
+  const monthCloseActionNotices = useMemo(() => ([
+    { key: 'withdrawMonthClose', label: '결재 요청 회수', action: monthCloseActions?.withdrawMonthClose },
+    { key: 'requestMonthReopen', label: '재오픈 요청', action: monthCloseActions?.requestMonthReopen },
+  ] as const)
+    .filter((entry) => entry.action && entry.action.enabled !== true && Boolean(entry.action.guide))
+    .map((entry) => ({ key: entry.key, label: entry.label, guide: entry.action!.guide })),
+  [monthCloseActions?.requestMonthReopen, monthCloseActions?.withdrawMonthClose]);
 
   const monthClosePreparation = useMemo(() => {
     if (monthCloseError) {
@@ -2804,10 +2824,36 @@ export function CashflowProjectSheet({
                       <div className="text-[13px] font-bold text-card-foreground">월 결산</div>
                       <Badge className={`h-6 rounded-md px-2 text-[12px] shadow-none ${monthCloseStatusClass}`}>{monthCloseLoading ? '상태 확인 중' : monthCloseStatusLabel}</Badge>
                     </div>
-                    {monthCloseActions?.requestMonthClose.guide ? (
+                    {monthCloseBlockers.length > 0 ? (
+                      <div role="alert" className="mt-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] leading-5 text-red-800">
+                        <div className="flex items-center gap-1.5 font-bold">
+                          <AlertTriangle className="h-3.5 w-3.5" />
+                          월 결산을 진행할 수 없어요
+                        </div>
+                        <ul className="mt-1 space-y-0.5">
+                          {monthCloseBlockers.map((blocker) => (
+                            <li key={blocker.code}>
+                              · {blocker.message}
+                              {blocker.lines.length > 0 ? (
+                                <ul className="mt-0.5 ml-3 space-y-0.5 text-red-700">
+                                  {blocker.lines.map((line) => <li key={line}>- {line}</li>)}
+                                </ul>
+                              ) : null}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    ) : monthCloseActions?.requestMonthClose.guide ? (
                       <div className="mt-1 text-[12px] leading-4 text-muted-foreground">
                         {monthCloseActions.requestMonthClose.guide}
                       </div>
+                    ) : null}
+                    {monthCloseActionNotices.length > 0 ? (
+                      <ul className="mt-1 space-y-0.5 text-[12px] leading-4 text-muted-foreground">
+                        {monthCloseActionNotices.map((notice) => (
+                          <li key={notice.key}>{notice.label} · {notice.guide}</li>
+                        ))}
+                      </ul>
                     ) : null}
                     {monthCloseRequestError ? (
                       <div role="alert" className="mt-2 flex flex-wrap items-center gap-2 text-[12px] text-red-700">
@@ -2902,7 +2948,9 @@ export function CashflowProjectSheet({
               </div>
               <div className="space-y-2">
                 {(monthCloseResult?.dashboard?.managementChecks || []).map((check) => {
-                  const tone: CashflowOpsTone = check.status === 'OK' ? 'success' : check.status === 'WARNING' ? 'warning' : 'neutral';
+                  // REVIEW_REQUIRED 가 neutral(회색) 이면 정상보다도 눈에 안 띈다. 확인이 필요한 것은
+                  // 확인이 필요해 보여야 한다.
+                  const tone: CashflowOpsTone = check.status === 'OK' ? 'success' : 'warning';
                   return (
                     <div key={check.id} className="rounded-md border border-border bg-secondary px-3 py-2">
                       <div className="flex items-center gap-2">
@@ -2910,11 +2958,11 @@ export function CashflowProjectSheet({
                         <span className="text-[12px] font-bold text-secondary-foreground">{check.title}</span>
                       </div>
                       {check.findings?.length ? (
-                        <ul className="mt-1 space-y-0.5 text-[12px] leading-4 text-muted-foreground">
+                        <ul className={`mt-1 space-y-0.5 text-[12px] leading-4 ${check.status === 'OK' ? 'text-muted-foreground' : 'text-secondary-foreground'}`}>
                           {check.findings.map((finding) => <li key={finding}>· {finding}</li>)}
                         </ul>
                       ) : (
-                        <div className="mt-1 text-[12px] leading-4 text-muted-foreground">{check.detail}</div>
+                        <div className={`mt-1 text-[12px] leading-4 ${check.status === 'OK' ? 'text-muted-foreground' : 'text-secondary-foreground'}`}>{check.detail}</div>
                       )}
                     </div>
                   );

--- a/src/app/components/cashflow/cashflow-action-tooltips.shell.test.ts
+++ b/src/app/components/cashflow/cashflow-action-tooltips.shell.test.ts
@@ -50,7 +50,17 @@ describe('cashflow action chrome', () => {
     expect(cashflowProjectSheetSource).toContain('월 결산 승인 요청');
     expect(cashflowProjectSheetSource).toContain('monthCloseActions?.requestMonthClose.enabled');
     expect(cashflowProjectSheetSource).toContain('monthCloseActions?.requestMonthClose.guide');
-    expect(cashflowProjectSheetSource).not.toContain('dashboard?.validation?.blockers');
+    // 2026-08-19: 막는 사유를 회색 안내 한 줄로만 보여줘서 경고인지 알 수 없었다. 이제 서버가 준
+    // 블로커를 빨간 경고로 펴고, 어느 칸인지(셀 주소·주차)까지 보여준다. 판정은 서버 그대로 쓴다.
+    expect(cashflowProjectSheetSource).toContain('monthCloseBlockers');
+    expect(cashflowProjectSheetSource).toContain('describeCashflowMonthCloseIssue');
+    expect(cashflowProjectSheetSource).toContain('월 결산을 진행할 수 없어요');
+    expect(cashflowProjectSheetSource).not.toContain('validation.blockers.filter');
+    expect(cashflowProjectSheetSource).not.toContain('validation.blockers.some');
+    // 버튼을 숨기면 "기능이 없다"로 읽힌다. 못 하는 이유(서버 문구)는 남긴다.
+    expect(cashflowProjectSheetSource).toContain('monthCloseActionNotices');
+    expect(cashflowProjectSheetSource).toContain("label: '결재 요청 회수'");
+    expect(cashflowProjectSheetSource).toContain("label: '재오픈 요청'");
     expect(cashflowProjectSheetSource).not.toContain('캐시플로 항목 사람 확인');
     expect(cashflowProjectSheetSource).not.toContain('prepareAuditedWeekAmounts');
     expect(cashflowProjectSheetSource).not.toContain('showAuditBlock');

--- a/src/app/components/cashflow/cashflow-month-close-blocker-helpers.test.ts
+++ b/src/app/components/cashflow/cashflow-month-close-blocker-helpers.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { describeCashflowMonthCloseIssue } from './cashflow-month-close-blocker-helpers';
+
+describe('describeCashflowMonthCloseIssue', () => {
+  it('names the cell and the value that is not a number', () => {
+    expect(describeCashflowMonthCloseIssue({
+      code: 'SHEET_VALUE_INVALID',
+      message: '시트의 날짜 또는 금액 형식을 확인해 주세요.',
+      details: [
+        { code: 'sheet_value_invalid', field: 'line:SALES_IN', sourceCell: 'AK17', rawValue: '3월 말' },
+        { code: 'control_total_missing', field: 'depositControl', sourceCell: 'BO9' },
+      ],
+    })).toEqual([
+      'AK17 칸 · 매출액(입금)이(가) 숫자가 아니에요 (지금 값: 3월 말).',
+      'BO9 칸 · 입금 예정 합계이(가) 비어 있어요. 값을 채워 주세요.',
+    ]);
+  });
+
+  it('names the week and which total could not be read', () => {
+    expect(describeCashflowMonthCloseIssue({
+      code: 'SHEET_CALCULATION_VALUE_INVALID',
+      message: '월 결산 대상의 입금·출금 합계 또는 잔액 값을 확인해 주세요.',
+      details: [{
+        mode: 'actual',
+        weekNo: 3,
+        matches: { depositTotal: true, withdrawalTotal: null, balance: null },
+        sourceCells: { depositTotal: 'AB56', withdrawalTotal: 'AB57', balance: 'AB58' },
+      }],
+    })).toEqual(['Actual 3주차 · 출금 합계(AB57), 잔액(AB58) 값을 읽지 못했어요. 숫자인지 확인해 주세요.']);
+  });
+
+  it('separates a mismatch from an unreadable value', () => {
+    expect(describeCashflowMonthCloseIssue({
+      code: 'SHEET_CALCULATION_MISMATCH',
+      message: '월 결산 대상의 시트 합계 또는 잔액이 항목 합계와 다릅니다.',
+      details: [{
+        mode: 'projection',
+        weekNo: 5,
+        matches: { depositTotal: true, withdrawalTotal: true, balance: false },
+        sourceCells: { balance: 'X33' },
+      }],
+    })).toEqual(['Projection 5주차 · 잔액(X33)이(가) 항목을 더한 값과 달라요.']);
+  });
+
+  it('lists every mismatching control total row by its business label', () => {
+    expect(describeCashflowMonthCloseIssue({
+      code: 'SHEET_CONTROL_TOTAL_MISMATCH',
+      message: '전체 주차 합계와 시트 BO control total이 다릅니다.',
+      details: {
+        deposit: { matches: false, sourceCell: 'BO9' },
+        rows: [{ kind: 'line', lineId: 'DIRECT_COST_OUT', sourceCell: 'BO25', matches: false }],
+      },
+    })).toEqual([
+      '입금 예정 합계(BO9)이(가) 주차 합계와 달라요.',
+      '직접사업비(BO25) · 시트 합계와 주차 합계가 달라요.',
+    ]);
+  });
+
+  it('passes management findings through, falling back to the detail sentence', () => {
+    expect(describeCashflowMonthCloseIssue({
+      code: 'MANAGEMENT_CHECK_NEGATIVE_PROJECTION_BALANCE',
+      message: 'Projection 잔액 음수',
+      details: { status: 'WARNING', detail: '3주차 잔액이 음수입니다.', findings: ['26-8-3 잔액 -1,200,000원'] },
+    })).toEqual(['26-8-3 잔액 -1,200,000원']);
+    expect(describeCashflowMonthCloseIssue({
+      code: 'MANAGEMENT_CHECK_LABOR_TRANSFER',
+      message: '인건비 이체',
+      details: { status: 'REVIEW_REQUIRED', detail: '확인이 필요합니다.', findings: [] },
+    })).toEqual(['확인이 필요합니다.']);
+  });
+
+  it('stays silent when the server sent no usable detail', () => {
+    expect(describeCashflowMonthCloseIssue(null)).toEqual([]);
+    expect(describeCashflowMonthCloseIssue({ code: 'SHEET_FACTS_MISSING', message: '시트 검증값이 없습니다.' })).toEqual([]);
+    expect(describeCashflowMonthCloseIssue({ code: 'SHEET_VALUE_INVALID', message: 'x', details: 'not-an-array' })).toEqual([]);
+  });
+});

--- a/src/app/components/cashflow/cashflow-month-close-blocker-helpers.ts
+++ b/src/app/components/cashflow/cashflow-month-close-blocker-helpers.ts
@@ -1,0 +1,111 @@
+import { CASHFLOW_SHEET_LINE_LABELS, type CashflowSheetLineId } from '../../data/types';
+
+// 서버는 막는 사유마다 어느 칸인지(셀 주소·주차·구분)까지 보내는데 화면은 첫 줄 문장만 쓰고 버렸다.
+// 담당자가 시트 전체를 뒤지지 않도록, 받은 값을 그대로 사람이 읽는 한 줄로 옮긴다.
+// 여기서 새로 판정하지 않는다 - 서버가 준 것만 옮겨 적는다.
+
+export interface CashflowMonthCloseIssue {
+  code: string;
+  message: string;
+  details?: unknown;
+}
+
+const MODE_LABEL: Record<string, string> = { projection: 'Projection', actual: 'Actual' };
+
+const CALCULATION_LABEL: Record<string, string> = {
+  depositTotal: '입금 합계',
+  withdrawalTotal: '출금 합계',
+  balance: '잔액',
+  openingBalance: '전기 이월 잔액',
+};
+
+const CONTROL_FIELD_LABEL: Record<string, string> = {
+  depositControl: '입금 예정 합계',
+  unpaidControl: '미수금 합계',
+};
+
+const asArray = (value: unknown): unknown[] => (Array.isArray(value) ? value : []);
+const asRecord = (value: unknown): Record<string, unknown> => (
+  value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+);
+const text = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
+const cell = (value: unknown): string => (text(value) ? `${text(value)} 칸` : '');
+
+function lineLabel(record: Record<string, unknown>): string {
+  const lineId = text(record.lineId);
+  if (lineId) return CASHFLOW_SHEET_LINE_LABELS[lineId as CashflowSheetLineId] || lineId;
+  const derived = text(record.derivedKind);
+  return CALCULATION_LABEL[derived] || derived;
+}
+
+// field 는 `${kind}:${lineId|derivedKind}` 또는 depositControl/unpaidControl 이다.
+function fieldLabel(field: string): string {
+  if (CONTROL_FIELD_LABEL[field]) return CONTROL_FIELD_LABEL[field];
+  const name = field.includes(':') ? field.slice(field.indexOf(':') + 1) : field;
+  return CASHFLOW_SHEET_LINE_LABELS[name as CashflowSheetLineId] || CALCULATION_LABEL[name] || name || '값';
+}
+
+function sheetValueLines(details: unknown): string[] {
+  return asArray(details).map((entry) => {
+    const record = asRecord(entry);
+    const where = cell(record.sourceCell);
+    const what = fieldLabel(text(record.field));
+    const raw = text(record.rawValue);
+    if (text(record.code) === 'control_total_missing') {
+      return `${where ? `${where} · ` : ''}${what}이(가) 비어 있어요. 값을 채워 주세요.`;
+    }
+    return `${where ? `${where} · ` : ''}${what}이(가) 숫자가 아니에요${raw ? ` (지금 값: ${raw})` : ''}.`;
+  });
+}
+
+function calculationLines(details: unknown, kind: 'invalid' | 'mismatch'): string[] {
+  return asArray(details).map((entry) => {
+    const record = asRecord(entry);
+    const mode = MODE_LABEL[text(record.mode)] || text(record.mode);
+    const weekNo = Number(record.weekNo);
+    const where = `${mode}${Number.isSafeInteger(weekNo) ? ` ${weekNo}주차` : ''}`;
+    const matches = asRecord(record.matches);
+    const cells = asRecord(record.sourceCells);
+    const failed = Object.keys(CALCULATION_LABEL)
+      .filter((key) => (kind === 'invalid' ? matches[key] === null : matches[key] === false))
+      .map((key) => `${CALCULATION_LABEL[key]}${text(cells[key]) ? `(${text(cells[key])})` : ''}`);
+    const named = failed.length > 0 ? failed.join(', ') : '합계·잔액';
+    return kind === 'invalid'
+      ? `${where} · ${named} 값을 읽지 못했어요. 숫자인지 확인해 주세요.`
+      : `${where} · ${named}이(가) 항목을 더한 값과 달라요.`;
+  });
+}
+
+function controlTotalLines(details: unknown): string[] {
+  const record = asRecord(details);
+  const lines: string[] = [];
+  const deposit = asRecord(record.deposit);
+  if (deposit.matches === false) {
+    lines.push(`입금 예정 합계${cell(deposit.sourceCell) ? `(${text(deposit.sourceCell)})` : ''}이(가) 주차 합계와 달라요.`);
+  }
+  for (const entry of asArray(record.rows)) {
+    const row = asRecord(entry);
+    lines.push(`${lineLabel(row)}${text(row.sourceCell) ? `(${text(row.sourceCell)})` : ''} · 시트 합계와 주차 합계가 달라요.`);
+  }
+  return lines;
+}
+
+function managementLines(details: unknown): string[] {
+  const record = asRecord(details);
+  const findings = asArray(record.findings).map(text).filter(Boolean);
+  if (findings.length > 0) return findings;
+  const detail = text(record.detail);
+  return detail ? [detail] : [];
+}
+
+/** 서버가 준 막는 사유·경고 하나를 "무엇이 · 어디서 · 왜" 한 줄들로 편다. */
+export function describeCashflowMonthCloseIssue(issue: CashflowMonthCloseIssue | null | undefined): string[] {
+  if (!issue) return [];
+  const code = text(issue.code);
+  if (code === 'SHEET_VALUE_INVALID') return sheetValueLines(issue.details);
+  if (code === 'SHEET_CALCULATION_VALUE_INVALID') return calculationLines(issue.details, 'invalid');
+  if (code === 'SHEET_CALCULATION_MISMATCH') return calculationLines(issue.details, 'mismatch');
+  if (code === 'SHEET_CONTROL_TOTAL_MISMATCH') return controlTotalLines(issue.details);
+  if (code.startsWith('MANAGEMENT_CHECK_')) return managementLines(issue.details);
+  return [];
+}


### PR DESCRIPTION
## 근거 (프리즈 예외 — 라이브 QA 결함)
2026-08-19 화면: `월 결산 / 결산 전 / 월 결산 대상의 입금·출금 합계 또는 잔액 값을 확인해 주세요.` 가 상태 배지 아래 **회색 한 줄**로만 떴어요. 보람: "막을거면 왜 막는지 확실히 메세지를 띄워… 회색 글씨로 보여주면 그게 경고인지 누가 알아!"

## 무엇
1. **막는 사유 = 빨간 경고 + 구체 위치.** 서버는 이미 셀 주소·구분·주차를 `details` 로 보내는데 화면이 첫 문장만 쓰고 버렸어요. 이제 이렇게 나와요:
   - `AK17 칸 · 매출액(입금)이(가) 숫자가 아니에요 (지금 값: 3월 말).`
   - `Actual 3주차 · 출금 합계(AB57), 잔액(AB58) 값을 읽지 못했어요.`
   - `Projection 5주차 · 잔액(X33)이(가) 항목을 더한 값과 달라요.`
   - `직접사업비(BO25) · 시트 합계와 주차 합계가 달라요.`
   판정은 서버 것을 그대로 옮겨 적기만 해요 — 화면이 다시 계산하지 않습니다.
2. **주요 관리 항목** `REVIEW_REQUIRED` 가 회색(neutral)이라 OK 보다도 안 보였어요 → OK 아니면 주의 톤.
3. **비활성 동작의 이유 표시.** 회수 버튼이 그냥 사라져서 "기능이 없다"로 읽혔어요. 서버가 이미 주는 문구를 남깁니다 — `결재 요청 회수 · 본인이 요청한 검토 전 월 결산만 회수할 수 있습니다.`

## 확인
새 헬퍼 + 테스트 6개, cashflow 162개 통과, typecheck·build 통과. `validation.blockers` 를 못 쓰게 막던 핀은 새 동작 핀으로 교체(주석에 이유 기록).

🤖 Generated with [Claude Code](https://claude.com/claude-code)