### PR TITLE
feat(cashflow): consume JVM month close calendar

### DIFF
--- a/server/bff/cashflow-close-calendar.mjs
+++ b/server/bff/cashflow-close-calendar.mjs
@@ -1,14 +1,9 @@
-// 누적 월 결산의 달력 규칙 (BFF 쪽 도메인).
+// 누적 월 결산의 범위·authority 문서 계약 (BFF 읽기/쓰기 경계).
 //
 // 누적 결산은 2023-01 을 기점으로 "선택한 회차 월의 직전 월"까지를 한 번에 덮는다.
-// 이 모듈은 그 범위 계산만 안다 - HTTP 상태코드도, Firestore 도 모른다. 범위가
+// 이 모듈은 deadline을 계산하지 않고 범위만 안다 - HTTP 상태코드도, Firestore 도 모른다. 범위가
 // 성립하지 않으면 null 을 돌려주고, 사용자에게 뭐라고 말할지는 라우트가 정한다.
 //
-// 회차 기한(회차 월의 10일)은 기한 규칙의 단일 소스인 cashflow-close-deadline 에서
-// 파생한다. 회차 월의 10일 == "직전 월을 대상 월로 본 기한" 이며, JVM 의
-// CashflowCloseDeadline.forCumulativeCycle 과 같은 표현이다.
-import { cashflowMonthCloseDeadline } from './cashflow-close-deadline.mjs';
-
 export const CASHFLOW_CUMULATIVE_CLOSE_CONTRACT = 'cashflow-cumulative-close-v2';
 export const CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH = '2023-01';
 const SHA256_PATTERN = /^sha256:[0-9a-f]{64}$/;
@@ -148,19 +143,5 @@ export function readCashflowCumulativeCloseScope(record = {}) {
     validRange: Boolean(expected && fromMonth === expected.fromMonth) || (legacy && legacyRange),
     strictRange: !legacy,
     legacy,
-  };
-}
-
-export function cashflowCumulativeCloseCycle(yearMonth, businessDate) {
-  if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(String(yearMonth))
-    || !/^20\d{2}-(0[1-9]|1[0-2])-\d{2}$/.test(String(businessDate))) return null;
-  const targetYearMonth = previousYearMonth(yearMonth);
-  return {
-    cycleYearMonth: yearMonth,
-    targetYearMonth,
-    // 회차 월의 10일. 기한 규칙의 단일 소스에서 파생한다 - `${yearMonth}-10` 을
-    // 여기서 또 쓰면 기한 규칙이 세 번째로 복제된다.
-    deadline: cashflowMonthCloseDeadline(targetYearMonth),
-    eligible: targetYearMonth < String(businessDate).slice(0, 7),
   };
 }

--- a/server/bff/cashflow-close-calendar.test.mjs
+++ b/server/bff/cashflow-close-calendar.test.mjs
@@ -1,13 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
   CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH,
-  cashflowCumulativeCloseCycle,
   cumulativeCloseMonthsOrNull,
   monthsBetween,
   previousYearMonth,
   readCashflowCumulativeCloseAuthority,
 } from './cashflow-close-calendar.mjs';
