### PR TITLE
feat(cashflow): expose JVM month settlement deadlines

### DIFF
--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSettlementStatusesResponse.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/api/CashflowSettlementStatusesResponse.java
@@ -14,7 +14,20 @@ public record CashflowSettlementStatusesResponse(
         String submittedBy,
         String approvedAt,
         String approvedBy,
-        long revision
+        long revision,
+        String deadlineAt,
+        String approverDeadlineAt
     ) {
+        public Item(
+            String period,
+            String status,
+            String submittedAt,
+            String submittedBy,
+            String approvedAt,
+            String approvedBy,
+            long revision
+        ) {
+            this(period, status, submittedAt, submittedBy, approvedAt, approvedBy, revision, null, null);
+        }
     }
 }

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -80,6 +80,8 @@ import dev.merryai.innerplatform.weekly.domain.CellValidationStatus;
 import dev.merryai.innerplatform.weekly.domain.CashflowLineCatalog;
 import dev.merryai.innerplatform.weekly.domain.CashflowProjectionActualSummaryCalculator;
 import dev.merryai.innerplatform.weekly.domain.CashflowMonthSettlementLifecycle;
+import dev.merryai.innerplatform.weekly.domain.ApproverDeadlineCalculator;
+import dev.merryai.innerplatform.weekly.domain.CashflowCloseDeadline;
 import dev.merryai.innerplatform.weekly.domain.CashflowFormulaValidator;
 import dev.merryai.innerplatform.weekly.domain.ClipboardCell;
 import dev.merryai.innerplatform.weekly.domain.ClipboardPayload;
@@ -109,6 +111,7 @@ import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.Clock;
+import java.time.YearMonth;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
@@ -265,10 +268,24 @@ public class WeeklyExpenseCommandService {
         return new CashflowSettlementStatusesResponse(
             projectId,
             yearMonth,
-            records.stream().map(record -> new CashflowSettlementStatusesResponse.Item(
-                record.period(), record.status(), record.submittedAt(), record.submittedBy(),
-                record.approvedAt(), record.approvedBy(), record.revision()
-            )).toList()
+            records.stream().map(record -> settlementStatusItem(yearMonth, record)).toList()
+        );
+    }
+
+    private static CashflowSettlementStatusesResponse.Item settlementStatusItem(
+        String yearMonth,
+        WeeklyExpensePersistence.CashflowSettlementStatusRecord record
+    ) {
+        String deadlineAt = null;
+        String approverDeadlineAt = null;
+        if ("MONTH".equals(record.period())) {
+            YearMonth targetMonth = YearMonth.parse(yearMonth);
+            deadlineAt = CashflowCloseDeadline.settlementDeadlineAt(targetMonth).toString();
+            approverDeadlineAt = ApproverDeadlineCalculator.monthly(yearMonth, 3).toString();
+        }
+        return new CashflowSettlementStatusesResponse.Item(
+            record.period(), record.status(), record.submittedAt(), record.submittedBy(),
+            record.approvedAt(), record.approvedBy(), record.revision(), deadlineAt, approverDeadlineAt
         );
     }
 
@@ -400,7 +417,8 @@ public class WeeklyExpenseCommandService {
                 ? new CashflowSettlementStatusesResponse.Item(
                     item.period(),
                     CashflowMonthSettlementLifecycle.resolveMonthStatus(item.status(), monthCloseRequestStatus),
-                    item.submittedAt(), item.submittedBy(), item.approvedAt(), item.approvedBy(), item.revision()
+                    item.submittedAt(), item.submittedBy(), item.approvedAt(), item.approvedBy(), item.revision(),
+                    item.deadlineAt(), item.approverDeadlineAt()
                 )
                 : item
             ).toList()

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowWeeklyOverviewServiceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowWeeklyOverviewServiceTest.java
@@ -3,6 +3,7 @@ package dev.merryai.innerplatform.weekly.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import dev.merryai.innerplatform.weekly.api.CashflowWeeklyOverviewRequest;
 import dev.merryai.innerplatform.weekly.api.CashflowWeeklyOverviewResponse;
+import dev.merryai.innerplatform.weekly.api.CashflowSettlementStatusesResponse;
 import dev.merryai.innerplatform.weekly.api.TrustedActorContext;
 import dev.merryai.innerplatform.weekly.domain.CashflowLedgerSource;
 import dev.merryai.innerplatform.weekly.storage.WeeklyExpensePersistence;
@@ -50,6 +51,12 @@ class CashflowWeeklyOverviewServiceTest {
         assertThat(response.items()).hasSize(2);
         assertThat(response.items().get(0).settlementStatuses().items().getFirst().status()).isEqualTo("COMPLETED");
         assertThat(response.items().get(1).settlementStatuses().items().getFirst().status()).isEqualTo("PENDING_APPROVAL");
+        assertThat(response.items()).allSatisfy(item -> assertThat(item.settlementStatuses().items().getFirst())
+            .extracting(
+                CashflowSettlementStatusesResponse.Item::deadlineAt,
+                CashflowSettlementStatusesResponse.Item::approverDeadlineAt
+            )
+            .containsExactly("2026-09-10T15:00:00Z", "2026-09-13T15:00:00Z"));
         assertThat(response.items()).allSatisfy(item -> assertThat(item.projectionActualSummary()).isNotNull());
         assertThat(response.errors()).isEmpty();
         verify(authorization).requireProjectsAllowedForCommands(


### PR DESCRIPTION
## What/why
- expose the existing JVM monthly deadline contract on settlement status items
- preserve old constructors and all Firestore/read/write paths
- let the next BFF change remove its duplicate monthly deadline calculation

## Verification
- `mvn -q -f server/jvm-weekly-api/pom.xml -Dtest=CashflowWeeklyOverviewServiceTest test`

This is an additive contract; deploy and verify before the BFF helper removal.