### PR TITLE
perf(cashflow): activity timeline waits for month-close before loading

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -22,7 +22,7 @@ describe('CashflowProjectSheet staged loading', () => {
   });
   it('loads the activity timeline only when it scrolls into view, and the roster after month-close', () => {
     expect(source).toContain('new IntersectionObserver(');
-    expect(source).toContain('if (!opsTimelineVisible) return;\n    void loadCashflowEvents();');
+    expect(source).toContain('if (!opsTimelineVisible || !monthCloseSettled) return;\n    void loadCashflowEvents();');
     expect(source).toContain('<div ref={opsTimelineRef} className="min-w-0">{renderOpsTimeline()}</div>');
     expect(source).toContain('usePersonRoster(monthCloseSettled)');
   });

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1157,9 +1157,11 @@ export function CashflowProjectSheet({
   }, []);
   useEffect(() => {
     setCashflowEvents([]);
-    if (!opsTimelineVisible) return;
+    // 넓은 화면에선 타임라인이 처음부터 보여서 "보이면 읽는다"가 첫 발사에 끼었다(2026-08-19).
+    // 보조 정보이니 month-close 가 끝난 뒤에만 읽는다.
+    if (!opsTimelineVisible || !monthCloseSettled) return;
     void loadCashflowEvents();
-  }, [loadCashflowEvents, opsTimelineVisible]);
+  }, [loadCashflowEvents, monthCloseSettled, opsTimelineVisible]);
 
   const monthClosePinnedSource = useMemo<CashflowSheetLabMirrorResult | null>(() => {
     const dashboard = monthCloseResult?.dashboard;


### PR DESCRIPTION
#615 배포 후 측정: 넓은 화면에선 타임라인이 처음부터 보여서 이력 3종이 첫 발사 200ms 뒤에 끼었음. 보조 정보라 month-close 가 끝난 뒤에만 읽도록 조건 하나 추가. 첫 발사 = config + month-close 정확히 2개.

한 줄 + 핀 1줄. 셸 72개·typecheck·build 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)