### PR TITLE
feat(projects): 정산을 뒤로 · 입력 중인 줄 표시 · Enter 로 다음 칸

### DIFF
--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -73,6 +73,7 @@ import {
 } from '../../platform/project-contract-amount';
 import { buildContractDocumentEditPolicy } from '../../platform/project-contract-document-policy';
 import { deriveProjectStatusFromContractPeriod } from '../../platform/project-status-from-period';
+import { advanceFocusToNextInput, shouldAdvanceOnEnter } from '../../platform/form-advance-on-enter';
 import {
   PROJECT_REQUEST_DOCUMENT_UPLOAD_MAX_SIZE_BYTES,
   PROJECT_REQUEST_DOCUMENT_UPLOAD_MAX_SIZE_LABEL,
@@ -640,12 +641,19 @@ function ProjectFormRow({ label, required, note, hints, errors, issueLabel, chil
   const visibleHints = (hints || []).filter(Boolean);
   const visibleErrors = (errors || []).filter(Boolean);
   return (
+    /*
+     * 지금 입력하는 줄을 눈에 띄게 둔다. `focus-within` 이라 상태를 새로 들지 않고,
+     * 왼쪽 얇은 액센트 막대와 라벨 색만 바뀐다. 배경까지 칠하면 값이 읽히지 않는다.
+     */
     <div
       data-issue-label={issueLabel}
-      className="grid gap-2 lg:grid-cols-[168px_minmax(0,1fr)] lg:gap-x-6"
+      className={cn(
+        'grid gap-2 rounded-md border-l-2 border-transparent pl-2 transition-colors lg:grid-cols-[168px_minmax(0,1fr)] lg:gap-x-6',
+        'focus-within:border-l-[#0176D3] focus-within:bg-[#0176D3]/[0.04]',
+      )}
     >
       <div className="lg:pt-2">
-        <Label className={cn('inline-flex', FORM_LABEL_CLASS)}>
+        <Label className={cn('inline-flex text-slate-700 [div:focus-within>&]:text-[#0176D3]', FORM_LABEL_CLASS)}>
           <span>
             {label}
           </span>
@@ -2492,133 +2500,6 @@ export function ProjectEditorWizard({
 
   const renderFinancialStep = () => (
     <div className={FORM_SECTION_STACK_CLASS}>
-      {/*
-        정산(사업유형)이 아래 입력의 필요 여부를 결정한다. 뒤에 두면 서류와 금액을 다 채운
-        뒤에야 "이 사업은 정산이 없다"를 알게 되므로 맨 앞으로 옮겼다.
-      */}
-      <ProjectFormSection title="정산">
-        {/* 사업유형이 정산 기준을 결정한다. 둘을 세로로 쌓으면 그 관계가 보이지 않아 나란히 둔다. */}
-        <ProjectFormFieldPair>
-        <ProjectFormRow
-          label={usesRegistrationV2 ? '사업유형' : '정산 유형'}
-          required={usesRegistrationV2}
-          issueLabel="사업유형"
-          errors={fieldIssues('사업유형')}
-        >
-          <Select
-            value={usesRegistrationV2 && draft.settlementType === 'NONE' ? undefined : draft.settlementType}
-            onValueChange={(value) => update('settlementType', value as SettlementType)}
-          >
-            <SelectTrigger className={cn('max-w-xs', FORM_CONTROL_CLASS)}><SelectValue placeholder={usesRegistrationV2 ? '사업유형 선택' : '정산 유형 선택'} /></SelectTrigger>
-            <SelectContent>
-              {(Object.entries(SETTLEMENT_TYPE_LABELS) as [SettlementType, string][]).filter(([key]) => !usesRegistrationV2 || key !== 'NONE').map(([key, value]) => (
-                <SelectItem key={key} value={key}>{value}</SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </ProjectFormRow>
-        {usesRegistrationV2 ? (
-          <ProjectFormRow label="정산 기준">
-            <Select value={draft.basis} onValueChange={(value) => update('basis', value as Basis)}>
-              <SelectTrigger className={cn('max-w-xs', FORM_CONTROL_CLASS)}><SelectValue /></SelectTrigger>
-              <SelectContent>
-                {(Object.entries(BASIS_LABELS) as [Basis, string][]).filter(([key]) => usesRegistrationV2 ? key !== '기타' : key !== 'NONE').map(([key]) => (
-                  <SelectItem key={key} value={key}>{REGISTRATION_V2_BASIS_LABELS[key as Exclude<Basis, '기타'>]}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </ProjectFormRow>
-        ) : draft.settlementType === 'NONE' ? (
-          <p className={cn('rounded-lg border border-dashed border-slate-300 bg-slate-50 px-3 py-3', FORM_HINT_CLASS)}>
-            정산 없음은 정산 기준·통장·정산 시스템 입력이 필요하지 않습니다.
-          </p>
-        ) : (
-          <ProjectFormRow label="정산 기준">
-            <Select value={draft.basis === 'NONE' ? undefined : draft.basis} onValueChange={(value) => update('basis', value as Basis)}>
-              <SelectTrigger className={cn('max-w-xs', FORM_CONTROL_CLASS)}><SelectValue placeholder="정산 기준 선택" /></SelectTrigger>
-              <SelectContent>
-                {(Object.entries(BASIS_LABELS) as [Basis, string][]).filter(([key]) => usesRegistrationV2 ? key !== '기타' : key !== 'NONE').map(([key, value]) => (
-                  <SelectItem key={key} value={key}>{value}</SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </ProjectFormRow>
-        )}
-        </ProjectFormFieldPair>
-        {settlementDetailsEnabled ? (
-          <>
-            <ProjectFormRow label="통장 유형">
-              <Select value={draft.accountType} onValueChange={(value) => update('accountType', value as AccountType)}>
-                <SelectTrigger className={cn('max-w-xs', FORM_CONTROL_CLASS)}><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  {(Object.entries(ACCOUNT_TYPE_LABELS) as [AccountType, string][]).map(([key, value]) => (
-                    <SelectItem key={key} value={key}>{value}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </ProjectFormRow>
-            <ProjectFormRow label="이자 반납 여부">
-              <Select value={draft.interestRefundPolicy || undefined} onValueChange={(value) => update('interestRefundPolicy', value as InterestRefundPolicy)}>
-                <SelectTrigger className={cn('max-w-xs', FORM_CONTROL_CLASS)}><SelectValue placeholder="이자 반납 여부 선택" /></SelectTrigger>
-                <SelectContent>
-                  {(Object.entries(INTEREST_REFUND_POLICY_LABELS) as [InterestRefundPolicy, string][]).map(([key, value]) => (
-                    <SelectItem key={key} value={key}>{value}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </ProjectFormRow>
-            <ProjectFormRow
-              label="정산 시스템"
-              issueLabel="기타 정산 시스템 이름"
-              errors={fieldIssues('기타 정산 시스템 이름', '기타 정산 시스템 이름은 100자 이하여야 합니다.')}
-            >
-              <Select
-                value={draft.settlementSystem === 'OTHER' && draft.settlementSystemOther.trim() ? `OTHER:${draft.settlementSystemOther.trim()}` : draft.settlementSystem}
-                onValueChange={updateSettlementSystem}
-              >
-                <SelectTrigger className={cn('max-w-sm', FORM_CONTROL_CLASS)}><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  {[
-                    ...PROJECT_SETTLEMENT_SYSTEM_CODES,
-                    ...(PROJECT_SETTLEMENT_SYSTEM_CODES.includes(draft.settlementSystem) ? [] : [draft.settlementSystem]),
-                  ].map((key) => (
-                    <SelectItem key={key} value={key}>{SETTLEMENT_SYSTEM_LABELS[key]}</SelectItem>
-                  ))}
-                  {[...settlementSystemOptions, draft.settlementSystemOther]
-                    .map((value) => value.replace(/\s+/g, ' ').trim())
-                    .filter((value, index, values) => value && values.findIndex((candidate) => candidate.toLocaleLowerCase('ko-KR') === value.toLocaleLowerCase('ko-KR')) === index)
-                    .map((value) => (
-                    <SelectItem key={`OTHER:${value}`} value={`OTHER:${value}`}>{value}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {draft.settlementSystem === 'OTHER' ? (
-                <Input
-                  value={draft.settlementSystemOther}
-                  onChange={(event) => update('settlementSystemOther', event.target.value)}
-                  placeholder="정산 시스템 이름 직접 입력"
-                  aria-label="기타 정산 시스템 이름"
-                  className={cn('mt-2 max-w-sm', FORM_CONTROL_CLASS)}
-                />
-              ) : null}
-            </ProjectFormRow>
-            <ProjectFormRow label="인건비 정산 기준">
-              <Select value={draft.laborSettlementBasis} onValueChange={(value) => update('laborSettlementBasis', value as LaborSettlementBasis)}>
-                <SelectTrigger className={cn('max-w-xs', FORM_CONTROL_CLASS)}><SelectValue /></SelectTrigger>
-                <SelectContent>
-                  {(Object.entries(LABOR_SETTLEMENT_BASIS_LABELS) as [LaborSettlementBasis, string][]).map(([key, value]) => (
-                    <SelectItem key={key} value={key}>{value}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </ProjectFormRow>
-          </>
-        ) : usesRegistrationV2 ? (
-          <p className={cn('rounded-lg border border-dashed border-slate-300 bg-slate-50 px-3 py-3', FORM_HINT_CLASS)}>
-            정산 기준이 정산없음이면 통장·정산 시스템 입력이 필요하지 않습니다.
-          </p>
-        ) : null}
-      </ProjectFormSection>
       {onContractFileUpload || onProjectDocumentFileUpload ? (
         <div>
           {usesRegistrationV2 ? (
@@ -2829,6 +2710,133 @@ export function ProjectEditorWizard({
           {renderPaymentFields()}
         </ProjectFormSection>
       ) : null}
+      {/*
+        정산은 계약 내용과 입금 계획을 다 넣은 뒤에 정리한다. 앞에 두었더니 아직
+        아무 값도 없는 상태에서 정산 유형부터 고르게 되어 판단할 근거가 없었다.
+      */}
+      <ProjectFormSection title="정산">
+        {/* 사업유형이 정산 기준을 결정한다. 둘을 세로로 쌓으면 그 관계가 보이지 않아 나란히 둔다. */}
+        <ProjectFormFieldPair>
+        <ProjectFormRow
+          label={usesRegistrationV2 ? '사업유형' : '정산 유형'}
+          required={usesRegistrationV2}
+          issueLabel="사업유형"
+          errors={fieldIssues('사업유형')}
+        >
+          <Select
+            value={usesRegistrationV2 && draft.settlementType === 'NONE' ? undefined : draft.settlementType}
+            onValueChange={(value) => update('settlementType', value as SettlementType)}
+          >
+            <SelectTrigger className={cn('max-w-xs', FORM_CONTROL_CLASS)}><SelectValue placeholder={usesRegistrationV2 ? '사업유형 선택' : '정산 유형 선택'} /></SelectTrigger>
+            <SelectContent>
+              {(Object.entries(SETTLEMENT_TYPE_LABELS) as [SettlementType, string][]).filter(([key]) => !usesRegistrationV2 || key !== 'NONE').map(([key, value]) => (
+                <SelectItem key={key} value={key}>{value}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </ProjectFormRow>
+        {usesRegistrationV2 ? (
+          <ProjectFormRow label="정산 기준">
+            <Select value={draft.basis} onValueChange={(value) => update('basis', value as Basis)}>
+              <SelectTrigger className={cn('max-w-xs', FORM_CONTROL_CLASS)}><SelectValue /></SelectTrigger>
+              <SelectContent>
+                {(Object.entries(BASIS_LABELS) as [Basis, string][]).filter(([key]) => usesRegistrationV2 ? key !== '기타' : key !== 'NONE').map(([key]) => (
+                  <SelectItem key={key} value={key}>{REGISTRATION_V2_BASIS_LABELS[key as Exclude<Basis, '기타'>]}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </ProjectFormRow>
+        ) : draft.settlementType === 'NONE' ? (
+          <p className={cn('rounded-lg border border-dashed border-slate-300 bg-slate-50 px-3 py-3', FORM_HINT_CLASS)}>
+            정산 없음은 정산 기준·통장·정산 시스템 입력이 필요하지 않습니다.
+          </p>
+        ) : (
+          <ProjectFormRow label="정산 기준">
+            <Select value={draft.basis === 'NONE' ? undefined : draft.basis} onValueChange={(value) => update('basis', value as Basis)}>
+              <SelectTrigger className={cn('max-w-xs', FORM_CONTROL_CLASS)}><SelectValue placeholder="정산 기준 선택" /></SelectTrigger>
+              <SelectContent>
+                {(Object.entries(BASIS_LABELS) as [Basis, string][]).filter(([key]) => usesRegistrationV2 ? key !== '기타' : key !== 'NONE').map(([key, value]) => (
+                  <SelectItem key={key} value={key}>{value}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </ProjectFormRow>
+        )}
+        </ProjectFormFieldPair>
+        {settlementDetailsEnabled ? (
+          <>
+            <ProjectFormRow label="통장 유형">
+              <Select value={draft.accountType} onValueChange={(value) => update('accountType', value as AccountType)}>
+                <SelectTrigger className={cn('max-w-xs', FORM_CONTROL_CLASS)}><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {(Object.entries(ACCOUNT_TYPE_LABELS) as [AccountType, string][]).map(([key, value]) => (
+                    <SelectItem key={key} value={key}>{value}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </ProjectFormRow>
+            <ProjectFormRow label="이자 반납 여부">
+              <Select value={draft.interestRefundPolicy || undefined} onValueChange={(value) => update('interestRefundPolicy', value as InterestRefundPolicy)}>
+                <SelectTrigger className={cn('max-w-xs', FORM_CONTROL_CLASS)}><SelectValue placeholder="이자 반납 여부 선택" /></SelectTrigger>
+                <SelectContent>
+                  {(Object.entries(INTEREST_REFUND_POLICY_LABELS) as [InterestRefundPolicy, string][]).map(([key, value]) => (
+                    <SelectItem key={key} value={key}>{value}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </ProjectFormRow>
+            <ProjectFormRow
+              label="정산 시스템"
+              issueLabel="기타 정산 시스템 이름"
+              errors={fieldIssues('기타 정산 시스템 이름', '기타 정산 시스템 이름은 100자 이하여야 합니다.')}
+            >
+              <Select
+                value={draft.settlementSystem === 'OTHER' && draft.settlementSystemOther.trim() ? `OTHER:${draft.settlementSystemOther.trim()}` : draft.settlementSystem}
+                onValueChange={updateSettlementSystem}
+              >
+                <SelectTrigger className={cn('max-w-sm', FORM_CONTROL_CLASS)}><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {[
+                    ...PROJECT_SETTLEMENT_SYSTEM_CODES,
+                    ...(PROJECT_SETTLEMENT_SYSTEM_CODES.includes(draft.settlementSystem) ? [] : [draft.settlementSystem]),
+                  ].map((key) => (
+                    <SelectItem key={key} value={key}>{SETTLEMENT_SYSTEM_LABELS[key]}</SelectItem>
+                  ))}
+                  {[...settlementSystemOptions, draft.settlementSystemOther]
+                    .map((value) => value.replace(/\s+/g, ' ').trim())
+                    .filter((value, index, values) => value && values.findIndex((candidate) => candidate.toLocaleLowerCase('ko-KR') === value.toLocaleLowerCase('ko-KR')) === index)
+                    .map((value) => (
+                    <SelectItem key={`OTHER:${value}`} value={`OTHER:${value}`}>{value}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {draft.settlementSystem === 'OTHER' ? (
+                <Input
+                  value={draft.settlementSystemOther}
+                  onChange={(event) => update('settlementSystemOther', event.target.value)}
+                  placeholder="정산 시스템 이름 직접 입력"
+                  aria-label="기타 정산 시스템 이름"
+                  className={cn('mt-2 max-w-sm', FORM_CONTROL_CLASS)}
+                />
+              ) : null}
+            </ProjectFormRow>
+            <ProjectFormRow label="인건비 정산 기준">
+              <Select value={draft.laborSettlementBasis} onValueChange={(value) => update('laborSettlementBasis', value as LaborSettlementBasis)}>
+                <SelectTrigger className={cn('max-w-xs', FORM_CONTROL_CLASS)}><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {(Object.entries(LABOR_SETTLEMENT_BASIS_LABELS) as [LaborSettlementBasis, string][]).map(([key, value]) => (
+                    <SelectItem key={key} value={key}>{value}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </ProjectFormRow>
+          </>
+        ) : usesRegistrationV2 ? (
+          <p className={cn('rounded-lg border border-dashed border-slate-300 bg-slate-50 px-3 py-3', FORM_HINT_CLASS)}>
+            정산 기준이 정산없음이면 통장·정산 시스템 입력이 필요하지 않습니다.
+          </p>
+        ) : null}
+      </ProjectFormSection>
     </div>
   );
 
@@ -3721,7 +3729,19 @@ export function ProjectEditorWizard({
       {/* 단계 이름은 위 칩과 진행 표시에 이미 두 번 나온다. 카드 제목까지 두면 같은 말이
           섹션 제목 바로 위에서 세 번 반복되므로, 카드 안에서는 섹션 제목만 남긴다. */}
       <Card className="border-slate-200/90 shadow-sm">
-        <CardContent className={cn('space-y-6 pt-6', PROJECT_EDITOR_FORM_SURFACE_CLASS)}>
+        <CardContent
+          className={cn('space-y-6 pt-6', PROJECT_EDITOR_FORM_SURFACE_CLASS)}
+          /*
+           * 한 칸을 다 넣고 Enter 를 누르면 다음 입력으로 넘어간다. 숫자를 연달아 넣는
+           * 화면이라 손이 Tab 보다 Enter 로 간다. 판정은 form-advance-on-enter 가 한다
+           * (textarea · 한글 조합 중 · 셀렉트 · 수식 키는 건드리지 않는다).
+           */
+          onKeyDown={(event) => {
+            if (!shouldAdvanceOnEnter(event)) return;
+            const moved = advanceFocusToNextInput(event.currentTarget, event.target as HTMLInputElement);
+            if (moved) event.preventDefault();
+          }}
+        >
           <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3">
             <p className={FORM_LABEL_CLASS}>이 단계에서 준비할 것</p>
             <ul className={cn('mt-2 space-y-1', FORM_HINT_CLASS)}>

--- a/src/app/platform/form-advance-on-enter.test.ts
+++ b/src/app/platform/form-advance-on-enter.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { shouldAdvanceOnEnter } from './form-advance-on-enter';
+
+// DOM 없이 규칙만 검증한다 (vitest 환경이 node 다).
+function inputOf(type: string, extra: Record<string, unknown> = {}) {
+  return { tagName: 'INPUT', type, ...extra };
+}
+
+describe('shouldAdvanceOnEnter', () => {
+  it('숫자·텍스트 칸에서 Enter 를 받는다', () => {
+    for (const type of ['text', 'number', 'date', 'month', 'url']) {
+      expect(shouldAdvanceOnEnter({ key: 'Enter', target: inputOf(type) })).toBe(true);
+    }
+  });
+
+  it('한글 조합 중 Enter 는 확정이지 이동이 아니다', () => {
+    // 이동으로 먹으면 조합 중이던 글자가 사라진다.
+    expect(shouldAdvanceOnEnter({
+      key: 'Enter', target: inputOf('text'), nativeEvent: { isComposing: true },
+    })).toBe(false);
+  });
+
+  it('textarea 와 버튼은 건드리지 않는다', () => {
+    expect(shouldAdvanceOnEnter({ key: 'Enter', target: { tagName: 'TEXTAREA' } })).toBe(false);
+    expect(shouldAdvanceOnEnter({ key: 'Enter', target: { tagName: 'BUTTON' } })).toBe(false);
+  });
+
+  it('읽기 전용·비활성 칸은 넘기지 않는다', () => {
+    expect(shouldAdvanceOnEnter({ key: 'Enter', target: inputOf('text', { readOnly: true }) })).toBe(false);
+    expect(shouldAdvanceOnEnter({ key: 'Enter', target: inputOf('text', { disabled: true }) })).toBe(false);
+  });
+
+  it('수식 키가 눌린 Enter 는 제출 단축키 몫으로 남긴다', () => {
+    for (const mod of ['shiftKey', 'metaKey', 'ctrlKey', 'altKey'] as const) {
+      expect(shouldAdvanceOnEnter({ key: 'Enter', target: inputOf('text'), [mod]: true })).toBe(false);
+    }
+  });
+
+  it('파일 선택처럼 넘길 수 없는 칸은 제외한다', () => {
+    expect(shouldAdvanceOnEnter({ key: 'Enter', target: inputOf('file') })).toBe(false);
+    expect(shouldAdvanceOnEnter({ key: 'Enter', target: inputOf('checkbox') })).toBe(false);
+  });
+});

--- a/src/app/platform/form-advance-on-enter.ts
+++ b/src/app/platform/form-advance-on-enter.ts
@@ -1,0 +1,57 @@
+/**
+ * 한 칸을 다 넣고 Enter 를 누르면 다음 입력으로 넘어간다.
+ *
+ * Tab 은 원래 되지만(폼에 tabIndex 를 두지 않아 DOM 순서 그대로다) 숫자를 연달아 넣는
+ * 화면에서는 손이 Enter 로 간다. 그 습관을 막지 않고 받아준다.
+ *
+ * 건드리지 않는 것:
+ * - **textarea** — 줄바꿈이 Enter 다.
+ * - **조합 중인 한글** (`isComposing`) — 확정 Enter 를 이동으로 먹으면 글자가 사라진다.
+ * - **버튼·셀렉트·체크박스** — Enter 가 이미 "누름" 이라 뜻을 빼앗지 않는다.
+ * - 수식 키가 눌린 Enter — 제출 단축키와 겹치지 않게 둔다.
+ */
+const ADVANCEABLE_INPUT_TYPES = new Set([
+  'text', 'number', 'tel', 'url', 'email', 'search', 'date', 'month', 'password',
+]);
+
+/** DOM 인스턴스가 아니라 모양으로 본다. 규칙을 DOM 없이도 검증할 수 있게 하려는 것이다. */
+export function isAdvanceableTarget(value: unknown): boolean {
+  const el = value as { tagName?: string; type?: string; disabled?: boolean; readOnly?: boolean } | null;
+  if (!el || String(el.tagName || '').toUpperCase() !== 'INPUT') return false;
+  if (el.disabled === true || el.readOnly === true) return false;
+  return ADVANCEABLE_INPUT_TYPES.has(String(el.type || ''));
+}
+
+/** 화면에 실제로 보이고 초점을 받을 수 있는 입력만 다음 후보로 본다. */
+function focusableInputs(root: HTMLElement): HTMLInputElement[] {
+  return Array.from(root.querySelectorAll('input'))
+    .filter((input) => isAdvanceableTarget(input))
+    .filter((input) => input.offsetParent !== null || input.getClientRects().length > 0);
+}
+
+export function shouldAdvanceOnEnter(event: {
+  key: string;
+  nativeEvent?: { isComposing?: boolean };
+  shiftKey?: boolean;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  altKey?: boolean;
+  /** React 의 이벤트도, 테스트가 만드는 형태 객체도 받는다. 판정은 모양으로만 한다. */
+  target: unknown;
+}): boolean {
+  if (event.key !== 'Enter') return false;
+  if (event.nativeEvent?.isComposing) return false;
+  if (event.shiftKey || event.metaKey || event.ctrlKey || event.altKey) return false;
+  return isAdvanceableTarget(event.target);
+}
+
+/** 다음 입력으로 초점을 옮긴다. 마지막 칸이면 아무것도 하지 않는다(제출을 가로채지 않는다). */
+export function advanceFocusToNextInput(root: HTMLElement, current: HTMLInputElement): boolean {
+  const inputs = focusableInputs(root);
+  const index = inputs.indexOf(current);
+  if (index < 0 || index >= inputs.length - 1) return false;
+  const next = inputs[index + 1];
+  next.focus();
+  if (typeof next.select === 'function' && next.type !== 'date' && next.type !== 'month') next.select();
+  return true;
+}


### PR DESCRIPTION
라이브 화면 피드백 3건입니다.

## 1. 정산을 입금 계획 뒤로

어제 맨 앞으로 올렸는데 **반대가 맞았습니다.** 앞에 두니 아직 아무 값도 없는 상태에서 정산 유형부터 고르게 되어 판단할 근거가 없었습니다. 계약 내용과 입금 계획을 다 넣은 뒤에 정리하는 자리로 돌립니다.

**새 순서:** 등록 제출서류 → 첨부 서류 → 계약 정보 → 관리자 입력 → 입금 계획 → **정산**

## 2. 지금 입력하는 줄 표시

`ProjectFormRow` 에 `focus-within` 으로 **왼쪽 얇은 액센트 막대와 라벨 색만** 바꿉니다.

- 상태를 새로 들지 않으므로 **리렌더가 없습니다** (CSS 만)
- 배경까지 칠하지 않아 값이 계속 읽힙니다
- 색은 기존 액센트 `#0176D3`. 새 색을 들이면 *"액센트는 한 가지 뜻만 갖는다"* 는 폼 골격 계약이 깨집니다

## 3. Enter 로 다음 칸

**Tab 은 원래 정상이었습니다** — 폼에 `tabIndex` 가 하나도 없어 DOM 순서 그대로 동작합니다. 확인해보니 끊는 요소가 없었습니다. 다만 숫자를 연달아 넣는 화면이라 손이 Enter 로 가므로 그 습관을 받아줍니다.

판정은 `form-advance-on-enter.ts` 가 하고 **다음은 건드리지 않습니다.**

| 건드리지 않는 것 | 이유 |
|---|---|
| `textarea` | 줄바꿈이 Enter 다 |
| 한글 조합 중 (`isComposing`) | 확정 Enter 를 이동으로 먹으면 **글자가 사라진다** |
| 버튼 · 셀렉트 · 체크박스 · 파일 | Enter 가 이미 "누름" 이다 |
| 수식 키가 눌린 Enter | 제출 단축키 몫으로 남긴다 |
| 마지막 칸 | 아무것도 하지 않는다 (제출을 가로채지 않는다) |

판정을 DOM 인스턴스가 아니라 **모양으로** 하도록 써서 vitest `node` 환경에서도 규칙을 검증합니다. 경계 6가지를 테스트로 고정했습니다.

## 검증

전체 3,263 통과 · typecheck clean · build 성공

> `cashflow-sheet-lab` · `jvm-weekly-api` 2건은 알려진 flake 입니다. 이 PR 의 변경은 `src/app/**` 뿐이라 코드 경로가 겹치지 않습니다.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)