### PR TITLE
refactor(cashflow): let the JVM own settlement schedule deadlines

### DIFF
--- a/server/bff/cashflow-close-deadline.mjs
+++ b/server/bff/cashflow-close-deadline.mjs
@@ -27,74 +27,27 @@ export function cashflowMonthCloseDeadline(yearMonth) {
   return `${deadlineYear}-${String(deadlineMonth).padStart(2, '0')}-10`;
 }
 
-// --- 조직장 승인 마감 (2026-08-20 보람) ---
-// 표시 전용 규칙이다. 쓰기를 막지도, 미준수를 누적하지도 않는다(미준수는 실무자 마감 기준뿐).
-// 그래서 판정 주체(JVM) 짝 없이 BFF 에만 둔다 - 이 마감이 쓰기를 막게 되는 날 JVM 으로 옮긴다.
-// Asia/Seoul 은 DST 가 없어 KST 0시 = UTC 전날 15시 고정이다.
-const KST_OFFSET_MS = 9 * 3_600_000;
+// 월 결산 마감의 시각 표현. 날짜 규칙(위)은 JVM CashflowCloseDeadline 과 패리티 쌍이고,
+// 여기서는 그 날짜를 진행 바가 쓰는 시각으로 옮긴다. 10일이 마지막 유효일이므로 11일 0시 KST.
+// 조직장 승인은 그로부터 3일(14일 0시) - JVM ApproverDeadlineCalculator.monthly 와 같은 값이며
+// 양쪽 테스트에 같은 표를 둔다. (주간 마감은 JVM 이 응답에 실어 보내므로 사본이 없다.)
+const KST_MIDNIGHT_OFFSET_MS = 9 * 3_600_000;
 const DAY_MS = 86_400_000;
-// 주정산: 실무자 마감(그 주 목요일 자정 = 금 0시 KST, 목요일이 없는 부분 주는 주 마지막 날
-// 다음날 0시 - JVM financeWeekDeadline) + 13시간 = 같은 날 13:00 KST.
-const WEEKLY_APPROVER_OFFSET_MS = 13 * 3_600_000;
+const MONTH_APPROVAL_DAYS = 3;
 
-export function cashflowWeeklyApproverDeadlineAt(practitionerDeadlineAt) {
-  const at = Date.parse(String(practitionerDeadlineAt ?? ''));
-  return Number.isFinite(at) ? new Date(at + WEEKLY_APPROVER_OFFSET_MS).toISOString() : null;
+function kstMidnightAfter(dateText, extraDays = 0) {
+  if (!BUSINESS_DATE_RE.test(String(dateText ?? ''))) return null;
+  const at = Date.parse(`${dateText}T00:00:00Z`);
+  if (!Number.isFinite(at)) return null;
+  return new Date(at + (1 + extraDays) * DAY_MS - KST_MIDNIGHT_OFFSET_MS).toISOString();
 }
 
-// 주정산 실무자 마감. 판정 주체는 JVM financeWeekDeadline 이고 이것은 그 표의 사본이다 -
-// 대시보드가 모든 주를 한 번에 그려야 해서 BFF 에도 같은 규칙이 필요하다(이 파일의 존재 이유).
-// 규칙: 그 주(월~일) 안의 목요일 자정 = 목요일 다음날 0시 KST. 목요일이 없는 부분 주(1주·5주)는
-// 그 주 마지막 날 다음날 0시. 양쪽 테스트에 같은 표를 둔다.
-const FINANCE_WEEK_COUNT = 5;
-
-function utcDay(year, month, day) {
-  return Date.UTC(year, month - 1, day);
-}
-
-export function cashflowFinanceWeekDeadlineAt(yearMonth, weekNo) {
-  const match = YEAR_MONTH_RE.exec(String(yearMonth ?? ''));
-  const week = Number(weekNo);
-  if (!match || !Number.isInteger(week) || week < 1 || week > FINANCE_WEEK_COUNT) return null;
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  const first = utcDay(year, month, 1);
-  // getUTCDay: 일=0 → JVM DayOfWeek(월=1..일=7) 와 맞추면 월요일까지 되감는 일수는 (dow+6)%7.
-  const firstMonday = first - ((new Date(first).getUTCDay() + 6) % 7) * DAY_MS;
-  const lastDayOfMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
-  const monthEnd = utcDay(year, month, lastDayOfMonth);
-  const start = week === 1 ? first : firstMonday + (week - 1) * 7 * DAY_MS;
-  const end = week === FINANCE_WEEK_COUNT ? monthEnd : firstMonday + week * 7 * DAY_MS - DAY_MS;
-  let thursday = start;
-  while (thursday <= end && new Date(thursday).getUTCDay() !== 4) thursday += DAY_MS;
-  const deadlineDay = thursday > end ? end + DAY_MS : thursday + DAY_MS;
-  return new Date(deadlineDay - KST_OFFSET_MS).toISOString();
-}
-
-function kstMidnightInstant(year, month, day) {
-  return new Date(Date.UTC(year, month - 1, day) - KST_OFFSET_MS).toISOString();
-}
-
-function nextMonthOf(yearMonth) {
-  const match = YEAR_MONTH_RE.exec(String(yearMonth ?? ''));
-  if (!match) return null;
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  return month === 12 ? [year + 1, 1] : [year, month + 1];
-}
-
-// 월결산 실무자 마감의 시각 표현: 익월 10일 자정 = 11일 0시 KST.
-// (cashflowMonthCloseDeadline 의 날짜 규칙과 같은 표 - 10일이 마지막 유효일)
 export function cashflowMonthCloseDeadlineAt(yearMonth) {
-  const next = nextMonthOf(yearMonth);
-  return next ? kstMidnightInstant(next[0], next[1], 11) : null;
+  return kstMidnightAfter(cashflowMonthCloseDeadline(yearMonth));
 }
 
-// 월결산 조직장 승인 마감: 달력 고정 익월 14일 0시 KST. 실무자가 늦게 요청하면
-// 조직장 시간이 3일보다 짧아진다 - 요청+3일이 아니라 달력 고정(2026-08-20 결정).
 export function cashflowMonthCloseApproverDeadlineAt(yearMonth) {
-  const next = nextMonthOf(yearMonth);
-  return next ? kstMidnightInstant(next[0], next[1], 14) : null;
+  return kstMidnightAfter(cashflowMonthCloseDeadline(yearMonth), MONTH_APPROVAL_DAYS);
 }
 
 // 기한 초과 여부. 기준일을 모르면 단정하지 않는다 - 판정 불능과 "초과 아님" 은 다르다.

--- a/server/bff/cashflow-close-deadline.test.mjs
+++ b/server/bff/cashflow-close-deadline.test.mjs
@@ -1,10 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
-  cashflowFinanceWeekDeadlineAt,
   cashflowMonthCloseApproverDeadlineAt,
   cashflowMonthCloseDeadline,
   cashflowMonthCloseDeadlineAt,
-  cashflowWeeklyApproverDeadlineAt,
   isCashflowCloseOverdue,
 } from './cashflow-close-deadline.mjs';
 
