### PR TITLE
fix(projects): 수정 초안 열기와 저장 검증 경계를 복구

### DIFF
--- a/server/bff/routes/project-info-drafts.mjs
+++ b/server/bff/routes/project-info-drafts.mjs
@@ -664,30 +664,31 @@ export function createProjectInfoDraftService({
         await assertLease(tx, current, nowDate);
         const existing = draftSnap.exists ? (draftSnap.data() || {}) : null;
         const previousRequest = requestSnap.exists ? (requestSnap.data() || {}) : {};
-        const seed = buildProjectInfoDraftSeed(project, previousRequest);
-        const draft = existing?.status === 'ACTIVE' && readOptionalText(existing.ownerUid) === current.actorId
-          ? existing
-          : {
-              ownerUid: current.actorId,
-              tenantId: current.tenantId,
-              resourceType: RESOURCE_TYPE,
-              resourceId: current.projectId,
-              draftRevision: 0,
-              baseCanonicalVersion: Number.isInteger(project.version) && project.version > 0 ? project.version : 1,
-              // Frozen copy of the canonical values this draft started from, so a
-              // later rebase can tell "the user changed it" from "someone else did".
-              baseSnapshot: seed,
-              payload: seed,
-              attachmentRefs: resumableDraftAttachments(
-                current.tenantId,
-                current.draftDocumentId,
-                previousRequest,
-              ),
-              stepIndex: 0,
-              status: 'ACTIVE',
-              createdAt: timestamp,
-              updatedAt: timestamp,
-            };
+        let draft = existing;
+        if (existing?.status !== 'ACTIVE' || readOptionalText(existing.ownerUid) !== current.actorId) {
+          const seed = buildProjectInfoDraftSeed(project, previousRequest);
+          draft = {
+            ownerUid: current.actorId,
+            tenantId: current.tenantId,
+            resourceType: RESOURCE_TYPE,
+            resourceId: current.projectId,
+            draftRevision: 0,
+            baseCanonicalVersion: Number.isInteger(project.version) && project.version > 0 ? project.version : 1,
+            // Frozen copy of the canonical values this draft started from, so a
+            // later rebase can tell "the user changed it" from "someone else did".
+            baseSnapshot: seed,
+            payload: seed,
+            attachmentRefs: resumableDraftAttachments(
+              current.tenantId,
+              current.draftDocumentId,
+              previousRequest,
+            ),
+            stepIndex: 0,
+            status: 'ACTIVE',
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          };
+        }
         assertDraftSize(draft);
         const body = { draft: draftContract(draft) };
         if (draft !== existing) {

--- a/server/bff/routes/project-info-drafts.test.mjs
+++ b/server/bff/routes/project-info-drafts.test.mjs
@@ -512,6 +512,177 @@ describe('project information private drafts', () => {
     })).rejects.toMatchObject({ statusCode: 404, code: 'not_found' });
   });
 
