### PR TITLE
feat(participation): 등록/수정 폼에 참여율 시트 링크를 받는다

### DIFF
--- a/server/bff/routes/projects.mjs
+++ b/server/bff/routes/projects.mjs
@@ -1490,6 +1490,7 @@ export function buildProjectRegistrationCanonicalDocuments({
     description: readOptionalText(payload.description),
     clientOrg: readOptionalText(payload.clientOrg),
     businessManagementGoogleFolderLink: readOptionalText(payload.businessManagementGoogleFolderLink) || undefined,
+    participationSheetLink: readOptionalText(payload.participationSheetLink) || undefined,
     department: normalizeProjectOrganizationLabel(payload.department),
     groupwareName: readOptionalText(payload.groupwareName) || undefined,
     currency: normalizeProjectCurrency(readOptionalText(payload.currency)),

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -1858,6 +1858,21 @@ export function ProjectEditorWizard({
         />
       </ProjectFormRow>
 
+      {/* 참여율 시트를 이 사업에 묶는 지점. 시트 안에는 사업 식별자를 적지 않는다 -
+          사람이 적는 식별자는 어긋난다. 링크를 저장하는 것이 곧 바인딩이다. */}
+      <ProjectFormRow
+        label="참여율 시트 링크"
+        hints={['참여율 표준양식을 복사해 만든 이 사업 전용 시트 링크를 입력해 주세요.']}
+      >
+        <Input
+          type="url"
+          value={draft.participationSheetLink}
+          onChange={(event) => update('participationSheetLink', event.target.value)}
+          placeholder="https://docs.google.com/spreadsheets/d/..."
+          className={FORM_CONTROL_CLASS}
+        />
+      </ProjectFormRow>
+
       <ProjectFormRow
         label="프로젝트 목적"
         required={usesRegistrationV2}

--- a/src/app/data/types.ts
+++ b/src/app/data/types.ts
@@ -721,6 +721,7 @@ export interface Project {
   // MYSC-specific fields
   clientOrg: string;             // 발주기관(계약기관)
   businessManagementGoogleFolderLink?: string;
+  participationSheetLink?: string; // 참여율 입력 시트(표준양식 사본) 링크
   groupwareName: string;         // 그룹웨어 프로젝트등록명
   participantCondition: string;  // 참여기업 조건
   note?: string;                  // PM/관리자 참고 메모
@@ -910,6 +911,7 @@ export interface ProjectRequestPayload {
   description: string;
   clientOrg: string;
   businessManagementGoogleFolderLink?: string;
+  participationSheetLink?: string;
   department: string;
   groupwareName?: string;
   currency?: ProjectCurrency;

--- a/src/app/platform/project-editor.test.ts
+++ b/src/app/platform/project-editor.test.ts
@@ -901,3 +901,24 @@ describe('project editor draft mapping', () => {
     }]));
   });
 });
+
+// 참여율 시트를 사업에 묶는 지점. 시트 안에는 사업 식별자를 적지 않으므로(사람이 적는
+// 식별자는 어긋난다) 이 링크를 저장하는 것이 곧 바인딩이다. 왕복에서 사라지면 바인딩이 끊긴다.
+describe('참여율 시트 링크', () => {
+  it('불러오기 → 저장 왕복에서 값을 잃지 않는다', () => {
+    const link = 'https://docs.google.com/spreadsheets/d/abc123/edit';
+    const project = { ...baseProject, participationSheetLink: link };
+    const draft = buildProjectEditorDraftFromProject(project);
+    expect(draft.participationSheetLink).toBe(link);
+    const patch = buildProjectEditorProjectPatch(draft, {
+      mode: 'admin', actorId: 'u1', actorName: '보람', now: '2026-08-21T00:00:00.000Z',
+    });
+    expect(patch.participationSheetLink).toBe(link);
+    expect(buildProjectRequestPayloadFromDraft(draft).participationSheetLink).toBe(link);
+  });
+
+  it('값이 없으면 빈 문자열로 시작한다', () => {
+    expect(createProjectEditorDraft().participationSheetLink).toBe('');
+    expect(buildProjectEditorDraftFromProject(baseProject).participationSheetLink).toBe('');
+  });
+});

