### PR TITLE
fix(jvm): lockState 없는 완료를 확정이 아니라 확정 대기로 읽는다

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -357,7 +357,10 @@ function cashflowSectionErrorsForResponse(sectionErrors) {
 // JVM 이 내는 주간 준수 상태는 ON_TIME · COMPLETED_LATE · MISSED · PENDING 넷이다
 // (FirestoreInheritedWeeklyExpensePersistence). 예전 이 표는 존재하지 않는 COMPLETED 를
 // 기다리고 ON_TIME 을 몰라서, 기한 내 완료한 주차를 "확인 필요" 로 그렸다.
-// lockState: SUBMITTED = 완료 요청됨(조직장 확정 대기). LOCKED/없음 = 준수 상태 그대로.
+// lockState: SUBMITTED = 완료 요청됨(조직장 확정 대기). LOCKED = 조직장 확정됨.
+// 빈 값을 여기서 재해석하지 않는다 - 판정 주체는 JVM 이고, 값이 없는 옛 기록을 무엇으로
+// 볼지는 JVM 이 정한다(FirestoreInheritedWeeklyExpensePersistence 의 기본값). 그 판정을
+// BFF 가 한 번 더 하면 두 곳이 조용히 갈린다.
 export function cashflowWeeklyStatusLabel(status, available, lockState = '') {
   if (!available) return '주간 정산 상태 확인 필요';
   if (lockState === 'SUBMITTED') return '확정 대기';

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -54,6 +54,16 @@ describe('cashflow section error presentation', () => {
     })).toBe(tone);
   });
 
