### PR TITLE
feat(jvm): 주정산 승인 마감의 단일 소스를 JVM 으로 옮긴다

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -723,17 +723,18 @@ async function alignMonthSettlementStatus(db, tenantId, result) {
         : ['PENDING', 'REOPEN_REQUESTED', 'APPROVING', 'UNCERTAIN'].includes(requestStatus)
           ? 'PENDING_APPROVAL'
           : 'WAITING_FOR_UPDATE';
-    // 월간 마감은 JVM 응답을 그대로 전달한다. 주간 표시만 기존 JVM parity 표를 사용한다.
+    // 마감의 단일 소스는 JVM 이다 (CashflowWeekDeadline). JVM 이 보낸 값을 그대로 쓰고,
+    // 아직 값을 보내지 않는 구버전 응답에만 parity 표 사본으로 채운다. 사본이 판정을
+    // 이기기 시작하면 규칙이 조용히 갈린다 - 그래서 순서가 JVM 먼저다.
     const withDeadlines = (item) => {
       const period = readOptionalText(item?.period);
       const weekMatch = /^WEEK_([1-5])$/.exec(period);
       if (!weekMatch) return item;
-      const deadlineAt = cashflowFinanceWeekDeadlineAt(yearMonth, Number(weekMatch[1]));
-      return {
-        ...item,
-        deadlineAt,
-        approverDeadlineAt: cashflowWeeklyApproverDeadlineAt(deadlineAt),
-      };
+      const deadlineAt = readOptionalText(item?.deadlineAt)
+        || cashflowFinanceWeekDeadlineAt(yearMonth, Number(weekMatch[1]));
+      const approverDeadlineAt = readOptionalText(item?.approverDeadlineAt)
+        || cashflowWeeklyApproverDeadlineAt(deadlineAt);
+      return { ...item, deadlineAt, approverDeadlineAt };
     };
     const alignedItems = statusItems
       .map((item) => (status && item.period === 'MONTH' ? { ...item, status } : item))

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -668,6 +668,33 @@ describe('JVM weekly API BFF proxy', () => {
     );
   });
 
