### PR TITLE
fix(cashflow): 회차가 덮지 않는 달은 예정으로 그린다 · 주차 완료 시각 전달

### DIFF
--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -1027,6 +1027,9 @@ async function readCashflowRequestPartyNames({ db, tenantId, record }) {
 
 async function readCashflowMonthCloseRequest({ db, tenantId, projectId, yearMonth }) {
   if (!db?.doc) return null;
+  // 문서 ID 는 회차를 실행한 달이다. 그 회차가 덮는 대상 월(throughMonth)과 다를 수 있으나
+  // 여기서 걸러내지 않는다 - 회차 월로 조회해야 그 회차를 회수·승인할 수 있기 때문이다.
+  // "이 달의 결산이 끝났는가" 는 다른 질문이고, throughMonth 로 화면이 판단한다.
   const direct = await db.doc(cashflowMonthCloseRequestPath(tenantId, `${projectId}-${yearMonth}`)).get();
   if (direct.exists) return direct.data() || null;
   if (typeof db.collection !== 'function') return null;
@@ -2837,6 +2840,10 @@ function deadlineSummaryFromCompliance(compliance, comparisonBoundary, weeklyYea
       lockState: readOptionalText(item.lockState) || null,
       deadline: item.deadline,
       approverDeadline: cashflowWeeklyApproverDeadlineAt(item.deadline),
+      // 완료 정보는 JVM 이 이미 주는 값이다(CashflowWeeklyComplianceHistoryResponse.Item).
+      // 여기서 떨어뜨리면 지난 주차가 "언제 완료했는지" 를 화면이 알 길이 없어진다.
+      completedAt: readOptionalText(item.completedAt) || null,
+      completedBy: readOptionalText(item.completedBy) || null,
       updateResult: item.updateResult,
       operationId: item.operationId,
       auditId: item.auditId,

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -23,7 +23,18 @@ describe('CashflowProjectSheet schedule bar', () => {
   it('does not invent a confirm timestamp, and drops withdrawn or rejected requests back to "not requested"', () => {
     expect(source).toContain("approverDone: current.lockState === 'LOCKED'");
     expect(source).not.toContain('current.confirmedAt || current.completedAt');
-    expect(source).toContain("const requested = ['PENDING', 'APPROVING', 'UNCERTAIN', 'APPROVED', 'REOPEN_REQUESTED'].includes(status);");
+    // 회수·반려된 요청은 "요청 전" 으로 되돌아간다. 진행 중으로 보는 상태는 이 다섯뿐이다.
+    expect(source).toContain("const inFlight = ['PENDING', 'APPROVING', 'UNCERTAIN', 'APPROVED', 'REOPEN_REQUESTED'].includes(status);");
+  });
+
+  // 회차 월과 덮는 대상 월은 다르다. 누적 결산을 8월에 돌려도 대상은 throughMonth 까지다.
+  // 회차가 있다는 것만 보고 그렸더니 아직 아무도 하지 않은 8월이 완료로 보였다(JLIN IBS).
+  // 덮이지 않는 달은 진행도를 빌리지 않고 예정 날짜만 그린다. 회차 자체는 건드리지 않는다 -
+  // 회수·승인은 회차 월로 하는 것이 맞고, 그 경로는 BFF 조회가 그대로 유지한다.
+  it('does not borrow a cycle progress for a month the cycle does not cover', () => {
+    expect(source).toContain('const monthCoveredByRequest =');
+    expect(source).toContain('return yearMonth <= through;');
+    expect(source).toContain('const requested = inFlight && monthCoveredByRequest;');
   });
 });
 

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -1315,11 +1315,30 @@ export function CashflowProjectSheet({
 
   // 안내는 한 줄. 상태에서 결정적인 것 하나만 고른다(2026-08-19 보람: 다 보여주니 정보가 아님).
   // 회수·반려된 요청은 "요청 안 한 상태" 로 되돌린다 - 진행 바가 끝난 일처럼 보이면 안 된다.
+  /*
+   * 회차 월과 덮는 대상 월은 다르다. 누적 결산은 8월에 돌려도 대상이 2026-07 까지다
+   * (throughMonth). 회차가 있다는 것만 보고 "이 달 결산 완료" 로 그리면, 아직 아무도
+   * 하지 않은 8월이 완료로 보인다 - 라이브에서 그랬다(JLIN IBS).
+   *
+   * 회차 자체는 그대로 둔다. 회수·승인은 회차 월로 하는 것이 맞다. 여기서는 "보고 있는
+   * 달이 그 회차에 덮이는가" 만 따로 판단한다. 값은 서버가 이미 준다.
+   */
+  const monthCoveredByRequest = useMemo(() => {
+    const through = String(monthCloseRequest?.throughMonth || monthCloseRequest?.yearMonth || '');
+    if (!/^20\d{2}-(0[1-9]|1[0-2])$/.test(through)) return true;
+    return yearMonth <= through;
+  }, [monthCloseRequest?.throughMonth, monthCloseRequest?.yearMonth, yearMonth]);
+
   const monthRequestProgress = useMemo(() => {
     const status = String(monthCloseRequest?.status || '').toUpperCase();
-    const requested = ['PENDING', 'APPROVING', 'UNCERTAIN', 'APPROVED', 'REOPEN_REQUESTED'].includes(status);
-    return { requested, approved: ['APPROVED', 'REOPEN_REQUESTED'].includes(status) };
-  }, [monthCloseRequest?.status]);
+    const inFlight = ['PENDING', 'APPROVING', 'UNCERTAIN', 'APPROVED', 'REOPEN_REQUESTED'].includes(status);
+    // 덮이지 않는 달은 그 회차의 진행도를 빌려 쓰지 않는다.
+    const requested = inFlight && monthCoveredByRequest;
+    return {
+      requested,
+      approved: requested && ['APPROVED', 'REOPEN_REQUESTED'].includes(status),
+    };
+  }, [monthCloseRequest?.status, monthCoveredByRequest]);
 
   // 일정 진행 바. 마감·완료 시각·초과 판정은 서버 값이고, 여기서는 단계 상태만 고른다.
   const weeklyScheduleSteps = useMemo(() => {


### PR DESCRIPTION
## 라이브 증상

8월 결산을 **아무도 하지 않았는데** "결산 요청 · 완료 8/10" 으로 보였습니다 (JLIN IBS). 8/10 에 하신 것은 **7월분 누적 결산**입니다.

## 원인

회차 월과 덮는 대상 월은 다릅니다.

```
문서 ID       p1776054335896-2026-08   ← 회차를 돌린 달
throughMonth  2026-07                  ← 실제로 덮는 마지막 달
requestedAt   2026-08-10 19:25 KST     ← 7월 결산 마감일
```

화면이 **"회차가 있다 = 이 달 결산 완료"** 로 읽은 것이 원인입니다.

## 고친 방식 — 구조에 표시를 맞춤

보고 있는 달이 그 회차에 **덮이는지만** 따로 판단합니다. 덮이지 않으면 진행도를 빌리지 않으므로, **기존 단계 표시가 그대로 예정(마감 날짜)만** 그립니다. 새 화면도 새 상태도 만들지 않았습니다.

| 화면 | 이전 | 이후 |
|---|---|---|
| 7월 | 승인 완료 | 승인 완료 (그대로) |
| 8월 | **결산 요청·완료 8/10** ❌ | 결산 요청 · 예정 (9/10 자정까지) |

## BFF 조회는 건드리지 않았습니다 — 되돌린 이유

처음엔 문서 ID 조회에 `covers` 게이트를 걸었다가 **되돌렸습니다.** 회차 월로 조회해야 그 회차를 **회수·승인**할 수 있고, 기존 테스트가 정확히 그것을 고정하고 있었습니다 (`withdrawMonthClose.enabled`).

*"이 달 결산이 끝났는가"* 는 다른 질문이고, 화면이 이미 받고 있는 `throughMonth` 로 답합니다. **판정을 서버에 하나 더 만들지 않았습니다.**

## 함께 — 지난 주차 완료 시각

`weeklyStatuses` 가 `completedAt`·`completedBy` 를 떨어뜨리고 있었습니다. **JVM 이 이미 주는 값**인데(`CashflowWeeklyComplianceHistoryResponse.Item`) BFF 가 옮기지 않아, 지난 주차가 언제 완료됐는지 화면이 알 길이 없었습니다. 새로 만들지 않고 전달만 합니다.

## 사보타주 검증

`monthCoveredByRequest` 가드를 제거하면 shell 테스트가 **실제로 실패하는 것**을 확인한 뒤 원복했습니다.

## 검증

cashflow 192/192 · BFF 라우트 271/271 · 전체 3,282 · typecheck clean · build 성공
(`cashflow-sheet-lab` 2건은 단독 통과 — 알려진 flake)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)