+  // 라이브 사고(2026-08, JLIN IBS · GGGI): 완료 문서 55건 전부에 lockState 가 없었는데
+  // JVM 이 없는 값을 LOCKED 로 읽어, 확정한 적 없는 주가 "완료" 로 보이고 회수까지 막혔다.
+  // 고친 자리는 JVM 이다. BFF 는 받은 값을 옮기기만 하고 빈 값을 재해석하지 않는다 -
+  // 여기서 한 번 더 판정하면 두 곳이 조용히 갈린다.
+  it('maps lockState it receives without reinterpreting a blank one', () => {
+    expect(jvmWeeklyApiModule.cashflowWeeklyStatusLabel('ON_TIME', true, 'SUBMITTED')).toBe('확정 대기');
+    expect(jvmWeeklyApiModule.cashflowWeeklyStatusLabel('ON_TIME', true, 'LOCKED')).toBe('기한 내 완료');
+    expect(jvmWeeklyApiModule.cashflowWeeklyStatusLabel('ON_TIME', true, '')).toBe('기한 내 완료');
+  });
+
   it('never labels a known JVM weekly status as 확인 필요', () => {
     for (const status of ['ON_TIME', 'COMPLETED_LATE', 'MISSED', 'PENDING']) {
       expect(jvmWeeklyApiModule.cashflowWeeklyStatusLabel(status, true)).not.toBe('주간 정산 상태 확인 필요');

--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -1545,8 +1545,16 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                 text(value.get("operationId"), ""),
                 text(value.get("auditId"), ""),
                 text(value.get("updateResult"), ""),
-                // lockState 도입 전 버전(확정 개념 없던 완료) 은 확정으로 본다.
-                text(value.get("lockState"), "LOCKED")
+                /*
+                 * lockState 가 없는 완료는 "완료 요청됨" 으로 본다.
+                 *
+                 * 예전에는 확정으로 봤는데, 그것이 사실과 반대였다. lockState 는 조직장
+                 * 확정 단계와 함께 생긴 필드이고, 그 필드가 없다는 것은 확정 단계를 지난
+                 * 적이 없다는 뜻이다. 확정으로 읽으면 확정한 적 없는 주가 "조직장 확정 ·
+                 * 완료" 로 보이고, 회수(SUBMITTED 에서만 가능)까지 막힌다 - 라이브에서
+                 * 실제로 그렇게 막혔다(2026-08, JLIN IBS · GGGI).
+                 */
+                text(value.get("lockState"), "SUBMITTED")
             ));
         }
         // 현재 완료 문서가 OPEN(회수됨) 이면 버전 이력과 무관하게 그 주는 완료가 아니다.

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -3934,8 +3934,11 @@ class FirestoreCashflowLeaseGuardTest {
         assertThat(before.items()).anySatisfy(item -> {
             assertThat(item.id()).isEqualTo("2026-07-w2");
             assertThat(item.status()).isEqualTo("ON_TIME");
-            // lockState 없는 옛 버전은 확정으로 본다
-            assertThat(item.lockState()).isEqualTo("LOCKED");
+            // lockState 없는 옛 버전은 확정 대기로 본다. 그 필드는 확정 단계와 함께
+            // 생겼으므로, 없다는 것은 확정을 지난 적이 없다는 뜻이다. 예전에는 확정으로
+            // 읽어서 라이브에서 확정한 적 없는 주가 완료로 보이고 회수가 막혔다
+            // (2026-08, JLIN IBS · GGGI - 완료 문서 55건 전부 lockState 없음).
+            assertThat(item.lockState()).isEqualTo("SUBMITTED");
         });
         assertThat(before.onTimeCount()).isEqualTo(1L);
 

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/WeeklyLegacyLockStateTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/WeeklyLegacyLockStateTest.java
@@ -1,0 +1,33 @@
+package dev.merryai.innerplatform.weekly.storage;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * lockState 가 없는 완료 기록의 해석을 고정한다.
+ *
+ * <p>라이브 사고(2026-08, JLIN IBS · GGGI): 완료 문서 55건 전부에 lockState 가 없었는데
+ * 이 자리가 없는 값을 LOCKED 로 읽어, 조직장이 확정한 적 없는 주가 "조직장 확정 · 완료"
+ * 로 보이고 회수(SUBMITTED 에서만 가능)까지 막혔다. lockState 는 확정 단계와 함께 생긴
+ * 필드이므로, 없다는 것은 확정을 지난 적이 없다는 뜻이다.
+ */
+class WeeklyLegacyLockStateTest {
+    @Test
+    void treatsCompletionsWithoutLockStateAsAwaitingConfirmation() throws Exception {
+        String source = Files.readString(Path.of(
+            "src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java"
+        ));
+
+        assertThat(source)
+            .as("lockState 없는 완료는 확정 대기(SUBMITTED)로 읽어야 한다")
+            .contains("text(value.get(\"lockState\"), \"SUBMITTED\")")
+            .doesNotContain("text(value.get(\"lockState\"), \"LOCKED\")");
+        // 확정 쓰기는 그대로 LOCKED 여야 한다 - 읽기 기본값만 바뀐 것이다.
+        assertThat(source).contains("version.put(\"lockState\", \"LOCKED\")");
+        assertThat(source).contains("version.put(\"lockState\", \"SUBMITTED\")");
+    }
+}


### PR DESCRIPTION
## 라이브 증상

JLIN IBS · GGGI 에서 **확정한 적 없는 주가 "조직장 확정 · 완료"** 로 보이고, **회수 버튼까지 막혔습니다.**

## 원인 — 한 줄

```java
text(value.get("lockState"), "LOCKED")   // 없으면 확정으로 봄
```

`lockState` 는 조직장 확정 단계와 **함께 생긴 필드**입니다. 그 필드가 없다는 것은 **확정을 지난 적이 없다**는 뜻인데 반대로 읽고 있었습니다. 회수는 `SUBMITTED` 에서만 열리므로, 확정으로 읽는 순간 **회수가 영구히 막힙니다.**

## 프로덕션 실측 (읽기 전용 조회)

```
완료 문서 총 55건
  lockState 없음: 55건 (34개 프로젝트)
  SUBMITTED: 0 / LOCKED: 0
```

**"옛 기록 일부" 가 아니라 아직 아무도 확정 단계를 쓴 적이 없습니다.** 그래서 기본값을 `SUBMITTED` 로 바꾸는 것이 사실에 맞습니다.

## 범위

- **쓰기는 그대로** — 완료 요청은 `SUBMITTED`, 조직장 확정은 `LOCKED` 를 명시적으로 씁니다. 바뀐 건 **값이 없을 때의 읽기 해석뿐**입니다.
- **BFF 는 건드리지 않습니다.** 처음엔 BFF 라벨도 함께 고쳤다가 되돌렸습니다 — 판정 주체는 JVM 이고 빈 값을 무엇으로 볼지도 JVM 이 정합니다. BFF 가 한 번 더 해석하면 **두 곳이 조용히 갈립니다.** 그 이유를 주석과 테스트에 남겼습니다.
- 기존 테스트가 옛 규칙(*"lockState 없는 옛 버전은 확정으로 본다"*)을 고정하고 있어 함께 정정했습니다.

## 검증

| 게이트 | 결과 |
|---|---|
| `mvn test` | **439/439** |
| BFF 라우트 | 271/271 |
| `npm test` 전체 | 3,283 통과 |
| typecheck / build | clean / 성공 |

**주차 규칙 정렬 재확인** — 회사 표 규칙(`cashflow-week-core.mjs`, 시트 좌표 계약) 대비 **36개월 180개 주차 불일치 0건**. JVM 주차 계산은 임의 로직이 아니라 회사 표와 동일합니다.

## 배포 주의

JVM 소스 변경이라 **Cloud Run 리비전이 나갑니다.**

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)