### PR TITLE
fix(cashflow): apply toast says how many cells changed, and which

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,7 +9,7 @@ export default function App() {
     <FirebaseProvider>
       <AuthProvider>
         <RouterProvider router={router} />
-        <Toaster position="bottom-right" />
+        <Toaster position="bottom-right" toastOptions={{ classNames: { description: 'whitespace-pre-line' } }} />
       </AuthProvider>
     </FirebaseProvider>
   );

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -282,7 +282,10 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).toContain('weeklyActionNotice && !weeklyWithdrawError');
     expect(source).toContain("setWeeklyActionNotice(''), 6000");
     expect(source).toContain("import { toast } from 'sonner';");
-    expect(source).toContain('건을 MYSCube에 반영했어요.');
+    // 반영 건수는 다시 쓴 월의 셀 수(appliedLineCount, 월당 160)가 아니라 검토 단계의 변경 후보 수.
+    // 내용(어떤 칸이 얼마→얼마)도 같이 말한다.
+    expect(source).toContain('buildSheetApplyNotice({ stagedLineCount: stage.stagedLineCount, candidates: stage.candidates })');
+    expect(source).not.toContain('result.appliedLineCount.toLocaleString');
     expect(source).toContain("toast.success('월 결산 승인 요청을 보냈어요. 조직장 승인을 기다립니다.')");
     expect(source).toContain("toast.success('월 결산 요청을 회수했어요.')");
     expect(source).not.toContain('toast.error');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -100,6 +100,7 @@ import { buildOrgMemberPickerOptions } from '../../data/project-team-member-opti
 import { usePersonRoster } from '../../data/use-person-roster';
 import { loadCashflowActivitySourcesSequentially } from './cashflow-activity-loader';
 import { describeCashflowMonthCloseIssue } from './cashflow-month-close-blocker-helpers';
+import { buildSheetApplyNotice } from './cashflow-sheet-apply-notice';
 
 type CashflowOpsTone = 'neutral' | 'info' | 'warning' | 'danger' | 'success';
 
