### PR TITLE
fix(participation): 시트를 그대로 표로, 공유 계정과 실패 이유를 알린다

### DIFF
--- a/server/bff/routes/participation-dashboard.mjs
+++ b/server/bff/routes/participation-dashboard.mjs
@@ -9,15 +9,32 @@ import {
   toParticipationSheetInput,
 } from '../participation-sheet-ranges.mjs';
 
+/** 캐시플로우 시트 연동과 같은 방식으로 서비스 계정 주소를 얻는다. */
+function resolveSystemAccountEmail(googleSheetsService) {
+  if (typeof googleSheetsService?.getServiceAccountEmail === 'function') {
+    return readOptionalText(googleSheetsService.getServiceAccountEmail());
+  }
+  return readOptionalText(googleSheetsService?.serviceAccountEmail);
+}
+
 /**
  * 시트 읽기 실패를 사람이 읽을 한 가지 코드로 정규화한다.
- * 권한·쿼터·삭제는 원인이 다르지만 사람이 할 일은 같다 - 링크와 공유를 확인하고 다시 시도한다.
+ * 권한·쿼터·삭제는 원인이 다르지만 사람이 할 일은 같다 - 공유를 확인하고 다시 시도한다.
+ *
+ * 가장 흔한 원인은 공유 누락이라 **누구에게 공유해야 하는지**를 함께 적는다. 주소를 모르면
+ * 사람은 무엇을 고쳐야 할지 알 수 없고, "잠시 후 다시 시도" 만 되풀이하게 된다.
  */
-function participationSheetUnreachable(error) {
+function participationSheetUnreachable(error, systemAccountEmail = '') {
   const detail = readOptionalText(error?.message) || '시트를 읽지 못했습니다.';
+  const share = systemAccountEmail
+    ? ` 시트를 ${systemAccountEmail} 에 보기 권한으로 공유했는지 확인해 주세요.`
+    : ' 시트 공유 권한을 확인해 주세요.';
+  const missingTab = /참여율|Unable to parse range|not found/i.test(detail)
+    ? ' 표준양식의 "참여율" 탭이 있는지도 확인해 주세요.'
+    : '';
   return createHttpError(
     502,
-    `참여율 시트를 읽지 못했습니다. 링크와 공유 권한을 확인해 주세요. (${detail})`,
+    `참여율 시트를 읽지 못했습니다.${share}${missingTab} (${detail})`,
     'participation_sheet_unreachable',
   );
 }
@@ -39,7 +56,7 @@ async function readParticipationSheet(googleSheetsService, sheetLink) {
     ]);
     return { format, period, header, meta, cells };
   } catch (error) {
-    throw participationSheetUnreachable(error);
+    throw participationSheetUnreachable(error, resolveSystemAccountEmail(googleSheetsService));
   }
 }
 
