### PR TITLE
fix(jvm): stop repeating shared audit fields on every applied cell

### DIFF
--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -4756,20 +4756,23 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
             String requestId = text(metadata.get("requestId"), "");
             String approvalId = text(metadata.get("approvalId"), "");
             String operationId = text(metadata.get("operationId"), "");
-            List<Map<String, Object>> applied = changes.stream().map(change -> {
-                Map<String, Object> item = new LinkedHashMap<>(change);
-                item.put("actorId", event.getActorId());
-                item.put("changedAt", event.getCreatedAt().toString());
-                item.put("reason", reason);
-                item.put("sourceRevision", sourceRevision);
-                item.put("targetRevision", targetRevision);
-                item.put("requestId", requestId);
-                item.put("approvalId", approvalId);
-                item.put("operationId", operationId);
-                item.put("auditId", auditId);
-                item.put("idempotencyKey", event.getIdempotencyKey());
-                return Collections.unmodifiableMap(item);
-            }).toList();
+            // These ten values are identical for every change in one audit event. Repeating them per
+            // cell pushed a full sheet apply (1,920 cells) past the 1 MB Firestore field limit, so the
+            // apply failed with INVALID_ARGUMENT and no sheet could be applied at all. Write them once;
+            // the reader already falls back from the change to this metadata, so older records still read.
+            List<Map<String, Object>> applied = changes.stream()
+                .map(change -> Collections.unmodifiableMap(new LinkedHashMap<>(change)))
+                .toList();
+            metadata.put("actorId", event.getActorId());
+            metadata.put("changedAt", event.getCreatedAt().toString());
+            metadata.put("reason", reason);
+            metadata.put("sourceRevision", sourceRevision);
+            metadata.put("targetRevision", targetRevision);
+            metadata.put("requestId", requestId);
+            metadata.put("approvalId", approvalId);
+            metadata.put("operationId", operationId);
+            metadata.put("auditId", auditId);
+            metadata.put("idempotencyKey", event.getIdempotencyKey());
             metadata.put("appliedCellChanges", applied);
             metadata.put("appliedCellChangeCount", applied.size());
             changes.clear();

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -5789,11 +5789,15 @@ class FirestoreCashflowLeaseGuardTest {
         Map<String, Object> metadata = new ObjectMapper().readValue(String.valueOf(auditDocs.getFirst().get("metadataJson")), Map.class);
         assertThat(metadata).containsEntry("appliedCellChangeCount", 1);
         List<Map<String, Object>> changes = (List<Map<String, Object>>) metadata.get("appliedCellChanges");
+        // The ten shared values live once on the event, not on every cell: repeating them per cell
+        // pushed a full sheet apply past the 1 MB Firestore field limit and blocked the apply entirely.
+        assertThat(metadata).containsKeys("actorId", "changedAt", "reason", "sourceRevision", "targetRevision",
+            "requestId", "approvalId", "operationId", "auditId", "idempotencyKey");
         assertThat(changes).singleElement().satisfies(change -> {
             assertThat(change).containsEntry("yearMonth", "2026-07").containsEntry("weekNo", 2)
                 .containsEntry("mode", "projection").containsEntry("cashflowLine", "SALES_IN")
-                .containsKeys("actorId", "changedAt", "reason", "sourceRevision", "targetRevision", "requestId",
-                    "approvalId", "operationId", "auditId", "idempotencyKey");
+                .doesNotContainKeys("actorId", "changedAt", "reason", "sourceRevision", "targetRevision",
+                    "requestId", "approvalId", "operationId", "auditId", "idempotencyKey");
             assertThat((Map<String, Object>) change.get("before")).containsEntry("cellState", "EMPTY").containsEntry("amount", null);
             assertThat((Map<String, Object>) change.get("after")).containsEntry("cellState", "VALUE").containsEntry("amount", 1234);
         });


### PR DESCRIPTION
## 근거 (프리즈 예외 — 라이브 장애)
**KDB넥스트원 광주(`p1780662870530`) 는 시트 반영이 아예 안 되는 상태였습니다.** 07:05:23 과 07:05:51 두 번 다 503, JVM 로그:

```
INVALID_ARGUMENT: The value of property "metadataJson" is longer than 1048487 bytes
```

## 원인
감사 기록이 **반영된 셀마다** 같은 값 10개를 복사해 넣습니다 — `actorId` `changedAt` `reason` `sourceRevision` `targetRevision` `requestId` `approvalId` `operationId` `auditId` `idempotencyKey`. 한 번의 반영 안에서 이 열 개는 **전부 동일**합니다.

```
진짜 데이터  약 120B × 1,920셀 = 약 230KB
반복 10개    약 420B × 1,920셀 = 약 800KB   ← 전부 같은 값
합계 1MB 초과 → Firestore 거부 → 반영 불가
```

## 수정
열 개를 **기록 맨 위에 한 번만** 씁니다. 정보 손실 없음 — 읽는 쪽(`appliedCellChangeItem`)이 이미 `change → metadata → source` 순으로 폴백하므로 **이전에 저장된 기록도 그대로 읽힙니다.**

## 확인
`FirestoreCashflowLeaseGuardTest` 의 감사 기록 테스트를 "열 개는 위에 한 번, 셀에는 없음" 으로 갱신. JVM 전체 **425개 통과**.

## 남는 것
1MB 상한은 다른 곳에도 있습니다(시트 미러 문서는 현재 44%, 시트 연도가 3개면 초과). 프리즈 해제 후 별도로 다룹니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)