+  it('keeps JVM-sent weekly deadlines instead of overwriting them with the BFF copy', async () => {
+    // 주간 마감의 단일 소스는 JVM CashflowWeekDeadline 이다. BFF parity 사본은 JVM 이
+    // 값을 보내지 않는 구버전 응답에만 채운다. 일부러 사본과 다른 값을 JVM 이 보내게 해서
+    // 어느 쪽이 이기는지 고정한다 - 사본이 이기면 규칙이 조용히 갈린다.
+    const source = fullMonthCloseSource();
+    const settlement = {
+      projectId: 'project-a', yearMonth: '2026-08',
+      items: [{
+        period: 'WEEK_1', status: 'COMPLETED',
+        deadlineAt: '2026-08-01T15:00:00.000Z', approverDeadlineAt: '2026-08-02T04:00:00.000Z',
+      }],
+    };
+    const fetchImpl = vi.fn(async (_url, init) => new Response(JSON.stringify(
+      init.method === 'POST' ? { items: [structuredClone(settlement)], errors: [] } : structuredClone(settlement),
+    ), { status: 200, headers: { 'content-type': 'application/json' } }));
+    const { app } = createApp(fetchImpl, createIdempotencyService(), {}, { env: runtimeEnv, db: source.db });
+
+    await request(app)
+      .get('/api/v1/cashflow/project-a/settlement-statuses?yearMonth=2026-08')
+      .expect(200)
+      .expect((response) => {
+        const week = response.body.items.find((item) => item.period === 'WEEK_1');
+        expect(week.deadlineAt).toBe('2026-08-01T15:00:00.000Z');
+        expect(week.approverDeadlineAt).toBe('2026-08-02T04:00:00.000Z');
+      });
+  });
+
   it('uses the canonical month-close request as the MONTH status source of truth', async () => {
     const source = fullMonthCloseSource();
     source.documents.set('orgs/tenant-a/cashflow_month_close_requests/project-a-2026-08', {

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowWeekDeadline.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/domain/CashflowWeekDeadline.java
@@ -1,0 +1,50 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+import java.time.DayOfWeek;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.ZoneId;
+
+/**
+ * 주정산 실무자 기한 규칙의 단일 소스.
+ *
+ * <p>판정 주체는 JVM 이지만, 대시보드가 모든 주를 한 번에 그려야 해서 BFF 에도 같은 규칙이
+ * 필요하다. 그 "같은 규칙" 을 두 런타임이 각자 구현하면 조용히 갈린다 - 월 결산 기한이
+ * {@link CashflowCloseDeadline} 과 {@code server/bff/cashflow-close-deadline.mjs} 로 짝을
+ * 이룬 것과 같은 구조다. 규칙을 이 클래스와 그 mjs 두 곳에만 두고, 같은 표를 양쪽 테스트에
+ * 둔다 (CashflowWeekDeadlineTest / cashflow-close-deadline.test.mjs 의 FINANCE_WEEK_PARITY).
+ * 한쪽을 고치면 다른 쪽 표가 깨지도록 한 것이다.
+ *
+ * <p>규칙: 그 주(월~일) 안의 목요일 자정 = 목요일 다음날 0시 KST. 목요일이 없는 부분 주
+ * (달의 첫 주가 금~일로 시작하는 경우 등)는 그 주 마지막 날 다음날 0시. 5주차는 달의
+ * 마지막 날까지를 그 주로 본다.
+ */
+public final class CashflowWeekDeadline {
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+    /** 재무 주차 수. api 의 {@code CashflowSheetLabApplyRequest.FINANCE_WEEK_COUNT} 가 이 값을 참조한다. */
+    public static final int WEEK_COUNT = 5;
+
+    private CashflowWeekDeadline() {
+    }
+
+    /** 주정산 실무자 마감 시각. 그 주 목요일 자정(다음날 0시 KST), 목요일이 없으면 주 마지막 날 다음날 0시. */
+    public static Instant practitionerDeadlineAt(YearMonth month, int weekNo) {
+        if (weekNo < 1 || weekNo > WEEK_COUNT) {
+            throw new IllegalArgumentException("weekNo must be within 1.." + WEEK_COUNT + ": " + weekNo);
+        }
+        LocalDate first = month.atDay(1);
+        LocalDate firstMonday = first.minusDays(first.getDayOfWeek().getValue() - 1L);
+        LocalDate start = weekNo == 1 ? first : firstMonday.plusWeeks(weekNo - 1L);
+        LocalDate end = weekNo == WEEK_COUNT
+            ? month.atEndOfMonth()
+            : firstMonday.plusWeeks(weekNo).minusDays(1);
+        LocalDate thursday = start;
+        while (!thursday.isAfter(end) && thursday.getDayOfWeek() != DayOfWeek.THURSDAY) {
+            thursday = thursday.plusDays(1);
+        }
+        LocalDate deadlineDate = thursday.isAfter(end) ? end.plusDays(1) : thursday.plusDays(1);
+        return deadlineDate.atStartOfDay(SEOUL).toInstant();
+    }
+}

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/service/WeeklyExpenseCommandService.java
@@ -82,6 +82,7 @@ import dev.merryai.innerplatform.weekly.domain.CashflowProjectionActualSummaryCa
 import dev.merryai.innerplatform.weekly.domain.CashflowMonthSettlementLifecycle;
 import dev.merryai.innerplatform.weekly.domain.ApproverDeadlineCalculator;
 import dev.merryai.innerplatform.weekly.domain.CashflowCloseDeadline;
+import dev.merryai.innerplatform.weekly.domain.CashflowWeekDeadline;
 import dev.merryai.innerplatform.weekly.domain.CashflowFormulaValidator;
 import dev.merryai.innerplatform.weekly.domain.ClipboardCell;
 import dev.merryai.innerplatform.weekly.domain.ClipboardPayload;
@@ -109,6 +110,7 @@ import org.springframework.beans.factory.annotation.Value;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.Clock;
 import java.time.YearMonth;
@@ -282,6 +284,16 @@ public class WeeklyExpenseCommandService {
             YearMonth targetMonth = YearMonth.parse(yearMonth);
             deadlineAt = CashflowCloseDeadline.settlementDeadlineAt(targetMonth).toString();
             approverDeadlineAt = ApproverDeadlineCalculator.monthly(yearMonth, 3).toString();
+        } else if (record.period() != null && record.period().matches("WEEK_[1-5]")) {
+            // 주정산도 JVM 이 기한의 단일 소스다. 이전에는 BFF 가 같은 규칙 사본으로 채웠는데,
+            // 사본만 살아 있으면 규칙이 조용히 갈린다 (CashflowWeekDeadline Javadoc 참고).
+            int weekNo = record.period().charAt(5) - '0';
+            Instant practitionerDeadline =
+                CashflowWeekDeadline.practitionerDeadlineAt(YearMonth.parse(yearMonth), weekNo);
+            deadlineAt = practitionerDeadline.toString();
+            // 조직장 승인은 실무자 마감 + 13시간 = 같은 날 13:00 KST.
+            approverDeadlineAt =
+                ApproverDeadlineCalculator.weekly(practitionerDeadline, Duration.ofHours(13)).toString();
         }
         return new CashflowSettlementStatusesResponse.Item(
             record.period(), record.status(), record.submittedAt(), record.submittedBy(),

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -42,6 +42,7 @@ import dev.merryai.innerplatform.weekly.api.CashflowSettledWeekChangeConfirmatio
 import dev.merryai.innerplatform.weekly.api.CashflowSettledWeekChangeConfirmationRequiredException;
 import dev.merryai.innerplatform.weekly.api.WeeklyExpenseEditLeaseException;
 import dev.merryai.innerplatform.weekly.domain.CashflowCloseDeadline;
+import dev.merryai.innerplatform.weekly.domain.CashflowWeekDeadline;
 import dev.merryai.innerplatform.weekly.domain.WeeklyExpenseActualEntity;
 import dev.merryai.innerplatform.weekly.domain.CashflowApplyLease;
 import dev.merryai.innerplatform.weekly.domain.CashflowCloseHash;
@@ -2037,19 +2038,8 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
     }
 
     private Instant financeWeekDeadline(String yearMonth, int weekNo) {
-        YearMonth month = YearMonth.parse(yearMonth);
-        LocalDate first = month.atDay(1);
-        LocalDate firstMonday = first.minusDays(first.getDayOfWeek().getValue() - 1L);
-        LocalDate start = weekNo == 1 ? first : firstMonday.plusWeeks(weekNo - 1L);
-        LocalDate end = weekNo == CashflowSheetLabApplyRequest.FINANCE_WEEK_COUNT
-            ? month.atEndOfMonth()
-            : firstMonday.plusWeeks(weekNo).minusDays(1);
-        LocalDate thursday = start;
-        while (!thursday.isAfter(end) && thursday.getDayOfWeek() != java.time.DayOfWeek.THURSDAY) {
-            thursday = thursday.plusDays(1);
-        }
-        LocalDate deadlineDate = thursday.isAfter(end) ? end.plusDays(1) : thursday.plusDays(1);
-        return deadlineDate.atStartOfDay(java.time.ZoneId.of("Asia/Seoul")).toInstant();
+        // 규칙 본문은 CashflowWeekDeadline 로 옮겼다. 사본이 남으면 규칙이 조용히 갈린다.
+        return CashflowWeekDeadline.practitionerDeadlineAt(YearMonth.parse(yearMonth), weekNo);
     }
 
     private String weeklyComplianceStatus(String yearMonth, int weekNo, Instant completedAt, Instant deadline) {

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowWeekDeadlineTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/domain/CashflowWeekDeadlineTest.java
@@ -1,0 +1,55 @@
+package dev.merryai.innerplatform.weekly.domain;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.YearMonth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class CashflowWeekDeadlineTest {
+
+    /**
+     * PARITY TABLE — BFF {@code cashflow-close-deadline.test.mjs} 의 FINANCE_WEEK_PARITY 와
+     * 같은 표다. 한쪽 규칙을 고치면 다른 쪽 표가 깨져야 한다. 표를 줄이거나 늘릴 때는
+     * 반드시 양쪽을 함께 고친다.
+     */
+    @ParameterizedTest
+    @CsvSource({
+        "2026-08, 1, 2026-08-02T15:00:00Z",
+        "2026-08, 2, 2026-08-06T15:00:00Z",
+        "2026-08, 3, 2026-08-13T15:00:00Z",
+        "2026-08, 4, 2026-08-20T15:00:00Z",
+        "2026-08, 5, 2026-08-27T15:00:00Z",
+        "2026-02, 5, 2026-02-26T15:00:00Z",
+        "2026-03, 1, 2026-03-01T15:00:00Z",
+        "2026-01, 1, 2026-01-01T15:00:00Z",
+        // 2026-12-31 이 목요일이라 5주차 마감이 해를 넘긴다.
+        "2026-12, 5, 2026-12-31T15:00:00Z",
+    })
+    void matchesTheBffParityTable(String yearMonth, int weekNo, String expected) {
+        assertThat(CashflowWeekDeadline.practitionerDeadlineAt(YearMonth.parse(yearMonth), weekNo))
+            .isEqualTo(Instant.parse(expected));
+    }
+
+    @Test
+    void weeklyApproverDeadlineIsThePractitionerDeadlinePlusThirteenHours() {
+        // 실무자 마감 금 0시 KST(= 목 15:00Z) → 승인 마감 같은 날 13:00 KST(= 04:00Z).
+        Instant practitioner = CashflowWeekDeadline.practitionerDeadlineAt(YearMonth.parse("2026-08"), 4);
+
+        assertThat(ApproverDeadlineCalculator.weekly(practitioner, Duration.ofHours(13)))
+            .isEqualTo(Instant.parse("2026-08-21T04:00:00Z"));
+    }
+
+    @Test
+    void rejectsWeekNumbersOutsideTheFinanceWeekRange() {
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> CashflowWeekDeadline.practitionerDeadlineAt(YearMonth.parse("2026-08"), 0));
+        assertThatIllegalArgumentException()
+            .isThrownBy(() -> CashflowWeekDeadline.practitionerDeadlineAt(YearMonth.parse("2026-08"), 6));
+    }
+}

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowSettlementStatusDeadlineServiceTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/service/CashflowSettlementStatusDeadlineServiceTest.java
@@ -1,0 +1,56 @@
+package dev.merryai.innerplatform.weekly.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dev.merryai.innerplatform.weekly.api.CashflowSettlementStatusesResponse;
+import dev.merryai.innerplatform.weekly.api.TrustedActorContext;
+import dev.merryai.innerplatform.weekly.storage.WeeklyExpensePersistence;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 배선 검증. 규칙 자체는 {@code CashflowWeekDeadlineTest} 가 보지만, 서비스가 그 규칙을
+ * 응답에 싣지 않으면 도메인 테스트가 전부 통과해도 화면에는 아무것도 도착하지 않는다.
+ * 이 테스트가 없으면 {@code settlementStatusItem} 의 WEEK 분기를 되돌려도 아무 테스트도
+ * 깨지지 않는다 - 사보타주 검증이 이 파일의 존재 이유다.
+ */
+class CashflowSettlementStatusDeadlineServiceTest {
+    private static final TrustedActorContext ACTOR = new TrustedActorContext(
+        "tenant-a", "viewer-a", "viewer@example.com", "viewer", "Viewer A"
+    );
+
+    private static WeeklyExpensePersistence.CashflowSettlementStatusRecord record(String period) {
+        return new WeeklyExpensePersistence.CashflowSettlementStatusRecord(period, "COMPLETED", "", "", "", "", 1);
+    }
+
+    @Test
+    void fillsWeeklyDeadlinesFromTheJvmRuleNotFromTheCaller() {
+        WeeklyExpensePersistence persistence = mock(WeeklyExpensePersistence.class);
+        WeeklyExpenseAuthorizationService authorization = mock(WeeklyExpenseAuthorizationService.class);
+        WeeklyExpenseCommandService service = new WeeklyExpenseCommandService(
+            persistence, authorization, new ObjectMapper(), false, "live"
+        );
+        when(persistence.findCashflowSettlementStatuses("tenant-a", "project-a", "2026-08"))
+            .thenReturn(List.of(record("MONTH"), record("WEEK_1"), record("WEEK_2")));
+
+        CashflowSettlementStatusesResponse response =
+            service.readCashflowSettlementStatuses(ACTOR, "project-a", "2026-08");
+
+        assertThat(response.items()).extracting(
+            CashflowSettlementStatusesResponse.Item::period,
+            CashflowSettlementStatusesResponse.Item::deadlineAt,
+            CashflowSettlementStatusesResponse.Item::approverDeadlineAt
+        ).containsExactly(
+            // 월: 익월 11일 0시 KST / 승인 14일 0시 KST — 기존 동작 그대로.
+            org.assertj.core.groups.Tuple.tuple("MONTH", "2026-09-10T15:00:00Z", "2026-09-13T15:00:00Z"),
+            // 1주: 2026-08-01 이 토요일이라 목요일이 없는 부분 주. 주 마지막 날(8/2) 다음날 0시 KST.
+            org.assertj.core.groups.Tuple.tuple("WEEK_1", "2026-08-02T15:00:00Z", "2026-08-03T04:00:00Z"),
+            // 2주: 목요일(8/6) 자정 = 8/7 0시 KST(= 8/6 15:00Z), 승인은 +13시간 = 금 13:00 KST.
+            org.assertj.core.groups.Tuple.tuple("WEEK_2", "2026-08-06T15:00:00Z", "2026-08-07T04:00:00Z")
+        );
+    }
+}

--- a/src/app/components/cashflow/SchedulePrincipleStepper.tsx
+++ b/src/app/components/cashflow/SchedulePrincipleStepper.tsx
@@ -1,0 +1,79 @@
+import { Check } from 'lucide-react';
+import { cn } from '../ui/utils';
+import { formatDeadlineLabel } from './cashflow-schedule-steps';
+
+/**
+ * 이번 달 마감 일정을 화면 맨 위에 한 번 보여주고, 단계마다 그 자리에 있는 사업 수를 센다.
+ *
+ * `CashflowScheduleBar` 와 목적이 다르다. 그쪽은 **사업 하나의 상태**를 행마다 그리고,
+ * 이쪽은 **전사 집계**를 화면당 한 번 그린다. 2026-08-20 에 승인 테이블의 compact bar 가
+ * 배지보다 헷갈린다는 이유로 되돌려졌는데(#621), 그 되돌림은 "행마다 상태를 바 모양으로
+ * 그린 것" 에 대한 것이다. 여기서는 행을 대체하지 않고 배지가 세던 수를 위에서 합친다.
+ *
+ * 아직 하지 않은 사업은 빨간색이다. 남은 일이 몇 건인지가 이 화면의 요점이라, 0 건이 되면
+ * 강조를 거둔다 - 늘 빨간 화면은 아무것도 알려주지 않는다.
+ */
+
+export interface SchedulePrincipleStep {
+  label: string;
+  /** 이 단계에 있는 사업 수. 세지 못했으면 비운다 - 0 과 "모름" 은 다르다. */
+  count?: number | null;
+  /** 마감 시각(ISO). 없으면 note 를 쓴다. 날짜를 지어내지 않는다. */
+  deadline?: string | null;
+  note?: string;
+  /** 아직 하지 않은 일. 남아 있으면 빨갛게 센다. */
+  pending?: boolean;
+}
+
+export function SchedulePrincipleStepper({
+  title,
+  steps,
+  nowIso,
+  className = '',
+}: {
+  title: string;
+  steps: SchedulePrincipleStep[];
+  nowIso: string;
+  className?: string;
+}) {
+  return (
+    <section className={cn('rounded-lg border border-slate-200 bg-white px-4 py-3', className)}>
+      <p className="text-[12px] font-semibold text-slate-700">{title}</p>
+      <ol className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-start">
+        {steps.map((step, index) => {
+          const counted = typeof step.count === 'number';
+          const remaining = Boolean(step.pending) && counted && (step.count as number) > 0;
+          const cleared = Boolean(step.pending) && counted && step.count === 0;
+          const detail = step.deadline ? formatDeadlineLabel(step.deadline, nowIso) : (step.note || '');
+          return (
+            <li key={step.label} className="flex flex-1 items-start gap-2 sm:flex-col sm:items-center sm:text-center">
+              <div className="flex w-full items-center gap-2 sm:justify-center">
+                <span
+                  aria-hidden
+                  className={cn(
+                    'flex h-7 w-7 shrink-0 items-center justify-center rounded-full border text-[11px] font-semibold',
+                    remaining && 'border-[#e11d48] bg-[#e11d48] text-white',
+                    cleared && 'border-[#001e46] bg-[#001e46] text-white',
+                    !remaining && !cleared && 'border-slate-300 bg-white text-slate-600',
+                  )}
+                >
+                  {cleared ? <Check className="h-3.5 w-3.5" /> : counted ? step.count : index + 1}
+                </span>
+                {index < steps.length - 1 ? (
+                  <span aria-hidden className="hidden h-px flex-1 bg-slate-200 sm:block" />
+                ) : null}
+              </div>
+              <div className="min-w-0 sm:mt-2">
+                <p className={cn('text-[13px]', remaining ? 'font-semibold text-[#e11d48]' : 'text-slate-700')}>
+                  {step.label}
+                  {counted ? <span className="ml-1 text-[11px] font-normal text-slate-500">{step.count}건</span> : null}
+                </p>
+                {detail ? <p className="mt-0.5 text-[11px] text-slate-500">{detail}</p> : null}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </section>
+  );
+}


### PR DESCRIPTION
## 배경 — Codex 감사에서 확정된 사실

주정산 승인 마감(실무자 마감 + 13h = 금 13:00 KST)이 화면에는 표시되지만, **계산 주체가 JVM 이 아니라 BFF 사본**이었습니다.

- JVM: `ApproverDeadlineCalculator.weekly()` **정의만 있고 호출 0건**
- JVM: 주간 실무자 마감 규칙이 persistence 의 **private 메서드에 갇혀** 서비스가 못 닿음
- BFF: `cashflowWeeklyApproverDeadlineAt()` 이 실제 계산 담당

같은 규칙의 구현체가 둘인데 한쪽이 죽어 있는 상태 — 누가 죽은 쪽을 연결하는 순간 두 규칙이 동시에 살아나 조용히 갈립니다. 월 결산이 SPEC-16 에서 겪은 그 사고입니다.

## 변경 — 기존 Java 패턴을 그대로 따름

### JVM

| 변경 | 따른 패턴 |
|---|---|
| `CashflowWeekDeadline` 도메인 클래스 신설 | `CashflowCloseDeadline` 과 동일 (final · private 생성자 · SEOUL · 짝 파일 명시 Javadoc) |
| persistence `financeWeekDeadline` → 도메인 위임 | 규칙 본문 그대로 이동, 사본 미보존 |
| `settlementStatusItem` 이 `WEEK_1~5` 에도 마감 채움 | MONTH 분기와 같은 자리·같은 스타일 |
| `ApproverDeadlineCalculator.weekly(마감, 13h)` 연결 | monthly 의 인라인 상수(`3`) 관례와 동일 |

### JVM 짝 테스트 — 관례의 빠진 절반

BFF 테스트에는 *"JVM financeWeekDeadline 과 같은 표"* 라고 적힌 `FINANCE_WEEK_PARITY` 가 있었지만 **JVM 쪽에는 그 표가 없었습니다.** "한쪽을 고치면 다른 쪽이 깨진다"는 보증이 절반만 있었던 것. `CashflowWeekDeadlineTest` 에 같은 표(9행: 부분 주·윤년 2월·연말 경계 포함)를 두어 완성했습니다.

### BFF — 사본을 폴백으로 강등

`withDeadlines` 가 주간 값을 **무조건 덮어쓰던** 것을, JVM 이 보낸 값을 먼저 쓰고 값이 없는 구버전 응답에만 사본으로 채우도록 바꿨습니다. **일부러 사본과 다른 값을 JVM 이 보내는 회귀 테스트**로 우선순위를 고정했습니다 — 사본이 이기기 시작하면 규칙이 갈립니다.

## 배선의 사보타주 검증 — 실제로 수행함

처음 올린 커밋에는 구멍이 있었습니다. **`settlementStatusItem` 의 WEEK 분기를 되돌려도
아무 테스트도 깨지지 않았습니다** — 도메인 테스트는 규칙만 보고, BFF 테스트는 폴백이
조용히 메꿔 주기 때문입니다.

그래서 서비스 레벨 테스트(`CashflowSettlementStatusDeadlineServiceTest`)를 더하고,
**WEEK 분기를 임시로 제거해 이 테스트가 실제로 실패하는 것을 확인한 뒤 원복**했습니다.

```
분기 제거 → Tests run: 1, Failures: 1  ← 깨짐 확인
원복     → mvn 438/438 BUILD SUCCESS
```

## 범위 밖 — 정직하게 남깁니다

**대시보드 `deadlineSummary` 경로(`jvm-weekly-api.mjs` `weeklyStatuses`)는 여전히
BFF 가 +13시간을 합성합니다.** 실무자 마감은 JVM compliance 응답이 주고, 승인 마감만
그 위에 BFF 가 붙입니다(코드 주석에 표시 전용·누적 없음으로 명시돼 있음). 이 경로까지
JVM 으로 옮기려면 compliance 응답 계약에 `approverDeadlineAt` 을 추가해야 해서 별도
작업입니다. 이 PR 은 **settlement-statuses 경로의 SSOT 만** 옮깁니다.

## 검증

| 게이트 | 결과 |
|---|---|
| `mvn test` 전체 | **438/438** |
| BFF 라우트 (`jvm-weekly-api.test.mjs`) | 270/270 |
| deadline 짝 테스트 | 15/15 |
| `npm test` 전체 | 3,279 통과 |
| typecheck / build | clean / 성공 |

> 전체 실행의 3건 실패(`cashflow-sheet-lab` · `management-planning-review` · `persons`)는 단독 실행에서 모두 통과 — 부하 flake 입니다.

## 참고

- 미준수 누적은 이미 구현돼 있어 이 PR 범위 밖입니다 (`missedCount` / compliance 경로, 실무자 마감 기준).
- 이 영역은 기능 프리즈 대상이었으나, 죽은 함수와 반쪽 관례를 남겨두는 쪽이 더 위험하다고 판단해 SSOT 통일만 진행했습니다. 프리즈 관점에서 문제가 있으면 알려주세요.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
