### PR TITLE
fix(participation): 참여행 연결 키에서 역할을 뺀다

### DIFF
--- a/server/bff/routes/projects.mjs
+++ b/server/bff/routes/projects.mjs
@@ -2302,11 +2302,26 @@ function normalizeSyncKeySegment(value, fallback = 'na') {
   return normalized || fallback;
 }
 
-function buildProjectTeamMemberSyncKey(member) {
-  return [
-    normalizeSyncKeySegment(member.memberNickname || member.memberName, 'member'),
-    normalizeSyncKeySegment(member.role, 'role'),
-  ].join('__');
+/**
+ * 참여행 연결 키를 팀원 명단 전체에서 한 번에 만든다. 키는 **사람만으로** 만든다.
+ *
+ * 예전에는 `닉네임__역할` 이었다. 사업의 역할명을 고치면 키가 통째로 바뀌고, 참여행 문서 ID 가
+ * 이 키로 만들어지므로 같은 사람의 참여행 연결이 끊겼다(라이브 26건 중 16건이 이 경우).
+ * 참여율은 사람 단위로 합산해 보여주므로 키가 역할까지 구분할 이유가 없다.
+ *
+ * 다만 한 사업에 같은 사람이 두 역할로 올라 있으면 그때만 역할을 덧붙인다 - 키가 겹치면
+ * 참여행 문서 하나가 다른 하나를 덮어써 참여율이 조용히 사라지기 때문이다.
+ */
+export function buildProjectTeamMemberSyncKeys(teamMembers) {
+  const members = Array.isArray(teamMembers) ? teamMembers : [];
+  const personSegments = members.map((member) => normalizeSyncKeySegment(member?.memberNickname || member?.memberName, 'member'));
+  const occurrences = new Map();
+  for (const person of personSegments) occurrences.set(person, (occurrences.get(person) || 0) + 1);
+  return personSegments.map((person, index) => (
+    occurrences.get(person) > 1
+      ? `${person}__${normalizeSyncKeySegment(members[index]?.role, 'role')}`
+      : person
+  ));
 }
 
 export function resolveProjectTeamMemberLookupKeys(member) {
@@ -2410,10 +2425,11 @@ export async function syncProjectParticipationEntries({
   }
 
   const desiredEntries = new Map();
-  for (const member of teamMembers) {
+  const teamMemberSyncKeys = buildProjectTeamMemberSyncKeys(teamMembers);
+  for (const [index, member] of teamMembers.entries()) {
     const personId = readOptionalText(member?.personId);
     if (!member.role || (!personId && !member.memberName && !member.memberNickname)) continue;
-    const key = buildProjectTeamMemberSyncKey(member);
+    const key = teamMemberSyncKeys[index];
     const matchedMember = resolveProjectTeamMemberLookupKeys(member)
       .map((lookupKey) => memberByIdentity.get(lookupKey))
       .find(Boolean);

--- a/server/bff/routes/projects.participation-sync-key.test.mjs
+++ b/server/bff/routes/projects.participation-sync-key.test.mjs
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { buildProjectTeamMemberSyncKeys } from './projects.mjs';
+
+// 참여행 문서 ID 가 이 키로 만들어진다(`pte-{사업}-{키}`). 키가 바뀌면 연결이 끊기고,
+// 키가 겹치면 참여행이 서로 덮어써 참여율이 사라진다. 두 가지를 함께 지킨다.
+describe('참여행 연결 키', () => {
+  it('역할을 넣지 않는다 - 역할명을 고쳐도 같은 사람의 연결이 유지되어야 한다', () => {
+    const before = buildProjectTeamMemberSyncKeys([
+      { memberName: '김정태', memberNickname: '에이블', role: '사업 총괄' },
+    ]);
+    const afterRoleRename = buildProjectTeamMemberSyncKeys([
+      { memberName: '김정태', memberNickname: '에이블', role: '총괄책임자' },
+    ]);
+    expect(before).toEqual(['에이블']);
+    expect(afterRoleRename).toEqual(before);
+  });
+
+  it('닉네임이 없으면 이름으로 만든다', () => {
+    expect(buildProjectTeamMemberSyncKeys([{ memberName: '노성진', role: '사업총괄' }])).toEqual(['노성진']);
+  });
+
+  it('한 사업에 같은 사람이 두 역할로 있으면 그때만 역할을 덧붙인다', () => {
+    expect(buildProjectTeamMemberSyncKeys([
+      { memberNickname: '에이블', role: '사업총괄' },
+      { memberNickname: '에이블', role: '서류총괄' },
+      { memberNickname: '유자', role: '실무책임자' },
+    ])).toEqual(['에이블__사업총괄', '에이블__서류총괄', '유자']);
+  });
+
+  it('겹치는 사람의 키가 서로 달라 참여행이 덮어써지지 않는다', () => {
+    const keys = buildProjectTeamMemberSyncKeys([
+      { memberNickname: '에이블', role: '사업총괄' },
+      { memberNickname: '에이블', role: '서류총괄' },
+    ]);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('사람도 역할도 비어 있으면 자리표시자로 채워 키가 빈 문자열이 되지 않는다', () => {
+    expect(buildProjectTeamMemberSyncKeys([{}, {}])).toEqual(['member__role', 'member__role']);
+  });
+
+  it('명단이 비었거나 배열이 아니면 빈 결과를 준다', () => {
+    expect(buildProjectTeamMemberSyncKeys([])).toEqual([]);
+    expect(buildProjectTeamMemberSyncKeys(undefined)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 왜

참여행 문서 ID 가 연결 키로 만들어집니다(`pte-{사업}-{키}`). 그 키가 `닉네임__역할` 이라
**사업의 역할명만 고쳐도 키가 통째로 바뀌어 같은 사람의 참여행 연결이 끊겼습니다.**

| 참여행 키 | 현재 팀원 키 | 사람 |
|---|---|---|
| `에이블__사업-총괄` | `에이블__총괄책임자` | 김정태 |
| `싱아__운영-정산지원` | `싱아__사업운영` | 이시은 |

라이브에서 26건이 이 상태였고, 그중 16건이 `2026상스캠10기` 한 사업에 몰려 있었습니다(#640에서 연결).

**참여율은 사람 단위로 합산해서 보여줍니다.** 대시보드는 이 키를 아예 읽지 않고 `personId` 만
씁니다. 키가 역할까지 구분할 이유가 없습니다.

## 무엇을

키를 **사람만으로** 만듭니다. 한 사업에 같은 사람이 두 역할로 올라 있을 때만 역할을 덧붙입니다 —
키가 겹치면 참여행 문서 하나가 다른 하나를 덮어써 **참여율이 조용히 사라지기** 때문입니다.

```
[에이블/사업총괄]                        → ['에이블']
[에이블/사업총괄, 에이블/서류총괄, 유자]  → ['에이블__사업총괄', '에이블__서류총괄', '유자']
```

한 명씩 보는 함수로는 같은 사업 안의 중복을 알 수 없어, 키 생성을 **팀원 명단 단위 순수 함수**
(`buildProjectTeamMemberSyncKeys`)로 분리했습니다.

## 라이브 데이터에 대한 확인 — 셋 다 읽기 전용으로 미리 쟀습니다

키가 바뀌면 문서 ID 가 바뀝니다. 그래서 세 가지를 실제 라이브 데이터로 확인했습니다.

| 확인 | 결과 |
|---|---|
| 한 사업에 같은 사람이 두 역할? | **0건** — 합쳐질 데이터 없음 |
| 옛 키 문서가 고아로 남아 이중 집계? | **0건** — 273건 전부 `PROJECT_TEAM_SYNC` 에 ID 규칙 일치라 재저장 시 정리됨 |
| 재저장하면 연결이 끊기는 참여행? | **0건** — 연결된 263건 전부 팀원행에도 `personId` 가 있음 |

세 번째가 가장 걱정됐습니다. 새 참여행은 팀원행의 `personId` 로만 채워지므로, 팀원행에
`personId` 가 없으면 재저장 때 #640에서 채운 연결이 사라질 수 있었습니다. 실제로는 0건입니다.

## 검증

| 게이트 | 결과 |
|---|---|
| `npm test` | 3298 passed / 4 failed — 아래 |
| 새 테스트 | 6 passed (`projects.participation-sync-key.test.mjs`) |
| `npm run typecheck` | no new type errors (185 known, 30 files) |
| `npm run policy:verify` | 통과 |
| `npm run build` | ✓ built in 30.35s |

**삭제 검증**: 중복 가드(`occurrences.get(person) > 1 ? … : person`)를 걷어내고 돌려
6건 중 3건이 실패하는 것을 확인한 뒤 되돌렸습니다.

### 실패 4건은 전부 무관한 부하 flake

전체 실행에서 실패한 파일은 `server/mcp/server.test.mjs`,
`server/bff/standalone-workers.test.ts`, `server/bff/routes/cashflow-sheet-lab.test.mjs`,
`server/bff/routes/jvm-weekly-api.test.mjs` — **이 저장소에 기록된 부하 flake 목록과 정확히
일치**합니다. 단독 실행 결과:

| 파일 | 단독 |
|---|---|
| `server.test.mjs` | 1/1 통과 |
| `standalone-workers.test.ts` | 3/3 통과 |
| `jvm-weekly-api.test.mjs` | 271/271 통과 |
| `cashflow-sheet-lab.test.mjs` | 재실행 2회 **109/109 통과** |

네 파일 모두 `buildProjectTeamMemberSyncKeys` / `syncProjectParticipationEntries` 를
쓰지 않습니다.

## 남은 것 (이 PR 밖)

팀원행 75건(23개 사업)에 아직 `personId` 가 없습니다. 지금 연결된 참여행과는 겹치지 않아
이 변경으로 나빠지는 건 없지만, 그 사람들은 사업을 저장해도 계속 "연결 대기" 로 남습니다.
백필에 **참여행을 거치지 않고 People 에서 바로 잇는 단계**를 넣으면 줄일 수 있습니다 —
라이브 데이터를 건드리는 일이라 따로 여쭙고 진행하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)