### PR TITLE
feat(participation): 하드코딩으로 수식이 깨져도 안전하게

### DIFF
--- a/scripts/build-participation-sheet-template.mjs
+++ b/scripts/build-participation-sheet-template.mjs
@@ -100,6 +100,13 @@ async function main() {
     ['', '  줄 삭제 · 열 추가/삭제 · 1~2행(머리글) 수정. 양식이 달라지면 반영이 거부됩니다.'],
     ['', '  사업 기간이 바뀌면 플랫폼에서 계약 기간을 먼저 수정합니다. 반영 시 시트 기간과 대조합니다.'],
     ['', ''],
+    ['굵게', '칸을 덮어쓴 뒤에 - 되돌리기와 빨간 칸'],
+    ['', '  숫자를 적으면 그 칸의 자동 채움 수식이 지워집니다. 정상이며, 손댄 칸은 노랗게 남습니다.'],
+    ['', '  기본값으로 되돌리려면: 같은 줄의 노랗지 않은 칸 하나를 복사해 붙여넣으세요. 수식이 자리에'],
+    ['', '  맞게 살아납니다. 줄 전체를 덮어썼다면 아래 여유 줄의 아무 칸이나 복사해도 됩니다.'],
+    ['', '  진한 빨간 칸 = 투입기간 밖에 남은 옛 값입니다(기간·투입월을 바꾼 뒤 남은 흔적). 지우거나'],
+    ['', '  기간을 확인하세요. 이 값이 남아 있으면 반영이 거부됩니다.'],
+    ['', ''],
     ['굵게', '기간을 바꿀 때 - 종료월만 바꿉니다'],
     ['', '  연장·단축 → 종료월만 바꾸면 월 칸이 그에 맞춰 늘어나거나 줄어듭니다. 이미 적은 값은 그대로입니다.'],
     ['', '  시작월은 값을 적기 전에 정하고, 그 뒤에는 바꾸지 않습니다 - 바꾸면 이미 적은 값의 달이 한 칸씩'],
@@ -241,22 +248,34 @@ async function main() {
   });
 
   // 조건부 서식: 회색 = 기간 밖(헤더 없음) · 빨강 = 투입기간 안의 미입력 · 노랑 = 기본과 다른 값(diff)
