### PR TITLE
feat(cashflow): expose approver deadlines for the schedule bar (display only)

### DIFF
--- a/server/bff/cashflow-close-deadline.mjs
+++ b/server/bff/cashflow-close-deadline.mjs
@@ -27,6 +27,46 @@ export function cashflowMonthCloseDeadline(yearMonth) {
   return `${deadlineYear}-${String(deadlineMonth).padStart(2, '0')}-10`;
 }
 
+// --- 조직장 승인 마감 (2026-08-20 보람) ---
+// 표시 전용 규칙이다. 쓰기를 막지도, 미준수를 누적하지도 않는다(미준수는 실무자 마감 기준뿐).
+// 그래서 판정 주체(JVM) 짝 없이 BFF 에만 둔다 - 이 마감이 쓰기를 막게 되는 날 JVM 으로 옮긴다.
+// Asia/Seoul 은 DST 가 없어 KST 0시 = UTC 전날 15시 고정이다.
+const KST_OFFSET_MS = 9 * 3_600_000;
+// 주정산: 실무자 마감(그 주 목요일 자정 = 금 0시 KST, 목요일이 없는 부분 주는 주 마지막 날
+// 다음날 0시 - JVM financeWeekDeadline) + 13시간 = 같은 날 13:00 KST.
+const WEEKLY_APPROVER_OFFSET_MS = 13 * 3_600_000;
+
+export function cashflowWeeklyApproverDeadlineAt(practitionerDeadlineAt) {
+  const at = Date.parse(String(practitionerDeadlineAt ?? ''));
+  return Number.isFinite(at) ? new Date(at + WEEKLY_APPROVER_OFFSET_MS).toISOString() : null;
+}
+
+function kstMidnightInstant(year, month, day) {
+  return new Date(Date.UTC(year, month - 1, day) - KST_OFFSET_MS).toISOString();
+}
+
+function nextMonthOf(yearMonth) {
+  const match = YEAR_MONTH_RE.exec(String(yearMonth ?? ''));
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  return month === 12 ? [year + 1, 1] : [year, month + 1];
+}
+
+// 월결산 실무자 마감의 시각 표현: 익월 10일 자정 = 11일 0시 KST.
+// (cashflowMonthCloseDeadline 의 날짜 규칙과 같은 표 - 10일이 마지막 유효일)
+export function cashflowMonthCloseDeadlineAt(yearMonth) {
+  const next = nextMonthOf(yearMonth);
+  return next ? kstMidnightInstant(next[0], next[1], 11) : null;
+}
+
+// 월결산 조직장 승인 마감: 달력 고정 익월 14일 0시 KST. 실무자가 늦게 요청하면
+// 조직장 시간이 3일보다 짧아진다 - 요청+3일이 아니라 달력 고정(2026-08-20 결정).
+export function cashflowMonthCloseApproverDeadlineAt(yearMonth) {
+  const next = nextMonthOf(yearMonth);
+  return next ? kstMidnightInstant(next[0], next[1], 14) : null;
+}
+
 // 기한 초과 여부. 기준일을 모르면 단정하지 않는다 - 판정 불능과 "초과 아님" 은 다르다.
 export function isCashflowCloseOverdue({ yearMonth, status, businessDate }) {
   if (!BUSINESS_DATE_RE.test(String(businessDate ?? ''))) return false;

--- a/server/bff/cashflow-close-deadline.test.mjs
+++ b/server/bff/cashflow-close-deadline.test.mjs
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  cashflowMonthCloseApproverDeadlineAt,
   cashflowMonthCloseDeadline,
+  cashflowMonthCloseDeadlineAt,
+  cashflowWeeklyApproverDeadlineAt,
   isCashflowCloseOverdue,
 } from './cashflow-close-deadline.mjs';
 
@@ -46,5 +49,30 @@ describe('close overdue', () => {
   // 기준일을 모르는 것과 "초과 아님" 은 다르다 — 단정하지 않는다.
   it.each(['', 'not-a-date', undefined])('does not assert overdue without a business date (%j)', (businessDate) => {
     expect(isCashflowCloseOverdue({ yearMonth: '2026-07', status: 'OPEN', businessDate })).toBe(false);
+  });
+});
+
+// 조직장 승인 마감(2026-08-20)은 표시 전용이라 JVM 짝이 없다 - 쓰기를 막게 되면 그때 JVM 으로.
+describe('approver deadlines — display only, KST', () => {
+  it('weekly approver deadline is the practitioner deadline + 13 hours', () => {
+    // 실무자 마감 금 0시 KST = 목 15:00Z → 승인 마감 금 13:00 KST = 금 04:00Z
+    expect(cashflowWeeklyApproverDeadlineAt('2026-08-20T15:00:00Z')).toBe('2026-08-21T04:00:00.000Z');
+    // 목요일이 없는 부분 주의 대체 마감에도 같은 +13시간이 따라간다.
+    expect(cashflowWeeklyApproverDeadlineAt('2026-08-31T15:00:00.000Z')).toBe('2026-09-01T04:00:00.000Z');
+    expect(cashflowWeeklyApproverDeadlineAt('')).toBeNull();
+    expect(cashflowWeeklyApproverDeadlineAt(undefined)).toBeNull();
+  });
+
+  it('month practitioner instant is the 11th 00:00 KST — same table as the date rule', () => {
+    // 10일이 마지막 유효일 = 11일 0시 KST = 10일 15:00Z
+    expect(cashflowMonthCloseDeadlineAt('2026-07')).toBe('2026-08-10T15:00:00.000Z');
+    expect(cashflowMonthCloseDeadlineAt('2026-12')).toBe('2027-01-10T15:00:00.000Z');
+    expect(cashflowMonthCloseDeadlineAt('2026-13')).toBeNull();
+  });
+
+  it('month approver deadline is calendar-fixed at the 14th 00:00 KST, not request+3d', () => {
+    expect(cashflowMonthCloseApproverDeadlineAt('2026-07')).toBe('2026-08-13T15:00:00.000Z');
+    expect(cashflowMonthCloseApproverDeadlineAt('2026-12')).toBe('2027-01-13T15:00:00.000Z');
+    expect(cashflowMonthCloseApproverDeadlineAt('nope')).toBeNull();
   });
 });

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -52,7 +52,13 @@ import {
   withdrawPendingCumulativeCloseRequest,
 } from '../cashflow-month-close-withdrawal.mjs';
 export { cashflowCumulativeCloseCycle };
