### PR TITLE
feat(participation): 참여인력을 시트에서 연동한다 - 수기 입력을 걷어낸다

### DIFF
--- a/server/bff/routes/participation-dashboard.mjs
+++ b/server/bff/routes/participation-dashboard.mjs
@@ -22,6 +22,55 @@ function participationSheetUnreachable(error) {
   );
 }
 
+/** 다섯 범위를 함께 읽는다. 한 번에 읽어야 사람이 그 사이 고쳐도 한 장면으로 남는다. */
+async function readParticipationSheet(googleSheetsService, sheetLink) {
+  const readRange = (rangeA1) => googleSheetsService.getSheetValues({
+    spreadsheetId: sheetLink,
+    sheetName: PARTICIPATION_SHEET_TAB,
+    rangeA1,
+  });
+  try {
+    const [format, period, header, meta, cells] = await Promise.all([
+      readRange(PARTICIPATION_FORMAT_RANGE),
+      readRange(PARTICIPATION_PERIOD_RANGE),
+      readRange(PARTICIPATION_HEADER_RANGE),
+      readRange(PARTICIPATION_META_RANGE),
+      readRange(PARTICIPATION_CELL_RANGE),
+    ]);
+    return { format, period, header, meta, cells };
+  } catch (error) {
+    throw participationSheetUnreachable(error);
+  }
+}
+
+/**
+ * 화면이 그대로 그릴 수 있는 모양. 참여행(entries)은 반영 단계의 재료라 돌려주지 않는다.
+ * personId·기본투입률은 등록/수정 화면이 명단을 채우는 데 쓴다.
+ */
+function participationPreviewBody(analysis, extra = {}) {
+  return {
+    ok: analysis.ok,
+    summary: analysis.summary,
+    blocking: analysis.blocking,
+    months: analysis.parsed.months,
+    rows: analysis.rows.map((row) => ({
+      rowIndex: row.rowIndex,
+      nickname: row.nickname,
+      name: row.name,
+      role: row.role,
+      stintStart: row.stintStart,
+      stintEnd: row.stintEnd,
+      baseRate: row.baseRate,
+      personId: row.personId || '',
+      linkState: row.linkState,
+      monthlyRates: row.monthlyRates,
+    })),
+    missing: analysis.missing,
+    candidates: analysis.candidates,
+    ...extra,
+  };
+}
+
 export function mountParticipationDashboardRoutes(app, { db, now, googleSheetsService, idempotencyService } = {}) {
   app.get('/api/v1/participation-dashboard', asyncHandler(async (req, res) => {
     assertActorRoleAllowed(req, ROUTE_ROLES.readCore, 'read participation dashboard');
@@ -95,26 +144,7 @@ export function mountParticipationDashboardRoutes(app, { db, now, googleSheetsSe
       );
     }
 
-    const readRange = (rangeA1) => googleSheetsService.getSheetValues({
-      spreadsheetId: sheetLink,
-      sheetName: PARTICIPATION_SHEET_TAB,
-      rangeA1,
-    });
-    let sheetValues;
-    try {
-      // 다섯 범위를 함께 읽는다. 한 번에 읽어야 사람이 그 사이에 고쳐도 한 장면으로 남는다.
-      const [format, period, header, meta, cells] = await Promise.all([
-        readRange(PARTICIPATION_FORMAT_RANGE),
-        readRange(PARTICIPATION_PERIOD_RANGE),
-        readRange(PARTICIPATION_HEADER_RANGE),
-        readRange(PARTICIPATION_META_RANGE),
-        readRange(PARTICIPATION_CELL_RANGE),
-      ]);
-      sheetValues = { format, period, header, meta, cells };
-    } catch (error) {
-      throw participationSheetUnreachable(error);
-    }
-
+    const sheetValues = await readParticipationSheet(googleSheetsService, sheetLink);
     const peopleSnap = await db.collection(`orgs/${tenantId}/persons`).get();
     const analysis = analyzeParticipationSheet({
       sheet: toParticipationSheetInput(sheetValues),
@@ -124,29 +154,50 @@ export function mountParticipationDashboardRoutes(app, { db, now, googleSheetsSe
       projectId,
     });
 
-    // 참여행(entries)은 반영 단계의 재료라 여기서는 돌려주지 않는다. 이 화면은 읽기 전용이다.
-    res.status(200).json({
+    res.status(200).json(participationPreviewBody(analysis, {
       projectId,
       projectName: readOptionalText(project.name) || projectId,
       sheetLink,
       checkedAt: now ? now() : new Date().toISOString(),
-      ok: analysis.ok,
-      summary: analysis.summary,
-      blocking: analysis.blocking,
-      months: analysis.parsed.months,
-      rows: analysis.rows.map((row) => ({
-        rowIndex: row.rowIndex,
-        nickname: row.nickname,
-        name: row.name,
-        role: row.role,
-        stintStart: row.stintStart,
-        stintEnd: row.stintEnd,
-        linkState: row.linkState,
-        monthlyRates: row.monthlyRates,
-      })),
-      missing: analysis.missing,
-      candidates: analysis.candidates,
+    }));
+  }));
+
+  /*
+   * 저장 전에도 확인할 수 있는 경로. 등록 중에는 사업 문서가 아직 없고, 수정 중에는 화면의
+   * 링크가 저장본과 다를 수 있다. 그래서 링크와 계약 기간을 요청에 담아 받는다.
+   * 읽기만 하므로 GET 과 같은 권한이고 아무것도 쓰지 않는다.
+   */
+  app.post('/api/v1/participation-dashboard/sheet-preview', asyncHandler(async (req, res) => {
+    assertActorRoleAllowed(req, ROUTE_ROLES.readCore, 'preview participation sheet by link');
+    if (!db) throw createHttpError(503, '참여율 시트를 확인할 수 없습니다.', 'firestore_unconfigured');
+    const tenantId = readOptionalText(req.context?.tenantId);
+    if (!tenantId) throw createHttpError(400, 'tenantId is required.', 'tenant_required');
+    if (!googleSheetsService?.getSheetValues) {
+      throw createHttpError(503, 'Google Sheets 연동이 설정되지 않았습니다.', 'google_sheets_unconfigured');
+    }
+    const sheetLink = readOptionalText(req.body?.sheetLink);
+    if (!sheetLink) {
+      throw createHttpError(400, '참여율 시트 링크를 입력해 주세요.', 'participation_sheet_link_missing');
+    }
+
+    const sheetValues = await readParticipationSheet(googleSheetsService, sheetLink);
+    const peopleSnap = await db.collection(`orgs/${tenantId}/persons`).get();
+    const analysis = analyzeParticipationSheet({
+      sheet: toParticipationSheetInput(sheetValues),
+      // 계약 기간은 화면의 초안 값이다. 저장된 사업이 아직 없을 수 있다.
+      project: {
+        contractStart: readOptionalText(req.body?.contractStart),
+        contractEnd: readOptionalText(req.body?.contractEnd),
+      },
+      people: peopleSnap.docs.map((doc) => ({ id: doc.id, ...(doc.data() || {}) })),
+      tenantId,
+      projectId: readOptionalText(req.body?.projectId),
     });
+
+    res.status(200).json(participationPreviewBody(analysis, {
+      sheetLink,
+      checkedAt: now ? now() : new Date().toISOString(),
+    }));
   }));
 
   app.post('/api/v1/participation-dashboard/rules', createMutatingRoute(idempotencyService, async (req) => {

--- a/server/bff/routes/participation-sheet-preview.test.mjs
+++ b/server/bff/routes/participation-sheet-preview.test.mjs
@@ -194,3 +194,49 @@ describe('사람이 확인할 것', () => {
     expect(response.body.candidates).toEqual([]);
   });
 });
+
+
+// 등록 중에는 사업 문서가 아직 없고, 수정 중에는 화면의 링크가 저장본과 다를 수 있다.
+// 그래서 저장 전에도 확인할 수 있어야 한다 - 저장해야만 확인되면 사람이 저장부터 하게 된다.
+describe('저장 전 연동 - 링크와 기간을 요청에 담는다', () => {
+  const linkUrl = '/api/v1/participation-dashboard/sheet-preview';
+  const body = {
+    sheetLink: 'https://docs.google.com/spreadsheets/d/sheet-abc/edit',
+    contractStart: '2026-01-01',
+    contractEnd: '2026-03-31',
+  };
+
+  it('사업이 저장돼 있지 않아도 확인된다', async () => {
+    const { app } = createApp({ documents: PEOPLE });
+    const response = await request(app).post(linkUrl).send(body);
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.rows[0]).toMatchObject({ name: '김정태', linkState: 'LINKED' });
+  });
+
+  it('명단을 채울 수 있게 personId 와 기본투입률을 함께 준다', async () => {
+    const { app } = createApp({ documents: PEOPLE });
+    const response = await request(app).post(linkUrl).send(body);
+    expect(response.body.rows[0]).toMatchObject({ personId: 'p-kim', baseRate: 30 });
+  });
+
+  it('화면의 계약 기간과 다르면 막는다 - 저장본이 아니라 지금 값과 맞춰야 한다', async () => {
+    const { app } = createApp({ documents: PEOPLE });
+    const response = await request(app).post(linkUrl).send({ ...body, contractEnd: '2026-06-30' });
+    expect(response.body.ok).toBe(false);
+    expect(response.body.blocking[0].code).toBe('participation_period_mismatch');
+  });
+
+  it('링크가 없으면 무엇을 넣어야 하는지 알려준다', async () => {
+    const { app } = createApp({ documents: PEOPLE });
+    const response = await request(app).post(linkUrl).send({ ...body, sheetLink: '' });
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe('participation_sheet_link_missing');
+  });
+
+  it('확인만으로 아무것도 쓰지 않는다', async () => {
+    const { app, writes } = createApp({ documents: PEOPLE });
+    await request(app).post(linkUrl).send(body);
+    expect(writes).toEqual([]);
+  });
+});

--- a/src/app/components/projects/ProjectEditorWizard.shell.test.ts
+++ b/src/app/components/projects/ProjectEditorWizard.shell.test.ts
@@ -94,9 +94,6 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain('· 기존 선택');
     // Linkage is still judged against the ledger, so the unlinked warning keeps firing.
     expect(source).toContain('ledgerMemberOptions.find((member) => member.uid === draft.registeredById)');
-    expect(source).toContain("onSelect({ personId: undefined, memberName: '', memberNickname: '' })");
-    expect(source).toContain('currentTeamMemberOptionExists');
-    expect(source).toContain('member.memberNickname ? `${member.memberName} (${member.memberNickname})` : member.memberName');
   });
 
   it('uses a member select for project owner instead of free text manager input', () => {
@@ -130,30 +127,38 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain('const executiveApproverOptions = useMemo');
   });
 
-  it('uses a searchable team member picker for registration and edit flows', () => {
-    expect(source).toContain('function TeamMemberSearchCombobox');
-    expect(source).toContain('<CommandInput placeholder="이름/닉네임으로 검색" />');
-    // 후보의 출처는 인력 명부(roster) 하나다. 계정 원장을 출처로 쓰면 퇴사 후 계정이
-    // 남은 사람이 계속 뜨고, 명부에만 있는 사람은 안 뜬다. members 는 명부를 못 읽었을
-    // 때의 안전망으로만 남는다.
-    expect(source).toContain('buildProjectTeamMemberOptions(roster, members)');
-    // PM·조직장은 계정이 필수라 계정 원장이 출처지만, 명부가 문지기 역할을 한다.
-    expect(source).toContain('buildOrgMemberPickerOptions(members, roster)');
-    expect(source).toContain('options.length}명 중 검색');
-    expect(source).toContain('options={availableTeamMemberOptions}');
-    expect(source).toContain('<TeamMemberSearchCombobox');
-    expect(source).toContain("aria-label={selectedLabel ? `팀원 선택: ${selectedLabel}` : '팀원 검색'}");
-    expect(source).toContain('selectedNames={selectedNames}');
-    expect(source).toContain('이미 추가됨');
-    expect(source).not.toContain("value={member.memberName || 'none'}");
+  /*
+   * 참여인력은 참여율 시트에서 온다. 사람이 같은 내용을 두 곳에 적지 않게 하려고 수기 입력을
+   * 걷어냈다. 여기서는 연동 경로가 살아 있는지와, 걷어낸 수기 입력이 되살아나지 않는지를 본다.
+   */
+  it('syncs the participation roster from the sheet instead of manual entry', () => {
+    expect(source).toContain('const syncTeamFromSheet = () => {');
+    expect(source).toContain('previewParticipationSheetByLinkViaBff(');
+    expect(source).toContain("{teamSyncing ? '연동 중' : '연동하기'}");
+    // 저장 전에도 눌러야 하므로 화면의 링크·계약 기간을 그대로 보낸다.
+    expect(source).toContain('contractStart: draft.contractStart,');
+    expect(source).toContain('contractEnd: draft.contractEnd,');
+    // 명단은 승인 서류·인력 현황·사업 검색이 쓴다. 연동이 그것까지 채워야 끊기지 않는다.
+    expect(source).toContain("update('teamMembersDetailed', preview.rows.map((row) => ({");
+    expect(source).toContain('personId: row.personId || undefined,');
+    expect(source).toContain('participationRate: row.baseRate ?? 0,');
+    expect(source).toContain('laborAllocationStartMonth: row.stintStart,');
   });
 
-  it('allows manual team member identity entry when the picker is missing a member', () => {
-    expect(source).toContain('팀원 검색');
-    expect(source).toContain('직접 입력');
-    expect(source).toContain('placeholder="이름(별명)"');
-    expect(source).toContain('parseProjectTeamMemberIdentityInput');
-    expect(source).toContain("inputMode: 'manual'");
+  it('does not judge the sheet again in the browser', () => {
+    // 막는 이유는 서버가 적어 준 대로 보여 준다. 화면이 다시 판정하면 두 곳이 어긋난다.
+    expect(source).toContain('preview.blocking.map((issue) => issue.message)');
+    expect(source).not.toContain('function TeamMemberSearchCombobox');
+    expect(source).not.toContain('const addTeamMember');
+    expect(source).not.toContain('createEmptyTeamMember');
+  });
+
+  it('requires the sheet link instead of an operating manager headcount', () => {
+    // 역할 구성은 시트를 보고 사람이 판단할 일이라 저장을 막지 않는다. 대신 참여율을 적을 곳
+    // 자체가 없는 상태는 막는다.
+    expect(source).toContain("issues.push({ step: 'team', label: '참여율 시트 링크' });");
+    expect(source).not.toContain("label: '운영매니저 1인 이상'");
+    expect(source).not.toContain('hasProjectOperatingManager');
   });
 
   it('uses project operations terminology and exposes currency selection', () => {
@@ -177,12 +182,6 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(adminWizardSource).toContain('departmentOptions={departmentOptions}');
   });
 
-  it('keeps manual team member input bound to the raw typed value instead of reparsing formatted text', () => {
-    expect(source).toContain('formatTeamMemberIdentityInput(member)');
-    expect(source).toContain('identityInput: event.target.value');
-    expect(source).toContain('value={member.identityInput ?? formatTeamMemberIdentityInput(member)}');
-  });
-
   it('does not key editable team member rows by typed member name', () => {
     expect(source).toContain("key={`team-member-${index}`}");
     expect(source).not.toContain("key={`${member.memberName || 'member'}-${index}`}");
@@ -197,20 +196,16 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).not.toContain('<ReviewRow label="참여 조건"');
   });
 
-  it('keeps team member add rows editable and aligns the add button with the primary next action', () => {
-    const addTeamMemberBlock = source.slice(source.indexOf('const addTeamMember'), source.indexOf('const updateTeamMember'));
-
+  // 팀원 줄은 시트에서 오므로 추가·수정 버튼이 없다. 투입기간은 시트의 투입시작·종료월이
+  // 그대로 들어오고, 저장 경로의 정규화는 그대로 남아 있어야 한다.
+  it('keeps the roster normalization while the rows come from the sheet', () => {
     expect(source).toContain('createProjectEditorWizardDraft');
     expect(source).toContain('normalizeProjectTeamMemberDraftRows');
-    expect(addTeamMemberBlock).toContain('teamMembersDetailed: [...prev.teamMembersDetailed, createEmptyTeamMember()]');
-    expect(addTeamMemberBlock).not.toContain('createProjectEditorDraft');
-    expect(source).not.toContain('<Label className="text-xs">인건비 시작월</Label>');
-    expect(source).not.toContain('<Label className="text-xs">인건비 종료월</Label>');
     expect(source).toContain('laborAllocationStartMonth');
     expect(source).toContain('laborAllocationEndMonth');
-    expect(source).toContain('<Plus className="h-4 w-4" />');
-    expect(source).toContain('<Button type="button" onClick={addTeamMember} className="gap-2">');
-    expect(source).not.toContain('variant="outline" size="sm" onClick={addTeamMember}');
+    expect(source).toContain("key={`team-member-${index}`}");
+    expect(source).not.toContain('<Label className="text-xs">인건비 시작월</Label>');
+    expect(source).not.toContain('onClick={addTeamMember}');
   });
 
   it('treats zero-won payment split values as explicit editable values', () => {
@@ -412,17 +407,15 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain('고객사 사업자등록증 PDF');
     expect(source).toContain('계약 종료일은 시작일 이후여야 합니다.');
     expect(source).not.toContain('인건비 투입 종료월은 시작월 이후여야 합니다.');
-    expect(source).toContain('운영매니저 1인 이상');
+    expect(source).toContain('참여인력은 참여율 시트에서 연동합니다. 시트 링크를 먼저 넣어 주세요.');
     // 정산지원 담당자는 저장을 막지 않는다. 예전에는 submitIssues 에 들어가 최종 저장을
     // 막았고, 후보 드롭다운도 두 사람으로 좁혀 다른 사람을 아예 고를 수 없었다. 담당이
     // 바뀌거나 그 두 분이 자리를 비우면 프로젝트 등록 자체가 멈춘다.
     expect(source).not.toContain("issues.push({ step: 'team', label: '정산지원은 도담 또는 써니를 선택' })");
     expect(source).not.toContain('hasInvalidProjectSettlementSupportMember');
     expect(source).not.toContain('정산지원은 도담 또는 써니를 선택해 주세요.');
-    expect(source).toContain('const availableTeamMemberOptions = teamMemberOptions;');
     expect(source).toContain("const requiresSettlementConfirmations = usesRegistrationV2 ? draft.basis !== 'NONE' : draft.settlementType !== 'NONE'");
     expect(source).not.toContain('정산 기준이 정산없음인 사업은 인건비·고객사 정산 확인을 입력하지 않습니다.');
-    expect(source).toContain('md:grid-cols-3');
     expect(source).not.toContain('xl:grid-cols-[132px_minmax(0,1.4fr)_minmax(0,1fr)_110px_120px_140px_140px]');
     expect(source).not.toContain('alternativeDocumentAttached');
     expect(source).not.toContain('특이사항 (메모란)');
@@ -483,8 +476,6 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain('년 선금·중도금 합계 70% 미만 사유`}');
     expect(source).toContain("updateFinancialYear(financialYearIndex!, 'advanceInterimBelow70Reason'");
     expect(source).not.toContain('년 계약/재무 정산 완료');
-    expect(source).toContain('(기존값 · 선택 불가)');
-    expect(source).toContain('disabled>{member.role}');
     expect(source).not.toContain('최종 입금 주차 ${row.finalPaymentExpectedWeek || \'-\'}');
     expect(source).not.toContain('disabled={!financeWeekYear}');
     expect(source).not.toContain('계약 종료일을 입력하면 재무주차를 선택할 수 있습니다.');
@@ -712,10 +703,10 @@ describe('ProjectEditorWizard safe exit contract', () => {
 // 참여율 시트 링크는 참여인력 섹션 안에 있어야 한다. 기본 정보에 두면 참여율을 입력하는
 // 사람이 그 칸을 영영 만나지 못한다(보람: "거기 넣으면 아무도 모른다").
 describe('참여율 시트 링크 자리', () => {
-  it('참여인력 섹션 안에 있고 팀원 목록보다 먼저 나온다', () => {
+  it('참여인력 섹션 안에 있고 연동 결과 표보다 먼저 나온다', () => {
     const sectionAt = source.indexOf('title="참여인력 (서류상·실제)"');
     const linkAt = source.indexOf('label="참여율 시트 링크"');
-    const teamListAt = source.indexOf('data-issue-label="참여인력 이름·역할"');
+    const teamListAt = source.indexOf('시트 링크를 넣고 연동하기를 누르면');
     expect(sectionAt).toBeGreaterThan(-1);
     expect(linkAt).toBeGreaterThan(sectionAt);
     expect(linkAt).toBeLessThan(teamListAt);

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -9,7 +9,7 @@ import {
   ClipboardList,
   FileText,
   Loader2,
-  Plus,
+  RefreshCw,
   Save,
   Trash2,
   Upload,
@@ -18,6 +18,11 @@ import {
   Wallet,
 } from 'lucide-react';
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState, type ChangeEvent, type ReactNode } from 'react';
+import { useAuth } from '../../data/auth-store';
+import { useFirebase } from '../../lib/firebase-context';
+import { PlatformApiError } from '../../platform/api-client';
+import { resolveApiErrorPresentation } from '../../platform/api-error-messages';
+import { previewParticipationSheetByLinkViaBff } from '../../lib/platform-bff-client';
 import { toast } from 'sonner';
 import { useBlocker } from 'react-router';
 import {
@@ -58,8 +63,6 @@ import { PROJECT_DEPARTMENT_OPTIONS, dedupeProjectDepartmentLabels } from '../..
 import { checkContractAmount } from '../../platform/project-contract-amount-check';
 import type { DirectoryPerson } from '../../platform/person-directory';
 import {
-  buildProjectTeamMemberOptions,
-  type ProjectTeamMemberOption,
 } from '../../data/project-team-member-options';
 import {
   CONTRACT_AMOUNT_ITEM_FIELDS,
@@ -105,7 +108,6 @@ import {
 import {
   formatProjectTeamMembersSummary,
   hasIncompleteProjectTeamMembers,
-  hasProjectOperatingManager,
   isProjectSettlementSupportMember,
   normalizeProjectTeamMemberDraftRows,
   parseProjectTeamMemberIdentityInput,
@@ -401,7 +403,7 @@ const STEP_PREPARATION_NOTES: Record<ProjectEditorStep, string[]> = {
   ],
   team: [
     '사업 담당자와 최종 결재자를 구성원 원장에서 고를 수 있어야 합니다.',
-    '참여인력은 운영매니저 1인 이상이 필요합니다.',
+    '참여인력은 참여율 시트에서 연동합니다. 시트 링크를 먼저 넣어 주세요.',
   ],
   review: [
     '저장 전 마지막 확인 단계입니다.',
@@ -533,19 +535,6 @@ function updateFlag(flags: ProjectFinancialInputFlags, key: keyof ProjectFinanci
   return {
     ...normalizeProjectFinancialInputFlags(flags),
     [key]: hasExplicitProjectAmountInput(rawValue),
-  };
-}
-
-function createEmptyTeamMember(): ProjectTeamMemberAssignment {
-  return {
-    inputMode: 'search',
-    memberName: '',
-    memberNickname: '',
-    role: '',
-    participationRate: 0,
-    isDocumentOnly: false,
-    laborAllocationStartMonth: '',
-    laborAllocationEndMonth: '',
   };
 }
 
@@ -710,119 +699,6 @@ function ProjectComputedValue({ value, numeric = true }: { value: string; numeri
   );
 }
 
-interface TeamMemberSearchComboboxProps {
-  member: ProjectTeamMemberAssignment;
-  options: ProjectTeamMemberOption[];
-  optionMap: Record<string, ProjectTeamMemberOption>;
-  selectedNames: Set<string>;
-  currentTeamMemberOptionExists: boolean;
-  onSelect: (patch: Partial<ProjectTeamMemberAssignment>) => void;
-}
-
-function TeamMemberSearchCombobox({
-  member,
-  options,
-  optionMap,
-  selectedNames,
-  currentTeamMemberOptionExists,
-  onSelect,
-}: TeamMemberSearchComboboxProps) {
-  const [open, setOpen] = useState(false);
-  const selectedLabel = member.memberName
-    ? (member.memberNickname ? `${member.memberName} (${member.memberNickname})` : member.memberName)
-    : '';
-
-  const handleSelect = (value: string) => {
-    if (value === 'none') {
-      onSelect({ personId: undefined, memberName: '', memberNickname: '' });
-      setOpen(false);
-      return;
-    }
-    const option = optionMap[value];
-    if (!option) return;
-    onSelect({
-      inputMode: 'search',
-      identityInput: undefined,
-      personId: option.personId,
-      memberName: option.name,
-      memberNickname: option.nickname,
-    });
-    setOpen(false);
-  };
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          role="combobox"
-          aria-label={selectedLabel ? `팀원 선택: ${selectedLabel}` : '팀원 검색'}
-          aria-expanded={open}
-          className={cn('h-9 w-full justify-between px-3 text-left font-normal', FORM_VALUE_CLASS)}
-        >
-          <span className={cn('truncate', !selectedLabel && 'text-muted-foreground')}>
-            {selectedLabel || '팀원 검색'}
-          </span>
-          <ChevronsUpDown className="ml-2 h-3.5 w-3.5 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-0">
-        <Command>
-          <CommandInput placeholder="이름/닉네임으로 검색" />
-          <CommandList className="max-h-[260px]">
-            <CommandEmpty>검색 결과가 없습니다</CommandEmpty>
-            <CommandGroup heading="선택">
-              <CommandItem value="none 선택 안 함" onSelect={() => handleSelect('none')}>
-                <Check className={cn('h-4 w-4', !member.memberName ? 'opacity-100' : 'opacity-0')} />
-                선택 안 함
-              </CommandItem>
-            </CommandGroup>
-            <CommandSeparator />
-            <CommandGroup heading={`${options.length}명 중 검색`}>
-              {!currentTeamMemberOptionExists && member.memberName ? (
-                <CommandItem
-                  value={`${member.memberName} ${member.memberNickname}`}
-                  onSelect={() => {
-                    onSelect({
-                      memberName: member.memberName,
-                      memberNickname: member.memberNickname,
-                    });
-                    setOpen(false);
-                  }}
-                >
-                  <Check className="h-4 w-4 opacity-100" />
-                  <span className="truncate">
-                    {member.memberNickname ? `${member.memberName} (${member.memberNickname})` : member.memberName}
-                  </span>
-                </CommandItem>
-              ) : null}
-              {options.map((option) => {
-                    const disabled = selectedNames.has(option.personId);
-                    const selected = option.personId === member.personId;
-                return (
-                  <CommandItem
-                    key={option.value}
-                    value={`${option.name} ${option.nickname} ${option.label}`}
-                    disabled={disabled}
-                    onSelect={() => handleSelect(option.value)}
-                  >
-                    <Check className={cn('h-4 w-4', selected ? 'opacity-100' : 'opacity-0')} />
-                    <span className="truncate">{option.label}</span>
-                    {disabled ? (
-                      <span className={cn('ml-auto shrink-0', FORM_HINT_CLASS)}>이미 추가됨</span>
-                    ) : null}
-                  </CommandItem>
-                );
-              })}
-            </CommandGroup>
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
-  );
-}
-
 export function ProjectEditorWizard({
   mode,
   initialDraft,
@@ -853,6 +729,11 @@ export function ProjectEditorWizard({
   onLeave,
   onSubmit,
 }: ProjectEditorWizardProps) {
+  const { user } = useAuth();
+  const { orgId } = useFirebase();
+  const [teamSyncing, setTeamSyncing] = useState(false);
+  const [teamSyncNotice, setTeamSyncNotice] = useState('');
+  const [teamSyncError, setTeamSyncError] = useState('');
   const [stepIndex, setStepIndex] = useState(0);
   const [draft, setDraft] = useState<ProjectEditorDraft>(() => createProjectEditorWizardDraft(initialDraft));
   const [documentUploadState, setDocumentUploadState] = useState<Record<ProjectRequestDocumentKind, ContractUploadState>>({
@@ -1234,15 +1115,6 @@ export function ProjectEditorWizard({
   const teamMembersSummary = formatProjectTeamMembersSummary(draft.teamMembersDetailed, '', '\n');
   const projectTypeOptions = getProjectTypeSelectableOptions(draft.type);
   const contractTypeOptions = getProjectContractTypeSelectableOptions(draft.contractType);
-  // 팀원 후보의 출처는 인력 명부(roster) 하나다. 배정에는 이름·별명만 저장되므로 계정이
-  // 없어도 되고, 인턴은 근로형태로 걸러진다. members 는 명부를 못 읽었을 때의 안전망.
-  const teamMemberOptions = useMemo(
-    () => buildProjectTeamMemberOptions(roster, members),
-    [roster, members],
-  );
-  const teamMemberOptionMap = useMemo(() => Object.fromEntries(
-    teamMemberOptions.map((option) => [option.value, option]),
-  ) as Record<string, ProjectTeamMemberOption>, [teamMemberOptions]);
   // The ledger list decides whether a stored value is still linked, so the "not in the
   // member ledger" warning keeps working. The picker lists carry the stored value on top
   // of it so opening an old project never silently drops its owner or approver.
@@ -1400,27 +1272,69 @@ export function ProjectEditorWizard({
     });
   };
 
-  const addTeamMember = () => {
-    setDraft((prev) => ({
-      ...prev,
-      teamMembersDetailed: [...prev.teamMembersDetailed, createEmptyTeamMember()],
-    }));
+  /*
+   * 참여율 시트에서 참여인력을 읽어 명단을 채운다.
+   *
+   * 사람이 두 곳에 같은 내용을 적지 않게 하는 것이 목적이다. 월별 참여율의 원천은 시트이고,
+   * 여기에는 승인 서류·인력 현황·사업 검색이 쓰는 명단(이름·역할·투입기간·기본투입률)만 남긴다.
+   * 저장 전에도 눌러야 하므로 화면의 링크와 계약 기간을 그대로 보낸다.
+   */
+  const syncTeamFromSheet = () => {
+    if (teamSyncing) return;
+    const sheetLink = String(draft.participationSheetLink || '').trim();
+    setTeamSyncNotice('');
+    if (!sheetLink) {
+      setTeamSyncError('참여율 시트 링크를 먼저 입력해 주세요.');
+      return;
+    }
+    if (!draft.contractStart || !draft.contractEnd) {
+      setTeamSyncError('계약 시작일과 종료일을 먼저 입력해 주세요. 시트의 기간과 대조합니다.');
+      return;
+    }
+    if (!orgId || !user) {
+      setTeamSyncError('로그인 정보를 확인하지 못했습니다.');
+      return;
+    }
+    setTeamSyncing(true);
+    setTeamSyncError('');
+    void previewParticipationSheetByLinkViaBff({
+      tenantId: orgId,
+      actor: user,
+      sheetLink,
+      contractStart: draft.contractStart,
+      contractEnd: draft.contractEnd,
+    })
+      .then((preview) => {
+        if (!preview.ok) {
+          // 막는 이유를 서버가 적어 준 대로 보여 준다. 화면이 다시 판정하지 않는다.
+          setTeamSyncError(preview.blocking.map((issue) => issue.message).slice(0, 3).join(' / ')
+            || '시트를 반영할 수 없는 상태입니다.');
+          return;
+        }
+        update('teamMembersDetailed', preview.rows.map((row) => ({
+          personId: row.personId || undefined,
+          memberName: row.name,
+          memberNickname: row.nickname,
+          role: row.role,
+          participationRate: row.baseRate ?? 0,
+          laborAllocationStartMonth: row.stintStart,
+          laborAllocationEndMonth: row.stintEnd,
+        })));
+        const pending = preview.summary?.pendingLinkCount || 0;
+        setTeamSyncNotice(pending > 0
+          ? `참여인력 ${preview.rows.length}명을 가져왔습니다. 그중 ${pending}명은 People 등록 전이라 연결 대기입니다.`
+          : `참여인력 ${preview.rows.length}명을 가져왔습니다.`);
+      })
+      .catch((error) => {
+        const status = error instanceof PlatformApiError ? error.status : 500;
+        const code = error instanceof PlatformApiError ? error.code : '';
+        const serverMessage = error instanceof PlatformApiError ? String(error.message || '').trim() : '';
+        setTeamSyncError(serverMessage || resolveApiErrorPresentation(code, status).guide);
+      })
+      .finally(() => setTeamSyncing(false));
   };
 
-  const updateTeamMember = (index: number, patch: Partial<ProjectTeamMemberAssignment>) => {
-    setDraft((prev) => {
-      const next = [...prev.teamMembersDetailed];
-      next[index] = { ...next[index], ...patch };
-      return createProjectEditorWizardDraft({ ...prev, teamMembersDetailed: next });
-    });
-  };
 
-  const removeTeamMember = (index: number) => {
-    setDraft((prev) => createProjectEditorWizardDraft({
-      ...prev,
-      teamMembersDetailed: prev.teamMembersDetailed.filter((_, itemIndex) => itemIndex !== index),
-    }));
-  };
 
   const getDocumentInputRef = (kind: ProjectRequestDocumentKind) => ({
     contract: contractUploadInputRef,
@@ -1679,11 +1593,10 @@ export function ProjectEditorWizard({
     if (!draft.executiveApproverId || !selectedExecutiveApprover) {
       issues.push({ step: 'team', label: '최종 결재자 지정 (사업총괄)' });
     }
-    if (usesRegistrationV2 && hasIncompleteProjectTeamMembers(draft.teamMembersDetailed)) {
-      issues.push({ step: 'team', label: '참여인력 이름·역할' });
-    }
-    if (usesRegistrationV2 && !hasProjectOperatingManager(draft.teamMembersDetailed)) {
-      issues.push({ step: 'team', label: '운영매니저 1인 이상' });
+    // 참여인력은 시트에서 온다. 역할 구성(운영매니저 1인 이상)은 시트를 보고 사람이 판단할
+    // 일이라 저장을 막지 않는다. 대신 시트 링크가 없으면 참여율을 적을 곳 자체가 없어 막는다.
+    if (usesRegistrationV2 && !draft.participationSheetLink.trim()) {
+      issues.push({ step: 'team', label: '참여율 시트 링크' });
     }
     // 정산지원 담당자는 저장을 막지 않는다. 담당이 정해져 있다는 안내일 뿐이고,
     // 담당자가 바뀌거나 자리를 비운 사이에 프로젝트 등록 자체가 막히면 안 된다.
@@ -2914,9 +2827,9 @@ export function ProjectEditorWizard({
         title="참여인력 (서류상·실제)"
         description="계약·협약서에 남길 참여인력과 역할을 저장합니다."
         action={(
-          <Button type="button" onClick={addTeamMember} className="gap-2">
-            <Plus className="h-4 w-4" />
-            팀원 추가
+          <Button type="button" onClick={syncTeamFromSheet} disabled={teamSyncing} className="gap-2">
+            {teamSyncing ? <Loader2 className="h-4 w-4 animate-spin" /> : <RefreshCw className="h-4 w-4" />}
+            {teamSyncing ? '연동 중' : '연동하기'}
           </Button>
         )}
       >
@@ -2939,10 +2852,10 @@ export function ProjectEditorWizard({
           />
         </ProjectFormRow>
 
-        <div data-issue-label="참여인력 이름·역할" className={FORM_FIELD_STACK_CLASS}>
-          {fieldIssues('참여인력 이름·역할', '운영매니저 1인 이상').length > 0 ? (
+        <div data-issue-label="참여율 시트 링크" className={FORM_FIELD_STACK_CLASS}>
+          {fieldIssues('참여율 시트 링크').length > 0 ? (
             <ul className={cn('space-y-1', FORM_ERROR_CLASS)} role="alert">
-              {fieldIssues('참여인력 이름·역할', '운영매니저 1인 이상').map((message) => (
+              {fieldIssues('참여율 시트 링크').map((message) => (
                 <li key={message} className="flex gap-1.5">
                   <span aria-hidden className="shrink-0">•</span>
                   <span className="min-w-0">{describeSubmitIssue(message)}</span>
@@ -2950,112 +2863,55 @@ export function ProjectEditorWizard({
               ))}
             </ul>
           ) : null}
+          {teamSyncError ? (
+            <p className={cn('rounded-lg border border-red-200 bg-red-50 px-4 py-3', FORM_ERROR_CLASS)} role="alert">
+              {teamSyncError}
+            </p>
+          ) : null}
+          {teamSyncNotice ? (
+            <p className={cn('rounded-lg border border-slate-200 bg-slate-50 px-4 py-3', FORM_HINT_CLASS)}>
+              {teamSyncNotice}
+            </p>
+          ) : null}
           {draft.teamMembersDetailed.length === 0 ? (
             <p className={cn('rounded-lg border border-dashed border-slate-300 bg-white px-4 py-5', FORM_HINT_CLASS)}>
-              아직 추가된 팀원이 없습니다.
+              시트 링크를 넣고 연동하기를 누르면 참여인력이 여기에 표시됩니다.
             </p>
           ) : (
-            <div className={FORM_FIELD_STACK_CLASS}>
-          {draft.teamMembersDetailed.map((member, index) => {
-            const teamMemberInputMode = member.inputMode === 'manual' ? 'manual' : 'search';
-            const selectedNames = new Set(
-              draft.teamMembersDetailed
-                .map((item, itemIndex) => (itemIndex === index ? '' : item.personId))
-                .filter((personId): personId is string => Boolean(personId)),
-            );
-            // 정산지원이라고 후보를 두 사람으로 좁히지 않는다. 담당이 바뀌거나 그 두 분이
-            // 자리를 비우면 아무도 고를 수 없게 된다. 담당자 안내는 아래 문구로 남긴다.
-            const availableTeamMemberOptions = teamMemberOptions;
-            const availableTeamMemberOptionMap = teamMemberOptionMap;
-            const currentTeamMemberOptionExists = !member.personId
-              || availableTeamMemberOptions.some((option) => option.personId === member.personId);
-            return (
-              <div key={`team-member-${index}`} className="rounded-lg border border-slate-200 bg-white p-4">
-                <div className="flex items-center justify-between gap-3">
-                  <div className={FORM_LABEL_CLASS}>팀원 {index + 1}</div>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    aria-label={`팀원 ${index + 1} 삭제`}
-                    className="h-7 px-2 text-slate-500 hover:text-red-700"
-                    onClick={() => removeTeamMember(index)}
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </Button>
-                </div>
-                {/* 팀원 한 명이 곧 짧은 값 세 개다. 라벨 열을 다시 쓰면 세로로만 길어지므로
-                    오른쪽 입력 영역과 같은 규칙(라벨 12/600 · 값 13)으로 한 줄에 놓는다. */}
-                <div className="mt-2 grid gap-4 md:grid-cols-3">
-                  <div className="grid gap-2">
-                    <Label className={FORM_LABEL_CLASS}>입력 방식</Label>
-                    <Select
-                      value={teamMemberInputMode}
-                      onValueChange={(value) => updateTeamMember(index, {
-                        inputMode: value === 'manual' ? 'manual' : 'search',
-                        identityInput: value === 'manual' ? '' : undefined,
-                        personId: undefined,
-                        memberName: '',
-                        memberNickname: '',
-                      })}
-                    >
-                      <SelectTrigger className={FORM_CONTROL_CLASS}>
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="search">팀원 검색</SelectItem>
-                        <SelectItem value="manual">직접 입력</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div className="grid gap-2">
-                    <Label className={FORM_LABEL_CLASS}>팀원</Label>
-                    {teamMemberInputMode === 'search' ? (
-                      <TeamMemberSearchCombobox
-                        member={member}
-                        options={availableTeamMemberOptions}
-                        optionMap={availableTeamMemberOptionMap}
-                        selectedNames={selectedNames}
-                        currentTeamMemberOptionExists={currentTeamMemberOptionExists}
-                        onSelect={(patch) => updateTeamMember(index, patch)}
-                      />
-                    ) : (
-                      <Input
-                        value={member.identityInput ?? formatTeamMemberIdentityInput(member)}
-                        onChange={(event) => updateTeamMember(index, {
-                          inputMode: 'manual',
-                          identityInput: event.target.value,
-                          ...parseProjectTeamMemberIdentityInput(event.target.value),
-                        })}
-                        placeholder="이름(별명)"
-                        className={FORM_CONTROL_CLASS}
-                      />
-                    )}
-                  </div>
-                  <div className="grid gap-2">
-                    <Label className={FORM_LABEL_CLASS}>역할</Label>
-                    <div>
-                      <Select value={member.role || undefined} onValueChange={(value) => updateTeamMember(index, { role: value })}>
-                        <SelectTrigger className={FORM_CONTROL_CLASS}><SelectValue placeholder="역할 선택" /></SelectTrigger>
-                        <SelectContent>
-                          {PROJECT_TEAM_MEMBER_ROLES.map((role) => <SelectItem key={role} value={role}>{role}</SelectItem>)}
-                          {RETIRED_PROJECT_TEAM_MEMBER_ROLES.includes(member.role as typeof RETIRED_PROJECT_TEAM_MEMBER_ROLES[number]) ? (
-                            <SelectItem value={member.role} disabled>{member.role} (기존값 · 선택 불가)</SelectItem>
-                          ) : null}
-                        </SelectContent>
-                      </Select>
-                      {/* 담당 안내일 뿐 저장을 막지 않는다. 오류 색을 쓰지 않는 이유다. */}
-                      {member.role === '정산지원' && !isProjectSettlementSupportMember(member) ? (
-                        <p className={cn('mt-2 text-amber-700', FORM_HINT_CLASS)}>
-                          정산지원은 보통 도담 또는 써니가 맡습니다. 다른 분으로 지정하려면 그대로 두셔도 됩니다.
-                        </p>
-                      ) : null}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            );
-          })}
+            <div className="overflow-x-auto rounded-lg border border-slate-200 bg-white">
+              <table className="w-full min-w-[640px] text-left">
+                <thead>
+                  <tr className="border-b border-slate-200 bg-slate-50">
+                    <th className="px-3 py-2 text-[12px] font-semibold text-slate-700">이름</th>
+                    <th className="px-3 py-2 text-[12px] font-semibold text-slate-700">역할</th>
+                    <th className="px-3 py-2 text-[12px] font-semibold text-slate-700">투입기간</th>
+                    <th className="px-3 py-2 text-right text-[12px] font-semibold text-slate-700">기본투입률</th>
+                    <th className="px-3 py-2 text-[12px] font-semibold text-slate-700">People 연결</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {draft.teamMembersDetailed.map((member, index) => (
+                    <tr key={`team-member-${index}`} className="border-b border-slate-100 last:border-b-0">
+                      <td className="px-3 py-2 text-[13px] font-medium text-slate-800">
+                        {member.memberName || member.memberNickname || '이름 없음'}
+                        {member.memberName && member.memberNickname
+                          ? <span className="ml-1 text-slate-500">({member.memberNickname})</span>
+                          : null}
+                      </td>
+                      <td className="px-3 py-2 text-[13px] text-slate-600">{member.role || '―'}</td>
+                      <td className="px-3 py-2 text-[13px] text-slate-600">
+                        {member.laborAllocationStartMonth || '미입력'} ~ {member.laborAllocationEndMonth || '진행 중'}
+                      </td>
+                      <td className="px-3 py-2 text-right text-[13px] tabular-nums text-slate-800">
+                        {member.participationRate ? `${member.participationRate}%` : '―'}
+                      </td>
+                      <td className={cn('px-3 py-2 text-[13px]', member.personId ? 'text-slate-600' : 'font-semibold text-amber-700')}>
+                        {member.personId ? '연결됨' : '연결 대기'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
           )}
         </div>

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -100,6 +100,9 @@ export interface ParticipationSheetPreview {
     role: string;
     stintStart: string;
     stintEnd: string;
+    /** 시트의 기본투입률. 월별 값은 monthlyRates 가 원천이다. */
+    baseRate: number | null;
+    personId: string;
     linkState: 'LINKED' | 'PENDING_LINK' | 'PLACEHOLDER';
     monthlyRates: Record<string, number>;
   }>;
@@ -2197,6 +2200,39 @@ export async function fetchParticipationSheetPreviewViaBff(params: {
   const response = await resolveClient(params.client).get<ParticipationSheetPreview>(
     `/api/v1/participation-dashboard/projects/${encodeURIComponent(params.projectId)}/sheet-preview`,
     { tenantId: params.tenantId, actor: toRequestActor(params.actor), timeoutMs: 30_000 },
+  );
+  return response.data;
+}
+
+/**
+ * 저장 전 시트 연동. 등록 중에는 사업 문서가 아직 없고, 수정 중에는 화면의 링크가 저장본과
+ * 다를 수 있어 링크와 계약 기간을 함께 보낸다. 읽기만 하며 아무것도 쓰지 않는다.
+ */
+export async function previewParticipationSheetByLinkViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  sheetLink: string;
+  contractStart: string;
+  contractEnd: string;
+  projectId?: string;
+  client?: PlatformApiClientLike;
+}): Promise<ParticipationSheetPreview> {
+  // 캐시플로우 시트 연동과 같은 모양으로 부른다(라이브에서 도는 경로).
+  // retries: 0 - 시트 읽기는 쿼터를 쓴다. 실패를 자동으로 되풀이하면 쿼터만 더 먹는다.
+  const response = await resolveClient(params.client).post<ParticipationSheetPreview>(
+    '/api/v1/participation-dashboard/sheet-preview',
+    {
+      tenantId: params.tenantId,
+      actor: toRequestActor(params.actor),
+      body: {
+        sheetLink: params.sheetLink,
+        contractStart: params.contractStart,
+        contractEnd: params.contractEnd,
+        projectId: params.projectId || '',
+      },
+      timeoutMs: 30000,
+      retries: 0,
+    },
   );
   return response.data;
 }


### PR DESCRIPTION
## 왜 (보람)

> 여기서 뭐 연동하기 같은 버튼이 하나 있고 > 그 다음에 여기 밑에 테이블로 보여야 할 것 같은데
> 팀원 1 … 팀원 2 … **이건 이제 지우고**
> 운영매니저 1인 이상을(를) 입력해 주세요. **이것도 링크 필수 규칙으로 넘기고**

사람이 같은 내용을 시트와 폼 두 곳에 적지 않게 합니다.

## 무엇

```
참여인력 (서류상·실제)                                    [연동하기]

  참여율 시트 링크  https://docs.google.com/spreadsheets/d/...

  이름            역할        투입기간            기본투입률   People 연결
  김정태(에이블)   총괄책임자   2026-01 ~ 진행 중       30%      연결됨
  김혜령(테일러)   연구        2026-03 ~ 진행 중       30%      연결 대기
```

- `팀원 추가` → **`연동하기`**, 아래는 **읽기 전용 표**
- **연동이 명단(`teamMembersDetailed`)까지 채웁니다.** 표시만 하면 승인 서류·인력 현황·
  사업 검색이 빕니다(15개 파일이 이 값을 읽습니다). `personId` 도 함께 채워 대시보드 연결이
  끊기지 않게 했습니다
- 검증 규칙 교체: **`운영매니저 1인 이상` → `참여율 시트 링크` 필수**. 역할 구성은 시트를 보고
  사람이 판단할 일이라 저장을 막지 않고, 참여율을 적을 곳 자체가 없는 상태만 막습니다

## 저장 전에도 눌러야 합니다

등록 중에는 사업 문서가 아직 없고, 수정 중에는 화면의 링크가 저장본과 다를 수 있습니다.
그래서 링크·계약 기간을 요청에 담는 경로를 새로 뒀습니다
(`POST /participation-dashboard/sheet-preview`). 저장해야만 확인되면 사람이 저장부터 하게 됩니다.

**막는 이유는 서버가 적어 준 대로** 보여 줍니다. 화면이 다시 판정하면 두 곳이 어긋납니다.

## 캐시플로우 연동을 레퍼런스로

보람 지적대로 라이브에서 도는 경로를 참고했습니다 — 클라이언트 호출을
`post(path, { tenantId, actor, body, timeoutMs, retries })` 모양으로 맞췄고,
**`retries: 0`** 도 그대로 따랐습니다. 시트 읽기는 쿼터를 쓰므로 실패를 자동으로 되풀이하면
쿼터만 더 먹습니다(오늘 겪은 QUOTA_EXCEEDED).

## 이전 코드 정리

접근을 바꿨으므로 함께 걷어냈습니다: `TeamMemberSearchCombobox`, `addTeamMember`,
`removeTeamMember`, `updateTeamMember`, `createEmptyTeamMember`, `teamMemberOptions`,
그리고 죽은 import 6개. 그 코드를 지키던 셸 테스트도 새 동작을 지키도록 다시 썼습니다.

## 검증

| 게이트 | 결과 |
|---|---|
| `npm test` | 3401 passed / 2 failed — 아래 |
| 등록·수정 영역 | 93 passed |
| BFF 라우트 | 17 passed (저장 전 연동 5건 추가) |
| `typecheck` · `policy:verify` · `build` | 통과 |

**삭제 검증 2건**:

| 걷어낸 것 | 결과 |
|---|---|
| 연동이 명단을 채우는 부분 | 1건 실패 |
| 시트 링크 필수 규칙 | 1건 실패 |

처음 시도한 사보타주(`void 0 &&` 로 무력화)는 **통과했습니다** — 소스 텍스트 검사라 코드가
남아 있으면 잡지 못합니다. 실제로 지워서 다시 확인했습니다. 셸 테스트의 한계를 기록해 둡니다.

실패 2건은 `cashflow-sheet-lab`·`jvm-weekly-api` 로 **단독 실행 115/115, 284/284 통과**한
알려진 부하 flake입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)