### PR TITLE
fix(cashflow): one decisive line under the month-close status

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -9,7 +9,8 @@ const source = readFileSync(resolve(import.meta.dirname, 'CashflowProjectSheet.t
 
 describe('CashflowProjectSheet monthly close shell', () => {
   it('uses the server month-close guide instead of rebuilding a target-month deadline label', () => {
-    expect(source).toContain('monthCloseActions?.requestMonthClose.guide ? (');
+    // 서버 guide 는 한 줄 안내의 폴백으로 쓴다(화면이 기한 라벨을 다시 만들지 않는다).
+    expect(source).toContain('requestGuide: monthCloseActions?.requestMonthClose.guide');
     expect(source).not.toContain('monthCloseResult.dashboard.summary.targetYearMonth}월 결산');
   });
 
@@ -546,7 +547,7 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(operations).not.toContain('목요일 자정 업데이트');
     expect(operations).toContain('monthCloseActions?.requestMonthClose.enabled');
     expect(operations).not.toContain("monthCloseError || (monthCloseResult?.status !== 'CLOSED'");
-    expect(operations).toContain('monthCloseActions?.requestMonthClose.guide');
+    expect(operations).toContain('monthCloseNotice ? (');
     expect(operations).not.toContain('closeDeadline');
     expect(operations).not.toContain('작성자 전용 임시저장본을 저장했습니다.');
   });

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -101,6 +101,7 @@ import { usePersonRoster } from '../../data/use-person-roster';
 import { loadCashflowActivitySourcesSequentially } from './cashflow-activity-loader';
 import { describeCashflowMonthCloseIssue } from './cashflow-month-close-blocker-helpers';
 import { buildSheetApplyNotice } from './cashflow-sheet-apply-notice';
+import { pickCashflowMonthCloseNotice } from './cashflow-month-close-notice';
 
 type CashflowOpsTone = 'neutral' | 'info' | 'warning' | 'danger' | 'success';
 
@@ -1192,15 +1193,21 @@ export function CashflowProjectSheet({
     }))
   ), [monthCloseResult?.dashboard?.validation?.blockers]);
 
