### PR TITLE
feat(cashflow): expose the JVM month close calendar

### DIFF
--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowMonthDashboardSourceResponse.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowMonthDashboardSourceResponse.java
@@ -14,7 +14,8 @@ public record CashflowMonthDashboardSourceResponse(
     List<Blocker> blockers,
     List<SectionError> sectionErrors,
     ActionCapability reopenRequest,
-    OperationalCycle operationalCycle
+    OperationalCycle operationalCycle,
+    List<MonthSettlementCalendarItem> monthCloseCalendar
 ) {
     public CashflowMonthDashboardSourceResponse(
         CashflowMonthCloseResponse monthClose,
@@ -27,7 +28,7 @@ public record CashflowMonthDashboardSourceResponse(
     ) {
         this(
             monthClose, monthClose, null, cashflow, openingBalances, snapshotCompatibility, cumulativeClose,
-            projectionActualSummary, blockers, List.of(), ActionCapability.unavailable(), null
+            projectionActualSummary, blockers, List.of(), ActionCapability.unavailable(), null, List.of()
         );
     }
 
@@ -41,7 +42,7 @@ public record CashflowMonthDashboardSourceResponse(
     ) {
         this(
             monthClose, monthClose, null, cashflow, openingBalances, snapshotCompatibility, cumulativeClose,
-            projectionActualSummary, List.of(), List.of(), ActionCapability.unavailable(), null
+            projectionActualSummary, List.of(), List.of(), ActionCapability.unavailable(), null, List.of()
         );
     }
 
@@ -53,7 +54,7 @@ public record CashflowMonthDashboardSourceResponse(
     ) {
         this(
             monthClose, monthClose, null, cashflow, openingBalances, snapshotCompatibility, CumulativeClose.missing(),
-            null, List.of(), List.of(), ActionCapability.unavailable(), null
+            null, List.of(), List.of(), ActionCapability.unavailable(), null, List.of()
         );
     }
 
@@ -70,6 +71,7 @@ public record CashflowMonthDashboardSourceResponse(
         blockers = blockers == null ? List.of() : List.copyOf(blockers);
         sectionErrors = sectionErrors == null ? List.of() : List.copyOf(sectionErrors);
         reopenRequest = reopenRequest == null ? ActionCapability.unavailable() : reopenRequest;
+        monthCloseCalendar = monthCloseCalendar == null ? List.of() : List.copyOf(monthCloseCalendar);
     }
 
     public record Blocker(String code, String message) {}
@@ -88,6 +90,13 @@ public record CashflowMonthDashboardSourceResponse(
         String closeDeadline,
         boolean closeEligible,
         boolean late
+    ) {}
+
+    public record MonthSettlementCalendarItem(
+        String yearMonth,
+        String closeDeadline,
+        String closeDeadlineAt,
+        String approverDeadlineAt
     ) {}
 
     public record MonthStatusEvidence(

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseController.java
@@ -33,6 +33,7 @@ import dev.merryai.innerplatform.weekly.service.command.CashflowSheetAnnualApply
 import dev.merryai.innerplatform.weekly.service.port.CashflowMonthReopenPort;
 import dev.merryai.innerplatform.weekly.service.query.CashflowMonthDashboardQueryService;
 import dev.merryai.innerplatform.weekly.domain.CashflowAnnualCellSet;
+import dev.merryai.innerplatform.weekly.domain.ApproverDeadlineCalculator;
 import dev.merryai.innerplatform.weekly.domain.CashflowCloseDeadline;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -586,7 +587,8 @@ public class WeeklyExpenseController {
                 result.reopenRequest().enabled(),
                 result.reopenRequest().reasonCode()
             ),
-            operationalCycle(yearMonth, operationalStatus, latestRun)
+            operationalCycle(yearMonth, operationalStatus, latestRun),
+            monthCloseCalendar(yearMonth)
         );
     }
 
@@ -605,6 +607,21 @@ public class WeeklyExpenseController {
             open && targetMonth.isBefore(YearMonth.from(evaluatedBusinessDate)),
             open ? evaluatedBusinessDate.isAfter(closeDeadline) : latestRun.late()
         );
+    }
+
+    private static List<CashflowMonthDashboardSourceResponse.MonthSettlementCalendarItem> monthCloseCalendar(
+        String yearMonth
+    ) {
+        YearMonth selectedYear = YearMonth.parse(yearMonth).withMonth(1);
+        return java.util.stream.IntStream.range(0, 12)
+            .mapToObj(selectedYear::plusMonths)
+            .map(targetMonth -> new CashflowMonthDashboardSourceResponse.MonthSettlementCalendarItem(
+                targetMonth.toString(),
+                CashflowCloseDeadline.forTargetMonth(targetMonth).toString(),
+                CashflowCloseDeadline.settlementDeadlineAt(targetMonth).toString(),
+                ApproverDeadlineCalculator.monthly(targetMonth.toString(), 3).toString()
+            ))
+            .toList();
     }
 
     private String blockerGuide(String code) {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowCloseDeadline.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowCloseDeadline.java
@@ -1,7 +1,9 @@
 package dev.merryai.innerplatform.weekly.domain;
 
 import java.time.LocalDate;
+import java.time.Instant;
 import java.time.YearMonth;
+import java.time.ZoneId;
 
 /**
  * 월 결산 기한 규칙의 단일 소스.
@@ -17,6 +19,7 @@ import java.time.YearMonth;
  * 대상 월은 직전 월이므로 두 표현은 같은 날짜를 가리킨다.
  */
 public final class CashflowCloseDeadline {
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
 
     private CashflowCloseDeadline() {
     }
@@ -33,6 +36,11 @@ public final class CashflowCloseDeadline {
 
     public static LocalDate forMonth(YearMonth cycleOrTargetMonth, boolean cumulative) {
         return cumulative ? forCumulativeCycle(cycleOrTargetMonth) : forTargetMonth(cycleOrTargetMonth);
+    }
+
+    /** 실무자 마감 시각. 대상 월 다음 달 11일 00:00 KST. */
+    public static Instant settlementDeadlineAt(YearMonth targetMonth) {
+        return forTargetMonth(targetMonth).plusDays(1).atStartOfDay(SEOUL).toInstant();
     }
 
     /** 기한 초과 여부. 확정된 달은 초과로 보지 않는다. */

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/api/WeeklyExpenseControllerTest.java
@@ -1741,6 +1741,15 @@ class WeeklyExpenseControllerTest {
         assertThat(json.path("operationalCycle").path("closeDeadline").asText()).isEqualTo("2026-08-10");
         assertThat(json.path("operationalCycle").path("closeEligible").asBoolean()).isTrue();
         assertThat(json.path("operationalCycle").path("late").asBoolean()).isTrue();
+        assertThat(json.path("monthCloseCalendar")).hasSize(12);
+        assertThat(json.path("monthCloseCalendar").get(0).path("yearMonth").asText()).isEqualTo("2026-01");
+        assertThat(json.path("monthCloseCalendar").get(7).path("yearMonth").asText()).isEqualTo("2026-08");
+        assertThat(json.path("monthCloseCalendar").get(7).path("closeDeadline").asText())
+            .isEqualTo("2026-09-10");
+        assertThat(json.path("monthCloseCalendar").get(7).path("closeDeadlineAt").asText())
+            .isEqualTo("2026-09-10T15:00:00Z");
+        assertThat(json.path("monthCloseCalendar").get(7).path("approverDeadlineAt").asText())
+            .isEqualTo("2026-09-13T15:00:00Z");
         assertThat(json.path("reopenRequest").path("enabled").asBoolean()).isTrue();
     }
 

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowCloseDeadlineTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowCloseDeadlineTest.java
@@ -3,6 +3,7 @@ package dev.merryai.innerplatform.weekly.domain;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
+import java.time.Instant;
 import java.time.YearMonth;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -37,6 +38,14 @@ class CashflowCloseDeadlineTest {
         // 회차가 덮는 대상 월은 직전 월이므로 두 표현은 같은 날짜여야 한다.
         assertThat(CashflowCloseDeadline.forCumulativeCycle(YearMonth.parse("2026-08")))
             .isEqualTo(CashflowCloseDeadline.forTargetMonth(YearMonth.parse("2026-07")));
+    }
+
+    @Test
+    void settlementDeadlineAtIsTheEleventhAtMidnightInSeoul() {
+        assertThat(CashflowCloseDeadline.settlementDeadlineAt(YearMonth.parse("2026-08")))
+            .isEqualTo(Instant.parse("2026-09-10T15:00:00Z"));
+        assertThat(CashflowCloseDeadline.settlementDeadlineAt(YearMonth.parse("2026-12")))
+            .isEqualTo(Instant.parse("2027-01-10T15:00:00Z"));
     }
 
     @Test


### PR DESCRIPTION
## Scope\nJVM dashboard-source에 선택 연도의 12개월 monthCloseCalendar 계약을 추가합니다. BFF가 날짜 규칙을 재계산하지 않고 읽기 전용으로 소비할 수 있는 1차 계약입니다.\n\n각 항목: yearMonth, closeDeadline, closeDeadlineAt, approverDeadlineAt.\n기존 operationalCycle과 Firestore read/write 경로는 유지합니다.\n\n## Verification\n- JVM deadline boundary tests\n- dashboard-source JSON 12-item/order/instant contract assertions\n\nBFF helper 제거는 이 JVM 배포와 실제 응답 확인 뒤 별도 단계로 진행합니다.