### PR TITLE
revert(cashflow): roll the admin table back to status badges

### DIFF
--- a/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
+++ b/src/app/components/cashflow/CashflowWeeklyPage.shell.test.ts
@@ -39,12 +39,13 @@ describe('CashflowWeeklyPage settlement status surface', () => {
     expect(source).toContain('fetchCashflowWeeklyOverviewViaBff');
     expect(source).toContain('transitionCashflowSettlementStatusViaBff');
     expect(source).toContain("onAction={(action) => void transition(project.id, 'MONTH', action, yearMonth)}");
-    // 2026-08-20: 상태 배지를 진행 바로 대체했다. 승인은 그 바를 눌러서 한다.
-    expect(source).toContain('<CashflowScheduleBarCompact steps={steps} />');
-    expect(source).toContain("onClick={() => onAction('APPROVE')}");
-    expect(source).toContain('승인하기');
+    // 2026-08-20: 진행 바로 바꿨다가 헷갈린다는 피드백으로 배지로 롤백. 기간 줄만 유지.
+    expect(source).toContain('주정산 이전');
+    expect(source).toContain('결산 전');
+    expect(source).toContain('조직장 승인 필요');
+    expect(source).toContain('승인 완료');
     expect(source).toContain('<ProjectPeriodLine start={project.contractStart} end={project.contractEnd} />');
-    expect(source).not.toContain("bg-emerald-50 px-2.5 font-semibold text-emerald-700");
+    expect(source).not.toContain('CashflowScheduleBarCompact');
     expect(source).toContain("user?.uid === project.executiveApproverId");
     expect(source).toContain('setRefreshSequence((current) => current + 1)');
     expect(source).not.toContain('fetchCashflowSettlementStatusesBatchViaBff');
@@ -122,7 +123,6 @@ describe('CashflowWeeklyPage settlement status surface', () => {
   });
 
   it('keeps the status filter labels aligned with their settlement period', () => {
-    // 필터 드롭다운의 말은 그대로다 - 바뀐 것은 표 안의 표시뿐이다.
     expect(source).toContain("period === 'MONTH' ? '결산 전' : '주정산 이전'");
     expect(source).toContain('조직장 승인 필요');
   });

--- a/src/app/components/cashflow/CashflowWeeklyPage.tsx
+++ b/src/app/components/cashflow/CashflowWeeklyPage.tsx
@@ -5,8 +5,7 @@ import { toast } from 'sonner';
 import { PageHeader } from '../layout/PageHeader';
 import { Card, CardContent } from '../ui/card';
 import { Button } from '../ui/button';
-import { CashflowScheduleBarCompact } from './CashflowScheduleBar';
-import { buildScheduleSteps, formatProjectPeriod } from './cashflow-schedule-steps';
+import { formatProjectPeriod } from './cashflow-schedule-steps';
 import { Label } from '../ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { useAppStore } from '../../data/store';
@@ -112,31 +111,23 @@ function SettlementStatusButton({
   onAction: (action: 'SUBMIT' | 'APPROVE') => void;
 }) {
   const status = item?.status || 'WAITING_FOR_UPDATE';
-  // 상태 배지를 진행 바로 대체한다(2026-08-20 보람). 승인은 그대로 여기서 누른다.
-  const steps = buildScheduleSteps({
-    practitionerLabel: period === 'MONTH' ? '결산 요청' : '완료 요청',
-    approverLabel: period === 'MONTH' ? '조직장 승인' : '조직장 확정',
-    practitionerDeadline: item?.deadlineAt,
-    approverDeadline: item?.approverDeadlineAt,
-    practitionerDoneAt: status === 'WAITING_FOR_UPDATE' ? null : item?.submittedAt || null,
-    approverDoneAt: status === 'COMPLETED' ? item?.approvedAt || null : null,
-    approverDone: status === 'COMPLETED',
-    nowIso: new Date().toISOString(),
-  });
-  const bar = <CashflowScheduleBarCompact steps={steps} />;
-  if (status !== 'PENDING_APPROVAL') return bar;
+  if (status === 'COMPLETED') {
+    return <span className="inline-flex min-h-8 items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 font-semibold text-emerald-700"><span className="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden="true" />승인 완료</span>;
+  }
+  if (status === 'WAITING_FOR_UPDATE') {
+    return <span className="inline-flex min-h-8 items-center gap-1.5 rounded-full border border-red-200 bg-red-50 px-2.5 font-semibold text-red-700"><span className="h-1.5 w-1.5 rounded-full bg-red-500" aria-hidden="true" />{period === 'MONTH' ? '결산 전' : '주정산 이전'}</span>;
+  }
   return (
     <Button
       type="button"
       size="sm"
       variant="outline"
-      className="min-h-8 w-full flex-col gap-1 whitespace-normal rounded-md border-slate-300 bg-white px-2 py-1.5 text-[11px] font-semibold text-[#17324D] hover:bg-slate-50"
+      className="min-h-8 gap-1.5 whitespace-normal rounded-full border-amber-200 bg-amber-50 px-2.5 text-[11px] font-semibold text-amber-800 hover:bg-amber-100"
       disabled={loading || !canApprove}
       onClick={() => onAction('APPROVE')}
-      title="조직장 승인"
     >
-      {bar}
-      <span>{loading ? '처리 중…' : '승인하기'}</span>
+      <span className="h-1.5 w-1.5 rounded-full bg-amber-500" aria-hidden="true" />
+      {loading ? '처리 중…' : '조직장 승인 필요'}
     </Button>
   );
 }


### PR DESCRIPTION
## 왜
보람: "관리자 > 전사 현금흐름 현황은 오히려 헷갈리네" — #619 에서 배지 3종을 컴팩트 진행 바로 바꿨는데(승인은 그 바를 눌러서 그대로 동작), 관리자 표에서는 배지가 더 명확했음.

## 무엇
`CashflowWeeklyPage.tsx` 를 #619 이전 상태(925fd976)로 되돌림 — 배지(주정산 이전/조직장 승인 필요/승인 완료), 승인 버튼, 필터 라벨 전부 원상복구.

**프로젝트 기간 줄은 유지** — "헷갈리네"는 진행 바에 대한 얘기였고 기간 줄은 아니었음. 실무자 화면이 이미 읽는 것과 같은 값이라 추가 호출 없음.

**실무자 카드 진행 바는 그대로** — 이 PR 은 관리자 표만 건드림.

## 확인
셸 테스트 7개, typecheck, build 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)