### PR TITLE
fix(participation): 역할명이 바뀐 참여행도 사람으로 잇는다

### DIFF
--- a/scripts/backfill-participation-person-ids.mjs
+++ b/scripts/backfill-participation-person-ids.mjs
@@ -26,6 +26,11 @@ function syncKey(member) {
   return `${segment(member?.memberNickname || member?.memberName, 'member')}__${segment(member?.role, 'role')}`;
 }
 
+/** 연결 키의 사람 부분. 역할 부분은 버린다. 두 조각 모두 `-` 로만 정규화돼 `__` 는 구분자로만 남는다. */
+function personSegment(value) {
+  return text(value).split('__')[0];
+}
+
 function add(index, value, personId) {
   const valueKey = key(value);
   if (!valueKey) return;
@@ -70,9 +75,13 @@ async function main() {
     add(peopleByNickname, person.nickname, personId);
   }
   const teamMemberByProjectKey = new Map();
+  // 사람 부분만으로도 찾을 수 있게 따로 모은다. 역할이 바뀌면 키가 통째로 어긋나기 때문이다.
+  const teamMembersByProjectPerson = new Map();
   for (const projectDoc of projectsSnap.docs) {
     for (const member of (Array.isArray(projectDoc.data()?.teamMembersDetailed) ? projectDoc.data().teamMembersDetailed : [])) {
       teamMemberByProjectKey.set(`${projectDoc.id}:${syncKey(member)}`, member);
+      const personKey = `${projectDoc.id}:${personSegment(syncKey(member))}`;
+      teamMembersByProjectPerson.set(personKey, [...(teamMembersByProjectPerson.get(personKey) || []), member]);
     }
   }
 
@@ -80,10 +89,20 @@ async function main() {
   const entryPlans = [];
   const resolvedByProjectKey = new Map();
   const unresolved = [];
+  let roleDriftMatches = 0;
   for (const entry of entries) {
     const projectId = text(entry.projectId);
     const entryKey = text(entry.projectTeamMemberKey);
-    const member = teamMemberByProjectKey.get(`${projectId}:${entryKey}`);
+    /*
+     * 참여행은 만들어질 때의 역할을 키에 담고 있어서, 사업의 역할명이 바뀌면 키가 통째로 어긋난다
+     * (참여행 `에이블__사업-총괄` vs 현재 팀원 `에이블__총괄책임자`). 사람은 그대로인데 연결만 끊긴다.
+     * 그래서 역할 키로 못 찾으면 사람 부분만 보고 다시 찾되, 그 사업 안에서 한 명으로 좁혀질 때만 쓴다.
+     * 같은 사람이 한 사업에 두 역할로 올라 있으면 어느 쪽인지 알 수 없으므로 잇지 않는다.
+     */
+    const exactMember = teamMemberByProjectKey.get(`${projectId}:${entryKey}`);
+    const personMatches = exactMember ? [] : (teamMembersByProjectPerson.get(`${projectId}:${personSegment(entryKey)}`) || []);
+    const member = exactMember || (personMatches.length === 1 ? personMatches[0] : null);
+    if (!exactMember && member) roleDriftMatches += 1;
     const existing = text(entry.personId);
     let personId = knownPersonIds.has(existing) ? existing : unique(peopleByUid, [entry.memberId]);
     let source = personId ? (existing ? 'EXISTING_PERSON_ID' : 'EXACT_UID') : '';
@@ -98,8 +117,8 @@ async function main() {
       continue;
     }
     if (existing !== personId) entryPlans.push({ entryId: entry.id, personId, source });
-    if (entryKey) {
-      const mapKey = `${projectId}:${entryKey}`;
+    // 옛 키와 현재 키 양쪽에 남긴다. 프로젝트 문서는 현재 키로 찾으므로 옛 키만 남기면 팀원이 안 채워진다.
+    for (const mapKey of new Set([entryKey && `${projectId}:${entryKey}`, member && `${projectId}:${syncKey(member)}`].filter(Boolean))) {
       const previous = resolvedByProjectKey.get(mapKey);
       resolvedByProjectKey.set(mapKey, previous && previous !== personId ? null : personId);
     }
@@ -124,6 +143,7 @@ async function main() {
     partEntriesToUpdate: entryPlans.length, projectsToUpdate: projectPlans.length,
     exactUidMatches: entryPlans.filter((plan) => plan.source === 'EXACT_UID').length,
     uniquePeopleIdentityMatches: entryPlans.filter((plan) => plan.source === 'UNIQUE_PEOPLE_IDENTITY').length,
+    roleDriftMatches,
     unresolvedCount: unresolved.length, unresolvedPreview: unresolved.slice(0, 20),
   };
   if (dumpDir) {


### PR DESCRIPTION
## 배경 — 참여인력 대시보드에 아무도 안 나왔다

라이브에서 표가 완전히 비어 있었습니다. 원인은 코드가 아니라 **#567의 People SSOT 일회성
마이그레이션이 라이브에 안 돌아간 것**이었습니다.

대시보드는 People ID로만 사람을 잇고 이름·닉네임으로는 되짚지 않습니다(의도된 설계).
참여행 273건 전부 `personId` 가 비어 있어 273건이 전부 버려졌습니다.

```
사람 91명 · 사업 71개 · 참여행 273건 → 표에 0명, "People 연결 대기 273건"
```

백필을 사본 뜬 뒤 적용해 **247건이 이어졌고 표에 69명이 나왔습니다.** 남은 26건이 이 PR의 대상입니다.

## 이 PR이 고치는 것

참여행은 **만들어질 때의 역할**을 연결 키에 담습니다. 사업의 역할명이 바뀌면 사람은 그대로인데
키가 통째로 어긋나 연결이 끊깁니다.

| 참여행 키 | 현재 팀원 키 | 사람 |
|---|---|---|
| `에이블__사업-총괄` | `에이블__총괄책임자` | 김정태 |
| `싱아__운영-정산지원` | `싱아__사업운영` | 이시은 |
| `제이__투자-실무운영` | `제이__운영매니저` | 변준재 |

역할 키로 못 찾으면 **사람 부분만 보고 다시 찾는 단계**를 넣었습니다.

**애매하면 잇지 않습니다.** 그 사업 안에서 한 명으로 좁혀질 때만 씁니다 — 같은 사람이 한
사업에 두 역할로 올라 있으면 어느 쪽인지 알 수 없기 때문입니다. People 조회는 그대로라
사람을 못 좁히면 여전히 안 잇습니다.

프로젝트 문서의 팀원도 채워지도록 **옛 키와 현재 키 양쪽에** 남깁니다. 옛 키만 남기면
프로젝트 쪽 조회가 현재 키로 이뤄져 팀원 `personId` 가 계속 비어 있었습니다.

**런타임은 그대로입니다.** 이름·닉네임 되짚기는 이 일회성 마이그레이션 안에만 있습니다.

## 검증 — 라이브 end-to-end

`scripts/**` 는 vitest 대상이 아니라(`src/**` · `server/**` 만 포함) 단위 테스트를 붙여도
CI에서 안 돕니다. 대신 **독립 분석 스크립트로 먼저 예측하고, 도구 결과와 대조**했습니다.

| 단계 | 결과 |
|---|---|
| 사전 분석(별도 스크립트) | 이어짐 16 · **애매함 0** · 못 이음 3 |
| 백필 dry-run | `partEntriesToUpdate: 16` · `roleDriftMatches: 16` — 일치 |
| 적용 | 참여행 16건 · 프로젝트 2건 |
| 실제 집계 함수로 재확인 | 연결 대기 **26 → 10** |

집계는 `buildParticipationDashboardSnapshot` 에 라이브 데이터를 그대로 물려 확인했습니다.
사람 수는 69명 그대로이고 **참여 사업 수가 올라갔습니다** — 16건이 이미 표에 있던 사람들의
추가 참여행이기 때문입니다.

```
김정태 13개 → 14개    김세은 5개 → 6개
유자인  6개 →  7개    나미소 4개 → 5개
```

## 남은 10건 — 사람이 봐야 합니다

| 부류 | 건수 | 내용 |
|---|---|---|
| 팀 명단에서 빠짐 | 3 | 파커 · 안소니 · 제리 — 참여행은 있는데 현재 팀원에 없음 |
| People에 없음 | 7 | 테일러(김혜령) · 데이나(김다은) · 하에나(강에나) + `신규채용1/2` 자리 2건 |

둘 다 자동으로 이으면 딴 사람에게 붙을 수 있어 손대지 않았습니다. 화면에 "연결 대기 10건" 으로
계속 남으니 조용히 사라지지 않습니다.

## 사본 · 되돌리기

`~/backups/participation-people-link/` 아래 두 시점:

- `2026-08-21/` — 백필 **전** 전체(참여행 273 + 사업 71)
- `2026-08-21-step2/` — 이 PR 적용 **전**

각 폴더에 `restore.mjs` 가 있고 **dry-run까지 돌려 확인했습니다**(273건·71개 인식).
백필이 건드린 필드만 되돌리므로 그 사이 다른 수정은 안 덮어씁니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)