### PR TITLE
revert(jvm): lockState 기본값을 LOCKED 로 되돌린다 (라이브 회수 400 수습)

### DIFF
--- a/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
+++ b/server/jvm-weekly-api/src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java
@@ -1546,15 +1546,16 @@ public class FirestoreInheritedWeeklyExpensePersistence implements WeeklyExpense
                 text(value.get("auditId"), ""),
                 text(value.get("updateResult"), ""),
                 /*
-                 * lockState 가 없는 완료는 "완료 요청됨" 으로 본다.
+                 * lockState 가 없는 완료는 확정(LOCKED)으로 본다.
                  *
-                 * 예전에는 확정으로 봤는데, 그것이 사실과 반대였다. lockState 는 조직장
-                 * 확정 단계와 함께 생긴 필드이고, 그 필드가 없다는 것은 확정 단계를 지난
-                 * 적이 없다는 뜻이다. 확정으로 읽으면 확정한 적 없는 주가 "조직장 확정 ·
-                 * 완료" 로 보이고, 회수(SUBMITTED 에서만 가능)까지 막힌다 - 라이브에서
-                 * 실제로 그렇게 막혔다(2026-08, JLIN IBS · GGGI).
+                 * 2026-08-20 에 이 기본값을 SUBMITTED 로 바꿨다가 되돌렸다. 회수 가능
+                 * 여부를 판정하는 필드는 lockState 가 아니라 완료 문서의 status 이고
+                 * (jvm-weekly-api.mjs 의 reopen 라우트), 라이브 문서는 status="LOCKED" 다.
+                 * lockState 만 바꾸니 화면은 "확정 대기" 로 열리는데 회수는 400
+                 * (cashflow_weekly_reopen_reason_required) 으로 막히는 불일치가 났다.
+                 * 두 필드를 함께 다루기 전에는 이 기본값을 건드리지 않는다.
                  */
-                text(value.get("lockState"), "SUBMITTED")
+                text(value.get("lockState"), "LOCKED")
             ));
         }
         // 현재 완료 문서가 OPEN(회수됨) 이면 버전 이력과 무관하게 그 주는 완료가 아니다.

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/FirestoreCashflowLeaseGuardTest.java
@@ -3934,11 +3934,8 @@ class FirestoreCashflowLeaseGuardTest {
         assertThat(before.items()).anySatisfy(item -> {
             assertThat(item.id()).isEqualTo("2026-07-w2");
             assertThat(item.status()).isEqualTo("ON_TIME");
-            // lockState 없는 옛 버전은 확정 대기로 본다. 그 필드는 확정 단계와 함께
-            // 생겼으므로, 없다는 것은 확정을 지난 적이 없다는 뜻이다. 예전에는 확정으로
-            // 읽어서 라이브에서 확정한 적 없는 주가 완료로 보이고 회수가 막혔다
-            // (2026-08, JLIN IBS · GGGI - 완료 문서 55건 전부 lockState 없음).
-            assertThat(item.lockState()).isEqualTo("SUBMITTED");
+            // lockState 없는 옛 버전은 확정으로 본다 (회수 판정은 status 가 한다)
+            assertThat(item.lockState()).isEqualTo("LOCKED");
         });
         assertThat(before.onTimeCount()).isEqualTo(1L);
 

--- a/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/WeeklyLegacyLockStateTest.java
+++ b/server/jvm-weekly-api/src/test/java/dev/merryai/innerplatform/weekly/storage/WeeklyLegacyLockStateTest.java
@@ -10,22 +10,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * lockState 가 없는 완료 기록의 해석을 고정한다.
  *
- * <p>라이브 사고(2026-08, JLIN IBS · GGGI): 완료 문서 55건 전부에 lockState 가 없었는데
- * 이 자리가 없는 값을 LOCKED 로 읽어, 조직장이 확정한 적 없는 주가 "조직장 확정 · 완료"
- * 로 보이고 회수(SUBMITTED 에서만 가능)까지 막혔다. lockState 는 확정 단계와 함께 생긴
- * 필드이므로, 없다는 것은 확정을 지난 적이 없다는 뜻이다.
+ * <p>2026-08-20 에 이 기본값을 SUBMITTED 로 바꿨다가 되돌렸다. 회수 가능 여부를 판정하는
+ * 필드는 lockState 가 아니라 완료 문서의 status 이고, 라이브 문서는 status="LOCKED" 다.
+ * lockState 만 바꾸니 화면은 회수 버튼을 열어 주는데 서버가 400 으로 막는 불일치가 났다.
+ * 두 필드를 함께 다루기 전에는 이 기본값을 건드리지 않는다.
  */
 class WeeklyLegacyLockStateTest {
     @Test
-    void treatsCompletionsWithoutLockStateAsAwaitingConfirmation() throws Exception {
+    void treatsCompletionsWithoutLockStateAsConfirmed() throws Exception {
         String source = Files.readString(Path.of(
             "src/main/java/dev/merryai/innerplatform/weekly/storage/FirestoreInheritedWeeklyExpensePersistence.java"
         ));
 
         assertThat(source)
-            .as("lockState 없는 완료는 확정 대기(SUBMITTED)로 읽어야 한다")
-            .contains("text(value.get(\"lockState\"), \"SUBMITTED\")")
-            .doesNotContain("text(value.get(\"lockState\"), \"LOCKED\")");
+            .as("회수 판정은 완료 문서의 status 가 하고, lockState 만 바꾸면 화면과 서버가 갈린다")
+            .contains("text(value.get(\"lockState\"), \"LOCKED\")")
+            .doesNotContain("text(value.get(\"lockState\"), \"SUBMITTED\")");
         // 확정 쓰기는 그대로 LOCKED 여야 한다 - 읽기 기본값만 바뀐 것이다.
         assertThat(source).contains("version.put(\"lockState\", \"LOCKED\")");
         assertThat(source).contains("version.put(\"lockState\", \"SUBMITTED\")");


### PR DESCRIPTION
## 되돌리는 이유

#633 에서 `lockState` 없는 완료를 `SUBMITTED` 로 읽게 바꿨는데, 그것이 **라이브에서 화면과 서버를 갈라놓았습니다.**

회수 가능 여부를 판정하는 필드는 `lockState` 가 아니라 완료 문서의 **`status`** 입니다 (`weekly-update-complete/reopen` 라우트). 라이브 문서는 `status="LOCKED"` 이고 `lockState` 만 비어 있습니다.

```
화면   lockState 없음  → "확정 대기" → 회수 버튼 열림
서버   status="LOCKED" → 사유 필수  → 400 cashflow_weekly_reopen_reason_required
```

이전에는 화면도 "확정 완료" 라 버튼이 비활성이어서 불일치가 없었습니다. **제가 `lockState` 한 필드만 보고 "아무도 확정한 적 없다" 고 판단한 것이 틀렸습니다** — `status` 를 함께 봤어야 했습니다.

## 실측

```
p1776054335896-2026-08-w4
  status    = "LOCKED"      ← 판정 필드
  lockState = undefined     ← 표시 필드
```

## 범위

기본값 한 줄만 원복하고, 그 이유를 본문 주석과 테스트에 남깁니다. 두 필드를 함께 다루는 설계 전에는 건드리지 않습니다.

## 검증

`mvn test` **439/439**

JVM 소스 변경이라 Cloud Run 리비전이 나갑니다.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)