### PR TITLE
feat(cashflow): expose the JVM month close operational cycle

### DIFF
--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowMonthDashboardSourceResponse.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowMonthDashboardSourceResponse.java
@@ -13,7 +13,8 @@ public record CashflowMonthDashboardSourceResponse(
     CashflowProjectionActualSummaryBatchResponse.Item projectionActualSummary,
     List<Blocker> blockers,
     List<SectionError> sectionErrors,
-    ActionCapability reopenRequest
+    ActionCapability reopenRequest,
+    OperationalCycle operationalCycle
 ) {
     public CashflowMonthDashboardSourceResponse(
         CashflowMonthCloseResponse monthClose,
@@ -26,7 +27,7 @@ public record CashflowMonthDashboardSourceResponse(
     ) {
         this(
             monthClose, monthClose, null, cashflow, openingBalances, snapshotCompatibility, cumulativeClose,
-            projectionActualSummary, blockers, List.of(), ActionCapability.unavailable()
+            projectionActualSummary, blockers, List.of(), ActionCapability.unavailable(), null
         );
     }
 
@@ -40,7 +41,7 @@ public record CashflowMonthDashboardSourceResponse(
     ) {
         this(
             monthClose, monthClose, null, cashflow, openingBalances, snapshotCompatibility, cumulativeClose,
-            projectionActualSummary, List.of(), List.of(), ActionCapability.unavailable()
+            projectionActualSummary, List.of(), List.of(), ActionCapability.unavailable(), null
         );
     }
 
@@ -52,7 +53,7 @@ public record CashflowMonthDashboardSourceResponse(
     ) {
         this(
             monthClose, monthClose, null, cashflow, openingBalances, snapshotCompatibility, CumulativeClose.missing(),
-            null, List.of(), List.of(), ActionCapability.unavailable()
+            null, List.of(), List.of(), ActionCapability.unavailable(), null
         );
     }
 
@@ -80,6 +81,14 @@ public record CashflowMonthDashboardSourceResponse(
             return new ActionCapability(false, "CUMULATIVE_CLOSE_AUTHORITY_UNAVAILABLE");
         }
     }
+
+    public record OperationalCycle(
+        String cycleYearMonth,
+        String targetYearMonth,
+        String closeDeadline,
+        boolean closeEligible,
+        boolean late
+    ) {}
 
     public record MonthStatusEvidence(
         String authority,

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -33,9 +33,12 @@ import dev.merryai.innerplatform.weekly.service.command.CashflowSheetAnnualApply
 import dev.merryai.innerplatform.weekly.service.port.CashflowMonthReopenPort;
 import dev.merryai.innerplatform.weekly.service.query.CashflowMonthDashboardQueryService;
 import dev.merryai.innerplatform.weekly.domain.CashflowAnnualCellSet;
+import dev.merryai.innerplatform.weekly.domain.CashflowCloseDeadline;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -582,7 +585,25 @@ public class WeeklyExpenseController {
             new CashflowMonthDashboardSourceResponse.ActionCapability(
                 result.reopenRequest().enabled(),
                 result.reopenRequest().reasonCode()
-            )
+            ),
+            operationalCycle(yearMonth, operationalStatus, latestRun)
+        );
+    }
+
+    private static CashflowMonthDashboardSourceResponse.OperationalCycle operationalCycle(
+        String yearMonth,
+        String operationalStatus,
+        CashflowMonthCloseResponse latestRun
+    ) {
+        YearMonth cycleMonth = YearMonth.parse(yearMonth);
+        YearMonth targetMonth = cycleMonth.minusMonths(1);
+        LocalDate evaluatedBusinessDate = LocalDate.parse(latestRun.evaluatedBusinessDate());
+        LocalDate closeDeadline = CashflowCloseDeadline.forCumulativeCycle(cycleMonth);
+        boolean open = "OPEN".equals(operationalStatus);
+        return new CashflowMonthDashboardSourceResponse.OperationalCycle(
+            cycleMonth.toString(), targetMonth.toString(), closeDeadline.toString(),
+            open && targetMonth.isBefore(YearMonth.from(evaluatedBusinessDate)),
+            open ? evaluatedBusinessDate.isAfter(closeDeadline) : latestRun.late()
         );
     }
 

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
@@ -1735,6 +1735,12 @@ class WeeklyExpenseControllerTest {
             .isEqualTo("2026-07");
         assertThat(json.path("cumulativeClose").path("settlementMonth").asText())
             .isEqualTo("2026-08");
+        assertThat(json.path("operationalCycle")).isNotNull();
+        assertThat(json.path("operationalCycle").path("cycleYearMonth").asText()).isEqualTo("2026-08");
+        assertThat(json.path("operationalCycle").path("targetYearMonth").asText()).isEqualTo("2026-07");
+        assertThat(json.path("operationalCycle").path("closeDeadline").asText()).isEqualTo("2026-08-10");
+        assertThat(json.path("operationalCycle").path("closeEligible").asBoolean()).isTrue();
+        assertThat(json.path("operationalCycle").path("late").asBoolean()).isTrue();
         assertThat(json.path("reopenRequest").path("enabled").asBoolean()).isTrue();
     }
 


### PR DESCRIPTION
JVM dashboard-source에 additive operationalCycle 계약을 추가합니다. BFF는 아직 읽지 않으므로 무중단 1차 배포입니다.\n\n포함 필드: cycleYearMonth, targetYearMonth, closeDeadline, closeEligible, late.\n\n검증: WeeklyExpenseControllerTest.