### PR TITLE
fix(participation): 참여행 없는 팀원도 People 에 바로 잇는다

### DIFF
--- a/scripts/backfill-participation-person-ids.mjs
+++ b/scripts/backfill-participation-person-ids.mjs
@@ -124,14 +124,37 @@ async function main() {
     }
   }
 
+  /*
+   * 참여행을 거치지 않고 People 에서 바로 잇는다.
+   *
+   * 팀원 personId 는 참여행에서 역으로 채워지는데, 참여행이 아직 없는 팀원은 손이 닿지 않아
+   * 계속 비어 있었다(라이브 75건). 새 참여행은 팀원행의 personId 로만 채워지므로, 비어 있으면
+   * 사업을 저장할 때마다 연결이 빈 참여행이 다시 생긴다.
+   *
+   * 팀원행이 이름과 닉네임을 둘 다 들고 있으면 둘이 같은 사람을 가리킬 때만 잇는다. 한쪽만 맞는 것은
+   * 받지 않는다 - People 에 아직 없는 동명이인일 수 있다.
+   * 애초에 한쪽만 적힌 팀원행은 모순될 신호 자체가 없으므로 그 한쪽으로 잇는다.
+   */
+  let teamMemberIdentityMatches = 0;
+  function personIdFromIdentity(member) {
+    const nameId = unique(peopleByName, [member?.memberName]);
+    const nicknameId = unique(peopleByNickname, [member?.memberNickname]);
+    if (text(member?.memberName) && text(member?.memberNickname)) {
+      return nameId && nicknameId && nameId === nicknameId ? nameId : '';
+    }
+    return nameId || nicknameId;
+  }
+
   const projectPlans = [];
   for (const projectDoc of projectsSnap.docs) {
     const current = Array.isArray(projectDoc.data()?.teamMembersDetailed) ? projectDoc.data().teamMembersDetailed : [];
     let changed = false;
     const next = current.map((member) => {
       if (text(member?.personId)) return member;
-      const personId = resolvedByProjectKey.get(`${projectDoc.id}:${syncKey(member)}`);
+      const fromEntry = resolvedByProjectKey.get(`${projectDoc.id}:${syncKey(member)}`);
+      const personId = fromEntry || personIdFromIdentity(member);
       if (!personId) return member;
+      if (!fromEntry) teamMemberIdentityMatches += 1;
       changed = true;
       return { ...member, personId };
     });
@@ -144,6 +167,7 @@ async function main() {
     exactUidMatches: entryPlans.filter((plan) => plan.source === 'EXACT_UID').length,
     uniquePeopleIdentityMatches: entryPlans.filter((plan) => plan.source === 'UNIQUE_PEOPLE_IDENTITY').length,
     roleDriftMatches,
+    teamMemberIdentityMatches,
     unresolvedCount: unresolved.length, unresolvedPreview: unresolved.slice(0, 20),
   };
   if (dumpDir) {


### PR DESCRIPTION
## 왜

팀원 `personId` 는 **참여행에서 역으로만** 채워졌습니다. 참여행이 아직 없는 팀원은 손이 닿지
않아 계속 비어 있었습니다 — 라이브에서 **75건, 23개 사업**.

새 참여행은 팀원행의 `personId` 로만 채워집니다. 그래서 비어 있으면 사업을 저장할 때마다
연결이 빈 참여행이 다시 생깁니다. 어제 #640에서 이은 것이 시간이 지나며 도로 풀리는 구조였습니다.

## 무엇을

참여행을 거치지 않고 **People 에서 바로 잇는 단계**를 넣었습니다.

| 팀원행 | 판정 |
|---|---|
| 이름·닉네임 둘 다 있음 | 둘이 **같은 사람**을 가리킬 때만 이음 |
| 둘 다 있는데 엇갈림 | **잇지 않음** |
| 한쪽만 적혀 있음 | 모순될 신호가 없으므로 그 한쪽으로 이음 |

한쪽만 맞는 경우를 받지 않는 이유는 **People 에 아직 없는 동명이인**일 수 있어서입니다.
반대로 애초에 한쪽만 적힌 팀원행은 모순될 신호 자체가 없어 그대로 씁니다 —
`박정호`(닉네임 없음, People 에서 유일)가 이 규칙으로 이어졌습니다.

## 라이브 적용 결과

| | 전 | 후 |
|---|---|---|
| 팀원행 `personId` 있음 | 264 | **329** |
| 팀원행 `personId` 없음 | 75 | **10** |
| 구멍 있는 사업 | 23 | **7** |
| 재저장하면 연결 끊기는 참여행 | 0 | **0** |
| 표에 나오는 사람 | 69 | 69 |

**참여행은 한 건도 건드리지 않았습니다**(`partEntriesToUpdate: 0`). 팀원행만 채웠습니다.
표의 사람 수가 그대로인 것은 정상입니다 — 이 변경은 지금 보이는 값이 아니라
**다음 저장 때 연결이 풀리지 않게** 하는 것입니다.

적용 전에 읽기 전용으로 65건이 **누구에게** 이어지는지 전부 확인했습니다
(김영우(앵커) · 강현주(헤일리) · 나미소(쏘) … 39명).

## 남은 10건 — 사람이 잡기로 함

| 사람 | 상태 |
|---|---|
| 김혜령(테일러) ×3 · 김다은(데이나) · 강에나(하에나) · 김원희(청) · 노성진 | People 에 없음 |
| `신규채용1` · `신규채용2` | 채용 예정 자리 |
| (이름·닉네임 둘 다 빈 행 1건) | 2026 에코스타트업 |

## 검증

`scripts/**` 는 vitest 대상이 아니라(`src/**` · `server/**` 만 포함) 단위 테스트를 붙여도
CI에서 안 돕니다. 대신 **독립 분석 스크립트로 먼저 예측하고 도구 결과와 대조**했습니다.

| 단계 | 결과 |
|---|---|
| 사전 분석(별도 스크립트) | 이어짐 64 · 남음 11 |
| 규칙 정밀화 후 dry-run | `teamMemberIdentityMatches: 65` — 박정호 1건 추가, 일치 |
| 적용 | 프로젝트 18건 · 참여행 0건 |
| 적용 후 재측정 | 팀원행 없음 75 → 10 · 재저장 위험 0 · 표 69명 유지 |

## 사본 · 되돌리기

`~/backups/participation-people-link/2026-08-21-step3/` — 이 적용 **전** 전체 사본과
`restore.mjs`. **적용 전에 restore dry-run 을 돌려** 273건·71개를 인식하는 것을 확인했습니다.

## ⚠️ 후속 — 등록/수정 폼의 "직접 입력"

폼에는 `팀원 검색`(People 선택, `personId` 들어감)과 `직접 입력`(이름만, **`personId` 없음**)
두 모드가 있습니다. 직접 입력으로 넣은 사람은 참여율 집계에 잡히지 않습니다.

데이터를 폼으로 다시 받을 예정이라 이 구멍이 그대로 재생됩니다. 직접 입력 자체는 외부 인력·채용
예정 자리에 필요하므로 막을 수는 없고, 별도로 다루겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)