### PR TITLE
perf(cashflow): stabilize sheet staging and activity reads

### DIFF
--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -165,7 +165,23 @@
       ]
     },
     {
+      "collectionGroup": "cashflow_sheet_refresh_runs",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "projectId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "weekly_api_audit_events",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "projectId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "cashflow_events",
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "projectId", "order": "ASCENDING" },

--- a/server/bff/cashflow-performance.mjs
+++ b/server/bff/cashflow-performance.mjs
@@ -31,7 +31,16 @@ export function createCashflowPerformanceTrace({
   logger = defaultLogger,
   now = () => performance.now(),
 } = {}) {
-  const startedAt = now();
+  const readNow = () => {
+    try {
+      const value = Number(now());
+      if (Number.isFinite(value)) return value;
+    } catch {
+      // Diagnostics must never affect the request being measured.
+    }
+    return performance.now();
+  };
+  const startedAt = readNow();
   // 응답 헤더(Server-Timing)로 내보낼 span 기록. 로그를 못 보는 자리(브라우저)에서도 분해가 보이게.
   const spans = [];
 
@@ -52,7 +61,7 @@ export function createCashflowPerformanceTrace({
       ...(Number.isSafeInteger(details.itemCount) ? { itemCount: details.itemCount } : {}),
       ...(Number.isSafeInteger(details.issueCount) ? { issueCount: details.issueCount } : {}),
       durationMs: safeDuration(details.durationMs),
-      totalMs: safeDuration(now() - startedAt),
+      totalMs: safeDuration(readNow() - startedAt),
     };
     if (details.outcome) spans.push({ phase: payload.phase, attempt: payload.attempt, durationMs: payload.durationMs, outcome: payload.outcome });
     if (logger === defaultLogger && process.env.NODE_ENV === 'test') return;
@@ -74,10 +83,10 @@ export function createCashflowPerformanceTrace({
   };
 
   const measure = async (phase, task, details = {}) => {
-    const phaseStartedAt = now();
+    const phaseStartedAt = readNow();
     try {
       const result = await task();
-      emit(phase, { ...details, outcome: 'ok', durationMs: now() - phaseStartedAt });
+      emit(phase, { ...details, outcome: 'ok', durationMs: readNow() - phaseStartedAt });
       return result;
     } catch (error) {
       emit(phase, {
@@ -85,17 +94,17 @@ export function createCashflowPerformanceTrace({
         outcome: 'error',
         statusCode: error?.statusCode,
         errorCode: error?.code || error?.name,
-        durationMs: now() - phaseStartedAt,
+        durationMs: readNow() - phaseStartedAt,
       });
       throw error;
     }
   };
 
   const measureSync = (phase, task, details = {}) => {
-    const phaseStartedAt = now();
+    const phaseStartedAt = readNow();
     try {
       const result = task();
-      emit(phase, { ...details, outcome: 'ok', durationMs: now() - phaseStartedAt });
+      emit(phase, { ...details, outcome: 'ok', durationMs: readNow() - phaseStartedAt });
       return result;
     } catch (error) {
       emit(phase, {
@@ -103,7 +112,7 @@ export function createCashflowPerformanceTrace({
         outcome: 'error',
         statusCode: error?.statusCode,
         errorCode: error?.code || error?.name,
-        durationMs: now() - phaseStartedAt,
+        durationMs: readNow() - phaseStartedAt,
       });
       throw error;
     }
@@ -116,7 +125,7 @@ export function createCashflowPerformanceTrace({
       const desc = span.outcome === 'error' ? ';desc="error"' : '';
       return `${name};dur=${span.durationMs}${desc}`;
     });
-    entries.push(`total;dur=${safeDuration(now() - startedAt)}`);
+    entries.push(`total;dur=${safeDuration(readNow() - startedAt)}`);
     return entries.join(', ');
   };
 

--- a/server/bff/cashflow-performance.test.mjs
+++ b/server/bff/cashflow-performance.test.mjs
@@ -43,6 +43,19 @@ describe('cashflow performance trace', () => {
     await flushLogs();
   });
 
+  it('preserves the measured result and timing header when the diagnostic clock throws', async () => {
+    const trace = createCashflowPerformanceTrace({
+      requestId: 'req-clock',
+      operation: 'cashflow.read',
+      logger: () => {},
+      now: () => { throw new Error('clock failed'); },
+    });
+
+    await expect(trace.measure('body_read', async () => 'same-result')).resolves.toBe('same-result');
+    expect(() => trace.serverTiming()).not.toThrow();
+    expect(trace.serverTiming()).toMatch(/^body_read;dur=\d+, total;dur=\d+$/);
+  });
+
   it('logs a safe error code and rethrows the original error', async () => {
     const events = [];
     const error = Object.assign(new Error('contains private workbook value'), {

--- a/server/bff/routes/cashflow-sheet-lab.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.mjs
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import {
   asyncHandler,
   chunkArray,
@@ -235,14 +235,48 @@ function normalizeRouteError(error) {
 }
 
 function logCashflowSheetLab(event, req, details = {}, level = 'info') {
-  const write = typeof console[level] === 'function' ? console[level] : console.info;
-  write('[CashflowSheetLab]', event, {
-    requestId: req.context?.requestId || req.requestId || null,
-    tenantId: req.context?.tenantId || null,
-    actorId: req.context?.actorId || null,
-    actorRole: req.context?.actorRole || null,
-    ...details,
-  });
+  try {
+    const write = typeof console[level] === 'function' ? console[level] : console.info;
+    write('[CashflowSheetLab]', event, {
+      requestId: req.context?.requestId || req.requestId || null,
+      tenantId: req.context?.tenantId || null,
+      actorId: req.context?.actorId || null,
+      actorRole: req.context?.actorRole || null,
+      ...details,
+    });
+  } catch {
+    // Diagnostics must never affect a financial command.
+  }
+}
+
+function cashflowStageMetricNow(performanceNow) {
+  try {
+    const value = Number(typeof performanceNow === 'function' ? performanceNow() : Date.now());
+    return Number.isFinite(value) ? value : Date.now();
+  } catch {
+    return Date.now();
+  }
+}
+
+function cashflowStageJsonBytes(value) {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), 'utf8');
+  } catch {
+    return 0;
+  }
+}
+
+function emitCashflowStageMetric(performanceLogger, payload) {
+  try {
+    if (typeof performanceLogger === 'function') {
+      performanceLogger(payload);
+    } else if (process.env.NODE_ENV !== 'test') {
+      // eslint-disable-next-line no-console
+      console.log(JSON.stringify(payload));
+    }
+  } catch {
+    // Diagnostics must never affect a financial stage.
+  }
 }
 
 function routeErrorDetails(error) {
@@ -634,6 +668,16 @@ function mergeCashflowSourceMirror(previous, next, sourceYear) {
     next?.sheetFacts?.depositScheduleRows,
     (row) => Number(readOptionalText(row?.yearMonth).slice(0, 4)),
   );
+  const projectionActualDifferences = replaceYearRows(
+    previous?.sheetFacts?.projectionActualDifferences,
+    next?.sheetFacts?.projectionActualDifferences,
+    (row) => Number(readOptionalText(row?.yearMonth).slice(0, 4)),
+  );
+  const weeklyCalculationChecks = replaceYearRows(
+    previous?.sheetFacts?.weeklyCalculationChecks,
+    next?.sheetFacts?.weeklyCalculationChecks,
+    (row) => Number(readOptionalText(row?.yearMonth).slice(0, 4)),
+  );
   const annualFinancialTotals = replaceYearRows(
     previous?.sheetFacts?.annualFinancialTotals,
     next?.sheetFacts?.annualFinancialTotals,
@@ -674,6 +718,8 @@ function mergeCashflowSourceMirror(previous, next, sourceYear) {
     sheetFacts: {
       ...(next.sheetFacts || {}),
       depositScheduleRows,
+      projectionActualDifferences,
+      weeklyCalculationChecks,
       annualFinancialTotals,
       annualCashflowTotals,
       cashflowGrandTotalsBySourceYear,
@@ -765,37 +811,104 @@ async function saveCashflowSheetLabConfig({ db, tenantId, projectId, project, pa
   return config;
 }
 
-async function saveCashflowChangeCandidates({ db, tenantId, candidates }) {
-  if (!db || candidates.length === 0) return;
+function cashflowChangeCandidateManifestHash(candidates) {
+  const normalized = candidates.map((candidate) => {
+    const {
+      createdAt: _createdAt,
+      updatedAt: _updatedAt,
+      actorUid: _actorUid,
+      actorName: _actorName,
+      actorEmail: _actorEmail,
+      ...stableCandidate
+    } = candidate;
+    return stripUndefinedDeep(stableCandidate);
+  }).sort((left, right) => {
+    const leftText = stableStringify(left);
+    const rightText = stableStringify(right);
+    if (leftText === rightText) return 0;
+    return leftText < rightText ? -1 : 1;
+  });
+  return `sha256:${stableHash(normalized)}`;
+}
+
+async function saveCashflowChangeCandidates({
+  db,
+  tenantId,
+  candidates,
+  candidateManifestHash,
+  stageAttemptId,
+  runRef,
+  requestHash,
+  reservationExpiresAt,
+}) {
+  if (!db || candidates.length === 0) return { candidateCount: candidates.length, batchCommitCount: 0 };
+  let batchCommitCount = 0;
   for (let offset = 0; offset < candidates.length; offset += 450) {
-    await Promise.all(candidates.slice(offset, offset + 450).map((candidate) => {
-      const id = `cfc_${stableHash({
-        runId: candidate.runId,
-        projectId: candidate.projectId,
-        scope: candidate.scope,
-        year: candidate.year,
-        mode: candidate.mode,
-        yearMonth: candidate.yearMonth,
-        weekNo: candidate.weekNo,
-        lineId: candidate.lineId,
-      }).slice(0, 32)}`;
-      return db.doc(`orgs/${tenantId}/${CASHFLOW_CHANGE_CANDIDATES_COLLECTION_ID}/${id}`).set(stripUndefinedDeep({ ...candidate, id }));
-    }));
+    const chunk = candidates.slice(offset, offset + 450);
+    await db.runTransaction(async (transaction) => {
+      const currentRunSnap = await transaction.get(runRef);
+      const currentRun = currentRunSnap.exists ? (currentRunSnap.data() || {}) : {};
+      if (
+        readOptionalText(currentRun.status) !== 'STAGING'
+        || readOptionalText(currentRun.requestHash) !== requestHash
+        || readOptionalText(currentRun.stageAttemptId) !== stageAttemptId
+        || readOptionalText(currentRun.candidateManifestHash) !== candidateManifestHash
+        || readOptionalText(currentRun.reservationExpiresAt) !== reservationExpiresAt
+      ) {
+        throw createHttpError(
+          409,
+          '시트 검토 완료 상태가 변경되었습니다. 다시 확인해 주세요.',
+          'cashflow_sheet_stage_completion_conflict',
+        );
+      }
+      for (const candidate of chunk) {
+        const id = `cfc_${stableHash({
+          runId: candidate.runId,
+          projectId: candidate.projectId,
+          scope: candidate.scope,
+          year: candidate.year,
+          mode: candidate.mode,
+          yearMonth: candidate.yearMonth,
+          weekNo: candidate.weekNo,
+          lineId: candidate.lineId,
+          candidateManifestHash,
+        }).slice(0, 32)}`;
+        transaction.set(
+          db.doc(`orgs/${tenantId}/${CASHFLOW_CHANGE_CANDIDATES_COLLECTION_ID}/${id}`),
+          stripUndefinedDeep({ ...candidate, id, candidateManifestHash, stageAttemptId }),
+        );
+      }
+    });
+    batchCommitCount += 1;
   }
+  return { candidateCount: candidates.length, batchCommitCount };
 }
 
 async function readCashflowChangeCandidatesByRun({ db, tenantId, projectId, runId }) {
   if (!db) return [];
+  const run = await readCashflowSheetStageRun(db, tenantId, projectId, runId);
+  const candidateManifestHash = readOptionalText(run.candidateManifestHash);
+  const stageAttemptId = readOptionalText(run.stageAttemptId);
   const snap = await db.collection(`orgs/${tenantId}/${CASHFLOW_CHANGE_CANDIDATES_COLLECTION_ID}`)
     .where('runId', '==', runId)
     .get();
-  return snap.docs
+  const candidates = snap.docs
     .map((doc) => ({ id: doc.id, ...doc.data() }))
     .filter((candidate) => (
       readOptionalText(candidate.projectId) === readOptionalText(projectId)
       && readOptionalText(candidate.runId) === readOptionalText(runId)
       && readOptionalText(candidate.status || 'pending_review') === 'pending_review'
+      && (!candidateManifestHash || readOptionalText(candidate.candidateManifestHash) === candidateManifestHash)
+      && (!stageAttemptId || readOptionalText(candidate.stageAttemptId) === stageAttemptId)
     ));
+  if (candidateManifestHash && candidates.length !== Number(run.stagedLineCount)) {
+    throw createHttpError(
+      409,
+      '검토 후보 저장이 완전하지 않습니다. 시트 값을 다시 검토해 주세요.',
+      'cashflow_sheet_stage_candidates_incomplete',
+    );
+  }
+  return candidates;
 }
 
 async function markCashflowChangeCandidatesStatus({ db, tenantId, candidates, status, now }) {
@@ -1036,13 +1149,39 @@ function stageRunInProgressError() {
   return createHttpError(409, '같은 시트 검토 요청이 이미 처리 중입니다.', 'idempotency_request_in_progress');
 }
 
+const CASHFLOW_STAGE_RESPONSE_RUN_FIELDS = [
+  'closedMonthDifferences',
+  'closedMonthDifferenceCount',
+  'closedMonthDifferenceManifestHash',
+  'pendingApprovalDifferences',
+  'pendingApprovalDifferenceCount',
+  'pendingApprovalDifferenceManifestHash',
+  'pendingApprovalContractIssues',
+];
+
+function compactCashflowSheetStageResponse(response) {
+  const compact = { ...response };
+  for (const field of CASHFLOW_STAGE_RESPONSE_RUN_FIELDS) delete compact[field];
+  return compact;
+}
+
+function hydrateCashflowSheetStageResponse(run) {
+  if (!run?.response || typeof run.response !== 'object' || Array.isArray(run.response)) return null;
+  const response = { ...run.response };
+  for (const field of CASHFLOW_STAGE_RESPONSE_RUN_FIELDS) {
+    if (Object.hasOwn(run, field)) response[field] = run[field];
+  }
+  return response;
+}
+
 async function reserveCashflowSheetStageRun({ db, runRef, requestHash, reservation }) {
   return db.runTransaction(async (transaction) => {
     const snap = await transaction.get(runRef);
     if (snap.exists) {
       const run = snap.data() || {};
       assertStageRunRequestMatches(run, requestHash);
-      if (run.response) return run.response;
+      const response = hydrateCashflowSheetStageResponse(run);
+      if (response) return response;
       const reservationExpiresAt = Date.parse(readOptionalText(run.reservationExpiresAt));
       if (readOptionalText(run.status) === 'STAGING' && reservationExpiresAt > Date.now()) {
         throw stageRunInProgressError();
@@ -1052,6 +1191,8 @@ async function reserveCashflowSheetStageRun({ db, runRef, requestHash, reservati
       ...reservation,
       requestHash,
       status: 'STAGING',
+      failedAt: null,
+      failure: null,
     }), { merge: true });
     return null;
   });
@@ -2205,11 +2346,8 @@ async function readCashflowSheetApplyStatus({ db, tenantId, projectId, nowMs = D
       'cashflow_sheet_apply_recovery_invalid',
     );
   }
-  const stagedRun = (
-    stageRunDocument.response
-    && typeof stageRunDocument.response === 'object'
-    && !Array.isArray(stageRunDocument.response)
-  ) ? stageRunDocument.response : {
+  const persistedStageResponse = hydrateCashflowSheetStageResponse(stageRunDocument);
+  const stagedRun = persistedStageResponse || {
     ok: true,
     commandName: 'cashflowSheetLab.stage.firebase',
     projectId,
@@ -3593,7 +3731,34 @@ async function stagePinnedCashflowSheetLab({
   parsed = {},
   context = {},
   logger = () => {},
+  trace = null,
+  performanceNow,
+  onMetric = () => {},
 } = {}) {
+  const phaseDurationMs = { read: 0, build: 0, write: 0 };
+  let stageTimingsPublished = false;
+  const measureAsync = async (phase, task) => {
+    const startedAt = cashflowStageMetricNow(performanceNow);
+    try {
+      return await task();
+    } finally {
+      phaseDurationMs[phase] += Math.max(0, cashflowStageMetricNow(performanceNow) - startedAt);
+    }
+  };
+  const publishStageTimings = () => {
+    if (stageTimingsPublished) return;
+    stageTimingsPublished = true;
+    for (const phase of ['read', 'build', 'write']) {
+      try {
+        trace?.emit?.(`stage_${phase}`, {
+          outcome: 'ok',
+          durationMs: Math.round(phaseDurationMs[phase]),
+        });
+      } catch {
+        // Diagnostics must never affect a financial stage.
+      }
+    }
+  };
   logger('start', {
     projectId,
     expectedMirrorRevision: parsed.expectedMirrorRevision,
@@ -3607,7 +3772,7 @@ async function stagePinnedCashflowSheetLab({
   });
   const runId = `cfstage_${stableHash({ tenantId, projectId, idempotencyKey: parsed.idempotencyKey }).slice(0, 32)}`;
   const runRef = db.doc(`orgs/${tenantId}/${CASHFLOW_SHEET_STAGE_RUNS_COLLECTION_ID}/${runId}`);
-  const mirror = await readCashflowSheetMirror(db, tenantId, projectId);
+  const mirror = await measureAsync('read', () => readCashflowSheetMirror(db, tenantId, projectId));
   if (!mirror?.sourceRevision) {
     throw createHttpError(409, '먼저 시트 연동하기를 실행해 주세요.', 'cashflow_sheet_mirror_required');
   }
@@ -3616,17 +3781,22 @@ async function stagePinnedCashflowSheetLab({
   }
   assertFreshCashflowSheetMirror(mirror);
   const configRevision = readOptionalText(mirror.configRevision);
-  const existingRunSnap = await runRef.get();
+  const existingRunSnap = await measureAsync('read', () => runRef.get());
   if (existingRunSnap.exists) {
     const existingRun = existingRunSnap.data() || {};
     assertStageRunRequestMatches(existingRun, requestHash);
-    if (existingRun.response) return existingRun.response;
+    const response = hydrateCashflowSheetStageResponse(existingRun);
+    if (response) {
+      publishStageTimings();
+      return response;
+    }
     const reservationExpiresAt = Date.parse(readOptionalText(existingRun.reservationExpiresAt));
     if (readOptionalText(existingRun.status) === 'STAGING' && reservationExpiresAt > Date.now()) {
       throw stageRunInProgressError();
     }
   }
 
+  const initialBuildStartedAt = cashflowStageMetricNow(performanceNow);
   const stageYear = parsed.yearMonth ? Number(parsed.yearMonth.slice(0, 4)) : Number(mirror.sourceYear);
   const calculationCells = (mirror.cells || []).filter((cell) => parsed.yearMonth
     ? readOptionalText(cell.yearMonth) >= '2023-01' && readOptionalText(cell.yearMonth) <= parsed.yearMonth
@@ -3649,6 +3819,7 @@ async function stagePinnedCashflowSheetLab({
       }))
     : [];
   const hasAnnualCells = !parsed.yearMonth && (mirror.annualCells || []).length > 0;
+  phaseDurationMs.build += Math.max(0, cashflowStageMetricNow(performanceNow) - initialBuildStartedAt);
   if (pinnedMonths.length === 0 && !hasAnnualCells) {
     throw createHttpError(
       409,
@@ -3657,19 +3828,20 @@ async function stagePinnedCashflowSheetLab({
     );
   }
 
-  const cashflowSnapshot = await readCashflowWeeksSnapshot(db, tenantId, projectId);
+  const cashflowSnapshot = await measureAsync('read', () => readCashflowWeeksSnapshot(db, tenantId, projectId));
   const currentTargetRevision = computeCashflowTargetRevision(cashflowSnapshot);
   // 시트가 진실(replaceAllActualSources)이어도, 팝업에서 본 diff 는 불러온 시점의 결산 상태 기준이다.
   // 그 사이 결산이 움직였으면 diff 가 거짓이 되므로 쓰기 모드와 무관하게 다시 불러오게 한다.
   if (currentTargetRevision !== readOptionalText(mirror.targetRevisionAtFetch)) {
     throw createHttpError(409, '시트 연동 후 캐시플로우 값이 변경되었습니다. 다시 연동해 주세요.', 'cashflow_sheet_target_revision_conflict');
   }
-  const closedMonths = await readCanonicalClosedCashflowMonths({
+  const closedMonths = await measureAsync('read', () => readCanonicalClosedCashflowMonths({
     db,
     tenantId,
     projectId,
     yearMonths: pinnedMonths,
-  });
+  }));
+  const candidateBuildStartedAt = cashflowStageMetricNow(performanceNow);
   const candidatePinnedCells = parsed.yearMonth
     ? pinnedCells.filter((cell) => readOptionalText(cell.yearMonth) === parsed.yearMonth
       || closedMonths.has(readOptionalText(cell.yearMonth)))
@@ -3696,16 +3868,20 @@ async function stagePinnedCashflowSheetLab({
     now,
   });
   const candidates = [...weekly.candidates, ...annual.candidates];
+  phaseDurationMs.build += Math.max(0, cashflowStageMetricNow(performanceNow) - candidateBuildStartedAt);
   // 결재 중인 회차 차단은 쓰기 모드와 무관하다. 7월에 replaceAllActualSources 에 묶여 꺼져 있었다.
-  const pendingApproval = await readPendingApprovalDifferences({
+  const pendingApproval = await measureAsync('read', () => readPendingApprovalDifferences({
     db, tenantId, projectId, candidates,
-  });
+  }));
+  const finalBuildStartedAt = cashflowStageMetricNow(performanceNow);
   const pendingBlockedMonths = new Set(pendingApproval.blockedMonths || []);
   const candidatesForStage = candidates.filter((candidate) => {
     if (pendingApproval.blockAllCandidates) return false;
     if (readOptionalText(candidate.scope) === 'annual') return true;
     return !pendingBlockedMonths.has(readOptionalText(candidate.yearMonth));
   });
+  const stageAttemptId = randomUUID();
+  const candidateManifestHash = cashflowChangeCandidateManifestHash(candidatesForStage);
   const annualForStage = pendingApproval.blockAllCandidates
     ? { candidates: [], documents: [], stagedYears: [] }
     : annual;
@@ -3744,7 +3920,10 @@ async function stagePinnedCashflowSheetLab({
       now,
     });
   });
-  const responseCandidates = candidatesForStage.slice(0, 500);
+  const responseCandidates = [
+    ...candidatesForStage.filter((candidate) => candidate.beforeHadValue),
+    ...candidatesForStage.filter((candidate) => !candidate.beforeHadValue),
+  ].slice(0, 3);
   const closedMonthDifferenceCount = weekly.closedMonthDifferences.reduce((sum, month) => sum + month.differenceCount, 0);
   const closedMonthDifferenceManifestHash = `sha256:${stableHash(weekly.closedMonthDifferences)}`;
   const response = {
@@ -3792,6 +3971,8 @@ async function stagePinnedCashflowSheetLab({
     projectId,
     idempotencyKey: parsed.idempotencyKey,
     requestHash,
+    stageAttemptId,
+    candidateManifestHash,
     reservationExpiresAt,
     configRevision,
     sourceRevision: mirror.sourceRevision,
@@ -3817,18 +3998,38 @@ async function stagePinnedCashflowSheetLab({
     createdAt: now,
     createdBy: response.lastStagedBy,
   });
+  const persistedResponse = response.status === 'NO_CHANGES'
+    ? response
+    : compactCashflowSheetStageResponse(response);
+  phaseDurationMs.build += Math.max(0, cashflowStageMetricNow(performanceNow) - finalBuildStartedAt);
+  const stageWriteStartedAt = cashflowStageMetricNow(performanceNow);
   const replay = await reserveCashflowSheetStageRun({
     db,
     runRef,
     requestHash,
     reservation: runDocument,
   });
-  if (replay) return replay;
+  if (replay) {
+    phaseDurationMs.write += Math.max(0, cashflowStageMetricNow(performanceNow) - stageWriteStartedAt);
+    publishStageTimings();
+    return replay;
+  }
+  let candidateBatchCount = 0;
+  let persistedRunJsonBytes = 0;
   try {
     if (response.status === 'NO_CHANGES') {
       const mirrorRef = db.doc(cashflowSheetMirrorDocPath(tenantId, projectId));
       const cashflowQuery = db.collection(`orgs/${tenantId}/${CASHFLOW_WEEKS_COLLECTION_ID}`)
         .where('projectId', '==', projectId);
+      const finalRunDocument = stripUndefinedDeep({
+        ...runDocument,
+        status: 'APPLIED',
+        reservationExpiresAt: null,
+        appliedAt: now,
+        failedAt: null,
+        failure: null,
+        response: persistedResponse,
+      });
       await db.runTransaction(async (transaction) => {
         const currentRunSnap = await transaction.get(runRef);
         const currentMirrorSnap = await transaction.get(mirrorRef);
@@ -3839,6 +4040,8 @@ async function stagePinnedCashflowSheetLab({
         if (
           readOptionalText(currentRun.status) !== 'STAGING'
           || readOptionalText(currentRun.requestHash) !== requestHash
+          || readOptionalText(currentRun.stageAttemptId) !== stageAttemptId
+          || readOptionalText(currentRun.candidateManifestHash) !== candidateManifestHash
           || readOptionalText(currentRun.reservationExpiresAt) !== reservationExpiresAt
           || readOptionalText(currentMirror.configRevision) !== configRevision
           || readOptionalText(currentMirror.sourceRevision) !== readOptionalText(mirror.sourceRevision)
@@ -3849,13 +4052,8 @@ async function stagePinnedCashflowSheetLab({
         ) {
           throw createHttpError(409, '시트 검토 완료 상태가 변경되었습니다. 다시 확인해 주세요.', 'cashflow_sheet_stage_completion_conflict');
         }
-        transaction.set(runRef, stripUndefinedDeep({
-          ...runDocument,
-          status: 'APPLIED',
-          reservationExpiresAt: null,
-          appliedAt: now,
-          response,
-        }), { merge: true });
+        persistedRunJsonBytes = cashflowStageJsonBytes(stripUndefinedDeep({ ...currentRun, ...finalRunDocument }));
+        transaction.set(runRef, finalRunDocument, { merge: true });
         // 바뀐 것이 없다 = 이 시점의 시트와 결산이 같다. source 만 올리고 target 을 안 올리면
         // 월결산·주정산 뒤 첫 불러오기부터 영원히 리비전 불일치로 남는다.
         transaction.set(mirrorRef, {
@@ -3866,19 +4064,56 @@ async function stagePinnedCashflowSheetLab({
         }, { merge: true });
       });
     } else {
-      await saveCashflowChangeCandidates({ db, tenantId, candidates: candidatesForStage });
-      await Promise.all(stagedMonthDocuments.map((month) => db
-        .doc(cashflowSheetStageMonthDocPath(tenantId, runId, month.yearMonth))
-        .set(month)));
-      await Promise.all(annualForStage.documents.map((yearDocument) => db
-        .doc(cashflowSheetStageYearDocPath(tenantId, runId, yearDocument.year))
-        .set(yearDocument)));
-      await runRef.set(stripUndefinedDeep({
+      const candidatePersistence = await saveCashflowChangeCandidates({
+        db,
+        tenantId,
+        candidates: candidatesForStage,
+        candidateManifestHash,
+        stageAttemptId,
+        runRef,
+        requestHash,
+        reservationExpiresAt,
+      });
+      candidateBatchCount = candidatePersistence.batchCommitCount;
+      const finalRunDocument = stripUndefinedDeep({
         ...runDocument,
         status: response.status,
         reservationExpiresAt: null,
-        response,
-      }), { merge: true });
+        failedAt: null,
+        failure: null,
+        response: persistedResponse,
+      });
+      await db.runTransaction(async (transaction) => {
+        const currentRunSnap = await transaction.get(runRef);
+        const currentRun = currentRunSnap.exists ? (currentRunSnap.data() || {}) : {};
+        if (
+          readOptionalText(currentRun.status) !== 'STAGING'
+          || readOptionalText(currentRun.requestHash) !== requestHash
+          || readOptionalText(currentRun.stageAttemptId) !== stageAttemptId
+          || readOptionalText(currentRun.candidateManifestHash) !== candidateManifestHash
+          || readOptionalText(currentRun.reservationExpiresAt) !== reservationExpiresAt
+        ) {
+          throw createHttpError(
+            409,
+            '시트 검토 완료 상태가 변경되었습니다. 다시 확인해 주세요.',
+            'cashflow_sheet_stage_completion_conflict',
+          );
+        }
+        persistedRunJsonBytes = cashflowStageJsonBytes(stripUndefinedDeep({ ...currentRun, ...finalRunDocument }));
+        for (const month of stagedMonthDocuments) {
+          transaction.set(
+            db.doc(cashflowSheetStageMonthDocPath(tenantId, runId, month.yearMonth)),
+            month,
+          );
+        }
+        for (const yearDocument of annualForStage.documents) {
+          transaction.set(
+            db.doc(cashflowSheetStageYearDocPath(tenantId, runId, yearDocument.year)),
+            yearDocument,
+          );
+        }
+        transaction.set(runRef, finalRunDocument, { merge: true });
+      });
     }
   } catch (error) {
     await db.runTransaction(async (transaction) => {
@@ -3886,6 +4121,7 @@ async function stagePinnedCashflowSheetLab({
       const currentRun = currentRunSnap.exists ? (currentRunSnap.data() || {}) : {};
       if (
         readOptionalText(currentRun.status) !== 'STAGING'
+        || readOptionalText(currentRun.stageAttemptId) !== stageAttemptId
         || readOptionalText(currentRun.reservationExpiresAt) !== reservationExpiresAt
       ) return;
       transaction.set(runRef, stripUndefinedDeep({
@@ -3896,6 +4132,19 @@ async function stagePinnedCashflowSheetLab({
       }), { merge: true });
     }).catch(() => null);
     throw error;
+  }
+  phaseDurationMs.write += Math.max(0, cashflowStageMetricNow(performanceNow) - stageWriteStartedAt);
+  publishStageTimings();
+  try {
+    onMetric({
+      phase: 'stage_persistence',
+      outcome: 'ok',
+      candidateCount: candidatesForStage.length,
+      candidateBatchCount,
+      persistedRunJsonBytes,
+    });
+  } catch {
+    // Diagnostics must never affect a financial stage.
   }
   logger('ok', {
     projectId,
@@ -4505,10 +4754,24 @@ export function mountCashflowSheetLabRoutes(app, {
         projectId,
         parsed,
         context: req.context,
+        trace,
+        performanceNow,
+        onMetric: (metric) => emitCashflowStageMetric(performanceLogger, {
+          severity: 'INFO',
+          message: 'cashflow.performance',
+          requestId: req.context?.requestId || req.requestId || 'unknown',
+          operation: 'cashflow.sheet_stage',
+          ...metric,
+        }),
         logger: (event, details = {}, level = 'info') => {
           logCashflowSheetLab(`stage.${event}`, req, details, level);
         },
       }));
+      try {
+        res.set('Server-Timing', trace.serverTiming());
+      } catch {
+        // Diagnostics must never affect a financial stage.
+      }
       res.status(200).json(result);
     } catch (error) {
       logCashflowSheetLab('stage.error', req, {

--- a/server/bff/routes/cashflow-sheet-lab.test.mjs
+++ b/server/bff/routes/cashflow-sheet-lab.test.mjs
@@ -76,6 +76,10 @@ function closeHash(value) {
   return `sha256:${createHash('sha256').update(stableStringify(value)).digest('hex')}`;
 }
 
+function stageManifestHash(value) {
+  return `sha256:${createHash('sha256').update(JSON.stringify(value)).digest('hex')}`;
+}
+
 function cumulativeMonths(throughMonth) {
   const months = [];
   for (let year = 2023, month = 1; `${year}-${String(month).padStart(2, '0')}` <= throughMonth;) {
@@ -419,6 +423,16 @@ function buildMultiYearMatrix() {
   return matrix;
 }
 
+function buildMaximumCandidateMatrix() {
+  return buildOfficialMatrix({
+    annualYears: [2024, 2025, 2027, 2028, 2029, 2030, 2031, 2032],
+    projectionAnnualValue: '100',
+    actualAnnualValue: '50',
+    projectionAnnualValues: { 2027: '100' },
+    actualAnnualValues: { 2027: '50' },
+  });
+}
+
 function buildConflictingAnnualWeeklyMatrix() {
   return buildOfficialMatrix({
     annualYears: [2026],
@@ -427,16 +441,33 @@ function buildConflictingAnnualWeeklyMatrix() {
   });
 }
 
-function createDb({ project = { id: 'project-a' }, weeks = [], initialDocuments = {}, onGet, onQuery } = {}) {
+function createDb({
+  project = { id: 'project-a' },
+  weeks = [],
+  initialDocuments = {},
+  onGet,
+  onQuery,
+  onBatchCommit,
+  onWrite,
+} = {}) {
   const documents = new Map();
+  const documentVersions = new Map();
   const queries = [];
   const batchCommitSizes = [];
+  const directSetPaths = [];
+  let batchCommitAttempt = 0;
   documents.set('orgs/tenant-a/projects/project-a', { ...project });
   for (const week of weeks) {
     documents.set(`orgs/tenant-a/cashflow_weeks/${week.id}`, { ...week });
   }
   for (const [path, value] of Object.entries(initialDocuments)) {
     documents.set(path, { ...value });
+  }
+
+  function writeDocument(path, patch, options = {}) {
+    documents.set(path, options.merge ? { ...(documents.get(path) || {}), ...patch } : { ...patch });
+    documentVersions.set(path, (documentVersions.get(path) || 0) + 1);
+    onWrite?.({ path, patch, options, value: documents.get(path) });
   }
 
   function ref(path) {
@@ -450,7 +481,8 @@ function createDb({ project = { id: 'project-a' }, weeks = [], initialDocuments 
         };
       }),
       set: vi.fn(async (patch, options = {}) => {
-        documents.set(path, options.merge ? { ...(documents.get(path) || {}), ...patch } : { ...patch });
+        directSetPaths.push(path);
+        writeDocument(path, patch, options);
       }),
     };
   }
@@ -460,10 +492,20 @@ function createDb({ project = { id: 'project-a' }, weeks = [], initialDocuments 
     batch: vi.fn(() => {
       const operations = [];
       return {
-        set: (docRef, patch, options = {}) => operations.push(() => docRef.set(patch, options)),
+        set: (docRef, patch, options = {}) => operations.push({ path: docRef.path, patch, options }),
         commit: vi.fn(async () => {
+          batchCommitAttempt += 1;
+          if (onBatchCommit) {
+            await onBatchCommit({
+              attempt: batchCommitAttempt,
+              size: operations.length,
+              paths: operations.map((operation) => operation.path),
+            });
+          }
+          for (const operation of operations) {
+            writeDocument(operation.path, operation.patch, operation.options);
+          }
           batchCommitSizes.push(operations.length);
-          await Promise.all(operations.map((operation) => operation()));
         }),
       };
     }),
@@ -493,16 +535,49 @@ function createDb({ project = { id: 'project-a' }, weeks = [], initialDocuments 
         };
       }),
     })),
-    runTransaction: vi.fn(async (callback) => callback({
-      get: (docRef) => docRef.get(),
-      set: (docRef, patch, options) => docRef.set(patch, options),
-    })),
+    runTransaction: vi.fn(async (callback) => {
+      for (let retry = 0; retry < 5; retry += 1) {
+        const operations = [];
+        const readVersions = new Map();
+        const result = await callback({
+          get: async (target) => {
+            const snapshot = await target.get();
+            if (target.path) readVersions.set(target.path, documentVersions.get(target.path) || 0);
+            return snapshot;
+          },
+          set: (docRef, patch, options = {}) => operations.push({ path: docRef.path, patch, options }),
+        });
+        const candidateOperations = operations.filter(({ path }) => path.includes('/cashflow_change_candidates/'));
+        if (candidateOperations.length > 0) {
+          batchCommitAttempt += 1;
+          if (onBatchCommit) {
+            await onBatchCommit({
+              attempt: batchCommitAttempt,
+              size: candidateOperations.length,
+              paths: candidateOperations.map((operation) => operation.path),
+            });
+          }
+        }
+        const conflicted = [...readVersions].some(([path, version]) => (
+          (documentVersions.get(path) || 0) !== version
+        ));
+        if (conflicted) continue;
+        for (const operation of operations) {
+          writeDocument(operation.path, operation.patch, operation.options);
+        }
+        if (candidateOperations.length > 0) batchCommitSizes.push(candidateOperations.length);
+        return result;
+      }
+      throw new Error('transaction retry limit exceeded');
+    }),
     __getDocument: (path = 'orgs/tenant-a/projects/project-a') => documents.get(path),
     __getDocumentsByPrefix: (prefix) => [...documents.entries()]
       .filter(([path]) => path.startsWith(prefix))
       .map(([path, data]) => ({ path, data })),
     __getQueries: () => [...queries],
     __getBatchCommitSizes: () => [...batchCommitSizes],
+    __clearBatchCommitSizes: () => { batchCommitSizes.length = 0; },
+    __getDirectSetPaths: () => [...directSetPaths],
   };
 }
 
@@ -1370,7 +1445,7 @@ describe('cashflow sheet lab route', () => {
     const retried2025 = annualCalls.filter((call) => call.year === 2025);
     expect(retried2025).toHaveLength(2);
     expect(retried2025[0].idempotencyKey).toBe(retried2025[1].idempotencyKey);
-  });
+  }, 10_000);
 
   it('gives the weekly year no annual column so weekly and annual totals cannot conflict', async () => {
     const db = createDb({
@@ -1869,12 +1944,14 @@ describe('cashflow sheet lab route', () => {
     const previewSpreadsheet = vi.fn(async ({ value }) => {
       const year = String(value).includes('2027') ? 2027 : 2026;
       const labels = Array.from({ length: 5 }, (_, index) => `${String(year).slice(2)}-1-${index + 1}`);
+      const matrix = buildMatrixWithWeekLabels(labels);
+      matrix[10][4] = year === 2026 ? '101' : '202';
       return {
         spreadsheetId: `spreadsheet-${year}`,
         spreadsheetTitle: `${year} cashflow`,
         selectedSheetName: 'cashflow(사용내역 연동)',
         availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
-        matrix: buildMatrixWithWeekLabels(labels),
+        matrix,
       };
     });
     const app = createApp({ db, googleSheetsService: { previewSpreadsheet } });
@@ -1914,6 +1991,13 @@ describe('cashflow sheet lab route', () => {
       2027: { sourceYear: 2027, spreadsheetId: 'spreadsheet-2027' },
     });
     expect([...new Set(mirror.body.cells.map((cell) => Number(cell.yearMonth.slice(0, 4))))]).toEqual([2026, 2027]);
+    expect(mirror.body.sheetFacts.projectionActualDifferences).toEqual(expect.arrayContaining([
+      expect.objectContaining({ yearMonth: '2026-01', weekNo: 1, amount: 101, sourceCell: 'E11' }),
+      expect.objectContaining({ yearMonth: '2027-01', weekNo: 1, amount: 202, sourceCell: 'E11' }),
+    ]));
+    expect([...new Set(mirror.body.sheetFacts.weeklyCalculationChecks.map((row) => (
+      Number(row.yearMonth.slice(0, 4))
+    )))]).toEqual([2026, 2027]);
   });
 
   it('keeps each annual year from one closest sheet source instead of double-counting overlapping 2024/2025 totals', async () => {
@@ -2357,6 +2441,9 @@ describe('cashflow sheet lab route', () => {
       projectionLineCount: 80,
       actualLineCount: 80,
     });
+    expect(response.body.candidates).toEqual(expect.arrayContaining([
+      expect.objectContaining({ status: 'pending_review' }),
+    ]));
     expect(db.__getDocument('orgs/tenant-a/cashflow_weeks/project-a-2026-01-w1')).toMatchObject({
       projection: { MYSC_PREPAY_IN: 100 },
       actual: { MYSC_PREPAY_IN: 200 },
@@ -2371,7 +2458,10 @@ describe('cashflow sheet lab route', () => {
       sourceRevision: mirror.body.sourceRevision,
     });
     expect(stagedMonths[0].data.cells).toHaveLength(160);
-    expect(candidates.find((candidate) => candidate.data.mode === 'projection' && candidate.data.lineId === 'MYSC_PREPAY_IN')?.data).toMatchObject({
+    const persistedProjectionCandidate = candidates.find((candidate) => (
+      candidate.data.mode === 'projection' && candidate.data.lineId === 'MYSC_PREPAY_IN'
+    ))?.data;
+    expect(persistedProjectionCandidate).toMatchObject({
       projectId: 'project-a',
       status: 'pending_review',
       source: 'google_sheet',
@@ -2385,6 +2475,52 @@ describe('cashflow sheet lab route', () => {
     expect(candidates.find((candidate) => candidate.data.mode === 'actual' && candidate.data.lineId === 'MYSC_PREPAY_IN')?.data.riskFlags).toEqual([]);
     expect(previewSpreadsheet).toHaveBeenCalledTimes(1);
     expect(db.__getDocument().cashflowSheetLab.activeWeeks).toBeUndefined();
+  });
+
+  it('keeps a successful stage response when diagnostic logging and timing fail', async () => {
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        cashflowSheetLab: {
+          value: 'saved-spreadsheet-a',
+          sheetName: 'cashflow(사용내역 연동)',
+        },
+      },
+    });
+    const app = createApp({
+      db,
+      googleSheetsService: {
+        previewSpreadsheet: vi.fn(async () => ({
+          spreadsheetId: 'spreadsheet-a',
+          selectedSheetName: 'cashflow(사용내역 연동)',
+          availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
+          matrix: buildMatrix(),
+        })),
+      },
+      routeOptions: {
+        performanceNow: () => { throw new Error('diagnostic clock failed'); },
+      },
+    });
+    const mirror = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'refresh-stage-diagnostic-failure' })
+      .expect(200);
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {
+      throw new Error('diagnostic logger failed');
+    });
+    try {
+      const response = await request(app)
+        .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+        .send({
+          expectedMirrorRevision: mirror.body.sourceRevision,
+          idempotencyKey: 'stage-diagnostic-failure',
+        })
+        .expect(200);
+      expect(response.body.status).toBe('READY');
+      expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_stage_runs/')[0].data.status).toBe('READY');
+    } finally {
+      info.mockRestore();
+    }
   });
 
   it('rejects stage when the pinned source revision does not match', async () => {
@@ -2565,6 +2701,449 @@ describe('cashflow sheet lab route', () => {
 
     expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_change_candidates/')).toHaveLength(160);
     expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_stage_runs/')).toHaveLength(1);
+  });
+
+  it('persists all 2,176 stage candidates in five bounded batches with a three-item response preview', async () => {
+    const performanceEvents = [];
+    const candidatePrefix = 'orgs/tenant-a/cashflow_change_candidates/';
+    let retainedFieldInjected = false;
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        cashflowSheetLab: {
+          value: 'saved-spreadsheet-a',
+          sheetName: 'cashflow(사용내역 연동)',
+        },
+      },
+      onWrite: ({ path, patch, value }) => {
+        if (!retainedFieldInjected && path.includes('/cashflow_sheet_stage_runs/') && patch.status === 'STAGING') {
+          retainedFieldInjected = true;
+          value.preexistingDiagnostic = 'retained-by-merge';
+        }
+      },
+    });
+    const app = createApp({
+      db,
+      googleSheetsService: {
+        previewSpreadsheet: vi.fn(async () => ({
+          spreadsheetId: 'spreadsheet-a',
+          selectedSheetName: 'cashflow(사용내역 연동)',
+          availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
+          matrix: buildMaximumCandidateMatrix(),
+        })),
+      },
+      routeOptions: { performanceLogger: (event) => performanceEvents.push(event) },
+    });
+    const mirror = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'refresh-stage-maximum-batches' })
+      .expect(200);
+    const stage = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+      .send({
+        expectedMirrorRevision: mirror.body.sourceRevision,
+        idempotencyKey: 'stage-maximum-batches',
+      })
+      .expect(200);
+
+    expect(stage.body).toMatchObject({
+      status: 'READY',
+      stagedLineCount: 2176,
+      annualLineCount: 256,
+    });
+    const candidates = db.__getDocumentsByPrefix(candidatePrefix);
+    expect(candidates).toHaveLength(2176);
+    expect(candidates.every(({ path }) => /\/cfc_[a-f0-9]{32}$/.test(path))).toBe(true);
+    expect(db.__getBatchCommitSizes()).toEqual([450, 450, 450, 450, 376]);
+    expect(db.__getDirectSetPaths().filter((path) => path.startsWith(candidatePrefix))).toEqual([]);
+    expect(stage.body.candidates).toHaveLength(3);
+    expect(stage.body.omittedCandidateCount).toBe(2173);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(stage.headers['server-timing']).toMatch(/stage_read;dur=\d+/);
+    expect(stage.headers['server-timing']).toMatch(/stage_build;dur=\d+/);
+    expect(stage.headers['server-timing']).toMatch(/stage_write;dur=\d+/);
+    const persistedRun = db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_stage_runs/')[0].data;
+    expect(performanceEvents).toContainEqual(expect.objectContaining({
+      operation: 'cashflow.sheet_stage',
+      phase: 'stage_persistence',
+      outcome: 'ok',
+      candidateCount: 2176,
+      candidateBatchCount: 5,
+      persistedRunJsonBytes: Buffer.byteLength(JSON.stringify(persistedRun), 'utf8'),
+    }));
+  });
+
+  it('does not publish READY after a middle candidate batch fails and retries without duplicates', async () => {
+    const candidatePrefix = 'orgs/tenant-a/cashflow_change_candidates/';
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        cashflowSheetLab: {
+          value: 'saved-spreadsheet-a',
+          sheetName: 'cashflow(사용내역 연동)',
+        },
+      },
+      onBatchCommit: ({ attempt }) => {
+        if (attempt === 3) throw new Error('injected third candidate batch failure');
+      },
+    });
+    const app = createApp({
+      db,
+      googleSheetsService: {
+        previewSpreadsheet: vi.fn(async () => ({
+          spreadsheetId: 'spreadsheet-a',
+          selectedSheetName: 'cashflow(사용내역 연동)',
+          availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
+          matrix: buildMaximumCandidateMatrix(),
+        })),
+      },
+    });
+    const mirror = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'refresh-stage-batch-failure' })
+      .expect(200);
+    const payload = {
+      expectedMirrorRevision: mirror.body.sourceRevision,
+      idempotencyKey: 'stage-batch-failure',
+    };
+
+    const failed = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+      .send(payload);
+    expect(failed.status).toBe(500);
+
+    const partialCandidates = db.__getDocumentsByPrefix(candidatePrefix);
+    expect(partialCandidates).toHaveLength(900);
+    const partialCandidatePaths = partialCandidates.map(({ path }) => path);
+    const failedRuns = db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_stage_runs/');
+    expect(failedRuns).toHaveLength(1);
+    expect(failedRuns[0].data).toMatchObject({ status: 'STAGING_FAILED' });
+    expect(failedRuns[0].data.response).toBeUndefined();
+    expect(failedRuns.filter(({ data }) => data.status === 'READY')).toEqual([]);
+    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_stage_months/')).toEqual([]);
+    expect(db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_stage_years/')).toEqual([]);
+
+    const retried = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+      .send(payload)
+      .expect(200);
+    expect(retried.body).toMatchObject({ status: 'READY', stagedLineCount: 2176 });
+    const finalCandidates = db.__getDocumentsByPrefix(candidatePrefix);
+    const successfulRuns = db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_stage_runs/');
+    expect(successfulRuns).toHaveLength(1);
+    expect(successfulRuns[0].data).toMatchObject({
+      status: 'READY',
+      failedAt: null,
+      failure: null,
+    });
+    const currentCandidates = finalCandidates.filter(({ data }) => (
+      data.candidateManifestHash === successfulRuns[0].data.candidateManifestHash
+      && data.stageAttemptId === successfulRuns[0].data.stageAttemptId
+    ));
+    expect(currentCandidates).toHaveLength(2176);
+    expect(new Set(currentCandidates.map(({ path }) => path)).size).toBe(2176);
+    expect(finalCandidates).toHaveLength(2176);
+    expect(partialCandidatePaths.every((path) => currentCandidates.some((candidate) => candidate.path === path))).toBe(true);
+  });
+
+  it('excludes stale annual children when a failed stage retry loses an annual candidate year', async () => {
+    const candidatePrefix = 'orgs/tenant-a/cashflow_change_candidates/';
+    const yearMonths = Array.from(
+      { length: 12 },
+      (_unused, index) => `2026-${String(index + 1).padStart(2, '0')}`,
+    );
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        cashflowSheetLab: {
+          value: 'saved-spreadsheet-a',
+          sheetName: 'cashflow(사용내역 연동)',
+        },
+      },
+      weeks: matchingCanonicalWeeks(1120, yearMonths),
+      onBatchCommit: ({ attempt }) => {
+        if (attempt === 3) throw new Error('injected third candidate batch failure');
+      },
+    });
+    const javaWeeklyClient = {
+      applyCashflowSheetLab: vi.fn(async (input) => javaApplyResponse(input, `sha256:${'6'.repeat(64)}`)),
+      applyCashflowSheetBatch: vi.fn(async (input) => javaBatchApplyResponse(input, `sha256:${'6'.repeat(64)}`)),
+      applyCashflowSheetAnnualTotal: vi.fn(async (input) => javaAnnualApplyResponse(input)),
+    };
+    const previewSpreadsheet = vi.fn(async () => ({
+      spreadsheetId: 'spreadsheet-a',
+      selectedSheetName: 'cashflow(사용내역 연동)',
+      availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
+      matrix: buildMaximumCandidateMatrix(),
+    }));
+    const app = createApp({
+      db,
+      googleSheetsService: { previewSpreadsheet },
+      routeOptions: { javaWeeklyClient },
+    });
+    const mirror = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'refresh-stage-stale-child-first' })
+      .expect(200);
+    const payload = {
+      expectedMirrorRevision: mirror.body.sourceRevision,
+      idempotencyKey: 'stage-stale-child-retry',
+    };
+
+    await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+      .send(payload)
+      .expect(500);
+    const partialCandidates = db.__getDocumentsByPrefix(candidatePrefix);
+    expect(partialCandidates).toHaveLength(900);
+    expect(partialCandidates.filter(({ data }) => data.scope === 'annual' && data.year === 2024)).toHaveLength(32);
+
+    const projection2024 = Object.fromEntries(CASHFLOW_LINE_IDS.map((lineId) => [lineId, 100]));
+    const actual2024 = Object.fromEntries(CASHFLOW_LINE_IDS.map((lineId) => [lineId, 50]));
+    const valueStates = Object.fromEntries(CASHFLOW_LINE_IDS.map((lineId) => [lineId, 'VALUE']));
+    const annual2024Id = Buffer.from('project-a\n2024', 'utf8').toString('base64url');
+    await db.doc(`orgs/tenant-a/cashflow_sheet_year_totals/${annual2024Id}`).set({
+      projectId: 'project-a',
+      year: 2024,
+      revision: 1,
+      sourceRevision: 'canonical-2024',
+      projection: projection2024,
+      actual: actual2024,
+      projectionStates: valueStates,
+      actualStates: valueStates,
+    });
+
+    const retried = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+      .send(payload)
+      .expect(200);
+    expect(retried.body).toMatchObject({
+      status: 'READY',
+      stagedLineCount: 1024,
+      stagedMonths: ['2026-08', '2026-09', '2026-10', '2026-11', '2026-12'],
+      stagedYears: [2025, 2027, 2028, 2029, 2030, 2031, 2032],
+      annualLineCount: 224,
+    });
+
+    const applied = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
+      .send({ stageRunId: retried.body.runId, idempotencyKey: 'apply-stage-stale-child-retry' });
+    const appliedCandidates = db.__getDocumentsByPrefix(candidatePrefix)
+      .filter(({ data }) => data.status === 'applied');
+    expect({
+      status: applied.status,
+      code: applied.body.code,
+      appliedMonths: applied.body.appliedMonths,
+      appliedYears: applied.body.appliedYears,
+      appliedCandidateCount: appliedCandidates.length,
+      appliedWeeklyCandidateCount: appliedCandidates.filter(({ data }) => data.scope !== 'annual').length,
+      monthlyApplyCalls: javaWeeklyClient.applyCashflowSheetLab.mock.calls.length
+        + javaWeeklyClient.applyCashflowSheetBatch.mock.calls.length,
+      annualApplyCalls: javaWeeklyClient.applyCashflowSheetAnnualTotal.mock.calls.length,
+    }).toEqual({
+      status: 200,
+      code: undefined,
+      appliedMonths: ['2026-08', '2026-09', '2026-10', '2026-11', '2026-12'],
+      appliedYears: [2025, 2027, 2028, 2029, 2030, 2031, 2032],
+      appliedCandidateCount: 1024,
+      appliedWeeklyCandidateCount: 800,
+      monthlyApplyCalls: 1,
+      annualApplyCalls: 7,
+    });
+  });
+
+  it('keeps a newer READY attempt usable when an expired attempt finishes its candidate batches late', async () => {
+    let releaseExpiredAttempt;
+    let markExpiredAttemptBlocked;
+    const expiredAttemptBlocked = new Promise((resolve) => { markExpiredAttemptBlocked = resolve; });
+    const holdExpiredAttempt = new Promise((resolve) => { releaseExpiredAttempt = resolve; });
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        cashflowSheetLab: {
+          value: 'saved-spreadsheet-a',
+          sheetName: 'cashflow(사용내역 연동)',
+        },
+      },
+      onBatchCommit: async ({ attempt }) => {
+        if (attempt !== 1) return;
+        markExpiredAttemptBlocked();
+        await holdExpiredAttempt;
+      },
+    });
+    const javaWeeklyClient = {
+      applyCashflowSheetLab: vi.fn(async (input) => javaApplyResponse(input, `sha256:${'7'.repeat(64)}`)),
+      applyCashflowSheetBatch: vi.fn(async (input) => javaBatchApplyResponse(input, `sha256:${'7'.repeat(64)}`)),
+      applyCashflowSheetAnnualTotal: vi.fn(async (input) => javaAnnualApplyResponse(input)),
+    };
+    const app = createApp({
+      db,
+      googleSheetsService: {
+        previewSpreadsheet: vi.fn(async () => ({
+          spreadsheetId: 'spreadsheet-a',
+          selectedSheetName: 'cashflow(사용내역 연동)',
+          availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
+          matrix: buildMatrix(),
+        })),
+      },
+      routeOptions: { javaWeeklyClient },
+    });
+    const mirror = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'refresh-stage-expired-attempt' })
+      .expect(200);
+    const payload = {
+      expectedMirrorRevision: mirror.body.sourceRevision,
+      idempotencyKey: 'stage-expired-attempt',
+    };
+    let nowMs = Date.parse('2026-08-21T00:00:00.000Z');
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => nowMs);
+    const expiredRequest = request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+      .send(payload)
+      .then((response) => response);
+    let newerResponse;
+    let expiredResponse;
+    let appliedResponse;
+    try {
+      await expiredAttemptBlocked;
+      nowMs += 61_000;
+      newerResponse = await request(app)
+        .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+        .send(payload);
+      appliedResponse = await request(app)
+        .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
+        .send({ stageRunId: newerResponse.body.runId, idempotencyKey: 'apply-stage-expired-attempt' });
+      releaseExpiredAttempt();
+      expiredResponse = await expiredRequest;
+    } finally {
+      releaseExpiredAttempt();
+      nowSpy.mockRestore();
+    }
+
+    const run = db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_sheet_stage_runs/')[0].data;
+    const candidates = db.__getDocumentsByPrefix('orgs/tenant-a/cashflow_change_candidates/');
+    const currentCandidateCount = candidates
+      .filter(({ data }) => (
+        data.candidateManifestHash === run.candidateManifestHash
+        && data.stageAttemptId === run.stageAttemptId
+      ))
+      .length;
+    const appliedCandidateCount = candidates
+      .filter(({ data }) => (
+        data.candidateManifestHash === run.candidateManifestHash
+        && data.stageAttemptId === run.stageAttemptId
+        && data.status === 'applied'
+      ))
+      .length;
+
+    expect({
+      newerStatus: newerResponse.status,
+      expiredStatus: expiredResponse.status,
+      runStatus: run.status,
+      currentCandidateCount,
+      appliedCandidateCount,
+      stagedLineCount: run.stagedLineCount,
+      applyStatus: appliedResponse.status,
+      applyCode: appliedResponse.body.code,
+    }).toEqual({
+      newerStatus: 200,
+      expiredStatus: 409,
+      runStatus: 'APPLIED',
+      currentCandidateCount: run.stagedLineCount,
+      appliedCandidateCount: run.stagedLineCount,
+      stagedLineCount: run.stagedLineCount,
+      applyStatus: 200,
+      applyCode: undefined,
+    });
+  });
+
+  it('keeps a 12-month closed and pending stage under 900 KiB while replaying every confirmation detail', async () => {
+    const months = Array.from(
+      { length: 12 },
+      (_unused, index) => `2026-${String(index + 1).padStart(2, '0')}`,
+    );
+    const closedMonthDocuments = Object.fromEntries(months.map((yearMonth) => [
+      `orgs/tenant-a/monthly_closes/project-a-${yearMonth}`,
+      {
+        contractVersion: 'cashflow-month-close-v1',
+        tenantId: 'tenant-a',
+        projectId: 'project-a',
+        yearMonth,
+        status: 'CLOSED',
+      },
+    ]));
+    const db = createDb({
+      project: {
+        id: 'project-a',
+        cashflowSheetLab: {
+          value: 'saved-spreadsheet-a',
+          sheetName: 'cashflow(사용내역 연동)',
+        },
+      },
+      initialDocuments: {
+        ...cumulativeCloseRequestDocuments({ throughMonth: '2026-12' }),
+        ...closedMonthDocuments,
+      },
+    });
+    const app = createApp({
+      db,
+      googleSheetsService: {
+        previewSpreadsheet: vi.fn(async () => ({
+          spreadsheetId: 'spreadsheet-a',
+          selectedSheetName: 'cashflow(사용내역 연동)',
+          availableSheets: [{ sheetId: 1, title: 'cashflow(사용내역 연동)', index: 0 }],
+          matrix: buildMatrix(),
+        })),
+      },
+    });
+    const mirror = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/mirror/refresh')
+      .send({ idempotencyKey: 'refresh-stage-12-month-confirmations' })
+      .expect(200);
+    const payload = {
+      expectedMirrorRevision: mirror.body.sourceRevision,
+      idempotencyKey: 'stage-12-month-confirmations',
+    };
+    const stage = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+      .send(payload)
+      .expect(200);
+
+    expect(stage.body).toMatchObject({
+      status: 'READY',
+      stagedLineCount: 1920,
+      closedMonthDifferenceCount: 1920,
+      pendingApprovalDifferenceCount: 1920,
+    });
+    expect(stage.body.closedMonthDifferences).toHaveLength(12);
+    expect(stage.body.pendingApprovalDifferences).toHaveLength(12);
+    expect(stage.body.closedMonthDifferences.flatMap((difference) => difference.changes)).toHaveLength(1920);
+    expect(stage.body.pendingApprovalDifferences.flatMap((difference) => difference.changes)).toHaveLength(1920);
+    expect(stage.body.closedMonthDifferenceManifestHash)
+      .toBe(stageManifestHash(stage.body.closedMonthDifferences));
+    expect(stage.body.pendingApprovalDifferenceManifestHash)
+      .toBe(stageManifestHash(stage.body.pendingApprovalDifferences));
+
+    const persistedStageDocuments = db.__getDocumentsByPrefix('orgs/tenant-a/')
+      .filter(({ path }) => [
+        '/cashflow_change_candidates/',
+        '/cashflow_sheet_stage_runs/',
+        '/cashflow_sheet_stage_months/',
+        '/cashflow_sheet_stage_years/',
+      ].some((segment) => path.includes(segment)));
+    const oversizedDocuments = persistedStageDocuments
+      .map(({ path, data }) => ({ path, bytes: Buffer.byteLength(JSON.stringify(data), 'utf8') }))
+      .filter(({ bytes }) => bytes >= 900 * 1024);
+    expect(oversizedDocuments).toEqual([]);
+    expect(stage.body.candidates).toHaveLength(3);
+    expect(stage.body.omittedCandidateCount).toBe(1917);
+
+    const replay = await request(app)
+      .post('/api/v1/projects/project-a/cashflow-sheet-lab/stage')
+      .send(payload)
+      .expect(200);
+    expect(replay.body).toEqual(stage.body);
   });
 
   it('blocks only a month containing an invalid pinned cell', async () => {
@@ -3906,6 +4485,7 @@ describe('cashflow sheet lab route', () => {
       (_unused, index) => `2026-${String(index + 1).padStart(2, '0')}`,
     ));
 
+    db.__clearBatchCommitSizes();
     const apply = await request(app)
       .post('/api/v1/projects/project-a/cashflow-sheet-lab/apply')
       .send({ stageRunId: stage.body.runId, idempotencyKey: 'apply-260701-mock' })

--- a/server/bff/routes/jvm-weekly-api.mjs
+++ b/server/bff/routes/jvm-weekly-api.mjs
@@ -1180,128 +1180,398 @@ function parseAuditMetadata(value) {
   }
 }
 
-async function readCashflowActivityDocuments(db, tenantId, collectionId, projectId) {
-  if (!db?.collection) return [];
-  let query = db.collection(`orgs/${tenantId}/${collectionId}`)
-    .where('projectId', '==', projectId);
-  query = collectionId === 'weekly_api_audit_events'
-    ? query.limit(200)
-    : query.limit(200);
-  const snap = await query.get();
-  return snap.docs.map((doc) => ({ id: doc.id, ...(doc.data() || {}) }));
+const CASHFLOW_ACTIVITY_SOURCES = ['sheet_refresh', 'audit', 'legacy'];
+const CASHFLOW_ACTIVITY_COLLECTIONS = {
+  sheet_refresh: 'cashflow_sheet_refresh_runs',
+  audit: 'weekly_api_audit_events',
+  legacy: 'cashflow_events',
+};
+const CASHFLOW_ACTIVITY_DEFAULT_LIMIT = 50;
+const CASHFLOW_ACTIVITY_MAX_CURSOR_LENGTH = 4096;
+const CASHFLOW_ACTIVITY_RESPONSE_EVENT_BUDGET_BYTES = 1_750_000;
+const CASHFLOW_ACTIVITY_DOCUMENT_ID = Symbol('cashflowActivityDocumentId');
+
+function cashflowActivityMetricNow(performanceNow) {
+  try {
+    const value = Number(typeof performanceNow === 'function' ? performanceNow() : Date.now());
+    return Number.isFinite(value) ? value : Date.now();
+  } catch {
+    return Date.now();
+  }
 }
 
-async function readCashflowActivity(db, tenantId, projectId, source = '') {
-  const [refreshRuns, monthlyAudits, legacyEvents] = await Promise.all([
-    source && source !== 'sheet_refresh' ? [] : readCashflowActivityDocuments(db, tenantId, 'cashflow_sheet_refresh_runs', projectId),
-    source && source !== 'audit' ? [] : readCashflowActivityDocuments(db, tenantId, 'weekly_api_audit_events', projectId),
-    source && source !== 'legacy' ? [] : readCashflowActivityDocuments(db, tenantId, 'cashflow_events', projectId),
-  ]);
-  const refreshEvents = refreshRuns
-    .filter((run) => readOptionalText(run.status) === 'COMPLETED' && readOptionalText(run.response?.status) === 'FRESH')
-    .map((run) => ({
-      id: `sheet-refresh:${run.id}`,
-      projectId,
-      runId: readOptionalText(run.idempotencyKey) || run.id,
-      type: 'sheet_refresh',
-      source: 'google_sheet_refresh',
-      actorUid: readOptionalText(run.createdBy?.uid),
-      actorName: readOptionalText(run.createdBy?.name),
-      actorEmail: readOptionalText(run.createdBy?.email),
-      createdAt: readOptionalText(run.completedAt) || readOptionalText(run.createdAt),
-      sheetName: readOptionalText(run.response?.selectedSheetName),
-    }));
-  const closeEvents = monthlyAudits
-    .filter((audit) => readOptionalText(audit.commandName).startsWith('cashflowMonth.'))
-    .map((audit) => {
-      const metadata = parseAuditMetadata(audit.metadataJson);
-      return {
-        id: `month-close:${audit.id}`,
+function cashflowActivityJsonBytes(value) {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), 'utf8');
+  } catch {
+    return 0;
+  }
+}
+
+function cashflowActivityJsonArrayBytes(values) {
+  return values.reduce(
+    (total, value, index) => total + cashflowActivityJsonBytes(value) + (index > 0 ? 1 : 0),
+    2,
+  );
+}
+
+function emitCashflowActivityMetric(performanceLogger, payload) {
+  try {
+    if (typeof performanceLogger === 'function') {
+      performanceLogger(payload);
+    } else if (process.env.NODE_ENV !== 'test') {
+      // eslint-disable-next-line no-console
+      console.log(JSON.stringify(payload));
+    }
+  } catch {
+    // Diagnostics must never affect a financial read.
+  }
+}
+
+function cashflowActivityQueryInvalid() {
+  return createHttpError(400, '활동 기록 조회 범위가 올바르지 않습니다.', 'cashflow_activity_query_invalid');
+}
+
+function isCashflowActivityCursorInstant(value) {
+  const match = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,9}))?Z$/.exec(value);
+  if (!match) return false;
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return false;
+  const milliseconds = (match[2] || '').padEnd(3, '0').slice(0, 3);
+  return new Date(parsed).toISOString() === `${match[1]}.${milliseconds}Z`;
+}
+
+function isCashflowActivityCursorDocumentId(value) {
+  return Boolean(value)
+    && !value.includes('/')
+    && Buffer.byteLength(value, 'utf8') <= 1500;
+}
+
+function decodeCashflowActivityCursor(cursor, projectId, source) {
+  if (!cursor) return {};
+  if (cursor.length > CASHFLOW_ACTIVITY_MAX_CURSOR_LENGTH || !/^[A-Za-z0-9_-]+$/.test(cursor)) {
+    throw cashflowActivityQueryInvalid();
+  }
+  let decoded;
+  try {
+    decoded = objectValue(JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')));
+  } catch {
+    throw cashflowActivityQueryInvalid();
+  }
+  if (
+    !decoded
+    || decoded.version !== 1
+    || readOptionalText(decoded.projectId) !== projectId
+    || readOptionalText(decoded.source) !== source
+  ) throw cashflowActivityQueryInvalid();
+  const rawBoundaries = objectValue(decoded.boundaries);
+  if (!rawBoundaries) throw cashflowActivityQueryInvalid();
+  const boundaries = {};
+  for (const sourceName of source ? [source] : CASHFLOW_ACTIVITY_SOURCES) {
+    const rawBoundary = objectValue(rawBoundaries[sourceName]);
+    if (!rawBoundary || typeof rawBoundary.done !== 'boolean') throw cashflowActivityQueryInvalid();
+    if (rawBoundary.done) {
+      boundaries[sourceName] = { done: true };
+      continue;
+    }
+    const createdAt = readOptionalText(rawBoundary.createdAt);
+    const id = readOptionalText(rawBoundary.id);
+    if (!createdAt && !id) {
+      boundaries[sourceName] = { done: false };
+      continue;
+    }
+    if (
+      createdAt.length > 128
+      || !isCashflowActivityCursorInstant(createdAt)
+      || !isCashflowActivityCursorDocumentId(id)
+    ) throw cashflowActivityQueryInvalid();
+    boundaries[sourceName] = { done: false, createdAt, id };
+  }
+  return boundaries;
+}
+
+function encodeCashflowActivityCursor(projectId, source, boundaries) {
+  return Buffer.from(JSON.stringify({
+    version: 1,
+    projectId,
+    source,
+    boundaries,
+  }), 'utf8').toString('base64url');
+}
+
+async function readCashflowActivityDocuments(db, tenantId, collectionId, projectId, limit, boundary) {
+  if (boundary?.done || !db?.collection) return { documents: [], exhausted: true, queryCount: 0 };
+  let query = db.collection(`orgs/${tenantId}/${collectionId}`)
+    .where('projectId', '==', projectId)
+    .orderBy('createdAt', 'desc')
+    .orderBy('__name__', 'desc');
+  if (boundary?.createdAt && boundary?.id) {
+    query = query.startAfter(boundary.createdAt, boundary.id);
+  }
+  const snap = await query.limit(limit).get();
+  const documents = snap.docs.map((doc) => ({
+    id: doc.id,
+    ...(doc.data() || {}),
+    [CASHFLOW_ACTIVITY_DOCUMENT_ID]: doc.id,
+  }));
+  return { documents, exhausted: snap.docs.length < limit, queryCount: 1 };
+}
+
+function cashflowActivityDocumentId(document) {
+  return readOptionalText(document?.[CASHFLOW_ACTIVITY_DOCUMENT_ID]) || readOptionalText(document?.id);
+}
+
+function compareCashflowActivityDocuments(left, right) {
+  const leftCreatedAt = readOptionalText(left.document.createdAt);
+  const rightCreatedAt = readOptionalText(right.document.createdAt);
+  if (leftCreatedAt !== rightCreatedAt) return leftCreatedAt < rightCreatedAt ? 1 : -1;
+  const leftId = cashflowActivityDocumentId(left.document);
+  const rightId = cashflowActivityDocumentId(right.document);
+  if (leftId !== rightId) return leftId < rightId ? 1 : -1;
+  return CASHFLOW_ACTIVITY_SOURCES.indexOf(left.source) - CASHFLOW_ACTIVITY_SOURCES.indexOf(right.source);
+}
+
+function buildCashflowActivityDocumentEvents(source, document, projectId) {
+  const events = {
+    refresh: [],
+    sheetApply: [],
+    appliedCell: [],
+    close: [],
+    legacy: [],
+  };
+  if (source === 'sheet_refresh') {
+    if (readOptionalText(document.status) === 'COMPLETED' && readOptionalText(document.response?.status) === 'FRESH') {
+      events.refresh.push({
+        id: `sheet-refresh:${document.id}`,
         projectId,
-        runId: readOptionalText(audit.idempotencyKey) || audit.id,
-        type: 'month_close',
-        source: 'month_close',
-        yearMonth: readOptionalText(metadata.yearMonth),
-        status: readOptionalText(metadata.status),
-        actorUid: readOptionalText(audit.actorId),
-        actorEmail: readOptionalText(metadata.actorEmail),
-        actorName: readOptionalText(metadata.actorName),
-        createdAt: readOptionalText(audit.createdAt),
-      };
-    });
-  const sheetApplyEvents = monthlyAudits
-    .filter((audit) => readOptionalText(audit.commandName) === 'weeklyExpense.cashflowSheetLab.apply')
-    .map((audit) => {
-      const metadata = parseAuditMetadata(audit.metadataJson);
-      const projectionLineCount = Object.hasOwn(metadata, 'projectionLineCount')
-        ? safeAmount(metadata.projectionLineCount)
-        : 0;
-      const actualLineCount = Object.hasOwn(metadata, 'actualLineCount')
-        ? safeAmount(metadata.actualLineCount)
-        : 0;
-      return {
-        id: `sheet-apply:${audit.id}`,
-        projectId,
-        runId: readOptionalText(audit.idempotencyKey) || audit.id,
-        type: 'sheet_apply',
-        source: 'google_sheet_apply',
-        yearMonth: readOptionalText(metadata.yearMonth),
-        year: Number.isSafeInteger(Number(metadata.year)) ? Number(metadata.year) : undefined,
-        scope: readOptionalText(metadata.scope) || 'monthly',
-        projectionLineCount,
-        actualLineCount,
-        appliedLineCount: sumSafe([projectionLineCount, actualLineCount]),
-        actorUid: readOptionalText(audit.actorId),
-        actorEmail: readOptionalText(metadata.actorEmail),
-        actorName: readOptionalText(metadata.actorName),
-        createdAt: readOptionalText(audit.createdAt),
-      };
-    });
-  const appliedCellEvents = monthlyAudits
-    .filter((audit) => readOptionalText(audit.commandName) === 'weeklyExpense.cashflowSheetLab.apply')
-    .flatMap((audit) => {
-      const metadata = parseAuditMetadata(audit.metadataJson);
-      return (Array.isArray(metadata.appliedCellChanges) ? metadata.appliedCellChanges : []).map((rawChange, index) => {
-        const change = objectValue(rawChange) || {};
-        const before = objectValue(change.before) || {};
-        const after = objectValue(change.after) || {};
-        const mode = readOptionalText(change.mode).toLowerCase();
-        const beforeState = readOptionalText(before.cellState).toUpperCase();
-        const afterState = readOptionalText(after.cellState).toUpperCase();
-        const operationId = readOptionalText(change.operationId) || readOptionalText(metadata.operationId) || readOptionalText(audit.idempotencyKey);
-        return {
-          id: `sheet-apply-cell:${audit.id}:${index}`,
-          projectId,
-          runId: readOptionalText(change.idempotencyKey) || readOptionalText(audit.idempotencyKey) || operationId || audit.id,
-          type: mode === 'projection' ? 'projection_amount_change' : 'actual_amount_change',
-          source: 'google_sheet_apply',
-          sourceDetail: readOptionalText(change.source) || readOptionalText(metadata.source) || readOptionalText(audit.sheetKey),
-          operation: readOptionalText(change.operationType) || readOptionalText(change.operation) || readOptionalText(metadata.operationType) || readOptionalText(metadata.operation) || readOptionalText(audit.commandName),
-          operationId,
-          auditId: readOptionalText(change.auditId) || audit.id,
-          sourceRevision: readOptionalText(change.sourceRevision) || readOptionalText(metadata.sourceRevision),
-          targetRevision: readOptionalText(change.targetRevision) || readOptionalText(metadata.targetRevision),
-          yearMonth: readOptionalText(change.yearMonth),
-          weekNo: safeAmount(change.weekNo),
-          mode,
-          lineId: readOptionalText(change.lineId) || readOptionalText(change.cashflowLine),
-          beforeState,
-          beforeHadValue: beforeState !== 'EMPTY',
-          ...(beforeState !== 'EMPTY' ? { beforeAmount: safeAmount(before.amount) } : {}),
-          afterState,
-          afterHadValue: afterState !== 'EMPTY',
-          ...(afterState !== 'EMPTY' ? { afterAmount: safeAmount(after.amount) } : {}),
-          actorUid: readOptionalText(change.actorId) || readOptionalText(change.actorUid) || readOptionalText(audit.actorId),
-          actorName: readOptionalText(change.actorName) || readOptionalText(metadata.actorName),
-          actorEmail: readOptionalText(change.actorEmail) || readOptionalText(metadata.actorEmail),
-          reason: readOptionalText(change.reason) || readOptionalText(metadata.reason) || readOptionalText(metadata.amendmentReason),
-          createdAt: readOptionalText(change.changedAt) || readOptionalText(audit.createdAt),
-        };
+        runId: readOptionalText(document.idempotencyKey) || document.id,
+        type: 'sheet_refresh',
+        source: 'google_sheet_refresh',
+        actorUid: readOptionalText(document.createdBy?.uid),
+        actorName: readOptionalText(document.createdBy?.name),
+        actorEmail: readOptionalText(document.createdBy?.email),
+        createdAt: readOptionalText(document.createdAt),
+        sheetName: readOptionalText(document.response?.selectedSheetName),
       });
+    }
+    return events;
+  }
+  if (source === 'legacy') {
+    events.legacy.push(document);
+    return events;
+  }
+
+  const commandName = readOptionalText(document.commandName);
+  const metadata = parseAuditMetadata(document.metadataJson);
+  if (commandName.startsWith('cashflowMonth.')) {
+    events.close.push({
+      id: `month-close:${document.id}`,
+      projectId,
+      runId: readOptionalText(document.idempotencyKey) || document.id,
+      type: 'month_close',
+      source: 'month_close',
+      yearMonth: readOptionalText(metadata.yearMonth),
+      status: readOptionalText(metadata.status),
+      actorUid: readOptionalText(document.actorId),
+      actorEmail: readOptionalText(metadata.actorEmail),
+      actorName: readOptionalText(metadata.actorName),
+      createdAt: readOptionalText(document.createdAt),
     });
-  return [...legacyEvents, ...refreshEvents, ...sheetApplyEvents, ...appliedCellEvents, ...closeEvents]
-    .filter((event) => readOptionalText(event.createdAt))
-    .sort((left, right) => readOptionalText(right.createdAt).localeCompare(readOptionalText(left.createdAt)));
+    return events;
+  }
+  if (commandName !== 'weeklyExpense.cashflowSheetLab.apply') return events;
+
+  const projectionLineCount = Object.hasOwn(metadata, 'projectionLineCount')
+    ? safeAmount(metadata.projectionLineCount)
+    : 0;
+  const actualLineCount = Object.hasOwn(metadata, 'actualLineCount')
+    ? safeAmount(metadata.actualLineCount)
+    : 0;
+  events.sheetApply.push({
+    id: `sheet-apply:${document.id}`,
+    projectId,
+    runId: readOptionalText(document.idempotencyKey) || document.id,
+    type: 'sheet_apply',
+    source: 'google_sheet_apply',
+    yearMonth: readOptionalText(metadata.yearMonth),
+    year: Number.isSafeInteger(Number(metadata.year)) ? Number(metadata.year) : undefined,
+    scope: readOptionalText(metadata.scope) || 'monthly',
+    projectionLineCount,
+    actualLineCount,
+    appliedLineCount: sumSafe([projectionLineCount, actualLineCount]),
+    actorUid: readOptionalText(document.actorId),
+    actorEmail: readOptionalText(metadata.actorEmail),
+    actorName: readOptionalText(metadata.actorName),
+    createdAt: readOptionalText(document.createdAt),
+  });
+  events.appliedCell = (Array.isArray(metadata.appliedCellChanges) ? metadata.appliedCellChanges : [])
+    .map((rawChange, index) => {
+      const change = objectValue(rawChange) || {};
+      const before = objectValue(change.before) || {};
+      const after = objectValue(change.after) || {};
+      const mode = readOptionalText(change.mode).toLowerCase();
+      const beforeState = readOptionalText(before.cellState).toUpperCase();
+      const afterState = readOptionalText(after.cellState).toUpperCase();
+      const operationId = readOptionalText(change.operationId) || readOptionalText(metadata.operationId) || readOptionalText(document.idempotencyKey);
+      return {
+        id: `sheet-apply-cell:${document.id}:${index}`,
+        projectId,
+        runId: readOptionalText(change.idempotencyKey) || readOptionalText(document.idempotencyKey) || operationId || document.id,
+        type: mode === 'projection' ? 'projection_amount_change' : 'actual_amount_change',
+        source: 'google_sheet_apply',
+        sourceDetail: readOptionalText(change.source) || readOptionalText(metadata.source) || readOptionalText(document.sheetKey),
+        operation: readOptionalText(change.operationType) || readOptionalText(change.operation) || readOptionalText(metadata.operationType) || readOptionalText(metadata.operation) || commandName,
+        operationId,
+        auditId: readOptionalText(change.auditId) || document.id,
+        sourceRevision: readOptionalText(change.sourceRevision) || readOptionalText(metadata.sourceRevision),
+        targetRevision: readOptionalText(change.targetRevision) || readOptionalText(metadata.targetRevision),
+        yearMonth: readOptionalText(change.yearMonth),
+        weekNo: safeAmount(change.weekNo),
+        mode,
+        lineId: readOptionalText(change.lineId) || readOptionalText(change.cashflowLine),
+        beforeState,
+        beforeHadValue: beforeState !== 'EMPTY',
+        ...(beforeState !== 'EMPTY' ? { beforeAmount: safeAmount(before.amount) } : {}),
+        afterState,
+        afterHadValue: afterState !== 'EMPTY',
+        ...(afterState !== 'EMPTY' ? { afterAmount: safeAmount(after.amount) } : {}),
+        actorUid: readOptionalText(change.actorId) || readOptionalText(change.actorUid) || readOptionalText(document.actorId),
+        actorName: readOptionalText(change.actorName) || readOptionalText(metadata.actorName),
+        actorEmail: readOptionalText(change.actorEmail) || readOptionalText(metadata.actorEmail),
+        reason: readOptionalText(change.reason) || readOptionalText(metadata.reason) || readOptionalText(metadata.amendmentReason),
+        createdAt: readOptionalText(document.createdAt),
+      };
+    });
+  return events;
+}
+
+function cashflowActivityDocumentEventList(events) {
+  return [...events.legacy, ...events.refresh, ...events.sheetApply, ...events.appliedCell, ...events.close];
+}
+
+async function readCashflowActivity(db, tenantId, projectId, {
+  source = '', limit, boundaries, performanceNow, onSourceMetric = () => {},
+}) {
+  const selectedSources = source ? [source] : CASHFLOW_ACTIVITY_SOURCES;
+  const settled = await Promise.allSettled(selectedSources.map(async (sourceName) => {
+    const startedAt = cashflowActivityMetricNow(performanceNow);
+    try {
+      return {
+        source: sourceName,
+        page: await readCashflowActivityDocuments(
+          db,
+          tenantId,
+          CASHFLOW_ACTIVITY_COLLECTIONS[sourceName],
+          projectId,
+          limit,
+          boundaries[sourceName],
+        ),
+        durationMs: Math.max(0, Math.round(cashflowActivityMetricNow(performanceNow) - startedAt)),
+      };
+    } catch (error) {
+      onSourceMetric({
+        source: sourceName,
+        outcome: 'error',
+        queryCount: boundaries[sourceName]?.done ? 0 : 1,
+        documentCount: 0,
+        documentJsonBytes: 0,
+        responseJsonBytes: 0,
+        durationMs: Math.max(0, Math.round(cashflowActivityMetricNow(performanceNow) - startedAt)),
+      });
+      throw error;
+    }
+  }));
+  const pages = {};
+  const nextBoundaries = {};
+  const errors = [];
+  for (let index = 0; index < selectedSources.length; index += 1) {
+    const sourceName = selectedSources[index];
+    const result = settled[index];
+    if (result.status === 'rejected') {
+      if (source) throw result.reason;
+      errors.push({ source: sourceName, code: 'cashflow_activity_source_unavailable' });
+      nextBoundaries[sourceName] = { done: true };
+      continue;
+    }
+    pages[sourceName] = result.value.page;
+  }
+  const candidateDocuments = selectedSources
+    .flatMap((sourceName) => (pages[sourceName]?.documents || []).map((document) => ({ source: sourceName, document })))
+    .sort(compareCashflowActivityDocuments)
+    .slice(0, limit);
+  const selectedDocuments = [];
+  const selectedDocumentEvents = [];
+  let selectedEventCount = 0;
+  let selectedEventJsonBytes = 0;
+  for (const entry of candidateDocuments) {
+    const documentEvents = buildCashflowActivityDocumentEvents(entry.source, entry.document, projectId);
+    const eventList = cashflowActivityDocumentEventList(documentEvents);
+    const eventJsonBytes = cashflowActivityJsonArrayBytes(eventList) - 2;
+    const separatorBytes = selectedEventCount > 0 && eventList.length > 0 ? 1 : 0;
+    if (
+      selectedEventCount > 0
+      && eventList.length > 0
+      && selectedEventJsonBytes + separatorBytes + eventJsonBytes > CASHFLOW_ACTIVITY_RESPONSE_EVENT_BUDGET_BYTES
+    ) break;
+    selectedDocuments.push(entry);
+    selectedDocumentEvents.push(documentEvents);
+    selectedEventCount += eventList.length;
+    selectedEventJsonBytes += separatorBytes + eventJsonBytes;
+  }
+  for (const sourceName of selectedSources) {
+    if (!pages[sourceName]) continue;
+    const selectedForSource = selectedDocuments.filter((entry) => entry.source === sourceName);
+    const last = selectedForSource.at(-1)?.document;
+    const createdAt = readOptionalText(last?.createdAt);
+    if (last && createdAt) {
+      nextBoundaries[sourceName] = {
+        done: selectedForSource.length === pages[sourceName].documents.length && pages[sourceName].exhausted,
+        createdAt,
+        id: cashflowActivityDocumentId(last),
+      };
+    } else if (pages[sourceName].documents.length === 0) {
+      nextBoundaries[sourceName] = { done: true };
+    } else {
+      nextBoundaries[sourceName] = boundaries[sourceName]?.done === false
+        ? boundaries[sourceName]
+        : { done: false };
+    }
+  }
+  const refreshEvents = selectedDocumentEvents.flatMap((events) => events.refresh);
+  const sheetApplyEvents = selectedDocumentEvents.flatMap((events) => events.sheetApply);
+  const appliedCellEvents = selectedDocumentEvents.flatMap((events) => events.appliedCell);
+  const closeEvents = selectedDocumentEvents.flatMap((events) => events.close);
+  const legacyEvents = selectedDocumentEvents.flatMap((events) => events.legacy);
+  const responseEventsBySource = {
+    sheet_refresh: refreshEvents,
+    audit: [...sheetApplyEvents, ...appliedCellEvents, ...closeEvents],
+    legacy: legacyEvents,
+  };
+  for (const sourceName of selectedSources) {
+    const page = pages[sourceName];
+    if (!page) continue;
+    const settledPage = settled.find((entry) => (
+      entry.status === 'fulfilled' && entry.value.source === sourceName
+    ));
+    const responseJsonBytes = cashflowActivityJsonArrayBytes(responseEventsBySource[sourceName]);
+    onSourceMetric({
+      source: sourceName,
+      outcome: 'ok',
+      queryCount: page.queryCount,
+      documentCount: page.documents.length,
+      documentJsonBytes: cashflowActivityJsonArrayBytes(page.documents),
+      responseJsonBytes,
+      responseBudgetExceeded: responseJsonBytes > CASHFLOW_ACTIVITY_RESPONSE_EVENT_BUDGET_BYTES,
+      durationMs: settledPage?.status === 'fulfilled' ? settledPage.value.durationMs : 0,
+    });
+  }
+  return {
+    events: [...legacyEvents, ...refreshEvents, ...sheetApplyEvents, ...appliedCellEvents, ...closeEvents]
+      .filter((event) => readOptionalText(event.createdAt))
+      .sort((left, right) => readOptionalText(right.createdAt).localeCompare(readOptionalText(left.createdAt))),
+    errors,
+    boundaries: nextBoundaries,
+  };
 }
 
 
@@ -3774,10 +4044,37 @@ export function mountJvmWeeklyApiRoutes(app, {
     if (source && !['legacy', 'sheet_refresh', 'audit'].includes(source)) {
       throw createHttpError(400, '활동 기록 조회 출처가 올바르지 않습니다.', 'cashflow_activity_source_invalid');
     }
+    const limit = req.query.limit === undefined ? CASHFLOW_ACTIVITY_DEFAULT_LIMIT : Number(req.query.limit);
+    const cursor = readOptionalText(req.query.cursor);
+    if (!Number.isSafeInteger(limit) || limit < 1 || limit > CASHFLOW_ACTIVITY_DEFAULT_LIMIT) {
+      throw cashflowActivityQueryInvalid();
+    }
+    const boundaries = decodeCashflowActivityCursor(cursor, projectId, source);
+    const requestId = req.context?.requestId || req.requestId || 'unknown';
+    const activity = await readCashflowActivity(db, readOptionalText(req.context?.tenantId), projectId, {
+      source,
+      limit,
+      boundaries,
+      performanceNow,
+      onSourceMetric: (metric) => emitCashflowActivityMetric(performanceLogger, {
+        severity: metric.outcome === 'error' ? 'WARNING' : 'INFO',
+        message: 'cashflow.performance',
+        requestId,
+        operation: 'cashflow.activity.read',
+        phase: 'activity_source_read',
+        ...metric,
+      }),
+    });
+    const selectedSources = source ? [source] : CASHFLOW_ACTIVITY_SOURCES;
+    const hasNextPage = selectedSources.some((sourceName) => activity.boundaries[sourceName]?.done === false);
     res.status(200).json({
       projectId,
       ...(source ? { source } : {}),
-      events: await readCashflowActivity(db, readOptionalText(req.context?.tenantId), projectId, source),
+      events: activity.events,
+      errors: activity.errors,
+      nextCursor: hasNextPage
+        ? encodeCashflowActivityCursor(projectId, source, activity.boundaries)
+        : null,
     });
   }));
 

--- a/server/bff/routes/jvm-weekly-api.test.mjs
+++ b/server/bff/routes/jvm-weekly-api.test.mjs
@@ -615,6 +615,101 @@ function createApp(fetchImpl, idempotencyService = createIdempotencyService(), c
   return { app, idempotencyService };
 }
 
+function createCashflowActivityTestDb({ eventsByCollection = {}, failingCollections = [] } = {}) {
+  const queries = [];
+  const failures = new Set(failingCollections);
+  const fieldName = (field) => typeof field === 'string' ? field : String(field);
+  const compareValues = (left, right, direction) => {
+    const leftText = String(left ?? '');
+    const rightText = String(right ?? '');
+    const compared = leftText < rightText ? -1 : leftText > rightText ? 1 : 0;
+    return direction === 'desc' ? -compared : compared;
+  };
+
+  return {
+    queries,
+    db: {
+      collection: (collectionPath) => {
+        const collectionId = collectionPath.split('/').at(-1);
+        const state = {
+          filters: [],
+          orderBys: [],
+          limit: null,
+          startAfter: [],
+        };
+        const query = {
+          where: (field, operator, expected) => {
+            state.filters.push([fieldName(field), operator, expected]);
+            return query;
+          },
+          orderBy: (field, direction) => {
+            state.orderBys.push([fieldName(field), direction]);
+            return query;
+          },
+          startAfter: (...values) => {
+            const [first] = values;
+            state.startAfter = values.length === 1 && first?.id && typeof first.data === 'function'
+              ? [first.data()?.createdAt, first.id]
+              : values;
+            return query;
+          },
+          limit: (value) => {
+            state.limit = value;
+            return query;
+          },
+          get: async () => {
+            queries.push({
+              collectionId,
+              filters: structuredClone(state.filters),
+              orderBys: structuredClone(state.orderBys),
+              limit: state.limit,
+              startAfter: structuredClone(state.startAfter),
+            });
+            if (failures.has(collectionId)) throw new Error(`${collectionId} unavailable`);
+
+            let documents = (eventsByCollection[collectionId] || []).map((entry) => {
+              const { __documentId, ...value } = entry;
+              return {
+                id: __documentId || entry.id,
+                value,
+              };
+            });
+            documents = documents.filter((document) => state.filters.every(([field, operator, expected]) => (
+              operator === '==' && document.value[field] === expected
+            )));
+            if (state.orderBys.length > 0) {
+              documents.sort((left, right) => {
+                for (const [field, direction] of state.orderBys) {
+                  const leftValue = field === '__name__' ? left.id : left.value[field];
+                  const rightValue = field === '__name__' ? right.id : right.value[field];
+                  const compared = compareValues(leftValue, rightValue, direction);
+                  if (compared !== 0) return compared;
+                }
+                return 0;
+              });
+            }
+            if (state.startAfter.length > 0) {
+              const [createdAt, id] = state.startAfter;
+              const boundary = documents.findIndex((document) => (
+                document.value.createdAt === createdAt && document.id === id
+              ));
+              documents = boundary >= 0 ? documents.slice(boundary + 1) : [];
+            }
+            if (Number.isSafeInteger(state.limit)) documents = documents.slice(0, state.limit);
+            return {
+              docs: documents.map((document) => ({
+                id: document.id,
+                data: () => document.value,
+              })),
+            };
+          },
+        };
+        return query;
+      },
+    },
+  };
+}
+
 async function createCumulativeMonthCloseFixture({
   source,
   fetchImpl,
@@ -2610,7 +2705,7 @@ describe('JVM weekly API BFF proxy', () => {
   });
 
   it('combines explicit sheet refresh and JVM month-close audit records for the activity timeline', async () => {
-    const activityQueries = [];
+    const performanceEvents = [];
     const eventsByCollection = {
       cashflow_sheet_refresh_runs: [{
         id: 'refresh-1', projectId: 'project-a', idempotencyKey: 'refresh-key', status: 'COMPLETED',
@@ -2643,27 +2738,12 @@ describe('JVM weekly API BFF proxy', () => {
       ],
       cashflow_events: [],
     };
-    const db = {
-      collection: (path) => ({
-        where: () => {
-          const query = { collectionId: path.split('/').at(-1), orderBy: null, limit: null };
-          activityQueries.push(query);
-          const chain = {
-            orderBy: (field, direction) => {
-              query.orderBy = [field, direction];
-              return chain;
-            },
-            limit: (limit) => {
-              query.limit = limit;
-              return chain;
-            },
-            get: async () => ({ docs: (eventsByCollection[query.collectionId] || []).map((data) => ({ id: data.id, data: () => data })) }),
-          };
-          return chain;
-        },
-      }),
-    };
-    const { app } = createApp(vi.fn(), createIdempotencyService(), {}, { env: runtimeEnv, db });
+    const { db, queries: activityQueries } = createCashflowActivityTestDb({ eventsByCollection });
+    const { app } = createApp(vi.fn(), createIdempotencyService(), {}, {
+      env: runtimeEnv,
+      db,
+      performanceLogger: (event) => performanceEvents.push(event),
+    });
 
     await request(app)
       .get('/api/v1/cashflow/project-a/activity')
@@ -2680,9 +2760,525 @@ describe('JVM weekly API BFF proxy', () => {
         ]);
       });
     expect(activityQueries.find((query) => query.collectionId === 'weekly_api_audit_events')).toMatchObject({
-      orderBy: null,
-      limit: 200,
+      filters: [['projectId', '==', 'project-a']],
+      orderBys: [['createdAt', 'desc'], ['__name__', 'desc']],
+      limit: 50,
     });
+    expect(performanceEvents.filter((event) => event.operation === 'cashflow.activity.read')).toEqual(
+      expect.arrayContaining(['sheet_refresh', 'audit', 'legacy'].map((source) => expect.objectContaining({
+        phase: 'activity_source_read',
+        source,
+        outcome: 'ok',
+        queryCount: 1,
+        documentCount: expect.any(Number),
+        documentJsonBytes: expect.any(Number),
+        responseJsonBytes: expect.any(Number),
+        durationMs: expect.any(Number),
+      }))),
+    );
+  });
+
+  it('reads at most 50 raw documents per activity source and returns one globally newest page', async () => {
+    const createdAt = (index) => new Date(Date.UTC(2026, 6, 2, 0, 0, index)).toISOString();
+    const eventsByCollection = {
+      cashflow_sheet_refresh_runs: Array.from({ length: 60 }, (_, index) => ({
+        id: `refresh-${String(index).padStart(2, '0')}`,
+        projectId: 'project-a',
+        status: 'COMPLETED',
+        createdAt: createdAt(index),
+        response: { status: 'FRESH', selectedSheetName: 'cashflow(사용내역 연동)' },
+      })),
+      weekly_api_audit_events: Array.from({ length: 60 }, (_, index) => ({
+        id: `audit-${String(index).padStart(2, '0')}`,
+        projectId: 'project-a',
+        commandName: 'weeklyExpense.cashflowSheetLab.apply',
+        createdAt: createdAt(index),
+        metadataJson: JSON.stringify({ yearMonth: '2026-06', projectionLineCount: 1, actualLineCount: 0 }),
+      })),
+      cashflow_events: Array.from({ length: 60 }, (_, index) => ({
+        id: `legacy-${String(index).padStart(2, '0')}`,
+        projectId: 'project-a',
+        runId: `legacy-run-${index}`,
+        type: 'projection_completed',
+        createdAt: createdAt(index),
+      })),
+    };
+    const { db, queries } = createCashflowActivityTestDb({ eventsByCollection });
+    const { app } = createApp(vi.fn(), createIdempotencyService(), {}, { env: runtimeEnv, db });
+
+    const response = await request(app)
+      .get('/api/v1/cashflow/project-a/activity')
+      .expect(200);
+
+    expect(response.body.events).toHaveLength(50);
+    expect(queries.map((query) => ({
+      collectionId: query.collectionId,
+      filters: query.filters,
+      orderBys: query.orderBys,
+      limit: query.limit,
+    })).sort((left, right) => left.collectionId.localeCompare(right.collectionId))).toEqual([
+      'cashflow_events',
+      'cashflow_sheet_refresh_runs',
+      'weekly_api_audit_events',
+    ].map((collectionId) => ({
+      collectionId,
+      filters: [['projectId', '==', 'project-a']],
+      orderBys: [['createdAt', 'desc'], ['__name__', 'desc']],
+      limit: 50,
+    })));
+  });
+
+  it('does not return an older sparse-source event before the next newer audit page', async () => {
+    const auditDocuments = Array.from({ length: 51 }, (_, index) => ({
+      id: `audit-global-${String(index).padStart(2, '0')}`,
+      projectId: 'project-a',
+      commandName: 'weeklyExpense.cashflowSheetLab.apply',
+      createdAt: new Date(Date.UTC(2026, 6, 2, 0, 0, 59 - index)).toISOString(),
+      metadataJson: JSON.stringify({ yearMonth: '2026-06', projectionLineCount: 1, actualLineCount: 0 }),
+    }));
+    const { db } = createCashflowActivityTestDb({
+      eventsByCollection: {
+        cashflow_sheet_refresh_runs: [],
+        weekly_api_audit_events: auditDocuments,
+        cashflow_events: [{
+          id: 'legacy-old', projectId: 'project-a', runId: 'legacy-old',
+          type: 'projection_completed', createdAt: '2024-01-01T00:00:00.000Z',
+        }],
+      },
+    });
+    const { app } = createApp(vi.fn(), createIdempotencyService(), {}, { env: runtimeEnv, db });
+
+    const first = await request(app)
+      .get('/api/v1/cashflow/project-a/activity')
+      .expect(200);
+    expect(first.body.events).toHaveLength(50);
+    expect(first.body.events.some((event) => event.id === 'legacy-old')).toBe(false);
+
+    const second = await request(app)
+      .get(`/api/v1/cashflow/project-a/activity?cursor=${encodeURIComponent(first.body.nextCursor)}`)
+      .expect(200);
+    expect(second.body.events.map((event) => event.id)).toEqual([
+      'sheet-apply:audit-global-50',
+      'legacy-old',
+    ]);
+    expect(second.body.nextCursor).toBeNull();
+  });
+
+  it('uses one opaque aggregate cursor to return the second page without duplicating shorter sources', async () => {
+    const legacyEvents = Array.from({ length: 51 }, (_, index) => ({
+      id: `legacy-${String(index).padStart(2, '0')}`,
+      projectId: 'project-a',
+      runId: `legacy-run-${index}`,
+      type: 'projection_completed',
+      createdAt: new Date(Date.UTC(2026, 6, 2, 0, 0, 59 - index)).toISOString(),
+    }));
+    const eventsByCollection = {
+      cashflow_sheet_refresh_runs: [{
+        id: 'refresh-only', projectId: 'project-a', status: 'COMPLETED',
+        createdAt: '2026-07-03T00:00:00.000Z', response: { status: 'FRESH' },
+      }],
+      weekly_api_audit_events: [{
+        id: 'audit-only', projectId: 'project-a', commandName: 'cashflowMonth.close',
+        createdAt: '2026-07-03T00:00:01.000Z', metadataJson: JSON.stringify({ yearMonth: '2026-06', status: 'CLOSED' }),
+      }],
+      cashflow_events: legacyEvents,
+    };
+    const { db } = createCashflowActivityTestDb({ eventsByCollection });
+    const { app } = createApp(vi.fn(), createIdempotencyService(), {}, { env: runtimeEnv, db });
+
+    const first = await request(app)
+      .get('/api/v1/cashflow/project-a/activity')
+      .expect(200);
+    expect(first.body.nextCursor).toEqual(expect.any(String));
+    expect(first.body.nextCursor).not.toBe('legacy-49');
+
+    const second = await request(app)
+      .get(`/api/v1/cashflow/project-a/activity?cursor=${encodeURIComponent(first.body.nextCursor)}`)
+      .expect(200);
+    const firstIds = new Set(first.body.events.map((event) => event.id));
+    const secondIds = second.body.events.map((event) => event.id);
+    expect(secondIds).toEqual(['legacy-48', 'legacy-49', 'legacy-50']);
+    expect(secondIds.filter((id) => firstIds.has(id))).toEqual([]);
+    expect([...firstIds, ...secondIds]).toHaveLength(53);
+  });
+
+  it('does not skip same-timestamp mixed-case document ids when an aggregate page cuts inside one source', async () => {
+    const tiedCreatedAt = '2026-07-02T00:00:00.000Z';
+    const { db } = createCashflowActivityTestDb({
+      eventsByCollection: {
+        cashflow_sheet_refresh_runs: [{
+          id: 'refresh-newer', projectId: 'project-a', status: 'COMPLETED',
+          createdAt: '2026-07-03T00:00:00.000Z', response: { status: 'FRESH' },
+        }],
+        weekly_api_audit_events: ['a-audit', 'Z-audit'].map((id) => ({
+          id,
+          projectId: 'project-a',
+          commandName: 'weeklyExpense.cashflowSheetLab.apply',
+          createdAt: tiedCreatedAt,
+          metadataJson: JSON.stringify({ yearMonth: '2026-06', projectionLineCount: 1, actualLineCount: 0 }),
+        })),
+        cashflow_events: [],
+      },
+    });
+    const { app } = createApp(vi.fn(), createIdempotencyService(), {}, { env: runtimeEnv, db });
+
+    const first = await request(app)
+      .get('/api/v1/cashflow/project-a/activity?limit=2')
+      .expect(200);
+    const second = await request(app)
+      .get(`/api/v1/cashflow/project-a/activity?limit=2&cursor=${encodeURIComponent(first.body.nextCursor)}`)
+      .expect(200);
+
+    expect([...first.body.events, ...second.body.events].map((event) => event.id)).toEqual([
+      'sheet-refresh:refresh-newer',
+      'sheet-apply:a-audit',
+      'sheet-apply:Z-audit',
+    ]);
+  });
+
+  it('pages by the Firestore document id when the stored activity payload has a different id', async () => {
+    const createdAt = '2026-07-02T00:00:00.000Z';
+    const { db } = createCashflowActivityTestDb({
+      eventsByCollection: {
+        cashflow_events: [
+          {
+            __documentId: 'firestore-b', id: 'event-newer', projectId: 'project-a',
+            type: 'projection_completed', createdAt,
+          },
+          {
+            __documentId: 'firestore-a', id: 'event-older', projectId: 'project-a',
+            type: 'projection_completed', createdAt,
+          },
+        ],
+      },
+    });
+    const { app } = createApp(vi.fn(), createIdempotencyService(), {}, { env: runtimeEnv, db });
+
+    const first = await request(app)
+      .get('/api/v1/cashflow/project-a/activity?source=legacy&limit=1')
+      .expect(200);
+    const second = await request(app)
+      .get(`/api/v1/cashflow/project-a/activity?source=legacy&limit=1&cursor=${encodeURIComponent(first.body.nextCursor)}`)
+      .expect(200);
+    const third = await request(app)
+      .get(`/api/v1/cashflow/project-a/activity?source=legacy&limit=1&cursor=${encodeURIComponent(second.body.nextCursor)}`)
+      .expect(200);
+
+    expect(first.body.events.map((event) => event.id)).toEqual(['event-newer']);
+    expect(second.body.events.map((event) => event.id)).toEqual(['event-older']);
+    expect(third.body.events).toEqual([]);
+    expect(third.body.nextCursor).toBeNull();
+  });
+
+  it('keeps every derived activity timestamp inside the raw document cursor order across pages', async () => {
+    const rawCreatedAt = (index) => new Date(Date.UTC(2026, 6, 2, 0, 0, 59 - index)).toISOString();
+    const refreshDocuments = Array.from({ length: 51 }, (_, index) => ({
+      id: `refresh-order-${String(index).padStart(2, '0')}`,
+      projectId: 'project-a',
+      status: 'COMPLETED',
+      createdAt: rawCreatedAt(index),
+      completedAt: index === 50 ? '2030-01-01T00:00:00.000Z' : rawCreatedAt(index),
+      response: { status: 'FRESH' },
+    }));
+    const auditDocuments = Array.from({ length: 51 }, (_, index) => ({
+      id: `audit-order-${String(index).padStart(2, '0')}`,
+      projectId: 'project-a',
+      commandName: 'weeklyExpense.cashflowSheetLab.apply',
+      createdAt: rawCreatedAt(index),
+      metadataJson: JSON.stringify({
+        yearMonth: '2026-06',
+        projectionLineCount: 1,
+        actualLineCount: 0,
+        ...(index === 50 ? {
+          appliedCellChanges: [{
+            yearMonth: '2026-06', weekNo: 1, mode: 'projection', cashflowLine: 'SALES_IN',
+            before: { cellState: 'ZERO', amount: 0 },
+            after: { cellState: 'VALUE', amount: 1 },
+            changedAt: '2031-01-01T00:00:00.000Z',
+          }],
+        } : {}),
+      }),
+    }));
+    const { db } = createCashflowActivityTestDb({
+      eventsByCollection: {
+        cashflow_sheet_refresh_runs: refreshDocuments,
+        weekly_api_audit_events: auditDocuments,
+        cashflow_events: [],
+      },
+    });
+    const { app } = createApp(vi.fn(), createIdempotencyService(), {}, { env: runtimeEnv, db });
+
+    const first = await request(app)
+      .get('/api/v1/cashflow/project-a/activity')
+      .expect(200);
+    const second = await request(app)
+      .get(`/api/v1/cashflow/project-a/activity?cursor=${encodeURIComponent(first.body.nextCursor)}`)
+      .expect(200);
+
+    const oldestFirstPage = first.body.events
+      .map((event) => event.createdAt)
+      .sort()[0];
+    const newestSecondPage = second.body.events
+      .map((event) => event.createdAt)
+      .sort()
+      .at(-1);
+    expect(newestSecondPage.localeCompare(oldestFirstPage)).toBeLessThanOrEqual(0);
+  });
+
+  it.each([
+    { createdAt: 'not-an-instant', id: 'legacy-1' },
+    { createdAt: '2026-07-01T00:00:00.000Z', id: 'bad/id' },
+  ])('rejects malformed activity cursor boundaries before querying Firestore: %j', async (boundary) => {
+    const cursor = Buffer.from(JSON.stringify({
+      version: 1,
+      projectId: 'project-a',
+      source: 'legacy',
+      boundaries: { legacy: { done: false, ...boundary } },
+    }), 'utf8').toString('base64url');
+    const { db, queries } = createCashflowActivityTestDb();
+    const { app } = createApp(vi.fn(), createIdempotencyService(), {}, { env: runtimeEnv, db });
+
+    await request(app)
+      .get(`/api/v1/cashflow/project-a/activity?source=legacy&cursor=${encodeURIComponent(cursor)}`)
+      .expect(400)
+      .expect((response) => expect(response.body.code).toBe('cashflow_activity_query_invalid'));
+    expect(queries).toEqual([]);
+  });
+
+  it('returns successful activity sources and a structured error when one aggregate source query fails', async () => {
+    const eventsByCollection = {
+      cashflow_sheet_refresh_runs: [{
+        id: 'refresh-success', projectId: 'project-a', status: 'COMPLETED',
+        createdAt: '2026-07-03T00:00:00.000Z', response: { status: 'FRESH' },
+      }],
+      cashflow_events: [{
+        id: 'legacy-success', projectId: 'project-a', runId: 'legacy-success',
+        type: 'actual_completed', createdAt: '2026-07-02T00:00:00.000Z',
+      }],
+    };
+    const { db } = createCashflowActivityTestDb({
+      eventsByCollection,
+      failingCollections: ['weekly_api_audit_events'],
+    });
+    const { app } = createApp(vi.fn(), createIdempotencyService(), {}, { env: runtimeEnv, db });
+
+    await request(app)
+      .get('/api/v1/cashflow/project-a/activity')
+      .expect(200)
+      .expect((response) => {
+        expect(response.body.events).toEqual(expect.arrayContaining([
+          expect.objectContaining({ id: 'sheet-refresh:refresh-success', type: 'sheet_refresh' }),
+          expect.objectContaining({ id: 'legacy-success', type: 'actual_completed' }),
+        ]));
+        expect(response.body.errors).toContainEqual({
+          source: 'audit',
+          code: 'cashflow_activity_source_unavailable',
+        });
+      });
+  });
+
+  it('keeps all 100 cell changes from one audit document together at a raw-document page boundary', async () => {
+    const appliedCellChanges = Array.from({ length: 100 }, (_, index) => ({
+      yearMonth: '2026-06', weekNo: (index % 5) + 1,
+      mode: index % 2 === 0 ? 'projection' : 'actual',
+      cashflowLine: `BOUNDARY_LINE_${index}`,
+      before: { cellState: 'ZERO', amount: 0 },
+      after: { cellState: 'VALUE', amount: index + 1 },
+      changedAt: '2026-07-01T00:00:10.000Z',
+    }));
+    const auditDocuments = Array.from({ length: 51 }, (_, index) => ({
+      id: `audit-boundary-${String(index).padStart(2, '0')}`,
+      projectId: 'project-a',
+      idempotencyKey: `audit-run-${index}`,
+      commandName: 'weeklyExpense.cashflowSheetLab.apply',
+      createdAt: new Date(Date.UTC(2026, 6, 2, 0, 0, 59 - index)).toISOString(),
+      metadataJson: JSON.stringify({
+        yearMonth: '2026-06', projectionLineCount: 1, actualLineCount: 0,
+        ...(index === 49 ? { appliedCellChanges } : {}),
+      }),
+    }));
+    const { db } = createCashflowActivityTestDb({
+      eventsByCollection: {
+        cashflow_sheet_refresh_runs: [],
+        weekly_api_audit_events: auditDocuments,
+        cashflow_events: [],
+      },
+    });
+    const { app } = createApp(vi.fn(), createIdempotencyService(), {}, { env: runtimeEnv, db });
+
+    const first = await request(app)
+      .get('/api/v1/cashflow/project-a/activity')
+      .expect(200);
+    const firstBundle = first.body.events.filter((event) => event.id.startsWith('sheet-apply-cell:audit-boundary-49:'));
+    expect(firstBundle).toHaveLength(100);
+    expect(new Set(firstBundle.map((event) => event.id)).size).toBe(100);
+    expect(first.body.nextCursor).toEqual(expect.any(String));
+
+    const second = await request(app)
+      .get(`/api/v1/cashflow/project-a/activity?cursor=${encodeURIComponent(first.body.nextCursor)}`)
+      .expect(200);
+    expect(second.body.events.filter((event) => event.id.startsWith('sheet-apply-cell:audit-boundary-49:'))).toHaveLength(0);
+    expect(second.body.events).toEqual([
+      expect.objectContaining({ id: 'sheet-apply:audit-boundary-50', type: 'sheet_apply' }),
+    ]);
+  });
+
+  it('pages full-sheet audit bundles before the activity response exceeds its byte budget', async () => {
+    const appliedCellChanges = Array.from({ length: 1_920 }, (_, index) => ({
+      yearMonth: '2026-06', weekNo: (index % 5) + 1,
+      mode: index % 2 === 0 ? 'projection' : 'actual',
+      cashflowLine: `FULL_SHEET_LINE_${index}`,
+      before: { cellState: 'ZERO', amount: 0 },
+      after: { cellState: 'VALUE', amount: index + 1 },
+      changedAt: '2026-07-01T00:00:10.000Z',
+    }));
+    const auditDocuments = Array.from({ length: 5 }, (_, index) => ({
+      id: `audit-full-sheet-${index}`,
+      projectId: 'project-a',
+      idempotencyKey: `full-sheet-run-${index}`,
+      commandName: 'weeklyExpense.cashflowSheetLab.apply',
+      createdAt: new Date(Date.UTC(2026, 6, 2, 0, 0, 59 - index)).toISOString(),
+      metadataJson: JSON.stringify({
+        yearMonth: '2026-06', projectionLineCount: 960, actualLineCount: 960,
+        appliedCellChanges,
+      }),
+    }));
+    const { db } = createCashflowActivityTestDb({
+      eventsByCollection: {
+        cashflow_sheet_refresh_runs: [],
+        weekly_api_audit_events: auditDocuments,
+        cashflow_events: [],
+      },
+    });
+    const { app } = createApp(vi.fn(), createIdempotencyService(), {}, { env: runtimeEnv, db });
+
+    const eventIds = new Set();
+    let cursor = '';
+    let pageCount = 0;
+    do {
+      const response = await request(app)
+        .get(`/api/v1/cashflow/project-a/activity${cursor ? `?cursor=${encodeURIComponent(cursor)}` : ''}`)
+        .expect(200);
+      expect(Buffer.byteLength(JSON.stringify(response.body), 'utf8')).toBeLessThan(2 * 1024 * 1024);
+      for (const event of response.body.events) {
+        expect(eventIds.has(event.id)).toBe(false);
+        eventIds.add(event.id);
+      }
+      cursor = response.body.nextCursor || '';
+      pageCount += 1;
+      expect(pageCount).toBeLessThanOrEqual(5);
+    } while (cursor);
+
+    expect(pageCount).toBe(5);
+    expect(eventIds.size).toBe(5 * (1_920 + 1));
+  });
+
+  it('returns one oversized audit bundle whole and advances the cursor to older activity', async () => {
+    const oversizedChanges = Array.from({ length: 4_500 }, (_, index) => ({
+      yearMonth: '2026-06', weekNo: (index % 5) + 1,
+      mode: index % 2 === 0 ? 'projection' : 'actual',
+      cashflowLine: `OVERSIZED_LINE_${index}`,
+      before: { cellState: 'ZERO', amount: 0 },
+      after: { cellState: 'VALUE', amount: index + 1 },
+    }));
+    const { db } = createCashflowActivityTestDb({
+      eventsByCollection: {
+        cashflow_sheet_refresh_runs: [],
+        weekly_api_audit_events: [{
+          id: 'audit-oversized', projectId: 'project-a',
+          commandName: 'weeklyExpense.cashflowSheetLab.apply',
+          createdAt: '2026-07-02T00:00:02.000Z',
+          metadataJson: JSON.stringify({
+            yearMonth: '2026-06', projectionLineCount: 2_250, actualLineCount: 2_250,
+            appliedCellChanges: oversizedChanges,
+          }),
+        }, {
+          id: 'audit-older', projectId: 'project-a',
+          commandName: 'weeklyExpense.cashflowSheetLab.apply',
+          createdAt: '2026-07-02T00:00:01.000Z',
+          metadataJson: JSON.stringify({ yearMonth: '2026-06', projectionLineCount: 1, actualLineCount: 0 }),
+        }],
+        cashflow_events: [],
+      },
+    });
+    const performanceEvents = [];
+    const { app } = createApp(vi.fn(), createIdempotencyService(), {}, {
+      env: runtimeEnv,
+      db,
+      performanceLogger: (event) => performanceEvents.push(event),
+    });
+
+    const first = await request(app)
+      .get('/api/v1/cashflow/project-a/activity')
+      .expect(200);
+    const firstResponseBytes = Buffer.byteLength(JSON.stringify(first.body), 'utf8');
+    expect(first.body.events).toHaveLength(4_501);
+    expect(firstResponseBytes).toBeGreaterThan(2 * 1024 * 1024);
+    expect(firstResponseBytes).toBeLessThan(4 * 1024 * 1024);
+    expect(first.body.nextCursor).toEqual(expect.any(String));
+    expect(performanceEvents).toContainEqual(expect.objectContaining({
+      operation: 'cashflow.activity.read',
+      source: 'audit',
+      responseBudgetExceeded: true,
+    }));
+
+    const second = await request(app)
+      .get(`/api/v1/cashflow/project-a/activity?cursor=${encodeURIComponent(first.body.nextCursor)}`)
+      .expect(200);
+    expect(second.body.events.map((event) => event.id)).toEqual(['sheet-apply:audit-older']);
+    expect(second.body.nextCursor).toBeNull();
+  });
+
+  it('keeps mixed-source newest order when a whole audit bundle reaches the byte boundary', async () => {
+    const fullSheetChanges = Array.from({ length: 1_920 }, (_, index) => ({
+      yearMonth: '2026-06', weekNo: (index % 5) + 1,
+      mode: index % 2 === 0 ? 'projection' : 'actual',
+      cashflowLine: `MIXED_LINE_${index}`,
+      before: { cellState: 'ZERO', amount: 0 },
+      after: { cellState: 'VALUE', amount: index + 1 },
+    }));
+    const { db } = createCashflowActivityTestDb({
+      eventsByCollection: {
+        cashflow_sheet_refresh_runs: [{
+          id: 'refresh-between', projectId: 'project-a', status: 'COMPLETED',
+          createdAt: '2026-07-02T00:00:03.000Z', response: { status: 'FRESH' },
+        }],
+        weekly_api_audit_events: ['04', '02'].map((second) => ({
+          id: `audit-mixed-${second}`, projectId: 'project-a',
+          commandName: 'weeklyExpense.cashflowSheetLab.apply',
+          createdAt: `2026-07-02T00:00:${second}.000Z`,
+          metadataJson: JSON.stringify({
+            yearMonth: '2026-06', projectionLineCount: 960, actualLineCount: 960,
+            appliedCellChanges: fullSheetChanges,
+          }),
+        })),
+        cashflow_events: [{
+          id: 'legacy-older', projectId: 'project-a', type: 'projection_completed',
+          createdAt: '2026-07-02T00:00:01.000Z',
+        }],
+      },
+    });
+    const { app } = createApp(vi.fn(), createIdempotencyService(), {}, { env: runtimeEnv, db });
+
+    const summaries = [];
+    let cursor = '';
+    do {
+      const response = await request(app)
+        .get(`/api/v1/cashflow/project-a/activity${cursor ? `?cursor=${encodeURIComponent(cursor)}` : ''}`)
+        .expect(200);
+      expect(Buffer.byteLength(JSON.stringify(response.body), 'utf8')).toBeLessThan(2 * 1024 * 1024);
+      summaries.push(...response.body.events
+        .filter((event) => !event.id.startsWith('sheet-apply-cell:'))
+        .map((event) => event.id));
+      cursor = response.body.nextCursor || '';
+    } while (cursor);
+
+    expect(summaries).toEqual([
+      'sheet-apply:audit-mixed-04',
+      'sheet-refresh:refresh-between',
+      'sheet-apply:audit-mixed-02',
+      'legacy-older',
+    ]);
   });
 
   it('keeps malformed declared audit counts and cell amounts unavailable instead of coercing them to zero', async () => {
@@ -2709,6 +3305,7 @@ describe('JVM weekly API BFF proxy', () => {
       collection: () => ({
         where: () => {
           const chain = {
+            orderBy: () => chain,
             limit: () => chain,
             get: async () => ({ docs: [{ id: audit.id, data: () => audit }] }),
           };
@@ -2738,24 +3335,7 @@ describe('JVM weekly API BFF proxy', () => {
   });
 
   it('reads one bounded activity source without waiting for the other timeline sources', async () => {
-    const activityQueries = [];
-    const db = {
-      collection: (path) => ({
-        where: () => {
-          const query = { collectionId: path.split('/').at(-1), limit: null };
-          activityQueries.push(query);
-          const chain = {
-            orderBy: () => chain,
-            limit: (limit) => {
-              query.limit = limit;
-              return chain;
-            },
-            get: async () => ({ docs: [] }),
-          };
-          return chain;
-        },
-      }),
-    };
+    const { db, queries: activityQueries } = createCashflowActivityTestDb();
     const { app } = createApp(vi.fn(), createIdempotencyService(), {}, { env: runtimeEnv, db });
 
     await request(app)
@@ -2765,7 +3345,13 @@ describe('JVM weekly API BFF proxy', () => {
         expect(response.body).toMatchObject({ projectId: 'project-a', source: 'legacy', events: [] });
       });
 
-    expect(activityQueries).toEqual([{ collectionId: 'cashflow_events', limit: 200 }]);
+    expect(activityQueries).toEqual([{
+      collectionId: 'cashflow_events',
+      filters: [['projectId', '==', 'project-a']],
+      orderBys: [['createdAt', 'desc'], ['__name__', 'desc']],
+      limit: 50,
+      startAfter: [],
+    }]);
   });
 
   it('flattens all 100 exact applied cell changes from one JVM audit into General Activity', async () => {

--- a/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
+++ b/src/app/components/cashflow/CashflowProjectSheet.shell.test.ts
@@ -93,7 +93,9 @@ describe('CashflowProjectSheet staged loading', () => {
   });
   it('loads the activity timeline only when it scrolls into view, and the roster after month-close', () => {
     expect(source).toContain('new IntersectionObserver(');
-    expect(source).toContain('if (!opsTimelineVisible || !monthCloseSettled) return;\n    void loadCashflowEvents();');
+    expect(source).toContain('if (!opsTimelineVisible || !monthCloseSettled) return;');
+    expect(source).toContain('cashflowActivityOneClickRef.current.pendingAggregate = true;');
+    expect(source).toContain('void loadCashflowActivityAggregate();');
     expect(source).toContain('<div ref={opsTimelineRef} className="min-w-0">{renderOpsTimeline()}</div>');
     expect(source).toContain('usePersonRoster(monthCloseSettled)');
   });
@@ -896,27 +898,120 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(mergeSource).not.toContain('.slice(');
   });
 
-  it('loads and retries general activity sources independently without hiding loaded events', () => {
+  it('loads one aggregate activity page and retries only a failed source without hiding loaded events', () => {
     expect(source).toContain("from './cashflow-activity-loader'");
-    expect(source).toContain('fetchCashflowActivityViaBff({ tenantId: orgId, actor, projectId, source })');
+    expect(source).toContain("cashflowActivityRequestGuard.start('aggregate', { reset: true })");
+    expect(source).toContain("cashflowActivityRequestGuard.start(`source:${source}`)");
+    expect(source).toContain('cashflowEventLoading || cashflowEventLoadingMore || !projectId');
+    expect(source).toContain('limit: 50,');
+    expect(source).toContain('signal: ticket.signal,');
+    expect(source).toContain('response.errors.map');
     expect(source).toContain('setCashflowEvents((current) => mergeCashflowEvents(current, response.events))');
     expect(source).toContain('cashflowEventErrors.map');
-    expect(source).toContain('onClick={() => void loadCashflowEventSource(failure.source)}');
+    expect(source).toContain('onClick={() => void loadCashflowEventSource(failure.source, {');
+    expect(source).toContain('preservePagination: Boolean(failure.preservePagination)');
     expect(source).toContain('실제 반영 기록을 불러오는 중입니다.');
     expect(source).toContain('아직 표시할 변경 기록이 없습니다.');
     expect(source).toContain('role="alert"');
     expect(source).not.toContain("setCashflowEventsError(resolveApiErrorMessage(error, '변경 이력을 불러오지 못했습니다.'))");
   });
 
-  it('awaits activity sources sequentially instead of starting them in parallel', () => {
-    expect(source).toContain('loadCashflowActivitySourcesSequentially(');
-    expect(source).toContain('await loadCashflowEventSource(source, generation)');
-    expect(source).not.toContain('CASHFLOW_ACTIVITY_SOURCES.forEach((source) => void loadCashflowEventSource(source, generation))');
+  it('removes the three-source helper loop and pages opaque aggregate and recovery cursors', () => {
+    expect(source).not.toContain('loadCashflowActivitySourcesSequentially');
+    expect(source).toContain('const [cashflowActivityCursorQueue, setCashflowActivityCursorQueue] = useState<CashflowActivityCursor[]>');
+    const rootLoadStart = source.indexOf('const loadCashflowEvents = useCallback');
+    const rootLoadFlow = source.slice(rootLoadStart, source.indexOf('const loadMoreCashflowEvents', rootLoadStart));
+    expect(rootLoadFlow).toContain('setCashflowActivityCursorQueue([]);');
+    expect(source).toContain('const loadMoreCashflowEvents = useCallback(async (): Promise<void> => {');
+    expect(source).toContain('cashflowEventLoadingMoreRef.current || cashflowEventLoading || cashflowEventLoadingSources.length > 0');
+    expect(source).toContain('disabled={cashflowEventLoading || cashflowEventLoadingMore || cashflowEventLoadingSources.length > 0}');
+    expect(source).toContain('cursor: queuedCursor.cursor,');
+    expect(source).toContain('updateCashflowActivityCursorQueue(');
+    expect(source).toContain('if (response.nextCursor === queuedCursor.cursor)');
+    expect(source).toContain('updateCashflowActivityCursorQueue(current, queuedCursor.source, null)');
+    expect(source).toContain("이전 기록 더 불러오기");
+    expect(source).toContain('cashflowActivityCursorQueue.length > 0 ? loadMoreCashflowEvents() : loadCashflowActivityAggregate()');
   });
 
-  it('defines the shared activity reload used after sheet and month-close mutations', () => {
-    expect(source).toContain('const loadCashflowEvents = useCallback(async (): Promise<void> => {');
-    expect(source).toContain('void loadCashflowEvents();');
+  it('aborts stale project activity and keeps mutation reloads behind timeline visibility', () => {
+    expect(source).toContain('const loadCashflowActivityAggregate = useCallback(async (): Promise<void> => {');
+    expect(source).toContain('cashflowActivityRequestGuard.invalidate();');
+    expect(source).toContain('shouldStartCashflowActivityLoad({');
+    expect(source).toContain('visible: opsTimelineVisibleRef.current,');
+    expect(source).toContain('cashflowActivityScopeRef.current === activityScope');
+    expect(source).toContain('currentScope: isCurrentCashflowActivityScope(),');
+    expect(source).toContain("if (input.signal.aborted) throw new Error('활동 기록 요청이 중단되었습니다.');");
+    expect(source).toContain('void loadCashflowActivityAggregate();');
+  });
+
+  it('reloads only Activity sources that each completed mutation can actually write', () => {
+    expect(source).toContain("reloadCashflowActivityForMutations('sheet_mirror_refreshed')");
+    expect(source).toContain("reloadCashflowActivityForMutations('sheet_values_applied')");
+    expect(source).toContain("reloadCashflowActivityForMutations('month_reopen_completed')");
+
+    const requestStart = source.indexOf('const handleFinalizeMonthClose');
+    const requestFlow = source.slice(requestStart, source.indexOf('const handleWithdrawMonthCloseRequest', requestStart));
+    const withdrawStart = source.indexOf('const handleWithdrawMonthCloseRequest');
+    const withdrawFlow = source.slice(withdrawStart, source.indexOf('const handleMonthReopenAction', withdrawStart));
+    expect(requestFlow).not.toContain('loadCashflowEvents()');
+    expect(requestFlow).not.toContain('reloadCashflowActivityForMutations(');
+    expect(withdrawFlow).not.toContain('loadCashflowEvents()');
+    expect(withdrawFlow).not.toContain('reloadCashflowActivityForMutations(');
+  });
+
+  it('defers every one-click activity read and drains only successful sources outside frozen confirmation flows', () => {
+    const frozenActionStart = source.indexOf('const handleRefreshAndApplySheetValues');
+    const wrapperStart = source.indexOf('const handleDeferredRefreshAndApplySheetValues', frozenActionStart);
+    const frozenAction = source.slice(frozenActionStart, wrapperStart);
+    const action = source.slice(wrapperStart, source.indexOf('const handleOpenSheetOnboarding', wrapperStart));
+    expect(frozenAction).not.toContain('cashflowActivityOneClickRef');
+    expect(frozenAction).toContain("toast.error(mirror?.lastRefreshError?.message || '시트 최신값을 가져오지 못했습니다. 잠시 후 다시 시도해 주세요.');");
+    expect(action).toContain('const oneClickActivityScope = activityScope;');
+    expect(action).toContain('cashflowActivityOneClickRef.current.depth += 1;');
+    expect(action).toContain('} finally {');
+    expect(action).toContain('cashflowActivityOneClickRef.current.scope === oneClickActivityScope');
+    expect(action).toContain('cashflowActivityOneClickRef.current.depth -= 1;');
+    expect(action).toContain('setCashflowActivityDrainVersion((current) => current + 1);');
+    const terminalDrain = action.slice(action.indexOf('} finally {'));
+    expect(terminalDrain).not.toContain('cashflowActivityOneClickRef.current.pendingSources.clear();');
+    expect(terminalDrain).not.toContain('void reloadCashflowActivitySources(pendingSources);');
+    expect(action).not.toContain('loadCashflowEvents()');
+
+    expect(source).toContain('takeCashflowActivityPendingWork(cashflowActivityOneClickRef.current');
+    expect(source).toContain('busy: cashflowEventLoading || cashflowEventLoadingMore || cashflowEventLoadingSources.length > 0');
+    expect(source).toContain("if (pendingWork?.kind === 'aggregate') void loadCashflowActivityAggregate();");
+    expect(source).toContain("else if (pendingWork?.kind === 'sources') void reloadCashflowActivitySources(pendingWork.sources);");
+    expect(source).toContain('cashflowActivityDrainVersion,');
+
+    const mutationReloadStart = source.indexOf('const reloadCashflowActivityForMutations');
+    const mutationReload = source.slice(mutationReloadStart, source.indexOf('const loadCashflowEvents', mutationReloadStart));
+    expect(mutationReload).toContain('if (!opsTimelineVisibleRef.current) return;');
+    expect(mutationReload).toContain('sources.forEach((source) => cashflowActivityOneClickRef.current.pendingSources.add(source));');
+    expect(mutationReload).toContain('setCashflowActivityDrainVersion((current) => current + 1);');
+    expect(mutationReload).not.toContain('await reloadCashflowActivitySources(sources);');
+
+    const applyStart = source.indexOf('const handleApplyStagedSheetValues');
+    const applyFlow = source.slice(applyStart, source.indexOf('const handleStagePinnedSheetValues', applyStart));
+    const stageStart = source.indexOf('const handleStagePinnedSheetValues');
+    const stageFlow = source.slice(stageStart, frozenActionStart);
+    expect(applyFlow).not.toContain('cashflowActivityOneClickRef');
+    expect(stageFlow).not.toContain('cashflowActivityOneClickRef');
+    expect(applyFlow.indexOf('cashflow_formula_mismatch_confirmation_required')).toBeLessThan(applyFlow.indexOf('cashflow_closed_month_reason_required'));
+    expect(applyFlow.indexOf('cashflow_closed_month_reason_required')).toBeLessThan(applyFlow.indexOf('cashflow_pending_approval_confirmation_required'));
+    expect(source).toContain('onClick={() => void handleDeferredRefreshAndApplySheetValues()}');
+  });
+
+  it('keeps mutation head pages out of the aggregate cursor and replays a deferred initial aggregate once', () => {
+    expect(source).toContain('pendingAggregate: false,');
+    expect(source).toContain('cashflowActivityOneClickRef.current.pendingAggregate = true;');
+    expect(source).toContain('const pendingWork = takeCashflowActivityPendingWork(');
+    expect(source).toContain("if (pendingWork?.kind === 'aggregate') void loadCashflowActivityAggregate();");
+    expect(source).toContain("else if (pendingWork?.kind === 'sources') void reloadCashflowActivitySources(pendingWork.sources);");
+
+    expect(source).toContain('loadCashflowEventSource(source, { preservePagination: true })');
+    expect(source).toContain('if (!options.preservePagination) {');
+    expect(source).toContain('preservePagination: options.preservePagination');
+    expect(source).toContain('preservePagination: Boolean(failure.preservePagination)');
   });
 
   it('uses the server KST comparison week and totals only the visible comparison scope', () => {
@@ -984,7 +1079,10 @@ describe('CashflowProjectSheet monthly close shell', () => {
     expect(source).not.toContain("const totalProjection = projectLineTotalFor('projection', lineId)");
     expect(source).not.toContain("const totalActual = projectLineTotalFor('actual', lineId)");
     expect(source).toContain('Projection - Actual 차이</div>');
-    expect(source).toContain('현금흐름 관리시트 A11:BS11 기준');
+    expect(source).toContain('현금흐름 관리시트 E11:BL11 주별 수식 기준');
+    expect(source).not.toContain('!cashflowPresentation.comparison.changed');
+    expect(source).not.toContain('Projection과 Actual 차이가 없습니다.');
+    expect(source).toContain('`${rowSurface} text-slate-500`');
     expect(source).toContain('const columnCount = comparisonCells.length');
     expect(source).not.toContain('difference: hasValue ? projection - actual : null');
   });

--- a/src/app/components/cashflow/CashflowProjectSheet.tsx
+++ b/src/app/components/cashflow/CashflowProjectSheet.tsx
@@ -98,7 +98,16 @@ import { CashflowCanonicalSummary } from './CashflowCanonicalSummary';
 import { MemberPicker } from '../ui/member-picker';
 import { buildOrgMemberPickerOptions } from '../../data/project-team-member-options';
 import { usePersonRoster } from '../../data/use-person-roster';
-import { loadCashflowActivitySourcesSequentially } from './cashflow-activity-loader';
+import {
+  cashflowActivitySourcesForMutations,
+  createCashflowActivityRequestGuard,
+  filterCashflowActivityErrorsAfterSuccess,
+  shouldStartCashflowActivityLoad,
+  takeCashflowActivityPendingWork,
+  updateCashflowActivityCursorQueue,
+  type CashflowActivityCursor,
+  type CashflowActivityMutation,
+} from './cashflow-activity-loader';
 import { describeCashflowMonthCloseIssue } from './cashflow-month-close-blocker-helpers';
 import { buildSheetApplyNotice } from './cashflow-sheet-apply-notice';
 import { pickCashflowMonthCloseNotice } from './cashflow-month-close-notice';
@@ -545,9 +554,44 @@ export function CashflowProjectSheet({
     setSavedExecutiveApproverId(approverId);
   }, [project?.executiveApproverId, projectId]);
   const [cashflowEvents, setCashflowEvents] = useState<CashflowEvent[]>([]);
-  const [cashflowEventErrors, setCashflowEventErrors] = useState<Array<{ source: CashflowActivitySource; message: string }>>([]);
+  const [cashflowEventErrors, setCashflowEventErrors] = useState<Array<{
+    source: CashflowActivitySource;
+    message: string;
+    preservePagination?: boolean;
+  }>>([]);
+  const [cashflowEventLoading, setCashflowEventLoading] = useState(false);
   const [cashflowEventLoadingSources, setCashflowEventLoadingSources] = useState<CashflowActivitySource[]>([]);
-  const cashflowActivityGenerationRef = useRef(0);
+  const [cashflowActivityCursorQueue, setCashflowActivityCursorQueue] = useState<CashflowActivityCursor[]>([]);
+  const [cashflowEventLoadingMore, setCashflowEventLoadingMore] = useState(false);
+  const cashflowEventLoadingMoreRef = useRef(false);
+  const [cashflowActivityDrainVersion, setCashflowActivityDrainVersion] = useState(0);
+  const [cashflowEventLoadError, setCashflowEventLoadError] = useState('');
+  const cashflowActivityRequestGuardRef = useRef<ReturnType<typeof createCashflowActivityRequestGuard> | null>(null);
+  if (!cashflowActivityRequestGuardRef.current) {
+    cashflowActivityRequestGuardRef.current = createCashflowActivityRequestGuard();
+  }
+  const cashflowActivityRequestGuard = cashflowActivityRequestGuardRef.current;
+  const activityScope = `${orgId}:${projectId}`;
+  const cashflowActivityScopeRef = useRef(activityScope);
+  cashflowActivityScopeRef.current = activityScope;
+  const cashflowActivityOneClickRef = useRef({
+    scope: activityScope,
+    depth: 0,
+    pendingAggregate: false,
+    pendingSources: new Set<CashflowActivitySource>(),
+  });
+  if (cashflowActivityOneClickRef.current.scope !== activityScope) {
+    cashflowActivityOneClickRef.current = {
+      scope: activityScope,
+      depth: 0,
+      pendingAggregate: false,
+      pendingSources: new Set<CashflowActivitySource>(),
+    };
+  }
+  const opsTimelineRef = useRef<HTMLDivElement | null>(null);
+  const [opsTimelineVisible, setOpsTimelineVisible] = useState(false);
+  const opsTimelineVisibleRef = useRef(false);
+  opsTimelineVisibleRef.current = opsTimelineVisible;
   const [cashflowEventQuery, setCashflowEventQuery] = useState('');
   const [cashflowEventMode, setCashflowEventMode] = useState('ALL');
   const [cashflowEventMonth, setCashflowEventMonth] = useState('ALL');
@@ -561,8 +605,10 @@ export function CashflowProjectSheet({
     reopen: 0,
   });
   const selectedProjectIdRef = useRef(projectId);
+  const selectedOrgIdRef = useRef(orgId);
   const selectedYearMonthRef = useRef(yearMonth);
   selectedProjectIdRef.current = projectId;
+  selectedOrgIdRef.current = orgId;
   selectedYearMonthRef.current = yearMonth;
   const captureMonthCloseMutationScope = useCallback((operation: CashflowMonthCloseMutationOperation): CashflowMonthCloseMutationScope => {
     const generation = monthCloseMutationGenerationRef.current[operation] + 1;
@@ -1214,51 +1260,231 @@ export function CashflowProjectSheet({
     if (weeklyHistoryOpen) void loadWeeklyComplianceHistory();
   }, [loadWeeklyComplianceHistory, weeklyHistoryOpen]);
 
-  const loadCashflowEventSource = useCallback(async (source: CashflowActivitySource, generation = cashflowActivityGenerationRef.current): Promise<void> => {
-    if (!projectId || !orgId || !user?.uid) {
-      return;
+  const fetchCashflowActivityPage = useCallback(async (input: {
+    source?: CashflowActivitySource;
+    cursor?: string;
+    signal: AbortSignal;
+  }) => {
+    let actor = await resolveBffActor();
+    if (!actor?.idToken) throw new Error('로그인 세션이 만료되었습니다.');
+    if (input.signal.aborted) throw new Error('활동 기록 요청이 중단되었습니다.');
+    const request = (requestActor: NonNullable<Awaited<ReturnType<typeof resolveBffActor>>>) => fetchCashflowActivityViaBff({
+      tenantId: orgId,
+      actor: requestActor,
+      projectId,
+      limit: 50,
+      ...(input.source ? { source: input.source } : {}),
+      ...(input.cursor ? { cursor: input.cursor } : {}),
+      signal: input.signal,
+    });
+    try {
+      return await request(actor);
+    } catch (error) {
+      if (!isBffAuthRejection(error) || input.signal.aborted) throw error;
+      actor = await resolveBffActor({ forceRefresh: true });
+      if (!actor?.idToken || input.signal.aborted) throw error;
+      return request(actor);
     }
+  }, [orgId, projectId, resolveBffActor]);
+
+  const isCurrentCashflowActivityScope = useCallback(() => (
+    cashflowActivityScopeRef.current === activityScope
+    && selectedOrgIdRef.current === orgId
+    && selectedProjectIdRef.current === projectId
+  ), [activityScope, orgId, projectId]);
+
+  const cashflowActivityDeferred = useCallback(() => (
+    cashflowActivityOneClickRef.current.scope === activityScope
+    && cashflowActivityOneClickRef.current.depth > 0
+  ), [activityScope]);
+
+  const loadCashflowEventSource = useCallback(async (
+    source: CashflowActivitySource,
+    options: { preservePagination?: boolean } = {},
+  ): Promise<void> => {
+    if (cashflowEventLoading || cashflowEventLoadingMore || !projectId || !orgId || !user?.uid || !shouldStartCashflowActivityLoad({
+      visible: opsTimelineVisibleRef.current,
+      deferred: cashflowActivityDeferred(),
+      currentScope: isCurrentCashflowActivityScope(),
+    })) return;
+    const ticket = cashflowActivityRequestGuard.start(`source:${source}`);
     setCashflowEventLoadingSources((current) => current.includes(source) ? current : [...current, source]);
     try {
-      let actor = await resolveBffActor();
-      if (!actor?.idToken) throw new Error('로그인 세션이 만료되었습니다.');
-      try {
-        const response = await fetchCashflowActivityViaBff({ tenantId: orgId, actor, projectId, source });
-        if (cashflowActivityGenerationRef.current !== generation) return;
-        setCashflowEvents((current) => mergeCashflowEvents(current, response.events));
-      } catch (error) {
-        if (!isBffAuthRejection(error)) throw error;
-        actor = await resolveBffActor({ forceRefresh: true });
-        if (!actor?.idToken) throw error;
-        const response = await fetchCashflowActivityViaBff({ tenantId: orgId, actor, projectId, source });
-        if (cashflowActivityGenerationRef.current !== generation) return;
-        setCashflowEvents((current) => mergeCashflowEvents(current, response.events));
+      const response = await fetchCashflowActivityPage({ source, signal: ticket.signal });
+      if (!cashflowActivityRequestGuard.isCurrent(ticket) || !isCurrentCashflowActivityScope()) return;
+      setCashflowEvents((current) => mergeCashflowEvents(current, response.events));
+      setCashflowEventErrors((current) => filterCashflowActivityErrorsAfterSuccess(
+        current,
+        source,
+        Boolean(options.preservePagination),
+      ));
+      if (!options.preservePagination) {
+        setCashflowActivityCursorQueue((current) => updateCashflowActivityCursorQueue(current, source, response.nextCursor));
       }
-      setCashflowEventErrors((current) => current.filter((failure) => failure.source !== source));
     } catch (error) {
-      if (cashflowActivityGenerationRef.current !== generation) return;
+      if (!cashflowActivityRequestGuard.isCurrent(ticket) || !isCurrentCashflowActivityScope()) return;
       const message = resolveApiErrorMessage(error, `${CASHFLOW_ACTIVITY_SOURCE_LABELS[source]} 기록을 불러오지 못했습니다.`);
-      setCashflowEventErrors((current) => [...current.filter((failure) => failure.source !== source), { source, message }]);
+      setCashflowEventErrors((current) => [
+        ...current.filter((failure) => failure.source !== source),
+        { source, message, preservePagination: options.preservePagination },
+      ]);
     } finally {
-      if (cashflowActivityGenerationRef.current === generation) {
+      if (cashflowActivityRequestGuard.isCurrent(ticket) && isCurrentCashflowActivityScope()) {
         setCashflowEventLoadingSources((current) => current.filter((candidate) => candidate !== source));
       }
+      cashflowActivityRequestGuard.finish(ticket);
     }
-  }, [orgId, projectId, resolveBffActor, user?.uid]);
+  }, [cashflowActivityDeferred, cashflowActivityRequestGuard, cashflowEventLoading, cashflowEventLoadingMore, fetchCashflowActivityPage, isCurrentCashflowActivityScope, orgId, projectId, user?.uid]);
 
-  const loadCashflowEvents = useCallback(async (): Promise<void> => {
-    const generation = cashflowActivityGenerationRef.current + 1;
-    cashflowActivityGenerationRef.current = generation;
-    setCashflowEventErrors([]);
-    setCashflowEventLoadingSources([]);
-    await loadCashflowActivitySourcesSequentially(async (source) => {
-      await loadCashflowEventSource(source, generation);
-    });
+  const reloadCashflowActivitySources = useCallback(async (sources: readonly CashflowActivitySource[]): Promise<void> => {
+    await Promise.all([...new Set(sources)].map((source) => (
+      loadCashflowEventSource(source, { preservePagination: true })
+    )));
   }, [loadCashflowEventSource]);
 
+  const reloadCashflowActivityForMutations = useCallback(async (...mutations: CashflowActivityMutation[]): Promise<void> => {
+    const sources = cashflowActivitySourcesForMutations(mutations);
+    if (sources.length === 0) return;
+    if (!opsTimelineVisibleRef.current) return;
+    sources.forEach((source) => cashflowActivityOneClickRef.current.pendingSources.add(source));
+    setCashflowActivityDrainVersion((current) => current + 1);
+  }, []);
+
+  // Frozen apply flow keeps this symbol. A successful apply writes only the JVM audit source.
+  const loadCashflowEvents = useCallback(async (): Promise<void> => {
+    await reloadCashflowActivityForMutations('sheet_values_applied');
+  }, [reloadCashflowActivityForMutations]);
+
+  const loadCashflowActivityAggregate = useCallback(async (): Promise<void> => {
+    if (!projectId || !orgId || !user?.uid || !shouldStartCashflowActivityLoad({
+      visible: opsTimelineVisibleRef.current,
+      deferred: cashflowActivityDeferred(),
+      currentScope: isCurrentCashflowActivityScope(),
+    })) return;
+    if (cashflowActivityOneClickRef.current.scope === activityScope) {
+      cashflowActivityOneClickRef.current.pendingAggregate = false;
+      cashflowActivityOneClickRef.current.pendingSources.clear();
+    }
+    const ticket = cashflowActivityRequestGuard.start('aggregate', { reset: true });
+    cashflowEventLoadingMoreRef.current = false;
+    setCashflowEventLoading(true);
+    setCashflowEventLoadingMore(false);
+    setCashflowEventLoadError('');
+    setCashflowEventErrors([]);
+    setCashflowEventLoadingSources([]);
+    setCashflowActivityCursorQueue([]);
+    try {
+      const response = await fetchCashflowActivityPage({ signal: ticket.signal });
+      if (!cashflowActivityRequestGuard.isCurrent(ticket) || !isCurrentCashflowActivityScope()) return;
+      setCashflowEvents((current) => mergeCashflowEvents(current, response.events));
+      setCashflowEventErrors(response.errors.map((failure) => ({
+        source: failure.source,
+        message: '기록 일부를 일시적으로 불러오지 못했습니다.',
+      })));
+      setCashflowActivityCursorQueue(updateCashflowActivityCursorQueue([], undefined, response.nextCursor));
+    } catch (error) {
+      if (!cashflowActivityRequestGuard.isCurrent(ticket) || !isCurrentCashflowActivityScope()) return;
+      setCashflowEventLoadError(resolveApiErrorMessage(error, '변경 이력을 불러오지 못했습니다.'));
+    } finally {
+      if (cashflowActivityRequestGuard.isCurrent(ticket) && isCurrentCashflowActivityScope()) {
+        setCashflowEventLoading(false);
+      }
+      cashflowActivityRequestGuard.finish(ticket);
+    }
+  }, [activityScope, cashflowActivityDeferred, cashflowActivityRequestGuard, fetchCashflowActivityPage, isCurrentCashflowActivityScope, orgId, projectId, user?.uid]);
+
+  useEffect(() => {
+    const pendingWork = takeCashflowActivityPendingWork(cashflowActivityOneClickRef.current, {
+      scope: activityScope,
+      visible: opsTimelineVisible,
+      busy: cashflowEventLoading || cashflowEventLoadingMore || cashflowEventLoadingSources.length > 0,
+    });
+    if (pendingWork?.kind === 'aggregate') void loadCashflowActivityAggregate();
+    else if (pendingWork?.kind === 'sources') void reloadCashflowActivitySources(pendingWork.sources);
+  }, [
+    activityScope,
+    cashflowActivityDrainVersion,
+    cashflowEventLoading,
+    cashflowEventLoadingMore,
+    cashflowEventLoadingSources.length,
+    loadCashflowActivityAggregate,
+    opsTimelineVisible,
+    reloadCashflowActivitySources,
+  ]);
+
+  const loadMoreCashflowEvents = useCallback(async (): Promise<void> => {
+    if (cashflowActivityCursorQueue.length === 0 || cashflowEventLoadingMoreRef.current || cashflowEventLoading || cashflowEventLoadingSources.length > 0 || !shouldStartCashflowActivityLoad({
+      visible: opsTimelineVisibleRef.current,
+      deferred: cashflowActivityDeferred(),
+      currentScope: isCurrentCashflowActivityScope(),
+    })) return;
+    const queuedCursors = [...cashflowActivityCursorQueue];
+    cashflowEventLoadingMoreRef.current = true;
+    setCashflowEventLoadingMore(true);
+    setCashflowEventLoadError('');
+    let generation: number | null = null;
+    await Promise.all(queuedCursors.map(async (queuedCursor) => {
+      const ticket = cashflowActivityRequestGuard.start(queuedCursor.source ? `source:${queuedCursor.source}` : 'aggregate');
+      generation ??= ticket.generation;
+      try {
+        const response = await fetchCashflowActivityPage({
+          ...(queuedCursor.source ? { source: queuedCursor.source } : {}),
+          cursor: queuedCursor.cursor,
+          signal: ticket.signal,
+        });
+        if (!cashflowActivityRequestGuard.isCurrent(ticket) || !isCurrentCashflowActivityScope()) return;
+        setCashflowEvents((current) => mergeCashflowEvents(current, response.events));
+        const failedSources = new Set(response.errors.map((failure) => failure.source));
+        setCashflowEventErrors((current) => [
+          ...current.filter((failure) => failure.source !== queuedCursor.source && !failedSources.has(failure.source)),
+          ...response.errors.map((failure) => ({
+            source: failure.source,
+            message: '기록 일부를 일시적으로 불러오지 못했습니다.',
+          })),
+        ]);
+        if (response.nextCursor === queuedCursor.cursor) {
+          setCashflowEventLoadError('이력 페이지가 반복되어 추가 조회를 중단했습니다.');
+          setCashflowActivityCursorQueue((current) => updateCashflowActivityCursorQueue(current, queuedCursor.source, null));
+        } else {
+          setCashflowActivityCursorQueue((current) => updateCashflowActivityCursorQueue(current, queuedCursor.source, response.nextCursor));
+        }
+      } catch (error) {
+        if (!cashflowActivityRequestGuard.isCurrent(ticket) || !isCurrentCashflowActivityScope()) return;
+        const failedSource = queuedCursor.source;
+        if (failedSource) {
+          const message = resolveApiErrorMessage(error, `${CASHFLOW_ACTIVITY_SOURCE_LABELS[failedSource]} 기록을 불러오지 못했습니다.`);
+          setCashflowEventErrors((current) => [
+            ...current.filter((failure) => failure.source !== failedSource),
+            { source: failedSource, message },
+          ]);
+        } else {
+          setCashflowEventLoadError(resolveApiErrorMessage(error, '이전 변경 이력을 불러오지 못했습니다.'));
+        }
+      } finally {
+        cashflowActivityRequestGuard.finish(ticket);
+      }
+    }));
+    if (generation !== null && cashflowActivityRequestGuard.isGenerationCurrent(generation) && isCurrentCashflowActivityScope()) {
+      cashflowEventLoadingMoreRef.current = false;
+      setCashflowEventLoadingMore(false);
+    }
+  }, [cashflowActivityCursorQueue, cashflowActivityDeferred, cashflowActivityRequestGuard, cashflowEventLoading, cashflowEventLoadingSources.length, fetchCashflowActivityPage, isCurrentCashflowActivityScope]);
+
+  useEffect(() => {
+    setCashflowEvents([]);
+    setCashflowEventErrors([]);
+    setCashflowEventLoadError('');
+    setCashflowEventLoading(false);
+    setCashflowEventLoadingSources([]);
+    setCashflowActivityCursorQueue([]);
+    setCashflowEventLoadingMore(false);
+    cashflowEventLoadingMoreRef.current = false;
+    return () => {
+      cashflowActivityRequestGuard.invalidate();
+    };
+  }, [activityScope, cashflowActivityRequestGuard]);
+
   // 이력 타임라인은 화면 오른쪽/아래에 있다. 들어올 때 읽는다. 한 번 보이면 이후 갱신은 기존 경로대로.
-  const opsTimelineRef = useRef<HTMLDivElement | null>(null);
-  const [opsTimelineVisible, setOpsTimelineVisible] = useState(false);
   useEffect(() => {
     const node = opsTimelineRef.current;
     if (!node) return undefined;
@@ -1273,12 +1499,17 @@ export function CashflowProjectSheet({
     return () => observer.disconnect();
   }, []);
   useEffect(() => {
-    setCashflowEvents([]);
     // 넓은 화면에선 타임라인이 처음부터 보여서 "보이면 읽는다"가 첫 발사에 끼었다(2026-08-19).
     // 보조 정보이니 month-close 가 끝난 뒤에만 읽는다.
     if (!opsTimelineVisible || !monthCloseSettled) return;
-    void loadCashflowEvents();
-  }, [loadCashflowEvents, monthCloseSettled, opsTimelineVisible]);
+    if (cashflowActivityDeferred()) {
+      if (cashflowActivityOneClickRef.current.scope === activityScope) {
+        cashflowActivityOneClickRef.current.pendingAggregate = true;
+      }
+      return;
+    }
+    void loadCashflowActivityAggregate();
+  }, [activityScope, cashflowActivityDeferred, loadCashflowActivityAggregate, monthCloseSettled, opsTimelineVisible]);
 
   const monthClosePinnedSource = useMemo<CashflowSheetLabMirrorResult | null>(() => {
     const dashboard = monthCloseResult?.dashboard;
@@ -1795,7 +2026,6 @@ export function CashflowProjectSheet({
       await Promise.all([
         loadCashflowMonthClose(),
         loadMonthCloseRequest(),
-        loadCashflowEvents(),
       ]);
       if (!isCurrentMonthCloseMutation(mutationScope, request)) return;
       toast.success('월 결산 승인 요청을 보냈어요. 조직장 승인을 기다립니다.');
@@ -1827,7 +2057,6 @@ export function CashflowProjectSheet({
     captureMonthCloseMutationScope,
     isCurrentMonthCloseMutation,
     monthClosePinnedSource,
-    loadCashflowEvents,
     loadCashflowMonthClose,
     loadMonthCloseRequest,
     monthCloseCellsState,
@@ -1875,7 +2104,7 @@ export function CashflowProjectSheet({
       setMonthCloseWithdrawOpen(false);
       setMonthCloseWithdrawReason('');
       if (!isCurrentMonthCloseMutation(mutationScope, request)) return;
-      await Promise.all([loadCashflowMonthClose(), loadMonthCloseRequest(), loadCashflowEvents()]);
+      await Promise.all([loadCashflowMonthClose(), loadMonthCloseRequest()]);
       if (!isCurrentMonthCloseMutation(mutationScope, request)) return;
       toast.success('월 결산 요청을 회수했어요.');
       logCashflowSettlement({
@@ -1904,7 +2133,6 @@ export function CashflowProjectSheet({
   }, [
     captureMonthCloseMutationScope,
     isCurrentMonthCloseMutation,
-    loadCashflowEvents,
     loadCashflowMonthClose,
     loadMonthCloseRequest,
     monthCloseActions?.withdrawMonthClose,
@@ -1966,6 +2194,7 @@ export function CashflowProjectSheet({
       setMonthCloseRequest(result.request);
       if (!isCurrentMonthCloseMutation(mutationScope, result.request)) return;
       void loadMonthCloseRequest();
+      void reloadCashflowActivityForMutations('month_reopen_completed');
       setReopenAction(null);
       setReopenReason('');
       if (portalMode) {
@@ -1980,7 +2209,7 @@ export function CashflowProjectSheet({
     } finally {
       if (isCurrentMonthCloseMutation(mutationScope)) setMonthCloseBusy(false);
     }
-  }, [canReviewReopen, captureMonthCloseMutationScope, isCurrentMonthCloseMutation, loadMonthCloseRequest, monthCloseActions?.requestMonthReopen, monthCloseRequest, orgId, portalMode, projectId, reopenAction, reopenReason, resolveBffActor, yearMonth]);
+  }, [canReviewReopen, captureMonthCloseMutationScope, isCurrentMonthCloseMutation, loadMonthCloseRequest, monthCloseActions?.requestMonthReopen, monthCloseRequest, orgId, portalMode, projectId, reloadCashflowActivityForMutations, reopenAction, reopenReason, resolveBffActor, yearMonth]);
 
   const handleRefreshSheetMirror = useCallback(async (): Promise<CashflowSheetLabMirrorResult | null> => {
     if (!cashflowSheetConfig?.value) {
@@ -2018,7 +2247,7 @@ export function CashflowProjectSheet({
           }
         : mirror);
       if (mirror.status === 'FRESH' && mirror.sourceRevision) {
-        void loadCashflowEvents();
+        void reloadCashflowActivityForMutations('sheet_mirror_refreshed');
         } else if (mirror.status === 'STALE') {
         } else {
       }
@@ -2087,7 +2316,7 @@ export function CashflowProjectSheet({
     } finally {
       setSheetRefreshLoading(false);
     }
-  }, [cashflowSheetConfig, loadCashflowEvents, orgId, projectId, resolveBffActor, selectedYear, yearMonth]);
+  }, [cashflowSheetConfig, orgId, projectId, reloadCashflowActivityForMutations, resolveBffActor, selectedYear, yearMonth]);
 
   const handleMonthClosePreparationAction = useCallback(async (): Promise<void> => {
     if (monthClosePreparation.status === 'STATUS_RETRY_REQUIRED') {
@@ -2410,6 +2639,28 @@ export function CashflowProjectSheet({
       summary: { completedStep: 'stage', nextStep: 'apply_or_confirmation' },
     });
   }, [handleRefreshSheetMirror, handleStagePinnedSheetValues, projectId, yearMonth]);
+
+  const handleDeferredRefreshAndApplySheetValues = useCallback(async (): Promise<void> => {
+    const oneClickActivityScope = activityScope;
+    if (cashflowActivityOneClickRef.current.scope !== oneClickActivityScope) {
+      cashflowActivityOneClickRef.current = {
+        scope: oneClickActivityScope,
+        depth: 0,
+        pendingAggregate: false,
+        pendingSources: new Set<CashflowActivitySource>(),
+      };
+    }
+    if (cashflowActivityOneClickRef.current.depth === 0) cashflowActivityOneClickRef.current.pendingSources.clear();
+    cashflowActivityOneClickRef.current.depth += 1;
+    try {
+      await handleRefreshAndApplySheetValues();
+    } finally {
+      if (cashflowActivityOneClickRef.current.scope === oneClickActivityScope) {
+        cashflowActivityOneClickRef.current.depth -= 1;
+        setCashflowActivityDrainVersion((current) => current + 1);
+      }
+    }
+  }, [activityScope, handleRefreshAndApplySheetValues]);
 
   const handleOpenSheetOnboarding = useCallback(() => {
     setSheetReviewDialogOpen(true);
@@ -2934,7 +3185,7 @@ export function CashflowProjectSheet({
                 </HoverExplain>
               </div>
               <div className="text-[12px] text-slate-500">
-                현금흐름 관리시트 A11:BS11 기준
+                현금흐름 관리시트 E11:BL11 주별 수식 기준
               </div>
             </div>
             <Badge className="rounded-md border border-[#C7D3DF] bg-[#EAF0F5] px-2.5 py-1 text-[12px] text-[#17324D]">시트 수식값</Badge>
@@ -2952,34 +3203,26 @@ export function CashflowProjectSheet({
                 </tr>
               </thead>
               <tbody>
-                {!cashflowPresentation.comparison.changed ? (
-                  <tr>
-                    <td colSpan={columnCount + 1} className="px-3 py-8 text-center text-[12px] text-slate-500">
-                      Projection과 Actual 차이가 없습니다.
-                    </td>
-                  </tr>
-                ) : (
-                  <tr className="border-t-[6px] border-white">
-                    <td className="sticky left-0 z-10 w-[220px] min-w-[220px] border-r-[6px] border-r-white bg-white px-3 py-2">
-                      <div className="truncate text-emerald-700">Projection - Actual 차이</div>
-                    </td>
-                    {comparisonCells.map((cell) => {
-                      const rowSurface = 'bg-white';
-                      const differenceClass = cell.difference === null || cell.difference === 0
-                        ? `${rowSurface} text-slate-300`
-                        : 'bg-[#EAF0F5] text-sky-700';
-                      return (
-                        <td
-                          key={`sheet-projection-actual-difference-${cell.yearMonth}-${cell.weekNo}`}
-                          className={`min-w-[96px] border-l-[6px] border-l-white px-2 py-2 text-right font-semibold tabular-nums ${differenceClass}`}
-                          title={cell.difference === null ? `${cell.weekRange}\n시트 수식값 없음` : `${cell.weekRange}\n시트 차이 ${fmtSigned(cell.difference)}`}
-                        >
-                          {cell.difference === null ? '미입력' : fmtSigned(cell.difference)}
-                        </td>
-                      );
-                    })}
-                  </tr>
-                )}
+                <tr className="border-t-[6px] border-white">
+                  <td className="sticky left-0 z-10 w-[220px] min-w-[220px] border-r-[6px] border-r-white bg-white px-3 py-2">
+                    <div className="truncate text-emerald-700">Projection - Actual 차이</div>
+                  </td>
+                  {comparisonCells.map((cell) => {
+                    const rowSurface = 'bg-white';
+                    const differenceClass = cell.difference === null || cell.difference === 0
+                      ? `${rowSurface} text-slate-500`
+                      : 'bg-[#EAF0F5] text-sky-700';
+                    return (
+                      <td
+                        key={`sheet-projection-actual-difference-${cell.yearMonth}-${cell.weekNo}`}
+                        className={`min-w-[96px] border-l-[6px] border-l-white px-2 py-2 text-right font-semibold tabular-nums ${differenceClass}`}
+                        title={cell.difference === null ? `${cell.weekRange}\n시트 수식값 없음` : `${cell.weekRange}\n시트 차이 ${fmtSigned(cell.difference)}`}
+                      >
+                        {cell.difference === null ? '미입력' : fmtSigned(cell.difference)}
+                      </td>
+                    );
+                  })}
+                </tr>
               </tbody>
             </table>
           </div>
@@ -3276,7 +3519,7 @@ export function CashflowProjectSheet({
                       : 'border-slate-300 bg-white text-[#17324D] hover:bg-accent'
                   }`}
                   disabled={sheetRefreshLoading}
-                  onClick={() => void handleRefreshAndApplySheetValues()}
+                  onClick={() => void handleDeferredRefreshAndApplySheetValues()}
                 >
                   {sheetRefreshLoading ? <span aria-hidden="true" className="pointer-events-none absolute -inset-1 rounded-md border-2 border-transparent border-t-[#17324D] motion-safe:animate-spin" /> : null}
                   {sheetRefreshLoading ? <Loader2 className="mr-1 h-3 w-3 animate-spin" /> : <RefreshCw className="mr-1 h-3 w-3" />}
@@ -3699,11 +3942,35 @@ export function CashflowProjectSheet({
           {cashflowEventErrors.map((failure) => (
             <div key={failure.source} role="alert" className="mb-2 flex flex-wrap items-center justify-between gap-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-700">
               <span>{CASHFLOW_ACTIVITY_SOURCE_LABELS[failure.source]}: {failure.message}</span>
-              <Button type="button" size="sm" variant="outline" disabled={cashflowEventLoadingSources.includes(failure.source)} onClick={() => void loadCashflowEventSource(failure.source)}>다시 시도</Button>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={cashflowEventLoading || cashflowEventLoadingMore || cashflowEventLoadingSources.includes(failure.source)}
+                onClick={() => void loadCashflowEventSource(failure.source, {
+                  preservePagination: Boolean(failure.preservePagination),
+                })}
+              >
+                다시 시도
+              </Button>
             </div>
           ))}
+          {cashflowEventLoadError ? (
+            <div role="alert" className="mb-2 flex flex-wrap items-center justify-between gap-2 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-[12px] text-red-700">
+              <span>{cashflowEventLoadError}</span>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={cashflowEventLoading || cashflowEventLoadingMore}
+                onClick={() => void (cashflowActivityCursorQueue.length > 0 ? loadMoreCashflowEvents() : loadCashflowActivityAggregate())}
+              >
+                다시 시도
+              </Button>
+            </div>
+          ) : null}
           <div className="max-h-[230px] space-y-0 overflow-auto rounded-md border border-slate-200 bg-slate-50 px-2 py-2 pr-1">
-            {cashflowEventLoadingSources.length > 0 && filteredEvents.length === 0 ? (
+            {(cashflowEventLoading || cashflowEventLoadingSources.length > 0) && filteredEvents.length === 0 ? (
               <div role="status" className="px-2 py-8 text-center text-[12px] leading-4 text-slate-500">실제 반영 기록을 불러오는 중입니다.</div>
             ) : filteredEvents.length === 0 ? (
               <div className="px-2 py-8 text-center text-[12px] leading-4 text-slate-500">
@@ -3758,6 +4025,11 @@ export function CashflowProjectSheet({
               );
             })}
           </div>
+          {cashflowActivityCursorQueue.length > 0 ? (
+            <Button type="button" variant="outline" className="mt-2 w-full" disabled={cashflowEventLoading || cashflowEventLoadingMore || cashflowEventLoadingSources.length > 0} onClick={() => void loadMoreCashflowEvents()}>
+              {cashflowEventLoadingMore ? '이전 기록 불러오는 중…' : '이전 기록 더 불러오기'}
+            </Button>
+          ) : null}
         </CardContent>
       </Card>
     );

--- a/src/app/components/cashflow/cashflow-action-tooltips.shell.test.ts
+++ b/src/app/components/cashflow/cashflow-action-tooltips.shell.test.ts
@@ -15,7 +15,7 @@ const importEditorSource = readFileSync(
 describe('cashflow action chrome', () => {
   it('removes secondary cashflow toolbar actions and explanatory chrome', () => {
     expect(cashflowProjectSheetSource).toContain('Projection - Actual 차이');
-    expect(cashflowProjectSheetSource).toContain('현금흐름 관리시트 A11:BS11 기준');
+    expect(cashflowProjectSheetSource).toContain('현금흐름 관리시트 E11:BL11 주별 수식 기준');
     expect(cashflowProjectSheetSource).not.toContain('Actual - Projection');
     expect(cashflowProjectSheetSource).not.toContain('Actual에서 Projection을 뺀 값');
     expect(cashflowProjectSheetSource).not.toContain('actual - projection');

--- a/src/app/components/cashflow/cashflow-activity-loader.test.ts
+++ b/src/app/components/cashflow/cashflow-activity-loader.test.ts
@@ -1,52 +1,227 @@
 import { describe, expect, it, vi } from 'vitest';
-import { loadCashflowActivitySourcesSequentially } from './cashflow-activity-loader';
+import * as activityLoader from './cashflow-activity-loader';
+import {
+  createCashflowActivityRequestGuard,
+  shouldStartCashflowActivityLoad,
+  updateCashflowActivityCursorQueue,
+} from './cashflow-activity-loader';
 
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason?: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, resolve, reject };
+function cashflowActivitySourcesForMutations() {
+  expect(activityLoader).toHaveProperty('cashflowActivitySourcesForMutations');
+  return (activityLoader as typeof activityLoader & {
+    cashflowActivitySourcesForMutations: (mutations: string[]) => string[];
+  }).cashflowActivitySourcesForMutations;
 }
 
-describe('loadCashflowActivitySourcesSequentially', () => {
-  it('renders each success before starting the next source and continues after a middle timeout', async () => {
-    const legacy = deferred<string[]>();
-    const refresh = deferred<string[]>();
-    const audit = deferred<string[]>();
-    const timeline: string[] = [];
-    const visible: string[] = ['already-loaded'];
-    const loadSource = vi.fn((source: 'legacy' | 'sheet_refresh' | 'audit') => {
-      timeline.push(`start:${source}`);
-      return { legacy: legacy.promise, sheet_refresh: refresh.promise, audit: audit.promise }[source];
-    });
-
-    const completed = loadCashflowActivitySourcesSequentially(
-      loadSource,
-      (source, events) => {
-        visible.push(...events);
-        timeline.push(`success:${source}`);
+function takeCashflowActivityPendingWork() {
+  expect(activityLoader).toHaveProperty('takeCashflowActivityPendingWork');
+  return (activityLoader as typeof activityLoader & {
+    takeCashflowActivityPendingWork: (
+      state: {
+        scope: string;
+        depth: number;
+        pendingAggregate: boolean;
+        pendingSources: Set<'sheet_refresh' | 'audit'>;
       },
-      (source) => timeline.push(`error:${source}`),
+      input: { scope: string; visible: boolean; busy: boolean },
+    ) => { kind: 'aggregate' } | { kind: 'sources'; sources: Array<'sheet_refresh' | 'audit'> } | null;
+  }).takeCashflowActivityPendingWork;
+}
+
+function filterCashflowActivityErrorsAfterSuccess() {
+  expect(activityLoader).toHaveProperty('filterCashflowActivityErrorsAfterSuccess');
+  return (activityLoader as typeof activityLoader & {
+    filterCashflowActivityErrorsAfterSuccess: <T extends {
+      source: 'sheet_refresh' | 'audit';
+      preservePagination?: boolean;
+    }>(
+      failures: T[],
+      source: 'sheet_refresh' | 'audit',
+      preservePagination: boolean,
+    ) => T[];
+  }).filterCashflowActivityErrorsAfterSuccess;
+}
+
+describe('cashflow activity request guard', () => {
+  it('aborts superseded lanes and rejects every ticket from an invalidated project generation', () => {
+    const guard = createCashflowActivityRequestGuard();
+    const aggregate = guard.start('aggregate', { reset: true });
+    const audit = guard.start('source:audit');
+    const replacementAudit = guard.start('source:audit');
+
+    expect(aggregate.signal.aborted).toBe(false);
+    expect(audit.signal.aborted).toBe(true);
+    expect(guard.isCurrent(audit)).toBe(false);
+    expect(guard.isCurrent(replacementAudit)).toBe(true);
+
+    guard.invalidate();
+
+    expect(aggregate.signal.aborted).toBe(true);
+    expect(replacementAudit.signal.aborted).toBe(true);
+    expect(guard.isCurrent(aggregate)).toBe(false);
+    expect(guard.isGenerationCurrent(replacementAudit.generation)).toBe(false);
+  });
+
+  it('keeps independent aggregate and source-retry lanes alive in the same generation', () => {
+    const guard = createCashflowActivityRequestGuard();
+    const aggregate = guard.start('aggregate', { reset: true });
+    const audit = guard.start('source:audit');
+
+    expect(guard.isCurrent(aggregate)).toBe(true);
+    expect(guard.isCurrent(audit)).toBe(true);
+
+    guard.finish(audit);
+    expect(guard.isCurrent(audit)).toBe(false);
+    expect(guard.isCurrent(aggregate)).toBe(true);
+  });
+});
+
+describe('cashflow activity paging policy', () => {
+  it('queues the aggregate cursor and a recovered source cursor without losing either continuation', () => {
+    const aggregate = updateCashflowActivityCursorQueue([], undefined, 'aggregate-page-2');
+    const withAudit = updateCashflowActivityCursorQueue(aggregate, 'audit', 'audit-page-2');
+
+    expect(withAudit).toEqual([
+      { cursor: 'aggregate-page-2' },
+      { source: 'audit', cursor: 'audit-page-2' },
+    ]);
+    expect(updateCashflowActivityCursorQueue(withAudit, undefined, null)).toEqual([
+      { source: 'audit', cursor: 'audit-page-2' },
+    ]);
+  });
+
+  it('keeps the aggregate cursor authoritative when a mutation head page returns its own cursor', () => {
+    const aggregate = updateCashflowActivityCursorQueue([], undefined, 'aggregate-page-2');
+    const updateWithPolicy = updateCashflowActivityCursorQueue as typeof updateCashflowActivityCursorQueue & (
+      (
+        current: typeof aggregate,
+        source: 'audit',
+        cursor: string,
+        options: { preserveExisting: boolean },
+      ) => typeof aggregate
     );
 
-    expect(timeline).toEqual(['start:legacy']);
-    legacy.resolve(['legacy-event']);
-    await vi.waitFor(() => expect(timeline).toEqual(['start:legacy', 'success:legacy', 'start:sheet_refresh']));
-    expect(visible).toEqual(['already-loaded', 'legacy-event']);
+    const afterMutationHead = updateWithPolicy(
+      aggregate,
+      'audit',
+      'audit-head-page-2',
+      { preserveExisting: true },
+    );
 
-    refresh.reject(new Error('요청 중단'));
-    await vi.waitFor(() => expect(timeline).toContain('start:audit'));
-    expect(visible).toEqual(['already-loaded', 'legacy-event']);
+    expect(afterMutationHead).toBe(aggregate);
+    expect(afterMutationHead).toEqual([{ cursor: 'aggregate-page-2' }]);
+  });
 
-    audit.resolve(['audit-event']);
-    await completed;
-    expect(timeline).toEqual([
-      'start:legacy', 'success:legacy', 'start:sheet_refresh', 'error:sheet_refresh', 'start:audit', 'success:audit',
+  it('does not hide an aggregate history gap when a mutation head refresh succeeds', () => {
+    const filterAfterSuccess = filterCashflowActivityErrorsAfterSuccess();
+    const aggregateGap = { source: 'audit' as const, message: '이전 기록을 불러오지 못했습니다.' };
+    const mutationHeadFailure = {
+      source: 'audit' as const,
+      message: '최신 기록을 불러오지 못했습니다.',
+      preservePagination: true,
+    };
+
+    expect(filterAfterSuccess([aggregateGap], 'audit', true)).toEqual([aggregateGap]);
+    expect(filterAfterSuccess([mutationHeadFailure], 'audit', true)).toEqual([]);
+    expect(filterAfterSuccess([aggregateGap], 'audit', false)).toEqual([]);
+  });
+
+  it('starts no request while hidden, deferred, or scoped to a stale project', () => {
+    const fetchPage = vi.fn();
+    const attempts = [
+      { visible: false, deferred: false, currentScope: true },
+      { visible: true, deferred: true, currentScope: true },
+      { visible: true, deferred: false, currentScope: false },
+      { visible: true, deferred: false, currentScope: true },
+    ];
+
+    attempts.forEach((attempt) => {
+      if (shouldStartCashflowActivityLoad(attempt)) fetchPage();
+    });
+
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('cashflow activity mutation source policy', () => {
+  it('reloads only the Activity collection that the completed mutation actually changed', () => {
+    const sourcesFor = cashflowActivitySourcesForMutations();
+
+    expect(sourcesFor(['sheet_mirror_refreshed'])).toEqual(['sheet_refresh']);
+    expect(sourcesFor(['sheet_values_applied'])).toEqual(['audit']);
+    expect(sourcesFor(['month_reopen_completed'])).toEqual(['audit']);
+    expect(sourcesFor(['month_close_requested'])).toEqual([]);
+    expect(sourcesFor(['month_close_withdrawn'])).toEqual([]);
+    expect(sourcesFor(['month_close_approver_changed'])).toEqual([]);
+  });
+
+  it('deduplicates one-click refresh and apply into at most two bounded source pages', () => {
+    const sourcesFor = cashflowActivitySourcesForMutations();
+
+    expect(sourcesFor(['sheet_mirror_refreshed'])).toEqual(['sheet_refresh']);
+    const completed = sourcesFor([
+      'sheet_mirror_refreshed',
+      'sheet_values_applied',
+      'sheet_values_applied',
     ]);
-    expect(visible).toEqual(['already-loaded', 'legacy-event', 'audit-event']);
-    expect(loadSource).toHaveBeenCalledTimes(3);
+    expect(completed).toEqual(['sheet_refresh', 'audit']);
+    expect(completed.length * 50).toBeLessThanOrEqual(100);
+  });
+
+  it('keeps deferred aggregate work queued and lets it absorb mutation source pages once idle', () => {
+    const takePendingWork = takeCashflowActivityPendingWork();
+    const state = {
+      scope: 'org-a:project-a',
+      depth: 1,
+      pendingAggregate: true,
+      pendingSources: new Set(['sheet_refresh', 'audit'] as const),
+    };
+
+    expect(takePendingWork(state, {
+      scope: 'org-a:project-a', visible: true, busy: false,
+    })).toBeNull();
+    expect(state.pendingAggregate).toBe(true);
+    expect([...state.pendingSources]).toEqual(['sheet_refresh', 'audit']);
+
+    state.depth = 0;
+    expect(takePendingWork(state, {
+      scope: 'org-a:project-a', visible: true, busy: false,
+    })).toEqual({ kind: 'aggregate' });
+    expect(state.pendingAggregate).toBe(false);
+    expect([...state.pendingSources]).toEqual([]);
+    expect(takePendingWork(state, {
+      scope: 'org-a:project-a', visible: true, busy: false,
+    })).toBeNull();
+  });
+
+  it('drains only the completed mutation sources when no aggregate load is pending', () => {
+    const takePendingWork = takeCashflowActivityPendingWork();
+    const state = {
+      scope: 'org-a:project-a',
+      depth: 0,
+      pendingAggregate: false,
+      pendingSources: new Set(['sheet_refresh', 'audit'] as const),
+    };
+
+    expect(takePendingWork(state, {
+      scope: 'org-a:project-a', visible: true, busy: false,
+    })).toEqual({ kind: 'sources', sources: ['sheet_refresh', 'audit'] });
+    expect([...state.pendingSources]).toEqual([]);
+  });
+
+  it('never drains pending activity from a stale project scope', () => {
+    const takePendingWork = takeCashflowActivityPendingWork();
+    const state = {
+      scope: 'org-a:project-a',
+      depth: 0,
+      pendingAggregate: true,
+      pendingSources: new Set(['audit'] as const),
+    };
+
+    expect(takePendingWork(state, {
+      scope: 'org-a:project-b', visible: true, busy: false,
+    })).toBeNull();
+    expect(state.pendingAggregate).toBe(true);
+    expect([...state.pendingSources]).toEqual(['audit']);
   });
 });

--- a/src/app/components/cashflow/cashflow-activity-loader.ts
+++ b/src/app/components/cashflow/cashflow-activity-loader.ts
@@ -1,17 +1,129 @@
 import type { CashflowActivitySource } from '../../lib/platform-bff-client';
 
-export const CASHFLOW_ACTIVITY_SOURCES = ['legacy', 'sheet_refresh', 'audit'] as const satisfies readonly CashflowActivitySource[];
+export type CashflowActivityMutation =
+  | 'sheet_mirror_refreshed'
+  | 'sheet_values_applied'
+  | 'month_reopen_completed'
+  | 'month_close_requested'
+  | 'month_close_withdrawn'
+  | 'month_close_approver_changed';
 
-export async function loadCashflowActivitySourcesSequentially<T>(
-  loadSource: (source: CashflowActivitySource) => Promise<T>,
-  onSuccess: (source: CashflowActivitySource, result: T) => void = () => undefined,
-  onError: (source: CashflowActivitySource, error: unknown) => void = () => undefined,
-): Promise<void> {
-  for (const source of CASHFLOW_ACTIVITY_SOURCES) {
-    try {
-      onSuccess(source, await loadSource(source));
-    } catch (error) {
-      onError(source, error);
-    }
+const CASHFLOW_ACTIVITY_MUTATION_SOURCES = {
+  sheet_mirror_refreshed: ['sheet_refresh'],
+  sheet_values_applied: ['audit'],
+  month_reopen_completed: ['audit'],
+  month_close_requested: [],
+  month_close_withdrawn: [],
+  month_close_approver_changed: [],
+} as const satisfies Record<CashflowActivityMutation, readonly CashflowActivitySource[]>;
+
+export function cashflowActivitySourcesForMutations(
+  mutations: readonly CashflowActivityMutation[],
+): CashflowActivitySource[] {
+  const selected = new Set(mutations.flatMap((mutation) => CASHFLOW_ACTIVITY_MUTATION_SOURCES[mutation]));
+  return (['sheet_refresh', 'audit'] as const).filter((source) => selected.has(source));
+}
+
+export type CashflowActivityPendingWork =
+  | { kind: 'aggregate' }
+  | { kind: 'sources'; sources: CashflowActivitySource[] };
+
+export function takeCashflowActivityPendingWork(
+  state: {
+    scope: string;
+    depth: number;
+    pendingAggregate: boolean;
+    pendingSources: Set<CashflowActivitySource>;
+  },
+  input: {
+    scope: string;
+    visible: boolean;
+    busy: boolean;
+  },
+): CashflowActivityPendingWork | null {
+  if (state.scope !== input.scope || state.depth > 0 || !input.visible || input.busy) return null;
+  if (state.pendingAggregate) {
+    state.pendingAggregate = false;
+    state.pendingSources.clear();
+    return { kind: 'aggregate' };
   }
+  const pendingSources = [...state.pendingSources];
+  state.pendingSources.clear();
+  return pendingSources.length > 0 ? { kind: 'sources', sources: pendingSources } : null;
+}
+
+export interface CashflowActivityCursor {
+  source?: CashflowActivitySource;
+  cursor: string;
+}
+
+export interface CashflowActivityRequestTicket {
+  generation: number;
+  lane: string;
+  signal: AbortSignal;
+}
+
+export function createCashflowActivityRequestGuard() {
+  let generation = 0;
+  const controllers = new Map<string, AbortController>();
+
+  const invalidate = () => {
+    generation += 1;
+    controllers.forEach((controller) => controller.abort());
+    controllers.clear();
+  };
+
+  return {
+    start(lane: string, options: { reset?: boolean } = {}): CashflowActivityRequestTicket {
+      if (options.reset) invalidate();
+      controllers.get(lane)?.abort();
+      const controller = new AbortController();
+      controllers.set(lane, controller);
+      return { generation, lane, signal: controller.signal };
+    },
+    isCurrent(ticket: CashflowActivityRequestTicket): boolean {
+      return generation === ticket.generation
+        && controllers.get(ticket.lane)?.signal === ticket.signal
+        && !ticket.signal.aborted;
+    },
+    isGenerationCurrent(candidate: number): boolean {
+      return generation === candidate;
+    },
+    finish(ticket: CashflowActivityRequestTicket): void {
+      if (controllers.get(ticket.lane)?.signal === ticket.signal) controllers.delete(ticket.lane);
+    },
+    invalidate,
+  };
+}
+
+export function updateCashflowActivityCursorQueue(
+  current: CashflowActivityCursor[],
+  source: CashflowActivitySource | undefined,
+  cursor: string | null,
+  options: { preserveExisting?: boolean } = {},
+): CashflowActivityCursor[] {
+  if (options.preserveExisting) return current;
+  const remaining = current.filter((candidate) => candidate.source !== source);
+  return cursor ? [...remaining, { ...(source ? { source } : {}), cursor }] : remaining;
+}
+
+export function filterCashflowActivityErrorsAfterSuccess<T extends {
+  source: CashflowActivitySource;
+  preservePagination?: boolean;
+}>(
+  failures: T[],
+  source: CashflowActivitySource,
+  preservePagination: boolean,
+): T[] {
+  return failures.filter((failure) => (
+    failure.source !== source || (preservePagination && !failure.preservePagination)
+  ));
+}
+
+export function shouldStartCashflowActivityLoad(input: {
+  visible: boolean;
+  deferred: boolean;
+  currentScope: boolean;
+}): boolean {
+  return input.visible && !input.deferred && input.currentScope;
 }

--- a/src/app/lib/platform-bff-client.test.ts
+++ b/src/app/lib/platform-bff-client.test.ts
@@ -651,18 +651,63 @@ describe('platform-bff-client', () => {
     expect(result).toEqual(page);
   });
 
-  it('reads each general activity source through an isolated bounded request', async () => {
+  it('reads one bounded aggregate activity page with cursor and cancellation', async () => {
     const events = Array.from({ length: 101 }, (_, index) => ({ id: `event-${index}` }));
-    const page = { projectId: 'p001', source: 'audit' as const, events };
+    const page = {
+      projectId: 'p001',
+      events,
+      errors: [{ source: 'sheet_refresh' as const, code: 'cashflow_activity_source_unavailable' as const }],
+      nextCursor: 'next/cursor',
+    };
     const client = asMockClient({ post: vi.fn(), get: vi.fn(async () => ({ data: page })), request: vi.fn() });
+    const controller = new AbortController();
 
     const result = await fetchCashflowActivityViaBff({
-      tenantId: 'mysc', actor: { uid: 'admin-1', role: 'admin' }, projectId: 'p001', source: 'audit', client,
+      tenantId: 'mysc', actor: { uid: 'admin-1', role: 'admin' }, projectId: 'p001',
+      limit: 50, cursor: 'opaque/cursor', signal: controller.signal, client,
     });
 
-    expect(client.get).toHaveBeenCalledWith('/api/v1/cashflow/p001/activity?source=audit', expect.objectContaining({ retries: 0, timeoutMs: 12000 }));
+    expect(client.get).toHaveBeenCalledTimes(1);
+    expect(client.get).toHaveBeenCalledWith('/api/v1/cashflow/p001/activity?limit=50&cursor=opaque%2Fcursor', expect.objectContaining({
+      retries: 0,
+      timeoutMs: 12000,
+      signal: controller.signal,
+    }));
     expect(result).toBe(page);
     expect(result.events).toHaveLength(101);
+  });
+
+  it('defaults the initial aggregate activity request to 50 documents', async () => {
+    const page = { projectId: 'p001', events: [], errors: [], nextCursor: null };
+    const client = asMockClient({ post: vi.fn(), get: vi.fn(async () => ({ data: page })), request: vi.fn() });
+
+    await fetchCashflowActivityViaBff({
+      tenantId: 'mysc', actor: { uid: 'admin-1', role: 'admin' }, projectId: 'p001', client,
+    });
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/cashflow/p001/activity?limit=50', expect.objectContaining({
+      retries: 0,
+      timeoutMs: 12000,
+    }));
+  });
+
+  it('retries one failed activity source without reading the other sources', async () => {
+    const page = { projectId: 'p001', source: 'audit' as const, events: [], errors: [], nextCursor: null };
+    const client = asMockClient({ post: vi.fn(), get: vi.fn(async () => ({ data: page })), request: vi.fn() });
+    const controller = new AbortController();
+
+    const result = await fetchCashflowActivityViaBff({
+      tenantId: 'mysc', actor: { uid: 'admin-1', role: 'admin' }, projectId: 'p001', source: 'audit', limit: 50, client,
+      signal: controller.signal,
+    });
+
+    expect(client.get).toHaveBeenCalledTimes(1);
+    expect(client.get).toHaveBeenCalledWith('/api/v1/cashflow/p001/activity?limit=50&source=audit', expect.objectContaining({
+      retries: 0,
+      timeoutMs: 12000,
+      signal: controller.signal,
+    }));
+    expect(result).toBe(page);
   });
 
   it('routes projection through the fenced JVM-owned BFF endpoint', async () => {

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -879,6 +879,17 @@ export interface CashflowActivityEvent {
 
 export type CashflowActivitySource = 'legacy' | 'sheet_refresh' | 'audit';
 
+export interface CashflowActivityPage {
+  projectId: string;
+  source?: CashflowActivitySource;
+  events: CashflowActivityEvent[];
+  errors: Array<{
+    source: CashflowActivitySource;
+    code: 'cashflow_activity_source_unavailable';
+  }>;
+  nextCursor: string | null;
+}
+
 export interface CashflowAppliedCellChange {
   eventId: string;
   cellId: string;
@@ -1982,6 +1993,7 @@ export interface PlatformApiClientLike {
     headers?: HeadersInit;
     idempotencyKey?: string;
     requestId?: string;
+    signal?: AbortSignal;
     retries?: number;
     timeoutMs?: number;
   }): Promise<{ data: T }>;
@@ -3610,13 +3622,20 @@ export async function fetchCashflowActivityViaBff(params: {
   actor: ActorLike;
   projectId: string;
   source?: CashflowActivitySource;
+  limit?: number;
+  cursor?: string;
+  signal?: AbortSignal;
   client?: PlatformApiClientLike;
-}): Promise<{ projectId: string; source?: CashflowActivitySource; events: CashflowActivityEvent[] }> {
-  const response = await resolveClient(params.client).get<{ projectId: string; source?: CashflowActivitySource; events: CashflowActivityEvent[] }>(
-    `/api/v1/cashflow/${encodeURIComponent(params.projectId)}/activity${params.source ? `?source=${params.source}` : ''}`,
+}): Promise<CashflowActivityPage> {
+  const query = new URLSearchParams({ limit: String(params.limit ?? 50) });
+  if (params.source) query.set('source', params.source);
+  if (params.cursor) query.set('cursor', params.cursor);
+  const response = await resolveClient(params.client).get<CashflowActivityPage>(
+    `/api/v1/cashflow/${encodeURIComponent(params.projectId)}/activity?${query.toString()}`,
     {
       tenantId: params.tenantId,
       actor: toRequestActor(params.actor),
+      signal: params.signal,
       retries: 0,
       timeoutMs: 12000,
     },

--- a/src/app/platform/firestore-cashflow-activity-indexes.test.ts
+++ b/src/app/platform/firestore-cashflow-activity-indexes.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import firestoreIndexes from '../../../firebase/firestore.indexes.json';
+
+describe('Firestore cashflow activity indexes', () => {
+  it('deploys the bounded newest-first query index for every activity source', () => {
+    for (const collectionGroup of [
+      'cashflow_sheet_refresh_runs',
+      'weekly_api_audit_events',
+      'cashflow_events',
+    ]) {
+      expect(firestoreIndexes.indexes).toContainEqual({
+        collectionGroup,
+        queryScope: 'COLLECTION',
+        fields: [
+          { fieldPath: 'projectId', order: 'ASCENDING' },
+          { fieldPath: 'createdAt', order: 'DESCENDING' },
+        ],
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- 대량 시트 Stage 후보를 최대 450개 단위의 fenced transaction으로 저장해 2,176건 변경도 안정적으로 완료하고, 실패 후 재시도·동시 시도에서 stale 후보가 적용되지 않도록 했습니다.
- Stage run의 중복 confirmation payload를 compact persistence로 저장해 12개월 CLOSED+PENDING 증거도 Firestore 1 MiB 제한 아래로 유지합니다.
- 캐시플로 Activity를 source별 최대 50문서, opaque cursor, partial-source error, response byte budget으로 제한하고 one-click 동작 중 보조 조회를 제거했습니다.
- Projection - Actual 비교를 데이터 유무와 관계없이 같은 위치에 표시하고 실제 고정 좌표 계약인 E11:BL11로 안내합니다.
- Activity query 및 Stage read/build/write 비용을 no-throw performance trace로 계측합니다.

## Safety boundaries

- 어제 확정한 closed → formula → pending confirmation payload와 apply 순서는 변경하지 않았습니다.
- Google Sheet 고정 좌표, EMPTY/ZERO/VALUE 의미, JVM Java, RBAC, Firestore rules는 변경하지 않았습니다.
- 운영 Firestore composite indexes는 코드 배포 전에 `inner-platform-live-20260316`에서 READY 확인했습니다.

## Verification

- `cashflow-sheet-lab.test.mjs`: 115/115 PASS
- `jvm-weekly-api.test.mjs`: 284/284 PASS
- frontend/client/index/performance targeted: 166/166 PASS
- `npm run build`: PASS, 2,934 modules
- `git diff --check`: PASS
- credential redaction scan: 0 findings

## Deployment

- main CI green 이후 `Production Deploy`가 자동 실행됩니다.
- JVM Java 변경이 없으므로 `JVM Production Deploy`는 skip 대상입니다.
- 수동 workflow dispatch 및 로컬 production deploy는 사용하지 않습니다.

## Post-deploy checks

- Activity aggregate 최초 1회, one-click 진행 중 0회, visible terminal refresh 50 / apply 100 상한 확인
- Stage 2,176 candidate transaction 저장 및 READY/APPLIED 회복 확인
- Projection - Actual 행과 E11:BL11 안내 문구 확인