-import { cashflowMonthCloseDeadline } from './cashflow-close-deadline.mjs';
 
 describe('cashflow close calendar', () => {
   it('walks months inclusively and wraps years', () => {
@@ -26,23 +24,6 @@ describe('cashflow close calendar', () => {
     // 기점 이전 회차는 성립하지 않는다. HTTP 로 뭐라 말할지는 라우트의 일이다.
     expect(cumulativeCloseMonthsOrNull('2023-01')).toBeNull();
     expect(cumulativeCloseMonthsOrNull('2022-12')).toBeNull();
-  });
-
-  it('derives the cycle deadline from the single deadline rule', () => {
-    // 회차 월의 10일 == 직전 월을 대상 월로 본 기한. JVM CashflowCloseDeadline.forCumulativeCycle
-    // 과 같은 표현이며, 기한 규칙의 parity 표는 cashflow-close-deadline.test.mjs 가 가진다.
-    for (const cycle of ['2023-02', '2026-01', '2026-08', '2026-12']) {
-      const result = cashflowCumulativeCloseCycle(cycle, '2026-08-09');
-      expect(result?.deadline).toBe(`${cycle}-10`);
-      expect(result?.deadline).toBe(cashflowMonthCloseDeadline(previousYearMonth(cycle)));
-    }
-  });
-
-  it('marks the cycle eligible only after the target month has ended', () => {
-    expect(cashflowCumulativeCloseCycle('2026-08', '2026-08-09')?.eligible).toBe(true);
-    expect(cashflowCumulativeCloseCycle('2026-09', '2026-08-09')?.eligible).toBe(false);
-    expect(cashflowCumulativeCloseCycle('bad', '2026-08-09')).toBeNull();
-    expect(cashflowCumulativeCloseCycle('2026-08', 'bad')).toBeNull();
   });
 
   it('accepts only complete cumulative authority heads and the explicit empty JVM state', () => {

--- a/server/bff/cashflow-close-deadline.mjs
+++ b/server/bff/cashflow-close-deadline.mjs
@@ -1,35 +1,7 @@
-// 월 결산 기한 규칙의 단일 소스.
-//
-// 판정 주체는 JVM 이다. 다만 대시보드는 선택한 달 하나가 아니라 모든 달을 한 번에
-// 그려야 해서 BFF 에도 같은 규칙이 필요하다. 그 "같은 규칙" 을 두 런타임이 각자
-// 구현하면 조용히 갈린다 - SPEC-16 의 revision 해시가 JVM a400f3… / BFF ea20de… 로
-// 갈렸던 것이 같은 종류다.
-//
-// 그래서 규칙을 이 모듈 하나에 두고, JVM CashflowCloseDeadline 과 같은 표를
-// 양쪽 테스트에 둔다. 한쪽을 고치면 다른 쪽 표가 깨지도록 한 것이다.
-//
-// 규칙: 대상 월의 다음 달 10일. (JVM YearMonth.parse(ym).plusMonths(1).atDay(10))
+// 주간 표시 deadline 보조 함수. 월간 deadline은 JVM monthCloseCalendar 계약에서만 온다.
 
 const YEAR_MONTH_RE = /^(20\d{2})-(0[1-9]|1[0-2])$/;
-const BUSINESS_DATE_RE = /^20\d{2}-(0[1-9]|1[0-2])-\d{2}$/;
 
-export function isCashflowYearMonth(value) {
-  return YEAR_MONTH_RE.test(String(value ?? ''));
-}
-
-export function cashflowMonthCloseDeadline(yearMonth) {
-  const match = YEAR_MONTH_RE.exec(String(yearMonth ?? ''));
-  if (!match) return null;
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  const deadlineYear = month === 12 ? year + 1 : year;
-  const deadlineMonth = month === 12 ? 1 : month + 1;
-  return `${deadlineYear}-${String(deadlineMonth).padStart(2, '0')}-10`;
-}
-
-// --- 조직장 승인 마감 (2026-08-20 보람) ---
-// 표시 전용 규칙이다. 쓰기를 막지도, 미준수를 누적하지도 않는다(미준수는 실무자 마감 기준뿐).
-// 그래서 판정 주체(JVM) 짝 없이 BFF 에만 둔다 - 이 마감이 쓰기를 막게 되는 날 JVM 으로 옮긴다.
 // Asia/Seoul 은 DST 가 없어 KST 0시 = UTC 전날 15시 고정이다.
 const KST_OFFSET_MS = 9 * 3_600_000;
 const DAY_MS = 86_400_000;
@@ -69,38 +41,4 @@ export function cashflowFinanceWeekDeadlineAt(yearMonth, weekNo) {
   while (thursday <= end && new Date(thursday).getUTCDay() !== 4) thursday += DAY_MS;
   const deadlineDay = thursday > end ? end + DAY_MS : thursday + DAY_MS;
   return new Date(deadlineDay - KST_OFFSET_MS).toISOString();
-}
-
-function kstMidnightInstant(year, month, day) {
-  return new Date(Date.UTC(year, month - 1, day) - KST_OFFSET_MS).toISOString();
-}
-
-function nextMonthOf(yearMonth) {
-  const match = YEAR_MONTH_RE.exec(String(yearMonth ?? ''));
-  if (!match) return null;
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  return month === 12 ? [year + 1, 1] : [year, month + 1];
-}
-
-// 월결산 실무자 마감의 시각 표현: 익월 10일 자정 = 11일 0시 KST.
-// (cashflowMonthCloseDeadline 의 날짜 규칙과 같은 표 - 10일이 마지막 유효일)
-export function cashflowMonthCloseDeadlineAt(yearMonth) {
-  const next = nextMonthOf(yearMonth);
-  return next ? kstMidnightInstant(next[0], next[1], 11) : null;
-}
-
-// 월결산 조직장 승인 마감: 달력 고정 익월 14일 0시 KST. 실무자가 늦게 요청하면
-// 조직장 시간이 3일보다 짧아진다 - 요청+3일이 아니라 달력 고정(2026-08-20 결정).
-export function cashflowMonthCloseApproverDeadlineAt(yearMonth) {
-  const next = nextMonthOf(yearMonth);
-  return next ? kstMidnightInstant(next[0], next[1], 14) : null;
-}
-
-// 기한 초과 여부. 기준일을 모르면 단정하지 않는다 - 판정 불능과 "초과 아님" 은 다르다.
-export function isCashflowCloseOverdue({ yearMonth, status, businessDate }) {
-  if (!BUSINESS_DATE_RE.test(String(businessDate ?? ''))) return false;
-  if (String(status ?? '').toUpperCase() === 'CLOSED') return false;
-  const deadline = cashflowMonthCloseDeadline(yearMonth);
-  return Boolean(deadline) && String(businessDate) > deadline;
 }

--- a/server/bff/cashflow-close-deadline.test.mjs
+++ b/server/bff/cashflow-close-deadline.test.mjs
@@ -1,60 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
   cashflowFinanceWeekDeadlineAt,
-  cashflowMonthCloseApproverDeadlineAt,
-  cashflowMonthCloseDeadline,
-  cashflowMonthCloseDeadlineAt,
   cashflowWeeklyApproverDeadlineAt,
-  isCashflowCloseOverdue,
 } from './cashflow-close-deadline.mjs';
 
-// PARITY TABLE — JVM CashflowCloseDeadlineTest 와 같은 표다.
-// 한쪽 규칙을 고치면 다른 쪽 표가 깨지도록 의도적으로 중복해 둔 것이므로,
-// 값이 달라져야 한다면 반드시 두 파일을 함께 고쳐라.
-const DEADLINE_PARITY = [
-  ['2026-01', '2026-02-10'],
-  ['2026-07', '2026-08-10'],
-  ['2026-09', '2026-10-10'],
-  ['2026-11', '2026-12-10'],
-  ['2026-12', '2027-01-10'],
-  ['2027-12', '2028-01-10'],
-  ['2024-02', '2024-03-10'],
-];
-
-describe('cashflow close deadline — JVM parity', () => {
-  it.each(DEADLINE_PARITY)('%s 의 기한은 %s', (yearMonth, expected) => {
-    expect(cashflowMonthCloseDeadline(yearMonth)).toBe(expected);
-  });
-
-  it.each(['not-a-month', '', '2026-13', '2026-00', '1999-05', null, undefined])(
-    'rejects %j instead of guessing a deadline',
-    (value) => {
-      expect(cashflowMonthCloseDeadline(value)).toBeNull();
-    },
-  );
-});
-
-describe('close overdue', () => {
-  it('is overdue only after the deadline day', () => {
-    const base = { yearMonth: '2026-07', status: 'OPEN' };
-    expect(isCashflowCloseOverdue({ ...base, businessDate: '2026-08-09' })).toBe(false);
-    expect(isCashflowCloseOverdue({ ...base, businessDate: '2026-08-10' })).toBe(false);
-    expect(isCashflowCloseOverdue({ ...base, businessDate: '2026-08-11' })).toBe(true);
-  });
-
-  it('never marks a closed month overdue', () => {
-    expect(isCashflowCloseOverdue({ yearMonth: '2026-07', status: 'CLOSED', businessDate: '2026-12-31' })).toBe(false);
-    expect(isCashflowCloseOverdue({ yearMonth: '2026-07', status: 'closed', businessDate: '2026-12-31' })).toBe(false);
-  });
-
-  // 기준일을 모르는 것과 "초과 아님" 은 다르다 — 단정하지 않는다.
-  it.each(['', 'not-a-date', undefined])('does not assert overdue without a business date (%j)', (businessDate) => {
-    expect(isCashflowCloseOverdue({ yearMonth: '2026-07', status: 'OPEN', businessDate })).toBe(false);
-  });
-});
-
-// 조직장 승인 마감(2026-08-20)은 표시 전용이라 JVM 짝이 없다 - 쓰기를 막게 되면 그때 JVM 으로.
-describe('approver deadlines — display only, KST', () => {
+describe('weekly approver deadlines — display only, KST', () => {
   it('weekly approver deadline is the practitioner deadline + 13 hours', () => {
     // 실무자 마감 금 0시 KST = 목 15:00Z → 승인 마감 금 13:00 KST = 금 04:00Z
     expect(cashflowWeeklyApproverDeadlineAt('2026-08-20T15:00:00Z')).toBe('2026-08-21T04:00:00.000Z');
@@ -64,18 +14,6 @@ describe('approver deadlines — display only, KST', () => {
     expect(cashflowWeeklyApproverDeadlineAt(undefined)).toBeNull();
   });
 
-  it('month practitioner instant is the 11th 00:00 KST — same table as the date rule', () => {
-    // 10일이 마지막 유효일 = 11일 0시 KST = 10일 15:00Z
-    expect(cashflowMonthCloseDeadlineAt('2026-07')).toBe('2026-08-10T15:00:00.000Z');
-    expect(cashflowMonthCloseDeadlineAt('2026-12')).toBe('2027-01-10T15:00:00.000Z');
-    expect(cashflowMonthCloseDeadlineAt('2026-13')).toBeNull();
-  });
-
-  it('month approver deadline is calendar-fixed at the 14th 00:00 KST, not request+3d', () => {
-    expect(cashflowMonthCloseApproverDeadlineAt('2026-07')).toBe('2026-08-13T15:00:00.000Z');
-    expect(cashflowMonthCloseApproverDeadlineAt('2026-12')).toBe('2027-01-13T15:00:00.000Z');
-    expect(cashflowMonthCloseApproverDeadlineAt('nope')).toBeNull();
-  });
 });
 
 // PARITY TABLE — JVM FirestoreInheritedWeeklyExpensePersistence.financeWeekDeadline 과 같은 표다.

--- a/server/bff/routes/jvm-weekly-api.identity-token.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.identity-token.test.mjs
@@ -23,6 +23,22 @@ function liveJwt() {
   return `h.${payload}.s`;
 }
 
+function monthCloseCalendarFor(yearMonth) {
+  const year = Number(String(yearMonth).slice(0, 4));
+  return Array.from({ length: 12 }, (_unused, monthIndex) => {
+    const month = monthIndex + 1;
+    const nextMonth = month === 12 ? 1 : month + 1;
+    const nextYear = month === 12 ? year + 1 : year;
+    const isoAtKstMidnight = (day) => new Date(Date.UTC(nextYear, nextMonth - 1, day) - 9 * 60 * 60 * 1000).toISOString();
+    return {
+      yearMonth: `${year}-${String(month).padStart(2, '0')}`,
+      closeDeadline: `${nextYear}-${String(nextMonth).padStart(2, '0')}-10`,
+      closeDeadlineAt: isoAtKstMidnight(11),
+      approverDeadlineAt: isoAtKstMidnight(14),
+    };
+  });
+}
+
 function monthDashboardSource() {
   const monthClose = {
     ok: true,
@@ -53,6 +69,14 @@ function monthDashboardSource() {
       rootHash: `sha256:${'a'.repeat(64)}`,
       headRevision: 1,
     },
+    operationalCycle: {
+      cycleYearMonth: '2026-06',
+      targetYearMonth: '2026-05',
+      closeDeadline: '2026-06-10',
+      closeEligible: false,
+      late: false,
+    },
+    monthCloseCalendar: monthCloseCalendarFor('2026-06'),
     snapshotCompatibility: { status: 'LEGACY_EVIDENCE_ONLY', missingEvidence: ['OPENING_BALANCES', 'LEDGER_WEEKS'] },
     projectionActualSummary: {
       projectId: 'project-a',

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -40,7 +40,6 @@ import {
   CASHFLOW_CUMULATIVE_CLOSE_CONTRACT,
   CASHFLOW_CUMULATIVE_CLOSE_FROM_MONTH,
   cashflowCumulativeCloseScope,
-  cashflowCumulativeCloseCycle,
   cumulativeCloseMonthsOrNull,
   monthsBetween,
   previousYearMonth,
@@ -51,21 +50,14 @@ import {
   cashflowMonthCloseRequestPath,
   withdrawPendingCumulativeCloseRequest,
 } from '../cashflow-month-close-withdrawal.mjs';
-export { cashflowCumulativeCloseCycle };
 import {
   cashflowFinanceWeekDeadlineAt,
-  cashflowMonthCloseApproverDeadlineAt,
-  cashflowMonthCloseDeadline,
-  cashflowMonthCloseDeadlineAt,
   cashflowWeeklyApproverDeadlineAt,
-  isCashflowCloseOverdue,
 } from '../cashflow-close-deadline.mjs';
 import { cashflowMonthRequestCovers } from '../cashflow-month-state.mjs';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import * as z from 'zod/v4';
-
-export { cashflowMonthCloseDeadline };
 
 const CASHFLOW_LINE_INDEX = new Map(CASHFLOW_ALL_LINES.map((lineId, index) => [lineId, index]));
 const CASHFLOW_MONTH_CLOSE_ROUTE_TIMEOUT_MS = 26_000;
@@ -731,17 +723,9 @@ async function alignMonthSettlementStatus(db, tenantId, result) {
         : ['PENDING', 'REOPEN_REQUESTED', 'APPROVING', 'UNCERTAIN'].includes(requestStatus)
           ? 'PENDING_APPROVAL'
           : 'WAITING_FOR_UPDATE';
-    // 진행 바용 마감(표시 전용). 주차 마감은 JVM financeWeekDeadline 의 사본(패리티 표),
-    // 조직장 마감은 표시 전용 규칙이라 BFF 에만 있다.
+    // 월간 마감은 JVM 응답을 그대로 전달한다. 주간 표시만 기존 JVM parity 표를 사용한다.
     const withDeadlines = (item) => {
       const period = readOptionalText(item?.period);
-      if (period === 'MONTH') {
-        return {
-          ...item,
-          deadlineAt: cashflowMonthCloseDeadlineAt(yearMonth),
-          approverDeadlineAt: cashflowMonthCloseApproverDeadlineAt(yearMonth),
-        };
-      }
       const weekMatch = /^WEEK_([1-5])$/.exec(period);
       if (!weekMatch) return item;
       const deadlineAt = cashflowFinanceWeekDeadlineAt(yearMonth, Number(weekMatch[1]));
@@ -1077,6 +1061,71 @@ function commandBody(req) {
 
 function objectValue(value) {
   return value && typeof value === 'object' && !Array.isArray(value) ? value : null;
+}
+
+function jvmMonthCloseResponseInvalid() {
+  return createHttpError(502, 'JVM 월 결산 달력 자료가 올바르지 않습니다.', 'jvm_weekly_response_invalid');
+}
+
+function validJvmIsoDate(value) {
+  if (typeof value !== 'string' || value.trim() !== value
+    || !/^20\d{2}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00.000Z`);
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value;
+}
+
+function validJvmInstant(value) {
+  return typeof value === 'string'
+    && value.trim() === value
+    && value.length > 0
+    && Number.isFinite(Date.parse(value));
+}
+
+function readJvmOperationalCycle(source, yearMonth) {
+  if (!source || typeof source !== 'object' || !Object.hasOwn(source, 'operationalCycle')) {
+    throw jvmMonthCloseResponseInvalid();
+  }
+  const cycle = objectValue(source.operationalCycle);
+  if (!cycle || cycle.cycleYearMonth !== yearMonth
+    || !/^20\d{2}-(0[1-9]|1[0-2])$/.test(cycle.targetYearMonth)
+    || !validJvmIsoDate(cycle.closeDeadline)
+    || typeof cycle.closeEligible !== 'boolean'
+    || typeof cycle.late !== 'boolean') {
+    throw jvmMonthCloseResponseInvalid();
+  }
+  return {
+    cycleYearMonth: cycle.cycleYearMonth,
+    targetYearMonth: cycle.targetYearMonth,
+    deadline: cycle.closeDeadline,
+    eligible: cycle.closeEligible,
+    late: cycle.late,
+  };
+}
+
+function readJvmMonthCloseCalendar(source, yearMonth) {
+  if (!source || typeof source !== 'object' || !Object.hasOwn(source, 'monthCloseCalendar')) {
+    throw jvmMonthCloseResponseInvalid();
+  }
+  const calendar = source.monthCloseCalendar;
+  if (!Array.isArray(calendar) || calendar.length !== 12) throw jvmMonthCloseResponseInvalid();
+  const expectedYear = yearMonth.slice(0, 4);
+  const expectedMonths = Array.from({ length: 12 }, (_unused, index) => (
+    `${expectedYear}-${String(index + 1).padStart(2, '0')}`
+  ));
+  if (calendar.some((item, index) => {
+    const value = objectValue(item);
+    return !value
+      || value.yearMonth !== expectedMonths[index]
+      || !validJvmIsoDate(value.closeDeadline)
+      || !validJvmInstant(value.closeDeadlineAt)
+      || !validJvmInstant(value.approverDeadlineAt);
+  })) throw jvmMonthCloseResponseInvalid();
+  return new Map(calendar.map((item) => [item.yearMonth, {
+    yearMonth: item.yearMonth,
+    closeDeadline: item.closeDeadline,
+    closeDeadlineAt: item.closeDeadlineAt,
+    approverDeadlineAt: item.approverDeadlineAt,
+  }]));
 }
 
 function amendedSheetFormulaSnapshot(mirror, amendmentEvidence) {
@@ -2179,7 +2228,7 @@ function assertCashflowSheetPublicationReady(state) {
 
 
 async function readCashflowMonthCloseStatuses({
-  db, tenantId, projectId, selectedYear, weeklyYear, cumulativeAuthority, businessDate = '',
+  db, tenantId, projectId, selectedYear, weeklyYear, cumulativeAuthority, monthCloseCalendar, businessDate = '',
 }) {
   const canonicalWeeklyYear = readWeeklyYear(weeklyYear);
   const authority = objectValue(cumulativeAuthority) || {};
@@ -2321,6 +2370,7 @@ async function readCashflowMonthCloseStatuses({
   const historyUnavailable = historyByMonth === null;
   const statuses = Array.from({ length: 12 }, (_unused, monthIndex) => {
     const yearMonth = `${selectedYear}-${String(monthIndex + 1).padStart(2, '0')}`;
+    const calendarItem = monthCloseCalendar.get(yearMonth);
     const status = selectedYear === canonicalWeeklyYear && closedThrough && yearMonth <= closedThrough
       ? 'CLOSED'
       : 'OPEN';
@@ -2339,12 +2389,13 @@ async function readCashflowMonthCloseStatuses({
     return {
       yearMonth,
       status,
-      closeDeadline: cashflowMonthCloseDeadline(yearMonth),
-      // 진행 바용 시각 표현: 실무자 = 익월 11일 0시 KST, 조직장 승인 = 14일 0시 KST(표시 전용, 누적 없음).
-      closeDeadlineAt: cashflowMonthCloseDeadlineAt(yearMonth),
-      approverDeadlineAt: cashflowMonthCloseApproverDeadlineAt(yearMonth),
-      // 기준일을 모르면 기한 초과를 단정하지 않는다.
-      closeOverdue: isCashflowCloseOverdue({ yearMonth, status, businessDate }),
+      closeDeadline: calendarItem.closeDeadline,
+      closeDeadlineAt: calendarItem.closeDeadlineAt,
+      approverDeadlineAt: calendarItem.approverDeadlineAt,
+      // 기한 자체는 JVM 계약이고, 여기서는 기존 status/history join 에 기준일을 표시한다.
+      closeOverdue: /^20\d{2}-(0[1-9]|1[0-2])-\d{2}$/.test(businessDate)
+        && status !== 'CLOSED'
+        && businessDate > calendarItem.closeDeadline,
       sheetCalculationChecks: historyUnavailable
         ? null
         : Array.isArray(calculationChecks)
@@ -2790,7 +2841,7 @@ function deadlineSummaryFromCompliance(compliance, comparisonBoundary, weeklyYea
 
 async function composeCashflowMonthDashboard({
   db, req, projectId, yearMonth, close, cashflow, openingBalances, comparisonBoundary, weeklyCompliance,
-  projectionActualSummary, cumulativeAuthority, sectionErrors = [], sourceBlockers = [],
+  projectionActualSummary, cumulativeAuthority, monthCloseCalendar, sectionErrors = [], sourceBlockers = [],
   weeklyComplianceBoundary = comparisonBoundary,
 }) {
   const closedSnapshot = ['CLOSED', 'REOPEN_REQUESTED'].includes(readOptionalText(close?.status))
@@ -2833,7 +2884,7 @@ async function composeCashflowMonthDashboard({
     : readWeeklyYear(mirror?.weeklyYear);
   const [monthCloseStatusRead, annualTotals] = await Promise.all([
     readCashflowMonthCloseStatuses({
-      db, tenantId, projectId, selectedYear, weeklyYear, cumulativeAuthority, businessDate,
+      db, tenantId, projectId, selectedYear, weeklyYear, cumulativeAuthority, monthCloseCalendar, businessDate,
     }),
     readAnnualTotals({ db, tenantId, projectId, weeklyYear }),
   ]);
@@ -3219,6 +3270,8 @@ async function composeCashflowMonthDashboard({
       cycleYearMonth: readOptionalText(close?.cycleYearMonth) || yearMonth,
       targetYearMonth: readOptionalText(close?.targetYearMonth) || buildCumulativeCloseScope(yearMonth).throughMonth,
       closeDeadline: readOptionalText(close?.closeDeadline) || null,
+      closeDeadlineAt: readOptionalText(close?.closeDeadlineAt) || null,
+      approverDeadlineAt: readOptionalText(close?.approverDeadlineAt) || null,
       late: Boolean(close?.late),
     },
     validation: {
@@ -3896,6 +3949,9 @@ export function mountJvmWeeklyApiRoutes(app, {
         if (cashflow && readOptionalText(cashflow?.projectId) !== rawProjectId) {
           throw createHttpError(502, '다른 프로젝트의 자료가 도착했습니다. 화면을 새로고침해 주세요.', 'jvm_weekly_project_mismatch');
         }
+        const monthCloseCalendar = readJvmMonthCloseCalendar(source, yearMonth);
+        const operationalCycle = readJvmOperationalCycle(source, yearMonth);
+        const selectedCalendar = monthCloseCalendar.get(yearMonth);
         const cycleBusinessDate = readOptionalText(result?.evaluatedBusinessDate) || localComparisonBoundary.asOfDate;
         let comparisonBoundary;
         try {
@@ -3910,20 +3966,16 @@ export function mountJvmWeeklyApiRoutes(app, {
             'jvm_weekly_response_invalid',
           );
         }
-        const cumulativeCycle = cashflowCumulativeCloseCycle(yearMonth, cycleBusinessDate);
-        if (!cumulativeCycle) {
-          throw createHttpError(502, '월 결산 회차 기준일을 확인할 수 없습니다.', 'jvm_weekly_response_invalid');
-        }
         const cumulativeClose = {
           ...result,
-          cycleYearMonth: cumulativeCycle.cycleYearMonth,
-          targetYearMonth: cumulativeCycle.targetYearMonth,
+          cycleYearMonth: operationalCycle.cycleYearMonth,
+          targetYearMonth: operationalCycle.targetYearMonth,
           evaluatedBusinessDate: cycleBusinessDate,
-          closeDeadline: cumulativeCycle.deadline,
-          closeEligible: readOptionalText(result?.status) === 'OPEN' && cumulativeCycle.eligible,
-          late: readOptionalText(result?.status) === 'OPEN'
-            ? cycleBusinessDate > cumulativeCycle.deadline
-            : Boolean(result?.late),
+          closeDeadline: operationalCycle.deadline,
+          closeDeadlineAt: selectedCalendar.closeDeadlineAt,
+          approverDeadlineAt: selectedCalendar.approverDeadlineAt,
+          closeEligible: operationalCycle.eligible,
+          late: operationalCycle.late,
           monthState: monthCloseRequest ? cashflowMonthCloseRequestView(monthCloseRequest) : null,
         };
         const cashflowSourceUnavailable = jvmPartial.unavailableSections.has('cashflow');
@@ -3943,6 +3995,7 @@ export function mountJvmWeeklyApiRoutes(app, {
               weeklyCompliance,
               projectionActualSummary: null,
               cumulativeAuthority: objectValue(source?.cumulativeClose),
+              monthCloseCalendar,
               sectionErrors,
               sourceBlockers: jvmPartial.blockers,
               weeklyComplianceBoundary: comparisonBoundary,
@@ -4469,9 +4522,11 @@ export function mountJvmWeeklyApiRoutes(app, {
       ) {
         throw createHttpError(502, '월 결산 자료 일부가 도착하지 않았습니다. 잠시 후 다시 시도해 주세요.', 'jvm_weekly_response_invalid');
       }
+      const monthCloseCalendar = readJvmMonthCloseCalendar(source, yearMonth);
+      const operationalCycle = readJvmOperationalCycle(source, yearMonth);
+      const selectedCalendar = monthCloseCalendar.get(yearMonth);
       const cycleBusinessDate = readOptionalText(sourceClose?.evaluatedBusinessDate) || comparisonBoundary.asOfDate;
-      const cumulativeCycle = cashflowCumulativeCloseCycle(yearMonth, cycleBusinessDate);
-      if (readOptionalText(sourceClose?.status) !== 'OPEN' || !cumulativeCycle?.eligible) {
+      if (readOptionalText(sourceClose?.status) !== 'OPEN' || !operationalCycle.eligible) {
         throw createHttpError(
           409,
           '현재 월 결산 회차는 승인 요청을 만들 수 없습니다. 최신 상태를 다시 확인해 주세요.',
@@ -4480,11 +4535,14 @@ export function mountJvmWeeklyApiRoutes(app, {
       }
       const validationClose = {
         ...sourceClose,
-        cycleYearMonth: cumulativeCycle.cycleYearMonth,
-        targetYearMonth: cumulativeCycle.targetYearMonth,
+        cycleYearMonth: operationalCycle.cycleYearMonth,
+        targetYearMonth: operationalCycle.targetYearMonth,
         evaluatedBusinessDate: cycleBusinessDate,
-        closeDeadline: cumulativeCycle.deadline,
-        closeEligible: true,
+        closeDeadline: operationalCycle.deadline,
+        closeDeadlineAt: selectedCalendar.closeDeadlineAt,
+        approverDeadlineAt: selectedCalendar.approverDeadlineAt,
+        closeEligible: operationalCycle.eligible,
+        late: operationalCycle.late,
       };
       const validationDashboard = await composeCashflowMonthDashboard({
         db,
@@ -4498,6 +4556,7 @@ export function mountJvmWeeklyApiRoutes(app, {
         weeklyCompliance,
         projectionActualSummary: null,
         cumulativeAuthority: objectValue(source?.cumulativeClose),
+        monthCloseCalendar,
         sectionErrors: [],
         sourceBlockers: jvmPartial.blockers,
       });

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -1078,6 +1078,7 @@ function validJvmInstant(value) {
   return typeof value === 'string'
     && value.trim() === value
     && value.length > 0
+    && /^20\d{2}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/.test(value)
     && Number.isFinite(Date.parse(value));
 }
 

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -6,8 +6,6 @@ import * as jvmWeeklyApiModule from './jvm-weekly-api.mjs';
 import {
   buildCashflowManagementChecks,
   buildCashflowMonthCloseRevisionChanges,
-  cashflowCumulativeCloseCycle,
-  cashflowMonthCloseDeadline,
   mountJvmWeeklyApiRoutes,
 } from './jvm-weekly-api.mjs';
 
@@ -161,6 +159,29 @@ const ACTOR_MEMBER_ENTRY = ['orgs/tenant-a/members/pm-1', {
   uid: 'pm-1', email: 'pm@example.com', status: 'ACTIVE', role: 'pm', projectIds: ['project-a'],
 }];
 
+function monthCloseCalendarFor(yearMonth) {
+  const year = Number(String(yearMonth).slice(0, 4));
+  return Array.from({ length: 12 }, (_unused, monthIndex) => {
+    const month = monthIndex + 1;
+    const nextMonth = month === 12 ? 1 : month + 1;
+    const nextYear = month === 12 ? year + 1 : year;
+    const isoAtKstMidnight = (day) => new Date(Date.UTC(nextYear, nextMonth - 1, day) - 9 * 60 * 60 * 1000).toISOString();
+    return {
+      yearMonth: `${year}-${String(month).padStart(2, '0')}`,
+      closeDeadline: `${nextYear}-${String(nextMonth).padStart(2, '0')}-10`,
+      closeDeadlineAt: isoAtKstMidnight(11),
+      approverDeadlineAt: isoAtKstMidnight(14),
+    };
+  });
+}
+
+function previousMonthOf(yearMonth) {
+  const year = Number(String(yearMonth).slice(0, 4));
+  const month = Number(String(yearMonth).slice(5, 7));
+  const previous = month === 1 ? { year: year - 1, month: 12 } : { year, month: month - 1 };
+  return `${previous.year}-${String(previous.month).padStart(2, '0')}`;
+}
+
 function monthDashboardSource(
   monthClose,
   cashflow = { projectId: 'project-a', projection: [], actual: [], readModel: { months: [] } },
@@ -194,6 +215,7 @@ function monthDashboardSource(
   },
 ) {
   const liveCurrent = monthClose.status === 'OPEN' || snapshotCompatibility.status === 'LIVE_AMENDED';
+  const monthCloseCalendar = monthCloseCalendarFor(monthClose.yearMonth);
   return {
     monthClose,
     latestRun: monthClose,
@@ -210,6 +232,14 @@ function monthDashboardSource(
     snapshotCompatibility,
     cumulativeClose,
     reopenRequest,
+    operationalCycle: {
+      cycleYearMonth: monthClose.yearMonth,
+      targetYearMonth: previousMonthOf(monthClose.yearMonth),
+      closeDeadline: `${monthClose.yearMonth}-10`,
+      closeEligible: monthClose.status === 'OPEN',
+      late: false,
+    },
+    monthCloseCalendar,
     projectionActualSummary,
     weeklyCompliance: { items: [], nextCursor: '', onTimeCount: 0, missedCount: 0 },
   };
@@ -645,7 +675,10 @@ describe('JVM weekly API BFF proxy', () => {
     });
     const settlement = {
       projectId: 'project-a', yearMonth: '2026-08',
-      items: [{ period: 'MONTH', status: 'COMPLETED' }, { period: 'WEEK_1', status: 'COMPLETED' }],
+      items: [{
+        period: 'MONTH', status: 'COMPLETED',
+        deadlineAt: '2026-09-10T15:00:00.000Z', approverDeadlineAt: '2026-09-13T15:00:00.000Z',
+      }, { period: 'WEEK_1', status: 'COMPLETED' }],
     };
     const fetchImpl = vi.fn(async (_url, init) => new Response(JSON.stringify(
       init.method === 'POST' ? { items: [structuredClone(settlement)], errors: [] } : structuredClone(settlement),
@@ -797,7 +830,10 @@ describe('JVM weekly API BFF proxy', () => {
         projectId: 'project-1',
         settlementStatuses: {
           projectId: 'project-1', yearMonth: '2026-08',
-          items: [{ period: 'MONTH', status: 'COMPLETED' }, { period: 'WEEK_1', status: 'COMPLETED' }],
+          items: [{
+            period: 'MONTH', status: 'COMPLETED',
+            deadlineAt: '2026-09-10T15:00:00.000Z', approverDeadlineAt: '2026-09-13T15:00:00.000Z',
+          }, { period: 'WEEK_1', status: 'COMPLETED' }],
         },
         projectionActualSummary: null,
       }],
@@ -8480,36 +8516,68 @@ describe('JVM weekly API BFF proxy', () => {
   });
 });
 
-describe('cashflowMonthCloseDeadline', () => {
-  it('is the tenth of the following month and rolls over the year in December', () => {
-    expect(cashflowMonthCloseDeadline('2026-07')).toBe('2026-08-10');
-    expect(cashflowMonthCloseDeadline('2026-09')).toBe('2026-10-10');
-    // 12월은 다음 해 1월로 넘어간다. 자릿수도 두 자리를 유지해야 문자열 비교가 성립한다.
-    expect(cashflowMonthCloseDeadline('2026-12')).toBe('2027-01-10');
-    expect(cashflowMonthCloseDeadline('2026-01')).toBe('2026-02-10');
+describe('JVM month-close calendar contract', () => {
+  function createCalendarApp(source) {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(source),
+    }));
+    return createApp(fetchImpl, createIdempotencyService(), {}, {
+      env: runtimeEnv,
+      db: source.db,
+      now: () => new Date('2026-07-10T00:00:00.000Z'),
+    });
+  }
+
+  it('passes JVM calendar deadlines through the monthly status join and summary', async () => {
+    const source = fullMonthCloseSource();
+    const jvmSource = monthDashboardSource({
+      ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0,
+    });
+    jvmSource.monthCloseCalendar[5] = {
+      yearMonth: '2026-06',
+      closeDeadline: '2099-01-02',
+      closeDeadlineAt: '2099-01-03T00:00:00Z',
+      approverDeadlineAt: '2099-01-04T00:00:00Z',
+    };
+    const { app } = createCalendarApp({ ...jvmSource, db: source.db });
+
+    await request(app)
+      .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
+      .expect(200)
+      .expect((response) => {
+        expect(response.body.dashboard.monthCloseStatuses).toEqual(expect.arrayContaining([
+          expect.objectContaining({
+            yearMonth: '2026-06',
+            closeDeadline: '2099-01-02',
+            closeDeadlineAt: '2099-01-03T00:00:00Z',
+            approverDeadlineAt: '2099-01-04T00:00:00Z',
+          }),
+        ]));
+        expect(response.body.dashboard.summary).toMatchObject({
+          closeDeadline: '2026-06-10',
+          closeDeadlineAt: '2099-01-03T00:00:00Z',
+          approverDeadlineAt: '2099-01-04T00:00:00Z',
+        });
+      });
   });
 
-  it('returns null for a malformed month instead of guessing', () => {
-    expect(cashflowMonthCloseDeadline('not-a-month')).toBeNull();
-    expect(cashflowMonthCloseDeadline('')).toBeNull();
-  });
-});
+  it.each([
+    ['missing', (source) => { delete source.monthCloseCalendar; }],
+    ['wrong count', (source) => { source.monthCloseCalendar = source.monthCloseCalendar.slice(0, 11); }],
+    ['malformed item', (source) => { source.monthCloseCalendar[5].closeDeadlineAt = 'not-an-instant'; }],
+  ])('fails closed when the JVM calendar is %s', async (_label, mutate) => {
+    const source = fullMonthCloseSource();
+    const jvmSource = monthDashboardSource({
+      ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0,
+    });
+    mutate(jvmSource);
+    const { app } = createCalendarApp({ ...jvmSource, db: source.db });
 
-describe('cashflowCumulativeCloseCycle', () => {
-  it('keeps the current cycle while closing through the previous month', () => {
-    expect(cashflowCumulativeCloseCycle('2026-08', '2026-08-04')).toEqual({
-      cycleYearMonth: '2026-08',
-      targetYearMonth: '2026-07',
-      deadline: '2026-08-10',
-      eligible: true,
-    });
-    expect(cashflowCumulativeCloseCycle('2026-01', '2026-01-04')).toEqual({
-      cycleYearMonth: '2026-01',
-      targetYearMonth: '2025-12',
-      deadline: '2026-01-10',
-      eligible: true,
-    });
-    expect(cashflowCumulativeCloseCycle('2026-08', '2026-07-31')?.eligible).toBe(false);
-    expect(cashflowCumulativeCloseCycle('2026-08', '2026-08-01')?.eligible).toBe(true);
+    await request(app)
+      .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
+      .expect(502)
+      .expect((response) => expect(response.body.code).toBe('jvm_weekly_response_invalid'));
   });
 });

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -8580,4 +8580,36 @@ describe('JVM month-close calendar contract', () => {
       .expect(502)
       .expect((response) => expect(response.body.code).toBe('jvm_weekly_response_invalid'));
   });
+
+  it('does not authorize a month-close write from the calendar alone', async () => {
+    const source = fullMonthCloseSource();
+    const jvmSource = monthDashboardSource({
+      ok: true, projectId: 'project-a', yearMonth: '2026-06', status: 'OPEN', revision: 0,
+    });
+    jvmSource.operationalCycle.closeEligible = false;
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify(jvmSource),
+    }));
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {
+      actorId: 'pm-1', actorRole: 'pm',
+    }, { env: runtimeEnv, db: source.db, now: () => new Date('2026-07-10T00:00:00.000Z') });
+    const read = await request(app)
+      .get('/api/v1/cashflow/project-a/month-close?yearMonth=2026-06')
+      .expect(200);
+
+    await request(app)
+      .post('/api/v1/cashflow/project-a/month-close/requests')
+      .set('idempotency-key', 'calendar-ineligible')
+      .send({
+        yearMonth: '2026-06', expectedRevision: 0,
+        expectedApproverUid: 'finance-1', expectedProjectVersion: 0,
+        expectedOpeningBalances: read.body.dashboard.openingBalances,
+        closeInput: { ...source.closeInput, managementChecks: read.body.dashboard.managementChecks },
+      })
+      .expect(409)
+      .expect((response) => expect(response.body.code).toBe('cashflow_month_close_not_eligible'));
+    expect(source.documents.has('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-06')).toBe(false);
+  });
 });

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -1108,6 +1108,8 @@ export interface CashflowMonthCloseDashboard {
     yearMonth: string;
     status: 'OPEN' | 'CLOSED' | 'REOPEN_REQUESTED' | string;
     closeDeadline?: string | null;
+    closeDeadlineAt?: string | null;
+    approverDeadlineAt?: string | null;
     closeOverdue?: boolean;
     sheetCalculationChecks?: CashflowMonthCloseDashboard['sheetCalculationChecks'] | null;
   }> | null;


### PR DESCRIPTION
## What/why
- consume the deployed JVM `operationalCycle` and 12-month `monthCloseCalendar` contract
- pass monthly deadlines through the existing status/history join and summary
- remove BFF monthly deadline/cycle calculations after the additive JVM rollout
- keep authority, scope, lock, and Firestore write paths unchanged

## Safety
- malformed or missing JVM calendar/operational cycle fails closed with `jvm_weekly_response_invalid`
- calendar values do not authorize writes; POST still requires JVM operational eligibility and OPEN status
- no Firestore schema or write changes

## Verification
- targeted JVM month-close BFF contract tests
- existing BFF calendar/scope/authority tests
- full CI and build required before merge

Rollout order: #624 calendar -> #625 settlement item deadlines -> this BFF consumer.