### PR TITLE
fix(cashflow): 월결산 노드를 실행 회차와 대상 월로 나눈다

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -36,6 +36,31 @@ describe('CashflowProjectSheet schedule bar', () => {
     expect(source).toContain('return yearMonth <= through;');
     expect(source).toContain('const requested = inFlight && monthCoveredByRequest;');
   });
+
+  // 노드 하나가 두 회차를 그리던 문제. 배지는 8월에 돌린 7월분(완료)을, 단계는 8월분(9월 마감)을
+  // 봐서 "완료인데 진행 중" 이 됐다. 노드 하나는 회차 하나만 말한다.
+  it('splits the executed cycle out of the month it does not cover', () => {
+    // 실행된 회차는 그 달 안에서 일어난 일이므로 주정산 앞(월초)에 놓는다.
+    expect(source).toContain('const executedCycleNode: PortalTimelineNode | null');
+    expect(source).toContain('...(executedCycleNode ? [executedCycleNode] : []),\n      ...weeklyNodes,');
+    // 지난 회차의 마감은 이 화면의 관심이 아니다 - 완료 사실만 그리고 시각을 지어내지 않는다.
+    expect(source).toContain('practitionerDeadline: null,');
+    expect(source).toContain('practitionerDoneAt: monthCloseRequest.requestedAt,');
+    // 대상 월로 이름 붙인다. 사람은 "무엇을 결산했나" 로 기억한다.
+    expect(source).toContain("label: `${String(monthCloseRequest?.throughMonth || '').slice(5)}월분 결산`");
+  });
+
+  it('keeps one month-close action button, on the node that owns the request', () => {
+    expect(source).toContain('{executedCycleSteps.length > 0 ? null : renderMonthlyAction()}');
+    expect(source).toContain('{renderScheduleDetails(executedCycleSteps, true)}');
+  });
+
+  // 배지와 단계가 서로 다른 근거를 보면 화면이 스스로 모순된다("월 결산 완료" 위 "결산 요청 · 진행 중").
+  it('reads the month badge from the same source as the month schedule steps', () => {
+    expect(source).toContain('const monthOwnPresentation = useMemo(');
+    expect(source).toContain('const monthCloseStatusLabel = monthOwnPresentation.statusLabel;');
+    expect(source).not.toContain("const monthCloseStatusLabel = cashflowPresentation?.monthClose.statusLabel");
+  });
 });
 
 describe('CashflowProjectSheet staged loading', () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -192,7 +192,7 @@ type PortalTimelineTone = CashflowMonthClosePresentationWeek['surfaceTone'] | Ca
 
 type PortalTimelineNode = {
   key: string;
-  kind: 'weekly' | 'monthly' | 'project-end';
+  kind: 'weekly' | 'monthly' | 'monthly-executed' | 'project-end';
   label: string;
   statusLabel: string;
   tone: PortalTimelineTone;
@@ -1388,6 +1388,41 @@ export function CashflowProjectSheet({
     });
   }, [monthCloseRequest?.requestedAt, monthCloseRequest?.reviewedAt, monthRequestProgress, monthCloseResult?.dashboard?.summary]);
 
