### PR TITLE
feat(cashflow): forward the JVM month close cycle

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -1079,6 +1079,21 @@ function objectValue(value) {
   return value && typeof value === 'object' && !Array.isArray(value) ? value : null;
 }
 
+function readJvmOperationalCycle(source, yearMonth) {
+  const cycle = objectValue(source?.operationalCycle);
+  if (!cycle || readOptionalText(cycle.cycleYearMonth) !== yearMonth) return null;
+  const targetYearMonth = readOptionalText(cycle.targetYearMonth);
+  const deadline = readOptionalText(cycle.closeDeadline);
+  if (!targetYearMonth || !deadline || typeof cycle.closeEligible !== 'boolean' || typeof cycle.late !== 'boolean') return null;
+  return {
+    cycleYearMonth: yearMonth,
+    targetYearMonth,
+    deadline,
+    eligible: cycle.closeEligible,
+    late: cycle.late,
+  };
+}
+
 function amendedSheetFormulaSnapshot(mirror, amendmentEvidence) {
   const sourceRevision = readOptionalText(amendmentEvidence?.sourceRevision);
   const targetRevision = readOptionalText(amendmentEvidence?.resultingTargetRevision);
@@ -3910,7 +3925,8 @@ export function mountJvmWeeklyApiRoutes(app, {
             'jvm_weekly_response_invalid',
           );
         }
-        const cumulativeCycle = cashflowCumulativeCloseCycle(yearMonth, cycleBusinessDate);
+        const cumulativeCycle = readJvmOperationalCycle(source, yearMonth)
+          || cashflowCumulativeCloseCycle(yearMonth, cycleBusinessDate);
         if (!cumulativeCycle) {
           throw createHttpError(502, '월 결산 회차 기준일을 확인할 수 없습니다.', 'jvm_weekly_response_invalid');
         }
@@ -3920,10 +3936,8 @@ export function mountJvmWeeklyApiRoutes(app, {
           targetYearMonth: cumulativeCycle.targetYearMonth,
           evaluatedBusinessDate: cycleBusinessDate,
           closeDeadline: cumulativeCycle.deadline,
-          closeEligible: readOptionalText(result?.status) === 'OPEN' && cumulativeCycle.eligible,
-          late: readOptionalText(result?.status) === 'OPEN'
-            ? cycleBusinessDate > cumulativeCycle.deadline
-            : Boolean(result?.late),
+          closeEligible: cumulativeCycle.eligible,
+          late: cumulativeCycle.late,
           monthState: monthCloseRequest ? cashflowMonthCloseRequestView(monthCloseRequest) : null,
         };
         const cashflowSourceUnavailable = jvmPartial.unavailableSections.has('cashflow');
@@ -4470,7 +4484,8 @@ export function mountJvmWeeklyApiRoutes(app, {
         throw createHttpError(502, '월 결산 자료 일부가 도착하지 않았습니다. 잠시 후 다시 시도해 주세요.', 'jvm_weekly_response_invalid');
       }
       const cycleBusinessDate = readOptionalText(sourceClose?.evaluatedBusinessDate) || comparisonBoundary.asOfDate;
-      const cumulativeCycle = cashflowCumulativeCloseCycle(yearMonth, cycleBusinessDate);
+      const cumulativeCycle = readJvmOperationalCycle(source, yearMonth)
+        || cashflowCumulativeCloseCycle(yearMonth, cycleBusinessDate);
       if (readOptionalText(sourceClose?.status) !== 'OPEN' || !cumulativeCycle?.eligible) {
         throw createHttpError(
           409,

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -3933,8 +3933,8 @@ export function mountJvmWeeklyApiRoutes(app, {
             'jvm_weekly_response_invalid',
           );
         }
-        const cumulativeCycle = readJvmOperationalCycle(source, yearMonth)
-          || cashflowCumulativeCloseCycle(yearMonth, cycleBusinessDate);
+        const operationalCycle = readJvmOperationalCycle(source, yearMonth);
+        const cumulativeCycle = operationalCycle || cashflowCumulativeCloseCycle(yearMonth, cycleBusinessDate);
         if (!cumulativeCycle) {
           throw createHttpError(502, '월 결산 회차 기준일을 확인할 수 없습니다.', 'jvm_weekly_response_invalid');
         }
@@ -3944,8 +3944,14 @@ export function mountJvmWeeklyApiRoutes(app, {
           targetYearMonth: cumulativeCycle.targetYearMonth,
           evaluatedBusinessDate: cycleBusinessDate,
           closeDeadline: cumulativeCycle.deadline,
-          closeEligible: cumulativeCycle.eligible,
-          late: cumulativeCycle.late,
+          closeEligible: operationalCycle
+            ? operationalCycle.eligible
+            : readOptionalText(result?.status) === 'OPEN' && cumulativeCycle.eligible,
+          late: operationalCycle
+            ? operationalCycle.late
+            : readOptionalText(result?.status) === 'OPEN'
+              ? cycleBusinessDate > cumulativeCycle.deadline
+              : Boolean(result?.late),
           monthState: monthCloseRequest ? cashflowMonthCloseRequestView(monthCloseRequest) : null,
         };
         const cashflowSourceUnavailable = jvmPartial.unavailableSections.has('cashflow');
@@ -4492,8 +4498,8 @@ export function mountJvmWeeklyApiRoutes(app, {
         throw createHttpError(502, '월 결산 자료 일부가 도착하지 않았습니다. 잠시 후 다시 시도해 주세요.', 'jvm_weekly_response_invalid');
       }
       const cycleBusinessDate = readOptionalText(sourceClose?.evaluatedBusinessDate) || comparisonBoundary.asOfDate;
-      const cumulativeCycle = readJvmOperationalCycle(source, yearMonth)
-        || cashflowCumulativeCloseCycle(yearMonth, cycleBusinessDate);
+      const operationalCycle = readJvmOperationalCycle(source, yearMonth);
+      const cumulativeCycle = operationalCycle || cashflowCumulativeCloseCycle(yearMonth, cycleBusinessDate);
       if (readOptionalText(sourceClose?.status) !== 'OPEN' || !cumulativeCycle?.eligible) {
         throw createHttpError(
           409,

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -1080,11 +1080,19 @@ function objectValue(value) {
 }
 
 function readJvmOperationalCycle(source, yearMonth) {
+  if (!source || typeof source !== 'object' || !Object.prototype.hasOwnProperty.call(source, 'operationalCycle')) return null;
   const cycle = objectValue(source?.operationalCycle);
-  if (!cycle || readOptionalText(cycle.cycleYearMonth) !== yearMonth) return null;
+  if (!cycle || readOptionalText(cycle.cycleYearMonth) !== yearMonth) {
+    throw createHttpError(502, 'JVM 월 결산 회차 자료가 올바르지 않습니다.', 'jvm_weekly_response_invalid');
+  }
   const targetYearMonth = readOptionalText(cycle.targetYearMonth);
   const deadline = readOptionalText(cycle.closeDeadline);
-  if (!targetYearMonth || !deadline || typeof cycle.closeEligible !== 'boolean' || typeof cycle.late !== 'boolean') return null;
+  if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(targetYearMonth)
+    || !/^20\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/.test(deadline)
+    || typeof cycle.closeEligible !== 'boolean'
+    || typeof cycle.late !== 'boolean') {
+    throw createHttpError(502, 'JVM 월 결산 회차 자료가 올바르지 않습니다.', 'jvm_weekly_response_invalid');
+  }
   return {
     cycleYearMonth: yearMonth,
     targetYearMonth,

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -1050,20 +1050,21 @@ describe('JVM weekly API BFF proxy', () => {
 
   it('publishes the server-owned 2026 board, status joins, and comparison presentation', async () => {
     const source = fullMonthCloseSource();
+    const dashboardSource = monthDashboardSource(
+      { ok: true, projectId: 'project-a', yearMonth: '2026-08', status: 'OPEN', revision: 0 },
+      undefined, undefined, undefined, undefined, closedCumulativeAuthority('2026-07'),
+    );
+    dashboardSource.operationalCycle = {
+      cycleYearMonth: '2026-08', targetYearMonth: '2026-07', closeDeadline: '2099-01-02',
+      closeEligible: true, late: false,
+    };
     source.documents.set('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-08', {
       requestId: 'project-a-2026-08', projectId: 'project-a', yearMonth: '2026-08', status: 'PENDING',
     });
     const fetchImpl = vi.fn(async () => ({
       ok: true,
       status: 200,
-      text: async () => JSON.stringify(monthDashboardSource(
-        { ok: true, projectId: 'project-a', yearMonth: '2026-08', status: 'OPEN', revision: 0 },
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        closedCumulativeAuthority('2026-07'),
-      )),
+      text: async () => JSON.stringify(dashboardSource),
     }));
     const { app } = createApp(fetchImpl, createIdempotencyService(), {}, {
       env: runtimeEnv,
@@ -1100,6 +1101,9 @@ describe('JVM weekly API BFF proxy', () => {
           },
         });
         expect(presentation.weeks).toHaveLength(60);
+        expect(response.body.dashboard.summary).toMatchObject({
+          targetYearMonth: '2026-07', closeDeadline: '2099-01-02', late: false,
+        });
         expect(presentation.months).toHaveLength(12);
         expect(presentation.months.find((month) => month.yearMonth === '2026-07')).toMatchObject({
           label: '2026년 07월', columnCount: 5, status: 'CLOSED', locked: true, overdue: false,

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowMonthDashboardSourceResponse.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowMonthDashboardSourceResponse.java
@@ -13,7 +13,8 @@ public record CashflowMonthDashboardSourceResponse(
     CashflowProjectionActualSummaryBatchResponse.Item projectionActualSummary,
     List<Blocker> blockers,
     List<SectionError> sectionErrors,
-    ActionCapability reopenRequest
+    ActionCapability reopenRequest,
+    OperationalCycle operationalCycle
 ) {
     public CashflowMonthDashboardSourceResponse(
         CashflowMonthCloseResponse monthClose,
@@ -26,7 +27,7 @@ public record CashflowMonthDashboardSourceResponse(
     ) {
         this(
             monthClose, monthClose, null, cashflow, openingBalances, snapshotCompatibility, cumulativeClose,
-            projectionActualSummary, blockers, List.of(), ActionCapability.unavailable()
+            projectionActualSummary, blockers, List.of(), ActionCapability.unavailable(), null
         );
     }
 
@@ -40,7 +41,7 @@ public record CashflowMonthDashboardSourceResponse(
     ) {
         this(
             monthClose, monthClose, null, cashflow, openingBalances, snapshotCompatibility, cumulativeClose,
-            projectionActualSummary, List.of(), List.of(), ActionCapability.unavailable()
+            projectionActualSummary, List.of(), List.of(), ActionCapability.unavailable(), null
         );
     }
 
@@ -52,7 +53,7 @@ public record CashflowMonthDashboardSourceResponse(
     ) {
         this(
             monthClose, monthClose, null, cashflow, openingBalances, snapshotCompatibility, CumulativeClose.missing(),
-            null, List.of(), List.of(), ActionCapability.unavailable()
+            null, List.of(), List.of(), ActionCapability.unavailable(), null
         );
     }
 
@@ -80,6 +81,14 @@ public record CashflowMonthDashboardSourceResponse(
             return new ActionCapability(false, "CUMULATIVE_CLOSE_AUTHORITY_UNAVAILABLE");
         }
     }
+
+    public record OperationalCycle(
+        String cycleYearMonth,
+        String targetYearMonth,
+        String closeDeadline,
+        boolean closeEligible,
+        boolean late
+    ) {}
 
     public record MonthStatusEvidence(
         String authority,

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -33,9 +33,12 @@ import dev.merryai.innerplatform.weekly.service.command.CashflowSheetAnnualApply
 import dev.merryai.innerplatform.weekly.service.port.CashflowMonthReopenPort;
 import dev.merryai.innerplatform.weekly.service.query.CashflowMonthDashboardQueryService;
 import dev.merryai.innerplatform.weekly.domain.CashflowAnnualCellSet;
+import dev.merryai.innerplatform.weekly.domain.CashflowCloseDeadline;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -582,7 +585,25 @@ public class WeeklyExpenseController {
             new CashflowMonthDashboardSourceResponse.ActionCapability(
                 result.reopenRequest().enabled(),
                 result.reopenRequest().reasonCode()
-            )
+            ),
+            operationalCycle(yearMonth, operationalStatus, latestRun)
+        );
+    }
+
+    private static CashflowMonthDashboardSourceResponse.OperationalCycle operationalCycle(
+        String yearMonth,
+        String operationalStatus,
+        CashflowMonthCloseResponse latestRun
+    ) {
+        YearMonth cycleMonth = YearMonth.parse(yearMonth);
+        YearMonth targetMonth = cycleMonth.minusMonths(1);
+        LocalDate evaluatedBusinessDate = LocalDate.parse(latestRun.evaluatedBusinessDate());
+        LocalDate closeDeadline = CashflowCloseDeadline.forCumulativeCycle(cycleMonth);
+        boolean open = "OPEN".equals(operationalStatus);
+        return new CashflowMonthDashboardSourceResponse.OperationalCycle(
+            cycleMonth.toString(), targetMonth.toString(), closeDeadline.toString(),
+            open && targetMonth.isBefore(YearMonth.from(evaluatedBusinessDate)),
+            open ? evaluatedBusinessDate.isAfter(closeDeadline) : latestRun.late()
         );
     }
 

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
@@ -1735,6 +1735,12 @@ class WeeklyExpenseControllerTest {
             .isEqualTo("2026-07");
         assertThat(json.path("cumulativeClose").path("settlementMonth").asText())
             .isEqualTo("2026-08");
+        assertThat(json.path("operationalCycle")).isNotNull();
+        assertThat(json.path("operationalCycle").path("cycleYearMonth").asText()).isEqualTo("2026-08");
+        assertThat(json.path("operationalCycle").path("targetYearMonth").asText()).isEqualTo("2026-07");
+        assertThat(json.path("operationalCycle").path("closeDeadline").asText()).isEqualTo("2026-08-10");
+        assertThat(json.path("operationalCycle").path("closeEligible").asBoolean()).isTrue();
+        assertThat(json.path("operationalCycle").path("late").asBoolean()).isTrue();
         assertThat(json.path("reopenRequest").path("enabled").asBoolean()).isTrue();
     }
 


### PR DESCRIPTION
## Rollout\nThis is the second, compatibility-only step after #622. It consumes source.operationalCycle when present and keeps the existing BFF calculation only for old JVM responses without that field. No Firestore write path or portal UI changes.\n\n## Verification\n- targeted BFF board test passes\n- existing fallback remains in place\n\nDo not merge until #622 JVM deployment is live.