@@ -1742,6 +1743,12 @@ export function CashflowProjectSheet({
   ): Promise<void> => {
     if (!stage.runId || stage.stagedLineCount <= 0) return;
     const applyIdempotencyKey = `cashflow-sheet-apply-stage:${projectId}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
+    // 건수·내용은 검토 단계의 변경 후보로 말한다. 서버의 appliedLineCount 는 다시 쓴 월의
+    // 전체 셀 수(월당 160)라 "2건 바꿨는데 160건" 이 된다.
+    const notifySheetApplied = () => {
+      const notice = buildSheetApplyNotice({ stagedLineCount: stage.stagedLineCount, candidates: stage.candidates });
+      toast.success(notice.title, notice.lines.length > 0 ? { description: notice.lines.join('\n'), duration: 8000 } : undefined);
+    };
     const apply = async (actor: NonNullable<Awaited<ReturnType<typeof resolveBffActor>>>) => {
       return applyCashflowSheetLabViaBff({
         tenantId: orgId,
@@ -1792,7 +1799,7 @@ export function CashflowProjectSheet({
       }
       const result = await apply(actor);
       await rememberApplyResult(result);
-      toast.success(`시트값 ${result.appliedLineCount.toLocaleString('ko-KR')}건을 MYSCube에 반영했어요.`);
+      notifySheetApplied();
       logCashflowSettlement({ phase: 'success', operation: 'cashflow.sheet_apply', projectId, summary: { appliedLineCount: result.appliedLineCount } });
     } catch (error) {
       let finalError = error;
@@ -1802,7 +1809,7 @@ export function CashflowProjectSheet({
           if (!actor?.idToken) throw error;
           const result = await apply(actor);
           await rememberApplyResult(result);
-          toast.success(`시트값 ${result.appliedLineCount.toLocaleString('ko-KR')}건을 MYSCube에 반영했어요.`);
+          notifySheetApplied();
           logCashflowSettlement({ phase: 'success', operation: 'cashflow.sheet_apply', projectId, summary: { appliedLineCount: result.appliedLineCount, authRetried: true } });
           return;
         } catch (retryError) {

--- a/src/app/components/cashflow/cashflow-sheet-apply-notice.test.ts
+++ b/src/app/components/cashflow/cashflow-sheet-apply-notice.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { buildSheetApplyNotice, describeSheetApplyChange } from './cashflow-sheet-apply-notice';
+import type { CashflowSheetLabChangeCandidate } from '../../lib/sheets-cashflow-readonly-client';
+
+const base: CashflowSheetLabChangeCandidate = {
+  projectId: 'p1', runId: 'r1', source: 'google_sheet', status: 'pending_review',
+  mode: 'projection', yearMonth: '2026-04', weekNo: 5, lineId: 'SALES_IN', lineDirection: 'in',
+  beforeAmount: 100, beforeHadValue: true, proposedAmount: null, proposedHadValue: false,
+  createdAt: '2026-08-19T00:00:00.000Z', updatedAt: '2026-08-19T00:00:00.000Z',
+};
+
+describe('sheet apply notice', () => {
+  it('counts the changed cells, not the rewritten month (160 per month)', () => {
+    // 라이브 2026-08-19: 변경 2건인데 "160건 반영" 이 떴다. 160 은 다시 쓴 월의 전체 셀 수다.
+    const notice = buildSheetApplyNotice({
+      stagedLineCount: 2,
+      candidates: [
+        base,
+        { ...base, lineId: 'SALES_VAT_IN', beforeAmount: 10, proposedAmount: null },
+      ],
+    });
+    expect(notice.title).toBe('시트값 2건을 MYSCube에 반영했어요.');
+    expect(notice.lines).toEqual([
+      '26-4-5 Projection 매출액(입금) 100원 → 빈칸',
+      '26-4-5 Projection 매출부가세(입금) 10원 → 빈칸',
+    ]);
+  });
+
+  it('says what changed, before and after', () => {
+    expect(describeSheetApplyChange({
+      ...base, mode: 'actual', yearMonth: '2026-08', weekNo: 2, lineId: 'DIRECT_COST_OUT',
+      beforeAmount: null, beforeHadValue: false, proposedAmount: 2416709, proposedHadValue: true,
+    })).toBe('26-8-2 Actual 직접사업비 빈칸 → 2,416,709원');
+    expect(describeSheetApplyChange({
+      ...base, scope: 'annual', year: 2025, yearMonth: undefined, weekNo: undefined,
+      beforeAmount: 0, beforeHadValue: true, proposedAmount: 500000, proposedHadValue: true,
+    })).toBe('2025년 연간 Projection 매출액(입금) 0원 → 500,000원');
+  });
+
+  it('shows three lines and folds the rest into a count', () => {
+    const notice = buildSheetApplyNotice({
+      stagedLineCount: 7,
+      candidates: Array.from({ length: 7 }, (_, i) => ({ ...base, weekNo: (i % 5) + 1 })),
+    });
+    expect(notice.lines).toHaveLength(4);
+    expect(notice.lines.at(-1)).toBe('외 4건');
+  });
+
+  it('trusts stagedLineCount when the candidate list was truncated or missing', () => {
+    expect(buildSheetApplyNotice({ stagedLineCount: 612, candidates: [base] }).title)
+      .toBe('시트값 612건을 MYSCube에 반영했어요.');
+    expect(buildSheetApplyNotice({ stagedLineCount: 612, candidates: [base] }).lines.at(-1)).toBe('외 611건');
+    expect(buildSheetApplyNotice({ stagedLineCount: 3, candidates: null }))
+      .toEqual({ title: '시트값 3건을 MYSCube에 반영했어요.', lines: [] });
+  });
+
+  it('does not invent changes when nothing changed', () => {
+    expect(buildSheetApplyNotice({ stagedLineCount: 0, candidates: [] }))
+      .toEqual({ title: '시트값을 반영했어요. 바뀐 값은 없어요.', lines: [] });
+  });
+});

--- a/src/app/components/cashflow/cashflow-sheet-apply-notice.ts
+++ b/src/app/components/cashflow/cashflow-sheet-apply-notice.ts
@@ -1,0 +1,62 @@
+import { CASHFLOW_SHEET_LINE_LABELS, type CashflowSheetLineId } from '../../data/types';
+import type { CashflowSheetLabChangeCandidate } from '../../lib/sheets-cashflow-readonly-client';
+
+// 반영 완료 알림 문구. 서버의 appliedLineCount 는 "다시 쓴 월의 전체 셀 수"(월당 160)라
+// 사람이 듣고 싶은 "몇 건이 어떻게 바뀌었나"가 아니다. 검토 단계가 돌려준 변경 후보
+// (셀 단위 before→after) 로 말한다. 여기서 판정하지 않는다 - 서버가 준 후보를 옮겨 적는다.
+
+const MAX_DETAIL_LINES = 3;
+
+function won(value: number | null | undefined, hadValue: boolean): string {
+  if (!hadValue) return '빈칸';
+  return `${Number(value ?? 0).toLocaleString('ko-KR')}원`;
+}
+
+function weekLabel(candidate: CashflowSheetLabChangeCandidate): string {
+  if (candidate.scope === 'annual' || !candidate.yearMonth) {
+    return candidate.year ? `${candidate.year}년 연간` : '연간';
+  }
+  const [year, month] = candidate.yearMonth.split('-');
+  const base = `${year.slice(2)}-${Number(month)}`;
+  return candidate.weekNo ? `${base}-${candidate.weekNo}` : base;
+}
+
+function modeLabel(mode: string): string {
+  return mode === 'projection' ? 'Projection' : mode === 'actual' ? 'Actual' : mode;
+}
+
+function lineLabel(lineId: string): string {
+  return CASHFLOW_SHEET_LINE_LABELS[lineId as CashflowSheetLineId] || lineId;
+}
+
+export function describeSheetApplyChange(candidate: CashflowSheetLabChangeCandidate): string {
+  return `${weekLabel(candidate)} ${modeLabel(candidate.mode)} ${lineLabel(candidate.lineId)} `
+    + `${won(candidate.beforeAmount, candidate.beforeHadValue)} → ${won(candidate.proposedAmount, candidate.proposedHadValue)}`;
+}
+
+export interface SheetApplyNotice {
+  title: string;
+  lines: string[];
+}
+
+/**
+ * 반영 알림. 건수는 변경 후보 수(=stagedLineCount), 내용은 앞 몇 건을 한 줄씩.
+ * 후보 목록이 잘렸으면(서버 500건 상한) 건수는 stagedLineCount 를 믿는다.
+ */
+export function buildSheetApplyNotice({
+  stagedLineCount,
+  candidates,
+}: {
+  stagedLineCount: number;
+  candidates?: CashflowSheetLabChangeCandidate[] | null;
+}): SheetApplyNotice {
+  const list = Array.isArray(candidates) ? candidates : [];
+  const count = Number.isSafeInteger(stagedLineCount) && stagedLineCount >= 0 ? stagedLineCount : list.length;
+  const title = count === 0
+    ? '시트값을 반영했어요. 바뀐 값은 없어요.'
+    : `시트값 ${count.toLocaleString('ko-KR')}건을 MYSCube에 반영했어요.`;
+  const lines = list.slice(0, MAX_DETAIL_LINES).map(describeSheetApplyChange);
+  const rest = count - lines.length;
+  if (rest > 0 && lines.length > 0) lines.push(`외 ${rest.toLocaleString('ko-KR')}건`);
+  return { title, lines };
+}


### PR DESCRIPTION
## 근거 (라이브 QA 2026-08-19)
변경 2건인데 토스트가 "160건 반영" 이라고 함.

## 원인
서버의 `appliedLineCount` 는 **다시 쓴 월의 전체 셀 수** (16라인 × 5주 × 2모드 = 160). 반영이 월 단위 전체 교체라 서버 입장에선 맞는 숫자인데, 제가 그걸 "바뀐 건수" 로 토스트에 썼어요. 블러핑이 아니라 잘못된 숫자를 고른 것.

## 수정
화면이 이미 들고 있는 검토(stage) 결과를 씀 — `stagedLineCount` 가 실제 변경 건수, `stage.candidates` 에 셀별 before→after. 토스트:
```
시트값 2건을 MYSCube에 반영했어요.
26-4-5 Projection 매출액(입금) 100원 → 빈칸
26-4-5 Projection 매출부가세(입금) 10원 → 빈칸
```
3줄까지 보여주고 나머지는 "외 N건". 서버 변경 없음, 화면이 판정하지 않음(stage 가 준 것을 옮겨 적음).

## 확인
새 헬퍼 테스트 5개(160 회귀 포함), cashflow 169개 통과, typecheck·build 통과. 이 PR 은 이것 하나만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)