### PR TITLE
fix(participation): 시트 범위 조립을 바로잡는다

### DIFF
--- a/server/bff/google-sheets.test.ts
+++ b/server/bff/google-sheets.test.ts
@@ -89,6 +89,27 @@ describe('google-sheets helpers', () => {
     expect(fetchImpl.mock.calls[1]?.[0]).toContain(encodeURIComponent("'cashflow(사용내역 연동)'"));
   });
 
+  it('builds one valid A1 range from a spaced sheet name and local coordinates', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(JSON.stringify({ values: [['2026-01']] }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+    const service = createGoogleSheetsService({
+      fetchImpl,
+      authHeadersFactory: async () => ({ authorization: 'Bearer test-token' }),
+    });
+
+    await service.getSheetValues({
+      spreadsheetId: '1abcDEFghiJKlmnOPQ_rst-123',
+      sheetName: '참여율 관리',
+      rangeA1: 'B1:D1',
+    });
+
+    const requestUrl = decodeURIComponent(String(fetchImpl.mock.calls[0]?.[0]));
+    expect(requestUrl).toContain("/values/'참여율 관리'!B1:D1?");
+    expect(requestUrl).not.toContain("'Sheet1'");
+  });
+
   it('prefers caller google access token over service account auth', async () => {
     const fetchImpl = vi
       .fn()

--- a/server/bff/participation-sheet-ranges.mjs
+++ b/server/bff/participation-sheet-ranges.mjs
@@ -15,22 +15,18 @@
 export const PARTICIPATION_SHEET_TAB = '참여율 관리';
 export const PARTICIPATION_REF_TAB = '참조';
 
-/** 탭 이름에 공백이 있어 범위에 인용부호가 필요하다. */
 export function participationSheetRanges() {
-  const tab = PARTICIPATION_SHEET_TAB;
-  const quoted = `'${tab.replace(/'/g, "''")}'`;
   return {
-    tab,
     /** 양식 식별자. 반영·검증의 첫 관문이다. */
-    format: `'${PARTICIPATION_REF_TAB}'!F1`,
+    format: { sheetName: PARTICIPATION_REF_TAB, rangeA1: 'F1' },
     /** 계약 기간 설정칸(B1 시작월, D1 종료월). C1 은 물결 표시라 함께 읽고 버린다. */
-    period: `${quoted}!B1:D1`,
+    period: { sheetName: PARTICIPATION_SHEET_TAB, rangeA1: 'B1:D1' },
     /** 월 머리글 2행. 파서는 이 행만 읽는다 - 1행 연도 표시는 사람 보기용 장식이다. */
-    header: `${quoted}!G2:DV2`,
+    header: { sheetName: PARTICIPATION_SHEET_TAB, rangeA1: 'G2:DV2' },
     /** 고정 열 A~F: 닉네임·이름·역할·투입시작월·투입종료월·기본투입률 */
-    meta: `${quoted}!A3:F62`,
+    meta: { sheetName: PARTICIPATION_SHEET_TAB, rangeA1: 'A3:F62' },
     /** 월 칸 본문 */
-    cells: `${quoted}!G3:DV62`,
+    cells: { sheetName: PARTICIPATION_SHEET_TAB, rangeA1: 'G3:DV62' },
   };
 }
 

--- a/server/bff/routes/participation-dashboard.mjs
+++ b/server/bff/routes/participation-dashboard.mjs
@@ -38,10 +38,9 @@ function participationSheetUnreachable(error, systemAccountEmail = '') {
 /** 다섯 범위를 함께 읽는다. 한 번에 읽어야 사람이 그 사이 고쳐도 한 장면으로 남는다. */
 async function readParticipationSheet(googleSheetsService, sheetLink) {
   const ranges = participationSheetRanges();
-  // 범위에 탭 이름이 들어 있으므로 sheetName 을 따로 넘기지 않는다. 둘 다 주면 어느 쪽이
-  // 이기는지 호출부마다 달라진다.
-  const readRange = (rangeA1) => googleSheetsService.getSheetValues({
+  const readRange = ({ sheetName, rangeA1 }) => googleSheetsService.getSheetValues({
     spreadsheetId: sheetLink,
+    sheetName,
     rangeA1,
   });
   try {

--- a/server/bff/routes/participation-sheet-preview.test.mjs
+++ b/server/bff/routes/participation-sheet-preview.test.mjs
@@ -62,10 +62,11 @@ function createApp({ role = 'admin', documents = {}, ranges = sheetRanges(), she
   const requestedRanges = [];
   const googleSheetsService = {
     getServiceAccountEmail: () => 'mysc-sheets@mysc.iam.gserviceaccount.com',
-    getSheetValues: async ({ rangeA1 }) => {
-      requestedRanges.push(rangeA1);
+    getSheetValues: async ({ sheetName, rangeA1 }) => {
+      const quotedRange = `'${sheetName}'!${rangeA1}`;
+      requestedRanges.push({ sheetName, rangeA1 });
       if (sheetsError) throw new Error(sheetsError);
-      return ranges[rangeA1] || [];
+      return ranges[quotedRange] || [];
     },
   };
 
@@ -108,8 +109,12 @@ describe('참여율 시트 검증 - 읽기 전용', () => {
   it('계약이 고정한 다섯 범위만 읽는다', async () => {
     const { app, requestedRanges } = createApp({ documents: withProject() });
     await request(app).get(url);
-    expect(requestedRanges.sort()).toEqual([
-      "'참여율 관리'!A3:F62", "'참여율 관리'!B1:D1", "'참여율 관리'!G2:DV2", "'참여율 관리'!G3:DV62", "'참조'!F1",
+    expect(requestedRanges.sort((left, right) => `${left.sheetName}!${left.rangeA1}`.localeCompare(`${right.sheetName}!${right.rangeA1}`))).toEqual([
+      { sheetName: '참여율 관리', rangeA1: 'A3:F62' },
+      { sheetName: '참여율 관리', rangeA1: 'B1:D1' },
+      { sheetName: '참여율 관리', rangeA1: 'G2:DV2' },
+      { sheetName: '참여율 관리', rangeA1: 'G3:DV62' },
+      { sheetName: '참조', rangeA1: 'F1' },
     ]);
   });
 });


### PR DESCRIPTION
## 장애\n등록·수정의 참여율 시트 미리보기가 GET까지 도달한 뒤 502로 실패했습니다.\n\n## 원인\nGoogle Sheets adapter는 sheetName과 로컬 rangeA1을 받아 최종 A1을 조립합니다. 호출부가 탭이 포함된 범위를 넘기면서 sheetName을 생략해 기본 Sheet1이 중첩됐습니다.\n\n## 수정\n- 참여율 관리/참조 탭과 로컬 좌표를 별도 descriptor로 전달\n- 실제 Google adapter가 공백 탭을 한 번만 인용하는 회귀 테스트 추가\n- route mock도 실제 adapter 계약과 동일하게 변경\n\n## 검증\n- 관련 테스트 145/145 통과\n- production build 통과\n- git diff --check 통과\n\n## 영향\n- 읽기 전용 Google Sheets 조회 조립만 변경\n- Firestore/Google Sheet 쓰기 없음\n- JVM, RBAC, rules/index 변경 없음