@@ -114,6 +131,21 @@ export function mountParticipationDashboardRoutes(app, { db, now, googleSheetsSe
       .map((doc) => ({ id: doc.id, ...(doc.data() || {}) }))
       .filter((entry) => readOptionalText(entry.projectId) === projectId);
     res.status(200).json(buildProjectParticipationSnapshot({ project: { id: projectSnap.id, ...(projectSnap.data() || {}) }, entries }));
+  }));
+
+  /*
+   * 시트를 공유해야 할 상대. 사업마다 화면에 보여 준다.
+   *
+   * 서비스 계정은 전사 하나지만, 공유는 사업마다 새로 만든 시트에 대해 매번 해야 한다.
+   * 그래서 주소를 오류가 난 뒤에 알려주면 늦다 - 링크를 넣는 그 자리에 있어야 한다.
+   */
+  app.get('/api/v1/participation-dashboard/system-account', asyncHandler(async (req, res) => {
+    assertActorRoleAllowed(req, ROUTE_ROLES.readCore, 'read participation sheet system account');
+    const systemAccountEmail = resolveSystemAccountEmail(googleSheetsService);
+    res.status(200).json({
+      systemAccountEmail,
+      configured: Boolean(systemAccountEmail),
+    });
   }));
 
   /*

--- a/server/bff/routes/participation-sheet-preview.test.mjs
+++ b/server/bff/routes/participation-sheet-preview.test.mjs
@@ -61,6 +61,7 @@ function createApp({ role = 'admin', documents = {}, ranges = sheetRanges(), she
 
   const requestedRanges = [];
   const googleSheetsService = {
+    getServiceAccountEmail: () => 'mysc-sheets@mysc.iam.gserviceaccount.com',
     getSheetValues: async ({ rangeA1 }) => {
       requestedRanges.push(rangeA1);
       if (sheetsError) throw new Error(sheetsError);
@@ -122,12 +123,25 @@ describe('막히는 경우 - 조용히 끝나지 않는다', () => {
     expect(response.body.message).toContain('등록·수정');
   });
 
-  it('시트를 못 읽으면 원인이 무엇이든 한 코드로 정규화한다', async () => {
+  // 가장 흔한 원인은 공유 누락이다. 주소를 모르면 사람은 무엇을 고쳐야 할지 알 수 없고
+  // "잠시 후 다시 시도" 만 되풀이하게 된다.
+  it('시트를 못 읽으면 한 코드로 정규화하고 누구에게 공유할지 알려준다', async () => {
     const { app } = createApp({ documents: withProject(), sheetsError: 'quota exceeded' });
     const response = await request(app).get(url);
     expect(response.status).toBe(502);
     expect(response.body.code).toBe('participation_sheet_unreachable');
-    expect(response.body.message).toContain('공유 권한');
+    expect(response.body.message).toContain('mysc-sheets@mysc.iam.gserviceaccount.com');
+    expect(response.body.message).toContain('quota exceeded');
+  });
+
+  it('공유해야 할 계정을 따로 물어볼 수 있다 - 링크를 넣는 자리에서 보여 준다', async () => {
+    const { app } = createApp({ documents: withProject() });
+    const response = await request(app).get('/api/v1/participation-dashboard/system-account');
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      systemAccountEmail: 'mysc-sheets@mysc.iam.gserviceaccount.com',
+      configured: true,
+    });
   });
 
   it('사업이 없으면 404 다', async () => {

--- a/src/app/components/participation/ParticipationSheetPreviewPanel.tsx
+++ b/src/app/components/participation/ParticipationSheetPreviewPanel.tsx
@@ -31,8 +31,9 @@ function sheetErrorMessage(error: unknown): string {
   const status = error instanceof PlatformApiError ? error.status : 500;
   const code = error instanceof PlatformApiError ? error.code : '';
   const mapped = resolveApiErrorPresentation(code, status);
-  // 서버가 사람 말로 적어 준 안내가 있으면 그것이 더 구체적이다(어느 사업, 어느 기간).
-  const serverMessage = error instanceof PlatformApiError ? String(error.message || '').trim() : '';
+  // serverMessage 가 서버가 적어 준 안내다(어느 사업·어느 기간·누구에게 공유).
+  // message 는 상태코드별 일반 문구라 원인을 가린다.
+  const serverMessage = error instanceof PlatformApiError ? String(error.serverMessage || '').trim() : '';
   return serverMessage || mapped.guide;
 }
 
@@ -45,6 +46,8 @@ export function ParticipationSheetPreviewPanel({ tenantId, user, projects }: {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [preview, setPreview] = useState<ParticipationSheetPreview | null>(null);
+  // 계약이 10년이면 월 칸이 120개다. 연도로 잘라야 표가 옆으로 터지지 않는다.
+  const [year, setYear] = useState('');
 
   const missingByRow = useMemo(() => {
     const map = new Map<number, number>();
@@ -60,12 +63,23 @@ export function ParticipationSheetPreviewPanel({ tenantId, user, projects }: {
     setError('');
     setPreview(null);
     void fetchParticipationSheetPreviewViaBff({ tenantId, actor: user, projectId })
-      .then(setPreview)
+      .then((next) => {
+        setPreview(next);
+        setYear(next.months[0]?.slice(0, 4) || '');
+      })
       .catch((cause) => setError(sheetErrorMessage(cause)))
       .finally(() => setLoading(false));
   };
 
   const summary = preview?.summary;
+  const years = useMemo(
+    () => [...new Set((preview?.months || []).map((month) => month.slice(0, 4)))],
+    [preview?.months],
+  );
+  const visibleMonths = useMemo(
+    () => (preview?.months || []).filter((month) => month.startsWith(year)),
+    [preview?.months, year],
+  );
 
   return (
     <section className="overflow-hidden rounded-lg border border-border bg-card">
@@ -127,6 +141,14 @@ export function ParticipationSheetPreviewPanel({ tenantId, user, projects }: {
             <span className={summary.missingCount > 0 ? 'font-semibold text-red-700' : 'text-muted-foreground'}>
               미입력 {summary.missingCount}칸
             </span>
+            <Select value={year} onValueChange={setYear}>
+              <SelectTrigger className="h-7 w-[110px] text-[12px]" aria-label="확인할 연도">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {years.map((option) => <SelectItem key={option} value={option}>{option}년</SelectItem>)}
+              </SelectContent>
+            </Select>
             <a
               href={preview.sheetLink}
               target="_blank"
@@ -178,7 +200,7 @@ export function ParticipationSheetPreviewPanel({ tenantId, user, projects }: {
                     <TableHead className="min-w-[110px] text-xs font-semibold">역할</TableHead>
                     <TableHead className="min-w-[150px] text-xs font-semibold">투입기간</TableHead>
                     <TableHead className="min-w-[90px] text-xs font-semibold">연결</TableHead>
-                    {preview.months.map((month) => (
+                    {visibleMonths.map((month) => (
                       <TableHead key={month} className="min-w-[64px] text-center text-xs font-semibold">
                         {month.slice(2)}
                       </TableHead>
@@ -202,7 +224,7 @@ export function ParticipationSheetPreviewPanel({ tenantId, user, projects }: {
                         <TableCell className={`text-xs ${row.linkState === 'LINKED' ? 'text-muted-foreground' : 'font-semibold text-amber-700'}`}>
                           {LINK_STATE_LABEL[row.linkState]}
                         </TableCell>
-                        {preview.months.map((month) => {
+                        {visibleMonths.map((month) => {
                           const inStint = Boolean(row.stintStart)
                             && month >= row.stintStart
                             && (!row.stintEnd || month <= row.stintEnd);

--- a/src/app/components/projects/ProjectEditorWizard.shell.test.ts
+++ b/src/app/components/projects/ProjectEditorWizard.shell.test.ts
@@ -145,6 +145,20 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain('laborAllocationStartMonth: row.stintStart,');
   });
 
+  // 표는 저장된 명단이 아니라 방금 읽은 시트다. 저장본을 그리면 연동 전 옛 값이 보인다.
+  it('draws the sheet itself, sliced by year so a ten-year contract fits', () => {
+    expect(source).toContain('const [teamSyncPreview, setTeamSyncPreview]');
+    expect(source).toContain('teamSyncPreview.rows.map((row) => (');
+    expect(source).toContain("teamSyncPreview.months.filter((month) => month.startsWith(teamSyncYear))");
+    expect(source).toContain('aria-label="확인할 연도"');
+    expect(source).not.toContain('{draft.teamMembersDetailed.map((member, index) => (');
+  });
+
+  it('shows which account the sheet must be shared with', () => {
+    expect(source).toContain('fetchParticipationSystemAccountViaBff(');
+    expect(source).toContain('에 보기 권한으로 공유해 주세요.');
+  });
+
   it('does not judge the sheet again in the browser', () => {
     // 막는 이유는 서버가 적어 준 대로 보여 준다. 화면이 다시 판정하면 두 곳이 어긋난다.
     expect(source).toContain('preview.blocking.map((issue) => issue.message)');
@@ -183,7 +197,7 @@ describe('ProjectEditorWizard dropdown contract', () => {
   });
 
   it('does not key editable team member rows by typed member name', () => {
-    expect(source).toContain("key={`team-member-${index}`}");
+    expect(source).toContain("key={`sheet-row-${row.rowIndex}`}");
     expect(source).not.toContain("key={`${member.memberName || 'member'}-${index}`}");
   });
 
@@ -203,7 +217,6 @@ describe('ProjectEditorWizard dropdown contract', () => {
     expect(source).toContain('normalizeProjectTeamMemberDraftRows');
     expect(source).toContain('laborAllocationStartMonth');
     expect(source).toContain('laborAllocationEndMonth');
-    expect(source).toContain("key={`team-member-${index}`}");
     expect(source).not.toContain('<Label className="text-xs">인건비 시작월</Label>');
     expect(source).not.toContain('onClick={addTeamMember}');
   });

--- a/src/app/components/projects/ProjectEditorWizard.tsx
+++ b/src/app/components/projects/ProjectEditorWizard.tsx
@@ -22,7 +22,11 @@ import { useAuth } from '../../data/auth-store';
 import { useFirebase } from '../../lib/firebase-context';
 import { PlatformApiError } from '../../platform/api-client';
 import { resolveApiErrorPresentation } from '../../platform/api-error-messages';
-import { previewParticipationSheetByLinkViaBff } from '../../lib/platform-bff-client';
+import {
+  fetchParticipationSystemAccountViaBff,
+  previewParticipationSheetByLinkViaBff,
+  type ParticipationSheetPreview,
+} from '../../lib/platform-bff-client';
 import { toast } from 'sonner';
 import { useBlocker } from 'react-router';
 import {
@@ -734,6 +738,11 @@ export function ProjectEditorWizard({
   const [teamSyncing, setTeamSyncing] = useState(false);
   const [teamSyncNotice, setTeamSyncNotice] = useState('');
   const [teamSyncError, setTeamSyncError] = useState('');
+  // 표는 시트를 그대로 옮긴 것이다. 저장된 명단이 아니라 방금 읽은 시트를 보여 준다.
+  const [teamSyncPreview, setTeamSyncPreview] = useState<ParticipationSheetPreview | null>(null);
+  const [teamSyncYear, setTeamSyncYear] = useState('');
+  // 시트를 공유해야 할 상대. 오류가 난 뒤에 알려주면 늦다 - 링크를 넣는 그 자리에 있어야 한다.
+  const [sheetSystemAccount, setSheetSystemAccount] = useState('');
   const [stepIndex, setStepIndex] = useState(0);
   const [draft, setDraft] = useState<ProjectEditorDraft>(() => createProjectEditorWizardDraft(initialDraft));
   const [documentUploadState, setDocumentUploadState] = useState<Record<ProjectRequestDocumentKind, ContractUploadState>>({
@@ -1279,6 +1288,15 @@ export function ProjectEditorWizard({
    * 여기에는 승인 서류·인력 현황·사업 검색이 쓰는 명단(이름·역할·투입기간·기본투입률)만 남긴다.
    * 저장 전에도 눌러야 하므로 화면의 링크와 계약 기간을 그대로 보낸다.
    */
