### PR TITLE
fix(cashflow): 시트 검토·반영이 조용히 끝나지 않게 한다

### DIFF
--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -56,6 +56,21 @@ describe('CashflowProjectSheet schedule bar', () => {
   });
 
   // 배지와 단계가 서로 다른 근거를 보면 화면이 스스로 모순된다("월 결산 완료" 위 "결산 요청 · 진행 중").
+  // 시트 검토·반영이 실패해도 아무것도 띄우지 않고 끝나는 자리가 넷 있었다. 사람 눈에는 버튼만
+  // 원래대로 돌아오니 반영이 된 줄 안다. 성공은 토스트, 오류는 그 자리 인라인 배너(2026-08-19 결정).
+  it('never ends a sheet stage or apply in silence', () => {
+    expect(source).toContain('const [sheetOperationError, setSheetOperationError] = useState');
+    expect(source).toContain('function sheetOperationErrorMessage(error: unknown): string');
+    // 검토 실패 · 인증 재시도 실패 · 반영에서 어느 분기도 못 받은 오류, 셋 다 말한다.
+    expect(source.match(/setSheetOperationError\(sheetOperationErrorMessage\(/g)?.length).toBe(3);
+    // 반영할 수 없는 범위와 "이미 최신" 도 조용히 끝나지 않는다.
+    expect(source).toContain('반영할 수 없는 시트 범위가 있습니다.');
+    expect(source).toContain("toast.success('MYSCube가 이미 시트 최신값과 같습니다.');");
+    // 새 시도는 지난 오류를 지우고 시작한다.
+    expect(source.match(/setSheetOperationError\(''\)/g)?.length).toBe(2);
+    expect(source).toContain('{sheetOperationError ? (');
+  });
+
   it('reads the month badge from the same source as the month schedule steps', () => {
     expect(source).toContain('const monthOwnPresentation = useMemo(');
     expect(source).toContain('const monthCloseStatusLabel = monthOwnPresentation.statusLabel;');

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -346,6 +346,22 @@ function bffErrorCode(error: unknown): string {
   return source.body?.code || source.body?.error || '';
 }
 
+/*
+ * 시트 검토·반영에서 화면이 다루지 않는 오류의 문구.
+ *
+ * 이 두 흐름은 실패해도 아무것도 띄우지 않고 끝나는 자리가 여럿이었다. 사람 눈에는
+ * 버튼만 원래대로 돌아오니 반영이 된 줄 안다(실제 신고: "로직이 중도에 끝나는 느낌이고
+ * 토스트도 안 뜬다"). 문구는 서버 코드에 대한 공용 안내를 그대로 쓴다 - 여기서 새로 짓지 않는다.
+ * 이 화면의 오류는 토스트가 아니라 그 자리 인라인 배너로 남긴다(2026-08-19 결정).
+ */
+function sheetOperationErrorMessage(error: unknown): string {
+  const status = error instanceof PlatformApiError
+    ? error.status
+    : Number((error as { status?: number })?.status) || 400;
+  const code = error instanceof PlatformApiError ? error.code : bffErrorCode(error);
+  return resolveApiErrorPresentation(code, status).guide;
+}
+
 export function CashflowProjectSheet({
   projectId,
   projectName,
@@ -498,6 +514,8 @@ export function CashflowProjectSheet({
   const [reopenAction, setReopenAction] = useState<'request' | 'approve' | 'reject' | null>(null);
   const [reopenReason, setReopenReason] = useState('');
   const [sheetRefreshLoading, setSheetRefreshLoading] = useState(false);
+  // 시트 검토·반영이 실패한 이유. 성공만 토스트로 알리고 오류는 그 자리에 남긴다.
+  const [sheetOperationError, setSheetOperationError] = useState('');
   const [sheetReviewDialogOpen, setSheetReviewDialogOpen] = useState(false);
   const [lateSheetApply, setLateSheetApply] = useState<CashflowSheetLabStageResult | null>(null);
   const [sheetApplyResumeRequired, setSheetApplyResumeRequired] = useState(false);
@@ -2132,6 +2150,7 @@ export function CashflowProjectSheet({
     };
 
     setSheetStageApplyLoading(true);
+    setSheetOperationError('');
     logCashflowSettlement({
       phase: 'start',
       operation: 'cashflow.sheet_apply',
@@ -2191,6 +2210,9 @@ export function CashflowProjectSheet({
       } else {
         setLateSheetApply(null);
         setSheetApplyResumeRequired(false);
+        // 위 분기가 못 받은 오류는 여기서 끝난다. 말하지 않으면 사람은 반영이 된 줄 안다.
+        // 서버가 게이트를 새로 붙여도 조용히 사라지지 않게 하는 것이 이 분기의 목적이다.
+        setSheetOperationError(sheetOperationErrorMessage(finalError));
       }
     } finally {
       setSheetStageApplyLoading(false);
@@ -2241,10 +2263,14 @@ export function CashflowProjectSheet({
       if (result.status === 'BLOCKED') {
         const contractIssue = result.pendingApprovalContractIssues?.[0];
         const blockedMonths = (contractIssue?.blockedMonths || result.blockedMonths || []).join(', ');
+        setSheetOperationError(contractIssue
+          ? `${contractIssue.message}${blockedMonths ? ` 확인할 월: ${blockedMonths}` : ''}`
+          : `반영할 수 없는 시트 범위가 있습니다.${blockedMonths ? ` 확인할 월: ${blockedMonths}` : ''}`);
         return;
       }
       if (result.stagedLineCount <= 0) {
         // 없으면 없다고 말한다. 조용히 끝나면 반영이 중간에 멈춘 것처럼 보인다.
+        toast.success('MYSCube가 이미 시트 최신값과 같습니다.');
         return;
       }
       if (result.pendingApprovalDifferences?.length) {
@@ -2260,6 +2286,7 @@ export function CashflowProjectSheet({
       await handleApplyStagedSheetValues(result);
     };
     setSheetRefreshLoading(true);
+    setSheetOperationError('');
     logCashflowSettlement({
       phase: 'start',
       operation: 'cashflow.sheet_stage',
@@ -2292,9 +2319,11 @@ export function CashflowProjectSheet({
           await applyStageResult(await stageMirror(actor));
           return;
         } catch (retryError) {
+          setSheetOperationError(sheetOperationErrorMessage(retryError));
           return;
         }
       }
+      setSheetOperationError(sheetOperationErrorMessage(error));
     } finally {
       setSheetRefreshLoading(false);
     }
@@ -3265,6 +3294,12 @@ export function CashflowProjectSheet({
               <span className="ml-1 border-l border-border pl-3 text-muted-foreground">
                 세금계산서 발행일 · 입금일 · 입금액 주별 확인됨
               </span>
+            </div>
+          ) : null}
+
+          {sheetOperationError ? (
+            <div role="alert" className="rounded-md border border-red-200 bg-red-50 p-3 text-[12px] leading-5 text-red-800">
+              {sheetOperationError}
             </div>
           ) : null}
 

--- a/src/app/platform/api-error-messages.ts
+++ b/src/app/platform/api-error-messages.ts
@@ -48,6 +48,14 @@ const presentations = new Map<string, ApiErrorPresentation>([
     guide: '먼저 시트 값을 가져와 최신 고정본을 만든 뒤 진행해 주세요.',
     resolution: 'contact',
   }],
+  ['cashflow_pending_approval_confirmation_required', {
+    guide: '결재 중인 누적 결산과 달라지는 값이 있어요. 달라지는 전체 값을 확인한 뒤 반영해 주세요.',
+    resolution: 'contact',
+  }],
+  ['cashflow_pending_approval_evidence_stale', {
+    guide: '확인하는 동안 결재 중인 누적 결산이 변경됐어요. 시트 값을 다시 가져와 검토해 주세요.',
+    resolution: 'retry',
+  }],
   ['cashflow_formula_mismatch_confirmation_required', {
     guide: '시트의 합계·잔액과 MYSCube 계산 결과가 달라요. 차이를 확인한 뒤 그대로 반영하거나 시트 값을 다시 가져와 주세요.',
     resolution: 'contact',


### PR DESCRIPTION
## 신고

> 시트를 변경해서 월결산 완료한 곳에 대해서 반영을 누르면 첫째. 항목에 대해서 값을 못 받아오고
> 둘째, 사유 입력 후에 반영을 누르면 시트가 바뀌지 않아요. **로직도 뭔가 중도에 끝나는 느낌이고
> 토스트도 안 떠서** 한 번 봐야 할 것

## 원인 — 오류를 보여줄 자리가 없었다

`CashflowProjectSheet` 의 시트 검토·반영 흐름에는 **오류 표시 수단이 아예 없었습니다.**
실패해도 말없이 `return` 하는 지점이 넷이었습니다.

| 지점 | 하던 일 |
|---|---|
| 검토 결과 `BLOCKED` | 막힌 월(`blockedMonths`)을 계산해 변수에 담고 **버리고** `return` |
| `stagedLineCount <= 0` | 주석은 `없으면 없다고 말한다. 조용히 끝나면 반영이 중간에 멈춘 것처럼 보인다.` — 말하는 코드는 없음 |
| 검토 `catch` · 인증 재시도 실패 | 그대로 삼킴 |
| 반영 `catch` 의 마지막 `else` | `setLateSheetApply(null)` 로 다이얼로그만 닫고 끝 |

마지막 칸이 신고의 두 번째 증상입니다. 반영 catch 는 세 가지만 다룹니다 — 수식 불일치,
마감월 사유 필요, 불확실 결과. **`cashflow_pending_approval_confirmation_required` 는
어느 쪽도 아니라 else 로 떨어져 소리 없이 사라졌습니다.** 결재 중인 누적 결산이 있는
프로젝트에서는 사유를 입력하고 반영을 눌러도 매번 여기로 떨어집니다.

## 고친 것

넷 다 말하게 했습니다. 오류는 **시트 도구 바 아래 인라인 배너**로 남습니다.

이 화면은 `성공 확인만 우측 하단에 띄운다 … 에러는 그 자리 인라인 배너로 남긴다`
(2026-08-19) 로 정해져 있고 셸 테스트가 `toast.error` 를 금지합니다. 처음엔 토스트로
짰다가 그 테스트에 걸려 인라인으로 바꿨습니다 — **가드가 제대로 동작했습니다.**

문구는 새로 짓지 않고 서버 코드에 대한 공용 안내(`resolveApiErrorPresentation`)를 그대로
씁니다. 신고된 게이트 두 코드에만 안내를 추가했습니다:

- `cashflow_pending_approval_confirmation_required`
- `cashflow_pending_approval_evidence_stale`

나머지 코드는 기본 안내로 떨어지지만, **더 이상 아무 말 없이 사라지지 않습니다.**
서버가 게이트를 새로 붙여도 마찬가지입니다.

## 남은 것 — 첫 번째 증상

> 항목에 대해서 값을 못 받아오고

`cashflow_pending_approval_confirmation_required` 는 `details.pendingApprovalDifferences`
로 달라지는 전체 값을 함께 보냅니다. 이 PR 은 아직 그 목록을 꺼내 쓰지 않고 **왜 막혔는지만**
말합니다. 목록을 확인 다이얼로그(`CashflowLateSheetChangeDialog`, `kind: 'pendingApproval'`)
에 다시 채우는 것은 별도로 하겠습니다 — 흐름이 달라 같이 넣으면 이 수정의 인과가 흐려집니다.

## 검증

| 게이트 | 결과 |
|---|---|
| `npm test` | 3287 passed / 1 failed — 아래 |
| `npm run typecheck` | no new type errors (185 known, 30 files) |
| `npm run policy:verify` | 통과 |
| `npm run build` | ✓ built in 16.55s |

**회귀 테스트** `never ends a sheet stage or apply in silence` 를 추가했습니다. **삭제 검증**:
반영 catch-all 의 한 줄을 지우고 돌려 실패하는 것을 확인한 뒤 되돌렸습니다.

### 실패 1건은 무관한 부하 flake

`server/bff/routes/cashflow-sheet-lab.test.mjs` 가 전체 실행에서 `socket hang up` 으로 1건
실패했습니다. **단독 실행 109/109 통과**로 부하 flake 확인했습니다. 이 PR 이 바꾼 파일은
`src/app/**` 뿐이고 실패한 테스트는 `server/**` 입니다.

## 스크린샷 — 배포 후 확인 필요

결재 중 누적 결산이 있는 프로젝트에서 시트를 바꾼 뒤 반영:

1. 예전: 다이얼로그만 닫히고 아무 표시 없음
2. 지금: `결재 중인 누적 결산과 달라지는 값이 있어요…` 배너가 시트 도구 바 아래

🤖 Generated with [Claude Code](https://claude.com/claude-code)