-  // 버튼을 숨기면 "기능이 없다"로 읽힌다. 서버가 왜 못 하는지 이미 문구로 주므로 그대로 보여준다.
-  // 지금 화면에서 의미가 있는 것만 - 진행 중 요청의 회수, 승인 완료 회차의 재오픈.
-  const monthCloseActionNotices = useMemo(() => ([
-    { key: 'withdrawMonthClose', label: '결재 요청 회수', action: monthCloseActions?.withdrawMonthClose },
-    { key: 'requestMonthReopen', label: '재오픈 요청', action: monthCloseActions?.requestMonthReopen },
-  ] as const)
-    .filter((entry) => entry.action && entry.action.enabled !== true && Boolean(entry.action.guide))
-    .map((entry) => ({ key: entry.key, label: entry.label, guide: entry.action!.guide })),
-  [monthCloseActions?.requestMonthReopen, monthCloseActions?.withdrawMonthClose]);
+  // 안내는 한 줄. 상태에서 결정적인 것 하나만 고른다(2026-08-19 보람: 다 보여주니 정보가 아님).
+  const monthCloseNotice = useMemo(() => pickCashflowMonthCloseNotice({
+    requestStatus: monthCloseRequest?.status,
+    requestedByUid: monthCloseRequest?.requestedByUid,
+    requestedByName: monthCloseRequest?.requestedByName,
+    approverName: monthCloseRequest?.approverName,
+    requestedAt: monthCloseRequest?.requestedAt,
+    currentUid: user?.uid,
+    canWithdraw: monthCloseActions?.withdrawMonthClose.enabled === true,
+    withdrawGuide: monthCloseActions?.withdrawMonthClose.guide,
+    canRequestReopen: monthCloseActions?.requestMonthReopen.enabled === true,
+    reopenGuide: monthCloseActions?.requestMonthReopen.guide,
+    requestGuide: monthCloseActions?.requestMonthClose.guide,
+    todayIso: new Date().toISOString(),
+  }), [monthCloseActions?.requestMonthClose.guide, monthCloseActions?.requestMonthReopen, monthCloseActions?.withdrawMonthClose, monthCloseRequest?.approverName, monthCloseRequest?.requestedAt, monthCloseRequest?.requestedByName, monthCloseRequest?.requestedByUid, monthCloseRequest?.status, user?.uid]);
 
   const monthClosePreparation = useMemo(() => {
     if (monthCloseError) {
@@ -2860,17 +2867,13 @@ export function CashflowProjectSheet({
                           ))}
                         </ul>
                       </div>
-                    ) : monthCloseActions?.requestMonthClose.guide ? (
-                      <div className="mt-1 text-[12px] leading-4 text-muted-foreground">
-                        {monthCloseActions.requestMonthClose.guide}
+                    ) : monthCloseNotice ? (
+                      <div
+                        role={monthCloseNotice.tone === 'attention' ? 'status' : undefined}
+                        className={`mt-1 text-[12px] leading-4 ${monthCloseNotice.tone === 'attention' ? 'font-semibold text-red-700' : 'text-muted-foreground'}`}
+                      >
+                        {monthCloseNotice.text}
                       </div>
-                    ) : null}
-                    {monthCloseActionNotices.length > 0 ? (
-                      <ul className="mt-1 space-y-0.5 text-[12px] leading-4 text-muted-foreground">
-                        {monthCloseActionNotices.map((notice) => (
-                          <li key={notice.key}>{notice.label} · {notice.guide}</li>
-                        ))}
-                      </ul>
                     ) : null}
                     {monthCloseRequestError ? (
                       <div role="alert" className="mt-2 flex flex-wrap items-center gap-2 text-[12px] text-red-700">

--- a/src/app/components/cashflow/cashflow-action-tooltips.shell.test.ts
+++ b/src/app/components/cashflow/cashflow-action-tooltips.shell.test.ts
@@ -57,10 +57,12 @@ describe('cashflow action chrome', () => {
     expect(cashflowProjectSheetSource).toContain('월 결산을 진행할 수 없어요');
     expect(cashflowProjectSheetSource).not.toContain('validation.blockers.filter');
     expect(cashflowProjectSheetSource).not.toContain('validation.blockers.some');
-    // 버튼을 숨기면 "기능이 없다"로 읽힌다. 못 하는 이유(서버 문구)는 남긴다.
-    expect(cashflowProjectSheetSource).toContain('monthCloseActionNotices');
-    expect(cashflowProjectSheetSource).toContain("label: '결재 요청 회수'");
-    expect(cashflowProjectSheetSource).toContain("label: '재오픈 요청'");
+    // 안내는 한 줄: 상태에서 결정적인 것 하나만(승인 대기면 "누가 요청·누가 승인·며칠째·회수는 요청자만").
+    // 못 하는 이유를 다 나열하면 정보가 아니다(2026-08-19). 판정은 서버 것, 고르기만 한다.
+    expect(cashflowProjectSheetSource).toContain('pickCashflowMonthCloseNotice({');
+    expect(cashflowProjectSheetSource).toContain('requestedByUid: monthCloseRequest?.requestedByUid');
+    expect(cashflowProjectSheetSource).toContain("monthCloseNotice.tone === 'attention' ? 'font-semibold text-red-700'");
+    expect(cashflowProjectSheetSource).not.toContain('monthCloseActionNotices');
     expect(cashflowProjectSheetSource).not.toContain('캐시플로 항목 사람 확인');
     expect(cashflowProjectSheetSource).not.toContain('prepareAuditedWeekAmounts');
     expect(cashflowProjectSheetSource).not.toContain('showAuditBlock');

--- a/src/app/components/cashflow/cashflow-month-close-notice.test.ts
+++ b/src/app/components/cashflow/cashflow-month-close-notice.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { pickCashflowMonthCloseNotice } from './cashflow-month-close-notice';
+
+const base = {
+  requestStatus: 'PENDING',
+  requestedByUid: 'uid-kwon',
+  requestedByName: '권혁준',
+  approverName: '김조직',
+  requestedAt: '2026-08-10T11:18:33.931Z',
+  currentUid: 'uid-boram',
+  canWithdraw: false,
+  withdrawGuide: '본인이 요청한 검토 전 월 결산만 회수할 수 있습니다.',
+  canRequestReopen: false,
+  reopenGuide: '승인 완료된 월 결산만 재오픈을 요청할 수 있습니다.',
+  requestGuide: '이미 진행 중인 월 결산 승인 요청이 있습니다.',
+  todayIso: '2026-08-19T08:00:00.000Z',
+};
+
+describe('pickCashflowMonthCloseNotice', () => {
+  it('pending + someone else requested: one attention line naming who, approver, and days', () => {
+    expect(pickCashflowMonthCloseNotice(base)).toEqual({
+      tone: 'attention',
+      text: '권혁준 님이 요청한 월 결산이에요 · 김조직 님 승인 대기 · 8일째 대기. 회수는 요청한 사람만 할 수 있어요.',
+    });
+  });
+
+  it('pending + I requested (or can withdraw): nothing, the button speaks', () => {
+    expect(pickCashflowMonthCloseNotice({ ...base, canWithdraw: true })).toBeNull();
+    expect(pickCashflowMonthCloseNotice({ ...base, currentUid: 'uid-kwon' })).toBeNull();
+  });
+
+  it('approved: reopen guide only when reopen is not possible', () => {
+    expect(pickCashflowMonthCloseNotice({ ...base, requestStatus: 'APPROVED', canRequestReopen: true })).toBeNull();
+    expect(pickCashflowMonthCloseNotice({ ...base, requestStatus: 'APPROVED', reopenGuide: '승인 완료된 최신 월 결산만 재오픈을 요청할 수 있습니다.' }))
+      .toEqual({ tone: 'muted', text: '승인 완료된 최신 월 결산만 재오픈을 요청할 수 있습니다.' });
+  });
+
+  it('other states fall back to the request guide, muted', () => {
+    expect(pickCashflowMonthCloseNotice({ ...base, requestStatus: null, requestGuide: '먼저 시트값을 불러와 주세요.' }))
+      .toEqual({ tone: 'muted', text: '먼저 시트값을 불러와 주세요.' });
+    expect(pickCashflowMonthCloseNotice({ ...base, requestStatus: 'REJECTED', requestGuide: '' })).toBeNull();
+  });
+
+  it('degrades gracefully without names or dates', () => {
+    expect(pickCashflowMonthCloseNotice({ ...base, requestedByName: null, approverName: null, requestedAt: null })).toEqual({
+      tone: 'attention',
+      text: 'uid-kwon 님이 요청한 월 결산이에요. 회수는 요청한 사람만 할 수 있어요.',
+    });
+    expect(pickCashflowMonthCloseNotice({ ...base, requestedAt: base.todayIso })?.text).toContain('오늘 요청');
+  });
+});

--- a/src/app/components/cashflow/cashflow-month-close-notice.ts
+++ b/src/app/components/cashflow/cashflow-month-close-notice.ts
@@ -1,0 +1,63 @@
+// 월 결산 카드의 안내는 한 줄이다. 서버가 버튼마다 "왜 못 하는지"를 주지만 그걸 다 나열하면
+// 정보가 아니다(2026-08-19 보람). 지금 상태에서 결정적인 것 하나만 고르고, 그것만 강조한다.
+// 판정은 하지 않는다 - 서버가 준 상태·이름·문구를 고르기만 한다.
+
+export interface CashflowMonthCloseNoticeInput {
+  requestStatus: string | null | undefined;
+  requestedByUid?: string | null;
+  requestedByName?: string | null;
+  approverName?: string | null;
+  requestedAt?: string | null;
+  currentUid?: string | null;
+  canWithdraw: boolean;
+  withdrawGuide?: string | null;
+  canRequestReopen: boolean;
+  reopenGuide?: string | null;
+  requestGuide?: string | null;
+  todayIso?: string;
+}
+
+export interface CashflowMonthCloseNotice {
+  tone: 'attention' | 'muted';
+  text: string;
+}
+
+function daysBetween(fromIso: string | null | undefined, todayIso: string | undefined): number | null {
+  if (!fromIso || !todayIso) return null;
+  const from = Date.parse(fromIso);
+  const to = Date.parse(todayIso);
+  if (!Number.isFinite(from) || !Number.isFinite(to)) return null;
+  return Math.max(0, Math.floor((to - from) / 86_400_000));
+}
+
+function who(name: string | null | undefined, uid: string | null | undefined): string {
+  return (name && name.trim()) || (uid && uid.trim()) || '다른 담당자';
+}
+
+export function pickCashflowMonthCloseNotice(input: CashflowMonthCloseNoticeInput): CashflowMonthCloseNotice | null {
+  const status = (input.requestStatus || '').toUpperCase();
+
+  if (['PENDING', 'APPROVING', 'UNCERTAIN'].includes(status)) {
+    // 승인 대기 중: 관건은 "누가 움직일 수 있나". 본인이 요청자면 버튼이 있으니 말할 게 없다.
+    if (input.canWithdraw) return null;
+    const mine = Boolean(input.currentUid) && input.currentUid === input.requestedByUid;
+    if (mine) return null;
+    const days = daysBetween(input.requestedAt, input.todayIso);
+    const waited = days === null ? '' : days === 0 ? ' · 오늘 요청' : ` · ${days}일째 대기`;
+    const approver = input.approverName?.trim() ? ` · ${input.approverName.trim()} 님 승인 대기` : '';
+    return {
+      tone: 'attention',
+      text: `${who(input.requestedByName, input.requestedByUid)} 님이 요청한 월 결산이에요${approver}${waited}. 회수는 요청한 사람만 할 수 있어요.`,
+    };
+  }
+
+  if (status === 'APPROVED') {
+    // 승인 완료: 관건은 재오픈. 가능하면 버튼이 있으니 말할 게 없다.
+    if (input.canRequestReopen) return null;
+    const guide = input.reopenGuide?.trim();
+    return guide ? { tone: 'muted', text: guide } : null;
+  }
+
+  const guide = input.requestGuide?.trim();
+  return guide ? { tone: 'muted', text: guide } : null;
+}


### PR DESCRIPTION
## 보람 요청 (2026-08-19)
"안내는 결정적인 것 하나 정도만 빨간색으로. 다 보여주니 정보가 아니라서"

## 무엇
상태에 따라 **한 줄만**:
- 승인 대기 + 남이 요청 → **빨간 굵게** `권혁준 님이 요청한 월 결산이에요 · 김조직 님 승인 대기 · 8일째 대기. 회수는 요청한 사람만 할 수 있어요.`
- 승인 대기 + 내가 요청(회수 버튼 있음) → 아무 줄도 없음 (버튼이 말함)
- 승인 완료 + 재오픈 불가 → 재오픈 안내 한 줄(회색) / 가능하면 없음
- 그 외 → 기존 요청 안내 한 줄(회색)

서버가 준 상태·이름·문구를 **고르기만** 하고 판정하지 않음. 이 PR 은 이것 하나만.

## 확인
새 헬퍼 테스트 5개, cashflow 172개, typecheck, build 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)