### PR TITLE
feat(cashflow): settlement schedule bars for practitioners and admins

### DIFF
--- a/server/bff/cashflow-close-deadline.mjs
+++ b/server/bff/cashflow-close-deadline.mjs
@@ -32,6 +32,7 @@ export function cashflowMonthCloseDeadline(yearMonth) {
 // 그래서 판정 주체(JVM) 짝 없이 BFF 에만 둔다 - 이 마감이 쓰기를 막게 되는 날 JVM 으로 옮긴다.
 // Asia/Seoul 은 DST 가 없어 KST 0시 = UTC 전날 15시 고정이다.
 const KST_OFFSET_MS = 9 * 3_600_000;
+const DAY_MS = 86_400_000;
 // 주정산: 실무자 마감(그 주 목요일 자정 = 금 0시 KST, 목요일이 없는 부분 주는 주 마지막 날
 // 다음날 0시 - JVM financeWeekDeadline) + 13시간 = 같은 날 13:00 KST.
 const WEEKLY_APPROVER_OFFSET_MS = 13 * 3_600_000;
@@ -39,6 +40,35 @@ const WEEKLY_APPROVER_OFFSET_MS = 13 * 3_600_000;
 export function cashflowWeeklyApproverDeadlineAt(practitionerDeadlineAt) {
   const at = Date.parse(String(practitionerDeadlineAt ?? ''));
   return Number.isFinite(at) ? new Date(at + WEEKLY_APPROVER_OFFSET_MS).toISOString() : null;
+}
+
+// 주정산 실무자 마감. 판정 주체는 JVM financeWeekDeadline 이고 이것은 그 표의 사본이다 -
+// 대시보드가 모든 주를 한 번에 그려야 해서 BFF 에도 같은 규칙이 필요하다(이 파일의 존재 이유).
+// 규칙: 그 주(월~일) 안의 목요일 자정 = 목요일 다음날 0시 KST. 목요일이 없는 부분 주(1주·5주)는
+// 그 주 마지막 날 다음날 0시. 양쪽 테스트에 같은 표를 둔다.
+const FINANCE_WEEK_COUNT = 5;
+
+function utcDay(year, month, day) {
+  return Date.UTC(year, month - 1, day);
+}
+
+export function cashflowFinanceWeekDeadlineAt(yearMonth, weekNo) {
+  const match = YEAR_MONTH_RE.exec(String(yearMonth ?? ''));
+  const week = Number(weekNo);
+  if (!match || !Number.isInteger(week) || week < 1 || week > FINANCE_WEEK_COUNT) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const first = utcDay(year, month, 1);
+  // getUTCDay: 일=0 → JVM DayOfWeek(월=1..일=7) 와 맞추면 월요일까지 되감는 일수는 (dow+6)%7.
+  const firstMonday = first - ((new Date(first).getUTCDay() + 6) % 7) * DAY_MS;
+  const lastDayOfMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  const monthEnd = utcDay(year, month, lastDayOfMonth);
+  const start = week === 1 ? first : firstMonday + (week - 1) * 7 * DAY_MS;
+  const end = week === FINANCE_WEEK_COUNT ? monthEnd : firstMonday + week * 7 * DAY_MS - DAY_MS;
+  let thursday = start;
+  while (thursday <= end && new Date(thursday).getUTCDay() !== 4) thursday += DAY_MS;
+  const deadlineDay = thursday > end ? end + DAY_MS : thursday + DAY_MS;
+  return new Date(deadlineDay - KST_OFFSET_MS).toISOString();
 }
 
 function kstMidnightInstant(year, month, day) {

--- a/server/bff/cashflow-close-deadline.test.mjs
+++ b/server/bff/cashflow-close-deadline.test.mjs
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  cashflowFinanceWeekDeadlineAt,
   cashflowMonthCloseApproverDeadlineAt,
   cashflowMonthCloseDeadline,
   cashflowMonthCloseDeadlineAt,
@@ -75,4 +76,33 @@ describe('approver deadlines — display only, KST', () => {
     expect(cashflowMonthCloseApproverDeadlineAt('2026-12')).toBe('2027-01-13T15:00:00.000Z');
     expect(cashflowMonthCloseApproverDeadlineAt('nope')).toBeNull();
   });
+});
+
+// PARITY TABLE — JVM FirestoreInheritedWeeklyExpensePersistence.financeWeekDeadline 과 같은 표다.
+// 규칙: 그 주의 목요일 자정(= 다음날 0시 KST). 목요일이 없는 부분 주는 주 마지막 날 다음날 0시.
+// 2026-08-01 은 토요일이라 1주가 토·일 이틀뿐이고, 그 주에는 목요일이 없다.
+const FINANCE_WEEK_PARITY = [
+  ['2026-08', 1, '2026-08-02T15:00:00.000Z'],
+  ['2026-08', 2, '2026-08-06T15:00:00.000Z'],
+  ['2026-08', 3, '2026-08-13T15:00:00.000Z'],
+  ['2026-08', 4, '2026-08-20T15:00:00.000Z'],
+  ['2026-08', 5, '2026-08-27T15:00:00.000Z'],
+  ['2026-02', 5, '2026-02-26T15:00:00.000Z'],
+  ['2026-03', 1, '2026-03-01T15:00:00.000Z'],
+  ['2026-01', 1, '2026-01-01T15:00:00.000Z'],
+  // 2026-12-31 이 목요일이라 5주차 마감이 해를 넘긴다.
+  ['2026-12', 5, '2026-12-31T15:00:00.000Z'],
+];
+
+describe('finance week deadline — JVM parity', () => {
+  it.each(FINANCE_WEEK_PARITY)('%s %s주차 마감은 %s', (yearMonth, weekNo, expected) => {
+    expect(cashflowFinanceWeekDeadlineAt(yearMonth, weekNo)).toBe(expected);
+  });
+
+  it.each([['2026-08', 0], ['2026-08', 6], ['2026-13', 1], ['', 1], [null, 2]])(
+    'refuses to guess for %j %j',
+    (yearMonth, weekNo) => {
+      expect(cashflowFinanceWeekDeadlineAt(yearMonth, weekNo)).toBeNull();
+    },
+  );
 });

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -53,6 +53,7 @@ import {
 } from '../cashflow-month-close-withdrawal.mjs';
 export { cashflowCumulativeCloseCycle };
 import {
+  cashflowFinanceWeekDeadlineAt,
   cashflowMonthCloseApproverDeadlineAt,
   cashflowMonthCloseDeadline,
   cashflowMonthCloseDeadlineAt,
@@ -721,14 +722,38 @@ async function alignMonthSettlementStatus(db, tenantId, result) {
       : project?.settlementStatuses?.items;
     if (!projectId || !yearMonth || !Array.isArray(statusItems)) return;
     const snapshot = await db.doc(cashflowMonthCloseRequestPath(tenantId, `${projectId}-${yearMonth}`)).get();
-    if (!snapshot.exists) return;
-    const requestStatus = readOptionalText(snapshot.data()?.status);
-    const status = requestStatus === 'APPROVED'
-      ? 'COMPLETED'
-      : ['PENDING', 'REOPEN_REQUESTED', 'APPROVING', 'UNCERTAIN'].includes(requestStatus)
-        ? 'PENDING_APPROVAL'
-        : 'WAITING_FOR_UPDATE';
-    const alignedItems = statusItems.map((item) => item.period === 'MONTH' ? { ...item, status } : item);
+    const requestStatus = snapshot.exists ? readOptionalText(snapshot.data()?.status) : '';
+    // 요청 문서가 없으면 월 상태는 JVM 이 준 것을 그대로 둔다. 마감은 그것과 무관하게 붙인다.
+    const status = !snapshot.exists
+      ? null
+      : requestStatus === 'APPROVED'
+        ? 'COMPLETED'
+        : ['PENDING', 'REOPEN_REQUESTED', 'APPROVING', 'UNCERTAIN'].includes(requestStatus)
+          ? 'PENDING_APPROVAL'
+          : 'WAITING_FOR_UPDATE';
+    // 진행 바용 마감(표시 전용). 주차 마감은 JVM financeWeekDeadline 의 사본(패리티 표),
+    // 조직장 마감은 표시 전용 규칙이라 BFF 에만 있다.
+    const withDeadlines = (item) => {
+      const period = readOptionalText(item?.period);
+      if (period === 'MONTH') {
+        return {
+          ...item,
+          deadlineAt: cashflowMonthCloseDeadlineAt(yearMonth),
+          approverDeadlineAt: cashflowMonthCloseApproverDeadlineAt(yearMonth),
+        };
+      }
+      const weekMatch = /^WEEK_([1-5])$/.exec(period);
+      if (!weekMatch) return item;
+      const deadlineAt = cashflowFinanceWeekDeadlineAt(yearMonth, Number(weekMatch[1]));
+      return {
+        ...item,
+        deadlineAt,
+        approverDeadlineAt: cashflowWeeklyApproverDeadlineAt(deadlineAt),
+      };
+    };
+    const alignedItems = statusItems
+      .map((item) => (status && item.period === 'MONTH' ? { ...item, status } : item))
+      .map(withDeadlines);
     if (Array.isArray(project?.items)) {
       project.items = alignedItems;
     } else {

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -656,16 +656,33 @@ describe('JVM weekly API BFF proxy', () => {
       .get('/api/v1/cashflow/project-a/settlement-statuses?yearMonth=2026-08')
       .expect(200)
       .expect((response) => {
+        // 진행 바용 마감이 함께 실린다(표시 전용). 2026-08 은 1일이 토요일이라 1주차에 목요일이 없고,
+        // 그 주 마지막 날(8/2) 다음날 0시 KST 가 마감이다 - JVM financeWeekDeadline 과 같은 표.
         expect(response.body.items).toEqual([
-          { period: 'MONTH', status: 'PENDING_APPROVAL' },
-          { period: 'WEEK_1', status: 'COMPLETED' },
+          {
+            period: 'MONTH',
+            status: 'PENDING_APPROVAL',
+            deadlineAt: '2026-09-10T15:00:00.000Z',
+            approverDeadlineAt: '2026-09-13T15:00:00.000Z',
+          },
+          {
+            period: 'WEEK_1',
+            status: 'COMPLETED',
+            deadlineAt: '2026-08-02T15:00:00.000Z',
+            approverDeadlineAt: '2026-08-03T04:00:00.000Z',
+          },
         ]);
       });
     await request(app)
       .post('/api/v1/cashflow/settlement-statuses/batch')
       .send({ projectIds: ['project-a'], yearMonth: '2026-08' })
       .expect(200)
-      .expect((response) => expect(response.body.items[0].items[0]).toEqual({ period: 'MONTH', status: 'PENDING_APPROVAL' }));
+      .expect((response) => expect(response.body.items[0].items[0]).toEqual({
+        period: 'MONTH',
+        status: 'PENDING_APPROVAL',
+        deadlineAt: '2026-09-10T15:00:00.000Z',
+        approverDeadlineAt: '2026-09-13T15:00:00.000Z',
+      }));
   });
 
   it('blocks an administrator from submitting an uncompleted settlement', async () => {
@@ -798,8 +815,18 @@ describe('JVM weekly API BFF proxy', () => {
 
     expect(response.body).toMatchObject({ version: '3', yearMonth: '2026-08', monthCloseTargetYearMonth: '2026-07', monthCloseTargetLabel: '7월' });
     expect(response.body.items[0].settlementStatuses.items).toEqual([
-      { period: 'MONTH', status: 'PENDING_APPROVAL' },
-      { period: 'WEEK_1', status: 'COMPLETED' },
+      {
+        period: 'MONTH',
+        status: 'PENDING_APPROVAL',
+        deadlineAt: '2026-09-10T15:00:00.000Z',
+        approverDeadlineAt: '2026-09-13T15:00:00.000Z',
+      },
+      {
+        period: 'WEEK_1',
+        status: 'COMPLETED',
+        deadlineAt: '2026-08-02T15:00:00.000Z',
+        approverDeadlineAt: '2026-08-03T04:00:00.000Z',
+      },
     ]);
     expect(response.body.errors).toEqual([]);
 

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -7,6 +7,26 @@ import { describe, expect, it } from 'vitest';
 const source = readFileSync(resolve(import.meta.dirname, 'CashflowProjectSheet.tsx'), 'utf8')
   + readFileSync(resolve(import.meta.dirname, 'CashflowLateSheetChangeDialog.tsx'), 'utf8');
 
+describe('CashflowProjectSheet schedule bar', () => {
+  // 마감·완료 시각·초과 판정은 서버 값이고 화면은 단계만 고른다. 조직장 초과는 표시만(누적 없음).
+  it('draws a weekly and a month schedule bar from server deadlines', () => {
+    expect(source).toContain('buildScheduleSteps({');
+    expect(source).toContain("practitionerLabel: '완료 요청'");
+    expect(source).toContain("approverLabel: '조직장 확정'");
+    expect(source).toContain("practitionerLabel: '결산 요청'");
+    expect(source).toContain("approverLabel: '조직장 승인'");
+    expect(source).toContain('practitionerDeadline: summary.closeDeadlineAt');
+    expect(source).toContain('approverDeadline: summary.approverDeadlineAt');
+    expect(source).toContain('<CashflowScheduleBar steps={weeklyScheduleSteps}');
+    expect(source).toContain('<CashflowScheduleBar steps={monthScheduleSteps}');
+  });
+  it('does not invent a confirm timestamp, and drops withdrawn or rejected requests back to "not requested"', () => {
+    expect(source).toContain("approverDone: current.lockState === 'LOCKED'");
+    expect(source).not.toContain('current.confirmedAt || current.completedAt');
+    expect(source).toContain("const requested = ['PENDING', 'APPROVING', 'UNCERTAIN', 'APPROVED', 'REOPEN_REQUESTED'].includes(status);");
+  });
+});
+
 describe('CashflowProjectSheet staged loading', () => {
   // 첫 화면은 config + month-close 둘로 그린다. 나머지는 그 뒤(보조) 또는 보일 때(이력·명부)만 읽는다.
   // 12개가 동시에 나가면 Vercel 인스턴스가 늘어나는 동안 month-close 가 제일 늦게 끝났다(2026-08-19).

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -102,6 +102,8 @@ import { loadCashflowActivitySourcesSequentially } from './cashflow-activity-loa
 import { describeCashflowMonthCloseIssue } from './cashflow-month-close-blocker-helpers';
 import { buildSheetApplyNotice } from './cashflow-sheet-apply-notice';
 import { pickCashflowMonthCloseNotice } from './cashflow-month-close-notice';
+import { CashflowScheduleBar } from './CashflowScheduleBar';
+import { buildScheduleSteps } from './cashflow-schedule-steps';
 
 type CashflowOpsTone = 'neutral' | 'info' | 'warning' | 'danger' | 'success';
 
@@ -1233,6 +1235,45 @@ export function CashflowProjectSheet({
   ), [monthCloseResult?.dashboard?.validation?.blockers]);
 
   // 안내는 한 줄. 상태에서 결정적인 것 하나만 고른다(2026-08-19 보람: 다 보여주니 정보가 아님).
+  // 회수·반려된 요청은 "요청 안 한 상태" 로 되돌린다 - 진행 바가 끝난 일처럼 보이면 안 된다.
+  const monthRequestProgress = useMemo(() => {
+    const status = String(monthCloseRequest?.status || '').toUpperCase();
+    const requested = ['PENDING', 'APPROVING', 'UNCERTAIN', 'APPROVED', 'REOPEN_REQUESTED'].includes(status);
+    return { requested, approved: ['APPROVED', 'REOPEN_REQUESTED'].includes(status) };
+  }, [monthCloseRequest?.status]);
+
+  // 일정 진행 바. 마감·완료 시각·초과 판정은 서버 값이고, 여기서는 단계 상태만 고른다.
+  const weeklyScheduleSteps = useMemo(() => {
+    const current = monthCloseResult?.dashboard?.deadlineSummary?.current;
+    if (!current?.deadline) return [];
+    return buildScheduleSteps({
+      practitionerLabel: '완료 요청',
+      approverLabel: '조직장 확정',
+      practitionerDeadline: current.deadline,
+      approverDeadline: current.approverDeadline,
+      practitionerDoneAt: current.completedAt,
+      // 확정 시각은 응답에 없다. 시각을 지어내지 않고 "확정됨" 만 표시한다.
+      approverDoneAt: current.lockState === 'LOCKED' ? current.confirmedAt : null,
+      approverDone: current.lockState === 'LOCKED',
+      practitionerLate: current.status === 'COMPLETED_LATE',
+      nowIso: new Date().toISOString(),
+    });
+  }, [monthCloseResult?.dashboard?.deadlineSummary?.current]);
+
+  const monthScheduleSteps = useMemo(() => {
+    const summary = monthCloseResult?.dashboard?.summary;
+    if (!summary?.closeDeadlineAt) return [];
+    return buildScheduleSteps({
+      practitionerLabel: '결산 요청',
+      approverLabel: '조직장 승인',
+      practitionerDeadline: summary.closeDeadlineAt,
+      approverDeadline: summary.approverDeadlineAt,
+      practitionerDoneAt: monthRequestProgress.requested ? monthCloseRequest?.requestedAt : null,
+      approverDoneAt: monthRequestProgress.approved ? monthCloseRequest?.reviewedAt : null,
+      nowIso: new Date().toISOString(),
+    });
+  }, [monthCloseRequest?.requestedAt, monthCloseRequest?.reviewedAt, monthRequestProgress, monthCloseResult?.dashboard?.summary]);
+
   const monthCloseNotice = useMemo(() => pickCashflowMonthCloseNotice({
     requestStatus: monthCloseRequest?.status,
     requestedByUid: monthCloseRequest?.requestedByUid,
@@ -2856,6 +2897,7 @@ export function CashflowProjectSheet({
                 </div>
                 {weeklyWithdrawError ? <div role="alert" className="mt-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] leading-5 text-red-800">{weeklyWithdrawError}</div> : null}
                 {weeklyActionNotice && !weeklyWithdrawError ? <div role="status" className="mt-2 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-[12px] leading-5 text-emerald-900">{weeklyActionNotice}</div> : null}
+                {weeklyScheduleSteps.length > 0 ? <CashflowScheduleBar steps={weeklyScheduleSteps} className="mt-3" /> : null}
                 <div className="mt-3 flex items-center gap-4 text-[12px] text-muted-foreground">
                   <span>누적 미준수 <strong className="ml-1 text-red-700">{deadlineSummaryUnavailable ? '확인 불가' : formatCashflowCount(monthCloseResult?.dashboard?.deadlineSummary?.missedCount, '회')}</strong></span>
                   <span>기한 내 완료 <strong className="ml-1 text-primary">{deadlineSummaryUnavailable ? '확인 불가' : formatCashflowCount(monthCloseResult?.dashboard?.deadlineSummary?.completedCount, '회')}</strong></span>
@@ -2965,6 +3007,7 @@ export function CashflowProjectSheet({
                     ) : null}
                   </div>
                 </div>
+                {monthScheduleSteps.length > 0 ? <CashflowScheduleBar steps={monthScheduleSteps} className="mt-3" /> : null}
               </div>
           </section>
 

--- a/src/app/components/cashflow/CashflowScheduleBar.tsx
+++ b/src/app/components/cashflow/CashflowScheduleBar.tsx
@@ -1,0 +1,68 @@
+import { Check } from 'lucide-react';
+import type { ScheduleStep, ScheduleStepState } from './cashflow-schedule-steps';
+
+// 정산 일정 진행 바. 단계 판정은 cashflow-schedule-steps 가 하고 여기서는 그리기만 한다.
+// 색은 DESIGN.md 계열만 쓴다 - 참고 이미지의 보라 계열은 금지 색이다.
+const DOT: Record<ScheduleStepState, string> = {
+  done: 'border-[#001e46] bg-[#001e46] text-white',
+  done_late: 'border-[#001e46] bg-[#001e46] text-white',
+  current: 'border-[#0176D3] bg-white text-[#0176D3] ring-2 ring-[#0176D3]/20',
+  overdue: 'border-[#e11d48] bg-[#e11d48] text-white',
+  upcoming: 'border-slate-300 bg-white text-slate-400',
+};
+
+const LABEL: Record<ScheduleStepState, string> = {
+  done: 'text-slate-700',
+  done_late: 'text-slate-700',
+  current: 'font-semibold text-[#0176D3]',
+  overdue: 'font-semibold text-[#e11d48]',
+  upcoming: 'text-slate-400',
+};
+
+const DETAIL: Record<ScheduleStepState, string> = {
+  done: 'text-slate-500',
+  done_late: 'text-[#e11d48]',
+  current: 'text-slate-600',
+  overdue: 'text-[#e11d48]',
+  upcoming: 'text-slate-400',
+};
+
+const STATE_TEXT: Record<ScheduleStepState, string> = {
+  done: '완료',
+  done_late: '완료 · 기한 초과',
+  current: '진행 중',
+  overdue: '기한 지남',
+  upcoming: '대기',
+};
+
+export function CashflowScheduleBar({ steps, className = '' }: { steps: ScheduleStep[]; className?: string }) {
+  if (steps.length === 0) return null;
+  return (
+    <ol className={`flex items-start gap-0 ${className}`.trim()}>
+      {steps.map((step, index) => (
+        <li key={step.key} className={`flex min-w-0 items-start gap-2 ${index > 0 ? 'flex-1' : ''}`}>
+          {index > 0 ? (
+            <span
+              aria-hidden="true"
+              className={`mt-2.5 h-px flex-1 ${steps[index - 1].state === 'upcoming' ? 'bg-slate-200' : 'bg-[#001e46]/30'}`}
+            />
+          ) : null}
+          <div className="flex min-w-0 items-start gap-1.5">
+            <span className={`mt-0.5 inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full border ${DOT[step.state]}`}>
+              {step.state === 'done' || step.state === 'done_late'
+                ? <Check className="h-3 w-3" aria-hidden="true" />
+                : <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden="true" />}
+            </span>
+            <div className="min-w-0">
+              <div className={`text-[12px] leading-4 ${LABEL[step.state]}`}>
+                {step.label}
+                <span className="sr-only"> · {STATE_TEXT[step.state]}</span>
+              </div>
+              {step.detail ? <div className={`text-[11px] leading-4 ${DETAIL[step.state]}`}>{step.detail}</div> : null}
+            </div>
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/app/components/cashflow/CashflowScheduleBar.tsx
+++ b/src/app/components/cashflow/CashflowScheduleBar.tsx
@@ -35,6 +35,33 @@ const STATE_TEXT: Record<ScheduleStepState, string> = {
   upcoming: '대기',
 };
 
+/** 표 안처럼 좁은 자리용. 점만 보여주고 지금 단계의 한 줄만 아래에 적는다. */
+export function CashflowScheduleBarCompact({ steps, className = '' }: { steps: ScheduleStep[]; className?: string }) {
+  if (steps.length === 0) return null;
+  const active = steps.find((step) => step.state === 'overdue' || step.state === 'current') || steps[steps.length - 1];
+  return (
+    <div className={`flex flex-col items-center gap-1 ${className}`.trim()}>
+      <div className="flex items-center gap-1">
+        {steps.map((step, index) => (
+          <span key={step.key} className="flex items-center gap-1">
+            {index > 0 ? <span aria-hidden="true" className={`h-px w-4 ${steps[index - 1].state === 'upcoming' ? 'bg-slate-200' : 'bg-[#001e46]/30'}`} /> : null}
+            <span
+              title={`${step.label} · ${STATE_TEXT[step.state]}${step.detail ? ` · ${step.detail}` : ''}`}
+              className={`inline-flex h-4 w-4 items-center justify-center rounded-full border ${DOT[step.state]}`}
+            >
+              {step.state === 'done' || step.state === 'done_late'
+                ? <Check className="h-2.5 w-2.5" aria-hidden="true" />
+                : <span className="h-1 w-1 rounded-full bg-current" aria-hidden="true" />}
+              <span className="sr-only">{step.label} · {STATE_TEXT[step.state]}</span>
+            </span>
+          </span>
+        ))}
+      </div>
+      <span className={`text-[11px] leading-4 ${DETAIL[active.state]}`}>{active.detail || STATE_TEXT[active.state]}</span>
+    </div>
+  );
+}
+
 export function CashflowScheduleBar({ steps, className = '' }: { steps: ScheduleStep[]; className?: string }) {
   if (steps.length === 0) return null;
   return (

--- a/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
+++ b/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
@@ -39,10 +39,12 @@ describe('CashflowWeeklyPage settlement status surface', () => {
     expect(source).toContain('fetchCashflowWeeklyOverviewViaBff');
     expect(source).toContain('transitionCashflowSettlementStatusViaBff');
     expect(source).toContain("onAction={(action) => void transition(project.id, 'MONTH', action, yearMonth)}");
-    expect(source).toContain('주정산 이전');
-    expect(source).toContain('결산 전');
-    expect(source).toContain('조직장 승인 필요');
-    expect(source).toContain('승인 완료');
+    // 2026-08-20: 상태 배지를 진행 바로 대체했다. 승인은 그 바를 눌러서 한다.
+    expect(source).toContain('<CashflowScheduleBarCompact steps={steps} />');
+    expect(source).toContain("onClick={() => onAction('APPROVE')}");
+    expect(source).toContain('승인하기');
+    expect(source).toContain('<ProjectPeriodLine start={project.contractStart} end={project.contractEnd} />');
+    expect(source).not.toContain("bg-emerald-50 px-2.5 font-semibold text-emerald-700");
     expect(source).toContain("user?.uid === project.executiveApproverId");
     expect(source).toContain('setRefreshSequence((current) => current + 1)');
     expect(source).not.toContain('fetchCashflowSettlementStatusesBatchViaBff');
@@ -120,6 +122,7 @@ describe('CashflowWeeklyPage settlement status surface', () => {
   });
 
   it('keeps the status filter labels aligned with their settlement period', () => {
+    // 필터 드롭다운의 말은 그대로다 - 바뀐 것은 표 안의 표시뿐이다.
     expect(source).toContain("period === 'MONTH' ? '결산 전' : '주정산 이전'");
     expect(source).toContain('조직장 승인 필요');
   });

--- a/src/app/components/cashflow/CashflowWeeklyPage.tsx
+++ b/src/app/components/cashflow/CashflowWeeklyPage.tsx
@@ -5,6 +5,8 @@ import { toast } from 'sonner';
 import { PageHeader } from '../layout/PageHeader';
 import { Card, CardContent } from '../ui/card';
 import { Button } from '../ui/button';
+import { CashflowScheduleBarCompact } from './CashflowScheduleBar';
+import { buildScheduleSteps, formatProjectPeriod } from './cashflow-schedule-steps';
 import { Label } from '../ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { useAppStore } from '../../data/store';
@@ -110,25 +112,39 @@ function SettlementStatusButton({
   onAction: (action: 'SUBMIT' | 'APPROVE') => void;
 }) {
   const status = item?.status || 'WAITING_FOR_UPDATE';
-  if (status === 'COMPLETED') {
-    return <span className="inline-flex min-h-8 items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 font-semibold text-emerald-700"><span className="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden="true" />승인 완료</span>;
-  }
-  if (status === 'WAITING_FOR_UPDATE') {
-    return <span className="inline-flex min-h-8 items-center gap-1.5 rounded-full border border-red-200 bg-red-50 px-2.5 font-semibold text-red-700"><span className="h-1.5 w-1.5 rounded-full bg-red-500" aria-hidden="true" />{period === 'MONTH' ? '결산 전' : '주정산 이전'}</span>;
-  }
+  // 상태 배지를 진행 바로 대체한다(2026-08-20 보람). 승인은 그대로 여기서 누른다.
+  const steps = buildScheduleSteps({
+    practitionerLabel: period === 'MONTH' ? '결산 요청' : '완료 요청',
+    approverLabel: period === 'MONTH' ? '조직장 승인' : '조직장 확정',
+    practitionerDeadline: item?.deadlineAt,
+    approverDeadline: item?.approverDeadlineAt,
+    practitionerDoneAt: status === 'WAITING_FOR_UPDATE' ? null : item?.submittedAt || null,
+    approverDoneAt: status === 'COMPLETED' ? item?.approvedAt || null : null,
+    approverDone: status === 'COMPLETED',
+    nowIso: new Date().toISOString(),
+  });
+  const bar = <CashflowScheduleBarCompact steps={steps} />;
+  if (status !== 'PENDING_APPROVAL') return bar;
   return (
     <Button
       type="button"
       size="sm"
       variant="outline"
-      className="min-h-8 gap-1.5 whitespace-normal rounded-full border-amber-200 bg-amber-50 px-2.5 text-[11px] font-semibold text-amber-800 hover:bg-amber-100"
+      className="min-h-8 w-full flex-col gap-1 whitespace-normal rounded-md border-slate-300 bg-white px-2 py-1.5 text-[11px] font-semibold text-[#17324D] hover:bg-slate-50"
       disabled={loading || !canApprove}
       onClick={() => onAction('APPROVE')}
+      title="조직장 승인"
     >
-      <span className="h-1.5 w-1.5 rounded-full bg-amber-500" aria-hidden="true" />
-      {loading ? '처리 중…' : '조직장 승인 필요'}
+      {bar}
+      <span>{loading ? '처리 중…' : '승인하기'}</span>
     </Button>
   );
+}
+
+function ProjectPeriodLine({ start, end }: { start?: string | null; end?: string | null }) {
+  const period = formatProjectPeriod(start, end);
+  if (!period) return null;
+  return <p className="truncate text-[11px] font-normal text-muted-foreground">{period}</p>;
 }
 
 function SettlementStatusFilterSelect({
@@ -442,6 +458,8 @@ export function CashflowWeeklyPage() {
                     <tr key={project.id} className="border-t border-border/30 transition-colors hover:bg-muted/20">
                       <td className="sticky left-0 z-20 bg-white px-3 py-2">
                         <p className="truncate font-semibold">{project.name}</p>
+                        {/* 종료가 다가오면 체크아웃이 붙는다 - 일정 판단에 기간이 필요하다(2026-08-20 보람). */}
+                        <ProjectPeriodLine start={project.contractStart} end={project.contractEnd} />
                       </td>
                       <td className="sticky left-[180px] z-20 bg-white px-2 py-2 font-medium">{executiveApprover.label || <span className="text-red-700">연결 필요</span>}</td>
                       <td className="sticky left-[284px] z-20 bg-white px-2 py-2 font-medium">{manager.label || <span className="text-red-700">연결 필요</span>}</td>

--- a/src/app/components/cashflow/cashflow-schedule-steps.test.ts
+++ b/src/app/components/cashflow/cashflow-schedule-steps.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildScheduleSteps, formatDeadlineLabel } from './cashflow-schedule-steps';
+import { buildScheduleSteps, formatDeadlineLabel, formatProjectPeriod } from './cashflow-schedule-steps';
 
 // 2026-08-20 은 목요일. 주정산 실무자 마감 = 목 자정 = 금 0시 KST = 2026-08-20T15:00Z.
 // 조직장 마감 = 금 13:00 KST = 2026-08-21T04:00Z.
@@ -105,5 +105,20 @@ describe('approver step without a timestamp', () => {
       ...base, practitionerDoneAt: '2026-08-19T05:20:00Z', approverDone: true, nowIso: '2026-08-25T02:00:00Z',
     });
     expect(approver).toMatchObject({ state: 'done', detail: '완료' });
+  });
+});
+
+describe('formatProjectPeriod', () => {
+  it('shows the range, and warns as the end approaches', () => {
+    expect(formatProjectPeriod('2026-01-01', '2026-12-31', '2026-08-20T02:00:00Z')).toBe('2026-01-01 ~ 2026-12-31');
+    expect(formatProjectPeriod('2026-01-01', '2026-09-10', '2026-08-20T02:00:00Z')).toBe('2026-01-01 ~ 2026-09-10 · 종료 D-21');
+    expect(formatProjectPeriod('2026-01-01', '2026-08-20', '2026-08-20T02:00:00Z')).toBe('2026-01-01 ~ 2026-08-20 · 오늘 종료');
+    expect(formatProjectPeriod('2026-01-01', '2026-07-31', '2026-08-20T02:00:00Z')).toBe('2026-01-01 ~ 2026-07-31 · 종료됨');
+  });
+
+  it('says what it knows when a date is missing, and nothing when it knows neither', () => {
+    expect(formatProjectPeriod('2026-01-01', '', '2026-08-20T02:00:00Z')).toBe('2026-01-01 ~ 종료일 미정');
+    expect(formatProjectPeriod('', '', '2026-08-20T02:00:00Z')).toBe('');
+    expect(formatProjectPeriod(null, undefined, '2026-08-20T02:00:00Z')).toBe('');
   });
 });

--- a/src/app/components/cashflow/cashflow-schedule-steps.test.ts
+++ b/src/app/components/cashflow/cashflow-schedule-steps.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { buildScheduleSteps, formatDeadlineLabel } from './cashflow-schedule-steps';
+
+// 2026-08-20 은 목요일. 주정산 실무자 마감 = 목 자정 = 금 0시 KST = 2026-08-20T15:00Z.
+// 조직장 마감 = 금 13:00 KST = 2026-08-21T04:00Z.
+const PRACTITIONER = '2026-08-20T15:00:00.000Z';
+const APPROVER = '2026-08-21T04:00:00.000Z';
+const base = {
+  practitionerLabel: '완료 요청',
+  approverLabel: '조직장 확정',
+  practitionerDeadline: PRACTITIONER,
+  approverDeadline: APPROVER,
+  practitionerDoneAt: null,
+  approverDoneAt: null,
+};
+
+describe('formatDeadlineLabel', () => {
+  it('calls a midnight deadline by the day it actually ends', () => {
+    // 금 0시 마감은 사람에겐 "목요일 자정" 이다.
+    expect(formatDeadlineLabel(PRACTITIONER, '2026-08-20T01:00:00Z')).toBe('오늘 자정까지');
+    expect(formatDeadlineLabel(PRACTITIONER, '2026-08-19T01:00:00Z')).toBe('내일까지 · 8/20(목) 자정');
+    expect(formatDeadlineLabel(PRACTITIONER, '2026-08-17T01:00:00Z')).toBe('8/20(목) 자정까지 · D-3');
+    expect(formatDeadlineLabel(PRACTITIONER, '2026-08-21T01:00:00Z')).toBe('8/20(목) 자정 지남');
+  });
+
+  it('keeps a wall-clock deadline as it is', () => {
+    expect(formatDeadlineLabel(APPROVER, '2026-08-21T01:00:00Z')).toBe('오늘 13:00까지');
+    expect(formatDeadlineLabel(APPROVER, '2026-08-20T01:00:00Z')).toBe('내일까지 · 8/21(금) 13:00');
+  });
+
+  it('says nothing when it has nothing to say', () => {
+    expect(formatDeadlineLabel(null, '2026-08-20T01:00:00Z')).toBe('');
+    expect(formatDeadlineLabel('nope', '2026-08-20T01:00:00Z')).toBe('');
+  });
+});
+
+describe('buildScheduleSteps', () => {
+  it('before the deadline: practitioner is current, approver waits', () => {
+    const [practitioner, approver] = buildScheduleSteps({ ...base, nowIso: '2026-08-19T02:00:00Z' });
+    expect(practitioner).toMatchObject({ state: 'current', detail: '내일까지 · 8/20(목) 자정' });
+    expect(approver.state).toBe('upcoming');
+  });
+
+  it('past the practitioner deadline with nothing done: that step turns red', () => {
+    const [practitioner, approver] = buildScheduleSteps({ ...base, nowIso: '2026-08-21T02:00:00Z' });
+    expect(practitioner.state).toBe('overdue');
+    // 실무자가 아직인데 조직장 단계를 재촉하지 않는다.
+    expect(approver.state).toBe('upcoming');
+  });
+
+  it('done on time: completion is kept as completion', () => {
+    const [practitioner, approver] = buildScheduleSteps({
+      ...base, practitionerDoneAt: '2026-08-19T05:20:00Z', nowIso: '2026-08-20T02:00:00Z',
+    });
+    expect(practitioner).toMatchObject({ state: 'done', detail: '8/19(수) 14:20' });
+    expect(approver).toMatchObject({ state: 'current', detail: '내일까지 · 8/21(금) 13:00' });
+  });
+
+  it('done late: still done, with the overrun as a note — not a red step', () => {
+    const [practitioner] = buildScheduleSteps({
+      ...base, practitionerDoneAt: '2026-08-20T17:10:00Z', practitionerLate: true, nowIso: '2026-08-21T02:00:00Z',
+    });
+    expect(practitioner.state).toBe('done_late');
+    expect(practitioner.detail).toBe('8/21(금) 02:10 · 기한 초과');
+  });
+
+  it('approver past deadline is shown, and is judged by when they approved', () => {
+    const late = buildScheduleSteps({
+      ...base, practitionerDoneAt: '2026-08-19T05:20:00Z', approverDoneAt: '2026-08-21T06:00:00Z', nowIso: '2026-08-22T02:00:00Z',
+    })[1];
+    expect(late.state).toBe('done_late');
+    const onTime = buildScheduleSteps({
+      ...base, practitionerDoneAt: '2026-08-19T05:20:00Z', approverDoneAt: '2026-08-21T03:00:00Z', nowIso: '2026-08-22T02:00:00Z',
+    })[1];
+    expect(onTime.state).toBe('done');
+  });
+
+  it('practitioner done but approver window blown: approver turns red, practitioner stays done', () => {
+    const [practitioner, approver] = buildScheduleSteps({
+      ...base, practitionerDoneAt: '2026-08-19T05:20:00Z', nowIso: '2026-08-21T06:00:00Z',
+    });
+    expect(practitioner.state).toBe('done');
+    expect(approver.state).toBe('overdue');
+  });
+
+  it('works for the month cycle too — same shape, different labels', () => {
+    const [practitioner, approver] = buildScheduleSteps({
+      practitionerLabel: '결산 요청',
+      approverLabel: '조직장 승인',
+      practitionerDeadline: '2026-09-10T15:00:00.000Z',
+      approverDeadline: '2026-09-13T15:00:00.000Z',
+      practitionerDoneAt: null,
+      approverDoneAt: null,
+      nowIso: '2026-09-08T02:00:00Z',
+    });
+    expect(practitioner).toMatchObject({ label: '결산 요청', state: 'current', detail: '9/10(목) 자정까지 · D-2' });
+    expect(approver).toMatchObject({ label: '조직장 승인', state: 'upcoming' });
+  });
+});
+
+describe('approver step without a timestamp', () => {
+  it('says 완료 instead of inventing a time, and does not guess lateness', () => {
+    // 주정산 확정은 응답에 시각이 없다 - 확정됐다는 사실만 안다.
+    const [, approver] = buildScheduleSteps({
+      ...base, practitionerDoneAt: '2026-08-19T05:20:00Z', approverDone: true, nowIso: '2026-08-25T02:00:00Z',
+    });
+    expect(approver).toMatchObject({ state: 'done', detail: '완료' });
+  });
+});

--- a/src/app/components/cashflow/cashflow-schedule-steps.ts
+++ b/src/app/components/cashflow/cashflow-schedule-steps.ts
@@ -135,3 +135,22 @@ export function buildScheduleSteps(input: ScheduleBarInput): ScheduleStep[] {
 
   return [practitioner, approver];
 }
+
+/** 사업 기간 한 줄. 종료가 지났거나 다가오면 그 사실을 덧붙인다 - 종료 시 체크아웃이 붙는다. */
+export function formatProjectPeriod(
+  start: string | null | undefined,
+  end: string | null | undefined,
+  nowIso: string = new Date().toISOString(),
+): string {
+  const from = String(start ?? '').slice(0, 10);
+  const to = String(end ?? '').slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(from) && !/^\d{4}-\d{2}-\d{2}$/.test(to)) return '';
+  const range = `${from || '시작일 미정'} ~ ${to || '종료일 미정'}`;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(to)) return range;
+  const days = daysUntil(`${to}T00:00:00+09:00`, nowIso);
+  if (days === null) return range;
+  if (days < 0) return `${range} · 종료됨`;
+  if (days === 0) return `${range} · 오늘 종료`;
+  if (days <= 30) return `${range} · 종료 D-${days}`;
+  return range;
+}

--- a/src/app/components/cashflow/cashflow-schedule-steps.ts
+++ b/src/app/components/cashflow/cashflow-schedule-steps.ts
@@ -1,0 +1,137 @@
+// 정산 일정 진행 바의 단계 계산. 마감 시각·상태는 서버(BFF)가 준 것을 쓰고, 여기서는
+// "지금 어느 단계이고 무엇을 언제까지 해야 하는가" 만 정한다. 새로 판정하지 않는다.
+//
+// 표시 원칙(2026-08-20 보람): 혼내는 표시가 아니라 다가오는 마감을 알려주는 표시.
+// 늦게라도 끝낸 일은 완료로 남기고(보조 라벨로만 초과 표기), 지금 행동이 필요한 것만 빨간색.
+// 조직장 마감 초과는 표시만 하고 미준수로 세지 않는다 - 누적은 실무자 마감 기준뿐.
+
+export type ScheduleStepState = 'done' | 'done_late' | 'current' | 'overdue' | 'upcoming';
+
+export interface ScheduleStep {
+  key: 'practitioner' | 'approver';
+  label: string;
+  state: ScheduleStepState;
+  /** 단계 아래 한 줄. 완료면 완료 시각, 진행 중이면 남은 기한. */
+  detail: string;
+}
+
+const KST_OFFSET_MS = 9 * 3_600_000;
+const DAY_MS = 86_400_000;
+const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
+
+function kstParts(iso: string | null | undefined): { y: number; m: number; d: number; hh: number; mm: number; dow: number } | null {
+  const at = Date.parse(String(iso ?? ''));
+  if (!Number.isFinite(at)) return null;
+  const shifted = new Date(at + KST_OFFSET_MS);
+  return {
+    y: shifted.getUTCFullYear(),
+    m: shifted.getUTCMonth() + 1,
+    d: shifted.getUTCDate(),
+    hh: shifted.getUTCHours(),
+    mm: shifted.getUTCMinutes(),
+    dow: shifted.getUTCDay(),
+  };
+}
+
+/** 마감 시각을 사람이 읽는 말로. 자정 마감은 "그 전날 자정" 으로 적는다 - 금 0시는 목요일 마감이다. */
+export function formatDeadlineLabel(iso: string | null | undefined, nowIso: string): string {
+  const parts = kstParts(iso);
+  if (!parts) return '';
+  const midnight = parts.hh === 0 && parts.mm === 0;
+  const shownIso = midnight ? new Date(Date.parse(String(iso)) - DAY_MS).toISOString() : String(iso);
+  const shown = kstParts(shownIso);
+  if (!shown) return '';
+  // 남은 일수도 사람이 보는 날(자정 마감이면 그 전날)로 센다 - 그래야 "오늘 자정까지" 가 맞는다.
+  const days = daysUntil(shownIso, nowIso);
+  const when = midnight ? `${shown.m}/${shown.d}(${WEEKDAYS[shown.dow]}) 자정` : `${shown.m}/${shown.d}(${WEEKDAYS[shown.dow]}) ${String(shown.hh).padStart(2, '0')}:${String(shown.mm).padStart(2, '0')}`;
+  if (days === null) return `${when}까지`;
+  if (days < 0) return `${when} 지남`;
+  if (days === 0) return `오늘 ${when.split(' ').slice(1).join(' ')}까지`;
+  if (days === 1) return `내일까지 · ${when}`;
+  return `${when}까지 · D-${days}`;
+}
+
+/** KST 날짜 기준 남은 일수. 시각이 아니라 날짜로 세야 "오늘/내일" 이 사람 감각과 맞는다. */
+function daysUntil(deadlineIso: string | null | undefined, nowIso: string): number | null {
+  const deadline = kstParts(deadlineIso);
+  const now = kstParts(nowIso);
+  if (!deadline || !now) return null;
+  const deadlineDay = Date.UTC(deadline.y, deadline.m - 1, deadline.d);
+  const nowDay = Date.UTC(now.y, now.m - 1, now.d);
+  return Math.round((deadlineDay - nowDay) / DAY_MS);
+}
+
+function completedLabel(iso: string | null | undefined, late: boolean): string {
+  const parts = kstParts(iso);
+  if (!parts) return late ? '기한 초과 완료' : '완료';
+  const when = `${parts.m}/${parts.d}(${WEEKDAYS[parts.dow]}) ${String(parts.hh).padStart(2, '0')}:${String(parts.mm).padStart(2, '0')}`;
+  return late ? `${when} · 기한 초과` : when;
+}
+
+function isPast(iso: string | null | undefined, nowIso: string | null | undefined): boolean {
+  const at = Date.parse(String(iso ?? ''));
+  const now = Date.parse(String(nowIso ?? ''));
+  return Number.isFinite(at) && Number.isFinite(now) && now > at;
+}
+
+export interface ScheduleBarInput {
+  practitionerLabel: string;
+  approverLabel: string;
+  practitionerDeadline: string | null | undefined;
+  approverDeadline: string | null | undefined;
+  /** 실무자 단계 완료 시각 (주정산: 완료 요청, 월결산: 결산 요청). */
+  practitionerDoneAt: string | null | undefined;
+  /** 조직장 단계 완료 시각 (주정산: 확정, 월결산: 승인). 서버가 시각을 안 주면 비운다. */
+  approverDoneAt: string | null | undefined;
+  /** 시각 없이 "확정됨" 만 아는 경우(주정산 확정은 시각이 응답에 없다). 시각을 지어내지 않는다. */
+  approverDone?: boolean;
+  /** 서버가 실무자 단계를 기한 초과 완료로 판정했는지. 화면이 다시 판정하지 않는다. */
+  practitionerLate?: boolean;
+  nowIso: string;
+}
+
+export function buildScheduleSteps(input: ScheduleBarInput): ScheduleStep[] {
+  const {
+    practitionerLabel, approverLabel, practitionerDeadline, approverDeadline,
+    practitionerDoneAt, approverDoneAt, practitionerLate = false, nowIso,
+  } = input;
+
+  const practitionerDone = Boolean(practitionerDoneAt);
+  const approverDone = Boolean(approverDoneAt) || input.approverDone === true;
+
+  const practitioner: ScheduleStep = practitionerDone
+    ? {
+      key: 'practitioner',
+      label: practitionerLabel,
+      state: practitionerLate ? 'done_late' : 'done',
+      detail: completedLabel(practitionerDoneAt, practitionerLate),
+    }
+    : {
+      key: 'practitioner',
+      label: practitionerLabel,
+      // 마감이 지났는데 아직 안 했다 - 지금 행동이 필요한 유일한 상태.
+      state: isPast(practitionerDeadline, nowIso) ? 'overdue' : 'current',
+      detail: formatDeadlineLabel(practitionerDeadline, nowIso),
+    };
+
+  // 완료 시각을 모르면 초과 여부도 단정하지 않는다 - 판정 불능과 "제때" 는 다르다.
+  const approverLate = Boolean(approverDoneAt) && isPast(approverDeadline, approverDoneAt);
+  const approver: ScheduleStep = approverDone
+    ? {
+      key: 'approver',
+      label: approverLabel,
+      // 조직장 초과는 표시만 - 미준수 누적 대상이 아니다.
+      state: approverLate ? 'done_late' : 'done',
+      detail: approverDoneAt ? completedLabel(approverDoneAt, approverLate) : '완료',
+    }
+    : !practitionerDone
+      ? { key: 'approver', label: approverLabel, state: 'upcoming', detail: formatDeadlineLabel(approverDeadline, nowIso) }
+      : {
+        key: 'approver',
+        label: approverLabel,
+        state: isPast(approverDeadline, nowIso) ? 'overdue' : 'current',
+        detail: formatDeadlineLabel(approverDeadline, nowIso),
+      };
+
+  return [practitioner, approver];
+}

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -999,6 +999,8 @@ export interface CashflowDeadlineSummary {
     status: 'ON_TIME' | 'COMPLETED_LATE' | 'MISSED' | 'PENDING';
     lockState?: 'SUBMITTED' | 'LOCKED' | null;
     deadline?: string | null;
+    // 조직장 확정 마감(실무자 마감 +13시간). 표시 전용 - 미준수 누적 대상이 아니다.
+    approverDeadline?: string | null;
     completedAt?: string | null;
     completedBy?: string | null;
     updateResult?: 'CHANGED' | 'NO_CHANGES' | null;
@@ -1007,8 +1009,10 @@ export interface CashflowDeadlineSummary {
     yearMonth: string;
     weekNo: number;
     deadline: string;
+    approverDeadline?: string | null;
     completedAt: string | null;
     completedBy?: string | null;
+    confirmedAt?: string | null;
     status: 'ON_TIME' | 'COMPLETED_LATE' | 'MISSED' | 'PENDING';
     // SUBMITTED = 완료 요청됨(조직장 확정 대기), LOCKED = 확정, 없음 = 완료 요청 전
     lockState?: 'SUBMITTED' | 'LOCKED' | null;
@@ -1170,6 +1174,9 @@ export interface CashflowMonthCloseDashboard {
     cycleYearMonth?: string;
     targetYearMonth?: string;
     closeDeadline: string | null;
+    // 진행 바용 시각 표현(KST). closeDeadlineAt = 익월 11일 0시, approverDeadlineAt = 14일 0시.
+    closeDeadlineAt?: string | null;
+    approverDeadlineAt?: string | null;
     late: boolean;
   };
   validation: {

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -1598,6 +1598,9 @@ export type CashflowSettlementStatus = 'WAITING_FOR_UPDATE' | 'PENDING_APPROVAL'
 export interface CashflowSettlementStatusItem {
   period: CashflowSettlementPeriod;
   status: CashflowSettlementStatus;
+  // 진행 바용 마감(KST, 표시 전용). 주차 마감은 JVM financeWeekDeadline 과 같은 표.
+  deadlineAt?: string | null;
+  approverDeadlineAt?: string | null;
   submittedAt: string;
   submittedBy: string;
   approvedAt: string;


### PR DESCRIPTION
PR 2+3 합본. #618 이 넣은 마감 값을 두 화면에 그립니다.

## 실무자 (현금흐름 카드)
주간·월결산 카드 아래 2단계 바:
```
◉━━━━━━━━━━━━○
완료 요청        조직장 확정
오늘 자정까지     8/21(금) 13:00까지
```
`오늘 자정까지` / `내일까지 · 8/20(목) 자정` / `D-3` / `지남`. **금 0시 마감은 "목요일 자정"으로** 적습니다.

## 관리자 (승인 표)
상태 배지 3종 → **컴팩트 바로 대체**(점 2개 + 한 줄). 승인 대기면 **바 전체가 버튼**이고 라벨은 `승인하기` — 승인 동작은 그대로입니다. 필터 드롭다운 문구는 안 바꿨어요.
프로젝트명 아래 **계약 기간** 한 줄, 종료가 가까우면 `종료 D-21` / `오늘 종료` / `종료됨`(체크아웃이 붙는 자리).

## 표시 원칙 (보람: 혼내는 게 아니라 미리 알려주는 표시)
- 늦게라도 끝낸 단계는 **완료로 남고** 초과는 빨간 보조라벨
- **마감 지났는데 미완료인 것만 빨강**
- 실무자가 아직이면 조직장 단계를 재촉하지 않음
- 확정 시각이 응답에 없으면 `완료` 라고만 하고 **시각을 지어내지 않음**
- 회수·반려된 월 결산 요청은 "요청 안 함"으로 되돌림
- 조직장 초과는 표시만, **미준수 누적 대상 아님**

## 주차 마감 규칙 (BFF 사본)
관리자 표는 한 달의 모든 주를 한 번에 그려야 해서 — 이 모듈이 존재하는 바로 그 이유 — JVM `financeWeekDeadline` 의 **패리티 표**를 BFF 에 뒀습니다(목요일 자정, 목요일 없는 부분 주는 주 마지막 날 다음날 0시). 라이브 JVM 이 낸 2026-08 4주차 값과 교차 검증했고, 2026-12 5주차처럼 해를 넘기는 경계도 표에 넣었습니다.

## 색 (DESIGN.md)
완료 `#001e46` · 현재 `#0176D3` · 대기 slate · 초과 `#e11d48`. 참고 이미지의 보라 계열 제외, `text-[10px]` 미사용.

## 확인
헬퍼 13개 + 마감 모듈 36개(주차 패리티 포함) + cashflow 190개 + jvm-weekly-api 267개, typecheck·build 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)