+  const A = `$A${dataStartRow}`; const D = `$D${dataStartRow}`; const E = `$E${dataStartRow}`;
+  const CELL = `${firstMonthLetter}${dataStartRow}`; const HDR = `${firstMonthLetter}$2`;
   sheet.addConditionalFormatting({
     ref: `${firstMonthLetter}${dataStartRow}:${lastColLetter}${dataEndRow}`,
     rules: [
+      // ① 고아 값(최우선): 값이 있는데 헤더 밖이거나 투입기간 밖. 수식 칸은 그런 자리에서
+      //    스스로 비워지므로 이 규칙에 걸리는 것은 하드코딩 잔재뿐이다. 기간·투입월을 바꾼 뒤
+      //    남은 옛 값이 즉시 진한 빨강으로 드러난다. 반영도 이 값을 거부한다(이중 방어).
       {
         type: 'expression', priority: 1,
-        formulae: [`${firstMonthLetter}$2=""`],
-        style: { fill: { type: 'pattern', pattern: 'solid', bgColor: { argb: 'FFF1F5F9' } } },
+        formulae: [`AND(${CELL}<>"",OR(${HDR}="",${D}="",AND(${D}<>"",${HDR}<${D}),AND(${E}<>"",${HDR}>${E})))`],
+        style: { fill: { type: 'pattern', pattern: 'solid', bgColor: { argb: 'FFFCA5A5' } } },
       },
       {
         type: 'expression', priority: 2,
-        formulae: [`AND(${firstMonthLetter}$2<>"",$A${dataStartRow}<>"",$D${dataStartRow}<>"",${firstMonthLetter}$2>=$D${dataStartRow},OR($E${dataStartRow}="",${firstMonthLetter}$2<=$E${dataStartRow}),${firstMonthLetter}${dataStartRow}="")`],
-        style: { fill: { type: 'pattern', pattern: 'solid', bgColor: { argb: 'FFFDE0E0' } } },
+        formulae: [`${HDR}=""`],
+        style: { fill: { type: 'pattern', pattern: 'solid', bgColor: { argb: 'FFF1F5F9' } } },
       },
       {
         type: 'expression', priority: 3,
-        formulae: [`AND(${firstMonthLetter}${dataStartRow}<>"",$F${dataStartRow}<>"",${firstMonthLetter}${dataStartRow}<>$F${dataStartRow})`],
+        formulae: [`AND(${HDR}<>"",${A}<>"",${D}<>"",${HDR}>=${D},OR(${E}="",${HDR}<=${E}),${CELL}="")`],
+        style: { fill: { type: 'pattern', pattern: 'solid', bgColor: { argb: 'FFFDE0E0' } } },
+      },
+      // ④ diff 를 값 비교가 아니라 수식 여부(ISFORMULA)로 표시한다. 하드코딩한 칸은 값이
+      //    기본과 같아도 노랗다 - "수식이 깨진 곳" 지도와 "사람이 손댄 곳" 지도가 같아진다.
+      {
+        type: 'expression', priority: 4,
+        formulae: [`AND(${CELL}<>"",NOT(ISFORMULA(${CELL})))`],
         style: { fill: { type: 'pattern', pattern: 'solid', bgColor: { argb: 'FFFFF3C4' } } },
       },
     ],


### PR DESCRIPTION
## 신고

> 시트에 diff를 한 번 하드코딩해버리면 수식이 다 깨져버리네. 에러를 부를 것 같은데 대책이 있을까?

## 진단 — 덮어쓰기 자체는 설계이고, 위험은 딱 하나

숫자를 덮어쓰면 그 칸의 수식이 지워지는 것 — **그게 diff 메커니즘**입니다. 반영 파이프라인은
수식이 아니라 **값만** 읽으므로 수식 깨짐 자체는 데이터를 오염시키지 못합니다.

진짜 위험은 하나: 하드코딩한 뒤 기간(B1/D1)이나 투입월(D/E)을 바꾸면 **수식 칸은 스스로
비워지는데 하드코딩 칸은 그 자리에 남아** 기간 밖 고아 값이 됩니다. 급여 데이터에서 이게 사고입니다.

## 3층 방어

| 층 | 장치 |
|---|---|
| **① 고아 값 즉시 표시** (신규, 최우선 규칙) | 값이 있는데 헤더 밖/투입기간 밖 → **진한 빨강**. 수식 칸은 그 자리에서 스스로 비워지므로, 이 규칙에 걸리는 것은 하드코딩 잔재뿐 — 오탐 없음 |
| **② 손댄 곳 지도** (규칙 교체) | diff 표시를 값 비교 → **`ISFORMULA`** 로 변경. 손댄 칸은 값이 기본과 같아도 노랗게 — "수식 깨진 곳" 지도와 "사람이 손댄 곳" 지도가 정확히 일치 |
| **③ 반영 검증** (설계 #646 §3.1) | 고아 값은 `participation_value_outside_stint` 로 행·달을 짚어 거부. 시트 표시를 놓쳐도 여기서 걸림 |

## 복구는 원래 공짜였습니다 — 안내에 명시만

월 칸 수식이 `$A3`(열 고정·행 상대)·`G$2`(행 고정·열 상대)로 설계돼 있어, **같은 줄의 성한 칸
하나를 복사해 붙여넣으면 어느 자리든 수식이 맞게 살아납니다.** 줄 전체를 덮어썼으면 아래 여유
줄의 아무 칸이나 복사해도 됩니다. 안내 탭에 이 복구 절차를 실었습니다.

## 검증

xlsx 재개봉: 조건부서식 4규칙(고아→회색→미입력→ISFORMULA diff) 우선순위 확인 · 양식 식별자
유지. 구글 시트 변환 후 수동 확인 항목: 값 하드코딩 → 노랑, 그 뒤 투입종료월 당기기 → 기간
밖 값이 진한 빨강으로 바뀌는지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)