### PR TITLE
perf(cashflow): open the project sheet with two requests, not twelve

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -7,6 +7,27 @@ import { describe, expect, it } from 'vitest';
 const source = readFileSync(resolve(import.meta.dirname, 'CashflowProjectSheet.tsx'), 'utf8')
   + readFileSync(resolve(import.meta.dirname, 'CashflowLateSheetChangeDialog.tsx'), 'utf8');
 
+describe('CashflowProjectSheet staged loading', () => {
+  // 첫 화면은 config + month-close 둘로 그린다. 나머지는 그 뒤(보조) 또는 보일 때(이력·명부)만 읽는다.
+  // 12개가 동시에 나가면 Vercel 인스턴스가 늘어나는 동안 month-close 가 제일 늦게 끝났다(2026-08-19).
+  it('loads the mirror only as a fallback or for the review dialog, never on mount', () => {
+    expect(source).toContain('const mirrorNeeded = sheetReviewDialogOpen');
+    expect(source).toContain("|| (monthCloseSettled && !(monthCloseResult?.dashboard?.source && Array.isArray(monthCloseResult?.dashboard?.cells)))");
+    expect(source).toContain('if (!mirrorNeeded) return () => { cancelled = true; };');
+  });
+  it('defers request record, apply-status and freshness probe until month-close settled', () => {
+    expect(source).toContain('if (!monthCloseSettled) return;\n    void loadMonthCloseRequest();');
+    expect(source).toContain('if (!monthCloseSettled || !projectId || !orgId || !user?.uid) return () => { cancelled = true; };');
+    expect(source).toContain('if (!monthCloseSettled || !cashflowSheetConfigLoaded || !cashflowSheetConfig?.value');
+  });
+  it('loads the activity timeline only when it scrolls into view, and the roster after month-close', () => {
+    expect(source).toContain('new IntersectionObserver(');
+    expect(source).toContain('if (!opsTimelineVisible) return;\n    void loadCashflowEvents();');
+    expect(source).toContain('<div ref={opsTimelineRef} className="min-w-0">{renderOpsTimeline()}</div>');
+    expect(source).toContain('usePersonRoster(monthCloseSettled)');
+  });
+});
+
 describe('CashflowProjectSheet monthly close shell', () => {
   it('uses the server month-close guide instead of rebuilding a target-month deadline label', () => {
     // 서버 guide 는 한 줄 안내의 폴백으로 쓴다(화면이 기한 라벨을 다시 만들지 않는다).

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -384,6 +384,10 @@ export function CashflowProjectSheet({
   const [monthCloseRequestError, setMonthCloseRequestError] = useState<string | null>(null);
   const canReviewReopen = monthCloseRequest?.canDecideReopen === true;
   const [monthCloseLoading, setMonthCloseLoading] = useState(false);
+  // 화면 열 때 요청 12개가 동시에 나가면 Vercel 인스턴스가 늘어나는 동안 제일 중요한 month-close 가
+  // 제일 늦게 끝났다(2026-08-19, 2.6초 vs 7.8초). 첫 화면은 config + month-close 둘로 그리고,
+  // 나머지는 그 뒤(보조 정보) 또는 보일 때(이력·명부)만 읽는다. 데이터·자리는 그대로, 순서만 바뀐다.
+  const [monthCloseSettled, setMonthCloseSettled] = useState(false);
   const [monthCloseError, setMonthCloseError] = useState<string | null>(null);
   const [monthCloseErrorPresentation, setMonthCloseErrorPresentation] = useState<(ApiErrorPresentation & {
     code: string;
@@ -436,7 +440,7 @@ export function CashflowProjectSheet({
   const [sheetStageApplyLoading, setSheetStageApplyLoading] = useState(false);
   // 조직장은 로그인해서 승인해야 하므로 계정이 필수지만, 명부에 없는 사람(퇴사 후 계정이
   // 남은 경우)은 후보에서 빠져야 한다. 명부는 문지기로만 쓴다.
-  const approverRoster = usePersonRoster();
+  const approverRoster = usePersonRoster(monthCloseSettled);
   const executiveApproverOptions = useMemo(
     () => buildOrgMemberPickerOptions(members || [], approverRoster),
     [members, approverRoster],
@@ -591,7 +595,7 @@ export function CashflowProjectSheet({
   useEffect(() => {
     let cancelled = false;
     setCashflowSheetFreshness(null);
-    if (!cashflowSheetConfigLoaded || !cashflowSheetConfig?.value || !projectId || !orgId || !user?.uid) {
+    if (!monthCloseSettled || !cashflowSheetConfigLoaded || !cashflowSheetConfig?.value || !projectId || !orgId || !user?.uid) {
       return () => { cancelled = true; };
     }
 
@@ -625,6 +629,7 @@ export function CashflowProjectSheet({
     cashflowSheetConfig?.sourceYear,
     cashflowSheetConfig?.value,
     cashflowSheetConfigLoaded,
+    monthCloseSettled,
     orgId,
     projectId,
     resolveBffActor,
@@ -644,15 +649,20 @@ export function CashflowProjectSheet({
     setSheetReviewDialogOpen(true);
   }, [cashflowSheetConfig, cashflowSheetConfigLoaded, projectId]);
 
+  const [cashflowSheetMirrorLoading, setCashflowSheetMirrorLoading] = useState(false);
+  const mirrorNeeded = sheetReviewDialogOpen
+    || (monthCloseSettled && !(monthCloseResult?.dashboard?.source && Array.isArray(monthCloseResult?.dashboard?.cells)));
   useEffect(() => {
     let cancelled = false;
-    setCashflowSheetMirror(null);
-    if (!projectId || !orgId || !user?.uid) return () => { cancelled = true; };
+    if (!projectId || !orgId || !user?.uid) { setCashflowSheetMirror(null); return () => { cancelled = true; }; }
+    // 미러(약 1MB)는 보드를 그리는 데 쓰이지 않는다 - 대시보드가 있으면. 폴백이거나 검토 다이얼로그일 때만 읽는다.
+    if (!mirrorNeeded) return () => { cancelled = true; };
 
     const readMirror = (actor: NonNullable<Awaited<ReturnType<typeof resolveBffActor>>>) => (
       getCashflowSheetLabMirrorViaBff({ tenantId: orgId, actor, projectId })
     );
     const loadPinnedMirror = async (): Promise<void> => {
+      setCashflowSheetMirrorLoading(true);
       try {
         const actor = await resolveBffActor();
         if (!actor?.idToken) return;
@@ -668,11 +678,16 @@ export function CashflowProjectSheet({
         if (!cancelled) setCashflowSheetMirror(mirror);
       } catch {
         if (!cancelled) setCashflowSheetMirror(null);
+      } finally {
+        if (!cancelled) setCashflowSheetMirrorLoading(false);
       }
     };
     void loadPinnedMirror();
     return () => { cancelled = true; };
-  }, [orgId, projectId, resolveBffActor, user?.uid]);
+  }, [mirrorNeeded, orgId, projectId, resolveBffActor, user?.uid]);
+
+  // 프로젝트가 바뀌면 이전 프로젝트의 미러를 들고 있지 않는다.
+  useEffect(() => { setCashflowSheetMirror(null); }, [projectId]);
 
   const loadCashflowMonthClose = useCallback(async (): Promise<void> => {
     const requestGeneration = ++monthCloseRequestGenerationRef.current;
@@ -776,11 +791,15 @@ export function CashflowProjectSheet({
         error,
       });
     } finally {
-      if (isCurrentRequest()) setMonthCloseLoading(false);
+      if (isCurrentRequest()) {
+        setMonthCloseLoading(false);
+        setMonthCloseSettled(true);
+      }
     }
   }, [orgId, projectId, resolveBffActor, selectedYear, user?.uid, yearMonth]);
 
   useEffect(() => {
+    setMonthCloseSettled(false);
     void loadCashflowMonthClose();
   }, [loadCashflowMonthClose]);
 
@@ -838,8 +857,9 @@ export function CashflowProjectSheet({
   }, [orgId, projectId, resolveBffActor, user?.uid, yearMonth]);
 
   useEffect(() => {
+    if (!monthCloseSettled) return;
     void loadMonthCloseRequest();
-  }, [loadMonthCloseRequest]);
+  }, [loadMonthCloseRequest, monthCloseSettled]);
 
   useEffect(() => {
     if (!weeklyActionNotice) return;
@@ -1119,10 +1139,27 @@ export function CashflowProjectSheet({
     });
   }, [loadCashflowEventSource]);
 
+  // 이력 타임라인은 화면 오른쪽/아래에 있다. 들어올 때 읽는다. 한 번 보이면 이후 갱신은 기존 경로대로.
+  const opsTimelineRef = useRef<HTMLDivElement | null>(null);
+  const [opsTimelineVisible, setOpsTimelineVisible] = useState(false);
+  useEffect(() => {
+    const node = opsTimelineRef.current;
+    if (!node) return undefined;
+    if (typeof IntersectionObserver === 'undefined') { setOpsTimelineVisible(true); return undefined; }
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) {
+        setOpsTimelineVisible(true);
+        observer.disconnect();
+      }
+    }, { rootMargin: '200px' });
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, []);
   useEffect(() => {
     setCashflowEvents([]);
+    if (!opsTimelineVisible) return;
     void loadCashflowEvents();
-  }, [loadCashflowEvents]);
+  }, [loadCashflowEvents, opsTimelineVisible]);
 
   const monthClosePinnedSource = useMemo<CashflowSheetLabMirrorResult | null>(() => {
     const dashboard = monthCloseResult?.dashboard;
@@ -1860,7 +1897,7 @@ export function CashflowProjectSheet({
 
   useEffect(() => {
     let cancelled = false;
-    if (!projectId || !orgId || !user?.uid) return () => { cancelled = true; };
+    if (!monthCloseSettled || !projectId || !orgId || !user?.uid) return () => { cancelled = true; };
     const loadApplyStatus = async (): Promise<void> => {
       try {
         const actor = await resolveBffActor();
@@ -1879,7 +1916,7 @@ export function CashflowProjectSheet({
     return () => {
       cancelled = true;
     };
-  }, [orgId, projectId, resolveBffActor, user?.uid]);
+  }, [monthCloseSettled, orgId, projectId, resolveBffActor, user?.uid]);
 
   const handleStagePinnedSheetValues = useCallback(async (
     replaceAllActualSources = true,
@@ -3203,7 +3240,7 @@ export function CashflowProjectSheet({
       ) : null}
       <section className="grid gap-3 xl:grid-cols-[minmax(0,1fr)_320px]">
         {renderOperationsPanel()}
-        {renderOpsTimeline()}
+        <div ref={opsTimelineRef} className="min-w-0">{renderOpsTimeline()}</div>
       </section>
 
       <section id="projection-actual-comparison" data-cashflow-block="comparison" className="scroll-mt-4 space-y-3 rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
@@ -3508,7 +3545,7 @@ export function CashflowProjectSheet({
                 </div>
               </div>
               <Badge className={`w-fit rounded-md border px-2.5 py-1 text-[12px] ${sheetMirrorStatus === 'FRESH' ? 'border-slate-300 bg-slate-100 text-slate-700' : 'border-[#C7D3DF] bg-[#EAF0F5] text-[#17324D]'}`}>
-                {cashflowSheetConfig ? sheetMirrorStatus : '선택 설정'}
+                {cashflowSheetConfig ? (cashflowSheetMirrorLoading ? '확인 중' : sheetMirrorStatus) : '선택 설정'}
               </Badge>
             </div>
             <div className="flex items-start gap-2 rounded-md border border-[#C7D3DF] bg-[#EAF0F5] px-3 py-2 text-[12px] leading-5 text-slate-800">

--- a/src/app/data/use-person-roster.ts
+++ b/src/app/data/use-person-roster.ts
@@ -38,7 +38,7 @@ export function resetPersonRosterCache(): void {
   inflight = null;
 }
 
-export function usePersonRoster(): DirectoryPerson[] {
+export function usePersonRoster(enabled = true): DirectoryPerson[] {
   const { user: authUser } = useAuth();
   const { orgId } = useFirebase();
   const [roster, setRoster] = useState<DirectoryPerson[]>(() => cache || []);
@@ -48,7 +48,8 @@ export function usePersonRoster(): DirectoryPerson[] {
       setRoster(cache);
       return undefined;
     }
-    if (!featureFlags.platformApiEnabled || !authUser?.idToken) return undefined;
+    // enabled=false 면 읽지 않는다. 첫 화면에 필요 없는 곳(현금흐름 결재자 선택)이 뒤로 미룰 때 쓴다.
+    if (!enabled || !featureFlags.platformApiEnabled || !authUser?.idToken) return undefined;
 
     let cancelled = false;
     if (!inflight) {
@@ -67,7 +68,7 @@ export function usePersonRoster(): DirectoryPerson[] {
     });
 
     return () => { cancelled = true; };
-  }, [orgId, authUser?.uid, authUser?.idToken]);
+  }, [enabled, orgId, authUser?.uid, authUser?.idToken]);
 
   return roster;
 }


### PR DESCRIPTION
## 근거 (2026-08-19 라이브)
화면 열 때 요청 12개가 동시에 나감. 탭 둘이면 24개 → Vercel 인스턴스가 늘어나는 동안 **제일 중요한 `month-close` 가 제일 늦게** (같은 호출이 2.6초 vs 7.8초). 그중 `mirror`(~1MB)는 대시보드가 있으면 보드에 쓰이지도 않음.

## 무엇 (프론트만, 서버 변경 없음)
| 단계 | 요청 |
|---|---|
| 첫 화면 | `config` → `month-close` (보드·상태·버튼 전부) |
| month-close 끝난 뒤 | `requests/current` · `apply-status` · `changes/probe` · `persons`(결재자 선택용) |
| 보일 때 | 활동 이력 3종 (타임라인이 화면에 들어올 때, IntersectionObserver) |
| 필요할 때만 | `mirror` — 대시보드에 source 가 없을 때 폴백, 또는 검토 다이얼로그 열 때(그동안 배지 확인 중) |

같은 데이터를 같은 자리에, 순서만 바뀜. 첫 페인트 **12요청 → 2요청**, 전송량 ~4MB → ~1MB.

## 확인
셸 핀 3개 추가(마운트 시 미러 금지 · 보조 정보는 settled 뒤 · 이력은 보일 때), cashflow+data 329개 통과, typecheck·build 통과. `usePersonRoster(enabled)` 는 기본값 true 라 다른 화면 영향 없음.

## 되돌리기
프론트 배포 1회.

🤖 Generated with [Claude Code](https://claude.com/claude-code)