+  /*
+   * 이 달을 덮는 회차가 없으면 이 달은 아직 결산 전이다. 지난 회차의 "완료" 배지를
+   * 빌려 쓰면 배지는 완료인데 아래 단계는 진행 중이라 화면이 스스로 모순된다.
+   */
+  const monthOwnPresentation = useMemo(() => {
+    // 라벨은 서버 표현을 그대로 쓴다. 이 달을 덮는 회차가 있을 때만 그 표현이 이 달의 것이다.
+    if (monthCoveredByRequest) {
+      return {
+        statusLabel: cashflowPresentation?.monthClose.statusLabel || '확인 불가',
+        tone: cashflowPresentation?.monthClose.tone || 'neutral',
+      };
+    }
+    return { statusLabel: '결산 전', tone: 'neutral' as const };
+  }, [cashflowPresentation?.monthClose, monthCoveredByRequest]);
+
+  /*
+   * 이 달에 실행됐지만 이 달을 덮지 않는 회차(예: 8월에 돌린 7월분 누적 결산).
+   * 대상 월이 다르므로 이 달의 마감이 아니라 그 회차의 완료 사실만 그린다.
+   */
+  const executedCycleSteps = useMemo(() => {
+    if (monthCoveredByRequest || !monthCloseRequest?.requestedAt) return [];
+    const status = String(monthCloseRequest?.status || '').toUpperCase();
+    return buildScheduleSteps({
+      practitionerLabel: '결산 요청',
+      approverLabel: '조직장 승인',
+      // 지난 회차의 마감은 이 화면의 관심이 아니다. 시각을 지어내지 않는다.
+      practitionerDeadline: null,
+      approverDeadline: null,
+      practitionerDoneAt: monthCloseRequest.requestedAt,
+      approverDoneAt: ['APPROVED', 'REOPEN_REQUESTED'].includes(status) ? monthCloseRequest?.reviewedAt : null,
+      approverDone: ['APPROVED', 'REOPEN_REQUESTED'].includes(status),
+      nowIso: new Date().toISOString(),
+    });
+  }, [monthCloseRequest?.requestedAt, monthCloseRequest?.reviewedAt, monthCloseRequest?.status, monthCoveredByRequest]);
+
   const portalTimelineNodes = useMemo<PortalTimelineNode[]>(() => {
     if (!portalMode) return [];
     const weeklyNodes = (cashflowPresentation?.weeks || [])
@@ -1403,16 +1438,36 @@ export function CashflowProjectSheet({
         };
       });
     const monthlyPresentation = cashflowPresentation?.monthClose;
+    /*
+     * 월결산 노드를 둘로 나눈다.
+     *
+     * 예전에는 노드가 하나였고, 배지는 "이 달에 실행된 회차"(7월분 · 완료)를, 단계는
+     * "이 달을 대상으로 하는 결산"(8월분 · 9월 마감)을 그렸다. 서로 다른 두 회차가 한
+     * 자리에 섞여 "완료인데 진행 중" 으로 보였다. 노드 하나가 회차 하나만 말하게 한다.
+     */
+    const executedCycleNode: PortalTimelineNode | null = executedCycleSteps.length > 0
+      ? {
+        key: `monthly-executed-${monthCloseRequest?.throughMonth || ''}`,
+        kind: 'monthly-executed',
+        // 사람은 "무엇을 결산했나" 로 기억한다. 실행 시각은 아래 단계에 남는다.
+        label: `${String(monthCloseRequest?.throughMonth || '').slice(5)}월분 결산`,
+        statusLabel: monthlyPresentation?.statusLabel || '확인 불가',
+        tone: monthlyPresentation?.tone || 'neutral',
+        current: false,
+      }
+      : null;
     const monthlyNode: PortalTimelineNode = {
       key: `monthly-${yearMonth}`,
       kind: 'monthly',
       label: `${yearMonth.slice(5)}월 월결산`,
-      statusLabel: monthlyPresentation?.statusLabel || '확인 불가',
-      tone: monthlyPresentation?.tone || 'neutral',
+      // 이 달을 덮는 회차가 없으면 상태도 이 달 기준이어야 한다 - 지난 회차의 배지를 빌리지 않는다.
+      statusLabel: monthOwnPresentation.statusLabel,
+      tone: monthOwnPresentation.tone as PortalTimelineTone,
       current: false,
     };
     const projectEnd = project?.contractEnd;
     return [
+      ...(executedCycleNode ? [executedCycleNode] : []),
       ...weeklyNodes,
       monthlyNode,
       {
@@ -1424,7 +1479,7 @@ export function CashflowProjectSheet({
         current: false,
       },
     ];
-  }, [cashflowPresentation?.monthClose, cashflowPresentation?.weeks, portalMode, project?.contractEnd, yearMonth]);
+  }, [cashflowPresentation?.monthClose, cashflowPresentation?.weeks, executedCycleSteps, monthCloseRequest?.throughMonth, monthOwnPresentation, portalMode, project?.contractEnd, yearMonth]);
 
   const weeklyEnabledActions = [
     monthCloseActions?.completeWeekly.enabled ? 'complete' : null,
@@ -3045,10 +3100,17 @@ export function CashflowProjectSheet({
                         {renderWeeklyAction()}
                       </div>
                     ) : null}
+                    {node.kind === 'monthly-executed' ? (
+                      <div data-cashflow-portal-monthly-executed-node className="px-2">
+                        {renderScheduleDetails(executedCycleSteps, true)}
+                        {renderMonthlyAction()}
+                      </div>
+                    ) : null}
                     {node.kind === 'monthly' ? (
                       <div data-cashflow-portal-monthly-node className="px-2">
                         {renderScheduleDetails(monthScheduleSteps, true)}
-                        {renderMonthlyAction()}
+                        {/* 회수·재오픈은 요청 레코드를 가진 회차의 일이다. 그 회차가 앞 노드로 나갔으면 버튼도 거기 있다. */}
+                        {executedCycleSteps.length > 0 ? null : renderMonthlyAction()}
                       </div>
                     ) : null}
                   </div>
@@ -3624,10 +3686,10 @@ export function CashflowProjectSheet({
     );
   }
 
-  const monthCloseStatusLabel = cashflowPresentation?.monthClose.statusLabel || '확인 불가';
-  const monthCloseStatusClass = cashflowPresentation?.monthClose.tone === 'danger'
+  const monthCloseStatusLabel = monthOwnPresentation.statusLabel;
+  const monthCloseStatusClass = monthOwnPresentation.tone === 'danger'
     ? 'border border-red-200 bg-red-50 text-red-700'
-    : cashflowPresentation?.monthClose.tone === 'success'
+    : monthOwnPresentation.tone === 'success'
       ? 'border border-border bg-secondary text-secondary-foreground'
       : 'border border-border bg-accent text-accent-foreground';
   const sheetDashboardMetadata = cashflowPresentation?.evidenceSource === 'DASHBOARD'


### PR DESCRIPTION
## 무엇이 잘못돼 있었나

포털 정산 타임라인의 월결산 노드가 **하나뿐**이고 항상 주정산 뒤에 붙었습니다. 그 노드가:

- **배지** ← 8월에 실행된 7월분 누적 결산 (APPROVED → "월 결산 완료")
- **단계** ← 8월분 결산의 마감 (9/10 · 9/13 → "진행 중")

서로 다른 두 회차를 한 자리에 그려서 화면이 스스로 모순됐습니다.

```
08월 월결산 · 월 결산 완료 ✓
  결산 요청 · 진행 중   9/10(목) 자정까지 · D-21
  조직장 승인 · 대기     9/13(일) 자정까지 · D-24
```

8월 월결산은 아직 아무도 하지 않았습니다. 완료된 것은 7월분이고, 8월 10일에 했습니다.

## 어떻게 고쳤나

노드 하나가 회차 하나만 말하게 했습니다. 시간 순서대로 놓습니다.

```
[7월분 결산 · 완료]  26-8-1 … 26-8-5  [08월 월결산 · 결산 전]  [프로젝트 종료]
   8/10 실행            주정산            9/10 · 9/13 예정
```

- **앞 노드** — 이 달에 실행됐지만 이 달을 덮지 않는 회차(`throughMonth` 가 이전 달).
  대상 월로 이름 붙입니다 — 사람은 "무엇을 결산했나" 로 기억하지 "언제 눌렀나" 로 기억하지
  않습니다. 실행 시각은 아래 단계에 남습니다. 그런 회차가 없으면 노드도 없습니다.
- **뒤 노드** — 이 달을 대상으로 하는 결산. 덮는 회차가 없으면 `결산 전` 이고,
  9/10·9/13 은 그 노드의 예정 마감입니다.
- **회수·재오픈 버튼은 한 곳에만** — 요청 레코드를 가진 회차 노드에 붙습니다.
  앞 노드가 생기면 버튼도 거기로 따라갑니다. 두 개로 갈라지지 않습니다.
- **상단 배지도 같은 근거를 봅니다** (`monthOwnPresentation`). 이전엔 배지만 따로
  `cashflowPresentation.monthClose` 를 읽어 "완료" 를 띄웠습니다.

## 새로 만든 값이 없습니다

전부 서버가 이미 주는 값입니다 — `monthCloseRequest.throughMonth` · `requestedAt` ·
`reviewedAt` · `status`, `dashboard.summary.closeDeadlineAt` · `approverDeadlineAt`,
`presentation.monthClose`. 판정도 라벨도 새로 만들지 않았고, 라벨은 서버 표현을 그대로 씁니다
(`renders the server presentation contract…` 테스트가 계속 지킵니다).

지난 회차의 마감은 화면에 그리지 않습니다 — `summary` 는 이 달 것이라 그 회차의 마감이
아닙니다. **없는 시각을 지어내는 대신 비웁니다.**

## 검증

| 게이트 | 결과 |
|---|---|
| `npx vitest run src/app/components/cashflow/` | 195/195 통과 (25 files) |
| `npm run typecheck` | no new type errors (185 known, 30 files) |
| `npm run policy:verify` | rbac · jvm-command-roles · edge · privacy 통과 |
| `npm run build` | ✓ built in 1m 13s |

**회귀 테스트 3건** 을 `CashflowProjectSheet.shell.test.ts` 에 추가했습니다 (노드 분리 · 버튼
단일화 · 배지 근거 통일). **삭제 검증**: 노드 분리를 걷어내고 돌려 해당 테스트가 실패하는 것을
확인한 뒤 되돌렸습니다.

## 스크린샷 — 배포 후 확인 필요

JLIN IBS 8월 화면에서 확인할 것:

1. 주정산 앞에 **"7월분 결산 · 월 결산 완료"** 노드가 서고, 그 아래 `결산 요청 · 8/10(월) 19:31`
2. **"08월 월결산"** 배지가 `결산 전` 이고, 아래에 9/10 · 9/13 이 예정으로
3. 회수/재오픈 버튼이 **앞 노드에 한 개만**

🤖 Generated with [Claude Code](https://claude.com/claude-code)