-import { cashflowMonthCloseDeadline, isCashflowCloseOverdue } from '../cashflow-close-deadline.mjs';
+import {
+  cashflowMonthCloseApproverDeadlineAt,
+  cashflowMonthCloseDeadline,
+  cashflowMonthCloseDeadlineAt,
+  cashflowWeeklyApproverDeadlineAt,
+  isCashflowCloseOverdue,
+} from '../cashflow-close-deadline.mjs';
 import { cashflowMonthRequestCovers } from '../cashflow-month-state.mjs';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -2309,6 +2315,9 @@ async function readCashflowMonthCloseStatuses({
       yearMonth,
       status,
       closeDeadline: cashflowMonthCloseDeadline(yearMonth),
+      // 진행 바용 시각 표현: 실무자 = 익월 11일 0시 KST, 조직장 승인 = 14일 0시 KST(표시 전용, 누적 없음).
+      closeDeadlineAt: cashflowMonthCloseDeadlineAt(yearMonth),
+      approverDeadlineAt: cashflowMonthCloseApproverDeadlineAt(yearMonth),
       // 기준일을 모르면 기한 초과를 단정하지 않는다.
       closeOverdue: isCashflowCloseOverdue({ yearMonth, status, businessDate }),
       sheetCalculationChecks: historyUnavailable
@@ -2727,7 +2736,11 @@ function deadlineSummaryFromCompliance(compliance, comparisonBoundary, weeklyYea
     comparisonBoundary?.asOfWeek?.yearMonth,
     comparisonBoundary?.asOfWeek?.weekNo,
   );
-  const current = currentOrdinal === -1 ? null : indexed[currentOrdinal] || null;
+  const currentItem = currentOrdinal === -1 ? null : indexed[currentOrdinal] || null;
+  // 조직장 승인 마감은 표시 전용(누적 없음). 실무자 마감(JVM 이 준 deadline) + 13시간.
+  const current = currentItem
+    ? { ...currentItem, approverDeadline: cashflowWeeklyApproverDeadlineAt(currentItem.deadline) }
+    : null;
   return {
     trackingStartedAt: null,
     onTimeCount: Number(compliance?.onTimeCount) || 0,
@@ -2742,6 +2755,7 @@ function deadlineSummaryFromCompliance(compliance, comparisonBoundary, weeklyYea
       status: item.status,
       lockState: readOptionalText(item.lockState) || null,
       deadline: item.deadline,
+      approverDeadline: cashflowWeeklyApproverDeadlineAt(item.deadline),
       updateResult: item.updateResult,
       operationId: item.operationId,
       auditId: item.auditId,


### PR DESCRIPTION
## 배경 (보람 일정 규칙, 2026-08-20)
| | 실무자 | 조직장 |
|---|---|---|
| 주정산 | 목요일 자정 (기존, JVM) | **금요일 13:00 = 실무자 마감 +13h (신규)** |
| 월결산 | 익월 10일 자정 (기존) | **달력 고정 14일 0시 (신규)** — 요청+3일 아님 |

실무자 마감·미준수 누적은 **이미 JVM 에 있음** (`financeWeekDeadline`, ON_TIME/COMPLETED_LATE/MISSED). 이 PR 이 새로 넣는 건 **조직장 승인 마감 = 표시 전용** 필드뿐 — 쓰기를 막지 않고, 미준수를 누적하지 않음(누적은 실무자 기준만, 보람 확정).

## 왜 BFF 에만 (JVM 짝 없이)
표시 전용 = 순수 읽기 관심사 → 읽기 경로 계약("JVM 은 쓰기, BFF 는 읽기") 그대로. 모듈 주석에 "쓰기를 막게 되는 날 JVM 으로 옮긴다" 명시. KST 는 Asia/Seoul 고정 오프셋(DST 없음)으로 계산, 하드코딩 아님.

## 필드
- `deadlineSummary.current` / `weeklyStatuses[]` → `approverDeadline`
- 월 summary → `closeDeadlineAt`(11일 0시 KST), `approverDeadlineAt`(14일 0시 KST)

## 확인
모듈 테스트 22개(12월 롤오버·부분 주·달력 고정 포함), jvm-weekly-api 267개 통과(1회 flake 는 단독 통과 — 알려진 병렬 flake), typecheck 통과.

다음: PR 2 실무자 진행 바(현재 주기만), PR 3 관리자 타일 진행 바(승인 버튼 유지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)