--- a/src/app/platform/project-editor.ts
+++ b/src/app/platform/project-editor.ts
@@ -86,6 +86,7 @@ export interface ProjectEditorDraft {
   description: string;
   clientOrg: string;
   businessManagementGoogleFolderLink: string;
+  participationSheetLink: string;
   department: string;
   projectPurpose: string;
   status: ProjectStatus;
@@ -172,6 +173,7 @@ const DEFAULT_DRAFT: ProjectEditorDraft = {
   description: '',
   clientOrg: '',
   businessManagementGoogleFolderLink: '',
+  participationSheetLink: '',
   department: '',
   projectPurpose: '',
   status: 'CONTRACT_PENDING',
@@ -490,6 +492,7 @@ const REVIEW_CHANGE_FIELDS: Array<{
   { key: 'officialContractName', label: '공식 계약명', before: (project) => normalizeChangeValue(project.officialContractName), after: (draft) => normalizeChangeValue(draft.officialContractName) },
   { key: 'clientOrg', label: '계약 대상', before: (project) => normalizeChangeValue(project.clientOrg), after: (draft) => normalizeChangeValue(draft.clientOrg) },
   { key: 'businessManagementGoogleFolderLink', label: '사업관리 구글폴더링크', before: (project) => normalizeChangeValue(project.businessManagementGoogleFolderLink), after: (draft) => normalizeChangeValue(draft.businessManagementGoogleFolderLink) },
+  { key: 'participationSheetLink', label: '참여율 시트 링크', before: (project) => normalizeChangeValue(project.participationSheetLink), after: (draft) => normalizeChangeValue(draft.participationSheetLink) },
   { key: 'department', label: '담당조직(CIC)', before: (project) => normalizeChangeValue(project.department), after: (draft) => normalizeChangeValue(draft.department) },
   { key: 'type', label: '프로젝트 유형', before: (project) => PROJECT_TYPE_LABELS[normalizeProjectType(project.type)] || '-', after: (draft) => PROJECT_TYPE_LABELS[normalizeProjectType(draft.type)] || '-' },
   { key: 'contractPeriod', label: '계약 기간', before: (project) => formatDateRangeForChange(project.contractStart, project.contractEnd), after: (draft) => formatDateRangeForChange(draft.contractStart, draft.contractEnd) },
@@ -665,6 +668,9 @@ export function buildProjectEditorDraftFromProject(
     businessManagementGoogleFolderLink: text(
       normalizedProject.businessManagementGoogleFolderLink || payload?.businessManagementGoogleFolderLink,
     ),
+    participationSheetLink: text(
+      normalizedProject.participationSheetLink || payload?.participationSheetLink,
+    ),
     department: normalizeProjectDepartment(
       normalizedProject.department || normalizedProject.cic || payload?.department,
     ),
@@ -780,6 +786,7 @@ export function buildProjectRequestPayloadFromDraft(draftInput: ProjectEditorDra
     description: text(draft.description),
     clientOrg: text(draft.clientOrg),
     businessManagementGoogleFolderLink: text(draft.businessManagementGoogleFolderLink),
+    participationSheetLink: text(draft.participationSheetLink),
     department: normalizeProjectDepartment(draft.department),
     groupwareName: text(draft.groupwareName),
     currency: normalizeProjectCurrency(draft.currency),
@@ -925,6 +932,7 @@ export function buildProjectEditorProjectPatch(
     paymentPlanDesc: text(draft.paymentPlanDesc),
     clientOrg: text(draft.clientOrg),
     businessManagementGoogleFolderLink: text(draft.businessManagementGoogleFolderLink),
+    participationSheetLink: text(draft.participationSheetLink),
     groupwareName: text(draft.groupwareName),
     participantCondition: text(draft.participantCondition),
     teamMembersDetailed,


### PR DESCRIPTION
## 무엇 (설계 #646 의 PR-C)

참여율 시트를 사업에 묶는 지점입니다. 시트 안에는 사업 식별자를 적지 않습니다 — **사람이 적는
식별자는 반드시 어긋납니다.** 등록/수정에서 링크를 저장하는 것이 곧 바인딩이고, 반영은 그 링크를
읽는 명시적 동작이 됩니다.

`계약 정보` 섹션의 `사업관리 구글폴더링크` 바로 아래에 `참여율 시트 링크` 한 칸을 넣었습니다.

## 설계와 달라진 점 — 전용 라우트를 쓰지 않았습니다

#646 §3.2 는 `PUT /participation-sheet/config` 를 뒀지만 만들지 않았습니다. 이 값은
`businessManagementGoogleFolderLink` 와 똑같은 **평범한 프로젝트 필드**이고, 기존 저장 경로가
이미 검증·감사·변경이력을 태웁니다. 라우트를 새로 만들면 같은 문서를 쓰는 저장 경로가 둘이 됩니다.

기존 링크 필드와 정확히 같은 자리를 지납니다:

| 지점 | 내용 |
|---|---|
| `types.ts` | `Project` · 등록 payload 두 타입 |
| `project-editor.ts` | draft 타입 · 초기값 · **변경이력 필드**(승인 문서에 표시) · 불러오기 · 저장 payload 2곳 |
| `routes/projects.mjs` | payload 통과 |
| `ProjectEditorWizard.tsx` | 입력칸 |

## 검증

| 게이트 | 결과 |
|---|---|
| `project-editor.test.ts` | **34 passed** (왕복 테스트 2건 추가) |
| 등록/수정 영역 | 122 passed (12 files) |
| `npm run typecheck` | no new type errors |
| `npm run policy:verify` | 통과 |
| `npm run build` | 통과 |

**삭제 검증**: 저장 payload 에서 이 필드를 걷어내고 돌려 왕복 테스트가 실패하는 것을 확인한 뒤
되돌렸습니다. 바인딩이 조용히 끊기는 것이 이 PR 에서 가장 위험한 회귀입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)