### PR TITLE
fix(participation): 참여율 시트 링크를 참여인력 섹션으로 옮긴다

### DIFF
--- a/src/app/components/projects/ProjectEditorWizard.shell.test.ts
+++ b/src/app/components/projects/ProjectEditorWizard.shell.test.ts
@@ -708,3 +708,28 @@ describe('ProjectEditorWizard safe exit contract', () => {
     expect(source).toContain('await onLeave?.();');
   });
 });
+
+// 참여율 시트 링크는 참여인력 섹션 안에 있어야 한다. 기본 정보에 두면 참여율을 입력하는
+// 사람이 그 칸을 영영 만나지 못한다(보람: "거기 넣으면 아무도 모른다").
+describe('참여율 시트 링크 자리', () => {
+  it('참여인력 섹션 안에 있고 팀원 목록보다 먼저 나온다', () => {
+    const sectionAt = source.indexOf('title="참여인력 (서류상·실제)"');
+    const linkAt = source.indexOf('label="참여율 시트 링크"');
+    const teamListAt = source.indexOf('data-issue-label="참여인력 이름·역할"');
+    expect(sectionAt).toBeGreaterThan(-1);
+    expect(linkAt).toBeGreaterThan(sectionAt);
+    expect(linkAt).toBeLessThan(teamListAt);
+  });
+
+  it('기본 정보 섹션에는 없다', () => {
+    const basicAt = source.indexOf('<ProjectFormSection title="기본 정보">');
+    const linkAt = source.indexOf('label="참여율 시트 링크"');
+    const folderAt = source.indexOf('label="사업관리 구글폴더링크"');
+    expect(folderAt).toBeGreaterThan(basicAt);
+    expect(linkAt).toBeGreaterThan(folderAt + 1000);
+  });
+
+  it('검토 요약에도 실려 승인자가 본다', () => {
+    expect(source).toContain('<ReviewRow label="참여율 시트 링크" value={draft.participationSheetLink} />');
+  });
+});

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -1858,20 +1858,6 @@ export function ProjectEditorWizard({
         />
       </ProjectFormRow>
 
-      {/* 참여율 시트를 이 사업에 묶는 지점. 시트 안에는 사업 식별자를 적지 않는다 -
-          사람이 적는 식별자는 어긋난다. 링크를 저장하는 것이 곧 바인딩이다. */}
-      <ProjectFormRow
-        label="참여율 시트 링크"
-        hints={['참여율 표준양식을 복사해 만든 이 사업 전용 시트 링크를 입력해 주세요.']}
-      >
-        <Input
-          type="url"
-          value={draft.participationSheetLink}
-          onChange={(event) => update('participationSheetLink', event.target.value)}
-          placeholder="https://docs.google.com/spreadsheets/d/..."
-          className={FORM_CONTROL_CLASS}
-        />
-      </ProjectFormRow>
 
       <ProjectFormRow
         label="프로젝트 목적"
@@ -2934,6 +2920,25 @@ export function ProjectEditorWizard({
           </Button>
         )}
       >
+        {/* 이 섹션이 참여인력을 다루는 곳이라 시트 링크도 여기 있어야 한다. 기본 정보에 두면
+            참여율을 입력하는 사람이 이 칸을 영영 만나지 못한다. 링크 저장이 곧 사업 바인딩이고,
+            시트 안에는 사업 식별자를 적지 않는다 - 사람이 적는 식별자는 어긋난다. */}
+        <ProjectFormRow
+          label="참여율 시트 링크"
+          hints={[
+            '월별 참여율은 이 시트에 적습니다. 표준양식을 복사해 이 사업 전용 시트를 만든 뒤 링크를 넣어 주세요.',
+            '저장하면 참여인력 대시보드의 "시트 확인"에서 입력 상태를 볼 수 있습니다.',
+          ]}
+        >
+          <Input
+            type="url"
+            value={draft.participationSheetLink}
+            onChange={(event) => update('participationSheetLink', event.target.value)}
+            placeholder="https://docs.google.com/spreadsheets/d/..."
+            className={FORM_CONTROL_CLASS}
+          />
+        </ProjectFormRow>
+
         <div data-issue-label="참여인력 이름·역할" className={FORM_FIELD_STACK_CLASS}>
           {fieldIssues('참여인력 이름·역할', '운영매니저 1인 이상').length > 0 ? (
             <ul className={cn('space-y-1', FORM_ERROR_CLASS)} role="alert">
@@ -3408,6 +3413,7 @@ export function ProjectEditorWizard({
             <ReviewRow label="담당자 계정" value={draft.managerId || '-'} />
             <ReviewRow label="최종 결재자 지정 (사업총괄)" value={draft.executiveApproverName} />
             <ReviewRow label="참여인력 (서류상·실제)" value={teamMembersSummary} />
+            <ReviewRow label="참여율 시트 링크" value={draft.participationSheetLink} />
           </CardContent>
         </Card>
         <Card className="shadow-none lg:col-start-1 lg:row-start-3 lg:self-start">


### PR DESCRIPTION
## 왜

> 참여인력 (서류상·실제) — 계약·협약서에 남길 참여인력과 역할을 저장합니다.
> **여기에 넣어라 거기 넣으면 아무도 모른다**

맞습니다. `기본 정보` 에 두면 참여율을 입력하는 사람이 그 칸을 **영영 만나지 못합니다.**
시트가 참여인력을 다루는 물건이니 링크도 참여인력 섹션에 있어야 합니다.

## 무엇

`참여인력 (서류상·실제)` 섹션의 **맨 위**, 팀원 목록보다 앞에 놓았습니다 — "월별 참여율은
어디에 적나" 가 이 섹션의 첫 물음이 되도록.

안내 문구도 그 자리에 맞게 고쳤습니다:

> 월별 참여율은 이 시트에 적습니다. 표준양식을 복사해 이 사업 전용 시트를 만든 뒤 링크를 넣어 주세요.
> 저장하면 참여인력 대시보드의 "시트 확인"에서 입력 상태를 볼 수 있습니다.

**검토 요약에도 실었습니다.** 등록 서류에서 값이 보이지 않으면 승인자가 판단할 수 없습니다.

## 자리를 테스트로 붙잡았습니다

위치는 되돌리기 쉬운 종류의 변경이라, 셸 테스트로 고정했습니다:

- 참여인력 섹션 안에 있고 **팀원 목록보다 앞**인지
- **기본 정보 섹션에는 없는지**
- 검토 요약에 실렸는지

**삭제 검증**: 필드를 기본 정보로 되돌려 놓고 돌려 2건이 실패하는 것을 확인한 뒤 되돌렸습니다.

## 검증

| 게이트 | 결과 |
|---|---|
| `ProjectEditorWizard.shell.test.ts` | 56 passed (3건 추가) |
| 등록/수정 영역 | 124 passed |
| `typecheck` · `policy:verify` · `build` | 통과 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)