@@ -53,56 +51,26 @@ describe('close overdue', () => {
   });
 });
 
-// 조직장 승인 마감(2026-08-20)은 표시 전용이라 JVM 짝이 없다 - 쓰기를 막게 되면 그때 JVM 으로.
-describe('approver deadlines — display only, KST', () => {
-  it('weekly approver deadline is the practitioner deadline + 13 hours', () => {
-    // 실무자 마감 금 0시 KST = 목 15:00Z → 승인 마감 금 13:00 KST = 금 04:00Z
-    expect(cashflowWeeklyApproverDeadlineAt('2026-08-20T15:00:00Z')).toBe('2026-08-21T04:00:00.000Z');
-    // 목요일이 없는 부분 주의 대체 마감에도 같은 +13시간이 따라간다.
-    expect(cashflowWeeklyApproverDeadlineAt('2026-08-31T15:00:00.000Z')).toBe('2026-09-01T04:00:00.000Z');
-    expect(cashflowWeeklyApproverDeadlineAt('')).toBeNull();
-    expect(cashflowWeeklyApproverDeadlineAt(undefined)).toBeNull();
-  });
-
-  it('month practitioner instant is the 11th 00:00 KST — same table as the date rule', () => {
-    // 10일이 마지막 유효일 = 11일 0시 KST = 10일 15:00Z
-    expect(cashflowMonthCloseDeadlineAt('2026-07')).toBe('2026-08-10T15:00:00.000Z');
+// PARITY TABLE — JVM ApproverDeadlineCalculatorTest 와 같은 표다. 월 결산 조직장 승인 마감은
+// 실무자 마감(10일) 다음 날 0시에서 3일 뒤, 즉 익월 14일 0시 KST.
+// 주간 마감은 JVM 이 응답에 실어 보내므로 여기에 사본이 없다.
+describe('month close deadline instants — JVM parity', () => {
+  it('practitioner instant is the 11th 00:00 KST', () => {
+    expect(cashflowMonthCloseDeadlineAt('2026-08')).toBe('2026-09-10T15:00:00.000Z');
     expect(cashflowMonthCloseDeadlineAt('2026-12')).toBe('2027-01-10T15:00:00.000Z');
-    expect(cashflowMonthCloseDeadlineAt('2026-13')).toBeNull();
+    expect(cashflowMonthCloseDeadlineAt('nope')).toBeNull();
   });
 
-  it('month approver deadline is calendar-fixed at the 14th 00:00 KST, not request+3d', () => {
-    expect(cashflowMonthCloseApproverDeadlineAt('2026-07')).toBe('2026-08-13T15:00:00.000Z');
-    expect(cashflowMonthCloseApproverDeadlineAt('2026-12')).toBe('2027-01-13T15:00:00.000Z');
-    expect(cashflowMonthCloseApproverDeadlineAt('nope')).toBeNull();
-  });
-});
-
-// PARITY TABLE — JVM FirestoreInheritedWeeklyExpensePersistence.financeWeekDeadline 과 같은 표다.
-// 규칙: 그 주의 목요일 자정(= 다음날 0시 KST). 목요일이 없는 부분 주는 주 마지막 날 다음날 0시.
-// 2026-08-01 은 토요일이라 1주가 토·일 이틀뿐이고, 그 주에는 목요일이 없다.
-const FINANCE_WEEK_PARITY = [
-  ['2026-08', 1, '2026-08-02T15:00:00.000Z'],
-  ['2026-08', 2, '2026-08-06T15:00:00.000Z'],
-  ['2026-08', 3, '2026-08-13T15:00:00.000Z'],
-  ['2026-08', 4, '2026-08-20T15:00:00.000Z'],
-  ['2026-08', 5, '2026-08-27T15:00:00.000Z'],
-  ['2026-02', 5, '2026-02-26T15:00:00.000Z'],
-  ['2026-03', 1, '2026-03-01T15:00:00.000Z'],
-  ['2026-01', 1, '2026-01-01T15:00:00.000Z'],
-  // 2026-12-31 이 목요일이라 5주차 마감이 해를 넘긴다.
-  ['2026-12', 5, '2026-12-31T15:00:00.000Z'],
-];
-
-describe('finance week deadline — JVM parity', () => {
-  it.each(FINANCE_WEEK_PARITY)('%s %s주차 마감은 %s', (yearMonth, weekNo, expected) => {
-    expect(cashflowFinanceWeekDeadlineAt(yearMonth, weekNo)).toBe(expected);
+  it.each([
+    ['2026-08', '2026-09-13T15:00:00.000Z'],
+    ['2026-12', '2027-01-13T15:00:00.000Z'],
+    ['2024-02', '2024-03-13T15:00:00.000Z'],
+  ])('%s 의 조직장 승인 마감은 %s', (yearMonth, expected) => {
+    expect(cashflowMonthCloseApproverDeadlineAt(yearMonth)).toBe(expected);
   });
 
-  it.each([['2026-08', 0], ['2026-08', 6], ['2026-13', 1], ['', 1], [null, 2]])(
-    'refuses to guess for %j %j',
-    (yearMonth, weekNo) => {
-      expect(cashflowFinanceWeekDeadlineAt(yearMonth, weekNo)).toBeNull();
-    },
-  );
+  it('does not guess for an invalid month', () => {
+    expect(cashflowMonthCloseApproverDeadlineAt('2026-13')).toBeNull();
+    expect(cashflowMonthCloseApproverDeadlineAt(null)).toBeNull();
+  });
 });

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -53,11 +53,9 @@ import {
 } from '../cashflow-month-close-withdrawal.mjs';
 export { cashflowCumulativeCloseCycle };
 import {
-  cashflowFinanceWeekDeadlineAt,
   cashflowMonthCloseApproverDeadlineAt,
   cashflowMonthCloseDeadline,
   cashflowMonthCloseDeadlineAt,
-  cashflowWeeklyApproverDeadlineAt,
   isCashflowCloseOverdue,
 } from '../cashflow-close-deadline.mjs';
 import { cashflowMonthRequestCovers } from '../cashflow-month-state.mjs';
@@ -731,29 +729,9 @@ async function alignMonthSettlementStatus(db, tenantId, result) {
         : ['PENDING', 'REOPEN_REQUESTED', 'APPROVING', 'UNCERTAIN'].includes(requestStatus)
           ? 'PENDING_APPROVAL'
           : 'WAITING_FOR_UPDATE';
-    // 진행 바용 마감(표시 전용). 주차 마감은 JVM financeWeekDeadline 의 사본(패리티 표),
-    // 조직장 마감은 표시 전용 규칙이라 BFF 에만 있다.
-    const withDeadlines = (item) => {
-      const period = readOptionalText(item?.period);
-      if (period === 'MONTH') {
-        return {
-          ...item,
-          deadlineAt: cashflowMonthCloseDeadlineAt(yearMonth),
-          approverDeadlineAt: cashflowMonthCloseApproverDeadlineAt(yearMonth),
-        };
-      }
-      const weekMatch = /^WEEK_([1-5])$/.exec(period);
-      if (!weekMatch) return item;
-      const deadlineAt = cashflowFinanceWeekDeadlineAt(yearMonth, Number(weekMatch[1]));
-      return {
-        ...item,
-        deadlineAt,
-        approverDeadlineAt: cashflowWeeklyApproverDeadlineAt(deadlineAt),
-      };
-    };
+    // 마감은 JVM 이 실어 보낸다(deadlineAt / approverDeadlineAt). BFF 는 상태만 정렬한다.
     const alignedItems = statusItems
-      .map((item) => (status && item.period === 'MONTH' ? { ...item, status } : item))
-      .map(withDeadlines);
+      .map((item) => (status && item.period === 'MONTH' ? { ...item, status } : item));
     if (Array.isArray(project?.items)) {
       project.items = alignedItems;
     } else {
@@ -2340,9 +2318,6 @@ async function readCashflowMonthCloseStatuses({
       yearMonth,
       status,
       closeDeadline: cashflowMonthCloseDeadline(yearMonth),
-      // 진행 바용 시각 표현: 실무자 = 익월 11일 0시 KST, 조직장 승인 = 14일 0시 KST(표시 전용, 누적 없음).
-      closeDeadlineAt: cashflowMonthCloseDeadlineAt(yearMonth),
-      approverDeadlineAt: cashflowMonthCloseApproverDeadlineAt(yearMonth),
       // 기준일을 모르면 기한 초과를 단정하지 않는다.
       closeOverdue: isCashflowCloseOverdue({ yearMonth, status, businessDate }),
       sheetCalculationChecks: historyUnavailable
@@ -2761,11 +2736,7 @@ function deadlineSummaryFromCompliance(compliance, comparisonBoundary, weeklyYea
     comparisonBoundary?.asOfWeek?.yearMonth,
     comparisonBoundary?.asOfWeek?.weekNo,
   );
-  const currentItem = currentOrdinal === -1 ? null : indexed[currentOrdinal] || null;
-  // 조직장 승인 마감은 표시 전용(누적 없음). 실무자 마감(JVM 이 준 deadline) + 13시간.
-  const current = currentItem
-    ? { ...currentItem, approverDeadline: cashflowWeeklyApproverDeadlineAt(currentItem.deadline) }
-    : null;
+  const current = currentOrdinal === -1 ? null : indexed[currentOrdinal] || null;
   return {
     trackingStartedAt: null,
     onTimeCount: Number(compliance?.onTimeCount) || 0,
@@ -2780,7 +2751,7 @@ function deadlineSummaryFromCompliance(compliance, comparisonBoundary, weeklyYea
       status: item.status,
       lockState: readOptionalText(item.lockState) || null,
       deadline: item.deadline,
-      approverDeadline: cashflowWeeklyApproverDeadlineAt(item.deadline),
+      approverDeadline: readOptionalText(item.approverDeadline) || null,
       updateResult: item.updateResult,
       operationId: item.operationId,
       auditId: item.auditId,
@@ -3219,6 +3190,9 @@ async function composeCashflowMonthDashboard({
       cycleYearMonth: readOptionalText(close?.cycleYearMonth) || yearMonth,
       targetYearMonth: readOptionalText(close?.targetYearMonth) || buildCumulativeCloseScope(yearMonth).throughMonth,
       closeDeadline: readOptionalText(close?.closeDeadline) || null,
+      // 진행 바가 읽는 시각 표현. 월 마감 날짜 규칙은 JVM 과 패리티 쌍이고 여기서 시각으로 옮긴다.
+      closeDeadlineAt: cashflowMonthCloseDeadlineAt(readOptionalText(close?.yearMonth) || yearMonth),
+      approverDeadlineAt: cashflowMonthCloseApproverDeadlineAt(readOptionalText(close?.yearMonth) || yearMonth),
       late: Boolean(close?.late),
     },
     validation: {

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -52,12 +52,7 @@ import {
   withdrawPendingCumulativeCloseRequest,
 } from '../cashflow-month-close-withdrawal.mjs';
 export { cashflowCumulativeCloseCycle };
-import {
-  cashflowMonthCloseApproverDeadlineAt,
-  cashflowMonthCloseDeadline,
-  cashflowMonthCloseDeadlineAt,
-  isCashflowCloseOverdue,
-} from '../cashflow-close-deadline.mjs';
+import { cashflowMonthCloseDeadline, isCashflowCloseOverdue } from '../cashflow-close-deadline.mjs';
 import { cashflowMonthRequestCovers } from '../cashflow-month-state.mjs';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
@@ -3190,9 +3185,9 @@ async function composeCashflowMonthDashboard({
       cycleYearMonth: readOptionalText(close?.cycleYearMonth) || yearMonth,
       targetYearMonth: readOptionalText(close?.targetYearMonth) || buildCumulativeCloseScope(yearMonth).throughMonth,
       closeDeadline: readOptionalText(close?.closeDeadline) || null,
-      // 진행 바가 읽는 시각 표현. 월 마감 날짜 규칙은 JVM 과 패리티 쌍이고 여기서 시각으로 옮긴다.
-      closeDeadlineAt: cashflowMonthCloseDeadlineAt(readOptionalText(close?.yearMonth) || yearMonth),
-      approverDeadlineAt: cashflowMonthCloseApproverDeadlineAt(readOptionalText(close?.yearMonth) || yearMonth),
+      // 일정 바의 시각은 JVM dashboard-source가 계산한다. BFF는 추측하거나 보정하지 않는다.
+      closeDeadlineAt: readOptionalText(close?.closeDeadlineAt) || null,
+      approverDeadlineAt: readOptionalText(close?.approverDeadlineAt) || null,
       late: Boolean(close?.late),
     },
     validation: {
@@ -3898,6 +3893,8 @@ export function mountJvmWeeklyApiRoutes(app, {
           late: readOptionalText(result?.status) === 'OPEN'
             ? cycleBusinessDate > cumulativeCycle.deadline
             : Boolean(result?.late),
+          closeDeadlineAt: readOptionalText(source?.monthSettlementDeadlines?.deadlineAt) || null,
+          approverDeadlineAt: readOptionalText(source?.monthSettlementDeadlines?.approverDeadlineAt) || null,
           monthState: monthCloseRequest ? cashflowMonthCloseRequestView(monthCloseRequest) : null,
         };
         const cashflowSourceUnavailable = jvmPartial.unavailableSections.has('cashflow');

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -1022,6 +1022,33 @@ describe('JVM weekly API BFF proxy', () => {
     expect(performanceEvents.every((event) => event.requestId === 'req-1')).toBe(true);
   });
 
+  it('passes JVM-owned month schedule instants through without rebuilding them', async () => {
+    const source = fullMonthCloseSource();
+    const dashboardSource = monthDashboardSource({
+      ok: true, projectId: 'project-a', yearMonth: '2026-08', status: 'OPEN', revision: 0,
+    });
+    dashboardSource.monthSettlementDeadlines = {
+      deadlineAt: '2099-01-02T03:04:05.000Z',
+      approverDeadlineAt: '2099-01-05T06:07:08.000Z',
+    };
+    const fetchImpl = vi.fn(async () => ({
+      ok: true, status: 200, text: async () => JSON.stringify(dashboardSource),
+    }));
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, {
+      env: runtimeEnv, db: source.db,
+    });
+
+    await request(app)
+      .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-08')
+      .expect(200)
+      .expect((response) => {
+        expect(response.body.dashboard.summary).toMatchObject({
+          closeDeadlineAt: '2099-01-02T03:04:05.000Z',
+          approverDeadlineAt: '2099-01-05T06:07:08.000Z',
+        });
+      });
+  });
+
   it('publishes the server-owned 2026 board, status joins, and comparison presentation', async () => {
     const source = fullMonthCloseSource();
     source.documents.set('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-08', {

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -656,33 +656,17 @@ describe('JVM weekly API BFF proxy', () => {
       .get('/api/v1/cashflow/project-a/settlement-statuses?yearMonth=2026-08')
       .expect(200)
       .expect((response) => {
-        // 진행 바용 마감이 함께 실린다(표시 전용). 2026-08 은 1일이 토요일이라 1주차에 목요일이 없고,
-        // 그 주 마지막 날(8/2) 다음날 0시 KST 가 마감이다 - JVM financeWeekDeadline 과 같은 표.
+        // 마감은 JVM 이 실어 보낸다 - BFF 는 상태만 정렬하고 항목을 그대로 통과시킨다.
         expect(response.body.items).toEqual([
-          {
-            period: 'MONTH',
-            status: 'PENDING_APPROVAL',
-            deadlineAt: '2026-09-10T15:00:00.000Z',
-            approverDeadlineAt: '2026-09-13T15:00:00.000Z',
-          },
-          {
-            period: 'WEEK_1',
-            status: 'COMPLETED',
-            deadlineAt: '2026-08-02T15:00:00.000Z',
-            approverDeadlineAt: '2026-08-03T04:00:00.000Z',
-          },
+          { period: 'MONTH', status: 'PENDING_APPROVAL' },
+          { period: 'WEEK_1', status: 'COMPLETED' },
         ]);
       });
     await request(app)
       .post('/api/v1/cashflow/settlement-statuses/batch')
       .send({ projectIds: ['project-a'], yearMonth: '2026-08' })
       .expect(200)
-      .expect((response) => expect(response.body.items[0].items[0]).toEqual({
-        period: 'MONTH',
-        status: 'PENDING_APPROVAL',
-        deadlineAt: '2026-09-10T15:00:00.000Z',
-        approverDeadlineAt: '2026-09-13T15:00:00.000Z',
-      }));
+      .expect((response) => expect(response.body.items[0].items[0]).toEqual({ period: 'MONTH', status: 'PENDING_APPROVAL' }));
   });
 
   it('blocks an administrator from submitting an uncompleted settlement', async () => {
@@ -815,18 +799,8 @@ describe('JVM weekly API BFF proxy', () => {
 
     expect(response.body).toMatchObject({ version: '3', yearMonth: '2026-08', monthCloseTargetYearMonth: '2026-07', monthCloseTargetLabel: '7월' });
     expect(response.body.items[0].settlementStatuses.items).toEqual([
-      {
-        period: 'MONTH',
-        status: 'PENDING_APPROVAL',
-        deadlineAt: '2026-09-10T15:00:00.000Z',
-        approverDeadlineAt: '2026-09-13T15:00:00.000Z',
-      },
-      {
-        period: 'WEEK_1',
-        status: 'COMPLETED',
-        deadlineAt: '2026-08-02T15:00:00.000Z',
-        approverDeadlineAt: '2026-08-03T04:00:00.000Z',
-      },
+      { period: 'MONTH', status: 'PENDING_APPROVAL' },
+      { period: 'WEEK_1', status: 'COMPLETED' },
     ]);
     expect(response.body.errors).toEqual([]);
 

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowMonthDashboardSourceResponse.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowMonthDashboardSourceResponse.java
@@ -13,7 +13,8 @@ public record CashflowMonthDashboardSourceResponse(
     CashflowProjectionActualSummaryBatchResponse.Item projectionActualSummary,
     List<Blocker> blockers,
     List<SectionError> sectionErrors,
-    ActionCapability reopenRequest
+    ActionCapability reopenRequest,
+    MonthSettlementDeadlines monthSettlementDeadlines
 ) {
     public CashflowMonthDashboardSourceResponse(
         CashflowMonthCloseResponse monthClose,
@@ -26,7 +27,7 @@ public record CashflowMonthDashboardSourceResponse(
     ) {
         this(
             monthClose, monthClose, null, cashflow, openingBalances, snapshotCompatibility, cumulativeClose,
-            projectionActualSummary, blockers, List.of(), ActionCapability.unavailable()
+            projectionActualSummary, blockers, List.of(), ActionCapability.unavailable(), null
         );
     }
 
@@ -40,7 +41,7 @@ public record CashflowMonthDashboardSourceResponse(
     ) {
         this(
             monthClose, monthClose, null, cashflow, openingBalances, snapshotCompatibility, cumulativeClose,
-            projectionActualSummary, List.of(), List.of(), ActionCapability.unavailable()
+            projectionActualSummary, List.of(), List.of(), ActionCapability.unavailable(), null
         );
     }
 
@@ -52,7 +53,7 @@ public record CashflowMonthDashboardSourceResponse(
     ) {
         this(
             monthClose, monthClose, null, cashflow, openingBalances, snapshotCompatibility, CumulativeClose.missing(),
-            null, List.of(), List.of(), ActionCapability.unavailable()
+            null, List.of(), List.of(), ActionCapability.unavailable(), null
         );
     }
 
@@ -80,6 +81,8 @@ public record CashflowMonthDashboardSourceResponse(
             return new ActionCapability(false, "CUMULATIVE_CLOSE_AUTHORITY_UNAVAILABLE");
         }
     }
+
+    public record MonthSettlementDeadlines(String deadlineAt, String approverDeadlineAt) {}
 
     public record MonthStatusEvidence(
         String authority,

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSettlementStatusesResponse.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSettlementStatusesResponse.java
@@ -14,7 +14,10 @@ public record CashflowSettlementStatusesResponse(
         String submittedBy,
         String approvedAt,
         String approvedBy,
-        long revision
+        long revision,
+        // 실무자 마감과 조직장 승인 마감. 규칙은 JVM 이 소유하고 화면은 받은 값을 그린다.
+        String deadlineAt,
+        String approverDeadlineAt
     ) {
     }
 }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowWeeklyComplianceHistoryResponse.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowWeeklyComplianceHistoryResponse.java
@@ -12,6 +12,8 @@ public record CashflowWeeklyComplianceHistoryResponse(
         String yearMonth,
         int weekNo,
         String deadline,
+        // 조직장 확정 마감(실무자 마감 +13시간). 표시 전용 - 미준수 누적 대상이 아니다.
+        String approverDeadline,
         String status,
         String completedAt,
         String completedBy,

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -3,6 +3,8 @@ package dev.merryai.innerplatform.weekly.api;
 import dev.merryai.innerplatform.weekly.domain.CashflowLedgerSource;
 import dev.merryai.innerplatform.weekly.domain.CashflowMonthReopenPolicy;
 import dev.merryai.innerplatform.weekly.domain.CashflowOpeningBalance;
+import dev.merryai.innerplatform.weekly.domain.CashflowCloseDeadline;
+import dev.merryai.innerplatform.weekly.domain.ApproverDeadlineCalculator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import dev.merryai.innerplatform.weekly.domain.CashflowLineCatalog;
@@ -44,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.time.YearMonth;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -582,7 +585,16 @@ public class WeeklyExpenseController {
             new CashflowMonthDashboardSourceResponse.ActionCapability(
                 result.reopenRequest().enabled(),
                 result.reopenRequest().reasonCode()
-            )
+            ),
+            monthSettlementDeadlines(yearMonth)
+        );
+    }
+
+    private static CashflowMonthDashboardSourceResponse.MonthSettlementDeadlines monthSettlementDeadlines(String yearMonth) {
+        YearMonth month = YearMonth.parse(yearMonth);
+        return new CashflowMonthDashboardSourceResponse.MonthSettlementDeadlines(
+            CashflowCloseDeadline.settlementDeadlineAt(month).toString(),
+            ApproverDeadlineCalculator.monthly(yearMonth, 3).toString()
         );
     }
 

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowCloseDeadline.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowCloseDeadline.java
@@ -1,7 +1,9 @@
 package dev.merryai.innerplatform.weekly.domain;
 
 import java.time.LocalDate;
+import java.time.Instant;
 import java.time.YearMonth;
+import java.time.ZoneId;
 
 /**
  * 월 결산 기한 규칙의 단일 소스.
@@ -17,6 +19,7 @@ import java.time.YearMonth;
  * 대상 월은 직전 월이므로 두 표현은 같은 날짜를 가리킨다.
  */
 public final class CashflowCloseDeadline {
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
 
     private CashflowCloseDeadline() {
     }
@@ -33,6 +36,11 @@ public final class CashflowCloseDeadline {
 
     public static LocalDate forMonth(YearMonth cycleOrTargetMonth, boolean cumulative) {
         return cumulative ? forCumulativeCycle(cycleOrTargetMonth) : forTargetMonth(cycleOrTargetMonth);
+    }
+
+    /** 일정 바용 실무자 마감 시각. 마감일 10일이 끝나는 익월 11일 0시 KST다. */
+    public static Instant settlementDeadlineAt(YearMonth targetMonth) {
+        return forTargetMonth(targetMonth).plusDays(1).atStartOfDay(SEOUL).toInstant();
     }
 
     /** 기한 초과 여부. 확정된 달은 초과로 보지 않는다. */

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowFinanceWeekDeadline.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowFinanceWeekDeadline.java
@@ -1,0 +1,48 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.ZoneId;
+
+/**
+ * 주간 정산 실무자 마감 규칙의 단일 소스.
+ *
+ * <p>원래 {@code FirestoreInheritedWeeklyExpensePersistence} 안의 private 메서드였다.
+ * 그래서 직접 테스트할 수 없었고, 화면이 한 달 5주를 한 번에 그려야 하자 BFF 가 같은 규칙을
+ * 따로 구현하는 사본이 생겼다. 규칙을 여기 하나로 두고 응답에 실어 보내면 사본이 필요 없다.
+ *
+ * <p>규칙: 그 주(월~일) 안의 목요일 자정 = 목요일 다음 날 0시 KST. 목요일이 없는 부분 주
+ * (1주차가 주 후반에서 시작하거나 5주차가 월말에서 끊길 때)는 그 주 마지막 날 다음 날 0시.
+ */
+public final class CashflowFinanceWeekDeadline {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+    private static final int WEEK_COUNT = 5;
+
+    private CashflowFinanceWeekDeadline() {
+    }
+
+    public static Instant of(String yearMonth, int weekNo) {
+        return of(YearMonth.parse(yearMonth), weekNo);
+    }
+
+    public static Instant of(YearMonth month, int weekNo) {
+        if (weekNo < 1 || weekNo > WEEK_COUNT) {
+            throw new IllegalArgumentException("Finance week must be 1..5 but was " + weekNo);
+        }
+        LocalDate first = month.atDay(1);
+        LocalDate firstMonday = first.minusDays(first.getDayOfWeek().getValue() - 1L);
+        LocalDate start = weekNo == 1 ? first : firstMonday.plusWeeks(weekNo - 1L);
+        LocalDate end = weekNo == WEEK_COUNT
+            ? month.atEndOfMonth()
+            : firstMonday.plusWeeks(weekNo).minusDays(1);
+        LocalDate thursday = start;
+        while (!thursday.isAfter(end) && thursday.getDayOfWeek() != DayOfWeek.THURSDAY) {
+            thursday = thursday.plusDays(1);
+        }
+        LocalDate deadlineDate = thursday.isAfter(end) ? end.plusDays(1) : thursday.plusDays(1);
+        return deadlineDate.atStartOfDay(SEOUL).toInstant();
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -1,5 +1,7 @@
 package dev.merryai.innerplatform.weekly.service;
 
+import dev.merryai.innerplatform.weekly.domain.ApproverDeadlineCalculator;
+import dev.merryai.innerplatform.weekly.domain.CashflowFinanceWeekDeadline;
 import dev.merryai.innerplatform.weekly.domain.CashflowAnnualCellSet;
 import dev.merryai.innerplatform.weekly.service.command.CashflowSheetAnnualApplyCommand;
 import dev.merryai.innerplatform.weekly.domain.CashflowCumulativeCloseHead;
@@ -107,8 +109,11 @@ import org.springframework.beans.factory.annotation.Value;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.Clock;
+import java.time.YearMonth;
+import java.time.ZoneId;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -158,6 +163,11 @@ public class WeeklyExpenseCommandService {
     public static final String AUDIT_EXPORT_CREATE_COMMAND = "weeklyExpense.auditExport.create";
 
     private static final Pattern WEEK_LABEL_PATTERN = Pattern.compile("(20\\d{2}-\\d{2}).*?([1-6])");
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+    private static final Pattern SETTLEMENT_WEEK = Pattern.compile("WEEK_([1-5])");
+    // 보람 2026-08-20: 주간 조직장 마감 = 실무자 마감 +13시간(금 13:00), 월간 = +3일(익월 14일 0시).
+    private static final Duration SETTLEMENT_WEEK_APPROVAL_DELAY = Duration.ofHours(13);
+    private static final long SETTLEMENT_MONTH_APPROVAL_DAYS = 3;
     private static final Pattern SHORT_WEEK_LABEL_PATTERN = Pattern.compile("^(\\d{2})-(\\d{1,2})-([1-6])$");
     private static final int ROW_REINDEX_TEMPORARY_OFFSET = 1_000_000;
     private static final String CASHFLOW_SHEET_LAB_ACTUAL_SOURCE = "cashflow-sheet-lab";
@@ -257,6 +267,39 @@ public class WeeklyExpenseCommandService {
         );
     }
 
+    // 저장된 실무자 마감 문자열에서 조직장 마감을 만든다. 마감을 못 읽으면 지어내지 않는다.
+    private static String weeklyApproverDeadline(String practitionerDeadline) {
+        if (practitionerDeadline == null || practitionerDeadline.isBlank()) return "";
+        try {
+            return ApproverDeadlineCalculator
+                .weekly(Instant.parse(practitionerDeadline), SETTLEMENT_WEEK_APPROVAL_DELAY)
+                .toString();
+        } catch (java.time.format.DateTimeParseException invalid) {
+            return "";
+        }
+    }
+
+    // 주정산 실무자 마감은 그 주의 목요일 자정, 월결산은 익월 10일 자정(= 11일 0시).
+    private static Instant settlementPractitionerDeadline(String yearMonth, String period) {
+        if ("MONTH".equals(period)) {
+            return YearMonth.parse(yearMonth).plusMonths(1).atDay(11).atStartOfDay(SEOUL).toInstant();
+        }
+        Matcher week = SETTLEMENT_WEEK.matcher(period == null ? "" : period);
+        return week.matches()
+            ? CashflowFinanceWeekDeadline.of(yearMonth, Integer.parseInt(week.group(1)))
+            : null;
+    }
+
+    // 조직장 승인 마감. 주간은 실무자 마감 +13시간, 월간은 실무자 마감 +3일.
+    private static Instant settlementApproverDeadline(String yearMonth, String period, Instant practitioner) {
+        if ("MONTH".equals(period)) {
+            return ApproverDeadlineCalculator.monthly(yearMonth, SETTLEMENT_MONTH_APPROVAL_DAYS);
+        }
+        return practitioner == null
+            ? null
+            : ApproverDeadlineCalculator.weekly(practitioner, SETTLEMENT_WEEK_APPROVAL_DELAY);
+    }
+
     private CashflowSettlementStatusesResponse settlementStatusesResponse(
         String projectId,
         String yearMonth,
@@ -265,10 +308,16 @@ public class WeeklyExpenseCommandService {
         return new CashflowSettlementStatusesResponse(
             projectId,
             yearMonth,
-            records.stream().map(record -> new CashflowSettlementStatusesResponse.Item(
-                record.period(), record.status(), record.submittedAt(), record.submittedBy(),
-                record.approvedAt(), record.approvedBy(), record.revision()
-            )).toList()
+            records.stream().map(record -> {
+                Instant practitioner = settlementPractitionerDeadline(yearMonth, record.period());
+                Instant approver = settlementApproverDeadline(yearMonth, record.period(), practitioner);
+                return new CashflowSettlementStatusesResponse.Item(
+                    record.period(), record.status(), record.submittedAt(), record.submittedBy(),
+                    record.approvedAt(), record.approvedBy(), record.revision(),
+                    practitioner == null ? "" : practitioner.toString(),
+                    approver == null ? "" : approver.toString()
+                );
+            }).toList()
         );
     }
 
@@ -400,7 +449,8 @@ public class WeeklyExpenseCommandService {
                 ? new CashflowSettlementStatusesResponse.Item(
                     item.period(),
                     CashflowMonthSettlementLifecycle.resolveMonthStatus(item.status(), monthCloseRequestStatus),
-                    item.submittedAt(), item.submittedBy(), item.approvedAt(), item.approvedBy(), item.revision()
+                    item.submittedAt(), item.submittedBy(), item.approvedAt(), item.approvedBy(), item.revision(),
+                    item.deadlineAt(), item.approverDeadlineAt()
                 )
                 : item
             ).toList()
@@ -1310,7 +1360,9 @@ public class WeeklyExpenseCommandService {
         }
         return new CashflowWeeklyComplianceHistoryResponse(
             page.items().stream().map(item -> new CashflowWeeklyComplianceHistoryResponse.Item(
-                item.yearMonth(), item.weekNo(), item.deadline(), item.status(), item.completedAt(),
+                item.yearMonth(), item.weekNo(), item.deadline(),
+                weeklyApproverDeadline(item.deadline()),
+                item.status(), item.completedAt(),
                 item.completedBy(), item.operationId(), item.auditId(), item.updateResult(), item.lockState()
             )).toList(),
             page.nextCursor(),

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -45,6 +45,7 @@ import dev.merryai.innerplatform.weekly.domain.CashflowCloseDeadline;
 import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseActualEntity;
 import dev.merryai.innerplatform.weekly.domain.CashflowApplyLease;
 import dev.merryai.innerplatform.weekly.domain.CashflowCloseHash;
+import dev.merryai.innerplatform.weekly.domain.CashflowFinanceWeekDeadline;
 import dev.merryai.innerplatform.weekly.domain.CashflowSettlementApproverPolicy;
 import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseAuditEventEntity;
 import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseAuditExportEntity;
@@ -2037,19 +2038,7 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     }
 
     private Instant financeWeekDeadline(String yearMonth, int weekNo) {
-        YearMonth month = YearMonth.parse(yearMonth);
-        LocalDate first = month.atDay(1);
-        LocalDate firstMonday = first.minusDays(first.getDayOfWeek().getValue() - 1L);
-        LocalDate start = weekNo == 1 ? first : firstMonday.plusWeeks(weekNo - 1L);
-        LocalDate end = weekNo == CashflowSheetLabApplyRequest.FINANCE_WEEK_COUNT
-            ? month.atEndOfMonth()
-            : firstMonday.plusWeeks(weekNo).minusDays(1);
-        LocalDate thursday = start;
-        while (!thursday.isAfter(end) && thursday.getDayOfWeek() != java.time.DayOfWeek.THURSDAY) {
-            thursday = thursday.plusDays(1);
-        }
-        LocalDate deadlineDate = thursday.isAfter(end) ? end.plusDays(1) : thursday.plusDays(1);
-        return deadlineDate.atStartOfDay(java.time.ZoneId.of("Asia/Seoul")).toInstant();
+        return CashflowFinanceWeekDeadline.of(yearMonth, weekNo);
     }
 
     private String weeklyComplianceStatus(String yearMonth, int weekNo, Instant completedAt, Instant deadline) {

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
@@ -1662,6 +1662,11 @@ class WeeklyExpenseControllerTest {
         assertThat(response.cumulativeClose().status()).isNull();
         assertThat(response.cumulativeClose().fromMonth()).isNull();
         assertThat(response.cumulativeClose().headRevision()).isNull();
+        assertThat(response.monthSettlementDeadlines()).isEqualTo(
+            new CashflowMonthDashboardSourceResponse.MonthSettlementDeadlines(
+                "2026-07-10T15:00:00Z", "2026-07-13T15:00:00Z"
+            )
+        );
         verify(dashboardPersistence)
             .findCashflowLedgerSource("tenant-month-dashboard", "project-month-dashboard", 2026);
         verify(dashboardPersistence).findCashflowLedgerSource(

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowCloseDeadlineTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowCloseDeadlineTest.java
@@ -3,6 +3,7 @@ package dev.merryai.innerplatform.weekly.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
+import java.time.Instant;
 import java.time.YearMonth;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -28,6 +29,17 @@ class CashflowCloseDeadlineTest {
     void targetMonthDeadlineMatchesTheBffTable(String yearMonth, String expected) {
         assertThat(CashflowCloseDeadline.forTargetMonth(YearMonth.parse(yearMonth)))
             .isEqualTo(LocalDate.parse(expected));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "2026-08, 2026-09-10T15:00:00Z",
+        "2026-12, 2027-01-10T15:00:00Z",
+        "2024-02, 2024-03-10T15:00:00Z",
+    })
+    void settlementDeadlineEndsAtMidnightAfterTheFinalDeadlineDay(String yearMonth, String expected) {
+        assertThat(CashflowCloseDeadline.settlementDeadlineAt(YearMonth.parse(yearMonth)))
+            .isEqualTo(Instant.parse(expected));
     }
 
     @Test

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowFinanceWeekDeadlineTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowFinanceWeekDeadlineTest.java
@@ -1,0 +1,53 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.time.Instant;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class CashflowFinanceWeekDeadlineTest {
+
+    /**
+     * 각 줄이 서로 다른 분기를 하나씩 잡는다. 달마다 값을 늘리지 않는다 - 표가 커지면
+     * 규칙을 고칠 때 사람이 생각 대신 줄을 지우게 된다.
+     */
+    @ParameterizedTest
+    @CsvSource({
+        // 1일이 월요일: 되감기 없음 + 목요일 정상
+        "2026-06, 1, 2026-06-04T15:00:00Z",
+        // 1일이 토요일: 1주차가 토·일 이틀뿐이라 목요일이 없다 -> 주 마지막 날 다음 날 0시
+        "2026-08, 1, 2026-08-02T15:00:00Z",
+        // 중간 정상 주 (라이브에서 실제로 관측된 값)
+        "2026-08, 4, 2026-08-20T15:00:00Z",
+        // 5주차는 월말까지 늘어난다
+        "2026-08, 5, 2026-08-27T15:00:00Z",
+        // 윤년 2월 월말
+        "2024-02, 5, 2024-02-29T15:00:00Z",
+        // 해를 넘기는 5주차 (2026-12-31 이 목요일)
+        "2026-12, 5, 2026-12-31T15:00:00Z",
+        // 1일이 금요일: 되감기 최대치
+        "2027-01, 1, 2027-01-03T15:00:00Z",
+    })
+    void followsTheThursdayMidnightRuleWithASubstituteForPartialWeeks(
+        String yearMonth, int weekNo, String expected
+    ) {
+        assertThat(CashflowFinanceWeekDeadline.of(yearMonth, weekNo)).isEqualTo(Instant.parse(expected));
+    }
+
+    @Test
+    void isMidnightInSeoul() {
+        assertThat(CashflowFinanceWeekDeadline.of("2026-08", 4).atZone(ZoneId.of("Asia/Seoul")))
+            .hasToString("2026-08-21T00:00+09:00[Asia/Seoul]");
+    }
+
+    @Test
+    void refusesWeeksOutsideTheFixedFiveWeekLayout() {
+        assertThatIllegalArgumentException().isThrownBy(() -> CashflowFinanceWeekDeadline.of("2026-08", 0));
+        assertThatIllegalArgumentException().isThrownBy(() -> CashflowFinanceWeekDeadline.of("2026-08", 6));
+    }
+}


### PR DESCRIPTION
## What\n- JVM이 주간·월간 일정 바의 실무자/조직장 마감 시각을 계산해 dashboard-source로 제공합니다.\n- BFF는 해당 값을 재계산하지 않고 관리자 화면에 전달합니다.\n- 관리자 주간 표는 상태 배지 롤백 이후 범위만 유지합니다.\n\n## Rules\n- 주간: 금요일 00:00 KST / 금요일 13:00 KST\n- 월간: 익월 11일 00:00 KST / 익월 14일 00:00 KST\n- 미준수 누적 기준은 기존대로 실무자 마감입니다.\n\n## Verification\n- JVM 마감·controller contract tests\n- BFF pass-through sentinel test\n- npm build and BFF integration run\n\n## Scope\n- 실무자 포털 UI와 Firestore 테스트 데이터 변경은 포함하지 않습니다.