+  it('opens a pending V2 change draft for a legacy project before its participation sheet is linked', async () => {
+    const h = harness();
+    const manualTeam = [{
+      memberName: 'Actor A',
+      memberNickname: 'Actor',
+      role: '운영매니저',
+      participationRate: 50,
+      isDocumentOnly: false,
+    }];
+    h.db.documents.set('orgs/tenant-a/projects/project-a', {
+      id: 'project-a',
+      tenantId: 'tenant-a',
+      version: 3,
+      executiveReviewStatus: 'APPROVED',
+      executiveReviewHistory: [],
+      ...validPayload({ teamMembersDetailed: manualTeam }),
+    });
+    h.db.documents.set('orgs/tenant-a/project_requests/change-project-a', {
+      id: 'change-project-a',
+      requestKind: 'CHANGE',
+      status: 'PENDING',
+      targetProjectId: 'project-a',
+      proposedSnapshot: validV2Payload({ teamMembersDetailed: manualTeam }),
+    });
+    const projectBeforeOpen = clone(h.db.documents.get('orgs/tenant-a/projects/project-a'));
+    const requestBeforeOpen = clone(h.db.documents.get('orgs/tenant-a/project_requests/change-project-a'));
+
+    const opened = await openedDraft(h, 'open-legacy-pending-v2');
+
+    expect(opened).toMatchObject({
+      status: 200,
+      body: { draft: {
+        projectId: 'project-a',
+        draftRevision: 0,
+        payload: {
+          registrationRequirementsVersion: 2,
+          participationSheetLink: '',
+          teamMembersDetailed: manualTeam,
+        },
+      } },
+    });
+    expect(h.db.documents.get('orgs/tenant-a/projects/project-a')).toEqual(projectBeforeOpen);
+    expect(h.db.documents.get('orgs/tenant-a/project_requests/change-project-a')).toEqual(requestBeforeOpen);
+  });
+
+  it('hydrates a pending no-link sheet roster but still rejects it at submission', async () => {
+    const h = harness();
+    const manualTeam = [{
+      memberName: 'Actor A',
+      memberNickname: 'Actor',
+      role: '운영매니저',
+      participationRate: 50,
+      isDocumentOnly: false,
+    }];
+    const sheetTeam = [{
+      personId: 'person-a',
+      memberName: 'Actor A',
+      memberNickname: 'Actor',
+      role: '',
+      participationRate: 20,
+      laborAllocationStartMonth: '2026-07',
+      laborAllocationEndMonth: '2026-12',
+      monthlyRates: {
+        '2026-07': 20,
+        '2026-08': 0,
+        '2026-09': null,
+      },
+    }];
+    h.db.documents.set('orgs/tenant-a/projects/project-a', {
+      id: 'project-a',
+      tenantId: 'tenant-a',
+      version: 3,
+      executiveReviewStatus: 'APPROVED',
+      executiveReviewHistory: [],
+      ...validPayload({ teamMembersDetailed: manualTeam }),
+    });
+    h.db.documents.set('orgs/tenant-a/project_requests/change-project-a', {
+      id: 'change-project-a',
+      requestKind: 'CHANGE',
+      status: 'PENDING',
+      targetProjectId: 'project-a',
+      proposedSnapshot: validV2Payload({ teamMembersDetailed: sheetTeam }),
+    });
+    const projectBeforeOpen = clone(h.db.documents.get('orgs/tenant-a/projects/project-a'));
+    const requestBeforeOpen = clone(h.db.documents.get('orgs/tenant-a/project_requests/change-project-a'));
+
+    const opened = await openedDraft(h, 'open-legacy-pending-sheet-v2');
+
+    expect(opened.body.draft.payload).toMatchObject({
+      registrationRequirementsVersion: 2,
+      participationSheetLink: '',
+      teamMembersDetailed: sheetTeam,
+    });
+    expect(h.db.documents.get('orgs/tenant-a/projects/project-a')).toEqual(projectBeforeOpen);
+    expect(h.db.documents.get('orgs/tenant-a/project_requests/change-project-a')).toEqual(requestBeforeOpen);
+    await expect(h.service.submit({
+      ...h.base,
+      idempotencyKey: 'submit-legacy-pending-sheet-v2',
+      expectedDraftRevision: 0,
+      expectedVersion: 3,
+    })).rejects.toMatchObject({
+      statusCode: 422,
+      code: 'project_registration_invalid',
+      message: expect.stringContaining('participationSheetLink'),
+    });
+    expect(h.db.documents.get('orgs/tenant-a/projects/project-a')).toEqual(projectBeforeOpen);
+    expect(h.db.documents.get('orgs/tenant-a/project_requests/change-project-a')).toEqual(requestBeforeOpen);
+  });
+
+  it('returns an existing active owner draft without hydrating an incompatible pending seed', async () => {
+    const h = harness();
+    const projectPath = 'orgs/tenant-a/projects/project-a';
+    const requestPath = 'orgs/tenant-a/project_requests/change-project-a';
+    const draftId = `v1_${Buffer.from(JSON.stringify(['project-info', 'project-a', 'actor-a']), 'utf8').toString('base64url')}`;
+    const draftPath = `orgs/tenant-a/privateEditDrafts/${draftId}`;
+    const existingDraft = {
+      ownerUid: 'actor-a',
+      tenantId: 'tenant-a',
+      resourceType: 'project-info',
+      resourceId: 'project-a',
+      draftRevision: 7,
+      baseCanonicalVersion: 2,
+      baseSnapshot: { marker: 'original-base' },
+      payload: { marker: 'keep-existing-draft' },
+      attachmentRefs: [],
+      stepIndex: 3,
+      status: 'ACTIVE',
+      createdAt: '2026-07-11T23:00:00.000Z',
+      updatedAt: '2026-07-11T23:30:00.000Z',
+    };
+    h.db.documents.set(requestPath, {
+      id: 'change-project-a',
+      requestKind: 'CHANGE',
+      status: 'PENDING',
+      targetProjectId: 'project-a',
+      proposedSnapshot: validV2Payload({
+        participationSheetLink: '',
+        teamMembersDetailed: [{
+          personId: 'person-a',
+          memberName: 'Actor A',
+          laborAllocationStartMonth: '2026-07',
+          monthlyRates: { '2026-07': 120 },
+        }],
+      }),
+    });
+    h.db.documents.set(draftPath, existingDraft);
+    const projectBeforeOpen = clone(h.db.documents.get(projectPath));
+    const requestBeforeOpen = clone(h.db.documents.get(requestPath));
+    const draftBeforeOpen = clone(h.db.documents.get(draftPath));
+
+    const opened = await openedDraft(h, 'open-existing-active-draft');
+
+    expect(opened.body.draft).toEqual({
+      projectId: 'project-a',
+      resourceType: 'project-info',
+      resourceId: 'project-a',
+      draftRevision: 7,
+      baseCanonicalVersion: 2,
+      payload: { marker: 'keep-existing-draft' },
+      attachmentRefs: [],
+      stepIndex: 3,
+      status: 'ACTIVE',
+      createdAt: '2026-07-11T23:00:00.000Z',
+      updatedAt: '2026-07-11T23:30:00.000Z',
+    });
+    expect(h.db.documents.get(projectPath)).toEqual(projectBeforeOpen);
+    expect(h.db.documents.get(requestPath)).toEqual(requestBeforeOpen);
+    expect(h.db.documents.get(draftPath)).toEqual(draftBeforeOpen);
+    expect(h.auditChainService.appendManyInTransaction).not.toHaveBeenCalled();
+  });
+
   it('downloads a stored edit-draft attachment only for its owner and exact document kind', async () => {
     const downloadDraftAttachment = vi.fn(async () => ({
       buffer: Buffer.from('private-edit-pdf'), contentType: 'application/pdf', size: 16,

--- a/server/bff/routes/projects.mjs
+++ b/server/bff/routes/projects.mjs
@@ -1872,7 +1872,9 @@ function resolveProjectDepartmentFromPayload(payload, currentProject = {}) {
   );
 }
 
-export function buildProjectPatchFromChangeRequestPayload(payload = {}, currentProject = {}) {
+function buildProjectPatchFromChangeRequestPayloadInternal(payload = {}, currentProject = {}, {
+  validateParticipationSheetLink = true,
+} = {}) {
   const managerId = readOptionalText(payload.registeredById)
     || readOptionalText(payload.managerId)
     || readOptionalText(currentProject.registeredById)
@@ -1881,6 +1883,9 @@ export function buildProjectPatchFromChangeRequestPayload(payload = {}, currentP
     || readOptionalText(payload.managerName)
     || readOptionalText(currentProject.registeredByName)
     || readOptionalText(currentProject.managerName);
+  const effectiveParticipationSheetLink = Object.hasOwn(payload, 'participationSheetLink')
+    ? readOptionalText(payload.participationSheetLink)
+    : readOptionalText(currentProject.participationSheetLink);
   const effectiveContractStart = readOptionalText(payload.contractStart) || readOptionalText(currentProject.contractStart);
   const effectiveContractEnd = readOptionalText(payload.contractEnd) || readOptionalText(currentProject.contractEnd);
   const registrationVersion = registrationRequirementsVersion(
@@ -1888,10 +1893,21 @@ export function buildProjectPatchFromChangeRequestPayload(payload = {}, currentP
       ? payload.registrationRequirementsVersion
       : currentProject.registrationRequirementsVersion,
   );
-  // 참여율 시트 링크 검증은 제출 게이트(assertRegistrationPayload, PUT/PATCH 라우트)에서만 한다.
-  // 이 빌더는 draft open 시드 경로에서도 실행되므로, 여기서 검증하면 기존 데이터가
-  // 새 필수 규칙을 못 채운 프로젝트의 수정 화면 열기 자체가 막힌다.
+  const currentRegistrationVersion = registrationRequirementsVersion(
+    currentProject.registrationRequirementsVersion,
+  );
   const updatesTeamMembers = Object.hasOwn(payload, 'teamMembersDetailed');
+  const updatesParticipationSheet = participationSheetFieldsChanged(payload, currentProject);
+  if (validateParticipationSheetLink) {
+    assertParticipationSheetLinkForTeamMembers(
+      payload.teamMembersDetailed,
+      effectiveParticipationSheetLink,
+      {
+        required: registrationVersion === 2
+          && (updatesParticipationSheet || currentRegistrationVersion !== 2),
+      },
+    );
+  }
   const teamMembersDetailed = updatesTeamMembers
     ? normalizeProjectTeamMembersDetailed(payload.teamMembersDetailed, {
         contractStartMonth: effectiveContractStart.slice(0, 7),
@@ -1998,6 +2014,10 @@ export function buildProjectPatchFromChangeRequestPayload(payload = {}, currentP
   }), 'totalRevenueAmount');
 }
 
+export function buildProjectPatchFromChangeRequestPayload(payload = {}, currentProject = {}) {
+  return buildProjectPatchFromChangeRequestPayloadInternal(payload, currentProject);
+}
+
 const PROJECT_INFO_CHANGE_LABELS = {
   name: '프로젝트명',
   officialContractName: '공식 계약명',
@@ -2091,7 +2111,13 @@ function projectInfoChanges(beforeSnapshot, proposedSnapshot) {
   });
 }
 
-function projectInfoPayloadWithDocuments(payload, project, attachmentRefs, trustedStoredDocuments = {}) {
+function projectInfoPayloadWithDocuments(
+  payload,
+  project,
+  attachmentRefs,
+  trustedStoredDocuments = {},
+  { validateParticipationSheetLink = true } = {},
+) {
   const privateDocuments = registrationPrivateDocuments(attachmentRefs);
   const effectiveDocument = (field) => {
     if (privateDocuments[field]) return privateDocuments[field];
@@ -2104,7 +2130,9 @@ function projectInfoPayloadWithDocuments(payload, project, attachmentRefs, trust
     }
     return project[field] || null;
   };
-  const normalizedPatch = buildProjectPatchFromChangeRequestPayload(payload, project);
+  const normalizedPatch = buildProjectPatchFromChangeRequestPayloadInternal(payload, project, {
+    validateParticipationSheetLink,
+  });
   const proposedWithLegacyFallback = buildProjectRequestPayloadFromProject({ ...project, ...normalizedPatch }, payload);
   const proposed = Object.fromEntries(PROJECT_INFO_PAYLOAD_FIELDS.flatMap((field) => (
     Object.hasOwn(proposedWithLegacyFallback, field) ? [[field, proposedWithLegacyFallback[field]]] : []
@@ -2148,9 +2176,16 @@ export function buildProjectInfoDraftSeed(project, previousRequest) {
       project,
       [],
       trustedStoredChangeRequestDocuments(previousRequest),
+      { validateParticipationSheetLink: false },
     );
   }
-  return projectInfoPayloadWithDocuments(buildProjectRequestPayloadFromProject(project), project, []);
+  return projectInfoPayloadWithDocuments(
+    buildProjectRequestPayloadFromProject(project),
+    project,
+    [],
+    {},
+    { validateParticipationSheetLink: false },
+  );
 }
 
 export function buildProjectInfoChangeSubmission({
@@ -2198,6 +2233,8 @@ export function buildProjectInfoChangeSubmission({
     buildProjectRequestPayloadFromProject(project, previousRequest?.payload),
     project,
     [],
+    {},
+    { validateParticipationSheetLink: false },
   );
   const proposedSnapshot = projectInfoPayloadWithDocuments(
     payload,

--- a/server/bff/routes/projects.test.ts
+++ b/server/bff/routes/projects.test.ts
@@ -689,8 +689,8 @@ describe('project route helpers', () => {
     };
 
     expect(() => changeSubmission(payload, currentProject)).toThrowError(/participationSheetLink/);
-    // 열기/시드 경로는 같은 데이터로도 막히면 안 된다 — 링크는 폼에서 채워 제출할 때 검증한다.
-    expect(() => buildProjectPatchFromChangeRequestPayload(payload, currentProject)).not.toThrow();
+    expect(() => buildProjectPatchFromChangeRequestPayload(payload, currentProject))
+      .toThrowError(/participationSheetLink/);
   });
 
   it('rejects a V2 change submission with a manual roster but no participation sheet link', () => {
@@ -703,7 +703,8 @@ describe('project route helpers', () => {
     });
 
     expect(() => changeSubmission(payload, currentProject)).toThrowError(/participationSheetLink/);
-    expect(() => buildProjectPatchFromChangeRequestPayload(payload, currentProject)).not.toThrow();
+    expect(() => buildProjectPatchFromChangeRequestPayload(payload, currentProject))
+      .toThrowError(/participationSheetLink/);
   });
 
   it('preserves the current participation roster when a portal change does not touch it', () => {
@@ -738,9 +739,8 @@ describe('project route helpers', () => {
     };
 
     expect(() => changeSubmission(payload, currentProject)).toThrowError(/participationSheetLink/);
-    // 부분 patch(열기/시드 경로)는 온보딩 전 프로젝트라도 만들어져야 한다.
     expect(() => buildProjectPatchFromChangeRequestPayload({ contractEnd: '2028-12-31' }, currentProject))
-      .not.toThrow();
+      .toThrowError(/participationSheetLink/);
   });
 
   it('requires a participation sheet link at submit when a legacy project is upgraded to V2', () => {
@@ -760,7 +760,7 @@ describe('project route helpers', () => {
       .toThrowError(/participationSheetLink/);
     expect(() => buildProjectPatchFromChangeRequestPayload({
       registrationRequirementsVersion: 2,
-    }, currentProject)).not.toThrow();
+    }, currentProject)).toThrowError(/participationSheetLink/);
   });
 
   it('rejects a change submission whose sheet-backed row has no person identity', () => {
@@ -779,7 +779,8 @@ describe('project route helpers', () => {
     };
 
     expect(() => changeSubmission(payload, currentProject)).toThrowError(/identity is required/);
-    expect(() => buildProjectPatchFromChangeRequestPayload(payload, currentProject)).not.toThrow();
+    expect(() => buildProjectPatchFromChangeRequestPayload(payload, currentProject))
+      .toThrowError(/identity is required/);
   });
 
   it('opens the edit-form draft seed even when the saved roster is sheet-backed without a sheet link', () => {
@@ -800,6 +801,40 @@ describe('project route helpers', () => {
 
     expect(seed.teamMembersDetailed).toHaveLength(1);
     expect(seed.teamMembersDetailed[0].monthlyRates).toEqual({ '2026-01': 20 });
+  });
+
+  it('submits a repaired sheet link without revalidating the legacy before snapshot', () => {
+    const sheetMember = {
+      memberName: '김정태',
+      memberNickname: '에이블',
+      role: '',
+      participationRate: 20,
+      laborAllocationStartMonth: '2026-01',
+      monthlyRates: { '2026-01': 20 },
+    };
+    const canonical = registrationV2Canonical(
+      registrationV2Payload({
+        participationSheetLink: 'https://docs.google.com/spreadsheets/d/repaired/edit',
+        teamMembersDetailed: [sheetMember],
+      }),
+      registrationV2AttachmentKinds,
+      registrationV2AttachmentKinds,
+    );
+    const legacyProject = {
+      ...canonical.project,
+      participationSheetLink: '',
+      teamMembersDetailed: [sheetMember],
+    };
+
+    const openedDraft = buildProjectInfoDraftSeed(legacyProject, {});
+    const submission = changeSubmission({
+      ...openedDraft,
+      participationSheetLink: 'https://docs.google.com/spreadsheets/d/repaired/edit',
+      teamMembersDetailed: [sheetMember],
+    }, legacyProject);
+
+    expect(submission.projectRequest.proposedSnapshot.participationSheetLink)
+      .toBe('https://docs.google.com/spreadsheets/d/repaired/edit');
   });
 
   it('uses the current project contract end when a partial change omits contractEnd', () => {


### PR DESCRIPTION
## Summary

- 수정 초안 `open` 단계는 기존 V1/V2 사업이나 미완성 참여율 시트 상태를 그대로 hydration하여 편집 화면을 열 수 있게 합니다.
- 실제 제출·직접 수정·승인 적용 경로에는 참여율 시트 링크/행 검증을 유지해 잘못된 데이터 저장을 막습니다.
- 동일 소유자의 기존 ACTIVE 초안은 seed를 다시 만들거나 audit을 추가하지 않고 그대로 재사용합니다.
- 기존 데이터에 시트 링크를 보완한 뒤 정상 제출할 수 있는 repair flow를 회귀 테스트로 고정했습니다.

## Test Coverage

- Coverage audit: 18/18 changed code paths and user flows covered (100%).
- Targeted unit/service tests: 4 files, 182/182 passed.
- Firestore/BFF integration: 242 passed; Auth/Storage phase 2/2 passed.
- Participation preview isolation rerun: 19/19 passed.
- `npm run typecheck`: no new type errors.
- `npm run build`: passed.

## Pre-Landing Review

- Independent QA: GO.
- Specialist review: no findings.
- Claude and Codex adversarial reviews: no P0/P1 findings.
- Canonical project/request snapshots remain unchanged while opening a draft; invalid no-link submission still returns 422 without writes.

## Design Review

No frontend files changed; design review skipped.

## Eval Results

No prompt-related files changed; evals skipped.

## Plan Completion

No plan file detected; this is a focused production regression hotfix.

## Scope

Only four BFF implementation/test files changed. No database migration, Firestore rule change, external API change, or production data rewrite.

## Test plan

- [x] Legacy project + pending V2/no-link request opens as an editable draft
- [x] Existing ACTIVE owner draft reopens without rewrite or duplicate audit
- [x] Missing-link submit remains blocked with 422 and no canonical writes
- [x] Adding the valid participation sheet link allows submission
- [x] Targeted tests, BFF emulator integration, typecheck, and production build pass