+  useEffect(() => {
+    if (!orgId || !user) return;
+    let cancelled = false;
+    void fetchParticipationSystemAccountViaBff({ tenantId: orgId, actor: user })
+      .then((result) => { if (!cancelled) setSheetSystemAccount(result.systemAccountEmail || ''); })
+      .catch(() => { /* 안내 문구일 뿐이라 실패해도 화면을 막지 않는다. */ });
+    return () => { cancelled = true; };
+  }, [orgId, user]);
+
   const syncTeamFromSheet = () => {
     if (teamSyncing) return;
     const sheetLink = String(draft.participationSheetLink || '').trim();
@@ -1307,6 +1325,7 @@ export function ProjectEditorWizard({
       .then((preview) => {
         if (!preview.ok) {
           // 막는 이유를 서버가 적어 준 대로 보여 준다. 화면이 다시 판정하지 않는다.
+          setTeamSyncPreview(null);
           setTeamSyncError(preview.blocking.map((issue) => issue.message).slice(0, 3).join(' / ')
             || '시트를 반영할 수 없는 상태입니다.');
           return;
@@ -1320,15 +1339,20 @@ export function ProjectEditorWizard({
           laborAllocationStartMonth: row.stintStart,
           laborAllocationEndMonth: row.stintEnd,
         })));
+        setTeamSyncPreview(preview);
+        // 계약이 10년이면 월 칸이 120개다. 연도로 잘라야 표가 옆으로 터지지 않는다.
+        setTeamSyncYear(preview.months[0]?.slice(0, 4) || '');
         const pending = preview.summary?.pendingLinkCount || 0;
         setTeamSyncNotice(pending > 0
           ? `참여인력 ${preview.rows.length}명을 가져왔습니다. 그중 ${pending}명은 People 등록 전이라 연결 대기입니다.`
           : `참여인력 ${preview.rows.length}명을 가져왔습니다.`);
       })
       .catch((error) => {
+        setTeamSyncPreview(null);
         const status = error instanceof PlatformApiError ? error.status : 500;
         const code = error instanceof PlatformApiError ? error.code : '';
-        const serverMessage = error instanceof PlatformApiError ? String(error.message || '').trim() : '';
+        // serverMessage 가 서버가 적어 준 안내다. message 는 상태코드별 일반 문구라 원인을 가린다.
+        const serverMessage = error instanceof PlatformApiError ? String(error.serverMessage || '').trim() : '';
         setTeamSyncError(serverMessage || resolveApiErrorPresentation(code, status).guide);
       })
       .finally(() => setTeamSyncing(false));
@@ -2840,7 +2864,10 @@ export function ProjectEditorWizard({
           label="참여율 시트 링크"
           hints={[
             '월별 참여율은 이 시트에 적습니다. 표준양식을 복사해 이 사업 전용 시트를 만든 뒤 링크를 넣어 주세요.',
-            '저장하면 참여인력 대시보드의 "시트 확인"에서 입력 상태를 볼 수 있습니다.',
+            sheetSystemAccount
+              ? `만든 시트를 ${sheetSystemAccount} 에 보기 권한으로 공유해 주세요. 공유하지 않으면 연동이 되지 않습니다.`
+              : '만든 시트를 MYSC 시스템 계정에 보기 권한으로 공유해야 연동이 됩니다.',
+            '저장하면 참여인력 대시보드의 "시트 확인"에서도 입력 상태를 볼 수 있습니다.',
           ]}
         >
           <Input
@@ -2873,46 +2900,85 @@ export function ProjectEditorWizard({
               {teamSyncNotice}
             </p>
           ) : null}
-          {draft.teamMembersDetailed.length === 0 ? (
-            <p className={cn('rounded-lg border border-dashed border-slate-300 bg-white px-4 py-5', FORM_HINT_CLASS)}>
-              시트 링크를 넣고 연동하기를 누르면 참여인력이 여기에 표시됩니다.
-            </p>
-          ) : (
-            <div className="overflow-x-auto rounded-lg border border-slate-200 bg-white">
-              <table className="w-full min-w-[640px] text-left">
-                <thead>
-                  <tr className="border-b border-slate-200 bg-slate-50">
-                    <th className="px-3 py-2 text-[12px] font-semibold text-slate-700">이름</th>
-                    <th className="px-3 py-2 text-[12px] font-semibold text-slate-700">역할</th>
-                    <th className="px-3 py-2 text-[12px] font-semibold text-slate-700">투입기간</th>
-                    <th className="px-3 py-2 text-right text-[12px] font-semibold text-slate-700">기본투입률</th>
-                    <th className="px-3 py-2 text-[12px] font-semibold text-slate-700">People 연결</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {draft.teamMembersDetailed.map((member, index) => (
-                    <tr key={`team-member-${index}`} className="border-b border-slate-100 last:border-b-0">
-                      <td className="px-3 py-2 text-[13px] font-medium text-slate-800">
-                        {member.memberName || member.memberNickname || '이름 없음'}
-                        {member.memberName && member.memberNickname
-                          ? <span className="ml-1 text-slate-500">({member.memberNickname})</span>
-                          : null}
-                      </td>
-                      <td className="px-3 py-2 text-[13px] text-slate-600">{member.role || '―'}</td>
-                      <td className="px-3 py-2 text-[13px] text-slate-600">
-                        {member.laborAllocationStartMonth || '미입력'} ~ {member.laborAllocationEndMonth || '진행 중'}
-                      </td>
-                      <td className="px-3 py-2 text-right text-[13px] tabular-nums text-slate-800">
-                        {member.participationRate ? `${member.participationRate}%` : '―'}
-                      </td>
-                      <td className={cn('px-3 py-2 text-[13px]', member.personId ? 'text-slate-600' : 'font-semibold text-amber-700')}>
-                        {member.personId ? '연결됨' : '연결 대기'}
-                      </td>
+          {teamSyncPreview ? (
+            <div className="space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className={FORM_HINT_CLASS}>
+                  {teamSyncPreview.summary?.period.start} ~ {teamSyncPreview.summary?.period.end}
+                  {' · '}참여인력 {teamSyncPreview.rows.length}명
+                </span>
+                {/* 계약이 10년이면 월 칸이 120개다. 연도로 잘라야 표가 옆으로 터지지 않는다. */}
+                <Select value={teamSyncYear} onValueChange={setTeamSyncYear}>
+                  <SelectTrigger className="h-8 w-[120px] text-[13px]" aria-label="확인할 연도">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {[...new Set(teamSyncPreview.months.map((month) => month.slice(0, 4)))].map((year) => (
+                      <SelectItem key={year} value={year}>{year}년</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="overflow-x-auto rounded-lg border border-slate-200 bg-white">
+                <table className="w-full text-left">
+                  <thead>
+                    <tr className="border-b border-slate-200 bg-slate-50">
+                      <th className="sticky left-0 z-10 min-w-[140px] bg-slate-50 px-3 py-2 text-[12px] font-semibold text-slate-700">이름</th>
+                      <th className="min-w-[110px] px-3 py-2 text-[12px] font-semibold text-slate-700">역할</th>
+                      <th className="min-w-[150px] px-3 py-2 text-[12px] font-semibold text-slate-700">투입기간</th>
+                      {teamSyncPreview.months.filter((month) => month.startsWith(teamSyncYear)).map((month) => (
+                        <th key={month} className="min-w-[56px] px-2 py-2 text-center text-[12px] font-semibold text-slate-700">
+                          {Number(month.slice(5))}월
+                        </th>
+                      ))}
                     </tr>
-                  ))}
-                </tbody>
-              </table>
+                  </thead>
+                  <tbody>
+                    {teamSyncPreview.rows.map((row) => (
+                      <tr key={`sheet-row-${row.rowIndex}`} className="border-b border-slate-100 last:border-b-0">
+                        <td className="sticky left-0 z-10 bg-white px-3 py-2 text-[13px] font-medium text-slate-800">
+                          {row.name || row.nickname || '이름 없음'}
+                          {row.name && row.nickname ? <span className="ml-1 text-slate-500">({row.nickname})</span> : null}
+                          {row.linkState === 'LINKED'
+                            ? null
+                            : <span className="ml-1 text-[11px] font-semibold text-amber-700">
+                              {row.linkState === 'PLACEHOLDER' ? '사람 미정' : '연결 대기'}
+                            </span>}
+                        </td>
+                        <td className="px-3 py-2 text-[13px] text-slate-600">{row.role || '―'}</td>
+                        <td className="px-3 py-2 text-[13px] text-slate-600">
+                          {row.stintStart || '미입력'} ~ {row.stintEnd || '진행 중'}
+                        </td>
+                        {teamSyncPreview.months.filter((month) => month.startsWith(teamSyncYear)).map((month) => {
+                          const inStint = Boolean(row.stintStart)
+                            && month >= row.stintStart
+                            && (!row.stintEnd || month <= row.stintEnd);
+                          const value = row.monthlyRates[month];
+                          const hasValue = value !== undefined;
+                          // 시트의 색 규칙을 그대로 옮긴다. 미입력은 빨강, 투입기간 밖은 흐리게.
+                          return (
+                            <td
+                              key={month}
+                              className={cn(
+                                'px-2 py-2 text-center text-[13px] tabular-nums',
+                                hasValue ? 'font-semibold text-slate-800'
+                                  : inStint ? 'bg-red-50 font-semibold text-red-700' : 'text-slate-300',
+                              )}
+                            >
+                              {hasValue ? value : inStint ? '미입력' : '―'}
+                            </td>
+                          );
+                        })}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
             </div>
+          ) : (
+            <p className={cn('rounded-lg border border-dashed border-slate-300 bg-white px-4 py-5', FORM_HINT_CLASS)}>
+              시트 링크를 넣고 연동하기를 누르면 시트 내용이 여기에 표로 나타납니다.
+            </p>
           )}
         </div>
       </ProjectFormSection>

--- a/src/app/lib/platform-bff-client.ts
+++ b/src/app/lib/platform-bff-client.ts
@@ -2205,6 +2205,21 @@ export async function fetchParticipationSheetPreviewViaBff(params: {
 }
 
 /**
+ * 참여율 시트를 공유해야 할 상대. 전사 하나지만 공유는 사업마다 해야 하므로 폼에서 보여 준다.
+ */
+export async function fetchParticipationSystemAccountViaBff(params: {
+  tenantId: string;
+  actor: ActorLike;
+  client?: PlatformApiClientLike;
+}): Promise<{ systemAccountEmail: string; configured: boolean }> {
+  const response = await resolveClient(params.client).get<{ systemAccountEmail: string; configured: boolean }>(
+    '/api/v1/participation-dashboard/system-account',
+    { tenantId: params.tenantId, actor: toRequestActor(params.actor), timeoutMs: 10_000 },
+  );
+  return response.data;
+}
+
+/**
  * 저장 전 시트 연동. 등록 중에는 사업 문서가 아직 없고, 수정 중에는 화면의 링크가 저장본과
  * 다를 수 있어 링크와 계약 기간을 함께 보낸다. 읽기만 하며 아무것도 쓰지 않는다.
  */


### PR DESCRIPTION
## 라이브에서 나온 것 (hotfix)

```
POST /api/v1/participation-dashboard/sheet-preview → 502
화면: "요청을 처리하지 못했습니다. 잠시 후 다시 시도해 주세요."
```

**원인이 가려졌습니다.** 서버는 이유를 적어 보냈는데 화면이 상태코드별 일반 문구를 띄웠습니다.

### ① 서버가 적어 준 안내를 쓴다

`PlatformApiError` 에는 `serverMessage` 전용 필드가 있는데 제가 `message`(일반 문구)를
쓰고 있었습니다. 등록/수정·참여인력 대시보드 **두 곳 모두** 고쳤습니다.

### ② 누구에게 공유할지 알려준다

502 의 가장 흔한 원인은 **공유 누락**입니다. 주소를 모르면 사람은 무엇을 고칠지 알 수 없고
"잠시 후 다시 시도"만 되풀이합니다.

- 오류 메시지에 서비스 계정 주소를 담습니다(캐시플로우의 `resolveSystemAccountEmail` 재사용)
- `GET /participation-dashboard/system-account` 로 **폼에서 미리** 보여 줍니다 — 오류가 난
  뒤에 알려주면 늦습니다. 서비스 계정은 전사 하나지만 공유는 사업마다 새 시트에 매번 해야 합니다

## 표를 시트 그대로 (보람 지적)

> 변민욱(보람) 운영매니저 미입력 ~ 진행 중 ― 연결 대기
> 이런 식으로 보여주면 안 되고 **시트랑 동일하게 그냥 시트를 테이블로 바꿔서** 보여준다고 생각해야해

표가 **저장된 명단**을 그리고 있어 연동 전 옛 수기 값이 보였습니다. 방금 읽은 시트를 그대로
옮기도록 바꿨습니다 — 이름·역할·투입기간 + **월별 참여율 칸**, 시트와 같은 색 규칙(미입력
빨강, 투입기간 밖 흐리게).

## 연도 드롭다운 (보람 지적)

> 연도 드롭다운도 달아서 연도마다 자르게. 2035년되어 있으면 프론트 짤릴듯

맞습니다 — 계약이 10년이면 월 칸이 **120개**입니다. 연도로 잘라 12칸씩 보여 줍니다.
**참여인력 대시보드의 표도 같은 결함**이라 함께 고쳤습니다.

연동이 실패하면 옛 표를 지웁니다. 실패한 화면에 지난 결과가 남아 있으면 성공으로 읽힙니다.

## 검증

| 게이트 | 결과 |
|---|---|
| `npm test` | 3404 passed / 2 failed — 아래 |
| BFF 라우트 | 19 passed (공유 계정 2건 추가) |
| 등록·수정 | 95 passed (표·공유 안내 2건 추가) |
| `typecheck` · `policy:verify` · `build` | 통과 |

실패 2건은 `cashflow-sheet-lab`·`jvm-weekly-api` 로 단독 재실행 115/115, **284/284 ×2회**
통과한 알려진 부하 flake입니다. 이 브랜치가 건드린 파일에 그 둘은 없습니다.

## 배포 후 확인

시트를 서비스 계정에 공유한 뒤 연동하면 표가 뜹니다. 공유 전이라면 이제 **누구에게 공유할지**가
화면과 오류 양쪽에 나옵니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)