### PR TITLE
fix(projects): 수정 폼 열기를 참여율 시트 검증에서 분리

### DIFF
--- a/server/bff/routes/projects.mjs
+++ b/server/bff/routes/projects.mjs
@@ -1881,9 +1881,6 @@ export function buildProjectPatchFromChangeRequestPayload(payload = {}, currentP
     || readOptionalText(payload.managerName)
     || readOptionalText(currentProject.registeredByName)
     || readOptionalText(currentProject.managerName);
-  const effectiveParticipationSheetLink = Object.hasOwn(payload, 'participationSheetLink')
-    ? readOptionalText(payload.participationSheetLink)
-    : readOptionalText(currentProject.participationSheetLink);
   const effectiveContractStart = readOptionalText(payload.contractStart) || readOptionalText(currentProject.contractStart);
   const effectiveContractEnd = readOptionalText(payload.contractEnd) || readOptionalText(currentProject.contractEnd);
   const registrationVersion = registrationRequirementsVersion(
@@ -1891,19 +1888,10 @@ export function buildProjectPatchFromChangeRequestPayload(payload = {}, currentP
       ? payload.registrationRequirementsVersion
       : currentProject.registrationRequirementsVersion,
   );
-  const currentRegistrationVersion = registrationRequirementsVersion(
-    currentProject.registrationRequirementsVersion,
-  );
+  // 참여율 시트 링크 검증은 제출 게이트(assertRegistrationPayload, PUT/PATCH 라우트)에서만 한다.
+  // 이 빌더는 draft open 시드 경로에서도 실행되므로, 여기서 검증하면 기존 데이터가
+  // 새 필수 규칙을 못 채운 프로젝트의 수정 화면 열기 자체가 막힌다.
   const updatesTeamMembers = Object.hasOwn(payload, 'teamMembersDetailed');
-  const updatesParticipationSheet = participationSheetFieldsChanged(payload, currentProject);
-  assertParticipationSheetLinkForTeamMembers(
-    payload.teamMembersDetailed,
-    effectiveParticipationSheetLink,
-    {
-      required: registrationVersion === 2
-        && (updatesParticipationSheet || currentRegistrationVersion !== 2),
-    },
-  );
   const teamMembersDetailed = updatesTeamMembers
     ? normalizeProjectTeamMembersDetailed(payload.teamMembersDetailed, {
         contractStartMonth: effectiveContractStart.slice(0, 7),

--- a/server/bff/routes/projects.test.ts
+++ b/server/bff/routes/projects.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   buildProjectRegistrationCanonicalDocuments,
   buildProjectInfoChangeSubmission,
+  buildProjectInfoDraftSeed,
   buildProjectPatchFromChangeRequestPayload,
   formatProjectTypeSlackLabel,
   mergeProjectAndRequestDocs,
@@ -137,6 +138,21 @@ function registrationV2Canonical(
     actorName: 'PM A',
     actorEmail: 'pm-a@example.com',
     timestamp: '2026-07-14T00:00:00.000Z',
+  });
+}
+
+function changeSubmission(payload: Record<string, unknown>, project: Record<string, unknown>) {
+  return buildProjectInfoChangeSubmission({
+    tenantId: 'mysc',
+    project,
+    previousRequest: null,
+    payload,
+    attachmentRefs: [],
+    actorId: 'pm-a',
+    actorName: 'PM A',
+    actorEmail: 'pm-a@example.com',
+    timestamp: '2026-08-24T00:00:00.000Z',
+    targetProjectVersion: 2,
   });
 }
 
@@ -657,7 +673,7 @@ describe('project route helpers', () => {
     expect(buildProjectPatchFromChangeRequestPayload(payload, canonical.project).participationSheetLink).toBe(nextLink);
   });
 
-  it('rejects a portal change patch that carries sheet rates without a participation sheet link', () => {
+  it('rejects a change submission that carries sheet rates without a participation sheet link', () => {
     const currentProject = registrationV2Canonical(registrationV2Payload()).project;
     const payload = {
       ...registrationV2Payload(),
@@ -672,11 +688,12 @@ describe('project route helpers', () => {
       }],
     };
 
-    expect(() => buildProjectPatchFromChangeRequestPayload(payload, currentProject))
-      .toThrowError(/participationSheetLink/);
+    expect(() => changeSubmission(payload, currentProject)).toThrowError(/participationSheetLink/);
+    // 열기/시드 경로는 같은 데이터로도 막히면 안 된다 — 링크는 폼에서 채워 제출할 때 검증한다.
+    expect(() => buildProjectPatchFromChangeRequestPayload(payload, currentProject)).not.toThrow();
   });
 
-  it('rejects a V2 portal change patch with a manual roster but no participation sheet link', () => {
+  it('rejects a V2 change submission with a manual roster but no participation sheet link', () => {
     const currentProject = registrationV2Canonical(registrationV2Payload()).project;
     const payload = registrationV2Payload({
       participationSheetLink: '',
@@ -685,8 +702,8 @@ describe('project route helpers', () => {
       }],
     });
 
-    expect(() => buildProjectPatchFromChangeRequestPayload(payload, currentProject))
-      .toThrowError(/participationSheetLink/);
+    expect(() => changeSubmission(payload, currentProject)).toThrowError(/participationSheetLink/);
+    expect(() => buildProjectPatchFromChangeRequestPayload(payload, currentProject)).not.toThrow();
   });
 
   it('preserves the current participation roster when a portal change does not touch it', () => {
@@ -710,31 +727,43 @@ describe('project route helpers', () => {
     expect({ ...currentProject, ...patch }.participationSheetLink).toBe('');
   });
 
-  it('requires sheet onboarding when a pre-link V2 project changes its contract period', () => {
+  it('requires sheet onboarding at submit when a pre-link V2 project changes its contract period', () => {
     const currentProject = {
       ...registrationV2Canonical(registrationV2Payload()).project,
       participationSheetLink: '',
     };
+    const payload = {
+      ...registrationV2Payload({ participationSheetLink: '' }),
+      contractEnd: '2028-12-31',
+    };
 
+    expect(() => changeSubmission(payload, currentProject)).toThrowError(/participationSheetLink/);
+    // 부분 patch(열기/시드 경로)는 온보딩 전 프로젝트라도 만들어져야 한다.
     expect(() => buildProjectPatchFromChangeRequestPayload({ contractEnd: '2028-12-31' }, currentProject))
-      .toThrowError(/participationSheetLink/);
+      .not.toThrow();
   });
 
-  it('requires a participation sheet link when a legacy project is upgraded to V2', () => {
+  it('requires a participation sheet link at submit when a legacy project is upgraded to V2', () => {
     const currentProject = {
+      id: 'project-legacy',
+      version: 1,
       registrationRequirementsVersion: 1,
       participationSheetLink: '',
+      registeredById: 'pm-a',
+      managerId: 'pm-a',
       teamMembersDetailed: [{
         memberName: '변민욱', memberNickname: '보람', role: '운영매니저', participationRate: 50,
       }],
     };
 
+    expect(() => changeSubmission(registrationV2Payload({ participationSheetLink: '' }), currentProject))
+      .toThrowError(/participationSheetLink/);
     expect(() => buildProjectPatchFromChangeRequestPayload({
       registrationRequirementsVersion: 2,
-    }, currentProject)).toThrowError(/participationSheetLink/);
+    }, currentProject)).not.toThrow();
   });
 
-  it('rejects a portal change patch whose sheet-backed row has no person identity', () => {
+  it('rejects a change submission whose sheet-backed row has no person identity', () => {
     const currentProject = registrationV2Canonical(registrationV2Payload()).project;
     const payload = {
       ...registrationV2Payload(),
@@ -749,8 +778,28 @@ describe('project route helpers', () => {
       }],
     };
 
-    expect(() => buildProjectPatchFromChangeRequestPayload(payload, currentProject))
-      .toThrowError(/identity is required/);
+    expect(() => changeSubmission(payload, currentProject)).toThrowError(/identity is required/);
+    expect(() => buildProjectPatchFromChangeRequestPayload(payload, currentProject)).not.toThrow();
+  });
+
+  it('opens the edit-form draft seed even when the saved roster is sheet-backed without a sheet link', () => {
+    const project = {
+      ...registrationV2Canonical(registrationV2Payload()).project,
+      participationSheetLink: '',
+      teamMembersDetailed: [{
+        memberName: '김정태',
+        memberNickname: '에이블',
+        role: '',
+        participationRate: 20,
+        laborAllocationStartMonth: '2026-01',
+        monthlyRates: { '2026-01': 20 },
+      }],
+    };
+
+    const seed = buildProjectInfoDraftSeed(project, {});
+
+    expect(seed.teamMembersDetailed).toHaveLength(1);
+    expect(seed.teamMembersDetailed[0].monthlyRates).toEqual({ '2026-01': 20 });
   });
 
   it('uses the current project contract end when a partial change omits contractEnd', () => {


### PR DESCRIPTION
## 문제

#659 배포 후, 시트 연동 참여율(`monthlyRates`)이 저장된 프로젝트에 `participationSheetLink`가 비어 있으면 **수정 폼 열기 자체가 422**로 거부됨 (`POST /api/v1/project-info-drafts/{id}/open` → `Project registration participationSheetLink is required for sheet-backed team members`). 프로덕션에서 "AXR프로젝트 경비" 수정 불가로 발견.

데드락 구조: 링크를 채우려면 수정 폼을 열어야 하는데, 폼 열기가 링크 없다고 거부됨.

## 원인

#659가 `assertParticipationSheetLinkForTeamMembers` 호출을 `buildProjectPatchFromChangeRequestPayload` 안에 넣었는데, 이 빌더는 제출뿐 아니라 **draft open 시드 경로**(`open` → `buildProjectInfoDraftSeed` → `projectInfoPayloadWithDocuments`)와 승인 적용 경로에서도 실행됨.

## 수정

**열기는 무조건, 검증은 제출에서만.**

- `buildProjectPatchFromChangeRequestPayload`에서 assert 호출 제거
- 제출 게이트는 그대로 유지 (독립적으로 이미 존재):
  - `assertRegistrationPayload` — 등록 제출 + 정보변경 제출(`buildProjectInfoChangeSubmission`)
  - PUT/PATCH 프로젝트 라우트의 직접 assert
- 거부 테스트 5건을 제출 경로 기준으로 이전, open 시드 회귀 테스트 추가

## 검증

- `npx vitest run server/bff/routes/projects.test.ts` 128 passed
- draft/registration/participation 라우트 테스트 226 passed
- 전체 `npm test`: sheet-lab 병렬 flake 외 전부 통과 (해당 파일 단독 3회 green — 알려진 가짜 실패)
- `npm run typecheck` / `npm run policy:verify` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)