### PR TITLE
feat(portal): 종료사업 체크아웃 증빙을 그 화면에서 올린다

### DIFF
--- a/server/bff/project-request-contract-storage.mjs
+++ b/server/bff/project-request-contract-storage.mjs
@@ -150,6 +150,46 @@ export function createProjectRequestContractStorageService(options = {}) {
       };
     },
 
+    /**
+     * 종료사업 체크아웃 증빙을 프로젝트 문서 자리에 바로 올린다.
+     *
+     * 등록 초안을 거치지 않는다. 이미 승인이 끝난 사업의 마무리 증빙이라 초안으로 올리고
+     * 제출하면 조직장 결재가 다시 열린다(projects.mjs 의 executiveReviewReopens).
+     * 결재를 건드리지 않는 것이 이 경로의 존재 이유다.
+     */
+    async uploadProjectRegistrationAttachment(input) {
+      const tenantId = requireStoragePathSegment(input?.tenantId, 'tenantId');
+      const projectId = requireStoragePathSegment(input?.projectId, 'projectId');
+      const attachmentId = requireStoragePathSegment(input?.attachmentId, 'attachmentId');
+      const fileName = normalizeSafeFileName(input?.fileName);
+      const mimeType = readOptionalText(input?.mimeType) || 'application/octet-stream';
+      const buffer = input?.buffer instanceof Uint8Array
+        ? Buffer.from(input.buffer)
+        : Buffer.isBuffer(input?.buffer)
+          ? input.buffer
+          : null;
+      if (!buffer) throw new Error('buffer is required');
+
+      const uploadedAt = new Date().toISOString();
+      // 다운로드 라우트가 prefix 바로 아래 한 칸만 허용하므로 하위 경로를 만들지 않는다.
+      const path = `${projectRegistrationAttachmentPrefix(tenantId, projectId)}${attachmentId}-${fileName}`;
+      await bucket.file(path).save(buffer, {
+        resumable: false,
+        metadata: {
+          contentType: mimeType,
+          metadata: { tenantId, projectId, attachmentId },
+        },
+      });
+
+      return {
+        path,
+        name: readOptionalText(input?.fileName) || fileName,
+        size: buffer.byteLength,
+        contentType: mimeType,
+        uploadedAt,
+      };
+    },
+
     async deleteDraftAttachment(input) {
       const prefix = draftAttachmentPrefix(input?.tenantId, input?.draftId);
       const { path } = objectNameWithinPrefix(

--- a/server/bff/routes/checkout-attachments.shell.test.mjs
+++ b/server/bff/routes/checkout-attachments.shell.test.mjs
@@ -1,0 +1,48 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(import.meta.dirname, 'projects.mjs'), 'utf8');
+const route = source.slice(source.indexOf("app.post('/api/v1/projects/:projectId/checkout-attachments/"));
+const routeBody = route.slice(0, route.indexOf("app.get('/api/v1/project-requests/"));
+
+describe('종료사업 체크아웃 증빙 업로드 라우트', () => {
+  it('결재 상태를 건드리지 않는다', () => {
+    // 이 경로가 존재하는 이유다. 수정 초안으로 올리면 제출 시 executiveReviewReopens 가
+    // 조직장 결재를 다시 연다. 마무리 서류를 붙였다고 결재가 풀리면 안 된다.
+    for (const field of [
+      'executiveReviewStatus',
+      'managementPlanningReviewStatus',
+      'executiveReviewHistory',
+      'projectCode',
+      'executiveReviewReopens',
+    ]) {
+      expect(routeBody).not.toContain(field === 'executiveReviewReopens' ? field : `${field}:`);
+    }
+  });
+
+  it('체크아웃 증빙 네 종류만 받는다', () => {
+    expect(routeBody).toContain("performance_certificate: 'performanceCertificateDocument'");
+    expect(routeBody).toContain("tax_invoice: 'taxInvoiceDocument'");
+    expect(routeBody).toContain("final_settlement_report: 'finalSettlementReportDocument'");
+    expect(routeBody).toContain("final_report: 'finalReportDocument'");
+    // 등록 서류는 이 경로로 바꿀 수 없다.
+    expect(routeBody).not.toContain("contract: 'contractDocument'");
+    expect(routeBody).not.toContain("quote: 'quoteDocument'");
+  });
+
+  it('역할과 사업 배정을 확인하고, 파일을 검증한 뒤 저장한다', () => {
+    expect(routeBody).toContain("assertActorRoleAllowed(req, ROUTE_ROLES.writeCore");
+    expect(routeBody).toContain('Checkout attachment access denied');
+    expect(routeBody).toContain('projectDocumentValidationError(');
+    expect(routeBody).toContain('decodeCheckoutBase64(contentBase64, fileSize)');
+    // 크기 불일치는 디코더가 잡는다(라우트 밖 헬퍼).
+    expect(source).toContain('checkout_attachment_size_mismatch');
+  });
+
+  it('version 을 트랜잭션 안에서 올려 되돌려준다', () => {
+    expect(routeBody).toContain('db.runTransaction(');
+    expect(routeBody).toContain('const nextVersion = Number(current.version || 0) + 1');
+    expect(routeBody).toContain('res.status(200).json({ id: projectId, tenantId, version');
+  });
+});

--- a/server/bff/routes/projects.mjs
+++ b/server/bff/routes/projects.mjs
@@ -1,4 +1,6 @@
 import express from 'express';
+import { randomUUID } from 'node:crypto';
+import { projectDocumentValidationError } from '../project-document-validation.mjs';
 import { createOutboxEvent } from '../outbox.mjs';
 import {
   DriveServiceError,
@@ -488,6 +490,17 @@ function normalizeProjectStatus(value) {
 
 function normalizeProjectPhase(value) {
   return value === 'PROSPECT' || value === 'CONFIRMED' ? value : 'CONFIRMED';
+}
+
+function decodeCheckoutBase64(value, expectedSize) {
+  if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
+    throw createHttpError(400, 'contentBase64 is invalid', 'checkout_attachment_invalid');
+  }
+  const buffer = Buffer.from(value, 'base64');
+  if (buffer.byteLength !== expectedSize) {
+    throw createHttpError(422, 'Attachment size does not match its content', 'checkout_attachment_size_mismatch');
+  }
+  return buffer;
 }
 
 async function readProjectAttachmentMember({ db, tenantId, actorId }) {
@@ -2793,6 +2806,7 @@ export function mountProjectRoutes(app, {
       performance_certificate: 'performanceCertificateDocument',
       tax_invoice: 'taxInvoiceDocument',
       final_settlement_report: 'finalSettlementReportDocument',
+      final_report: 'finalReportDocument',
     }[documentKind];
     if (!projectId || !field) {
       throw createHttpError(400, 'Project attachment request is invalid', 'project_attachment_invalid');
@@ -2834,6 +2848,101 @@ export function mountProjectRoutes(app, {
       path,
     });
     sendPrivateProjectAttachment(res, downloaded, attachment, objectName);
+  }));
+
+  /*
+   * 종료사업 체크아웃 증빙 업로드.
+   *
+   * 초안·편집 리스를 거치지 않는다. 이미 승인이 끝난 사업의 마무리 증빙인데 수정 초안으로
+   * 올리면 제출 시 `executiveReviewReopens` 가 조직장 결재를 다시 연다. 마무리 서류를
+   * 붙였다고 결재가 풀리면 안 된다.
+   *
+   * 그래서 여기서는 문서 칸 하나와 version 만 올린다. 결재 관련 필드는 쓰지 않는다.
+   */
+  app.post('/api/v1/projects/:projectId/checkout-attachments/:documentKind', asyncHandler(async (req, res) => {
+    const { tenantId, actorId, actorRole } = req.context;
+    assertActorRoleAllowed(req, ROUTE_ROLES.writeCore, 'upload checkout attachments');
+    const projectId = readOptionalText(req.params.projectId);
+    const documentKind = readOptionalText(req.params.documentKind);
+    // 체크아웃 증빙만 받는다. 등록 서류는 이 경로로 바꿀 수 없다.
+    const field = {
+      performance_certificate: 'performanceCertificateDocument',
+      tax_invoice: 'taxInvoiceDocument',
+      final_settlement_report: 'finalSettlementReportDocument',
+      final_report: 'finalReportDocument',
+    }[documentKind];
+    if (!projectId || !field) {
+      throw createHttpError(400, 'Checkout attachment request is invalid', 'checkout_attachment_invalid');
+    }
+
+    const fileName = readOptionalText(req.body?.fileName);
+    const mimeType = readOptionalText(req.body?.mimeType) || 'application/pdf';
+    const fileSize = Number(req.body?.fileSize);
+    const contentBase64 = readOptionalText(req.body?.contentBase64);
+    if (!fileName || !contentBase64 || !Number.isFinite(fileSize) || fileSize <= 0) {
+      throw createHttpError(400, 'Checkout attachment payload is invalid', 'checkout_attachment_invalid');
+    }
+    const buffer = decodeCheckoutBase64(contentBase64, fileSize);
+    const validationError = projectDocumentValidationError({ buffer, mimeType, fileName, documentKind });
+    if (validationError) {
+      throw createHttpError(422, validationError, 'checkout_attachment_rejected');
+    }
+
+    const projectRef = db.doc(`orgs/${tenantId}/projects/${projectId}`);
+    const projectSnap = await projectRef.get();
+    if (!projectSnap.exists) throw createHttpError(404, `Project not found: ${projectId}`, 'not_found');
+    const project = projectSnap.data() || {};
+
+    const member = await readProjectAttachmentMember({ db, tenantId, actorId });
+    const profile = member?.portalProfile && typeof member.portalProfile === 'object' ? member.portalProfile : {};
+    const storedRole = normalizeRole(member?.role) || normalizeRole(actorRole);
+    const assignedProjectIds = new Set([
+      member?.projectId,
+      ...(Array.isArray(member?.projectIds) ? member.projectIds : []),
+      profile.projectId,
+      ...(Array.isArray(profile.projectIds) ? profile.projectIds : []),
+    ].map(readOptionalText).filter(Boolean));
+    if (
+      !['admin', 'finance'].includes(storedRole)
+      && !assignedProjectIds.has(projectId)
+      && readOptionalText(project.executiveApproverId) !== actorId
+    ) {
+      throw createHttpError(403, 'Checkout attachment access denied', 'forbidden');
+    }
+
+    if (typeof projectRequestContractStorageService?.uploadProjectRegistrationAttachment !== 'function') {
+      throw new Error('Project registration attachment storage is not configured');
+    }
+    const attachmentId = `att_${randomUUID().replace(/-/g, '')}`;
+    const uploaded = await projectRequestContractStorageService.uploadProjectRegistrationAttachment({
+      tenantId, projectId, attachmentId, fileName, mimeType, buffer,
+    });
+
+    const timestamp = now();
+    const attachment = {
+      attachmentId,
+      documentKind,
+      path: readOptionalText(uploaded?.path),
+      name: readOptionalText(uploaded?.name) || fileName,
+      size: buffer.byteLength,
+      contentType: mimeType,
+      uploadedAt: readOptionalText(uploaded?.uploadedAt) || timestamp,
+    };
+    const version = await db.runTransaction(async (tx) => {
+      const snap = await tx.get(projectRef);
+      if (!snap.exists) throw createHttpError(404, `Project not found: ${projectId}`, 'not_found');
+      const current = snap.data() || {};
+      const nextVersion = Number(current.version || 0) + 1;
+      tx.update(projectRef, {
+        [field]: attachment,
+        version: nextVersion,
+        updatedAt: timestamp,
+        updatedBy: actorId,
+      });
+      return nextVersion;
+    });
+
+    res.status(200).json({ id: projectId, tenantId, version, updatedAt: timestamp, documentKind, attachment });
   }));
 
   app.get('/api/v1/project-requests/:requestId/attachments/:documentKind', asyncHandler(async (req, res) => {

--- a/src/app/components/portal/PortalProjectCheckout.tsx
+++ b/src/app/components/portal/PortalProjectCheckout.tsx
@@ -19,7 +19,7 @@ type CheckField = keyof Pick<
   | 'usbEvidenceSubmitted' | 'evidenceDeletedAfterUsb'
 >;
 type CheckItem = { field: CheckField; label: string; done: boolean; note?: string };
-type UploadItem = { label: string; attached: boolean; note?: string };
+type UploadItem = { kind: string; label: string; attached: boolean; note?: string };
 
 function readChecklist(project: Project): CheckItem[] {
   const checkout = project.checkout;
@@ -39,21 +39,25 @@ function readUploads(project: Project): UploadItem[] {
   const checkout = project.checkout;
   return [
     {
+      kind: 'final_report',
       label: '최종 결과보고서 (원본)',
       attached: Boolean(project.finalReportDocument?.path),
       note: '종료사업은 결과보고서 원본을 제출합니다.',
     },
     {
+      kind: 'tax_invoice',
       label: '사업 관련 발행 세금계산서 PDF',
       attached: Boolean(project.taxInvoiceDocument?.path),
       note: checkout?.taxInvoiceEvidenceConfirmed ? '해당 사업으로 표시됨' : '해당 시에만 제출합니다.',
     },
     {
+      kind: 'performance_certificate',
       label: '고객사 용역수행실적증명서 PDF',
       attached: Boolean(project.performanceCertificateDocument?.path),
       note: checkout?.performanceCertificateDocumentApplicable ? '해당 사업으로 표시됨' : '해당 시에만 제출합니다.',
     },
     {
+      kind: 'final_settlement_report',
       label: '회계사 최종 정산리포트',
       attached: Boolean(project.finalSettlementReportDocument?.path),
       note: checkout?.finalSettlementReportConfirmed ? '해당 사업으로 표시됨' : '회계사 정산 사업만 해당합니다.',
@@ -62,7 +66,7 @@ function readUploads(project: Project): UploadItem[] {
 }
 
 export function PortalProjectCheckout() {
-  const { activeProjectId, projects, updateProjectCheckout } = usePortalStore();
+  const { activeProjectId, projects, updateProjectCheckout, uploadProjectCheckoutDocument } = usePortalStore();
   const project = useMemo(
     () => projects.find((candidate) => candidate.id === activeProjectId) || null,
     [activeProjectId, projects],
@@ -133,12 +137,25 @@ export function PortalProjectCheckout() {
         <h2 className="border-b border-slate-200 pb-2 text-[12px] font-semibold text-slate-700">업로드</h2>
         <ul className="space-y-2">
           {uploads.map((item) => (
-            <li key={item.label} className="flex items-start gap-2 text-[13px]">
+            <li key={item.kind} className="flex items-start gap-2 text-[13px]">
               <FileText aria-hidden className={`mt-0.5 h-4 w-4 shrink-0 ${item.attached ? 'text-[#047857]' : 'text-slate-300'}`} />
-              <span className="min-w-0">
+              <span className="min-w-0 flex-1">
                 <span className={item.attached ? 'text-slate-900' : 'text-slate-600'}>{item.label}</span>
                 <span className="ml-2 text-[12px] text-slate-500">{item.attached ? '첨부됨' : '미첨부'}</span>
                 {item.note ? <span className="mt-0.5 block text-[12px] text-slate-500">{item.note}</span> : null}
+                <label className="mt-1 inline-flex cursor-pointer items-center gap-1 text-[12px] text-[#0176D3] underline underline-offset-2">
+                  {item.attached ? 'PDF 교체' : 'PDF 올리기'}
+                  <input
+                    type="file"
+                    accept="application/pdf,.pdf"
+                    className="hidden"
+                    onChange={(event) => {
+                      const file = event.target.files?.[0];
+                      event.target.value = '';
+                      if (file) void uploadProjectCheckoutDocument(project.id, item.kind, file);
+                    }}
+                  />
+                </label>
               </span>
             </li>
           ))}
@@ -169,7 +186,7 @@ export function PortalProjectCheckout() {
       </section>
 
       <p className="text-[13px] text-slate-600">
-        체크는 이 화면에서 바로 저장됩니다. 증빙 업로드는{' '}
+        체크와 증빙 모두 이 화면에서 바로 저장되며, 조직장 결재는 다시 열리지 않습니다. 사업 내용을 고치려면{' '}
         <Link className="font-medium text-[#0176D3] underline underline-offset-2" to={`/portal/edit-project/${project.id}`}>
           프로젝트 수정
         </Link>

--- a/src/app/data/portal-store.tsx
+++ b/src/app/data/portal-store.tsx
@@ -107,6 +107,7 @@ import {
   saveWeeklyExpenseDraftViaBff,
   type UpsertProjectPayload,
   upsertProjectViaBff,
+  uploadProjectCheckoutAttachmentViaBff,
   upsertTransactionViaBff,
 } from '../lib/platform-bff-client';
 import type { CashflowMutationLease } from '../lib/cashflow-edit-lease';
@@ -522,6 +523,7 @@ interface PortalActions {
   patchProjectSnapshot: (project: Project) => void;
   updateProjectStatus: (projectId: string, status: ProjectStatus) => Promise<boolean>;
   updateProjectCheckout: (projectId: string, patch: Partial<ProjectCheckout>) => Promise<boolean>;
+  uploadProjectCheckoutDocument: (projectId: string, documentKind: string, file: File) => Promise<boolean>;
   logout: () => void;
   addExpenseSet: (set: ExpenseSet) => void;
   updateExpenseSet: (id: string, updates: Partial<ExpenseSet>) => void;
@@ -3518,6 +3520,64 @@ export function PortalProvider({ children }: { children: ReactNode }) {
   ]);
 
   /**
+   * 체크아웃 증빙 업로드. 체크 저장과 같은 줄에 세운다 - 둘 다 프로젝트 version 을 올리므로
+   * 동시에 나가면 서로를 409 로 튕긴다.
+   */
+  const uploadProjectCheckoutDocument = useCallback((
+    projectId: string,
+    documentKind: string,
+    file: File,
+  ): Promise<boolean> => {
+    const queued = checkoutSaveChainRef.current
+      .catch(() => undefined)
+      .then(async () => {
+        const targetProjectId = projectId.trim();
+        if (!targetProjectId || !includesProject(scopedProjectIds, targetProjectId)) {
+          toast.error('선택 가능한 사업이 아닙니다.');
+          return false;
+        }
+        if (!isPlatformApiEnabled()) {
+          toast.error('이 환경에서는 증빙 업로드를 지원하지 않습니다.');
+          return false;
+        }
+        try {
+          const buffer = await file.arrayBuffer();
+          let binary = '';
+          const bytes = new Uint8Array(buffer);
+          for (let i = 0; i < bytes.length; i += 1) binary += String.fromCharCode(bytes[i]);
+          const idToken = authUser?.idToken || await getAuthInstance()?.currentUser?.getIdToken() || undefined;
+          const saved = await uploadProjectCheckoutAttachmentViaBff({
+            tenantId: orgId,
+            actor: {
+              uid: authUser?.uid || portalUser?.id || 'portal-user',
+              email: authUser?.email || portalUser?.email || '',
+              role: authUser?.role || portalUser?.role || 'pm',
+              idToken,
+            },
+            projectId: targetProjectId,
+            documentKind,
+            file: { name: file.name, size: file.size, type: file.type, contentBase64: btoa(binary) },
+          });
+          if (typeof saved?.version === 'number') {
+            const versioned = projectsRef.current.map((project) => (
+              project.id === targetProjectId ? { ...project, version: saved.version } : project
+            ));
+            projectsRef.current = versioned;
+            setProjects(versioned);
+          }
+          toast.success('증빙을 올렸습니다.');
+          return true;
+        } catch (err) {
+          console.error('[PortalStore] uploadProjectCheckoutDocument error:', err);
+          toast.error('증빙 업로드에 실패했습니다.');
+          return false;
+        }
+      });
+    checkoutSaveChainRef.current = queued;
+    return queued;
+  }, [authUser?.email, authUser?.idToken, authUser?.role, authUser?.uid, orgId, portalUser?.email, portalUser?.id, portalUser?.role, scopedProjectIds]);
+
+  /**
    * 밖에서 부르는 입구. 실제 저장은 위 구현이 하고, 여기서는 줄을 세우기만 한다.
    * 체크박스를 연달아 누르면 요청이 동시에 나가 각자 자기가 읽은 version 을 보내고
    * 뒤엣것이 409 로 튕긴다 (라이브에서 실제로 났다).
@@ -3901,6 +3961,7 @@ export function PortalProvider({ children }: { children: ReactNode }) {
     patchProjectSnapshot,
     updateProjectStatus,
     updateProjectCheckout,
+    uploadProjectCheckoutDocument,
     logout,
     addExpenseSet,
     updateExpenseSet,

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -2275,6 +2275,38 @@ export async function upsertProjectViaBff(params: {
   return response.data;
 }
 
+/**
+ * 종료사업 체크아웃 증빙 업로드.
+ *
+ * 수정 초안을 거치지 않는다. 이미 승인이 끝난 사업이라 초안으로 올리고 제출하면 조직장
+ * 결재가 다시 열린다. 이 경로는 문서 칸과 version 만 올린다.
+ */
+export async function uploadProjectCheckoutAttachmentViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  projectId: string;
+  documentKind: string;
+  file: { name: string; size: number; type?: string; contentBase64: string };
+  client?: PlatformApiClientLike;
+}): Promise<{ id: string; version: number; updatedAt: string; documentKind: string }> {
+  const apiClient = resolveClient(params.client);
+  const response = await apiClient.post<{ id: string; version: number; updatedAt: string; documentKind: string }>(
+    `/api/v1/projects/${params.projectId}/checkout-attachments/${params.documentKind}`,
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      body: {
+        fileName: params.file.name,
+        fileSize: params.file.size,
+        mimeType: params.file.type || 'application/pdf',
+        contentBase64: params.file.contentBase64,
+      },
+    },
+  );
+
+  return response.data;
+}
+
 export async function trashProjectViaBff(params: {
   tenantId: string;
   actor: ActorLike;


### PR DESCRIPTION
## 왜 새 경로가 필요했나

체크는 체크아웃 화면에서 저장되는데 **증빙만 `프로젝트 수정` 화면으로 보내고** 있었습니다. 그런데 그 경로가 위험합니다.

`server/bff/routes/projects.mjs` 의 `executiveReviewReopens` — **승인된 사업을 수정 제출하면 조직장 결재가 다시 열립니다.** 즉 마무리 서류를 붙였다는 이유로 이미 끝난 결재가 풀립니다. 체크아웃은 정의상 승인이 끝난 사업이라 정면으로 부딪힙니다.

## 새 경로

```
POST /api/v1/projects/:projectId/checkout-attachments/:documentKind
```

- **체크아웃 증빙 네 종류만** 받습니다 (실적증명서 · 세금계산서 · 정산리포트 · 결과보고서). 등록 서류는 이 경로로 바꿀 수 없습니다.
- **문서 칸과 `version` 만** 트랜잭션으로 올립니다. 결재 관련 필드는 쓰지 않습니다.
- 역할(`writeCore`) + 사업 배정/결재자 확인, `projectDocumentValidationError` 파일 검증, base64 크기 대조 — 기존 초안 업로드와 **같은 규약**을 지킵니다.
- 저장소에 `uploadProjectRegistrationAttachment` 를 더했습니다. 다운로드 라우트가 prefix 바로 아래 한 칸만 허용하므로 하위 경로를 만들지 않습니다.

**"결재를 건드리지 않는다" 를 회귀 테스트로 고정**했습니다 — 라우트 본문에 `executiveReviewStatus` · `managementPlanningReviewStatus` · `projectCode` · `executiveReviewReopens` 가 등장하면 실패합니다.

## 프론트

업로드도 체크 저장과 **같은 줄에 세웠습니다.** 둘 다 프로젝트 `version` 을 올리므로 동시에 나가면 서로를 409 로 튕깁니다 — 방금 라이브에서 겪은 그 사고입니다.

## 곁다리 수정

`final_report` 가 프로젝트 첨부 **다운로드 매핑에서 빠져** 있었습니다. 올려도 못 받는 상태였는데 함께 고쳤습니다.

## 검증

전체 3,257 통과 · `policy:verify` 통과 · typecheck clean · build 성공

> `cashflow-sheet-lab` 1건은 flake 입니다. 단독 3회 중 2회 통과하고 **매번 다른 테스트**가 죽으며, `git stash` 로 변경을 걷어낸 상태에서도 같은 파일이 흔들립니다. 이 PR 의 변경과 코드 경로가 겹치지 않습니다.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)