### PR TITLE
chore(ui): toasts stay until closed, stack, and read larger

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,7 +9,23 @@ export default function App() {
     <FirebaseProvider>
       <AuthProvider>
         <RouterProvider router={router} />
-        <Toaster position="bottom-right" toastOptions={{ classNames: { description: 'whitespace-pre-line' } }} />
+        {/* 알림은 저절로 닫히지 않고 닫을 때까지 쌓인다(2026-08-19 보람). 읽기 전에 사라지면 없는 것과 같다. */}
+        <Toaster
+          position="bottom-right"
+          expand
+          closeButton
+          visibleToasts={8}
+          gap={10}
+          toastOptions={{
+            duration: Infinity,
+            classNames: {
+              toast: '!w-[420px] !max-w-[calc(100vw-2rem)] !p-4 !text-[14px] !leading-5 !shadow-lg',
+              title: '!text-[14px] !font-semibold',
+              description: 'whitespace-pre-line !text-[13px] !leading-5',
+              closeButton: '!h-6 !w-6',
+            },
+          }}
+        />
       </AuthProvider>
     </FirebaseProvider>
   );

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1747,7 +1747,7 @@ export function CashflowProjectSheet({
     // 전체 셀 수(월당 160)라 "2건 바꿨는데 160건" 이 된다.
     const notifySheetApplied = () => {
       const notice = buildSheetApplyNotice({ stagedLineCount: stage.stagedLineCount, candidates: stage.candidates });
-      toast.success(notice.title, notice.lines.length > 0 ? { description: notice.lines.join('\n'), duration: 8000 } : undefined);
+      toast.success(notice.title, notice.lines.length > 0 ? { description: notice.lines.join('\n') } : undefined);
     };
     const apply = async (actor: NonNullable<Awaited<ReturnType<typeof resolveBffActor>>>) => {
       return applyCashflowSheetLabViaBff({


### PR DESCRIPTION
## 보람 요청 (2026-08-19)
"토스트 조금만 더 크게, 자동으로 닫히지 말고 카톡처럼 닫기 안 하면 쌓이도록"

## 무엇 (`App.tsx` Toaster 설정 + 시트 반영 토스트의 개별 duration 제거)
- **자동 닫힘 없음** (`duration: Infinity`) + **닫기 버튼**
- **쌓임**: 최대 8개, 펼쳐서 보임(`expand`), 간격 10px
- **크기**: 폭 420px(화면 좁으면 맞춤), 제목 14px, 본문 13px, 패딩 16px

토스트 문구·발생 지점은 변경 없음. 이 PR 은 이것 하나만.

## 확인
provider-scope·shell 테스트 71개, typecheck, build 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)